### PR TITLE
feat: add web search and HTTP request tools

### DIFF
--- a/src/tools/http_request.rs
+++ b/src/tools/http_request.rs
@@ -1,0 +1,394 @@
+use super::traits::{Tool, ToolResult};
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::json;
+use std::time::Duration;
+
+/// Maximum HTTP request time before timeout.
+const REQUEST_TIMEOUT_SECS: u64 = 30;
+/// Maximum response body size in bytes (1MB).
+const MAX_RESPONSE_BYTES: usize = 1_048_576;
+/// Maximum allowed URL length to prevent abuse.
+const MAX_URL_LENGTH: usize = 2048;
+
+/// HTTP request tool for making API calls
+pub struct HttpRequestTool {
+    client: Client,
+}
+
+impl HttpRequestTool {
+    pub fn new() -> Self {
+        Self {
+            client: Client::builder()
+                .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+                .connect_timeout(Duration::from_secs(10))
+                .redirect(reqwest::redirect::Policy::limited(5))
+                .build()
+                .unwrap_or_else(|_| Client::new()),
+        }
+    }
+
+    fn validate_url(url: &str) -> anyhow::Result<()> {
+        if url.is_empty() {
+            anyhow::bail!("URL cannot be empty");
+        }
+
+        if url.len() > MAX_URL_LENGTH {
+            anyhow::bail!("URL exceeds maximum length of {MAX_URL_LENGTH} characters");
+        }
+
+        if !url.starts_with("https://") && !url.starts_with("http://") {
+            anyhow::bail!("Only http:// and https:// URLs are allowed");
+        }
+
+        // Block private/internal network access
+        let host = extract_host(url);
+        if is_private_host(&host) {
+            anyhow::bail!("Requests to private/internal networks are blocked: {host}");
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Tool for HttpRequestTool {
+    fn name(&self) -> &str {
+        "http_request"
+    }
+
+    fn description(&self) -> &str {
+        "Make HTTP requests to external APIs. Supports GET, POST, PUT, PATCH, DELETE methods. \
+         Returns status code, headers, and response body. Blocks requests to private networks."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "The URL to request (must be http:// or https://)"
+                },
+                "method": {
+                    "type": "string",
+                    "enum": ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"],
+                    "description": "HTTP method (default: GET)"
+                },
+                "headers": {
+                    "type": "object",
+                    "description": "Request headers as key-value pairs"
+                },
+                "body": {
+                    "type": "string",
+                    "description": "Request body (for POST, PUT, PATCH)"
+                },
+                "json": {
+                    "type": "object",
+                    "description": "JSON request body (sets Content-Type: application/json)"
+                }
+            },
+            "required": ["url"]
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        let url = args
+            .get("url")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("Missing 'url' parameter"))?;
+
+        if let Err(e) = Self::validate_url(url) {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(e.to_string()),
+            });
+        }
+
+        let method = args
+            .get("method")
+            .and_then(|v| v.as_str())
+            .unwrap_or("GET")
+            .to_uppercase();
+
+        let mut request = match method.as_str() {
+            "GET" => self.client.get(url),
+            "POST" => self.client.post(url),
+            "PUT" => self.client.put(url),
+            "PATCH" => self.client.patch(url),
+            "DELETE" => self.client.delete(url),
+            "HEAD" => self.client.head(url),
+            _ => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!("Unsupported HTTP method: {method}")),
+                });
+            }
+        };
+
+        // Add custom headers
+        if let Some(headers) = args.get("headers").and_then(|v| v.as_object()) {
+            for (key, value) in headers {
+                if let Some(val) = value.as_str() {
+                    request = request.header(key.as_str(), val);
+                }
+            }
+        }
+
+        // Add body
+        if let Some(json_body) = args.get("json") {
+            request = request.json(json_body);
+        } else if let Some(body) = args.get("body").and_then(|v| v.as_str()) {
+            request = request.body(body.to_string());
+        }
+
+        match request.send().await {
+            Ok(resp) => {
+                let status = resp.status();
+                let status_code = status.as_u16();
+
+                // Collect response headers
+                let headers: Vec<String> = resp
+                    .headers()
+                    .iter()
+                    .take(20)
+                    .map(|(k, v)| format!("{}: {}", k, v.to_str().unwrap_or("<binary>")))
+                    .collect();
+
+                let mut body = resp.text().await.unwrap_or_default();
+
+                if body.len() > MAX_RESPONSE_BYTES {
+                    body.truncate(MAX_RESPONSE_BYTES);
+                    body.push_str("\n... [response truncated at 1MB]");
+                }
+
+                let output = format!(
+                    "HTTP {status_code} {}\n\nHeaders:\n{}\n\nBody:\n{body}",
+                    status.canonical_reason().unwrap_or(""),
+                    headers.join("\n"),
+                );
+
+                Ok(ToolResult {
+                    success: status.is_success(),
+                    output,
+                    error: if status.is_success() {
+                        None
+                    } else {
+                        Some(format!("HTTP {status_code}"))
+                    },
+                })
+            }
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Request failed: {e}")),
+            }),
+        }
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn extract_host(url: &str) -> String {
+    let without_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .unwrap_or(url);
+
+    without_scheme
+        .split('/')
+        .next()
+        .unwrap_or(without_scheme)
+        .split(':')
+        .next()
+        .unwrap_or(without_scheme)
+        .to_lowercase()
+}
+
+fn is_private_host(host: &str) -> bool {
+    let private_patterns = [
+        "localhost",
+        "127.",
+        "10.",
+        "192.168.",
+        "172.16.",
+        "172.17.",
+        "172.18.",
+        "172.19.",
+        "172.20.",
+        "172.21.",
+        "172.22.",
+        "172.23.",
+        "172.24.",
+        "172.25.",
+        "172.26.",
+        "172.27.",
+        "172.28.",
+        "172.29.",
+        "172.30.",
+        "172.31.",
+        "0.0.0.0",
+        "::1",
+        "[::1]",
+    ];
+
+    private_patterns
+        .iter()
+        .any(|p| host.starts_with(p) || host == *p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool() -> HttpRequestTool {
+        HttpRequestTool::new()
+    }
+
+    #[test]
+    fn http_request_tool_name() {
+        assert_eq!(tool().name(), "http_request");
+    }
+
+    #[test]
+    fn http_request_tool_description() {
+        assert!(!tool().description().is_empty());
+    }
+
+    #[test]
+    fn http_request_tool_schema_has_url() {
+        let schema = tool().parameters_schema();
+        assert!(schema["properties"]["url"].is_object());
+        assert!(schema["required"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("url")));
+    }
+
+    #[test]
+    fn http_request_tool_schema_has_method() {
+        let schema = tool().parameters_schema();
+        assert!(schema["properties"]["method"].is_object());
+    }
+
+    #[test]
+    fn http_request_tool_spec_roundtrip() {
+        let t = tool();
+        let spec = t.spec();
+        assert_eq!(spec.name, "http_request");
+        assert!(spec.parameters.is_object());
+    }
+
+    #[tokio::test]
+    async fn http_request_missing_url() {
+        let result = tool().execute(json!({})).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("url"));
+    }
+
+    #[tokio::test]
+    async fn http_request_wrong_type_url() {
+        let result = tool().execute(json!({"url": 123})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn http_request_empty_url() {
+        let result = tool().execute(json!({"url": ""})).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("empty"));
+    }
+
+    #[tokio::test]
+    async fn http_request_invalid_scheme() {
+        let result = tool()
+            .execute(json!({"url": "ftp://example.com"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("http"));
+    }
+
+    #[tokio::test]
+    async fn http_request_blocks_localhost() {
+        let result = tool()
+            .execute(json!({"url": "http://localhost:8080/api"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("private"));
+    }
+
+    #[tokio::test]
+    async fn http_request_blocks_private_ip() {
+        let result = tool()
+            .execute(json!({"url": "http://192.168.1.1/admin"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("private"));
+    }
+
+    #[tokio::test]
+    async fn http_request_blocks_loopback() {
+        let result = tool()
+            .execute(json!({"url": "http://127.0.0.1:3000"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("private"));
+    }
+
+    #[tokio::test]
+    async fn http_request_unsupported_method() {
+        let result = tool()
+            .execute(json!({"url": "https://example.com", "method": "TRACE"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("Unsupported"));
+    }
+
+    #[tokio::test]
+    async fn http_request_url_too_long() {
+        let long_url = format!("https://example.com/{}", "a".repeat(2100));
+        let result = tool().execute(json!({"url": long_url})).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("length"));
+    }
+
+    #[test]
+    fn validate_url_accepts_https() {
+        assert!(HttpRequestTool::validate_url("https://api.example.com/v1").is_ok());
+    }
+
+    #[test]
+    fn validate_url_accepts_http() {
+        assert!(HttpRequestTool::validate_url("http://api.example.com/v1").is_ok());
+    }
+
+    #[test]
+    fn validate_url_rejects_ftp() {
+        assert!(HttpRequestTool::validate_url("ftp://files.example.com").is_err());
+    }
+
+    #[test]
+    fn extract_host_works() {
+        assert_eq!(
+            extract_host("https://api.example.com/v1"),
+            "api.example.com"
+        );
+        assert_eq!(extract_host("http://HOST:8080/path"), "host");
+    }
+
+    #[test]
+    fn is_private_host_detects_local() {
+        assert!(is_private_host("localhost"));
+        assert!(is_private_host("127.0.0.1"));
+        assert!(is_private_host("192.168.1.1"));
+        assert!(is_private_host("10.0.0.1"));
+        assert!(!is_private_host("example.com"));
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,17 +3,20 @@ pub mod browser_open;
 pub mod composio;
 pub mod file_read;
 pub mod file_write;
+pub mod http_request;
 pub mod memory_forget;
 pub mod memory_recall;
 pub mod memory_store;
 pub mod shell;
 pub mod traits;
+pub mod web_search;
 
 pub use browser::BrowserTool;
 pub use browser_open::BrowserOpenTool;
 pub use composio::ComposioTool;
 pub use file_read::FileReadTool;
 pub use file_write::FileWriteTool;
+pub use http_request::HttpRequestTool;
 pub use memory_forget::MemoryForgetTool;
 pub use memory_recall::MemoryRecallTool;
 pub use memory_store::MemoryStoreTool;
@@ -21,6 +24,7 @@ pub use shell::ShellTool;
 pub use traits::Tool;
 #[allow(unused_imports)]
 pub use traits::{ToolResult, ToolSpec};
+pub use web_search::WebSearchTool;
 
 use crate::memory::Memory;
 use crate::security::SecurityPolicy;
@@ -70,6 +74,10 @@ pub fn all_tools(
             tools.push(Box::new(ComposioTool::new(key)));
         }
     }
+
+    // Web search and HTTP tools (check for API keys at execution time)
+    tools.push(Box::new(WebSearchTool::new()));
+    tools.push(Box::new(HttpRequestTool::new()));
 
     tools
 }

--- a/src/tools/web_search.rs
+++ b/src/tools/web_search.rs
@@ -1,0 +1,529 @@
+use super::traits::{Tool, ToolResult};
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::json;
+use std::fmt::Write;
+use std::time::Duration;
+
+/// Maximum search request time before timeout.
+const SEARCH_TIMEOUT_SECS: u64 = 15;
+/// Maximum output size in bytes (50KB).
+const MAX_OUTPUT_BYTES: usize = 51_200;
+
+/// Web search tool with Tavily, Brave, and `DuckDuckGo` (free fallback)
+pub struct WebSearchTool {
+    tavily_key: Option<String>,
+    brave_key: Option<String>,
+    client: Client,
+}
+
+impl WebSearchTool {
+    pub fn new() -> Self {
+        Self {
+            tavily_key: std::env::var("TAVILY_API_KEY")
+                .ok()
+                .filter(|k| !k.is_empty()),
+            brave_key: std::env::var("BRAVE_API_KEY")
+                .ok()
+                .filter(|k| !k.is_empty()),
+            client: Client::builder()
+                .timeout(Duration::from_secs(SEARCH_TIMEOUT_SECS))
+                .connect_timeout(Duration::from_secs(10))
+                .build()
+                .unwrap_or_else(|_| Client::new()),
+        }
+    }
+
+    async fn search_tavily(
+        &self,
+        query: &str,
+        max_results: usize,
+        api_key: &str,
+    ) -> anyhow::Result<String> {
+        let body = json!({
+            "api_key": api_key,
+            "query": query,
+            "max_results": max_results,
+            "include_answer": true,
+        });
+
+        let resp = self
+            .client
+            .post("https://api.tavily.com/search")
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let err = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Tavily API error ({status}): {err}");
+        }
+
+        let data: TavilyResponse = resp.json().await?;
+        let mut output = String::new();
+
+        if let Some(answer) = &data.answer {
+            if !answer.is_empty() {
+                let _ = writeln!(output, "Answer: {answer}\n");
+            }
+        }
+
+        for (i, result) in data.results.iter().enumerate() {
+            let _ = writeln!(
+                output,
+                "{}. {}\n   {}\n   {}\n",
+                i + 1,
+                result.title,
+                result.url,
+                truncate_content(&result.content, 300),
+            );
+        }
+
+        if data.results.is_empty() {
+            output.push_str("No results found.");
+        }
+
+        Ok(output)
+    }
+
+    async fn search_brave(
+        &self,
+        query: &str,
+        max_results: usize,
+        api_key: &str,
+    ) -> anyhow::Result<String> {
+        let resp = self
+            .client
+            .get("https://api.search.brave.com/res/v1/web/search")
+            .header("X-Subscription-Token", api_key)
+            .header("Accept", "application/json")
+            .query(&[("q", query), ("count", &max_results.to_string())])
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let err = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Brave Search API error ({status}): {err}");
+        }
+
+        let data: BraveResponse = resp.json().await?;
+        let mut output = String::new();
+
+        let results = data.web.map(|w| w.results).unwrap_or_default();
+
+        for (i, result) in results.iter().enumerate() {
+            let _ = writeln!(
+                output,
+                "{}. {}\n   {}\n   {}\n",
+                i + 1,
+                result.title,
+                result.url,
+                truncate_content(result.description.as_deref().unwrap_or(""), 300),
+            );
+        }
+
+        if results.is_empty() {
+            output.push_str("No results found.");
+        }
+
+        Ok(output)
+    }
+
+    /// Free fallback search via `DuckDuckGo` Instant Answer API
+    async fn search_duckduckgo(&self, query: &str, max_results: usize) -> anyhow::Result<String> {
+        let resp = self
+            .client
+            .get("https://api.duckduckgo.com/")
+            .query(&[("q", query), ("format", "json"), ("no_html", "1")])
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            anyhow::bail!("DuckDuckGo API error ({status})");
+        }
+
+        let data: DdgResponse = resp.json().await?;
+        let mut output = String::new();
+
+        // Abstract is DuckDuckGo's top-level answer
+        if !data.r#abstract.is_empty() {
+            let _ = writeln!(output, "Answer: {}", data.r#abstract);
+            if !data.abstract_url.is_empty() {
+                let _ = writeln!(output, "Source: {}\n", data.abstract_url);
+            }
+        }
+
+        let limit = max_results.min(data.related_topics.len());
+        for (i, topic) in data.related_topics.iter().take(limit).enumerate() {
+            if let Some(ref text) = topic.text {
+                let _ = writeln!(
+                    output,
+                    "{}. {}\n   {}\n",
+                    i + 1,
+                    truncate_content(text, 300),
+                    topic.first_url.as_deref().unwrap_or(""),
+                );
+            }
+        }
+
+        if output.is_empty() {
+            output.push_str("No results found.");
+        }
+
+        Ok(output)
+    }
+}
+
+#[async_trait]
+impl Tool for WebSearchTool {
+    fn name(&self) -> &str {
+        "web_search"
+    }
+
+    fn description(&self) -> &str {
+        "Search the web for information. Uses Tavily or Brave if API keys are set, \
+         otherwise falls back to DuckDuckGo (no key required)."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The search query"
+                },
+                "max_results": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return (1-10, default 5)"
+                },
+                "provider": {
+                    "type": "string",
+                    "enum": ["tavily", "brave", "duckduckgo"],
+                    "description": "Search provider (default: auto — tries tavily, brave, then duckduckgo)"
+                }
+            },
+            "required": ["query"]
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        let query = args
+            .get("query")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("Missing 'query' parameter"))?;
+
+        if query.trim().is_empty() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("Search query cannot be empty".into()),
+            });
+        }
+
+        let max_results = args
+            .get("max_results")
+            .and_then(serde_json::Value::as_u64)
+            .map_or(5, |n| usize::try_from(n).unwrap_or(5).clamp(1, 10));
+
+        let preferred = args
+            .get("provider")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("tavily");
+
+        // Resolve provider: try preferred, then fallback chain -> duckduckgo
+        let result = match preferred {
+            "brave" if self.brave_key.is_some() => {
+                self.search_brave(query, max_results, self.brave_key.as_ref().unwrap())
+                    .await
+            }
+            "tavily" if self.tavily_key.is_some() => {
+                self.search_tavily(query, max_results, self.tavily_key.as_ref().unwrap())
+                    .await
+            }
+            "duckduckgo" => self.search_duckduckgo(query, max_results).await,
+            _ => {
+                // Auto: try tavily -> brave -> duckduckgo
+                if let Some(ref key) = self.tavily_key {
+                    self.search_tavily(query, max_results, key).await
+                } else if let Some(ref key) = self.brave_key {
+                    self.search_brave(query, max_results, key).await
+                } else {
+                    self.search_duckduckgo(query, max_results).await
+                }
+            }
+        };
+
+        match result {
+            Ok(mut output) => {
+                if output.len() > MAX_OUTPUT_BYTES {
+                    output.truncate(MAX_OUTPUT_BYTES);
+                    output.push_str("\n... [output truncated at 50KB]");
+                }
+                Ok(ToolResult {
+                    success: true,
+                    output,
+                    error: None,
+                })
+            }
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Search failed: {e}")),
+            }),
+        }
+    }
+}
+
+// ── API response types ──────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct TavilyResponse {
+    #[serde(default)]
+    answer: Option<String>,
+    #[serde(default)]
+    results: Vec<TavilyResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct TavilyResult {
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BraveResponse {
+    web: Option<BraveWebResults>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BraveWebResults {
+    #[serde(default)]
+    results: Vec<BraveResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct BraveResult {
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    url: String,
+    description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DdgResponse {
+    #[serde(rename = "Abstract", default)]
+    r#abstract: String,
+    #[serde(rename = "AbstractURL", default)]
+    abstract_url: String,
+    #[serde(rename = "RelatedTopics", default)]
+    related_topics: Vec<DdgTopic>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DdgTopic {
+    #[serde(rename = "Text")]
+    text: Option<String>,
+    #[serde(rename = "FirstURL")]
+    first_url: Option<String>,
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+fn truncate_content(s: &str, max_chars: usize) -> &str {
+    if s.len() <= max_chars {
+        return s;
+    }
+    // Find a safe UTF-8 boundary
+    let mut end = max_chars;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tool() -> WebSearchTool {
+        // Construct without env vars for testing
+        WebSearchTool {
+            tavily_key: None,
+            brave_key: None,
+            client: Client::new(),
+        }
+    }
+
+    #[test]
+    fn web_search_tool_name() {
+        assert_eq!(tool().name(), "web_search");
+    }
+
+    #[test]
+    fn web_search_tool_description() {
+        assert!(!tool().description().is_empty());
+    }
+
+    #[test]
+    fn web_search_tool_schema_has_query() {
+        let schema = tool().parameters_schema();
+        assert!(schema["properties"]["query"].is_object());
+        assert!(schema["required"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("query")));
+    }
+
+    #[test]
+    fn web_search_tool_schema_has_optional_fields() {
+        let schema = tool().parameters_schema();
+        assert!(schema["properties"]["max_results"].is_object());
+        assert!(schema["properties"]["provider"].is_object());
+    }
+
+    #[test]
+    fn web_search_tool_spec_roundtrip() {
+        let t = tool();
+        let spec = t.spec();
+        assert_eq!(spec.name, "web_search");
+        assert!(spec.parameters.is_object());
+    }
+
+    #[tokio::test]
+    async fn web_search_missing_query_param() {
+        let result = tool().execute(json!({})).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("query"));
+    }
+
+    #[tokio::test]
+    async fn web_search_wrong_type_param() {
+        let result = tool().execute(json!({"query": 123})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn web_search_empty_query() {
+        let result = tool().execute(json!({"query": "  "})).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("empty"));
+    }
+
+    #[tokio::test]
+    async fn web_search_no_api_key_falls_back_to_ddg() {
+        // Without API keys, should attempt DuckDuckGo (not error)
+        let result = tool()
+            .execute(json!({"query": "rust programming"}))
+            .await
+            .unwrap();
+        // Either succeeds via DDG or fails with network error — never "API key" error
+        if !result.success {
+            assert!(!result
+                .error
+                .as_ref()
+                .unwrap_or(&String::new())
+                .contains("API key"));
+        }
+    }
+
+    #[tokio::test]
+    async fn web_search_explicit_duckduckgo_provider() {
+        let result = tool()
+            .execute(json!({"query": "test", "provider": "duckduckgo"}))
+            .await
+            .unwrap();
+        // Should attempt DDG regardless of API keys
+        if !result.success {
+            assert!(!result
+                .error
+                .as_ref()
+                .unwrap_or(&String::new())
+                .contains("API key"));
+        }
+    }
+
+    #[test]
+    fn truncate_content_short_string() {
+        assert_eq!(truncate_content("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_content_exact_length() {
+        assert_eq!(truncate_content("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_content_long_string() {
+        let result = truncate_content("hello world", 5);
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn truncate_content_unicode_safe() {
+        // "café" — the 'é' is 2 bytes, so truncating at byte 4 would split it
+        let s = "caf\u{00e9}";
+        let result = truncate_content(s, 4);
+        assert!(result.len() <= 4);
+        // Must still be valid UTF-8
+        let _ = result.to_string();
+    }
+
+    #[test]
+    fn tavily_response_deserializes() {
+        let json_str = r#"{"answer": "Rust is great", "results": [{"title": "Rust Lang", "url": "https://rust-lang.org", "content": "Systems programming language"}]}"#;
+        let resp: TavilyResponse = serde_json::from_str(json_str).unwrap();
+        assert_eq!(resp.answer.as_deref(), Some("Rust is great"));
+        assert_eq!(resp.results.len(), 1);
+        assert_eq!(resp.results[0].title, "Rust Lang");
+    }
+
+    #[test]
+    fn tavily_response_empty() {
+        let json_str = r#"{"results": []}"#;
+        let resp: TavilyResponse = serde_json::from_str(json_str).unwrap();
+        assert!(resp.answer.is_none());
+        assert!(resp.results.is_empty());
+    }
+
+    #[test]
+    fn brave_response_deserializes() {
+        let json_str = r#"{"web": {"results": [{"title": "Test", "url": "https://example.com", "description": "A test result"}]}}"#;
+        let resp: BraveResponse = serde_json::from_str(json_str).unwrap();
+        let results = resp.web.unwrap().results;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Test");
+    }
+
+    #[test]
+    fn brave_response_no_web() {
+        let json_str = r#"{}"#;
+        let resp: BraveResponse = serde_json::from_str(json_str).unwrap();
+        assert!(resp.web.is_none());
+    }
+
+    #[test]
+    fn ddg_response_deserializes() {
+        let json_str = r#"{"Abstract": "Rust is a language", "AbstractURL": "https://rust-lang.org", "RelatedTopics": [{"Text": "Rust programming", "FirstURL": "https://example.com"}]}"#;
+        let resp: DdgResponse = serde_json::from_str(json_str).unwrap();
+        assert_eq!(resp.r#abstract, "Rust is a language");
+        assert_eq!(resp.related_topics.len(), 1);
+    }
+
+    #[test]
+    fn ddg_response_empty() {
+        let json_str = r#"{"Abstract": "", "AbstractURL": "", "RelatedTopics": []}"#;
+        let resp: DdgResponse = serde_json::from_str(json_str).unwrap();
+        assert!(resp.r#abstract.is_empty());
+        assert!(resp.related_topics.is_empty());
+    }
+}


### PR DESCRIPTION
Adds two missing tools that every other claw variant already has:

**web_search** — Tavily, Brave Search, and DuckDuckGo as a free fallback (no API key needed). Auto-detects available keys and picks the best provider. DuckDuckGo works out of the box for anyone without API keys.

**http_request** — lets the agent call external APIs (GET, POST, PUT, PATCH, DELETE, HEAD). Blocks private networks (localhost, 127.x, 192.168.x, 10.x, 172.16-31.x) to prevent SSRF. Truncates responses at 1MB.

Both tools follow the existing trait pattern and are auto-registered in `all_tools()`. 35 new tests covering parameter validation, error handling, response parsing, and SSRF protection.

No new dependencies — uses reqwest which is already in Cargo.toml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HTTP request tool enabling configurable web requests with URL validation, support for multiple HTTP methods, optional headers, and request body handling.
  * Added web search tool providing multi-provider search capability (Tavily, Brave, DuckDuckGo) with automatic fallback and result optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->