### PR TITLE
fix: use UTF-8 safe truncation in bootstrap file preview

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -209,8 +209,18 @@ fn inject_workspace_file(prompt: &mut String, workspace_dir: &std::path::Path, f
                 return;
             }
             let _ = writeln!(prompt, "### {filename}\n");
-            if trimmed.len() > BOOTSTRAP_MAX_CHARS {
-                prompt.push_str(&trimmed[..BOOTSTRAP_MAX_CHARS]);
+            // Use character-boundary-safe truncation for UTF-8
+            let truncated = if trimmed.chars().count() > BOOTSTRAP_MAX_CHARS {
+                trimmed
+                    .char_indices()
+                    .nth(BOOTSTRAP_MAX_CHARS)
+                    .map(|(idx, _)| &trimmed[..idx])
+                    .unwrap_or(trimmed)
+            } else {
+                trimmed
+            };
+            if truncated.len() < trimmed.len() {
+                prompt.push_str(truncated);
                 let _ = writeln!(
                     prompt,
                     "\n\n[... truncated at {BOOTSTRAP_MAX_CHARS} chars — use `read` for full file]\n"


### PR DESCRIPTION
## Summary
Fix panic when displaying workspace files containing multibyte UTF-8 characters (Chinese, Japanese, Korean, emoji) in the bootstrap context.

## Root Cause
The code used byte-based slicing `&trimmed[..BOOTSTRAP_MAX_CHARS]` which could land in the middle of a multibyte character, causing:
```
byte index 100 is not a char boundary; it is inside '正' (bytes 99..102)
```

## Fix
Now uses `char_indices().nth()` to find safe character boundaries before slicing, ensuring UTF-8 safety for all languages.

## Analysis
- The `truncate_with_ellipsis` function in `util.rs` was already UTF-8 safe
- All message preview locations were already using the safe function
- This fixes the remaining unsafe truncation in the workspace file bootstrap code

## Test plan
- [x] All 971 tests pass
- [x] Existing UTF-8 truncation tests cover Chinese, Japanese, emoji, accented characters
- [x] Verified no other unsafe byte slicing patterns exist in the codebase

## Impact
- Fixes crashes for users of non-ASCII languages (CJK, emoji-heavy text)
- Critical for international users

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed UTF-8 character truncation for large file contents. Files are now properly truncated at valid character boundaries instead of byte boundaries, preventing corruption of multi-byte Unicode characters and special symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->