### PR TITLE
docs(agents): add superseded-PR title/body template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,37 @@ When a PR supersedes another contributor's PR and carries forward substantive co
 - In the PR body, list superseded PR links and briefly state what was incorporated from each.
 - If no actual code/design was incorporated (only inspiration), do not use `Co-authored-by`; give credit in PR notes instead.
 
+### 9.3 Superseded-PR PR Template (Recommended)
+
+When superseding multiple PRs, use a consistent title/body structure to reduce reviewer ambiguity.
+
+- Recommended title format: `feat(<scope>): unify and supersede #<pr_a>, #<pr_b> [and #<pr_n>]`
+- If this is docs/chore/meta only, keep the same supersede suffix and use the appropriate conventional-commit type.
+- In the PR body, include the following template (fill placeholders, remove non-applicable lines):
+
+```md
+## Supersedes
+- #<pr_a> by @<author_a>
+- #<pr_b> by @<author_b>
+- #<pr_n> by @<author_n>
+
+## Integrated Scope
+- From #<pr_a>: <what was materially incorporated>
+- From #<pr_b>: <what was materially incorporated>
+- From #<pr_n>: <what was materially incorporated>
+
+## Attribution
+- Co-authored-by trailers added for materially incorporated contributors: Yes/No
+- If No, explain why (for example: no direct code/design carry-over)
+
+## Non-goals
+- <explicitly list what was not carried over>
+
+## Risk and Rollback
+- Risk: <summary>
+- Rollback: <revert commit/PR strategy>
+```
+
 Reference docs:
 
 - `CONTRIBUTING.md`


### PR DESCRIPTION
## Summary
- add `AGENTS.md` guidance for a fixed PR title/body template when superseding multiple PRs
- keep attribution policy from section 9.2 and add a copy-paste body template for consistency
- clarify expected sections: Supersedes, Integrated Scope, Attribution, Non-goals, Risk and Rollback

## Why
Makes superseding integrations easier to review and reduces ambiguity about what was carried over and who should receive co-author attribution.

## Scope
Docs-only change (process guidance), no runtime behavior changes.
