### PR TITLE
revert: roll back PR #404 for correct authorship flow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,15 +124,15 @@ rag-pdf = ["dep:pdf-extract"]
 
 [profile.release]
 opt-level = "z"      # Optimize for size
-lto = false           # Keep release buildable on low-RAM hosts (e.g., 1GB boards)
-codegen-units = 16    # Reduce peak compiler memory pressure
+lto = "thin"         # Lower memory use during release builds
+codegen-units = 8     # Faster, lower-RAM codegen for small devices
 strip = true          # Remove debug symbols
 panic = "abort"      # Reduce binary size
 
 [profile.dist]
 inherits = "release"
 opt-level = "z"
-lto = "fat"          # Maximum size/runtime optimization for published artifacts
+lto = "fat"
 codegen-units = 1
 strip = true
 panic = "abort"

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ zeroclaw migrate openclaw
 ```
 
 > **Dev fallback (no global install):** prefix commands with `cargo run --release --` (example: `cargo run --release -- status`).
-> **Low-memory boards (e.g., Raspberry Pi 3, 1GB RAM):** run `CARGO_BUILD_JOBS=1 cargo build --release` (the default release profile is tuned to avoid LTO OOM on small-memory hosts).
+> **Low-memory boards (e.g., Raspberry Pi 3, 1GB RAM):** run `CARGO_BUILD_JOBS=1 cargo build --release` if the kernel kills rustc during compilation.
 
 ## Architecture
 
@@ -456,10 +456,9 @@ See [aieos.org](https://aieos.org) for the full schema and live examples.
 
 ```bash
 cargo build              # Dev build
-cargo build --release    # Release build
-CARGO_BUILD_JOBS=1 cargo build --release    # Low-memory boards (Raspberry Pi 3, 1GB RAM)
-cargo build --profile dist --locked         # Max-optimized distribution build (CI/release)
-cargo test               # test suite
+cargo build --release    # Release build (~3.4MB)
+CARGO_BUILD_JOBS=1 cargo build --release    # Low-memory fallback (Raspberry Pi 3, 1GB RAM)
+cargo test               # 1,017 tests
 cargo clippy             # Lint (0 warnings)
 cargo fmt                # Format
 


### PR DESCRIPTION
## Why
This reverts PR #404.

The previous fix was merged with the wrong commit authorship attribution flow. We are rolling this back so the original contributor can rebase and re-submit with correct authorship.

## Changes
- revert release profile changes in `Cargo.toml`
- revert related documentation updates in `README.md`

Refs #395
