### PR TITLE
fix(labels): restore trusted contributor tier (>=5)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Describe this PR in 2-5 bullets:
 - Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
 - Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):
 - Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`):
-- Contributor tier label (`experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=10/20/50):
+- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
 - If any auto-label is incorrect, note requested correction:
 
 ## Change Metadata

--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -33,6 +33,7 @@ jobs:
               { label: "distinguished contributor", minMergedPRs: 50 },
               { label: "principal contributor", minMergedPRs: 20 },
               { label: "experienced contributor", minMergedPRs: 10 },
+              { label: "trusted contributor", minMergedPRs: 5 },
             ];
             const contributorTierLabels = contributorTierRules.map((rule) => rule.label);
             const contributorTierColor = "2ED9FF"; // Keep in sync with .github/workflows/labeler.yml

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -55,6 +55,7 @@ jobs:
                         { label: "distinguished contributor", minMergedPRs: 50 },
                         { label: "principal contributor", minMergedPRs: 20 },
                         { label: "experienced contributor", minMergedPRs: 10 },
+                        { label: "trusted contributor", minMergedPRs: 5 },
                       ];
                       const contributorTierLabels = contributorTierRules.map((rule) => rule.label);
                       const contributorTierColor = "2ED9FF"; // Keep in sync with .github/workflows/auto-response.yml
@@ -155,6 +156,7 @@ jobs:
                         "distinguished contributor",
                         "principal contributor",
                         "experienced contributor",
+                        "trusted contributor",
                       ];
                       const modulePrefixPriorityIndex = new Map(
                         modulePrefixPriority.map((prefix, index) => [prefix, index])

--- a/docs/ci-map.md
+++ b/docs/ci-map.md
@@ -32,7 +32,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
     - Additional behavior: provider-related keywords in provider/config/onboard/integration changes are promoted to `provider:*` labels (for example `provider:kimi`, `provider:deepseek`)
     - Additional behavior: hierarchical de-duplication keeps only the most specific scope labels (for example `tool:composio` suppresses `tool:core` and `tool`)
     - Additional behavior: module namespaces are compacted — one specific module keeps `prefix:component`; multiple specifics collapse to just `prefix`
-    - Additional behavior: applies contributor tiers on PRs by merged PR count (`experienced` >=10, `principal` >=20, `distinguished` >=50)
+    - Additional behavior: applies contributor tiers on PRs by merged PR count (`trusted` >=5, `experienced` >=10, `principal` >=20, `distinguished` >=50)
     - Additional behavior: final label set is priority-sorted (`risk:*` first, then `size:*`, then contributor tier, then module/path labels)
     - Additional behavior: managed label colors follow display order to produce a smooth left-to-right gradient when many labels are present
     - Additional behavior: risk + size labels are auto-corrected on manual PR label edits (`labeled`/`unlabeled` events); apply `risk: manual` when maintainers intentionally override automated risk selection
@@ -40,7 +40,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
     - Guardrail: maintainers can apply `risk: manual` to freeze automated risk recalculation
 - `.github/workflows/auto-response.yml` (`Auto Response`)
     - Purpose: first-time contributor onboarding + label-driven response routing (`r:support`, `r:needs-repro`, etc.)
-    - Additional behavior: applies contributor tiers on issues by merged PR count (`experienced` >=10, `principal` >=20, `distinguished` >=50)
+    - Additional behavior: applies contributor tiers on issues by merged PR count (`trusted` >=5, `experienced` >=10, `principal` >=20, `distinguished` >=50)
     - Additional behavior: contributor-tier labels are treated as automation-managed (manual add/remove on PR/issue is auto-corrected)
     - Guardrail: label-based close routes are issue-only; PRs are never auto-closed by route labels
 - `.github/workflows/stale.yml` (`Stale`)

--- a/docs/pr-workflow.md
+++ b/docs/pr-workflow.md
@@ -49,7 +49,7 @@ Maintain these branch protection rules on `main`:
 ### Step A: Intake
 
 - Contributor opens PR with full `.github/pull_request_template.md`.
-- `PR Labeler` applies scope/path labels + size labels + risk labels + module labels (for example `channel:telegram`, `provider:kimi`, `tool:shell`) and contributor tiers by merged PR count (`experienced` >=10, `principal` >=20, `distinguished` >=50), while de-duplicating less-specific scope labels when a more specific module label is present.
+- `PR Labeler` applies scope/path labels + size labels + risk labels + module labels (for example `channel:telegram`, `provider:kimi`, `tool:shell`) and contributor tiers by merged PR count (`trusted` >=5, `experienced` >=10, `principal` >=20, `distinguished` >=50), while de-duplicating less-specific scope labels when a more specific module label is present.
 - For all module prefixes, module labels are compacted to reduce noise: one specific module keeps `prefix:component`, but multiple specifics collapse to the base scope label `prefix`.
 - Label ordering is priority-first: `risk:*` -> `size:*` -> contributor tier -> module/path labels.
 - Hovering a label in GitHub shows its auto-managed description (rule/threshold summary).


### PR DESCRIPTION
## Summary
- restore `trusted contributor` as an active contributor tier with threshold `>=5` in both label automation workflows
- keep contributor-tier colors unified as blue (`2ED9FF`) across `labeler` and `auto-response`
- update PR template and docs threshold text to match runtime behavior (`>=5/10/20/50`)

## Why
`trusted contributor` should be a real auto-assigned tier (not only a legacy label name), and color/threshold semantics must stay consistent across automation and docs.

## Scope
Workflow + docs/template consistency update only.
