### PR TITLE
fix(dingtalk,daemon): process stream callbacks and supervise DingTalk channel

### DIFF
--- a/src/channels/dingtalk.rs
+++ b/src/channels/dingtalk.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 
 const DINGTALK_BOT_CALLBACK_TOPIC: &str = "/v1.0/im/bot/messages/get";
 
-/// DingTalk (钉钉) channel — connects via Stream Mode WebSocket for real-time messages.
+/// DingTalk channel — connects via Stream Mode WebSocket for real-time messages.
 /// Replies are sent through per-message session webhook URLs.
 pub struct DingTalkChannel {
     client_id: String,


### PR DESCRIPTION
## Summary
- include DingTalk in daemon supervised channel detection so `zeroclaw daemon` starts the channel supervisor when only DingTalk is configured
- subscribe to DingTalk bot callback topic during gateway registration
- handle both `CALLBACK` and `EVENT` stream frame types
- support both string and object payload shapes for `data`
- improve webhook key routing so private/group replies both resolve session webhooks

## Why
DingTalk channel could appear healthy and connected, but user messages were not processed/replied in daemon mode due to missing supervision and incomplete stream callback handling.

## Validation
- `cargo test parse_stream_data_supports_string_payload --package zeroclaw`
- `cargo test parse_stream_data_supports_object_payload --package zeroclaw`
- `cargo test resolve_chat_id_handles_numeric_group_conversation_type --package zeroclaw`
- manually verified service startup and DingTalk channel connection via `systemctl --user status zeroclaw.service` and `journalctl --user-unit zeroclaw.service`

## Risk
- low to medium: changes are scoped to DingTalk channel parsing/routing and daemon channel detection

## Rollback
- revert this PR commit to restore previous behavior
