### PR TITLE
feat: add Astrai as a named provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 Fast, small, and fully autonomous AI assistant infrastructure — deploy anywhere, swap anything.
 
 ```
-~3.4MB binary · <10ms startup · 1,017 tests · 22+ providers · 8 traits · Pluggable everything
+~3.4MB binary · <10ms startup · 1,017 tests · 23+ providers · 8 traits · Pluggable everything
 ```
 
 ### ✨ Features
@@ -187,7 +187,7 @@ Every subsystem is a **trait** — swap implementations with a config change, ze
 
 | Subsystem | Trait | Ships with | Extend |
 |-----------|-------|------------|--------|
-| **AI Models** | `Provider` | 22+ providers (OpenRouter, Anthropic, OpenAI, Ollama, Venice, Groq, Mistral, xAI, DeepSeek, Together, Fireworks, Perplexity, Cohere, Bedrock, etc.) | `custom:https://your-api.com` — any OpenAI-compatible API |
+| **AI Models** | `Provider` | 23+ providers (OpenRouter, Anthropic, OpenAI, Ollama, Venice, Groq, Mistral, xAI, DeepSeek, Together, Fireworks, Perplexity, Cohere, Bedrock, Astrai, etc.) | `custom:https://your-api.com` — any OpenAI-compatible API |
 | **Channels** | `Channel` | CLI, Telegram, Discord, Slack, iMessage, Matrix, WhatsApp, Webhook | Any messaging API |
 | **Memory** | `Memory` | SQLite with hybrid search (FTS5 + vector cosine similarity), Lucid bridge (CLI sync + SQLite fallback), Markdown | Any persistence backend |
 | **Tools** | `Tool` | shell, file_read, file_write, memory_store, memory_recall, memory_forget, browser_open (Brave + allowlist), browser (agent-browser / rust-native), composio (optional) | Any capability |

--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -640,6 +640,7 @@ mod tests {
             make_provider("Groq", "https://api.groq.com/openai", None),
             make_provider("Mistral", "https://api.mistral.ai", None),
             make_provider("xAI", "https://api.x.ai", None),
+            make_provider("Astrai", "https://as-trai.com/v1", None),
         ];
 
         for p in providers {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -135,6 +135,7 @@ fn resolve_api_key(name: &str, api_key: Option<&str>) -> Option<String> {
         "opencode" | "opencode-zen" => vec!["OPENCODE_API_KEY"],
         "vercel" | "vercel-ai" => vec!["VERCEL_API_KEY"],
         "cloudflare" | "cloudflare-ai" => vec!["CLOUDFLARE_API_KEY"],
+        "astrai" => vec!["ASTRAI_API_KEY"],
         _ => vec![],
     };
 
@@ -282,6 +283,11 @@ pub fn create_provider(name: &str, api_key: Option<&str>) -> anyhow::Result<Box<
         ))),
         "nvidia" | "nvidia-nim" | "build.nvidia.com" => Ok(Box::new(OpenAiCompatibleProvider::new(
             "NVIDIA NIM", "https://integrate.api.nvidia.com/v1", key, AuthStyle::Bearer,
+        ))),
+
+        // ── AI inference routers ─────────────────────────────
+        "astrai" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Astrai", "https://as-trai.com/v1", key, AuthStyle::Bearer,
         ))),
 
         // ── Bring Your Own Provider (custom URL) ───────────
@@ -612,6 +618,13 @@ mod tests {
         assert!(create_provider("nvidia", Some("nvapi-test")).is_ok());
         assert!(create_provider("nvidia-nim", Some("nvapi-test")).is_ok());
         assert!(create_provider("build.nvidia.com", Some("nvapi-test")).is_ok());
+    }
+
+    // ── AI inference routers ─────────────────────────────────
+
+    #[test]
+    fn factory_astrai() {
+        assert!(create_provider("astrai", Some("sk-astrai-test")).is_ok());
     }
 
     // ── Custom / BYOP provider ─────────────────────────────


### PR DESCRIPTION
## Summary

- Problem: No first-class Astrai provider — users must use `custom:https://as-trai.com/v1` workaround
- Why it matters: Astrai is a cross-provider AI inference router (routes across Anthropic, Groq, Mistral, and more) with built-in cost optimization, PII stripping, and compliance logging — a single `default_provider = "astrai"` config gives ZeroClaw users access to all of that
- What changed: Added `"astrai"` provider entry, `ASTRAI_API_KEY` env var resolution, unit test, compatible-provider test, README provider count + list
- What did **not** change (scope boundary): No changes to `Provider` trait, `OpenAiCompatibleProvider` struct, config schema, or any existing provider behavior

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `provider`
- Module labels: `provider:astrai`
- Contributor tier label: N/A (first contribution)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `provider`

## Linked Issue

- Closes: N/A
- Related: N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check          # ✅ clean (no output)
cargo clippy --all-targets -- -D clippy::correctness  # ✅ pass (no correctness errors)
cargo clippy --all-targets -- -D warnings             # ⚠️ 50+ pre-existing warnings (none from this PR)
cargo test                          # ✅ 1487 passed, 1 failed (pre-existing timing race in memory::lucid::tests::failure_cooldown_avoids_repeated_lucid_calls — unrelated to this PR)
```

- Evidence provided: local `fmt`, `clippy`, `test` results above
- If any command is intentionally skipped: N/A — all ran

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (provider is only invoked at user runtime when selected)
- Secrets/tokens handling changed? No (follows existing `resolve_api_key` pattern)
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A — no user data in this change
- Neutral wording confirmation: Uses project-native naming (`"astrai"` factory key, `"Astrai"` display name)

## Compatibility / Migration

- Backward compatible? Yes — purely additive
- Config/env changes? Yes — new optional `ASTRAI_API_KEY` env var (no impact if unset)
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Provider factory creates Astrai instance with valid key; env var resolution maps `"astrai"` → `ASTRAI_API_KEY`
- Edge cases checked: Missing API key returns appropriate error (covered by compatible provider test)
- What was not verified: Live API call to as-trai.com (requires active API key; factory + auth pattern matches all other providers)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `src/providers/` only
- Potential unintended effects: None — additive change, no existing behavior modified
- Guardrails/monitoring for early detection: Existing test suite covers provider factory invariants

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (codebase exploration, code generation, PR creation)
- Workflow/plan summary: Read `Provider` trait + `OpenAiCompatibleProvider` + existing provider entries → followed identical pattern used by Venice/Groq/Mistral to add Astrai → added tests mirroring existing provider tests → updated README counts
- Verification focus: Pattern consistency with existing providers, `cargo fmt`/`clippy`/`test` validation
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes — factory key lowercase `"astrai"`, display name `"Astrai"`, test named `factory_astrai`, no cross-subsystem coupling

## Rollback Plan (required)

- Fast rollback command/path: `git revert <sha>` — single commit, no migrations
- Feature flags or config toggles: N/A — provider is only active when explicitly selected by user
- Observable failure symptoms: `create_provider("astrai", ...)` returns error — caught by unit test

## Risks and Mitigations

- Risk: None — follows established pattern identical to 20+ existing providers