### PR TITLE
fix(ci): speed up main Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -68,7 +68,7 @@ jobs:
                   labels: ${{ steps.meta.outputs.labels }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
-                  platforms: linux/amd64,linux/arm64
+                  platforms: ${{ startsWith(github.ref, 'refs/tags/') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
             - name: Build smoke image (PR only)
               if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- make non-tag push builds use linux/amd64 only
- keep multi-arch (linux/amd64,linux/arm64) for version tags

## Why
Main branch Docker runs are taking too long due to multi-arch build overhead on every push. This keeps release/tag quality while reducing normal CI runtime and cost.

## Risk
Low: workflow-only change; release tags still publish multi-arch images.
