### PR TITLE
fix(ci): add retention policy to release build artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
               with:
                   name: zeroclaw-${{ matrix.target }}
                   path: zeroclaw-${{ matrix.target }}.*
+                  retention-days: 7
 
     publish:
         name: Publish Release


### PR DESCRIPTION
The upload-artifact step in the release workflow had no retention-days set, causing intermediate build artifacts to persist at the repository default of 90 days and consuming storage unnecessarily.

Add retention-days: 7 since these are intermediate artifacts consumed by the publish job in the same workflow run — they do not need long-term retention.