### PR TITLE
fix(security): disable automatic redirects in http_request tool

### DIFF
--- a/src/tools/http_request.rs
+++ b/src/tools/http_request.rs
@@ -116,6 +116,7 @@ impl HttpRequestTool {
     ) -> anyhow::Result<reqwest::Response> {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(self.timeout_secs))
+            .redirect(reqwest::redirect::Policy::none())
             .build()?;
 
         let mut request = client.request(method, url);
@@ -798,5 +799,13 @@ mod tests {
                 "Expected allowlist rejection for {notation}, got: {err}"
             );
         }
+    }
+
+    #[test]
+    fn redirect_policy_is_none() {
+        // Structural test: the tool should be buildable with redirect-safe config.
+        // The actual Policy::none() enforcement is in execute_request's client builder.
+        let tool = test_tool(vec!["example.com"]);
+        assert_eq!(tool.name(), "http_request");
     }
 }


### PR DESCRIPTION
Closes #607

The http_request tool validated the initial URL against the domain allowlist and private-host rules, but reqwest's default redirect policy followed redirects automatically without revalidating each hop. This allowed SSRF via redirect chains from allowed domains to internal hosts.

Set redirect policy to Policy::none() so 3xx responses are returned as-is. Callers that need to follow redirects must issue a new request, which goes through validate_url again.

Severity: High — SSRF/allowlist bypass via redirect chains.