### PR TITLE
fix(build): resolve ChannelMessage reply_target regression (fixes #537)

### DIFF
--- a/src/channels/cli.rs
+++ b/src/channels/cli.rs
@@ -40,7 +40,7 @@ impl Channel for CliChannel {
             let msg = ChannelMessage {
                 id: Uuid::new_v4().to_string(),
                 sender: "user".to_string(),
-                reply_to: "user".to_string(),
+                reply_target: "user".to_string(),
                 content: line,
                 channel: "cli".to_string(),
                 timestamp: std::time::SystemTime::now()

--- a/src/channels/dingtalk.rs
+++ b/src/channels/dingtalk.rs
@@ -238,7 +238,7 @@ impl Channel for DingTalkChannel {
                     let channel_msg = ChannelMessage {
                         id: Uuid::new_v4().to_string(),
                         sender: sender_id.to_string(),
-                        reply_to: chat_id,
+                        reply_target: chat_id,
                         content: content.to_string(),
                         channel: "dingtalk".to_string(),
                         timestamp: std::time::SystemTime::now()

--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -450,7 +450,7 @@ impl LarkChannel {
                     let channel_msg = ChannelMessage {
                         id: Uuid::new_v4().to_string(),
                         sender: lark_msg.chat_id.clone(),
-                        reply_to: lark_msg.chat_id.clone(),
+                        reply_target: lark_msg.chat_id.clone(),
                         content: text,
                         channel: "lark".to_string(),
                         timestamp: std::time::SystemTime::now()

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -709,7 +709,7 @@ async fn handle_whatsapp_message(
         {
             Ok(response) => {
                 // Send reply via WhatsApp
-                if let Err(e) = wa.send(&response, &msg.reply_to).await {
+                if let Err(e) = wa.send(&response, &msg.reply_target).await {
                     tracing::error!("Failed to send WhatsApp reply: {e}");
                 }
             }
@@ -718,7 +718,7 @@ async fn handle_whatsapp_message(
                 let _ = wa
                     .send(
                         "Sorry, I couldn't process your message right now.",
-                        &msg.reply_to,
+                        &msg.reply_target,
                     )
                     .await;
             }


### PR DESCRIPTION
## Summary
- restore `ChannelMessage.reply_target` usage in channel and gateway call sites
- remove stale `reply_to` field accesses that broke Linux builds
- resolve compile failures reported in issue #537

## Files changed
- `src/channels/cli.rs`
- `src/channels/dingtalk.rs`
- `src/channels/lark.rs`
- `src/gateway/mod.rs`

## Validation
- `./dev/ci.sh build` (Dockerized release build) passes

## Fixes
- Closes #537
