### PR TITLE
Use of stable lib feature instead of experimental

### DIFF
--- a/src/security/secrets.rs
+++ b/src/security/secrets.rs
@@ -238,7 +238,7 @@ fn hex_encode(data: &[u8]) -> String {
 
 /// Hex-decode a hex string to bytes.
 fn hex_decode(hex: &str) -> Result<Vec<u8>> {
-    if !hex.len().is_multiple_of(2) {
+    if hex.len() % 2 != 0 {
         anyhow::bail!("Hex string has odd length");
     }
     (0..hex.len())


### PR DESCRIPTION
The is_multiple_of is a new, experimental feature  introduced to the Rust standard library, but it is not yet stabilized. It requires the nightly compiler to work. Therefore, replacing it with the equivalent modulo operator (%) from stable release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal validation logic with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->