### PR TITLE
fix(channel:discord): use channel_id instead of author_id for reply routing

### DIFF
--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -352,7 +352,7 @@ impl Channel for DiscordChannel {
                         } else {
                             format!("discord_{message_id}")
                         },
-                        sender: author_id.to_string(),
+                        sender: channel_id.clone(),
                         content: content.to_string(),
                         channel: "discord".to_string(),
                         timestamp: std::time::SystemTime::now()


### PR DESCRIPTION
## Summary

- **Problem:** Discord channel replies always fail with `404 Unknown Channel` (error code 10003). The bot receives messages but can never respond.
- **Why it matters:** Discord channel is completely non-functional — zero messages can be delivered to users.
- **What changed:** In `src/channels/discord.rs`, `ChannelMessage.sender` is now populated with `channel_id` (the Discord channel where the message was sent) instead of `author_id` (the user who sent the message).
- **What did not change (scope boundary):** No changes to `ChannelMessage` struct, channel traits, or any other channel implementation. The fix is a single-line change isolated to Discord message construction.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel:discord`
- Contributor tier label: N/A (first contribution)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Related: Discord channel 404 "Unknown Channel" on every reply

## Validation Evidence (required)

Tested on a live deployment (Mac Mini, ZeroClaw daemon with Discord channel):

1. **Before fix:** Every Discord reply failed with:
   ```
   Failed to reply on discord: Discord send message failed (404 Not Found): {"message": "Unknown Channel", "code": 10003}
   ```
2. **After fix:** Bot correctly receives and replies to messages in Discord channels.

```bash
cargo build --release  # compiles without errors
# cargo fmt / clippy not run on deployment machine (no full toolchain)
```

- Evidence provided: Live deployment log showing successful message delivery after fix.
- If any command is intentionally skipped, explain why: `cargo fmt` and `cargo clippy` not available on deployment machine (Mac Mini). The change is a single-line substitution (`author_id.to_string()` → `channel_id.clone()`) with no formatting or lint implications.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Bot receiving @mention in a Discord guild text channel and replying successfully.
- Edge cases checked: Multiple messages in sequence, all replied correctly.
- What was not verified: DM channels (should work since DMs also have a channel_id).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Discord channel reply path only.
- Potential unintended effects: `msg.sender` is also used as a key for conversation dedup in `mod.rs` (`format!("{}_{}_{}", msg.channel, msg.sender, msg.id)`). Using `channel_id` instead of `author_id` means conversations are now keyed per-channel rather than per-user. This is arguably more correct for guild channels where multiple users interact in the same channel.
- Guardrails/monitoring for early detection: Discord reply errors are already logged.

## Rollback Plan (required)

- Fast rollback command/path: Revert this single commit.
- Feature flags or config toggles: None needed.
- Observable failure symptoms: 404 "Unknown Channel" errors in daemon logs on every Discord reply.

## Risks and Mitigations

- Risk: Conversation dedup key changes from per-user to per-channel.
  - Mitigation: This is more correct for guild text channels. Per-user conversation tracking in shared channels was not meaningful anyway.