### PR TITLE
test(channels): add regression for UTF-8 log truncation panic

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1023,6 +1023,19 @@ mod tests {
     }
 
     #[test]
+    fn channel_log_truncation_is_utf8_safe_for_multibyte_text() {
+        let msg = "你好！我是监察，武威节点的 AI 助手。目前节点运行正常，有什么需要我帮助的吗？";
+
+        // Reproduces the production crash path where channel logs truncate at 80 chars.
+        let result = std::panic::catch_unwind(|| crate::util::truncate_with_ellipsis(msg, 80));
+        assert!(result.is_ok(), "truncate_with_ellipsis should never panic on UTF-8");
+
+        let truncated = result.unwrap();
+        assert!(!truncated.is_empty());
+        assert!(truncated.is_char_boundary(truncated.len()));
+    }
+
+    #[test]
     fn prompt_workspace_path() {
         let ws = make_workspace();
         let prompt = build_system_prompt(ws.path(), "model", &[], &[], None);


### PR DESCRIPTION
## Summary\nAdd a regression test to ensure channel log truncation is UTF-8 safe for multibyte text (Chinese punctuation/characters).\n\n## Why\nOn older 0.1.0 deployments, channel logging paths used byte slicing () and could panic on multibyte boundaries, e.g.:\n\n```\nbyte index 80 is not a char boundary; it is inside '，'\n```\n\nCurrent code already uses  in , which is UTF-8 safe. This test protects that behavior from regression.\n\n## Test\n- Added  in \n- Verified with:\n  - 
running 1 test
test channels::tests::channel_log_truncation_is_utf8_safe_for_multibyte_text ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1096 filtered out; finished in 0.00s


running 1 test
test channels::tests::channel_log_truncation_is_utf8_safe_for_multibyte_text ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1114 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 7 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 8 filtered out; finished in 0.00s\n\n## Notes\nThis is especially relevant for Chinese-language Telegram/IM users where multibyte punctuation is common.