### PR TITLE
ci: pin cargo-audit to 0.22.1 in dev CI Dockerfile

### DIFF
--- a/dev/ci/Dockerfile
+++ b/dev/ci/Dockerfile
@@ -14,7 +14,7 @@ RUN rustup toolchain install 1.92 --profile minimal --component rustfmt --compon
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    cargo install --locked cargo-audit && \
+    cargo install --locked cargo-audit --version 0.22.1 && \
     cargo install --locked cargo-deny --version 0.18.5
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

- Pin `cargo-audit` to version 0.22.1 in `dev/ci/Dockerfile`, matching the version already pinned in `.github/workflows/security.yml`
- `cargo-deny` was already pinned to 0.18.5; this fixes the inconsistency

## Test plan

- [ ] CI passes (no Rust changes, Docker-only)

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)