### PR TITLE
fix(ci): remove hardcoded cargo-audit version pin

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,7 @@ jobs:
             timeout_minutes: 20
             toolchain: stable
             run_command: |
-                cargo install --locked cargo-audit --version 0.22.1
+                cargo install --locked cargo-audit
                 cargo audit
 
     deny:


### PR DESCRIPTION
The security workflow pinned cargo-audit to version 0.22.1, which silently falls behind on advisory database and tooling updates.

Remove the --version flag so 'cargo install --locked cargo-audit' always fetches the latest release. The --locked flag still ensures reproducible builds from upstream's Cargo.lock.

A rustsec/audit-check action was considered but is not on the repository's actions-source-policy allowlist, so the simplest fix is to unpin the version.