### PR TITLE
docs: add .env.example for local secret handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,26 @@
+# ZeroClaw Environment Variables
+# Copy this file to .env and fill in your values.
+# NEVER commit .env — it is listed in .gitignore.
+
+# ── Required ──────────────────────────────────────────────────
+# Your LLM provider API key
+# ZEROCLAW_API_KEY=sk-your-key-here
+API_KEY=your-api-key-here
+
+# ── Provider & Model ─────────────────────────────────────────
+# LLM provider: openrouter, openai, anthropic, ollama, glm
+PROVIDER=openrouter
+# ZEROCLAW_MODEL=anthropic/claude-sonnet-4-20250514
+# ZEROCLAW_TEMPERATURE=0.7
+
+# ── Gateway ──────────────────────────────────────────────────
+# ZEROCLAW_GATEWAY_PORT=3000
+# ZEROCLAW_GATEWAY_HOST=127.0.0.1
+# ZEROCLAW_ALLOW_PUBLIC_BIND=false
+
+# ── Workspace ────────────────────────────────────────────────
+# ZEROCLAW_WORKSPACE=/path/to/workspace
+
+# ── Docker Compose ───────────────────────────────────────────
+# Host port mapping (used by docker-compose.yml)
+# HOST_PORT=3000


### PR DESCRIPTION
## Summary

- Add `.env.example` template documenting all recognized environment variables
- Covers: API key, provider, model, temperature, gateway config, workspace, Docker Compose port
- `.env` is already in `.gitignore`

## Test plan

- [ ] CI passes (no code changes)

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)