### PR TITLE
fix(cli): respect config default_temperature (issue #452)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,9 +136,9 @@ enum Commands {
         #[arg(long)]
         model: Option<String>,
 
-        /// Temperature (0.0 - 2.0)
-        #[arg(short, long, default_value = "0.7")]
-        temperature: f64,
+        /// Temperature (0.0 - 2.0); defaults to config default_temperature
+        #[arg(short, long)]
+        temperature: Option<f64>,
 
         /// Attach a peripheral (board:path, e.g. nucleo-f401re:/dev/ttyACM0)
         #[arg(long)]
@@ -400,7 +400,10 @@ async fn main() -> Result<()> {
             model,
             temperature,
             peripheral,
-        } => agent::run(config, message, provider, model, temperature, peripheral).await,
+        } => {
+            let temp = temperature.unwrap_or(config.default_temperature);
+            agent::run(config, message, provider, model, temp, peripheral).await
+        }
 
         Commands::Gateway { port, host } => {
             if port == 0 {


### PR DESCRIPTION
## Summary
- Fixes issue #452 where `default_temperature` in config.toml was not being respected by the CLI
- Previously, the `--temperature` argument had a hardcoded default of 0.7, overriding any config setting
- Now `--temperature` is optional and falls back to `config.default_temperature` when not provided

## Changes
- Changed `Agent` command `temperature` argument from `f64` with `default_value = "0.7"` to `Option<f64>`
- When `--temperature` is not provided, uses `config.default_temperature` as fallback

## Test plan
- [x] All existing tests pass
- [x] Code is formatted with `cargo fmt`
- [x] Manual test: Users can now set `default_temperature = 1.0` for Azure OpenAI models that require it

## Related issues
Fixes #452