### PR TITLE
ci: route trusted security and workflow checks to self-hosted

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,7 @@ env:
 jobs:
     audit:
         name: Security Audit
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.event_name != 'pull_request' && fromJSON('["self-hosted","Linux","X64","lxc-ci"]') || 'ubuntu-latest' }}
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
 
     deny:
         name: License & Supply Chain
-        runs-on: ubuntu-latest
+        runs-on: ${{ github.event_name != 'pull_request' && fromJSON('["self-hosted","Linux","X64","lxc-ci"]') || 'ubuntu-latest' }}
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   no-tabs:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && fromJSON('["self-hosted","Linux","X64","lxc-ci"]') || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -55,7 +55,7 @@ jobs:
           PY
 
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'push' && fromJSON('["self-hosted","Linux","X64","lxc-ci"]') || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- route security.yml jobs to self-hosted labels for trusted events (push, schedule)
- keep security.yml pull_request jobs on ubuntu-latest
- route workflow-sanity.yml jobs to self-hosted labels on trusted push
- keep workflow-sanity.yml pull_request jobs on ubuntu-latest

## Security Rationale
- avoids executing untrusted fork PR code on self-hosted infrastructure
- preserves existing workflow logic and required checks, only changes runner routing

## Risk
Low/Medium: workflow runner selection only.

## Rollback
Revert this PR to return those jobs to GitHub-hosted runners.
