### PR TITLE
ci(release): add concurrency group to prevent duplicate release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
         tags: ["v*"]
 
 concurrency:
-    group: release-${{ github.ref }}
+    group: release
     cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
When two tags are pushed in quick succession, the release workflow could run concurrently, producing corrupted or incomplete GitHub releases.

Add a concurrency group scoped to the tag ref so that release runs for the same tag are serialized. cancel-in-progress is set to false to ensure a running release completes rather than being aborted.