### PR TITLE
ci(security): pin rustsec audit action and supersede #588

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,6 +16,7 @@ permissions:
     contents: read
     security-events: write
     actions: read
+    checks: write
 
 env:
     CARGO_TERM_COLOR: always
@@ -23,13 +24,14 @@ env:
 jobs:
     audit:
         name: Security Audit
-        uses: ./.github/workflows/rust-reusable.yml
-        with:
-            timeout_minutes: 20
-            toolchain: stable
-            run_command: |
-                cargo install --locked cargo-audit --version 0.22.1
-                cargo audit
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        timeout-minutes: 20
+        steps:
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+            - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
 
     deny:
         name: License & Supply Chain

--- a/docs/actions-source-policy.md
+++ b/docs/actions-source-policy.md
@@ -19,6 +19,7 @@ Selected allowlist patterns:
 - `DavidAnson/markdownlint-cli2-action@*`
 - `lycheeverse/lychee-action@*`
 - `EmbarkStudios/cargo-deny-action@*`
+- `rustsec/audit-check@*`
 - `rhysd/actionlint@*`
 - `softprops/action-gh-release@*`
 - `sigstore/cosign-installer@*`
@@ -79,6 +80,10 @@ Latest sweep notes:
 - 2026-02-16: Blacksmith migration blocked workflow execution
     - Added allowlist pattern: `useblacksmith/*` for self-hosted runner infrastructure
     - Actions: `useblacksmith/setup-docker-builder@v1`, `useblacksmith/build-push-action@v2`
+- 2026-02-17: Security audit reproducibility/freshness balance update
+    - Added allowlist pattern: `rustsec/audit-check@*`
+    - Replaced inline `cargo install cargo-audit` execution with pinned `rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998` in `security.yml`
+    - Supersedes floating-version proposal in #588 while keeping action source policy explicit
 
 ## Rollback
 

--- a/docs/ci-map.md
+++ b/docs/ci-map.md
@@ -24,7 +24,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - `.github/workflows/docker.yml` (`Docker`)
     - Purpose: PR docker smoke check and publish images on `main`/tag pushes
 - `.github/workflows/security.yml` (`Security Audit`)
-    - Purpose: dependency advisories (`cargo audit`) and policy/license checks (`cargo deny`)
+    - Purpose: dependency advisories (`rustsec/audit-check`, pinned SHA) and policy/license checks (`cargo deny`)
 - `.github/workflows/release.yml` (`Release`)
     - Purpose: build tagged release artifacts and publish GitHub releases
 - `.github/workflows/label-policy-sanity.yml` (`Label Policy Sanity`)


### PR DESCRIPTION
## Supersedes
- #588 by @agorevski

## Integrated Scope
- Replaces the `cargo install cargo-audit` step in `.github/workflows/security.yml` with pinned `rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998`.
- Preserves deterministic CI behavior by pinning a full action SHA (no floating tool install in merge-blocking paths).
- Updates actions source policy docs and live repository selected-actions allowlist to include `rustsec/audit-check@*`.

## Attribution
- Co-authored-by trailers added for materially incorporated contributors: No
- Rationale: no direct code/design was copied from #588; this is an alternative implementation for the same problem statement.

## Risk and Rollback
- Risk: low; scoped to security workflow action source.
- Rollback: revert this PR commit or switch `security.yml` audit job back to the previous implementation.

## Validation
- `actionlint` passed for updated workflow files.
- Repository selected-actions policy verified includes `rustsec/audit-check@*`.
