### PR TITLE
fix: harden private host detection against SSRF bypass via IP parsing

### DIFF
--- a/src/tools/browser.rs
+++ b/src/tools/browser.rs
@@ -730,6 +730,7 @@ fn is_private_host(host: &str) -> bool {
                             || v4.is_private()
                             || v4.is_link_local()
                             || v4.is_unspecified()
+                            || v4.is_broadcast()
                     })
             }
         };


### PR DESCRIPTION
## Summary
- Replaces string-prefix matching in `is_private_host()` with proper `std::net::IpAddr` parsing
- The previous approach only matched dotted-decimal prefixes and could be bypassed with IPv4-mapped IPv6 addresses (e.g., `::ffff:127.0.0.1`) or bracketed IPv6 (`[::1]`)
- Now correctly detects loopback, private, link-local, and unspecified addresses across all IP formats
- Falls back to string patterns for hostnames that don't parse as IPs

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] All existing `is_private_host` tests still pass
- [x] New tests: `is_private_host_catches_ipv6` and `is_private_host_catches_mapped_ipv4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bracket-aware host extraction and improved private/loopback detection (IPv6, bracketed forms, IPv4-mapped addresses), plus a string-pattern fallback to catch ambiguous inputs; URL validation now blocks more SSRF-like IPv6/IPv4-mapped cases.

* **Tests**
  * Added coverage for bracketed IPv6, IPv4-mapped IPv6, private IPv6 ranges, localhost and new URL validation scenarios.

* **Chores**
  * No public API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->