### PR TITLE
fix(security): block single-ampersand command chaining bypass

### DIFF
--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -341,6 +341,7 @@ impl SecurityPolicy {
     /// - Blocks subshell operators (`` ` ``, `$(`) that hide arbitrary execution
     /// - Splits on command separators (`|`, `&&`, `||`, `;`, newlines) and
     ///   validates each sub-command against the allowlist
+    /// - Blocks single `&` background chaining (`&&` remains supported)
     /// - Blocks output redirections (`>`, `>>`) that could write outside workspace
     pub fn is_command_allowed(&self, command: &str) -> bool {
         if self.autonomy == AutonomyLevel::ReadOnly {


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: command policy parsing did not handle standalone `&`, so `ls & <disallowed_cmd>` could pass allowlist checks.
- Why it matters: this is a shell-command bypass in a high-risk security surface (`src/security/policy.rs`).
- What changed: reject standalone single-`&` (while preserving `&&`), include `&` in risk segmentation, and add regression tests for both allowlist and validation layers.
- What did **not** change (scope boundary): no changes to tool execution runtime, allowlist defaults, approval model, or path policy logic.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS` (requested)
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `security,tests`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `security:policy`
- Contributor tier label (`experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `security`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `security`

## Linked Issue

- Closes #
- Related #465
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): No
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): no superseded code carried over
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): Pass

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- `cargo fmt --all -- --check`: pass
- `cargo clippy --all-targets -- -D warnings`: fails due existing repo-wide baseline issues unrelated to this patch
- `cargo test --locked command_injection_background_chain_blocked -- --nocapture`: pass
- `cargo test --locked validate_command_rejects_background_chain_bypass -- --nocapture`: pass
- `cargo test --locked security::policy::tests -- --nocapture`: pass
- `cargo test --locked`: fails only on known unrelated flaky test `memory::lucid::tests::failure_cooldown_avoids_repeated_lucid_calls` (`src/memory/lucid.rs:599`)
- Evidence provided (test/log/trace/screenshot/perf): test logs
- If any command is intentionally skipped, explain why: none skipped

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: test-only synthetic command strings
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: single-`&` chaining is denied; `&&`/`||` behavior remains unchanged; validation API rejects bypass strings.
- Edge cases checked: `ls & rm -rf /`, `ls&rm -rf /`, `echo ok & python3 -c 'print(1)'`.
- What was not verified: runtime-level shell execution traces for background process handling (policy-level gating is covered).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `security/policy` shell-command gating.
- Potential unintended effects: stricter policy rejects any standalone `&`, including benign literal use-cases.
- Guardrails/monitoring for early detection: targeted regression tests added in `security::policy::tests`.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local git + cargo + gh CLI.
- Workflow/plan summary (if any): reproduced bypass with failing test, patched parser/gate, added regression tests, reran focused suites.
- Verification focus: high-risk command-policy bypass prevention.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert this PR commit set.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: previously, disallowed commands could execute after an allowed command via single `&` chaining.

## Risks and Mitigations

- Risk: standalone `&` in otherwise benign commands is now denied (stricter behavior).
  - Mitigation: intentional secure-by-default choice for command execution; `&&` remains available for explicit chaining.
