### PR TITLE
fix(build): complete strict lint/test cleanup (replacement for #476)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -7,6 +7,7 @@ pub mod prompt;
 
 #[allow(unused_imports)]
 pub use agent::{Agent, AgentBuilder};
+#[allow(unused_imports)]
 pub use loop_::{process_message, run};
 
 #[cfg(test)]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -124,18 +124,13 @@ fn default_max_depth() -> u32 {
 // ── Hardware Config (wizard-driven) ─────────────────────────────
 
 /// Hardware transport mode.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum HardwareTransport {
+    #[default]
     None,
     Native,
     Serial,
     Probe,
-}
-
-impl Default for HardwareTransport {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 impl std::fmt::Display for HardwareTransport {
@@ -407,7 +402,7 @@ fn get_default_pricing() -> std::collections::HashMap<String, ModelPricing> {
 
 // ── Peripherals (hardware: STM32, RPi GPIO, etc.) ────────────────────────
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct PeripheralsConfig {
     /// Enable peripheral support (boards become agent tools)
     #[serde(default)]
@@ -442,16 +437,6 @@ fn default_peripheral_transport() -> String {
 
 fn default_peripheral_baud() -> u32 {
     115_200
-}
-
-impl Default for PeripheralsConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            boards: Vec::new(),
-            datasheet_dir: None,
-        }
-    }
 }
 
 impl Default for PeripheralBoardConfig {
@@ -710,6 +695,7 @@ fn default_http_timeout_secs() -> u64 {
 // ── Memory ───────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct MemoryConfig {
     /// "sqlite" | "lucid" | "markdown" | "none" (`none` = explicit no-op memory)
     pub backend: String,

--- a/src/memory/snapshot.rs
+++ b/src/memory/snapshot.rs
@@ -9,6 +9,7 @@
 use anyhow::Result;
 use chrono::Local;
 use rusqlite::{params, Connection};
+use std::fmt::Write;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -63,18 +64,17 @@ pub fn export_snapshot(workspace_dir: &Path) -> Result<usize> {
     output.push_str(SNAPSHOT_HEADER);
 
     let now = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
-    output.push_str(&format!("**Last exported:** {now}\n\n"));
-    output.push_str(&format!(
-        "**Total core memories:** {}\n\n---\n\n",
-        rows.len()
-    ));
+    write!(output, "**Last exported:** {now}\n\n").unwrap();
+    write!(output, "**Total core memories:** {}\n\n---\n\n", rows.len()).unwrap();
 
     for (key, content, _category, created_at, updated_at) in &rows {
-        output.push_str(&format!("### 🔑 `{key}`\n\n"));
-        output.push_str(&format!("{content}\n\n"));
-        output.push_str(&format!(
+        write!(output, "### 🔑 `{key}`\n\n").unwrap();
+        write!(output, "{content}\n\n").unwrap();
+        write!(
+            output,
             "*Created: {created_at} | Updated: {updated_at}*\n\n---\n\n"
-        ));
+        )
+        .unwrap();
     }
 
     let snapshot_path = snapshot_path(workspace_dir);

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -5,11 +5,14 @@ pub mod otel;
 pub mod traits;
 pub mod verbose;
 
+#[allow(unused_imports)]
 pub use self::log::LogObserver;
+#[allow(unused_imports)]
 pub use self::multi::MultiObserver;
 pub use noop::NoopObserver;
 pub use otel::OtelObserver;
 pub use traits::{Observer, ObserverEvent};
+#[allow(unused_imports)]
 pub use verbose::VerboseObserver;
 
 use crate::config::ObservabilityConfig;

--- a/src/peripherals/arduino_flash.rs
+++ b/src/peripherals/arduino_flash.rs
@@ -41,7 +41,6 @@ pub fn ensure_arduino_cli() -> Result<()> {
         if !arduino_cli_available() {
             anyhow::bail!("arduino-cli still not found after install. Ensure it's in PATH.");
         }
-        return Ok(());
     }
 
     #[cfg(target_os = "linux")]
@@ -58,6 +57,9 @@ pub fn ensure_arduino_cli() -> Result<()> {
         println!("arduino-cli not found. Install it: https://arduino.github.io/arduino-cli/");
         anyhow::bail!("arduino-cli not installed.");
     }
+
+    #[allow(unreachable_code)]
+    Ok(())
 }
 
 /// Ensure arduino:avr core is installed.

--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -412,10 +412,7 @@ impl Provider for ReliableProvider {
 
             // Convert channel receiver to stream
             return stream::unfold(rx, |mut rx| async move {
-                match rx.recv().await {
-                    Some(chunk) => Some((chunk, rx)),
-                    None => None,
-                }
+                rx.recv().await.map(|chunk| (chunk, rx))
             })
             .boxed();
         }

--- a/src/providers/traits.rs
+++ b/src/providers/traits.rs
@@ -140,7 +140,7 @@ impl StreamChunk {
 
     /// Estimate tokens (rough approximation: ~4 chars per token).
     pub fn with_token_estimate(mut self) -> Self {
-        self.token_count = (self.delta.len() + 3) / 4;
+        self.token_count = self.delta.len().div_ceil(4);
         self
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -49,6 +49,7 @@ pub use memory_recall::MemoryRecallTool;
 pub use memory_store::MemoryStoreTool;
 pub use pushover::PushoverTool;
 pub use schedule::ScheduleTool;
+#[allow(unused_imports)]
 pub use schema::{CleaningStrategy, SchemaCleanr};
 pub use screenshot::ScreenshotTool;
 pub use shell::ShellTool;

--- a/src/tools/schema.rs
+++ b/src/tools/schema.rs
@@ -103,7 +103,7 @@ pub enum CleaningStrategy {
 
 impl CleaningStrategy {
     /// Get the list of unsupported keywords for this strategy.
-    pub fn unsupported_keywords(&self) -> &'static [&'static str] {
+    pub fn unsupported_keywords(self) -> &'static [&'static str] {
         match self {
             Self::Gemini => GEMINI_UNSUPPORTED_KEYWORDS,
             Self::Anthropic => &["$ref", "$defs", "definitions"], // Anthropic doesn't resolve refs


### PR DESCRIPTION
## Supersedes
- #476 (closed due conflicts and stale base)

## Integrated scope (current diff vs `main`)
- `src/config/schema.rs`: derive-based defaults and targeted clippy allowance to keep schema stable.
- `src/memory/snapshot.rs`: replace `format!` + `push_str` chains with `write!` calls.
- `src/peripherals/arduino_flash.rs`: remove unreachable early return and keep explicit tail `Ok(())`.
- `src/providers/reliable.rs`: simplify stream unfold (`manual_map`).
- `src/providers/traits.rs`: use `.div_ceil(4)` token estimate.
- `src/agent/mod.rs`, `src/observability/mod.rs`, `src/tools/mod.rs`: explicit `unused_imports` allows for intentional public re-exports.
- `src/tools/schema.rs`: make `unsupported_keywords` take `self` by value for Copy enum.

## Validation status
- CI passed on latest head:
  - `Format & Lint`
  - `Build (Smoke)`
  - `Test`
  - `Lint Strict Delta`
  - `Security Audit`
  - `License & Supply Chain`
  - `CI Required Gate`
- Local spot-check completed:
  - `cargo fmt --all -- --check`

## Non-goals
- No feature expansion.
- No rebranding/content churn.
- No architecture surface changes.

## Attribution note
- This replacement PR is a fresh integration on top of current `main`; no direct commit cherry-pick was used from #476.