### PR TITLE
fix: use CSPRNG for pairing code generation

### DIFF
--- a/src/security/pairing.rs
+++ b/src/security/pairing.rs
@@ -150,10 +150,23 @@ fn generate_code() -> String {
     // UUID v4 uses getrandom (backed by /dev/urandom on Linux, BCryptGenRandom
     // on Windows) — a CSPRNG. We extract 4 bytes from it for a uniform random
     // number in [0, 1_000_000).
-    let uuid = uuid::Uuid::new_v4();
-    let bytes = uuid.as_bytes();
-    let raw = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-    format!("{:06}", raw % 1_000_000)
+    //
+    // Rejection sampling eliminates modulo bias: values above the largest
+    // multiple of 1_000_000 that fits in u32 are discarded and re-drawn.
+    // The rejection probability is ~0.02%, so this loop almost always exits
+    // on the first iteration.
+    const UPPER_BOUND: u32 = 1_000_000;
+    const REJECT_THRESHOLD: u32 = (u32::MAX / UPPER_BOUND) * UPPER_BOUND;
+
+    loop {
+        let uuid = uuid::Uuid::new_v4();
+        let bytes = uuid.as_bytes();
+        let raw = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+
+        if raw < REJECT_THRESHOLD {
+            return format!("{:06}", raw % UPPER_BOUND);
+        }
+    }
 }
 
 /// Generate a cryptographically-adequate bearer token (hex-encoded).
@@ -314,11 +327,15 @@ mod tests {
 
     #[test]
     fn generate_code_is_not_deterministic() {
-        // Two codes generated in the same process should differ (with overwhelming
-        // probability — collision chance is 1 in 1,000,000).
-        let c1 = generate_code();
-        let c2 = generate_code();
-        assert_ne!(c1, c2, "Two consecutive codes should differ (CSPRNG)");
+        // Two codes should differ with overwhelming probability. We try
+        // multiple pairs so a single 1-in-10^6 collision doesn't cause
+        // a flaky CI failure. All 10 pairs colliding is ~1-in-10^60.
+        for _ in 0..10 {
+            if generate_code() != generate_code() {
+                return; // Pass: found a non-matching pair.
+            }
+        }
+        panic!("Generated 10 pairs of codes and all were collisions — CSPRNG failure");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace `DefaultHasher` + `SystemTime` + `process::id()` with UUID v4 (OS CSPRNG) for pairing code generation
- Add test verifying non-deterministic output
- Zero new dependencies — reuses existing `uuid` crate

## Security context

The previous `generate_code()` used predictable entropy sources with a non-cryptographic hash (`SipHash`), making the 6-digit pairing code brute-forceable by an attacker who knows the approximate startup time. This replaces it with bytes from `uuid::Uuid::new_v4()`, which is backed by `getrandom` (i.e., `/dev/urandom` on Linux, `BCryptGenRandom` on Windows).

**Ref:** CWE-330 (Use of Insufficiently Random Values), closed issue #2

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes  
- [x] All 1,045 tests pass (including new `generate_code_is_not_deterministic` test)
- [x] No new dependencies added

> **Disclaimer:** This fix is human-driven and AI-assisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pairing code generation to use cryptographic randomness instead of deterministic methods.

* **Tests**
  * Added test to verify pairing codes are non-deterministic across consecutive calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->