### PR TITLE
fix(memory): harden lucid recall timeout and add cold-start regression test

### DIFF
--- a/src/memory/lucid.rs
+++ b/src/memory/lucid.rs
@@ -24,7 +24,9 @@ pub struct LucidMemory {
 impl LucidMemory {
     const DEFAULT_LUCID_CMD: &'static str = "lucid";
     const DEFAULT_TOKEN_BUDGET: usize = 200;
-    const DEFAULT_RECALL_TIMEOUT_MS: u64 = 120;
+    // Lucid CLI cold start can exceed 120ms on slower machines, which causes
+    // avoidable fallback to local-only memory and premature cooldown.
+    const DEFAULT_RECALL_TIMEOUT_MS: u64 = 500;
     const DEFAULT_STORE_TIMEOUT_MS: u64 = 800;
     const DEFAULT_LOCAL_HIT_THRESHOLD: usize = 3;
     const DEFAULT_FAILURE_COOLDOWN_MS: u64 = 15_000;
@@ -413,6 +415,38 @@ exit 1
         script_path.display().to_string()
     }
 
+    fn write_delayed_lucid_script(dir: &Path) -> String {
+        let script_path = dir.join("delayed-lucid.sh");
+        let script = r#"#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "store" ]]; then
+  echo '{"success":true,"id":"mem_1"}'
+  exit 0
+fi
+
+if [[ "${1:-}" == "context" ]]; then
+  # Simulate a cold start that is slower than 120ms but below the 500ms timeout.
+  sleep 0.2
+  cat <<'EOF'
+<lucid-context>
+- [decision] Delayed token refresh guidance
+</lucid-context>
+EOF
+  exit 0
+fi
+
+echo "unsupported command" >&2
+exit 1
+"#;
+
+        fs::write(&script_path, script).unwrap();
+        let mut perms = fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).unwrap();
+        script_path.display().to_string()
+    }
+
     fn write_probe_lucid_script(dir: &Path, marker_path: &Path) -> String {
         let script_path = dir.join("probe-lucid.sh");
         let marker = marker_path.display().to_string();
@@ -455,7 +489,7 @@ exit 1
             cmd,
             200,
             3,
-            Duration::from_millis(120),
+            Duration::from_millis(500),
             Duration::from_millis(400),
             Duration::from_secs(2),
         )
@@ -507,6 +541,31 @@ exit 1
     }
 
     #[tokio::test]
+    async fn recall_handles_lucid_cold_start_delay_within_timeout() {
+        let tmp = TempDir::new().unwrap();
+        let delayed_cmd = write_delayed_lucid_script(tmp.path());
+        let memory = test_memory(tmp.path(), delayed_cmd);
+
+        memory
+            .store(
+                "local_note",
+                "Local sqlite auth fallback note",
+                MemoryCategory::Core,
+            )
+            .await
+            .unwrap();
+
+        let entries = memory.recall("auth", 5).await.unwrap();
+
+        assert!(entries
+            .iter()
+            .any(|e| e.content.contains("Local sqlite auth fallback note")));
+        assert!(entries
+            .iter()
+            .any(|e| e.content.contains("Delayed token refresh guidance")));
+    }
+
+    #[tokio::test]
     async fn recall_skips_lucid_when_local_hits_are_enough() {
         let tmp = TempDir::new().unwrap();
         let marker = tmp.path().join("context_calls.log");
@@ -519,7 +578,7 @@ exit 1
             probe_cmd,
             200,
             1,
-            Duration::from_millis(120),
+            Duration::from_millis(500),
             Duration::from_millis(400),
             Duration::from_secs(2),
         );
@@ -584,7 +643,7 @@ exit 1
             failing_cmd,
             200,
             99,
-            Duration::from_millis(120),
+            Duration::from_millis(500),
             Duration::from_millis(400),
             Duration::from_secs(5),
         );


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: Lucid recall timeout was 120ms, which can be exceeded by Lucid CLI cold starts and causes premature fallback to local-only memory.
- Why it matters: Relevant Lucid context can be dropped on first recall, reducing memory quality and triggering failure cooldown behavior unnecessarily.
- What changed: Increased default Lucid recall timeout to 500ms and added a regression test that simulates a delayed Lucid context response (`sleep 0.2`) and asserts merged local+Lucid results.
- What did **not** change (scope boundary): No changes to Lucid command protocol, cooldown logic, merge algorithm, or non-memory modules.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S` (requested)
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `memory,tests`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `memory:lucid`
- Contributor tier label (`experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `memory`

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): No
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): No superseded PR/code carry-over.
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): Pass

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- `cargo fmt --all -- --check`: pass
- `cargo clippy --all-targets -- -D warnings`: fail due to pre-existing repo-wide warnings/lints unrelated to this patch (for example unused imports and feature `cfg` mismatches in `channels/*`, `security/*`, and other modules).
- `cargo test --locked memory::lucid::tests -- --nocapture`: pass (6/6)
- `cargo test --locked`: pass (1485 tests)
- Evidence provided (test/log/trace/screenshot/perf): test logs
- If any command is intentionally skipped, explain why: none skipped

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: test-only synthetic content
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: local-only short-circuit remains intact, Lucid merge still works, failure cooldown test still passes, delayed cold-start path now covered.
- Edge cases checked: delayed Lucid response between old timeout (120ms) and new timeout (500ms).
- What was not verified: real external Lucid binary behavior under high-latency hosts beyond scripted test delay.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `memory/lucid` recall timeout + Lucid unit tests.
- Potential unintended effects: slightly longer wait before fallback when Lucid is unavailable during recall.
- Guardrails/monitoring for early detection: existing recall/fallback tests plus new cold-start regression test.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local git + cargo + gh CLI.
- Workflow/plan summary (if any): reproduced timeout flake, raised timeout, added targeted regression test, reran scoped and full tests.
- Verification focus: memory recall reliability and deterministic test coverage.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert this PR commit.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: Lucid recall fallback occurring too frequently with missing Lucid context on cold-start invocations.

## Risks and Mitigations

- Risk: Increasing timeout could slightly increase recall latency when Lucid is unhealthy.
  - Mitigation: Timeout increase is bounded (120ms -> 500ms), failure cooldown behavior remains unchanged, and local fallback still occurs on timeout/error.
