### PR TITLE
fix(ci): sync devsecops with main and repair auto-response workflow

### DIFF
--- a/.github/workflows/auto-response.yml
+++ b/.github/workflows/auto-response.yml
@@ -36,11 +36,7 @@ jobs:
               { label: "trusted contributor", minMergedPRs: 5 },
             ];
             const contributorTierLabels = contributorTierRules.map((rule) => rule.label);
-<<<<<<< chore/labeler-spacing-trusted-tier
-            const contributorTierColor = "39FF14";
-=======
             const contributorTierColor = "2ED9FF"; // Keep in sync with .github/workflows/labeler.yml
->>>>>>> main
             const managedContributorLabels = new Set(contributorTierLabels);
             const action = context.payload.action;
             const changedLabel = context.payload.label?.name;


### PR DESCRIPTION
## Summary
- sync `devsecops` with latest `main`
- resolve merge conflict markers in `.github/workflows/auto-response.yml`
- align contributor tier label color with `.github/workflows/labeler.yml` (`2ED9FF`)

## Validation
- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.11`
- contributor-tier parity check script (same logic as workflow-sanity)

## Risk
- low (workflow-only fix)

## Rollback
- revert commit `eb88218`
