### PR TITLE
fix(ci): add pull-requests:write to contributor-tier-issues job

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       issues: write
+      pull-requests: write
     steps:
       - name: Apply contributor tier label for issue author
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8


### PR DESCRIPTION
## Summary

- Add missing `pull-requests: write` permission to the `contributor-tier-issues` job in the Auto Response workflow
- The job triggers on `pull_request_target` events but only had `issues: write`, causing a 403 `Resource not accessible by integration` error when setting labels on PRs ([failed run](https://github.com/zeroclaw-labs/zeroclaw/actions/runs/22082558275/job/63810587516))
- The `first-interaction` and `labeled-routes` jobs already had both permissions

Fixes the failing check on #400.

## Test plan

- [x] Verified the GitHub API response requires `issues=write; pull_requests=write` (from the `x-accepted-github-permissions` header in the error log)
- [ ] CI passes on this PR
- [ ] After merge, re-run the Auto Response workflow on #400 to confirm it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)