### PR TITLE
refactor: remove dead inject_openclaw_identity and replace unreachable with bail

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -190,38 +190,6 @@ pub fn build_system_prompt(
     }
 }
 
-/// Inject `OpenClaw` (markdown) identity files into the prompt
-fn inject_openclaw_identity(prompt: &mut String, workspace_dir: &std::path::Path) {
-    #[allow(unused_imports)]
-    use std::fmt::Write;
-
-    prompt.push_str("## Project Context\n\n");
-    prompt
-        .push_str("The following workspace files define your identity, behavior, and context.\n\n");
-
-    let bootstrap_files = [
-        "AGENTS.md",
-        "SOUL.md",
-        "TOOLS.md",
-        "IDENTITY.md",
-        "USER.md",
-        "HEARTBEAT.md",
-    ];
-
-    for filename in &bootstrap_files {
-        inject_workspace_file(prompt, workspace_dir, filename);
-    }
-
-    // BOOTSTRAP.md — only if it exists (first-run ritual)
-    let bootstrap_path = workspace_dir.join("BOOTSTRAP.md");
-    if bootstrap_path.exists() {
-        inject_workspace_file(prompt, workspace_dir, "BOOTSTRAP.md");
-    }
-
-    // MEMORY.md — curated long-term memory (main session only)
-    inject_workspace_file(prompt, workspace_dir, "MEMORY.md");
-}
-
 /// Inject a single workspace file into the prompt with truncation and missing-file markers.
 fn inject_workspace_file(prompt: &mut String, workspace_dir: &std::path::Path, filename: &str) {
     use std::fmt::Write;
@@ -255,12 +223,10 @@ fn inject_workspace_file(prompt: &mut String, workspace_dir: &std::path::Path, f
 pub fn handle_command(command: super::ChannelCommands, config: &Config) -> Result<()> {
     match command {
         super::ChannelCommands::Start => {
-            // Handled in main.rs (needs async), this is unreachable
-            unreachable!("Start is handled in main.rs")
+            anyhow::bail!("Start must be handled in main.rs (requires async runtime)")
         }
         super::ChannelCommands::Doctor => {
-            // Handled in main.rs (needs async), this is unreachable
-            unreachable!("Doctor is handled in main.rs")
+            anyhow::bail!("Doctor must be handled in main.rs (requires async runtime)")
         }
         super::ChannelCommands::List => {
             println!("Channels:");


### PR DESCRIPTION
## Summary
- Remove `inject_openclaw_identity()` which was defined but never called (superseded by `build_system_prompt()`)
- Replace `unreachable!()` panics for Start/Doctor commands with `anyhow::bail!()` to return a clean error instead of crashing if routing ever changes

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for command execution, now providing clear async-runtime requirement guidance instead of crashes.

* **Refactor**
  * Removed unused internal code to streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->