### PR TITLE
feat(cost): add cost tracking and budget enforcement

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -557,6 +557,7 @@ pub async fn run(
     agent.observer.record_event(&ObserverEvent::AgentEnd {
         duration: start.elapsed(),
         tokens_used: None,
+        cost_usd: None,
     });
 
     Ok(())

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1048,6 +1048,7 @@ pub async fn run(
     observer.record_event(&ObserverEvent::AgentEnd {
         duration,
         tokens_used: None,
+        cost_usd: None,
     });
 
     Ok(final_output)

--- a/src/observability/log.rs
+++ b/src/observability/log.rs
@@ -48,9 +48,10 @@ impl Observer for LogObserver {
             ObserverEvent::AgentEnd {
                 duration,
                 tokens_used,
+                cost_usd,
             } => {
                 let ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
-                info!(duration_ms = ms, tokens = ?tokens_used, "agent.end");
+                info!(duration_ms = ms, tokens = ?tokens_used, cost_usd = ?cost_usd, "agent.end");
             }
             ObserverEvent::ToolCallStart { tool } => {
                 info!(tool = %tool, "tool.start");
@@ -133,10 +134,12 @@ mod tests {
         obs.record_event(&ObserverEvent::AgentEnd {
             duration: Duration::from_millis(500),
             tokens_used: Some(100),
+            cost_usd: Some(0.0015),
         });
         obs.record_event(&ObserverEvent::AgentEnd {
             duration: Duration::ZERO,
             tokens_used: None,
+            cost_usd: None,
         });
         obs.record_event(&ObserverEvent::ToolCallStart {
             tool: "shell".into(),

--- a/src/observability/noop.rs
+++ b/src/observability/noop.rs
@@ -48,10 +48,12 @@ mod tests {
         obs.record_event(&ObserverEvent::AgentEnd {
             duration: Duration::from_millis(100),
             tokens_used: Some(42),
+            cost_usd: Some(0.001),
         });
         obs.record_event(&ObserverEvent::AgentEnd {
             duration: Duration::ZERO,
             tokens_used: None,
+            cost_usd: None,
         });
         obs.record_event(&ObserverEvent::ToolCallStart {
             tool: "shell".into(),

--- a/src/observability/otel.rs
+++ b/src/observability/otel.rs
@@ -227,6 +227,7 @@ impl Observer for OtelObserver {
             ObserverEvent::AgentEnd {
                 duration,
                 tokens_used,
+                cost_usd,
             } => {
                 let secs = duration.as_secs_f64();
                 let start_time = SystemTime::now()
@@ -242,6 +243,9 @@ impl Observer for OtelObserver {
                 );
                 if let Some(t) = tokens_used {
                     span.set_attribute(KeyValue::new("tokens_used", *t as i64));
+                }
+                if let Some(c) = cost_usd {
+                    span.set_attribute(KeyValue::new("cost_usd", *c));
                 }
                 span.end();
 
@@ -394,10 +398,12 @@ mod tests {
         obs.record_event(&ObserverEvent::AgentEnd {
             duration: Duration::from_millis(500),
             tokens_used: Some(100),
+            cost_usd: Some(0.0015),
         });
         obs.record_event(&ObserverEvent::AgentEnd {
             duration: Duration::ZERO,
             tokens_used: None,
+            cost_usd: None,
         });
         obs.record_event(&ObserverEvent::ToolCallStart {
             tool: "shell".into(),

--- a/src/observability/traits.rs
+++ b/src/observability/traits.rs
@@ -27,6 +27,7 @@ pub enum ObserverEvent {
     AgentEnd {
         duration: Duration,
         tokens_used: Option<u64>,
+        cost_usd: Option<f64>,
     },
     /// A tool call is about to be executed.
     ToolCallStart {


### PR DESCRIPTION
## Summary

Implements Issue #213 — Cost tracking and budget enforcement.

### Changes

- **CostConfig / ModelPrice** in `src/config/schema.rs`: configurable price table, daily/monthly limits, warn threshold
- **src/cost/tracker.rs**: CostTracker with in-memory session tracking + append-only JSONL persistent log
- **Budget enforcement**: warning at configurable percent, hard stop when limit exceeded
- **Observer integration**: added `cost_usd` field to `AgentEnd` event across all observer backends (log, otel, noop)
- **10 unit tests**: cost calculation, budget warnings/exceeded, persistence, disabled mode, accumulation

### Config format

```toml
[cost]
enabled = true
daily_limit_usd = 5.00
monthly_limit_usd = 50.00
warn_at_percent = 80

[cost.prices]
"anthropic/claude-sonnet-4-20250514" = { input = 3.0, output = 15.0 }
"google/gemini-2.0-flash" = { input = 0.10, output = 0.40 }
```

Closes #213