### PR TITLE
chore: add gemini provider + validation

### DIFF
--- a/scripts/validate_gemini.sh
+++ b/scripts/validate_gemini.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}=== ZeroClaw Google Gemini Validation Script ===${NC}"
+
+# Check for cargo
+if ! command -v cargo &> /dev/null; then
+    echo -e "${RED}Error: cargo is not installed or not in PATH.${NC}"
+    exit 1
+fi
+
+# Get API Key
+if [ -z "$1" ]; then
+    echo -n "Enter your Google Gemini API Key: "
+    read -r API_KEY
+else
+    API_KEY="$1"
+fi
+
+if [ -z "$API_KEY" ]; then
+    echo -e "${RED}Error: API Key is required.${NC}"
+    exit 1
+fi
+
+echo -e "\n${GREEN}Testing Gemini connection...${NC}"
+echo "Running: cargo run -- agent --provider gemini --model gemini-3-flash-preview --message 'Hello! Please creative a haiku about rust programming.'"
+
+# Run the agent with explicit provider and key via ENV
+# We use gemini-1.5-flash as a default model to test
+ZEROCLAW_API_KEY="$API_KEY" cargo run --quiet -- agent \
+    --provider gemini \
+    --model gemini-3-flash-preview \
+    --message "Hello! Please create a haiku about rust programming."
+
+if [ $? -eq 0 ]; then
+    echo -e "\n${GREEN}✅ Success! Gemini provider is working.${NC}"
+else
+    echo -e "\n${RED}❌ Failed to validate Gemini provider.${NC}"
+fi

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -63,6 +63,12 @@ pub fn create_provider(name: &str, api_key: Option<&str>) -> anyhow::Result<Box<
         "qianfan" | "baidu" => Ok(Box::new(OpenAiCompatibleProvider::new(
             "Qianfan", "https://aip.baidubce.com", api_key, AuthStyle::Bearer,
         ))),
+        "gemini" | "google" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Google Gemini",
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+            api_key,
+            AuthStyle::Bearer,
+        ))),
 
         // ── Extended ecosystem (community favorites) ─────────
         "groq" => Ok(Box::new(OpenAiCompatibleProvider::new(
@@ -240,6 +246,12 @@ mod tests {
         assert!(create_provider("baidu", Some("key")).is_ok());
     }
 
+    #[test]
+    fn factory_gemini() {
+        assert!(create_provider("gemini", Some("key")).is_ok());
+        assert!(create_provider("google", Some("key")).is_ok());
+    }
+
     // ── Extended ecosystem ───────────────────────────────────
 
     #[test]
@@ -378,6 +390,7 @@ mod tests {
             "minimax",
             "bedrock",
             "qianfan",
+            "gemini",
             "groq",
             "mistral",
             "xai",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Google Gemini is now supported as an AI provider, accessible via "gemini" and "google" provider aliases.

* **Tests**
  * Added a validation script to verify Google Gemini integration and API connectivity.
  * Extended test suite to ensure new Gemini provider aliases work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->