### PR TITLE
ci: route trusted pushes to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         name: Format & Lint
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.event_name == 'push' && fromJSON('["self-hosted","Linux","X64","lxc-ci"]') || 'ubuntu-latest' }}
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@v4
@@ -138,7 +138,7 @@ jobs:
         name: Test
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.event_name == 'push' && fromJSON('["self-hosted","Linux","X64","lxc-ci"]') || 'ubuntu-latest' }}
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@v4
@@ -153,7 +153,7 @@ jobs:
         name: Build (Smoke)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.event_name == 'push' && fromJSON('["self-hosted","Linux","X64","lxc-ci"]') || 'ubuntu-latest' }}
         timeout-minutes: 20
 
         steps:
@@ -187,7 +187,7 @@ jobs:
         name: Docs Quality
         needs: [changes]
         if: needs.changes.outputs.docs_changed == 'true'
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.event_name == 'push' && fromJSON('["self-hosted","Linux","X64","lxc-ci"]') || 'ubuntu-latest' }}
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- route heavy CI jobs in .github/workflows/ci.yml to self-hosted runner labels only on push events
- keep all pull_request jobs on GitHub-hosted runners to avoid exposing self-hosted infrastructure to untrusted fork PR code
- preserve existing CI gates and job behavior

## Security
- self-hosted labels used only for trusted push path: [self-hosted, Linux, X64, lxc-ci]
- PR path (including forks) stays on ubuntu-latest

## Risk
Low/Medium: workflow routing only.

## Rollback
Revert this PR to return all CI jobs to ubuntu-latest.
