### PR TITLE
fix(security): upgrade pairing token to 256-bit CSPRNG entropy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3597,6 +3597,7 @@ dependencies = [
  "directories",
  "fantoccini",
  "futures-util",
+ "getrandom 0.4.1",
  "glob",
  "hex",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ thiserror = "2.0"
 # UUID generation
 uuid = { version = "1.11", default-features = false, features = ["v4", "std"] }
 
+# CSPRNG bytes (transitive via uuid, explicit for token generation)
+getrandom = "0.4"
+
 # Authenticated encryption (AEAD) for secret store
 chacha20poly1305 = "0.10"
 


### PR DESCRIPTION
## Summary
- Replaces UUID v4-based token generation (~122 bits entropy) with `getrandom`-backed 32 random bytes (256 bits)
- Aligns token entropy with the project's ChaCha20-Poly1305 security level
- New token format: `zc_` + 64 hex chars (vs old `zc_` + 32 hex UUID chars)

## Changes
- **Cargo.toml**: Added explicit `getrandom = "0.4"` (already a transitive dep via `uuid`)
- **security/pairing.rs**: `generate_token()` now uses `getrandom::fill()` for 32 random bytes
- Updated test to validate 256-bit token length and hex format
- Added non-determinism test for tokens

## Backward compatibility
Existing tokens continue to work — `PairingGuard` hashes all tokens with SHA-256 on load regardless of the plaintext format.

## Test plan
- [x] All 28 pairing tests pass (including 2 new tests)
- [x] Full test suite (1435+ tests) passes
- [x] `getrandom` is already compiled into the binary via `uuid` — no new binary dependencies

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)