### PR TITLE
fix(providers): warn on shared API key for fallbacks and warm up all providers

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -130,6 +130,15 @@ pub fn create_resilient_provider(
             continue;
         }
 
+        if api_key.is_some() && fallback != "ollama" {
+            tracing::warn!(
+                fallback_provider = fallback,
+                primary_provider = primary_name,
+                "Fallback provider will use the primary provider's API key — \
+                 this will fail if the providers require different keys"
+            );
+        }
+
         match create_provider(fallback, api_key) {
             Ok(provider) => providers.push((fallback.clone(), provider)),
             Err(e) => {

--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -26,9 +26,11 @@ impl ReliableProvider {
 #[async_trait]
 impl Provider for ReliableProvider {
     async fn warmup(&self) -> anyhow::Result<()> {
-        if let Some((name, provider)) = self.providers.first() {
+        for (name, provider) in &self.providers {
             tracing::info!(provider = name, "Warming up provider connection pool");
-            provider.warmup().await?;
+            if let Err(e) = provider.warmup().await {
+                tracing::warn!(provider = name, "Warmup failed (non-fatal): {e}");
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Log a warning when fallback providers inherit the primary provider's API key, which will fail authentication for providers requiring different credentials
- Warm up all providers in the chain (not just the primary) so fallback providers don't suffer cold-start latency
- Warmup failures are logged as warnings rather than aborting startup

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all tests pass
- [ ] Configure a fallback provider and verify warning appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced provider startup process to gracefully handle failures in fallback providers, improving overall startup reliability.
  * Added diagnostic warnings when fallback provider configuration may impact expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->