### PR TITLE
chore(clippy): clear warning backlog and harden conversions

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1247,18 +1247,16 @@ Done."#;
     // Recovery Tests - Constants Validation
     // ═══════════════════════════════════════════════════════════════════════
 
-    #[test]
-    fn max_tool_iterations_is_reasonable() {
-        // Recovery: MAX_TOOL_ITERATIONS should be set to prevent runaway loops
+    const _: () = {
         assert!(MAX_TOOL_ITERATIONS > 0);
         assert!(MAX_TOOL_ITERATIONS <= 100);
-    }
-
-    #[test]
-    fn max_history_messages_is_reasonable() {
-        // Recovery: MAX_HISTORY_MESSAGES should be set to prevent memory bloat
         assert!(MAX_HISTORY_MESSAGES > 0);
         assert!(MAX_HISTORY_MESSAGES <= 1000);
+    };
+
+    #[test]
+    fn constants_bounds_are_compile_time_checked() {
+        // Bounds are enforced by the const assertions above.
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1148,7 +1148,7 @@ pub struct LarkConfig {
 // ── Security Config ─────────────────────────────────────────────────
 
 /// Security configuration for sandboxing, resource limits, and audit logging
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct SecurityConfig {
     /// Sandbox configuration
     #[serde(default)]
@@ -1161,16 +1161,6 @@ pub struct SecurityConfig {
     /// Audit logging configuration
     #[serde(default)]
     pub audit: AuditConfig,
-}
-
-impl Default for SecurityConfig {
-    fn default() -> Self {
-        Self {
-            sandbox: SandboxConfig::default(),
-            resources: ResourceLimitsConfig::default(),
-            audit: AuditConfig::default(),
-        }
-    }
 }
 
 /// Sandbox configuration for OS-level isolation
@@ -1200,10 +1190,11 @@ impl Default for SandboxConfig {
 }
 
 /// Sandbox backend selection
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum SandboxBackend {
     /// Auto-detect best available (default)
+    #[default]
     Auto,
     /// Landlock (Linux kernel LSM, native)
     Landlock,
@@ -1215,12 +1206,6 @@ pub enum SandboxBackend {
     Docker,
     /// No sandboxing (application-layer only)
     None,
-}
-
-impl Default for SandboxBackend {
-    fn default() -> Self {
-        Self::Auto
-    }
 }
 
 /// Resource limits for command execution

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 // ── Hardware transport enum ──────────────────────────────────────
 
 /// Transport protocol used to communicate with physical hardware.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum HardwareTransport {
     /// Direct GPIO access on a Linux SBC (Raspberry Pi, Orange Pi, etc.)
@@ -30,13 +30,8 @@ pub enum HardwareTransport {
     /// SWD/JTAG debug probe (probe-rs) for bare-metal MCUs
     Probe,
     /// No hardware — software-only mode
+    #[default]
     None,
-}
-
-impl Default for HardwareTransport {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 impl std::fmt::Display for HardwareTransport {
@@ -869,7 +864,9 @@ mod tests {
 
     #[test]
     fn validate_baud_rate_common_values_ok() {
-        for baud in [9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600] {
+        for baud in [
+            9600, 19200, 38400, 57600, 115_200, 230_400, 460_800, 921_600,
+        ] {
             let cfg = HardwareConfig {
                 enabled: true,
                 transport: "serial".into(),
@@ -938,7 +935,7 @@ mod tests {
             enabled: true,
             transport: "probe".into(),
             serial_port: None,
-            baud_rate: 115200,
+            baud_rate: 115_200,
             workspace_datasheets: false,
             discovered_board: None,
             probe_target: Some("nRF52840_xxAA".into()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,20 +273,6 @@ enum ModelCommands {
 }
 
 #[derive(Subcommand, Debug)]
-enum ModelCommands {
-    /// Refresh and cache provider models
-    Refresh {
-        /// Provider name (defaults to configured default provider)
-        #[arg(long)]
-        provider: Option<String>,
-
-        /// Force live refresh and ignore fresh cache
-        #[arg(long)]
-        force: bool,
-    },
-}
-
-#[derive(Subcommand, Debug)]
 enum ChannelCommands {
     /// List configured channels
     List,

--- a/src/observability/otel.rs
+++ b/src/observability/otel.rs
@@ -183,7 +183,9 @@ impl Observer for OtelObserver {
                     ],
                 );
             }
-            ObserverEvent::LlmRequest { .. } => {}
+            ObserverEvent::LlmRequest { .. }
+            | ObserverEvent::ToolCallStart { .. }
+            | ObserverEvent::TurnComplete => {}
             ObserverEvent::LlmResponse {
                 provider,
                 model,
@@ -247,7 +249,6 @@ impl Observer for OtelObserver {
                 // Note: tokens are recorded via record_metric(TokensUsed) to avoid
                 // double-counting. AgentEnd only records duration.
             }
-            ObserverEvent::ToolCallStart { .. } => {}
             ObserverEvent::ToolCall {
                 tool,
                 duration,
@@ -285,7 +286,6 @@ impl Observer for OtelObserver {
                 self.tool_duration
                     .record(secs, &[KeyValue::new("tool", tool.clone())]);
             }
-            ObserverEvent::TurnComplete => {}
             ObserverEvent::ChannelMessage { channel, direction } => {
                 self.channel_messages.add(
                     1,

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -1990,7 +1990,7 @@ fn setup_hardware() -> Result<HardwareConfig> {
         hw_config.baud_rate = match baud_idx {
             1 => 9600,
             2 => 57600,
-            3 => 230400,
+            3 => 230_400,
             4 => {
                 let custom: String = Input::new()
                     .with_prompt("  Custom baud rate")

--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -57,7 +57,12 @@ fn parse_retry_after_ms(err: &anyhow::Error) -> Option<u64> {
                 .take_while(|c| c.is_ascii_digit() || *c == '.')
                 .collect();
             if let Ok(secs) = num_str.parse::<f64>() {
-                return Some((secs * 1000.0) as u64);
+                if secs.is_finite() && secs >= 0.0 {
+                    let millis = Duration::from_secs_f64(secs).as_millis();
+                    if let Ok(value) = u64::try_from(millis) {
+                        return Some(value);
+                    }
+                }
             }
         }
     }

--- a/src/tools/composio.rs
+++ b/src/tools/composio.rs
@@ -902,8 +902,8 @@ mod tests {
         let json_str = r#"{"name": "GMAIL_SEND_EMAIL_WITH_ATTACHMENT", "appName": "gmail", "description": "Send email with attachment & special chars: <>'\"\"", "enabled": true}"#;
         let action: ComposioAction = serde_json::from_str(json_str).unwrap();
         assert_eq!(action.name, "GMAIL_SEND_EMAIL_WITH_ATTACHMENT");
-        assert!(action.description.as_ref().unwrap().contains("&"));
-        assert!(action.description.as_ref().unwrap().contains("<"));
+        assert!(action.description.as_ref().unwrap().contains('&'));
+        assert!(action.description.as_ref().unwrap().contains('<'));
     }
 
     #[test]

--- a/src/tools/git_operations.rs
+++ b/src/tools/git_operations.rs
@@ -29,7 +29,7 @@ impl GitOperationsTool {
                 || arg_lower.starts_with("--upload-pack=")
                 || arg_lower.starts_with("--receive-pack=")
                 || arg_lower.contains("$(")
-                || arg_lower.contains("`")
+                || arg_lower.contains('`')
                 || arg.contains('|')
                 || arg.contains(';')
             {
@@ -88,10 +88,8 @@ impl GitOperationsTool {
                 branch = line.trim_start_matches("# branch.head ").to_string();
             } else if let Some(rest) = line.strip_prefix("1 ") {
                 // Ordinary changed entry
-                let parts: Vec<&str> = rest.split(' ').collect();
-                if parts.len() >= 2 {
-                    let path = parts.get(1).unwrap_or(&"");
-                    let staging = parts.get(0).unwrap_or(&"");
+                let mut parts = rest.splitn(3, ' ');
+                if let (Some(staging), Some(path)) = (parts.next(), parts.next()) {
                     if !staging.is_empty() {
                         let status_char = staging.chars().next().unwrap_or(' ');
                         if status_char != '.' && status_char != ' ' {
@@ -201,7 +199,8 @@ impl GitOperationsTool {
     }
 
     async fn git_log(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
-        let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(10) as usize;
+        let limit_raw = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(10);
+        let limit = usize::try_from(limit_raw).unwrap_or(usize::MAX).min(1000);
         let limit_str = limit.to_string();
 
         let output = self
@@ -381,7 +380,9 @@ impl GitOperationsTool {
             "pop" => self.run_git_command(&["stash", "pop"]).await,
             "list" => self.run_git_command(&["stash", "list"]).await,
             "drop" => {
-                let index = args.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as i32;
+                let index_raw = args.get("index").and_then(|v| v.as_u64()).unwrap_or(0);
+                let index = i32::try_from(index_raw)
+                    .map_err(|_| anyhow::anyhow!("stash index too large: {index_raw}"))?;
                 self.run_git_command(&["stash", "drop", &format!("stash@{{{index}}}")])
                     .await
             }
@@ -514,12 +515,7 @@ impl Tool for GitOperationsTool {
                         error: Some("Action blocked: read-only mode".into()),
                     });
                 }
-                AutonomyLevel::Supervised => {
-                    // Allow but require tracking
-                }
-                AutonomyLevel::Full => {
-                    // Allow freely
-                }
+                AutonomyLevel::Supervised | AutonomyLevel::Full => {}
             }
         }
 
@@ -555,7 +551,6 @@ impl Tool for GitOperationsTool {
 mod tests {
     use super::*;
     use crate::security::SecurityPolicy;
-    use std::path::Path;
     use tempfile::TempDir;
 
     fn test_tool(dir: &std::path::Path) -> GitOperationsTool {


### PR DESCRIPTION
## Summary
This PR performs a deep cleanup to restore a clean `cargo clippy --all-targets -- -D warnings` baseline and fix a compile-time duplication in `main`.

## What changed
- Fixed unreadable numeric literals (`230_400`, `115_200`, etc.)
- Replaced manual `Default` impls with derive-based defaults where appropriate
- Consolidated identical `match` arms in observability and git tools
- Hardened numeric conversions using checked/infallible conversions
- Reworked git status parsing to avoid `get(0)` anti-pattern
- Improved audit API with structured command event input while keeping backward-compatible helper
- Moved constant bound checks in tests to compile-time const assertions
- Fixed duplicate `ModelCommands` enum definition in `src/main.rs`
- Cleaned char-pattern checks in tests (`contains('&')`, `contains('<')`, etc.)

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

All pass locally.

## Tracking
Closes #381
