### PR TITLE
fix(skills): prevent path traversal in skill remove command

### DIFF
--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -499,7 +499,7 @@ pub fn handle_command(command: super::SkillCommands, workspace_dir: &Path) -> Re
             let skills_path = skills_dir(workspace_dir);
             std::fs::create_dir_all(&skills_path)?;
 
-            if source.starts_with("http") || source.contains("github.com") {
+            if source.starts_with("https://") || source.starts_with("http://") {
                 // Git clone
                 let output = std::process::Command::new("git")
                     .args(["clone", "--depth", "1", &source])
@@ -585,7 +585,23 @@ pub fn handle_command(command: super::SkillCommands, workspace_dir: &Path) -> Re
             Ok(())
         }
         super::SkillCommands::Remove { name } => {
+            // Reject path traversal attempts
+            if name.contains("..") || name.contains('/') || name.contains('\\') {
+                anyhow::bail!("Invalid skill name: {name}");
+            }
+
             let skill_path = skills_dir(workspace_dir).join(&name);
+
+            // Verify the resolved path is actually inside the skills directory
+            let canonical_skills = skills_dir(workspace_dir)
+                .canonicalize()
+                .unwrap_or_else(|_| skills_dir(workspace_dir));
+            if let Ok(canonical_skill) = skill_path.canonicalize() {
+                if !canonical_skill.starts_with(&canonical_skills) {
+                    anyhow::bail!("Skill path escapes skills directory: {name}");
+                }
+            }
+
             if !skill_path.exists() {
                 anyhow::bail!("Skill not found: {name}");
             }


### PR DESCRIPTION
## Summary
- Reject skill names containing `..`, `/`, or `\` to prevent directory traversal attacks
- Verify resolved path stays within the skills directory via canonicalization
- Tighten install source validation to require `https://` or `http://` prefix instead of matching any string starting with "http"

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all tests pass
- [ ] Attempt `zeroclaw skill remove "../memory"` — should be rejected
- [ ] Attempt `zeroclaw skill install "httpmalicious.example.com"` — should be rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Remove command input validation and path canonicalization checks to enhance security and reliability.

* **Refactor**
  * Install path handling now strictly recognizes https:// and http:// URLs as Git references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->