### PR TITLE
ci: route trusted docker and release publish jobs to self-hosted

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -62,7 +62,7 @@ jobs:
     publish:
         name: Build and Push Docker Image
         if: github.event_name == 'push'
-        runs-on: ubuntu-latest
+        runs-on: [self-hosted, Linux, X64, lxc-ci]
         timeout-minutes: 25
         permissions:
             contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
   publish:
     name: Publish Release
     needs: build-release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, lxc-ci]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- route Docker publish job in docker.yml to self-hosted labels for trusted push events
- route release publish job in release.yml to self-hosted labels for trusted tag-push events
- keep PR paths and cross-platform build matrix behavior unchanged

## Security Rationale
- no self-hosted execution is introduced on pull_request paths
- change is limited to publish jobs triggered by trusted push/tag events

## Risk
Low/Medium: workflow runner routing only.

## Rollback
Revert this PR to move publish jobs back to GitHub-hosted runners.