### PR TITLE
fix(config): honor ZEROCLAW_WORKSPACE

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1601,7 +1601,10 @@ impl Config {
         let home = UserDirs::new()
             .map(|u| u.home_dir().to_path_buf())
             .context("Could not find home directory")?;
-        let zeroclaw_dir = home.join(".zeroclaw");
+        let zeroclaw_dir = std::env::var("ZEROCLAW_WORKSPACE")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from).unwrap_or_else(|| home.join(".zeroclaw"));
         let config_path = zeroclaw_dir.join("config.toml");
 
         if !zeroclaw_dir.exists() {


### PR DESCRIPTION
Closes #417

## Summary

Describe this PR in 2-5 bullets:

- Problem: code doesn't honor ZEROCLAW_WORKSPACE
- Why it matters: non-standrad workspace paths / multi agent/gateway setup
- What changed: read ZEROCLAW_WORKSPACE **before** construction of paths
- What did **not** change (scope boundary): nothing really

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): XS
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): config
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`):
- Contributor tier label (`experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=10/20/50): experienced contributor
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`):
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):

## Linked Issue

- Closes #417
