### PR TITLE
fix(labels): unify contributor-tier color to blue

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -35,7 +35,7 @@ jobs:
               { label: "experienced contributor", minMergedPRs: 10 },
             ];
             const contributorTierLabels = contributorTierRules.map((rule) => rule.label);
-            const contributorTierColor = "39FF14";
+            const contributorTierColor = "2ED9FF"; // Keep in sync with .github/workflows/labeler.yml
             const managedContributorLabels = new Set([
               legacyTrustedContributorLabel,
               ...contributorTierLabels,

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -57,7 +57,7 @@ jobs:
                         { label: "experienced contributor", minMergedPRs: 10 },
                       ];
                       const contributorTierLabels = contributorTierRules.map((rule) => rule.label);
-                      const contributorTierColor = "2ED9FF";
+                      const contributorTierColor = "2ED9FF"; // Keep in sync with .github/workflows/auto-response.yml
 
                       const managedPathLabels = [
                         "docs",


### PR DESCRIPTION
## Summary
- unify contributor-tier label color to blue (`2ED9FF`) across both automation paths
- update `.github/workflows/auto-response.yml` to use `2ED9FF` (was `39FF14`)
- keep `.github/workflows/labeler.yml` on `2ED9FF` and add reciprocal sync comments in both files

## Root Cause
Two workflows enforced different colors for the same labels:
- `auto-response.yml`: `39FF14` (green)
- `labeler.yml`: `2ED9FF` (blue)

Whichever workflow ran last overwrote repository label colors, causing flip-flops.

## Scope
Workflow automation only. No runtime/application code changes.

## Validation
- verified both workflow constants are now `2ED9FF`
- confirmed only two workflow files changed
