### PR TITLE
fix(ci): pin sandbox Dockerfile base image to digest

### DIFF
--- a/dev/sandbox/Dockerfile
+++ b/dev/sandbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:c7eb020043d8fc2ae0793fb35a37bff1cf33f156d4d4b12ccc7f3ef8706c38b1
 
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Closes #513

## Summary
- Pin `ubuntu:22.04` to `sha256:c7eb020043d8...` manifest digest
- Ensures reproducible sandbox builds and prevents tag mutation

## Risk and Rollback
- **Risk:** Low — Dockerfile-only change
- **Rollback:** Revert commit

## Test plan
- [ ] Sandbox container builds successfully with pinned digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)