### PR TITLE
fix: ollama provider ignores api_key parameter to prevent builder error

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -98,9 +98,9 @@ pub fn create_provider(name: &str, api_key: Option<&str>) -> anyhow::Result<Box<
         "openrouter" => Ok(Box::new(openrouter::OpenRouterProvider::new(api_key))),
         "anthropic" => Ok(Box::new(anthropic::AnthropicProvider::new(api_key))),
         "openai" => Ok(Box::new(openai::OpenAiProvider::new(api_key))),
-        "ollama" => Ok(Box::new(ollama::OllamaProvider::new(
-            api_key.filter(|k| !k.is_empty()),
-        ))),
+        // Ollama is a local service that doesn't use API keys.
+        // The api_key parameter is ignored to avoid it being misinterpreted as a base_url.
+        "ollama" => Ok(Box::new(ollama::OllamaProvider::new(None))),
         "gemini" | "google" | "google-gemini" => {
             Ok(Box::new(gemini::GeminiProvider::new(api_key)))
         }
@@ -267,6 +267,9 @@ mod tests {
     #[test]
     fn factory_ollama() {
         assert!(create_provider("ollama", None).is_ok());
+        // Ollama ignores the api_key parameter since it's a local service
+        assert!(create_provider("ollama", Some("dummy")).is_ok());
+        assert!(create_provider("ollama", Some("any-value-here")).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix ollama provider failing with \"builder error\" when api_key is set
- Ollama is a local service that doesn't use API keys
- The api_key parameter is now ignored to prevent it being misinterpreted as base_url

## Root Cause
The ollama provider was using `api_key.filter(|k| !k.is_empty())` as its `base_url` parameter. When users set a dummy API key during onboarding (e.g., \"dummy\"), the provider would try to connect to `http://dummy/api/chat` instead of `http://localhost:11434/api/chat`.

## Test plan
- [x] All existing tests pass
- [x] Added tests verifying ollama works with any api_key value
- [x] Verified fix resolves issue #119

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Ollama provider to consistently ignore API key input during initialization.

* **Tests**
  * Enhanced test coverage to verify Ollama provider creation succeeds across multiple API key configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->