### PR TITLE
ci: remove lint-strict-delta dependency from test and build jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,8 +167,8 @@ jobs:
 
     test:
         name: Test
-        needs: [changes, lint, lint-strict-delta]
-        if: needs.changes.outputs.rust_changed == 'true' && needs.lint.result == 'success' && needs.lint-strict-delta.result == 'success'
+        needs: [changes, lint]
+        if: needs.changes.outputs.rust_changed == 'true' && needs.lint.result == 'success'
         runs-on: blacksmith-2vcpu-ubuntu-2404
         timeout-minutes: 30
         steps:
@@ -182,8 +182,8 @@ jobs:
 
     build:
         name: Build (Smoke)
-        needs: [changes, lint, lint-strict-delta]
-        if: needs.changes.outputs.rust_changed == 'true' && needs.lint.result == 'success' && needs.lint-strict-delta.result == 'success'
+        needs: [changes, lint]
+        if: needs.changes.outputs.rust_changed == 'true' && needs.lint.result == 'success'
         runs-on: blacksmith-2vcpu-ubuntu-2404
         timeout-minutes: 20
 


### PR DESCRIPTION
Remove lint-strict-delta from the needs and if conditions of the test and build jobs so they can start as soon as lint (and changes) complete, rather than waiting for lint-strict-delta to also finish. This allows test, build, and lint-strict-delta to run in parallel after lint passes, reducing overall pipeline wall-clock time.

lint-strict-delta is still evaluated by lint-feedback and ci-status-gate, so its results are not lost.


From my anti-pattern analysis:

### Overly Sequential CI Pipeline

In `.github/workflows/ci.yml`, `test` and `build` jobs both depend on
**both** `lint` and `lint-strict-delta` completing successfully (line 170–171,
185–186). Since `test` and `build` are independent of each other and each lint
job is independent, this creates an unnecessary serial bottleneck:

```
changes → lint ──────────┐
                         ├→ test
changes → lint-strict-delta ──┤
                         └→ build
```

**Why it matters:** A 5-minute lint job delays both test and build even though
they could start once their specific lint dependency passes.

**Recommendation:** Allow `test` and `build` to depend on `lint` alone (or use
a single combined lint job), and run them in parallel.
