### PR TITLE
feat(channel): add typing indicator for Discord

### DIFF
--- a/src/channels/traits.rs
+++ b/src/channels/traits.rs
@@ -26,4 +26,15 @@ pub trait Channel: Send + Sync {
     async fn health_check(&self) -> bool {
         true
     }
+
+    /// Signal that the bot is processing a response (e.g. "typing" indicator).
+    /// Implementations should repeat the indicator as needed for their platform.
+    async fn start_typing(&self, _recipient: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Stop any active typing indicator.
+    async fn stop_typing(&self, _recipient: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

- **Problem:** The bot appears idle while processing LLM responses (up to 90s). Users have no feedback that their message was received.
- **Why it matters:** Discord shows "Bot is typing..." when bots call the typing endpoint, giving users immediate visual feedback.
- **What changed:** Added `start_typing`/`stop_typing` to the `Channel` trait (default no-ops). Discord implements them with a spawned tokio task that repeats the typing indicator every 8s, cancelled via `JoinHandle::abort()`. The message processing loop calls these generically around the LLM call.
- **What did not change:** No other channels modified. No new dependencies. `listen()`, `send()`, `health_check()` unchanged.

## Change Type

- [x] Feature

## Scope

- [x] Channel integration

## Linked Issue

- Related #223

## Testing

```bash
cargo fmt --all -- --check    # changed files clean (pre-existing issues in other files)
cargo clippy --all-targets -- -D warnings  # no new warnings from changed files
cargo test channels::discord   # 31/31 passed (5 new typing tests + 26 existing)
```

Validated end-to-end on a live ZeroClaw daemon — "Bot is typing..." persists in Discord until the reply arrives.

## Security Impact

- New permissions/capabilities? No
- New external network calls? Yes — POST to `/channels/{id}/typing` (same auth as existing message sends)
- Secrets/tokens handling changed? No
- File system access scope changed? No
- Mitigation: Uses same bot token and reqwest client already in use for message sending. Typing is best-effort; failures are ignored and never affect message delivery.

## Rollback Plan

- Fast rollback: Revert this commit; typing methods become no-ops via trait defaults
- Feature flags: None needed — typing is transparent and non-breaking
- Observable failure symptoms: Without this change, bot appears idle during processing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typing indicator support for Discord, allowing users to see when the bot is processing messages.
  * Improved message isolation to ensure bot responses and typing indicators are correctly scoped to individual channels rather than broadcasted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->