### PR TITLE
ci(release): add hard binary size gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,17 @@ jobs:
               if: runner.os != 'Windows'
               run: |
                   SIZE=$(stat -f%z target/${{ matrix.target }}/release/${{ matrix.artifact }} 2>/dev/null || stat -c%s target/${{ matrix.target }}/release/${{ matrix.artifact }})
-                  echo "Binary size: $((SIZE / 1024 / 1024))MB ($SIZE bytes)"
-                  if [ "$SIZE" -gt 5242880 ]; then
-                    echo "::warning::Binary exceeds 5MB target"
+                  SIZE_MB=$((SIZE / 1024 / 1024))
+                  echo "Binary size: ${SIZE_MB}MB ($SIZE bytes)"
+                  echo "### Binary Size: ${{ matrix.target }}" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- Size: ${SIZE_MB}MB ($SIZE bytes)" >> "$GITHUB_STEP_SUMMARY"
+                  if [ "$SIZE" -gt 15728640 ]; then
+                    echo "::error::Binary exceeds 15MB hard limit (${SIZE_MB}MB)"
+                    exit 1
+                  elif [ "$SIZE" -gt 5242880 ]; then
+                    echo "::warning::Binary exceeds 5MB target (${SIZE_MB}MB)"
+                  else
+                    echo "Binary size within target."
                   fi
 
             - name: Package (Unix)


### PR DESCRIPTION
Problem: The release workflow warns when binaries exceed 5MB but does not block the build. Since small binary size is a stated project goal (release profile uses opt-level="z", LTO, strip, panic=abort), size regressions can silently ship to users without any enforcement.

Solution: Convert the binary size check to a tiered gate:
- >5MB: emits a GitHub Actions warning (soft target, informational)
- >15MB: emits a GitHub Actions error and fails the build (hard limit)
- Adds a step summary with per-target binary size metrics for visibility in the Actions UI.

The 15MB hard limit provides headroom for legitimate growth while catching catastrophic regressions (e.g., debug symbols not stripped, accidental fat dependency additions).

Testing: Validated YAML syntax. The shell script logic is straightforward (stat + arithmetic comparison). The existing 
unner.os != 'Windows' guard is preserved.

Ref: zeroclaw-labs/zeroclaw#618 (item 3 — Binary Size Gating)