### PR TITLE
ci: add CodeQL security scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+    schedule:
+        - cron: "30 5 * * 1" # Weekly on Monday 5:30am UTC
+
+concurrency:
+    group: codeql-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+    security-events: write
+
+jobs:
+    analyze:
+        name: Analyze (Rust)
+        runs-on: ${{ github.event_name != 'pull_request' && fromJSON('["self-hosted","Linux","X64","lxc-ci"]') || 'ubuntu-latest' }}
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@f5c2471be782132e47a6e6f9c725e56730d6e9a3 # v3.32.3
+              with:
+                  languages: rust
+                  build-mode: none
+
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@f5c2471be782132e47a6e6f9c725e56730d6e9a3 # v3.32.3
+              with:
+                  category: "/language:rust"

--- a/docs/actions-source-policy.md
+++ b/docs/actions-source-policy.md
@@ -19,6 +19,7 @@ Selected allowlist patterns:
 - `DavidAnson/markdownlint-cli2-action@*`
 - `lycheeverse/lychee-action@*`
 - `EmbarkStudios/cargo-deny-action@*`
+- `github/codeql-action@*`
 - `rhysd/actionlint@*`
 - `softprops/action-gh-release@*`
 - `sigstore/cosign-installer@*`


### PR DESCRIPTION
Add GitHub CodeQL workflow for automated static security analysis of Rust codebase.

- Configure CodeQL to run on push to main, pull requests, and weekly schedule
- Use self-hosted runners for main branch, ubuntu-latest for PRs
- Set 30-minute timeout and concurrency controls
- Pin CodeQL action to v3.32.3 with SHA verification
- Update actions source policy to allowlist github/codeql-action

**TL;DR:**
Add a GitHub CodeQL workflow to enable automated semantic security analysis of the Rust codebase. CodeQL performs dataflow and taint tracking to detect real vulnerabilities (not just lint issues) on push, PR, and scheduled scans. This adds continuous security scanning, PR-level alerts, and long-term risk visibility directly in GitHub’s Security tab.