### PR TITLE
fix: clear environment variables in shell tool to prevent secret leakage

### DIFF
--- a/src/security/secrets.rs
+++ b/src/security/secrets.rs
@@ -241,7 +241,7 @@ fn hex_encode(data: &[u8]) -> String {
 
 /// Hex-decode a hex string to bytes.
 fn hex_decode(hex: &str) -> Result<Vec<u8>> {
-    if hex.len() % 2 != 0 {
+    if !hex.len().is_multiple_of(2) {
         anyhow::bail!("Hex string has odd length");
     }
     (0..hex.len())

--- a/src/tools/browser.rs
+++ b/src/tools/browser.rs
@@ -366,6 +366,7 @@ impl BrowserTool {
 }
 
 #[async_trait]
+#[allow(clippy::too_many_lines)]
 impl Tool for BrowserTool {
     fn name(&self) -> &str {
         "browser"


### PR DESCRIPTION
## Summary
Add `.env_clear()` to the shell command builder and whitelist only safe environment variables. Previously, all shell commands inherited the full parent process environment including `API_KEY` and `ZEROCLAW_API_KEY`.

## Changes
- **`src/tools/shell.rs`**: Added `SAFE_ENV_VARS` whitelist, `.env_clear()` call, selective re-addition of safe vars
- **Tests**: 2 new tests — verifies API keys are NOT in `env` output, verifies `HOME` IS available

## Test plan
- [x] `cargo test --verbose` — all tests pass (2 new tests)
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: run `env` via shell tool, verify no API keys in output

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shell execution now uses a controlled whitelist of environment variables to prevent leakage while preserving PATH, HOME and existing timeout behavior.
  * Improved hex input validation to explicitly reject odd-length hex strings.

* **Tests**
  * Added tests verifying environment variable handling (no secret leakage) and that PATH/HOME remain available inside executed shells.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->