### PR TITLE
docs(pr-template): require supersede attribution details

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,14 @@ Describe this PR in 2-5 bullets:
 - Depends on # (if stacked)
 - Supersedes # (if replacing older PR)
 
+## Supersede Attribution (required when `Supersedes #` is used)
+
+- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
+- Integrated scope by source PR (what was materially carried forward):
+- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
+- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
+- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)
+
 ## Validation Evidence (required)
 
 Commands and result summary:


### PR DESCRIPTION
## Summary
- add a dedicated `Supersede Attribution` section to `.github/pull_request_template.md`
- require explicit superseded PR+author listing when `Supersedes #` is used
- require integrated-scope mapping and `Co-authored-by` trailer status
- add a trailer-format sanity check to prevent escaped `\n` trailer mistakes

## Why
Align PR intake with the supersede attribution rules in `AGENTS.md`, so reviewer context and contributor credit are explicit and consistent.

## Scope
Docs/process template change only; no runtime or code behavior changes.
