### PR TITLE
docs(readme): restore donation links and polish hero intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@
   <a href="https://buymeacoffee.com/argenistherose"><img src="https://img.shields.io/badge/Buy%20Me%20a%20Coffee-Donate-yellow.svg?style=flat&logo=buy-me-a-coffee" alt="Buy Me a Coffee" /></a>
 </p>
 <p align="center">
-Built By Students and Members of the Harvard - MIT - Sundai.Club Communities.
+Built by students and members of the Harvard, MIT, and Sundai.Club communities.
 </p>
-Fast, small, and fully autonomous AI assistant infrastructure — deploy anywhere, swap anything.
 
-```
-~3.4MB binary · <10ms startup · 1,017 tests · 23+ providers · 8 traits · Pluggable everything
-```
+<p align="center">
+  <strong>Fast, small, and fully autonomous AI assistant infrastructure</strong><br />
+  Deploy anywhere. Swap anything.
+</p>
+
+<p align="center"><code>~3.4MB binary · &lt;10ms startup · 1,017 tests · 23+ providers · 8 traits · Pluggable everything</code></p>
 
 ### ✨ Features
 


### PR DESCRIPTION
## Summary
- restore Buy Me a Coffee links in README
- improve intro copy/layout below badges
- replace wide fenced stats block with centered inline code row to avoid awkward overflow rendering

## Validation Evidence (required)
- verified README sections render as intended in markdown source

## Security Impact (required)
- no security boundary or permission changes

## Privacy and Data Hygiene (required)
- no sensitive data introduced

## Rollback Plan (required)
- revert this PR commit if needed