### PR TITLE
fix(gateway): use constant-time comparison for WhatsApp verify_token

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -333,10 +333,12 @@ async fn handle_whatsapp_verify(
         return (StatusCode::NOT_FOUND, "WhatsApp not configured".to_string());
     };
 
-    // Verify the token matches
-    if params.mode.as_deref() == Some("subscribe")
-        && params.verify_token.as_deref() == Some(wa.verify_token())
-    {
+    // Verify the token matches (constant-time comparison to prevent timing attacks)
+    let token_matches = params
+        .verify_token
+        .as_deref()
+        .is_some_and(|t| constant_time_eq(t, wa.verify_token()));
+    if params.mode.as_deref() == Some("subscribe") && token_matches {
         if let Some(ch) = params.challenge {
             tracing::info!("WhatsApp webhook verified successfully");
             return (StatusCode::OK, ch);
@@ -412,7 +414,10 @@ async fn handle_whatsapp_message(State(state): State<AppState>, body: Bytes) -> 
             Err(e) => {
                 tracing::error!("LLM error for WhatsApp message: {e:#}");
                 let _ = wa
-                    .send("Sorry, I couldn't process your message right now.", &msg.sender)
+                    .send(
+                        "Sorry, I couldn't process your message right now.",
+                        &msg.sender,
+                    )
                     .await;
             }
         }


### PR DESCRIPTION
## Summary
- Replace direct string equality (`==`) with `constant_time_eq()` for WhatsApp webhook verification token
- Prevents timing side-channel attacks that could leak the token value byte-by-byte
- Uses the same `constant_time_eq` function already used for pairing codes and bearer tokens

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all tests pass
- [ ] Verify WhatsApp webhook verification still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened WhatsApp account verification security with enhanced authentication checks to better protect against unauthorized access.

* **Style**
  * Applied minor formatting improvements to WhatsApp messaging error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->