### PR TITLE
fix(memory): use SHA-256 for embedding cache keys instead of DefaultHasher

### DIFF
--- a/src/memory/sqlite.rs
+++ b/src/memory/sqlite.rs
@@ -136,7 +136,10 @@ impl SqliteMemory {
         use sha2::{Digest, Sha256};
         let hash = Sha256::digest(text.as_bytes());
         // First 8 bytes → 16 hex chars, matching previous format length
-        format!("{:016x}", u64::from_be_bytes(hash[..8].try_into().unwrap()))
+        format!(
+            "{:016x}",
+            u64::from_be_bytes(hash[..8].try_into().expect("SHA-256 always produces >= 8 bytes"))
+        )
     }
 
     /// Get embedding from cache, or compute + cache it


### PR DESCRIPTION
## Summary
- `DefaultHasher` is [explicitly documented](https://doc.rust-lang.org/std/collections/hash_map/struct.DefaultHasher.html) as unstable across Rust versions and runs
- Using it for embedding cache keys meant upgrading Rust or restarting the process could silently invalidate the entire cache
- Replaced with SHA-256 (already a dependency via `sha2` crate), truncated to 16 hex chars to match existing format

## Test plan
- [ ] Existing `content_hash_*` tests pass with new implementation
- [ ] Verify hash output is deterministic across multiple runs
- [ ] Verify cache entries from previous runs are NOT matched (one-time invalidation is expected and acceptable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding cache consistency and reliability through enhanced deterministic content identification, ensuring more stable caching behavior across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->