### PR TITLE
Improve endpoint compatibility and harden action safety paths

### DIFF
--- a/src/channels/email_channel.rs
+++ b/src/channels/email_channel.rs
@@ -191,8 +191,12 @@ impl EmailChannel {
         // TLS
         let mut root_store = rustls::RootCertStore::empty();
         root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+        let crypto_provider = rustls::crypto::CryptoProvider::get_default()
+            .cloned()
+            .unwrap_or_else(|| Arc::new(rustls::crypto::ring::default_provider()));
         let tls_config = Arc::new(
-            TlsConfig::builder()
+            TlsConfig::builder_with_provider(crypto_provider)
+                .with_protocol_versions(rustls::DEFAULT_VERSIONS)?
                 .with_root_certificates(root_store)
                 .with_no_client_auth(),
         );


### PR DESCRIPTION
## Summary

This PR applies a focused reliability and security hardening pass across provider routing, config persistence, UTF-8 safety, and action rate controls.

### 1) OpenAI-compatible endpoint routing hardening

- Adds flexible endpoint building for compatible providers and embedding providers.
- Prevents duplicate `/v1` segments when base URLs already include `/v1`.
- Supports custom providers with non-`/v1` API roots (e.g. `/api/coding/v3`) by automatically switching to raw endpoint mode.

Files:
- `src/providers/compatible.rs`
- `src/providers/mod.rs`
- `src/memory/embeddings.rs`

### 2) Config save robustness

- Ensures parent directories are created before writing `config.toml`.
- Fixes nested config-path write failures.

File:
- `src/config/schema.rs`

### 3) UTF-8-safe bootstrap truncation

- Replaces byte-slicing truncation with char-boundary-safe truncation for injected workspace files.
- Prevents invalid UTF-8 slicing panics on multibyte content.

File:
- `src/channels/mod.rs`

### 4) Unified action controls for tools/scheduler

- Adds `can_act()` + `record_action()` enforcement for mutation-capable paths and scheduler execution.
- Enforces rate limits consistently in:
  - `shell`
  - `file_read`
  - `file_write`
  - scheduler job command execution

Files:
- `src/tools/shell.rs`
- `src/tools/file_read.rs`
- `src/tools/file_write.rs`
- `src/cron/scheduler.rs`

### 5) rustls provider stability in email IMAP TLS path

- Uses explicit `builder_with_provider(...)` + `with_protocol_versions(...)` in IMAP TLS config.
- Avoids runtime ambiguity around crypto provider selection in mixed rustls feature environments.

File:
- `src/channels/email_channel.rs`

## Tests

### Formatting
- `cargo fmt -- --check` *(note: currently reports unrelated pre-existing formatting deltas in untouched files in this environment)*

### Lint
- `cargo clippy --all-targets` ✅

### Tests
- `cargo test` executed; 923 tests pass, 2 fail in `service::tests::*` due environment-specific shell profile noise (`/etc/profile.d/neofetch.sh`) contaminating stdout/stderr for `sh -lc` capture tests.
- All newly added and change-related regression tests pass.

## Notes

This PR is intentionally scoped and keeps behavior changes minimal while addressing reliability/security edge cases directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable API endpoint prefixes for OpenAI-compatible providers
  * Automatic parent directory creation when saving configuration files

* **Bug Fixes**
  * UTF‑8‑safe file truncation to avoid breaking multibyte characters
  * Tools now honor read-only and rate‑limit security gates (actions blocked when enforced)
  * Cleaner single-line bot reply output

* **Tests**
  * Expanded tests for security policy (read‑only and rate limiting) and endpoint/prefix behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->