### PR TITLE
fix: harden private host detection against SSRF bypass via IP parsing

### DIFF
--- a/src/tools/browser.rs
+++ b/src/tools/browser.rs
@@ -791,6 +791,25 @@ mod tests {
     }
 
     #[test]
+    fn extract_host_handles_ipv6() {
+        // IPv6 with brackets (required for URLs with ports)
+        assert_eq!(
+            extract_host("https://[::1]/path").unwrap(),
+            "[::1]"
+        );
+        // IPv6 with brackets and port
+        assert_eq!(
+            extract_host("https://[2001:db8::1]:8080/path").unwrap(),
+            "[2001:db8::1]"
+        );
+        // IPv6 with brackets, trailing slash
+        assert_eq!(
+            extract_host("https://[fe80::1]/").unwrap(),
+            "[fe80::1]"
+        );
+    }
+
+    #[test]
     fn is_private_host_detects_local() {
         assert!(is_private_host("localhost"));
         assert!(is_private_host("127.0.0.1"));


### PR DESCRIPTION
## Summary

Hardens browser tool against SSRF attacks via proper IP address parsing.

**Changes:**
- Fix  to properly handle IPv6 addresses with brackets like 
- Rewrite  to use  parsing instead of string patterns
- Catch IPv4-mapped IPv6 addresses (e.g., `::ffff:127.0.0.1`)
- Detect all IPv6 private ranges: unique-local (fc00::/7) and link-local (fe80::/10)
- Add comprehensive tests for IPv6 SSRF prevention

**Security Impact:**
Previously, attackers could bypass private host detection using:
- IPv4-mapped IPv6 addresses (`::ffff:127.0.0.1`)
- IPv6 private ranges
- Various IP representations

Now all representations are caught by proper IP parsing.

## Test plan
- All 900 tests pass
- New tests cover IPv6 URL extraction and SSRF blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IPv6 address handling in URL validation and extraction.
  * Enhanced detection of private/loopback hosts, including IPv6 variants and IPv4-mapped addresses.
  * Strengthened SSRF (Server-Side Request Forgery) protections.

* **Tests**
  * Added comprehensive test coverage for IPv6 and IPv4-mapped address scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->