### PR TITLE
fix(templates): quote Yes/No dropdown options in feature_request.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -91,8 +91,8 @@ body:
     attributes:
       label: Breaking change?
       options:
-        - No
-        - Yes
+        - "No"
+        - "Yes"
     validations:
       required: true
 


### PR DESCRIPTION
YAML 1.1 (used by GitHub's template parser) interprets bare Yes and No as boolean values (true/false) rather than strings. This caused GitHub to silently reject the feature_request.yml issue form template during validation, preventing it from appearing in the issue template chooser.

The fix quotes both values ("Yes" and "No") in the 'Breaking change?' dropdown so they are unambiguously parsed as strings, satisfying GitHub's schema requirement that dropdown options must be string-typed.

Root cause confirmed by loading the template with PyYAML (which also implements YAML 1.1): the unquoted options were deserialized as Python bool (True/False) instead of str. After quoting, they deserialize as strings as expected.

Ref: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms


https://github.com/zeroclaw-labs/zeroclaw/issues/576