### PR TITLE
fix(providers): warn on shared API key for fallbacks and warm up all providers

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -212,6 +212,15 @@ pub fn create_resilient_provider(
             continue;
         }
 
+        if api_key.is_some() && fallback != "ollama" {
+            tracing::warn!(
+                fallback_provider = fallback,
+                primary_provider = primary_name,
+                "Fallback provider will use the primary provider's API key — \
+                 this will fail if the providers require different keys"
+            );
+        }
+
         match create_provider(fallback, api_key) {
             Ok(provider) => providers.push((fallback.clone(), provider)),
             Err(e) => {

--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -26,9 +26,11 @@ impl ReliableProvider {
 #[async_trait]
 impl Provider for ReliableProvider {
     async fn warmup(&self) -> anyhow::Result<()> {
-        if let Some((name, provider)) = self.providers.first() {
+        for (name, provider) in &self.providers {
             tracing::info!(provider = name, "Warming up provider connection pool");
-            provider.warmup().await?;
+            if let Err(e) = provider.warmup().await {
+                tracing::warn!(provider = name, "Warmup failed (non-fatal): {e}");
+            }
         }
         Ok(())
     }

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -79,11 +79,8 @@ impl Tool for ShellTool {
             }
         }
 
-        let result = tokio::time::timeout(
-            Duration::from_secs(SHELL_TIMEOUT_SECS),
-            cmd.output(),
-        )
-        .await;
+        let result =
+            tokio::time::timeout(Duration::from_secs(SHELL_TIMEOUT_SECS), cmd.output()).await;
 
         match result {
             Ok(Ok(output)) => {


### PR DESCRIPTION
- Warn when fallback providers share the same API key as primary (could fail if providers require different keys)
- Warm up all providers instead of just the first, continuing on warmup failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added runtime warning notifications when using provider fallbacks with API keys, alerting users about potential key reuse behavior between primary and fallback providers.

* **Bug Fixes**
  * Enhanced provider warmup process to attempt initialization of all configured providers instead of stopping after the first failure, improving overall system resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->