### PR TITLE
Fix the typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ ls -lh target/release/zeroclaw
 /usr/bin/time -l target/release/zeroclaw status
 ```
 
-## Prerequesites
+## Prerequisites
 
 <details>
 <summary><strong>Windows</strong></summary>


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: Typo in `Prerequisites` heading
- Why it matters: Enhances readability
- What changed: **[README.md](https://github.com/zeroclaw-labs/zeroclaw?tab=readme-ov-file#prerequesites)**
- What did **not** change (scope boundary): All other code and configurations