### PR TITLE
chore: add pre-push hook enforcing fmt, clippy, and tests

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# pre-push hook — runs fmt, clippy, and tests before every push.
+# Install:  git config core.hooksPath .githooks
+# Skip:     git push --no-verify
+
+set -euo pipefail
+
+echo "==> pre-push: checking formatting..."
+cargo fmt -- --check || {
+    echo "FAIL: cargo fmt -- --check found unformatted code."
+    echo "Run 'cargo fmt' and try again."
+    exit 1
+}
+
+echo "==> pre-push: running clippy..."
+cargo clippy -- -D warnings || {
+    echo "FAIL: clippy reported warnings."
+    exit 1
+}
+
+echo "==> pre-push: running tests..."
+cargo test || {
+    echo "FAIL: some tests did not pass."
+    exit 1
+}
+
+echo "==> pre-push: all checks passed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,18 +9,33 @@ Thanks for your interest in contributing to ZeroClaw! This guide will help you g
 git clone https://github.com/theonlyhennygod/zeroclaw.git
 cd zeroclaw
 
+# Enable the pre-push hook (runs fmt, clippy, tests before every push)
+git config core.hooksPath .githooks
+
 # Build
 cargo build
 
-# Run tests (180 tests, all must pass)
+# Run tests (all must pass)
 cargo test
 
 # Format & lint (must pass before PR)
 cargo fmt && cargo clippy -- -D warnings
 
-# Release build (~3.1MB)
+# Release build (~3.4MB)
 cargo build --release
 ```
+
+### Pre-push hook
+
+The repo includes a pre-push hook in `.githooks/` that enforces `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` before every push. Enable it with `git config core.hooksPath .githooks`.
+
+To skip it during rapid iteration:
+
+```bash
+git push --no-verify
+```
+
+> **Note:** CI runs the same checks, so skipped hooks will be caught on the PR.
 
 ## Architecture: Trait-Based Pluggability
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,20 @@ cargo fmt                # Format
 cargo test --test memory_comparison -- --nocapture
 ```
 
+### Pre-push hook
+
+A git hook runs `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` before every push. Enable it once:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+To skip the hook when you need a quick push during development:
+
+```bash
+git push --no-verify
+```
+
 ## License
 
 MIT — see [LICENSE](LICENSE)


### PR DESCRIPTION
## Summary

- Adds `.githooks/pre-push` that runs `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` before every push
- Enable with `git config core.hooksPath .githooks`
- Skip with `git push --no-verify` for rapid iteration
- Documented in both README.md and CONTRIBUTING.md

## Test plan

- [x] Hook is syntactically valid (`bash -n`)
- [x] Hook fires on push and runs all three checks
- [x] `--no-verify` bypasses it cleanly
- [x] CI still runs the same checks as a safety net

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an automated pre-push Git hook that runs formatting, linting, and test checks before code is pushed.

* **Documentation**
  * Updated contribution guidelines and README with instructions to enable the pre-push hook and information on bypassing it when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->