### PR TITLE
fix(security): enforce action budget guardrails in file_read

### DIFF
--- a/src/tools/file_read.rs
+++ b/src/tools/file_read.rs
@@ -4,6 +4,8 @@ use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
 
+const MAX_FILE_SIZE_BYTES: u64 = 10 * 1024 * 1024;
+
 /// Read file contents with path sandboxing
 pub struct FileReadTool {
     security: Arc<SecurityPolicy>,
@@ -44,6 +46,14 @@ impl Tool for FileReadTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing 'path' parameter"))?;
 
+        if self.security.is_rate_limited() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
+            });
+        }
+
         // Security check: validate path is within workspace
         if !self.security.is_path_allowed(path) {
             return Ok(ToolResult {
@@ -79,15 +89,14 @@ impl Tool for FileReadTool {
         }
 
         // Check file size AFTER canonicalization to prevent TOCTOU symlink bypass
-        const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
         match tokio::fs::metadata(&resolved_path).await {
             Ok(meta) => {
-                if meta.len() > MAX_FILE_SIZE {
+                if meta.len() > MAX_FILE_SIZE_BYTES {
                     return Ok(ToolResult {
                         success: false,
                         output: String::new(),
                         error: Some(format!(
-                            "File too large: {} bytes (limit: {MAX_FILE_SIZE} bytes)",
+                            "File too large: {} bytes (limit: {MAX_FILE_SIZE_BYTES} bytes)",
                             meta.len()
                         )),
                     });
@@ -100,6 +109,14 @@ impl Tool for FileReadTool {
                     error: Some(format!("Failed to read file metadata: {e}")),
                 });
             }
+        }
+
+        if !self.security.record_action() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("Rate limit exceeded: action budget exhausted".into()),
+            });
         }
 
         match tokio::fs::read_to_string(&resolved_path).await {
@@ -126,6 +143,19 @@ mod tests {
         Arc::new(SecurityPolicy {
             autonomy: AutonomyLevel::Supervised,
             workspace_dir: workspace,
+            ..SecurityPolicy::default()
+        })
+    }
+
+    fn test_security_with(
+        workspace: std::path::PathBuf,
+        autonomy: AutonomyLevel,
+        max_actions_per_hour: u32,
+    ) -> Arc<SecurityPolicy> {
+        Arc::new(SecurityPolicy {
+            autonomy,
+            workspace_dir: workspace,
+            max_actions_per_hour,
             ..SecurityPolicy::default()
         })
     }
@@ -202,6 +232,50 @@ mod tests {
         let result = tool.execute(json!({"path": "/etc/passwd"})).await.unwrap();
         assert!(!result.success);
         assert!(result.error.as_ref().unwrap().contains("not allowed"));
+    }
+
+    #[tokio::test]
+    async fn file_read_blocks_when_rate_limited() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_read_rate_limited");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("test.txt"), "hello world")
+            .await
+            .unwrap();
+
+        let tool = FileReadTool::new(test_security_with(
+            dir.clone(),
+            AutonomyLevel::Supervised,
+            0,
+        ));
+        let result = tool.execute(json!({"path": "test.txt"})).await.unwrap();
+
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("Rate limit exceeded"));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_read_allows_readonly_mode() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_read_readonly");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("test.txt"), "readonly ok")
+            .await
+            .unwrap();
+
+        let tool = FileReadTool::new(test_security_with(dir.clone(), AutonomyLevel::ReadOnly, 20));
+        let result = tool.execute(json!({"path": "test.txt"})).await.unwrap();
+
+        assert!(result.success);
+        assert_eq!(result.output, "readonly ok");
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
This is the second focused split from closed #182. It only addresses one gap: missing action-budget guardrails in `file_read`.

## Problem
- `file_read` enforced path sandboxing and symlink-escape prevention, but did not enforce action budget/rate limiting.
- Under load, repeated read actions could bypass the intended hourly budget controls applied in other tools.

## Changes
### `src/tools/file_read.rs`
- Add preflight rate-limit check via `is_rate_limited`.
- Add action accounting via `record_action` before file read execution.
- Keep read-only mode behavior unchanged (read operations remain allowed).
- Refactor max-size constant to module-level `MAX_FILE_SIZE_BYTES` for consistency and clearer error text.

### Tests
- Add `file_read_blocks_when_rate_limited`.
- Add `file_read_allows_readonly_mode` to lock in non-regression of observe-only semantics.

## Scope / Non-goals
- No provider/config/channel changes.
- No policy semantics changes beyond adding missing budget enforcement on this tool path.

## Validation
- `cargo fmt --all -- --check` ✅
- `cargo test file_read -- --nocapture` ✅
- `cargo test` ✅

## Risk / Rollback
- Risk: low (security consistency hardening in one tool).
- Rollback: revert this commit.

## Context
- Follow-up split after #269.
- Supersedes remaining relevant `file_read` subset from closed #182.
