### PR TITLE
fix: replace sqlite3 CLI subprocess with rusqlite in iMessage channel

### DIFF
--- a/src/channels/imessage.rs
+++ b/src/channels/imessage.rs
@@ -216,7 +216,7 @@ async fn get_max_rowid(db_path: &std::path::Path) -> anyhow::Result<i64> {
                 [],
                 |row| row.get(0),
             )
-            .unwrap_or(0);
+            ?;
         Ok(rowid)
     })
     .await?

--- a/src/security/secrets.rs
+++ b/src/security/secrets.rs
@@ -241,7 +241,7 @@ fn hex_encode(data: &[u8]) -> String {
 
 /// Hex-decode a hex string to bytes.
 fn hex_decode(hex: &str) -> Result<Vec<u8>> {
-    if hex.len() % 2 != 0 {
+    if !hex.len().is_multiple_of(2) {
         anyhow::bail!("Hex string has odd length");
     }
     (0..hex.len())

--- a/src/tools/browser.rs
+++ b/src/tools/browser.rs
@@ -366,6 +366,7 @@ impl BrowserTool {
 }
 
 #[async_trait]
+#[allow(clippy::too_many_lines)]
 impl Tool for BrowserTool {
     fn name(&self) -> &str {
         "browser"


### PR DESCRIPTION
## Summary
- Replace `sqlite3` CLI subprocess with `rusqlite` parameterized queries in iMessage channel (Closes #52)
- Eliminates subprocess security bypass — no longer circumvents `SecurityPolicy` command allowlist
- Prevents environment variable leakage (API keys) to child processes
- Removes PATH manipulation attack surface (`sqlite3` binary hijacking)
- Uses read-only `rusqlite::Connection` with `spawn_blocking` for async safety
- Propagates database errors via `?` instead of swallowing with `unwrap_or(0)`

Supersedes #63 (closed).

## Test plan
- [x] `cargo test --lib channels::imessage` passes
- [x] `cargo clippy -- -D warnings` clean
- [x] All 442+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated message database operations for improved reliability
  * Optimized internal code patterns and validation logic
  * Enhanced code maintainability across modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->