### PR TITLE
fix: remove unused import and correct WhatsApp/Email registry status

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -78,7 +78,6 @@ fn spawn_supervised_listener(
 
 /// Load OpenClaw format bootstrap files into the prompt.
 fn load_openclaw_bootstrap_files(prompt: &mut String, workspace_dir: &std::path::Path) {
-    use std::fmt::Write;
     prompt.push_str("The following workspace files define your identity, behavior, and context.\n\n");
 
     let bootstrap_files = [

--- a/src/integrations/registry.rs
+++ b/src/integrations/registry.rs
@@ -55,9 +55,15 @@ pub fn all_integrations() -> Vec<IntegrationEntry> {
         },
         IntegrationEntry {
             name: "WhatsApp",
-            description: "QR pairing via web bridge",
+            description: "Meta Cloud API via webhook",
             category: IntegrationCategory::Chat,
-            status_fn: |_| IntegrationStatus::ComingSoon,
+            status_fn: |c| {
+                if c.channels_config.whatsapp.is_some() {
+                    IntegrationStatus::Active
+                } else {
+                    IntegrationStatus::Available
+                }
+            },
         },
         IntegrationEntry {
             name: "Signal",
@@ -614,9 +620,15 @@ pub fn all_integrations() -> Vec<IntegrationEntry> {
         },
         IntegrationEntry {
             name: "Email",
-            description: "Send & read emails",
+            description: "IMAP/SMTP email channel",
             category: IntegrationCategory::Social,
-            status_fn: |_| IntegrationStatus::ComingSoon,
+            status_fn: |c| {
+                if c.channels_config.email.is_some() {
+                    IntegrationStatus::Active
+                } else {
+                    IntegrationStatus::Available
+                }
+            },
         },
         // ── Platforms ───────────────────────────────────────────
         IntegrationEntry {
@@ -798,13 +810,35 @@ mod tests {
     fn coming_soon_integrations_stay_coming_soon() {
         let config = Config::default();
         let entries = all_integrations();
-        for name in ["WhatsApp", "Signal", "Nostr", "Spotify", "Home Assistant"] {
+        for name in ["Signal", "Nostr", "Spotify", "Home Assistant"] {
             let entry = entries.iter().find(|e| e.name == name).unwrap();
             assert!(
                 matches!((entry.status_fn)(&config), IntegrationStatus::ComingSoon),
                 "{name} should be ComingSoon"
             );
         }
+    }
+
+    #[test]
+    fn whatsapp_available_when_not_configured() {
+        let config = Config::default();
+        let entries = all_integrations();
+        let wa = entries.iter().find(|e| e.name == "WhatsApp").unwrap();
+        assert!(matches!(
+            (wa.status_fn)(&config),
+            IntegrationStatus::Available
+        ));
+    }
+
+    #[test]
+    fn email_available_when_not_configured() {
+        let config = Config::default();
+        let entries = all_integrations();
+        let email = entries.iter().find(|e| e.name == "Email").unwrap();
+        assert!(matches!(
+            (email.status_fn)(&config),
+            IntegrationStatus::Available
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remove unused `std::fmt::Write` import in `load_openclaw_bootstrap_files` (eliminates compiler warning on every build)
- Update WhatsApp integration from `ComingSoon` → config-driven (`Available`/`Active`) — full implementation already exists in `src/channels/whatsapp.rs`
- Update Email integration from `ComingSoon` → config-driven (`Available`/`Active`) — full implementation already exists in `src/channels/email_channel.rs`
- Update integration tests to reflect corrected statuses

## Test plan
- [x] `cargo check` — zero warnings
- [x] `cargo test integration` — 17/17 pass (was 14/15 with the stale assertion)
- [x] New tests: `whatsapp_available_when_not_configured`, `email_available_when_not_configured`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WhatsApp and Email integrations now correctly reflect their configuration status, displaying as Active when properly configured and Available otherwise, instead of always appearing as Coming Soon. Channel descriptions updated for clarity.

* **Chores**
  * Code cleanup and minor refactoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->