### PR TITLE
fix(imessage): escape newlines in AppleScript string interpolation

### DIFF
--- a/src/channels/imessage.rs
+++ b/src/channels/imessage.rs
@@ -36,8 +36,12 @@ impl IMessageChannel {
 /// This prevents injection attacks by escaping:
 /// - Backslashes (`\` → `\\`)
 /// - Double quotes (`"` → `\"`)
+/// - Newlines (`\n` → `\\n`, `\r` → `\\r`) to prevent code injection via line breaks
 fn escape_applescript(s: &str) -> String {
-    s.replace('\\', "\\\\").replace('"', "\\\"")
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
 }
 
 /// Validate that a target looks like a valid phone number or email address.
@@ -386,8 +390,10 @@ mod tests {
     }
 
     #[test]
-    fn escape_applescript_newlines_preserved() {
-        assert_eq!(escape_applescript("line1\nline2"), "line1\nline2");
+    fn escape_applescript_newlines_escaped() {
+        assert_eq!(escape_applescript("line1\nline2"), "line1\\nline2");
+        assert_eq!(escape_applescript("line1\rline2"), "line1\\rline2");
+        assert_eq!(escape_applescript("line1\r\nline2"), "line1\\r\\nline2");
     }
 
     // ══════════════════════════════════════════════════════════


### PR DESCRIPTION
Prevents code injection via line breaks by escaping newline and carriage return characters in AppleScript string interpolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper handling of newline characters in message processing, ensuring they are now correctly escaped.

* **Tests**
  * Updated test cases to verify newline character escaping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->