### PR TITLE
feat: add HTTP request tool for API interactions

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -396,6 +396,7 @@ pub async fn run(
         mem.clone(),
         composio_key,
         &config.browser,
+        &config.http_request,
         &config.agents,
         config.api_key.as_deref(),
     );

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,8 +2,8 @@ pub mod schema;
 
 pub use schema::{
     AutonomyConfig, BrowserConfig, ChannelsConfig, ComposioConfig, Config, DelegateAgentConfig,
-    DiscordConfig, DockerRuntimeConfig, GatewayConfig, HeartbeatConfig, IMessageConfig,
-    IdentityConfig, LarkConfig, MatrixConfig, MemoryConfig, ModelRouteConfig, ObservabilityConfig,
-    ReliabilityConfig, RuntimeConfig, SecretsConfig, SlackConfig, TelegramConfig, TunnelConfig,
-    WebhookConfig,
+    DiscordConfig, DockerRuntimeConfig, GatewayConfig, HeartbeatConfig, HttpRequestConfig,
+    IMessageConfig, IdentityConfig, LarkConfig, MatrixConfig, MemoryConfig, ModelRouteConfig,
+    ObservabilityConfig, ReliabilityConfig, RuntimeConfig, SecretsConfig, SlackConfig,
+    TelegramConfig, TunnelConfig, WebhookConfig,
 };

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -63,6 +63,9 @@ pub struct Config {
     pub browser: BrowserConfig,
 
     #[serde(default)]
+    pub http_request: HttpRequestConfig,
+
+    #[serde(default)]
     pub identity: IdentityConfig,
 
     /// Named delegate agents for agent-to-agent handoff.
@@ -270,6 +273,32 @@ pub struct BrowserConfig {
     /// Browser session name (for agent-browser automation)
     #[serde(default)]
     pub session_name: Option<String>,
+}
+
+// ── HTTP request tool ───────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HttpRequestConfig {
+    /// Enable `http_request` tool for API interactions
+    #[serde(default)]
+    pub enabled: bool,
+    /// Allowed domains for HTTP requests (exact or subdomain match)
+    #[serde(default)]
+    pub allowed_domains: Vec<String>,
+    /// Maximum response size in bytes (default: 1MB)
+    #[serde(default = "default_http_max_response_size")]
+    pub max_response_size: usize,
+    /// Request timeout in seconds (default: 30)
+    #[serde(default = "default_http_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+fn default_http_max_response_size() -> usize {
+    1_000_000 // 1MB
+}
+
+fn default_http_timeout_secs() -> u64 {
+    30
 }
 
 // ── Memory ───────────────────────────────────────────────────
@@ -902,6 +931,7 @@ impl Default for Config {
             composio: ComposioConfig::default(),
             secrets: SecretsConfig::default(),
             browser: BrowserConfig::default(),
+            http_request: HttpRequestConfig::default(),
             identity: IdentityConfig::default(),
             agents: HashMap::new(),
         }
@@ -1248,6 +1278,7 @@ mod tests {
             composio: ComposioConfig::default(),
             secrets: SecretsConfig::default(),
             browser: BrowserConfig::default(),
+            http_request: HttpRequestConfig::default(),
             identity: IdentityConfig::default(),
             agents: HashMap::new(),
         };
@@ -1320,6 +1351,7 @@ default_temperature = 0.7
             composio: ComposioConfig::default(),
             secrets: SecretsConfig::default(),
             browser: BrowserConfig::default(),
+            http_request: HttpRequestConfig::default(),
             identity: IdentityConfig::default(),
             agents: HashMap::new(),
         };

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -105,6 +105,7 @@ pub fn run_wizard() -> Result<Config> {
         composio: composio_config,
         secrets: secrets_config,
         browser: BrowserConfig::default(),
+        http_request: crate::config::HttpRequestConfig::default(),
         identity: crate::config::IdentityConfig::default(),
         agents: std::collections::HashMap::new(),
     };
@@ -297,6 +298,7 @@ pub fn run_quick_setup(
         composio: ComposioConfig::default(),
         secrets: SecretsConfig::default(),
         browser: BrowserConfig::default(),
+        http_request: crate::config::HttpRequestConfig::default(),
         identity: crate::config::IdentityConfig::default(),
         agents: std::collections::HashMap::new(),
     };


### PR DESCRIPTION
## Summary
Implements #210 - Add `http_request` tool that enables the agent to make HTTP requests to external APIs (REST, webhooks, etc.).

## Features
- **HTTP Methods**: GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS
- **JSON Handling**: Full support for JSON request/response bodies
- **Configurable Limits**: Timeout (default: 30s), max response size (default: 1MB)
- **Headers**: Custom headers with automatic redaction of sensitive auth tokens
- **Security**: Domain allowlist, blocks local/private IPs (SSRF protection)

## Config Example
```toml
[http_request]
enabled = true
allowed_domains = ["api.example.com", "api.github.com"]
max_response_size = 1_000_000  # 1MB
timeout_secs = 30
```

## Tool Usage Example
```
<invoke>
{"name": "http_request", "arguments": {"url": "https://api.github.com/repos/zeroclaw-labs/zeroclaw", "method": "GET", "headers": {"Authorization": "Bearer $TOKEN"}}}
</invoke>
```

## Test plan
- [x] All 1166 tests pass
- [x] cargo fmt check passes
- [x] Unit tests for domain validation, method validation, header redaction
- [x] Tests for security blocks (SSRF protection, rate limiting)

## Security Considerations
- **SSRF Protection**: Blocks localhost, private IPs (10.x, 172.16-31.x, 192.168.x, etc.)
- **Domain Allowlist**: Only configured domains allowed (subdomains supported)
- **Rate Limiting**: Respects `max_actions_per_hour` from security policy
- **Auth Redaction**: Sensitive headers are redacted from logs
- **Default Deny**: Tool disabled by default, requires explicit configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)