### PR TITLE
fix(ci): pin Blacksmith GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Setup Blacksmith Builder
-              uses: useblacksmith/setup-docker-builder@v1
+              uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
 
             - name: Extract metadata (tags, labels)
               id: meta
@@ -46,7 +46,7 @@ jobs:
                       type=ref,event=pr
 
             - name: Build smoke image
-              uses: useblacksmith/build-push-action@v2
+              uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
               with:
                   context: .
                   push: false
@@ -71,7 +71,7 @@ jobs:
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Setup Blacksmith Builder
-              uses: useblacksmith/setup-docker-builder@v1
+              uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
 
             - name: Log in to Container Registry
               uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -102,7 +102,7 @@ jobs:
                   echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
             - name: Build and push Docker image
-              uses: useblacksmith/build-push-action@v2
+              uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
               with:
                   context: .
                   push: true


### PR DESCRIPTION
Closes #512

## Summary
- Pin `useblacksmith/setup-docker-builder` from `@v1` to `@ef12d5b1` (commit SHA)
- Pin `useblacksmith/build-push-action` from `@v2` to `@30c71162` (commit SHA)
- Prevents supply-chain attacks via tag mutation on third-party Actions

## Risk and Rollback
- **Risk:** Low — YAML-only change, no behavior change
- **Rollback:** Revert commit

## Test plan
- [ ] Docker workflow triggers successfully on PR
- [ ] No change in build behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)