### PR TITLE
fix(providers): correct Fireworks AI base URL to include /v1 path

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -250,7 +250,7 @@ pub fn create_provider(name: &str, api_key: Option<&str>) -> anyhow::Result<Box<
             "Together AI", "https://api.together.xyz", key, AuthStyle::Bearer,
         ))),
         "fireworks" | "fireworks-ai" => Ok(Box::new(OpenAiCompatibleProvider::new(
-            "Fireworks AI", "https://api.fireworks.ai/inference", key, AuthStyle::Bearer,
+            "Fireworks AI", "https://api.fireworks.ai/inference/v1", key, AuthStyle::Bearer,
         ))),
         "perplexity" => Ok(Box::new(OpenAiCompatibleProvider::new(
             "Perplexity", "https://api.perplexity.ai", key, AuthStyle::Bearer,


### PR DESCRIPTION
The Fireworks API endpoint requires /v1/chat/completions, but the base URL was missing the /v1 path segment, causing 404 errors and triggering a broken responses fallback.

Fix: Add /v1 to base URL so correct endpoint is built:
  https://api.fireworks.ai/inference/v1/chat/completions

## Linked Issue

No issue opened as simple fix

## Validation Evidence (required)

Commands and result summary:

```bash
❯ ssh zeroclaw@zeroclaw-test
zeroclaw@zeroclaw-test:~$ zeroclaw agent -m "Hello, ZeroClaw!"
2026-02-16T14:43:50.967484Z  INFO zeroclaw::agent::loop_: Memory initialized backend="sqlite"
Hello! 👋 It's great to hear from you again! That's the fourth time you've greeted me — I appreciate the warm welcome each time. How can I help you today?
zeroclaw@zeroclaw-test:~$
```

- Evidence provided (test/log/trace/screenshot/perf): curl test
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

N/A

## Compatibility / Migration

- Backward compatible? Yes

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: previously calls to fireworks API were failing; this has fixed the issue:

Before (duplicate attempts removed for brevity):
```bash
❯ ssh zeroclaw@zeroclaw-test
zeroclaw@zeroclaw-test:~$ zeroclaw agent -m "Hello, ZeroClaw!"
2026-02-16T14:38:24.701713Z  INFO zeroclaw::agent::loop_: Memory initialized backend="sqlite"
2026-02-16T14:38:24.838467Z  WARN zeroclaw::providers::reliable: Provider call failed, retrying provider="fireworks" model="accounts/fireworks/models/kimi-k2p5" attempt=1 backoff_ms=500
Error: All providers/models failed. Attempts:
fireworks/accounts/fireworks/models/kimi-k2p5 attempt 1/3: Fireworks AI API error (chat completions unavailable; responses fallback failed: Fireworks AI Responses API error: {"error":{"message":"Path not found: /responses","param":null,"code":"NOT_FOUND","type":"error"},"request_id":"<redacted>"})

```


## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Providers

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Opencode

## Rollback Plan (required)

None - base path change

## Risks and Mitigations

None
