### PR TITLE
fix: remove UNIQUE constraint on memory key to allow multiple facts per conversation (fixes #221)

### DIFF
--- a/tests/memory_comparison.rs
+++ b/tests/memory_comparison.rs
@@ -311,8 +311,8 @@ async fn compare_upsert() {
     println!("  Markdown: count={md_count} (append-only, both entries kept)");
     println!("    Can still find latest: {}", !md_results.is_empty());
 
-    // SQLite: upsert replaces, count stays at 1
-    assert_eq!(sq_count, 1);
+    // SQLite: new behavior - inserts multiple records for same key
+    assert_eq!(sq_count, 2);
     assert_eq!(sq_entry.unwrap().content, "loves Rust");
 
     // Markdown: append-only, count increases


### PR DESCRIPTION
## Summary

Fixes #221 - SQLite Memory Override bug where memory recall fails for recently stored conversational facts.

## Root Cause

- The `key` column had a UNIQUE constraint
- The `store` method used `ON CONFLICT(key) DO UPDATE SET`
- Channels store all user messages with the same key (e.g., `slack_C04DR8LNAQZ`)
- This caused new messages to **overwrite** previous ones instead of creating new rows

## Changes

- Remove UNIQUE constraint from `key` column in schema
- Remove `ON CONFLICT(key) DO UPDATE SET` clause from store method
- Update `get()` to return the most recent entry when multiple rows share a key
- Update `fts5_syncs_on_update` test to reflect new behavior
- Add `sqlite_multiple_facts_same_key_can_all_be_recalled` test for issue #221
- Update `compare_upsert` test in memory_comparison.rs

## Behavior

- Multiple facts can now be stored with the same key (same conversation)
- `recall()` searches across all facts using FTS5 and vector similarity
- `get()` returns the most recent entry for a given key
- `forget()` deletes all rows with the given key

## Test Results

- Bug fix test `sqlite_multiple_facts_same_key_can_all_be_recalled` passes
- All sqlite memory tests updated and passing
- Code compiles successfully

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>