### PR TITLE
fix: Align tool use protocol tags with agent parser

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -319,8 +319,8 @@ pub fn build_system_prompt(
             let _ = writeln!(prompt, "- **{name}**: {desc}");
         }
         prompt.push_str("\n## Tool Use Protocol\n\n");
-        prompt.push_str("To use a tool, wrap a JSON object in <invoke> tags:\n\n");
-        prompt.push_str("```\n<invoke>\n{\"name\": \"tool_name\", \"arguments\": {\"param\": \"value\"}}\n</invoke>\n```\n\n");
+        prompt.push_str("To use a tool, wrap a JSON object in <tool_call></tool_call> tags:\n\n");
+        prompt.push_str("```\n<tool_call>\n{\"name\": \"tool_name\", \"arguments\": {\"param\": \"value\"}}\n</tool_call>\n```\n\n");
         prompt.push_str("You may use multiple tool calls in a single response. ");
         prompt.push_str("After tool execution, results appear in <tool_result> tags. ");
         prompt.push_str("Continue reasoning with the results until you can give a final answer.\n\n");


### PR DESCRIPTION
The tool use protocol in `channels/mod.rs` incorrectly used `<invoke>` tags, while the parser in `agent/loop_.rs` exclusively recognizes `<tool_call>` tags. This change ensures protocol consistency across all entry points.

## Summary

* **Problem**: The fix for #284 added tool use protocol to channel/daemon/gateway modes using `<invoke>` tags, causing a mismatch with the agent's parser.
* **Impact**: Tool calls initiated via channel mode would fail to be parsed or executed.
* **Solution**: Updated `<invoke>` to `<tool_call>` in `src/channels/mod.rs` (lines 322-323) to align with `agent/loop_.rs`.
* **Scope Boundary**: No logic changes; limited to string literal alignment with the existing parser.

## Change Type

* [x] Bug fix

## Scope

* [ ] Core runtime / daemon
* [ ] Provider integration
* [x] Channel integration
* [ ] Memory / storage
* [ ] Security / sandbox
* [ ] CI / release / tooling
* [ ] Documentation

## Linked Issue

* Closes #284

## Testing

Verified with standard linting and test suite:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test

```

## Security Impact

* New permissions/capabilities? No
* New external network calls? No
* Secrets/tokens handling changed? No
* File system access scope changed? No

## Rollback Plan

* Fast rollback command: `git revert HEAD`
* Feature flags or config toggles: None
* Observable failure symptoms: None; string literal change only.