### PR TITLE
fix(security): enforce autonomy + action budget for file writes and cron jobs

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -138,6 +138,20 @@ async fn run_job_command(
     security: &SecurityPolicy,
     job: &CronJob,
 ) -> (bool, String) {
+    if !security.can_act() {
+        return (
+            false,
+            "blocked by security policy: autonomy is read-only".to_string(),
+        );
+    }
+
+    if security.is_rate_limited() {
+        return (
+            false,
+            "blocked by security policy: rate limit exceeded".to_string(),
+        );
+    }
+
     if !security.is_command_allowed(&job.command) {
         return (
             false,
@@ -152,6 +166,13 @@ async fn run_job_command(
         return (
             false,
             format!("blocked by security policy: forbidden path argument: {path}"),
+        );
+    }
+
+    if !security.record_action() {
+        return (
+            false,
+            "blocked by security policy: action budget exhausted".to_string(),
         );
     }
 
@@ -259,6 +280,34 @@ mod tests {
         assert!(output.contains("blocked by security policy"));
         assert!(output.contains("forbidden path argument"));
         assert!(output.contains("/etc/passwd"));
+    }
+
+    #[tokio::test]
+    async fn run_job_command_blocks_readonly_mode() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp);
+        config.autonomy.level = crate::security::AutonomyLevel::ReadOnly;
+        let job = test_job("echo should-not-run");
+        let security = SecurityPolicy::from_config(&config.autonomy, &config.workspace_dir);
+
+        let (success, output) = run_job_command(&config, &security, &job).await;
+        assert!(!success);
+        assert!(output.contains("blocked by security policy"));
+        assert!(output.contains("read-only"));
+    }
+
+    #[tokio::test]
+    async fn run_job_command_blocks_rate_limited() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp);
+        config.autonomy.max_actions_per_hour = 0;
+        let job = test_job("echo should-not-run");
+        let security = SecurityPolicy::from_config(&config.autonomy, &config.workspace_dir);
+
+        let (success, output) = run_job_command(&config, &security, &job).await;
+        assert!(!success);
+        assert!(output.contains("blocked by security policy"));
+        assert!(output.contains("rate limit exceeded"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
This PR is a focused split from closed #182 and only addresses one concern: missing action guardrails on write/execute paths.

## Problem
- file_write enforced path sandboxing, but did not enforce autonomy (read-only) or action-budget gates.
- cron scheduler command execution validated command/path, but did not enforce autonomy/action-budget gates before spawning commands.

## Changes
### src/tools/file_write.rs
- Add can_act gate (read-only blocks writes).
- Add preflight rate-limit check (is_rate_limited).
- Add action accounting gate (record_action) before write execution.
- Add tests for read-only and rate-limited blocking.

### src/cron/scheduler.rs
- Add can_act and rate-limit gates to run_job_command.
- Add record_action gate before spawning shell command.
- Add tests for read-only and rate-limited blocking.

## Why this scope
- Keep the PR minimal and reversible (KISS/YAGNI).
- Avoid replaying stale broad changes from #182 against fast-moving main.

## Validation
- cargo fmt --all -- --check ✅
- cargo test ✅
- cargo test file_write -- --nocapture ✅
- cargo test scheduler::tests -- --nocapture ✅
- cargo clippy --all-targets -- -D warnings ⚠️ fails on pre-existing unrelated warnings currently on main (not introduced here).

## Risk / Rollback
- Risk: low-medium (policy hardening on action surfaces).
- Rollback: revert this commit.

## Context
- Supersedes the relevant security subset from closed #182.
