### PR TITLE
fix(cli): respect config gateway.port and gateway.host for Gateway/Daemon commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -147,24 +147,24 @@ enum Commands {
 
     /// Start the gateway server (webhooks, websockets)
     Gateway {
-        /// Port to listen on (use 0 for random available port)
-        #[arg(short, long, default_value = "8080")]
-        port: u16,
+        /// Port to listen on (use 0 for random available port); defaults to config gateway.port
+        #[arg(short, long)]
+        port: Option<u16>,
 
-        /// Host to bind to
-        #[arg(long, default_value = "127.0.0.1")]
-        host: String,
+        /// Host to bind to; defaults to config gateway.host
+        #[arg(long)]
+        host: Option<String>,
     },
 
     /// Start long-running autonomous runtime (gateway + channels + heartbeat + scheduler)
     Daemon {
-        /// Port to listen on (use 0 for random available port)
-        #[arg(short, long, default_value = "8080")]
-        port: u16,
+        /// Port to listen on (use 0 for random available port); defaults to config gateway.port
+        #[arg(short, long)]
+        port: Option<u16>,
 
-        /// Host to bind to
-        #[arg(long, default_value = "127.0.0.1")]
-        host: String,
+        /// Host to bind to; defaults to config gateway.host
+        #[arg(long)]
+        host: Option<String>,
     },
 
     /// Manage OS service lifecycle (launchd/systemd user service)
@@ -403,6 +403,8 @@ async fn main() -> Result<()> {
         } => agent::run(config, message, provider, model, temperature, peripheral).await,
 
         Commands::Gateway { port, host } => {
+            let port = port.unwrap_or(config.gateway.port);
+            let host = host.unwrap_or_else(|| config.gateway.host.clone());
             if port == 0 {
                 info!("🚀 Starting ZeroClaw Gateway on {host} (random port)");
             } else {
@@ -412,6 +414,8 @@ async fn main() -> Result<()> {
         }
 
         Commands::Daemon { port, host } => {
+            let port = port.unwrap_or(config.gateway.port);
+            let host = host.unwrap_or_else(|| config.gateway.host.clone());
             if port == 0 {
                 info!("🧠 Starting ZeroClaw Daemon on {host} (random port)");
             } else {


### PR DESCRIPTION
The CLI --port and --host args had hardcoded defaults (8080, 127.0.0.1) that always overrode the user's config.toml [gateway] settings (port=3000, host=127.0.0.1). Changed both args to Option types and fall back to config.gateway.port / config.gateway.host when not explicitly provided.

Similar to my last PR for temperature issues
https://github.com/zeroclaw-labs/zeroclaw/pull/455