### PR TITLE
fix(discord): add DIRECT_MESSAGES intent to enable DM support

### DIFF
--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -258,9 +258,12 @@ impl Channel for DiscordChannel {
 
                     // Guild filter
                     if let Some(ref gid) = guild_filter {
-                        let msg_guild = d.get("guild_id").and_then(serde_json::Value::as_str).unwrap_or("");
-                        if msg_guild != gid {
-                            continue;
+                        let msg_guild = d.get("guild_id").and_then(serde_json::Value::as_str);
+                        // DMs have no guild_id — let them through; for guild messages, enforce the filter
+                        if let Some(g) = msg_guild {
+                            if g != gid {
+                                continue;
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- **Problem:** Currently, the Discord channel implementation uses an intent bitmask (`33281`) that excludes `DIRECT_MESSAGES`. Additionally, DMs don't have a `guild_id`, causing them to be silently dropped if a `guild_id` filter is configured.
- **Why it matters:** ZeroClaw agents often rely on 1-on-1 private interactions (DMs). Without this fix, the agent can only respond to guild/server messages.
- **What changed:** 
  1. Updated the intent bitmask to `37377` (added `1 << 12` for `DIRECT_MESSAGES`).
  2. Modified the `guild_id` filter to allow messages without a `guild_id` (DMs) to pass through, applying the filter strictly to guild messages.
- **What did not change (scope boundary):** The core connection logic and message parsing remain intact. No other channels were modified.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore / infra

## Scope

- [ ] Core runtime / daemon
- [ ] Provider integration
- [x] Channel integration
- [ ] Memory / storage
- [ ] Security / sandbox
- [ ] CI / release / tooling
- [ ] Documentation

## Linked Issue

- Related # (N/A, self-discovered)

## Testing

Commands and result summary (required):

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```
Result: All passed. Verified locally by running a Discord bot instance and successfully chatting via Direct Messages.

## Security Impact

- New permissions/capabilities? (`Yes`)
- New external network calls? (`No`)
- Secrets/tokens handling changed? (`No`)
- File system access scope changed? (`No`)
- If any `Yes`, describe risk and mitigation:
  - We now request the `DIRECT_MESSAGES` intent from Discord. This is a standard non-privileged intent. Security is maintained by the existing `allowed_users` whitelist check, which correctly drops DMs from unauthorized users.

## Agent Collaboration Notes (recommended)

- [x] If agent/automation tools were used, I added brief workflow notes.
- [x] I included concrete validation evidence for this change.
- [x] I can explain design choices and rollback steps.

If agent tools were used, optional context:
- Tool(s): Cursor / Cline
- Prompt/plan summary: Identified why Discord channel ignores DMs, applied bitmask fix, CodeRabbit highlighted `guild_id` filtering bug, which was fixed in a subsequent commit.
- Verification focus: Ensuring DMs bypass the guild_filter without breaking guild messages.

## Rollback Plan

- Fast rollback command/path: `git revert <merge-commit-hash>`
- Feature flags or config toggles (if any): None needed.
- Observable failure symptoms: DMs will stop being received if rolled back.