### PR TITLE
feat(agent): wire Composio tool into LLM tool descriptions

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -118,6 +118,12 @@ pub async fn run(
             "Open approved HTTPS URLs in Brave Browser (allowlist-only, no scraping)",
         ));
     }
+    if config.composio.enabled {
+        tool_descs.push((
+            "composio",
+            "Execute actions on 1000+ apps via Composio (Gmail, Notion, GitHub, Slack, etc.). Use action='list' to discover, 'execute' to run, 'connect' to OAuth.",
+        ));
+    }
     let system_prompt = crate::channels::build_system_prompt(
         &config.workspace_dir,
         model_name,


### PR DESCRIPTION
## Summary
- The `ComposioTool` was fully implemented (403 LOC, 14 tests in `src/tools/composio.rs`) but never added to the `tool_descs` list in `src/agent/loop_.rs`, so the LLM had no way to discover or invoke it
- Adds a conditional `tool_descs.push(...)` entry when `config.composio.enabled` is true, making the tool visible in the system prompt
- Follows the same pattern as the existing browser_open conditional

## Changes
- `src/agent/loop_.rs`: Add `composio` to `tool_descs` when composio is enabled

## Test plan
- [x] All 979+ existing tests pass
- [x] `cargo clippy` clean (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Composio integration support, enabling access to actions and connections across 1000+ third-party applications. When enabled, the system can discover, list, and execute available integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->