### PR TITLE
fix: implement AIEOS v1.0.0 identity format support

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -124,11 +124,12 @@ pub async fn run(
             "Execute actions on 1000+ apps via Composio (Gmail, Notion, GitHub, Slack, etc.). Use action='list' to discover, 'execute' to run, 'connect' to OAuth.",
         ));
     }
-    let system_prompt = crate::channels::build_system_prompt(
+    let system_prompt = crate::channels::build_system_prompt_with_config(
         &config.workspace_dir,
         model_name,
         &tool_descs,
         &skills,
+        Some(&config),
     );
 
     // ── Execute ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR implements AIEOS v1.0.0 identity format support to fix issue #168. Previously, the `IdentityConfig` struct defined AIEOS-related fields (`format`, `aieos_path`, `aieos_inline`) but they were never actually used in the codebase.

## Changes

- Added AIEOS v1.0.0 schema structures for JSON deserialization
- Implemented `load_aieos_identity()` to load from file path or inline JSON
- Implemented `aieos_to_system_prompt()` to convert AIEOS data to markdown format
- Modified `build_system_prompt_with_config()` to check `config.identity.format`
- When format is "aieos", loads from AIEOS JSON instead of markdown files
- Falls back to markdown files with error message if AIEOS loading fails
- Updated call sites in `channels/mod.rs` and `agent/loop_.rs` to pass config
- Added 8 comprehensive tests for AIEOS functionality

## AIEOS Schema Support

The implementation supports all AIEOS v1.0.0 schema sections:
- **identity**: names, bio, origin, residence
- **physicality**: face, body, style
- **psychology**: neural_matrix, traits, moral_compass
- **linguistics**: voice, text_style, syntax
- **history**: origin_story, education, occupation, family
- **interests**: hobbies, favorites, lifestyle
- **motivations**: core_drive, goals, fears

## Test plan

- [x] All 972 existing tests pass
- [x] 8 new AIEOS-specific tests added and passing
- [x] Manual testing with AIEOS JSON file
- [x] Manual testing with inline AIEOS JSON
- [x] Verified fallback behavior when AIEOS loading fails

## Usage Example

```toml
[identity]
format = "aieos"
aieos_path = "identity.json"  # Relative to workspace
# OR
aieos_inline = '{"identity":{"names":["ZeroClaw"],"bio":"A helpful AI assistant"}}'
```

## Related Issues

Fixes #168

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AIEOS identity configuration support allowing identity definitions via inline JSON or file sources.
  * System automatically falls back to standard bootstraps if identity sources are unavailable.
  * Introduced configuration-aware system prompt generation for enhanced customization.

* **Tests**
  * Expanded test coverage for identity configuration integration and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->