### PR TITLE
fix: make release builds reliable on 1GB RAM hosts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,15 +124,15 @@ rag-pdf = ["dep:pdf-extract"]
 
 [profile.release]
 opt-level = "z"      # Optimize for size
-lto = "thin"         # Lower memory use during release builds
-codegen-units = 8     # Faster, lower-RAM codegen for small devices
+lto = false           # Keep release buildable on low-RAM hosts (e.g., 1GB boards)
+codegen-units = 16    # Reduce peak compiler memory pressure
 strip = true          # Remove debug symbols
 panic = "abort"      # Reduce binary size
 
 [profile.dist]
 inherits = "release"
 opt-level = "z"
-lto = "fat"
+lto = "fat"          # Maximum size/runtime optimization for published artifacts
 codegen-units = 1
 strip = true
 panic = "abort"

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ zeroclaw migrate openclaw
 ```
 
 > **Dev fallback (no global install):** prefix commands with `cargo run --release --` (example: `cargo run --release -- status`).
-> **Low-memory boards (e.g., Raspberry Pi 3, 1GB RAM):** run `CARGO_BUILD_JOBS=1 cargo build --release` if the kernel kills rustc during compilation.
+> **Low-memory boards (e.g., Raspberry Pi 3, 1GB RAM):** run `CARGO_BUILD_JOBS=1 cargo build --release` (the default release profile is tuned to avoid LTO OOM on small-memory hosts).
 
 ## Architecture
 
@@ -456,9 +456,10 @@ See [aieos.org](https://aieos.org) for the full schema and live examples.
 
 ```bash
 cargo build              # Dev build
-cargo build --release    # Release build (~3.4MB)
-CARGO_BUILD_JOBS=1 cargo build --release    # Low-memory fallback (Raspberry Pi 3, 1GB RAM)
-cargo test               # 1,017 tests
+cargo build --release    # Release build
+CARGO_BUILD_JOBS=1 cargo build --release    # Low-memory boards (Raspberry Pi 3, 1GB RAM)
+cargo build --profile dist --locked         # Max-optimized distribution build (CI/release)
+cargo test               # test suite
 cargo clippy             # Lint (0 warnings)
 cargo fmt                # Format
 


### PR DESCRIPTION
## Summary
- disable LTO in the default release profile to reduce peak compiler memory usage
- increase release `codegen-units` to further lower memory pressure during compilation
- clarify README guidance for low-memory boards and document `dist` profile for maximum optimization

## Why
Issue #395 reports `cargo build --release` being killed with SIGKILL on Raspberry Pi 3 (1GB RAM). The failure log includes linker-plugin-lto, indicating LTO-related memory pressure.

## Validation
- cargo clippy --locked --all-targets -- -D clippy::correctness
- cargo test --locked --verbose
- CARGO_BUILD_JOBS=1 cargo build --release --locked --verbose

Closes #395
