### PR TITLE
chore(ci): align lint gate and add strict audit path

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -7,17 +7,25 @@
 set -euo pipefail
 
 echo "==> pre-push: checking formatting..."
-cargo fmt -- --check || {
-    echo "FAIL: cargo fmt -- --check found unformatted code."
+cargo fmt --all -- --check || {
+    echo "FAIL: cargo fmt --all -- --check found unformatted code."
     echo "Run 'cargo fmt' and try again."
     exit 1
 }
 
 echo "==> pre-push: running clippy..."
-cargo clippy -- -D warnings || {
-    echo "FAIL: clippy reported warnings."
+cargo clippy --all-targets -- -D clippy::correctness || {
+    echo "FAIL: clippy correctness gate reported issues."
     exit 1
 }
+
+if [ "${ZEROCLAW_STRICT_LINT:-0}" = "1" ]; then
+    echo "==> pre-push: running strict clippy warnings gate (ZEROCLAW_STRICT_LINT=1)..."
+    cargo clippy --all-targets -- -D warnings || {
+        echo "FAIL: strict clippy warnings gate reported issues."
+        exit 1
+    }
+fi
 
 echo "==> pre-push: running tests..."
 cargo test || {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,12 @@ cargo build
 # Run tests (all must pass)
 cargo test
 
-# Format & lint (must pass before PR)
-cargo fmt && cargo clippy -- -D warnings
+# Format & lint (required before PR)
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D clippy::correctness
+
+# Optional strict lint audit (recommended periodically)
+cargo clippy --all-targets -- -D warnings
 
 # Release build (~3.4MB)
 cargo build --release
@@ -27,7 +31,19 @@ cargo build --release
 
 ### Pre-push hook
 
-The repo includes a pre-push hook in `.githooks/` that enforces `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` before every push. Enable it with `git config core.hooksPath .githooks`.
+The repo includes a pre-push hook in `.githooks/` that enforces `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D clippy::correctness`, and `cargo test` before every push. Enable it with `git config core.hooksPath .githooks`.
+
+For an opt-in strict lint pass during pre-push, set:
+
+```bash
+ZEROCLAW_STRICT_LINT=1 git push
+```
+
+For full CI parity in Docker, run:
+
+```bash
+./dev/ci.sh all
+```
 
 To skip it during rapid iteration:
 
@@ -325,8 +341,9 @@ impl Tool for YourTool {
 
 - [ ] PR template sections are completed (including security + rollback)
 - [ ] `cargo fmt --all -- --check` — code is formatted
-- [ ] `cargo clippy --all-targets -- -D warnings` — no warnings
+- [ ] `cargo clippy --all-targets -- -D clippy::correctness` — merge gate lint baseline passes
 - [ ] `cargo test` — all tests pass locally or skipped tests are explained
+- [ ] Optional strict audit: `cargo clippy --all-targets -- -D warnings` (run when doing lint cleanup or before release-hardening work)
 - [ ] New code has inline `#[cfg(test)]` tests
 - [ ] No new dependencies unless absolutely necessary (we optimize for binary size)
 - [ ] README updated if adding user-facing features

--- a/dev/README.md
+++ b/dev/README.md
@@ -110,6 +110,12 @@ This runs inside a container:
 - `cargo audit`
 - Docker smoke build (`docker build --target dev ...` + `--version` check)
 
+To run an opt-in strict lint audit locally:
+
+```bash
+./dev/ci.sh lint-strict
+```
+
 ### 3. Run targeted stages
 
 ```bash

--- a/dev/ci.sh
+++ b/dev/ci.sh
@@ -26,7 +26,8 @@ Usage: ./dev/ci.sh <command>
 Commands:
   build-image   Build/update the local CI image
   shell         Open an interactive shell inside the CI container
-  lint          Run rustfmt + clippy (container only)
+  lint          Run rustfmt + clippy correctness gate (container only)
+  lint-strict   Run rustfmt + full clippy warnings gate (container only)
   test          Run cargo test (container only)
   build         Run release build smoke check (container only)
   audit         Run cargo audit (container only)
@@ -54,6 +55,10 @@ case "$1" in
 
   lint)
     run_in_ci "cargo fmt --all -- --check && cargo clippy --locked --all-targets -- -D clippy::correctness"
+    ;;
+
+  lint-strict)
+    run_in_ci "cargo fmt --all -- --check && cargo clippy --locked --all-targets -- -D warnings"
     ;;
 
   test)

--- a/docs/ci-map.md
+++ b/docs/ci-map.md
@@ -9,7 +9,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 ### Merge-Blocking
 
 - `.github/workflows/ci.yml` (`CI`)
-    - Purpose: Rust validation (`fmt`, `clippy`, `test`, release build smoke) + docs quality checks when docs change
+    - Purpose: Rust validation (`cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D clippy::correctness`, `test`, release build smoke) + docs quality checks when docs change
     - Merge gate: `CI Required Gate`
 - `.github/workflows/workflow-sanity.yml` (`Workflow Sanity`)
     - Purpose: lint GitHub workflow files (`actionlint`, tab checks)
@@ -75,6 +75,8 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 ## Maintenance Rules
 
 - Keep merge-blocking checks deterministic and reproducible (`--locked` where applicable).
+- Keep merge-blocking clippy policy aligned across `.github/workflows/ci.yml`, `dev/ci.sh`, and `.githooks/pre-push` (`cargo clippy --all-targets -- -D clippy::correctness`).
+- Run strict lint audits regularly via `cargo clippy --all-targets -- -D warnings` (for example through `./dev/ci.sh lint-strict`) and track cleanup in focused PRs.
 - Prefer explicit workflow permissions (least privilege).
 - Use path filters for expensive workflows when practical.
 - Keep docs quality checks low-noise (`markdownlint` + offline link checks).


### PR DESCRIPTION
## Summary
This PR deepens lint governance without destabilizing merge throughput:

- Aligns merge-blocking lint baseline across CI/docs/hooks to `clippy::correctness`
- Adds an opt-in strict lint audit path for full `-D warnings`
- Clarifies contributor guidance and local Docker CI parity

## Why this shape
Current `main` still has strict warning debt (`cargo clippy --all-targets -- -D warnings`), so making strict mode merge-blocking right now would block normal delivery. This PR keeps merge safety deterministic while creating a concrete strict-audit workflow.

## Changes
- `dev/ci.sh`
  - `lint` remains merge-baseline (`-D clippy::correctness`)
  - new `lint-strict` command for full warning audits (`-D warnings`)
- `.githooks/pre-push`
  - baseline gate uses `clippy::correctness`
  - optional strict gate enabled via `ZEROCLAW_STRICT_LINT=1`
- `CONTRIBUTING.md`
  - updates required baseline commands
  - documents strict optional command + Docker CI parity command
  - updates PR checklist to distinguish required baseline vs optional strict audit
- `dev/README.md`
  - documents `./dev/ci.sh lint-strict`
- `docs/ci-map.md`
  - records aligned merge baseline and strict-audit policy

## Validation
- `bash -n dev/ci.sh`
- `bash -n .githooks/pre-push`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D clippy::correctness`
- `cargo test`

## Tracking
Refs #409
