### PR TITLE
fix: install default Rustls crypto provider to prevent TLS initialization error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,6 +2957,7 @@ dependencies = [
  "mail-parser",
  "reqwest",
  "rusqlite",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink"] 
 hostname = "0.4.2"
 lettre = { version = "0.11.19", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"] }
 mail-parser = "0.11.2"
+rustls = "0.23"
 rustls-pki-types = "1.14.0"
 tokio-rustls = "0.26.4"
 webpki-roots = "1.0.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,6 +255,13 @@ enum IntegrationCommands {
 #[tokio::main]
 #[allow(clippy::too_many_lines)]
 async fn main() -> Result<()> {
+    // Install default crypto provider for Rustls TLS.
+    // This prevents the error: "could not automatically determine the process-level CryptoProvider"
+    // when both aws-lc-rs and ring features are available (or neither is explicitly selected).
+    if let Err(e) = rustls::crypto::ring::default_provider().install_default() {
+        eprintln!("Warning: Failed to install default crypto provider: {e:?}");
+    }
+
     let cli = Cli::parse();
 
     // Initialize logging


### PR DESCRIPTION
## Summary
Fix the error "could not automatically determine the process-level CryptoProvider from Rustls crate features" that occurs when starting the zeroclaw daemon.

## Root Cause
Starting with Rustls 0.23, when multiple crypto providers are available (aws-lc-rs and ring), the library requires explicit selection of a default crypto provider at process startup.

## Fix
- Add `rustls` 0.23 as a direct dependency
- Call `rustls::crypto::ring::default_provider().install_default()` at `main()` entry point
- The ring-based provider has wide platform support and is the safe default choice

## Test plan
- [x] All tests pass
- [x] Daemon starts without CryptoProvider error
- [x] TLS connections work properly for all channels (HTTPS, webhooks, etc.)

## Impact
- Fixes daemon startup failures on systems where both aws-lc-rs and ring features are available
- No breaking changes - ring provider is widely supported

Fixes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TLS dependency to version 0.23, enhancing cryptographic support
  * Implemented automatic initialization of cryptographic provider at startup with robust error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->