### PR TITLE
feat(anthropic): enable OAuth setup-token auth and update model catalog

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -367,8 +367,14 @@ async fn main() -> Result<()> {
         api_key,
         provider,
         memory,
-    } = cli.command
+    } = &cli.command
     {
+        let interactive = *interactive;
+        let channels_only = *channels_only;
+        let api_key = api_key.clone();
+        let provider = provider.clone();
+        let memory = memory.clone();
+
         if interactive && channels_only {
             bail!("Use either --interactive or --channels-only, not both");
         }

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -467,7 +467,7 @@ fn default_model_for_provider(provider: &str) -> String {
         "groq" => "llama-3.3-70b-versatile".into(),
         "deepseek" => "deepseek-chat".into(),
         "gemini" => "gemini-2.5-pro".into(),
-        _ => "anthropic/claude-sonnet-4-5".into(),
+        _ => "anthropic/claude-sonnet-4.5".into(),
     }
 }
 
@@ -475,7 +475,7 @@ fn curated_models_for_provider(provider_name: &str) -> Vec<(String, String)> {
     match canonical_provider_name(provider_name) {
         "openrouter" => vec![
             (
-                "anthropic/claude-sonnet-4-5".to_string(),
+                "anthropic/claude-sonnet-4.5".to_string(),
                 "Claude Sonnet 4.5 (balanced, recommended)".to_string(),
             ),
             (
@@ -4343,6 +4343,16 @@ mod tests {
 
         assert!(ids.contains(&"gpt-5.2".to_string()));
         assert!(ids.contains(&"gpt-5-mini".to_string()));
+    }
+
+    #[test]
+    fn curated_models_for_openrouter_use_valid_anthropic_id() {
+        let ids: Vec<String> = curated_models_for_provider("openrouter")
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+
+        assert!(ids.contains(&"anthropic/claude-sonnet-4.5".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Problem:** Onboard wizard panics with "Cannot drop a runtime in a context where blocking is not allowed" when using `reqwest::blocking` inside the `#[tokio::main]` async context. Anthropic OAuth setup-tokens (`sk-ant-oat01-*`) are accepted but lack the required `anthropic-beta` header for API calls, causing 401s. Curated model list is outdated (Sonnet 4, Opus 4.1, Haiku 3.5).
- **Why it matters:** Pro/Max subscription users cannot use ZeroClaw with their setup-tokens; the wizard crashes on startup for all users.
- **What changed:** (1) Wrap onboard wizard in `spawn_blocking` to fix runtime panic. (2) Add `anthropic-beta: oauth-2025-04-20` header for OAuth tokens in both the provider and wizard. (3) Update curated Anthropic models to Opus 4.6, Sonnet 4.5, Haiku 4.5. (4) Improve error reporting for model fetch failures. (5) Add `ANTHROPIC_OAUTH_TOKEN` env var fallback for Anthropic credential resolution.
- **What did not change (scope boundary):** No changes to other providers, channels, gateway, security, or runtime. No new dependencies added.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `onboard`, `provider`
- Module labels: `provider:anthropic`, `onboard:wizard`
- Contributor tier label: N/A (first PR)

## Change Metadata

- Change type: `feature`
- Primary scope: `provider`

## Linked Issue

- No linked issue — addresses runtime crash and OAuth support gap discovered during manual testing.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check     # ✅ pass
cargo clippy --all-targets -- -D warnings  # ✅ no errors in changed files (28 pre-existing warnings in unrelated files)
cargo test "wizard"            # ✅ 38 passed, 0 failed
```

- Evidence provided: local CLI validation (fmt, clippy, test). Manual test of `./zeroclaw onboard --interactive` with OAuth setup-token confirmed wizard no longer panics and model fetch sends correct headers.
- Pre-existing clippy warnings (e.g., `git_operations.rs`) are outside this PR's scope.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (same endpoints, different auth header)
- Secrets/tokens handling changed? Yes — OAuth setup-tokens now sent as `Authorization: Bearer` with `anthropic-beta: oauth-2025-04-20` header instead of being rejected
- File system access scope changed? No
- **Mitigation:** Token detection uses explicit prefix check (`sk-ant-oat01-`). Bearer auth is only used for tokens matching this prefix; regular API keys continue using `x-api-key`. The `anthropic-beta` header is an Anthropic-documented beta flag for OAuth support.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No user data logged or stored. Token prefix check is non-extractive.
- Neutral wording confirmation: All test fixtures and labels use project-scoped identifiers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — new optional env var `ANTHROPIC_OAUTH_TOKEN` for credential resolution (additive, does not affect existing `ANTHROPIC_API_KEY` flow)
- Migration needed? No

## Human Verification (required)

- Verified scenarios: (1) `onboard --interactive` with OAuth setup-token — wizard launches without panic, model fetch attempted with Bearer + beta header. (2) Curated model list displays Opus 4.6, Sonnet 4.5, Haiku 4.5.
- Edge cases checked: Empty API key, missing env vars, non-OAuth API key flow unchanged.
- What was not verified: End-to-end inference call with setup-token against live Anthropic API (requires active Pro/Max subscription).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `onboard` wizard, `providers/anthropic` request construction
- Potential unintended effects: If Anthropic retires the `oauth-2025-04-20` beta flag, OAuth requests would fail. Mitigated by the beta flag being additive (ignored if unsupported).
- Guardrails/monitoring: Error messages now surface HTTP status + response body for faster diagnosis.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Opus 4.6 via Claude Code
- Workflow/plan summary: Systematic debugging of runtime panic → root cause in nested Tokio runtime → fix with `spawn_blocking`. Research of OpenClaw OAuth implementation to discover required `anthropic-beta` header. Model IDs verified against official Anthropic docs.
- Verification focus: fmt, clippy, test, manual onboard flow
- Confirmation: naming + architecture boundaries followed per `CONTRIBUTING.md`

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>` — single commit, no migrations
- Feature flags or config toggles: None needed; OAuth path is only triggered by `sk-ant-oat01-` prefix
- Observable failure symptoms: 401 errors on Anthropic API calls with setup-tokens, wizard crash on startup

## Risks and Mitigations

- Risk: Anthropic deprecates or changes the `oauth-2025-04-20` beta flag
  - Mitigation: Beta header is additive; regular API key path is unaffected. Error messages now surface full API response for fast diagnosis.
- Risk: `spawn_blocking` changes error propagation behavior
  - Mitigation: Double `?` (`await??`) correctly unwraps both `JoinError` and inner `Result`. All existing wizard tests pass.
