### PR TITLE
docs(readme): add PATH hint for ~/.cargo/bin in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ cd zeroclaw
 cargo build --release --locked
 cargo install --path . --force --locked
 
+# Ensure ~/.cargo/bin is in your PATH
+export PATH="$HOME/.cargo/bin:$PATH"
+
 # Quick setup (no prompts)
 zeroclaw onboard --api-key sk-... --provider openrouter
 


### PR DESCRIPTION
## Summary
- Adds an `export PATH` step to the Quick Start section after `cargo install`
- `~/.cargo/bin` may not be in the user's PATH by default, causing a "not found" error when running `zeroclaw` after install

## Test plan
- [ ] Verify the Quick Start instructions work on a fresh machine without `~/.cargo/bin` in PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)