### PR TITLE
fix: use atomic write-then-rename to prevent partial file corruption

### DIFF
--- a/src/tools/file_write.rs
+++ b/src/tools/file_write.rs
@@ -112,7 +112,11 @@ impl Tool for FileWriteTool {
 
         // Atomic write: write to a temporary file then rename, so a failed
         // write never leaves a partially-written file at the target path.
-        let tmp_path = resolved_target.with_extension("tmp");
+        let tmp_path = {
+            let mut name = resolved_target.file_name().unwrap().to_os_string();
+            name.push(".tmp");
+            resolved_parent.join(name)
+        };
 
         if let Err(e) = tokio::fs::write(&tmp_path, content).await {
             // Clean up partial temp file on write failure


### PR DESCRIPTION
## Summary
- File writes now go through a temporary `.tmp` file before being renamed to the target path
- If the write fails midway (e.g., disk full, I/O error), the original file is left intact instead of being replaced with a partially-written file
- The temp file is cleaned up on both write and rename failure

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] All 11 existing `file_write` tests pass (creates, overwrites, nested dirs, path traversal, symlink escape, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File writes are now atomic to prevent partial or corrupted files on failure.
  * Improved error handling with explicit failure messages for write and finalize stages.
  * Temporary write artifacts are cleaned up on failure.
  * Successful writes report byte count and target path for clearer confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->