### PR TITLE
fix(providers): clarify reliable failure entries for custom providers

### DIFF
--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -194,7 +194,7 @@ impl Provider for ReliableProvider {
                                 "retryable"
                             };
                             failures.push(format!(
-                                "{provider_name}/{current_model} attempt {}/{}: {failure_reason}",
+                                "provider={provider_name} model={current_model} attempt {}/{}: {failure_reason}",
                                 attempt + 1,
                                 self.max_retries + 1
                             ));
@@ -299,7 +299,7 @@ impl Provider for ReliableProvider {
                                 "retryable"
                             };
                             failures.push(format!(
-                                "{provider_name}/{current_model} attempt {}/{}: {failure_reason}",
+                                "provider={provider_name} model={current_model} attempt {}/{}: {failure_reason}",
                                 attempt + 1,
                                 self.max_retries + 1
                             ));
@@ -610,8 +610,8 @@ mod tests {
             .expect_err("all providers should fail");
         let msg = err.to_string();
         assert!(msg.contains("All providers/models failed"));
-        assert!(msg.contains("p1"));
-        assert!(msg.contains("p2"));
+        assert!(msg.contains("provider=p1 model=test"));
+        assert!(msg.contains("provider=p2 model=test"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- confirms `custom:https://...` providers already route through OpenAI-compatible `/chat/completions` with `model` in JSON body
- updates resilient provider failure formatting to avoid misleading `provider/model` path-style entries
- failure entries now use explicit key/value form: `provider=<name> model=<name>`

## Why
Issue #580 reports that logs look like custom provider URL path concatenation (`custom:https://.../glm-...`).
That behavior is log formatting ambiguity, not request URL construction. This patch removes the ambiguity.

## Validation
- Ran targeted provider test in repo CI container:
  - `docker compose -f dev/docker-compose.ci.yml run --rm local-ci cargo test returns_aggregated_error_when_all_providers_fail --lib`
  - result: pass
- Note: `--locked` variant failed due lockfile drift in current main branch state.
