### PR TITLE
fix: resolve merge conflict in anthropic.rs base_url field

### DIFF
--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -50,10 +50,7 @@ impl AnthropicProvider {
                 .map(str::trim)
                 .filter(|k| !k.is_empty())
                 .map(ToString::to_string),
-<<<<<<< HEAD
-=======
             base_url,
->>>>>>> origin/main
             client: Client::builder()
                 .timeout(std::time::Duration::from_secs(120))
                 .connect_timeout(std::time::Duration::from_secs(10))
@@ -95,11 +92,7 @@ impl Provider for AnthropicProvider {
 
         let mut request = self
             .client
-<<<<<<< HEAD
-            .post("https://api.anthropic.com/v1/messages")
-=======
             .post(format!("{}/v1/messages", self.base_url))
->>>>>>> origin/main
             .header("anthropic-version", "2023-06-01")
             .header("content-type", "application/json")
             .json(&request);
@@ -136,20 +129,14 @@ mod tests {
         let p = AnthropicProvider::new(Some("sk-ant-test123"));
         assert!(p.credential.is_some());
         assert_eq!(p.credential.as_deref(), Some("sk-ant-test123"));
-<<<<<<< HEAD
-=======
         assert_eq!(p.base_url, "https://api.anthropic.com");
->>>>>>> origin/main
     }
 
     #[test]
     fn creates_without_key() {
         let p = AnthropicProvider::new(None);
         assert!(p.credential.is_none());
-<<<<<<< HEAD
-=======
         assert_eq!(p.base_url, "https://api.anthropic.com");
->>>>>>> origin/main
     }
 
     #[test]
@@ -163,8 +150,6 @@ mod tests {
         let p = AnthropicProvider::new(Some("  sk-ant-test123  "));
         assert!(p.credential.is_some());
         assert_eq!(p.credential.as_deref(), Some("sk-ant-test123"));
-<<<<<<< HEAD
-=======
     }
 
     #[test]
@@ -184,7 +169,6 @@ mod tests {
     fn default_base_url_when_none_provided() {
         let p = AnthropicProvider::with_base_url(None, None);
         assert_eq!(p.base_url, "https://api.anthropic.com");
->>>>>>> origin/main
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes: https://github.com/theonlyhennygod/zeroclaw/issues/166
Resolved merge conflicts that occurred after the addition of base_url support for Anthropic provider. The conflicts prevented compilation with "encountered diff marker" errors.

Changes:
- Added base_url field initialization in AnthropicProvider constructor
- Updated POST request to use self.base_url instead of hardcoded URL
- Added base_url assertions in existing tests
- Added new tests for custom base_url functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anthropic provider now supports configurable API base URLs, allowing users to specify custom endpoints instead of using the default API address.

* **Refactor**
  * Improved API endpoint configuration to enable dynamic URL handling with proper fallback to default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->