### PR TITLE
fix(security): remove duplicate permissions causing workflow validation failure

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,8 +16,6 @@ permissions:
     contents: read
     security-events: write
     actions: read
-    security-events: write
-    actions: read
 
 env:
     CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Problem
The security.yml workflow had duplicate permission keys which caused YAML validation errors:
```yaml
permissions:
    contents: read
    security-events: write
    actions: read
    security-events: write  # DUPLICATE
    actions: read           # DUPLICATE
```

This prevented the workflow from running at all - no jobs would start.

## Solution
Removed the duplicate `security-events: write` and `actions: read` entries.

## Impact
- **Risk:** Low - simple YAML fix
- **Urgency:** High - security workflow completely broken on main
- **Rollback:** Revert this commit if needed

Fixes the "workflow file issue" failures on main branch.