### PR TITLE
chore: fix CHANGELOG date for version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `enc:` prefix for encrypted secrets — Use `enc2:` (ChaCha20-Poly1305) instead.
   Legacy values are still decrypted for backward compatibility but should be migrated.
 
-## [0.1.0] - 2025-02-13
+## [0.1.0] - 2026-02-13
 
 ### Added
 - **Core Architecture**: Trait-based pluggable system for Provider, Channel, Observer, RuntimeAdapter, Tool


### PR DESCRIPTION
Fix typo in release date: 2025-02-13 should be 2026-02-13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated release date documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->