### PR TITLE
fix(agent): align channel agent_turn signature with provider label

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -372,13 +372,14 @@ struct ParsedToolCall {
 
 /// Execute a single turn for channel runtime paths.
 ///
-/// Channels currently do not thread an explicit provider label into this call,
-/// so we route through the full loop with a stable placeholder provider name.
+/// Channel runtime now provides an explicit provider label so observer events
+/// stay consistent with the main agent loop execution path.
 pub(crate) async fn agent_turn(
     provider: &dyn Provider,
     history: &mut Vec<ChatMessage>,
     tools_registry: &[Box<dyn Tool>],
     observer: &dyn Observer,
+    provider_name: &str,
     model: &str,
     temperature: f64,
 ) -> Result<String> {
@@ -387,7 +388,7 @@ pub(crate) async fn agent_turn(
         history,
         tools_registry,
         observer,
-        "channel-runtime",
+        provider_name,
         model,
         temperature,
     )


### PR DESCRIPTION
## Summary
- fix the compile break caused by `agent_turn` signature drift
- add `provider_name: &str` parameter to `agent_turn`
- forward the provided label into `run_tool_call_loop` instead of a hardcoded placeholder
- update the function docs to match current channel runtime behavior

## Why
`src/channels/mod.rs` now calls `agent_turn` with an explicit provider label for observer parity. `agent_turn` still had the old 6-argument signature, causing:
- `error[E0061]: this function takes 6 arguments but 7 arguments were supplied`

## Scope
Minimal, single-file patch:
- `src/agent/loop_.rs`

## Validation
- `cargo fmt --all -- --check`
- `cargo check --keep-going`
- `cargo test`

All three commands pass in this branch.
