### PR TITLE
fix: prevent panics from byte-level string slicing on multi-byte UTF-8

### DIFF
--- a/src/memory/hygiene.rs
+++ b/src/memory/hygiene.rs
@@ -326,7 +326,7 @@ fn date_prefix(filename: &str) -> Option<NaiveDate> {
     if filename.len() < 10 {
         return None;
     }
-    NaiveDate::parse_from_str(&filename[..10], "%Y-%m-%d").ok()
+    NaiveDate::parse_from_str(&filename[..filename.floor_char_boundary(10)], "%Y-%m-%d").ok()
 }
 
 fn is_older_than(path: &Path, cutoff: SystemTime) -> bool {


### PR DESCRIPTION
Uses floor_char_boundary() instead of direct byte indexing to prevent panics when slicing strings containing multi-byte UTF-8 characters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of date extraction for non-ASCII characters.

* **New Features**
  * Enhanced shell command execution with modified environment variable handling.
  * Improved output truncation with better character boundary preservation.

* **Tests**
  * Added test coverage for shell environment handling and API key isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->