### PR TITLE
fix(security): stop leaking serde parse details in gateway error responses

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -544,8 +544,9 @@ async fn handle_webhook(
     let Json(webhook_body) = match body {
         Ok(b) => b,
         Err(e) => {
+            tracing::warn!("Webhook JSON parse error: {e}");
             let err = serde_json::json!({
-                "error": format!("Invalid JSON: {e}. Expected: {{\"message\": \"...\"}}")
+                "error": "Invalid JSON body. Expected: {\"message\": \"...\"}"
             });
             return (StatusCode::BAD_REQUEST, Json(err));
         }


### PR DESCRIPTION
## Summary
- Replaces dynamic `format!("Invalid JSON: {e}...")` in webhook error response with a static message
- Logs the detailed parse error server-side via `tracing::warn` for debugging

## Problem
The webhook JSON parsing error path included the raw `JsonRejection` error in the HTTP response, potentially exposing serde parsing details, internal field names, or type expectations to unauthenticated HTTP clients.

## Fix
- **Before:** `"Invalid JSON: Failed to deserialize... missing field 'message'. Expected: ..."`
- **After:** `"Invalid JSON body. Expected: {\"message\": \"...\"}"`

The detailed error is still logged server-side for operators to debug client issues.

## Test plan
- [x] All 24 gateway tests pass
- [x] No behavioral change for valid requests

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)