### PR TITLE
fix(ci): correct release matrix target triple for ubuntu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
             matrix:
                 include:
                     - os: ubuntu-latest
-                      target: blacksmith-2vcpu-ubuntu-2404
+                      target: x86_64-unknown-linux-gnu
                       artifact: zeroclaw
                     - os: macos-latest
                       target: x86_64-apple-darwin


### PR DESCRIPTION
The ubuntu-latest matrix entry had its target set to 'blacksmith-2vcpu-ubuntu-2404', which is a runner label — not a valid Rust target triple. This causes 'cargo build --target' to fail or produce artifacts for the wrong architecture.

Replace with 'x86_64-unknown-linux-gnu', the correct Rust target triple for the ubuntu runner.