### PR TITLE
fix: correct API endpoints for z.ai, opencode, and glm providers (#167)

### DIFF
--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -524,4 +524,38 @@ mod tests {
         let p = make_provider("test", "https://api.example.com/v1", None);
         assert_eq!(p.chat_completions_url(), "https://api.example.com/v1/chat/completions");
     }
+
+    // ══════════════════════════════════════════════════════════
+    // Provider-specific endpoint tests (Issue #167)
+    // ══════════════════════════════════════════════════════════
+
+    #[test]
+    fn chat_completions_url_zai() {
+        // Z.AI uses /api/paas/v4 base path
+        let p = make_provider("zai", "https://api.z.ai/api/paas/v4", None);
+        assert_eq!(
+            p.chat_completions_url(),
+            "https://api.z.ai/api/paas/v4/chat/completions"
+        );
+    }
+
+    #[test]
+    fn chat_completions_url_glm() {
+        // GLM (BigModel) uses /api/paas/v4 base path
+        let p = make_provider("glm", "https://open.bigmodel.cn/api/paas/v4", None);
+        assert_eq!(
+            p.chat_completions_url(),
+            "https://open.bigmodel.cn/api/paas/v4/chat/completions"
+        );
+    }
+
+    #[test]
+    fn chat_completions_url_opencode() {
+        // OpenCode Zen uses /zen/v1 base path
+        let p = make_provider("opencode", "https://opencode.ai/zen/v1", None);
+        assert_eq!(
+            p.chat_completions_url(),
+            "https://opencode.ai/zen/v1/chat/completions"
+        );
+    }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -186,13 +186,13 @@ pub fn create_provider(name: &str, api_key: Option<&str>) -> anyhow::Result<Box<
             "Synthetic", "https://api.synthetic.com", api_key, AuthStyle::Bearer,
         ))),
         "opencode" | "opencode-zen" => Ok(Box::new(OpenAiCompatibleProvider::new(
-            "OpenCode Zen", "https://api.opencode.ai", api_key, AuthStyle::Bearer,
+            "OpenCode Zen", "https://opencode.ai/zen/v1", api_key, AuthStyle::Bearer,
         ))),
         "zai" | "z.ai" => Ok(Box::new(OpenAiCompatibleProvider::new(
-            "Z.AI", "https://api.z.ai", api_key, AuthStyle::Bearer,
+            "Z.AI", "https://api.z.ai/api/paas/v4", api_key, AuthStyle::Bearer,
         ))),
         "glm" | "zhipu" => Ok(Box::new(OpenAiCompatibleProvider::new(
-            "GLM", "https://open.bigmodel.cn/api/paas", api_key, AuthStyle::Bearer,
+            "GLM", "https://open.bigmodel.cn/api/paas/v4", api_key, AuthStyle::Bearer,
         ))),
         "minimax" => Ok(Box::new(OpenAiCompatibleProvider::new(
             "MiniMax", "https://api.minimax.chat", api_key, AuthStyle::Bearer,


### PR DESCRIPTION
## Summary
- Fixes 404 errors for **z.ai** provider by updating endpoint from `https://api.z.ai` to `https://api.z.ai/api/paas/v4`
- Fixes response decoding errors for **opencode** provider by updating endpoint from `https://api.opencode.ai` to `https://opencode.ai/zen/v1`
- Also fixes **glm** provider endpoint from `https://open.bigmodel.cn/api/paas` to `https://open.bigmodel.cn/api/paas/v4`

## Root Cause
The base URLs for these providers were incorrect, causing:
- **z.ai**: 404 Not Found errors (missing `/api/paas/v4` path)
- **opencode**: Response decoding errors (incorrect base domain and path)
- **glm**: Incomplete endpoint path (missing `/v4`)

## Changes
- [providers/mod.rs] Updated provider base URLs
- [providers/compatible.rs] Added tests to verify correct URL construction

## Test Plan
- All 961 existing tests pass
- Added 3 new tests for provider-specific endpoint verification
- URLs now correctly construct to:
  - Z.AI: `https://api.z.ai/api/paas/v4/chat/completions`
  - OpenCode: `https://opencode.ai/zen/v1/chat/completions`
  - GLM: `https://open.bigmodel.cn/api/paas/v4/chat/completions`

## References
- Fixes #167
- Sources: [Z.AI API Docs](https://docs.z.ai/api-reference/llm/chat-completion), [OpenCode Zen Docs](https://opencode.ai/docs/zen/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added endpoint URL configuration verification tests for multiple AI provider services

* **Infrastructure Updates**
  * Updated base URLs for OpenCode Zen, Z.ai, and GLM provider integrations
  * Ensured compatibility with non-standard base path configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->