### PR TITLE
fix(container): address some docker container anti-patterns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     cargo build --release --locked
 RUN rm -rf src
 
-# 2. Copy source code
-COPY . .
+# 2. Copy only build-relevant source paths (avoid cache-busting on docs/tests/scripts)
+COPY src/ src/
+COPY firmware/ firmware/
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
@@ -31,14 +32,10 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     cp target/release/zeroclaw /app/zeroclaw && \
     strip /app/zeroclaw
 
-# ── Stage 2: Permissions & Config Prep ───────────────────────
-FROM busybox:1.37@sha256:b3255e7dfbcd10cb367af0d409747d511aeb66dfac98cf30e97e87e4207dd76f AS permissions
-# Create directory structure (simplified workspace path)
-RUN mkdir -p /zeroclaw-data/.zeroclaw /zeroclaw-data/workspace
-
-# Create minimal config for PRODUCTION (allows binding to public interfaces)
-# NOTE: Provider configuration must be done via environment variables at runtime
-RUN cat > /zeroclaw-data/.zeroclaw/config.toml <<EOF
+# Prepare runtime directory structure and default config inline (no extra stage)
+RUN mkdir -p /zeroclaw-data/.zeroclaw /zeroclaw-data/workspace && \
+    cat > /zeroclaw-data/.zeroclaw/config.toml <<EOF && \
+    chown -R 65534:65534 /zeroclaw-data
 workspace_dir = "/zeroclaw-data/workspace"
 config_path = "/zeroclaw-data/.zeroclaw/config.toml"
 api_key = ""
@@ -52,22 +49,16 @@ host = "[::]"
 allow_public_bind = true
 EOF
 
-RUN chown -R 65534:65534 /zeroclaw-data
-
-# ── Stage 3: Development Runtime (Debian) ────────────────────
+# ── Stage 2: Development Runtime (Debian) ────────────────────
 FROM debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba AS dev
 
-# Install runtime dependencies + basic debug tools
+# Install essential runtime dependencies only (use docker-compose.override.yml for dev tools)
 RUN apt-get update && apt-get install -y \
     ca-certificates \
-    openssl \
     curl \
-    git \
-    iputils-ping \
-    vim \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=permissions /zeroclaw-data /zeroclaw-data
+COPY --from=builder /zeroclaw-data /zeroclaw-data
 COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
 
 # Overwrite minimal config with DEV template (Ollama defaults)
@@ -92,11 +83,11 @@ EXPOSE 3000
 ENTRYPOINT ["zeroclaw"]
 CMD ["gateway", "--port", "3000", "--host", "[::]"]
 
-# ── Stage 4: Production Runtime (Distroless) ─────────────────
+# ── Stage 3: Production Runtime (Distroless) ─────────────────
 FROM gcr.io/distroless/cc-debian13:nonroot@sha256:84fcd3c223b144b0cb6edc5ecc75641819842a9679a3a58fd6294bec47532bf7 AS release
 
 COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
-COPY --from=permissions /zeroclaw-data /zeroclaw-data
+COPY --from=builder /zeroclaw-data /zeroclaw-data
 
 # Environment setup
 ENV ZEROCLAW_WORKSPACE=/zeroclaw-data/workspace

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,10 +49,11 @@ services:
           cpus: '0.5'
           memory: 512M
 
-    # Health check
+    # Health check — uses lightweight status instead of full diagnostics.
+    # For images with curl, prefer: curl -f http://localhost:3000/health
     healthcheck:
-      test: ["CMD", "zeroclaw", "doctor"]
-      interval: 30s
+      test: ["CMD", "zeroclaw", "status"]
+      interval: 60s
       timeout: 10s
       retries: 3
       start_period: 10s


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: The container build and runtime flow used broad copy patterns, an extra permissions stage, and a heavy healthcheck command for compose.
- Why it matters: This reduced Docker layer cache efficiency, increased image maintenance surface, and made container health probes slower/more expensive.
- What changed: The build stage now copies only `src/` and `firmware/`, prepares runtime data/config inline in `builder`, removes non-essential dev image packages, and switches compose healthcheck from `zeroclaw doctor` to `zeroclaw status` with a 60s interval.
- What did **not** change (scope boundary): No Rust source behavior, no gateway/security policy logic, and no new config keys/features.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `dev`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `dev:docker`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `refactor`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `runtime`

## Linked Issue

- Closes # N/A
- Related # N/A
- Depends on # (if stacked) N/A
- Supersedes # (if replacing older PR) N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
./scripts/ci/rust_quality_gate.sh
./scripts/ci/rust_strict_delta_gate.sh
./scripts/ci/docs_quality_gate.sh
cargo test --locked --workspace --all-targets
cargo run --locked -- status
```

- Evidence provided (test/log/trace/screenshot/perf):
  - `rust_quality_gate`: pass
  - `rust_strict_delta_gate`: pass (no Rust source deltas)
  - `docs_quality_gate`: pass (no docs deltas)
  - `cargo test --locked --workspace --all-targets`: pass
  - `cargo run --locked -- status`: pass (exit 0)
- If any command is intentionally skipped, explain why:
  - Docker smoke build command was attempted locally, but local Docker daemon was unresponsive on this workstation (`docker.sock` request canceled). CI `PR Docker Smoke` remains the authoritative container build validation for this change.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no personal/sensitive data introduced
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - CLI `status` command exits successfully for lightweight health probing path.
  - Container-file diffs are limited to Docker build/runtime optimization and compose healthcheck tuning.
- Edge cases checked:
  - Compile-time embedded firmware assets remain covered by `COPY firmware/`.
  - No non-English strings introduced in changed content.
- What was not verified:
  - Full local Docker build+run due local daemon availability issue (covered in CI).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
  - `Dockerfile` multi-stage build flow
  - `docker-compose.yml` healthcheck command/interval
- Potential unintended effects:
  - Development containers may miss previously bundled convenience tools (`vim`, `git`, `iputils-ping`, `openssl`).
- Guardrails/monitoring for early detection:
  - CI Docker smoke build plus startup healthcheck behavior in compose deployments.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `gh` CLI, local CI scripts
- Workflow/plan summary (if any): metadata review -> policy gate -> duplicate scan -> local validation -> intake template completion
- Verification focus: container build-path correctness and healthcheck safety
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed

## Rollback Plan (required)

- Fast rollback command/path:
  - `git revert <merge_commit_sha>`
- Feature flags or config toggles (if any): none
- Observable failure symptoms:
  - Docker build failures due missing copied assets
  - Compose healthcheck reports container as unhealthy unexpectedly

## Risks and Mitigations

- Risk: Removing extra packages from the dev image may surprise workflows depending on those tools.
  - Mitigation: Document/use `docker-compose.override.yml` for dev-only tooling, keep runtime image minimal by default.

<!-- intake-refresh: 2026-02-18T02:25Z -->
