### PR TITLE
feat(telegram): add typing indicator when receiving messages

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -464,6 +464,17 @@ Allowlist Telegram @username or numeric user ID, then run `zeroclaw onboard --ch
                         .map(|id| id.to_string())
                         .unwrap_or_default();
 
+                    // Send "typing" indicator immediately when we receive a message
+                    let typing_body = serde_json::json!({
+                        "chat_id": &chat_id,
+                        "action": "typing"
+                    });
+                    let _ = self.client
+                        .post(self.api_url("sendChatAction"))
+                        .json(&typing_body)
+                        .send()
+                        .await; // Ignore errors for typing indicator
+
                     let msg = ChannelMessage {
                         id: Uuid::new_v4().to_string(),
                         sender: chat_id,


### PR DESCRIPTION
Closes #207

# feat(telegram): add typing indicator when receiving messages

## Summary
Adds typing indicator support to Telegram channel, showing "...is typing" to users while the AI generates a response.

## Problem
Previously, Telegram users had no feedback while waiting for the bot to respond. This could take 3-10 seconds depending on model speed, creating uncertainty about whether:
- The message was received
- The bot is working
- Something went wrong

## Solution
Send Telegram `sendChatAction` with `action: "typing"` immediately when receiving a message, before passing it to the agent loop.

## Changes
**File: `src/channels/telegram.rs`**
- Added `sendChatAction` call in `listen()` method after receiving a valid message
- Placed immediately after `chat_id` extraction, before creating `ChannelMessage`
- Errors are gracefully ignored (don't break message handling)

## Implementation details
```rust
// Send "typing" indicator immediately when we receive a message
let typing_body = serde_json::json!({
    "chat_id": &chat_id,
    "action": "typing"
});
let _ = self.client
    .post(self.api_url("sendChatAction"))
    .json(&typing_body)
    .send()
    .await; // Ignore errors for typing indicator
```

**Why in `listen()` instead of `send()`:**
- `listen()`: Called immediately when message arrives → users see typing indicator for entire AI thinking time
- `send()`: Called after AI response is ready → users only see typing for <100ms (too late)

## Testing
- [x] Compiled successfully with `cargo build --release`
- [x] Tested on live Telegram bot
- [x] Verified typing indicator appears immediately when message is sent
- [x] Verified indicator persists during AI response generation
- [x] Verified graceful error handling (no crashes on API errors)
- [x] Backward compatible (no breaking changes)

## User experience improvement
**Before:**
```
User: [sends message]
[3-5 seconds of silence]
Bot: [sends reply]
```

**After:**
```
User: [sends message]
Bot: "...is typing" [immediately visible]
[3-5 seconds with visible indicator]
Bot: [sends reply]
```

## Related
- Telegram Bot API: https://core.telegram.org/bots/api#sendchataction
- Standard practice in modern Telegram bots
- Aligns with user expectations from other messaging platforms

## Scope
- Single file change
- No config changes needed
- No breaking changes
- Opt-in feature (works automatically once merged)
- No impact on other channels (Discord, Slack, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram messages now display a typing indicator while being processed, providing real-time feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->