### PR TITLE
fix: replace XOR cipher with ChaCha20-Poly1305 AEAD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +174,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +206,17 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -255,6 +300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -770,6 +816,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +967,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +1001,17 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1763,6 +1835,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2364,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chacha20poly1305",
  "chrono",
  "clap",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ thiserror = "2.0"
 # UUID generation
 uuid = { version = "1.11", default-features = false, features = ["v4", "std"] }
 
+# Authenticated encryption (AEAD) for secret store
+chacha20poly1305 = "0.10"
+
 # Async traits
 async-trait = "0.1"
 


### PR DESCRIPTION
## Summary

- Replaces the broken XOR cipher (`xor_cipher()`) in the secret store with **ChaCha20-Poly1305 AEAD** authenticated encryption
- Each encryption now uses a **random 12-byte nonce**, making ciphertexts non-deterministic
- **Poly1305 authentication tag** detects any ciphertext tampering or wrong-key decryption
- Existing `enc:` (legacy XOR) values are still decryptable for **backward compatibility** during migration
- New format: `enc2:<hex(nonce ‖ ciphertext ‖ tag)>` — same 32-byte key files, no key migration needed
- Adds `chacha20poly1305` 0.10 crate (pure Rust, no C deps — fits the project's minimal-dependency philosophy)

## Security Issue

The XOR cipher (CWE-327) was vulnerable to:
1. **Known-plaintext attacks** — API keys have known prefixes (`sk-`, `gsk_`, etc.) that directly reveal key bytes
2. **Deterministic output** — identical secrets produce identical ciphertext (no nonce/IV)
3. **No authentication** — tampered ciphertext decrypts silently to garbage

## Test plan

- [x] `cargo test` — all 652 tests pass (645 unit + 7 integration)
- [x] `cargo clippy -- -D warnings` — zero warnings
- [x] `cargo fmt -- --check` — clean
- [x] New tests cover: tamper detection, wrong-key rejection, nonce uniqueness, truncation, legacy XOR backward compat
- [ ] Verify existing `enc:`-prefixed config values still decrypt after upgrade

CWE-327 / CRIT-1

> ⚠️ This is a security fix. Disclosure: Human-driven, AI-assisted analysis (Claude Code used as a review tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Upgraded secret storage encryption method with enhanced authentication
  * Maintained full backward compatibility—existing encrypted data continues to work
  * New secrets encrypted using the updated scheme

* **Documentation**
  * Updated to reflect new encryption behavior and migration details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->