### PR TITLE
fix(security): harden shell path and variable expansion checks

### DIFF
--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -23,6 +23,64 @@ pub struct ShellTool {
     runtime: Arc<dyn RuntimeAdapter>,
 }
 
+fn is_env_assignment(word: &str) -> bool {
+    word.contains('=')
+        && word
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+}
+
+fn strip_wrapping_quotes(token: &str) -> &str {
+    token.trim_matches(|c| c == '"' || c == '\'')
+}
+
+fn forbidden_path_argument(security: &SecurityPolicy, command: &str) -> Option<String> {
+    let mut normalized = command.to_string();
+    for sep in ["&&", "||"] {
+        normalized = normalized.replace(sep, "\x00");
+    }
+    for sep in ['\n', ';', '|'] {
+        normalized = normalized.replace(sep, "\x00");
+    }
+
+    for segment in normalized.split('\x00') {
+        let tokens: Vec<&str> = segment.split_whitespace().collect();
+        if tokens.is_empty() {
+            continue;
+        }
+
+        // Skip leading env assignments and executable token.
+        let mut idx = 0;
+        while idx < tokens.len() && is_env_assignment(tokens[idx]) {
+            idx += 1;
+        }
+        if idx >= tokens.len() {
+            continue;
+        }
+        idx += 1;
+
+        for token in &tokens[idx..] {
+            let candidate = strip_wrapping_quotes(token);
+            if candidate.is_empty() || candidate.starts_with('-') || candidate.contains("://") {
+                continue;
+            }
+
+            let looks_like_path = candidate.starts_with('/')
+                || candidate.starts_with("./")
+                || candidate.starts_with("../")
+                || candidate.starts_with("~/")
+                || candidate.contains('/');
+
+            if looks_like_path && !security.is_path_allowed(candidate) {
+                return Some(candidate.to_string());
+            }
+        }
+    }
+
+    None
+}
+
 impl ShellTool {
     pub fn new(security: Arc<SecurityPolicy>, runtime: Arc<dyn RuntimeAdapter>) -> Self {
         Self { security, runtime }
@@ -112,6 +170,14 @@ impl Tool for ShellTool {
                     error: Some(reason),
                 });
             }
+        }
+
+        if let Some(path) = forbidden_path_argument(&self.security, command) {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Path blocked by security policy: {path}")),
+            });
         }
 
         if !self.security.record_action() {
@@ -296,6 +362,21 @@ mod tests {
         assert!(!result.success);
     }
 
+    #[tokio::test]
+    async fn shell_blocks_absolute_path_argument() {
+        let tool = ShellTool::new(test_security(AutonomyLevel::Supervised), test_runtime());
+        let result = tool
+            .execute(json!({"command": "cat /etc/passwd"}))
+            .await
+            .expect("absolute path argument should be blocked");
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("Path blocked"));
+    }
+
     fn test_security_with_env_cmd() -> Arc<SecurityPolicy> {
         Arc::new(SecurityPolicy {
             autonomy: AutonomyLevel::Supervised,
@@ -361,28 +442,37 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shell_preserves_path_and_home() {
+    async fn shell_preserves_path_and_home_for_env_command() {
         let tool = ShellTool::new(test_security_with_env_cmd(), test_runtime());
 
         let result = tool
+            .execute(json!({"command": "env"}))
+            .await
+            .expect("env command should succeed");
+        assert!(result.success);
+        assert!(
+            result.output.contains("HOME="),
+            "HOME should be available in shell environment"
+        );
+        assert!(
+            result.output.contains("PATH="),
+            "PATH should be available in shell environment"
+        );
+    }
+
+    #[tokio::test]
+    async fn shell_blocks_plain_variable_expansion() {
+        let tool = ShellTool::new(test_security_with_env_cmd(), test_runtime());
+        let result = tool
             .execute(json!({"command": "echo $HOME"}))
             .await
-            .expect("echo HOME command should succeed");
-        assert!(result.success);
-        assert!(
-            !result.output.trim().is_empty(),
-            "HOME should be available in shell"
-        );
-
-        let result = tool
-            .execute(json!({"command": "echo $PATH"}))
-            .await
-            .expect("echo PATH command should succeed");
-        assert!(result.success);
-        assert!(
-            !result.output.trim().is_empty(),
-            "PATH should be available in shell"
-        );
+            .expect("plain variable expansion should be blocked");
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("not allowed"));
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
## Summary

- Problem: `shell` execution allowed workspace-escape path arguments and plain shell variable expansion (`$VAR`) that could bypass path safety intent.
- Why it matters: allowed commands like `cat` could be used to target sensitive files outside workspace policy.
- What changed: added explicit plain variable-expansion blocking in command policy, added path-like argument validation in `ShellTool`, added regression tests, and aligned repo baseline files required by current CI gates (`Cargo.lock` sync + rustfmt output for `src/service/mod.rs`).
- What did **not** change (scope boundary): no changes to provider/channel/runtime behavior, no new config keys, no gateway/cron behavior changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: M`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `security,tool,service,dependencies,tests,ci`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `tool:shell,security:policy,service:autostart`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `security`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #597
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): n/a
- Integrated scope by source PR (what was materially carried forward): n/a
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): n/a
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): n/a
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): n/a

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
./scripts/ci/rust_strict_delta_gate.sh
./scripts/ci/rust_quality_gate.sh
./scripts/ci/docs_quality_gate.sh
```

- Evidence provided (test/log/trace/screenshot/perf): all commands above completed successfully in this workspace.
- If any command is intentionally skipped, explain why: full `cargo test` run not separately executed because CI already validated `Test` gate on this PR.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `Yes` (narrowed)
- If any `Yes`, describe risk and mitigation: file access via `shell` command arguments is now stricter (blocks disallowed path-like args), reducing exfiltration surface.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no personal/sensitive data added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `No` (intentional tightening)
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: command policy now rejects plain `$VAR` expansion; `shell` path argument guard rejects forbidden absolute paths.
- Edge cases checked: env assignment prefix parsing remains supported; safe env vars still present for `env` command output.
- What was not verified: additional non-Rust paths unrelated to this change.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `security::policy` command checks, `tools::shell` execution preflight, plus baseline formatting/lockfile CI alignment.
- Potential unintended effects: legitimate shell commands that rely on variable expansion may now be blocked.
- Guardrails/monitoring for early detection: regression tests added and CI gates now pass fully on this PR.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local shell, git, gh CLI.
- Workflow/plan summary (if any): revalidated issue, implemented hardening, added tests, fixed CI baseline drift, updated PR template-complete body.
- Verification focus: command-policy bypass vectors and workspace path boundaries.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert commits `ca9e192` and `8e6c839` from this PR.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: shell tool rejects commands using `$VAR` expansions that previously succeeded.

## Risks and Mitigations

- Risk: stricter command policy could block previously tolerated shell workflows.
  - Mitigation: scope is isolated, rollback is straightforward, and regression tests define intended strict behavior.
