### PR TITLE
fix: add tool use protocol to channel/daemon/gateway system prompts

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -318,7 +318,12 @@ pub fn build_system_prompt(
         for (name, desc) in tools {
             let _ = writeln!(prompt, "- **{name}**: {desc}");
         }
-        prompt.push('\n');
+        prompt.push_str("\n## Tool Use Protocol\n\n");
+        prompt.push_str("To use a tool, wrap a JSON object in <invoke> tags:\n\n");
+        prompt.push_str("```\n<invoke>\n{\"name\": \"tool_name\", \"arguments\": {\"param\": \"value\"}}\n</invoke>\n```\n\n");
+        prompt.push_str("You may use multiple tool calls in a single response. ");
+        prompt.push_str("After tool execution, results appear in <tool_result> tags. ");
+        prompt.push_str("Continue reasoning with the results until you can give a final answer.\n\n");
     }
 
     // ── 2. Safety ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Fixes #284 - Tool call format was missing from the system prompt in channel, daemon, and gateway modes. This caused LLMs to not know how to properly invoke tools when using these modes.

## Changes
- Added tool use protocol with `<invoke>` tags and JSON payload format to `build_system_prompt()` in `src/channels/mod.rs`
- Format now matches the implementation in agent loop mode (`src/agent/loop_.rs`)

## Test plan
- [x] All 1163 tests pass
- [x] cargo fmt check passes
- [x] Manual testing with LLM to verify tool call format is now clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)