### PR TITLE
fix(security): enforce cron tool autonomy and approval gates

### DIFF
--- a/src/tools/cron_run.rs
+++ b/src/tools/cron_run.rs
@@ -250,4 +250,28 @@ mod tests {
             .unwrap();
         assert!(approved.success, "{:?}", approved.error);
     }
+
+    #[tokio::test]
+    async fn blocks_run_when_rate_limited() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        config.autonomy.level = AutonomyLevel::Full;
+        config.autonomy.max_actions_per_hour = 0;
+        std::fs::create_dir_all(&config.workspace_dir).unwrap();
+        let cfg = Arc::new(config);
+        let job = cron::add_job(&cfg, "*/5 * * * *", "echo run-now").unwrap();
+        let tool = CronRunTool::new(cfg.clone(), test_security(&cfg));
+
+        let result = tool.execute(json!({ "job_id": job.id })).await.unwrap();
+        assert!(!result.success);
+        assert!(result
+            .error
+            .unwrap_or_default()
+            .contains("Rate limit exceeded"));
+        assert!(cron::list_runs(&cfg, &job.id, 10).unwrap().is_empty());
+    }
 }

--- a/src/tools/cron_update.rs
+++ b/src/tools/cron_update.rs
@@ -283,4 +283,34 @@ mod tests {
             .unwrap();
         assert!(approved.success, "{:?}", approved.error);
     }
+
+    #[tokio::test]
+    async fn blocks_update_when_rate_limited() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        config.autonomy.level = AutonomyLevel::Full;
+        config.autonomy.max_actions_per_hour = 0;
+        std::fs::create_dir_all(&config.workspace_dir).unwrap();
+        let cfg = Arc::new(config);
+        let job = cron::add_job(&cfg, "*/5 * * * *", "echo ok").unwrap();
+        let tool = CronUpdateTool::new(cfg.clone(), test_security(&cfg));
+
+        let result = tool
+            .execute(json!({
+                "job_id": job.id,
+                "patch": { "enabled": false }
+            }))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result
+            .error
+            .unwrap_or_default()
+            .contains("Rate limit exceeded"));
+        assert!(cron::get_job(&cfg, &job.id).unwrap().enabled);
+    }
 }


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: cron management/force-run tool paths did not consistently enforce autonomy/rate/action-budget policy gates, and shell-bearing cron paths lacked approval-gated command validation parity.
- Why it matters: scheduled jobs can trigger side effects without the same guardrails expected from direct tool execution, expanding security and policy bypass risk.
- What changed: added `SecurityPolicy` enforcement to `cron_remove`/`cron_run`, added policy prechecks + action-budget gates to cron mutation paths, switched cron shell validations to `validate_command_execution(..., approved)`, added `approved` parameter to cron add/update/run schemas, and added focused tests for read-only and supervised approval gates.
- What did **not** change (scope boundary): no changes to cron scheduling semantics, runtime execution backend, provider/channel logic, or non-cron tool behavior.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto-managed/read-only
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `cron,security,tool,tests`
- Module labels (`<module>:<component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `tool:cron,security:policy`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed/read-only
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `security`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `security`

## Linked Issue

- Closes #599
- Related #598
- Depends on # (if stacked): none
- Supersedes # (if replacing older PR): none

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- `cargo fmt --all -- --check`: pass
- `cargo clippy --locked --all-targets -- -D warnings`: pass
- `cargo test --locked cron_`: pass
- `cargo test --locked`: fails on pre-existing unrelated `memory::lucid` tests in current `main` baseline (`recall_merges_lucid_and_local_results`, `recall_handles_lucid_cold_start_delay_within_timeout`); cron/security changes are green in targeted scope.
- Evidence provided (test/log/trace/screenshot/perf): local test and clippy logs
- If any command is intentionally skipped, explain why: none skipped

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: tests use project-neutral placeholders only
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: cron add/update/run/remove enforce policy in read-only and supervised modes; medium-risk shell cron actions require explicit approval in supervised mode.
- Edge cases checked: missing args, cron-disabled path, missing job id, command policy denial.
- What was not verified: cross-platform runtime behavioral differences beyond local environment.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: cron tool surface (`cron_add`, `cron_update`, `cron_remove`, `cron_run`) and tool registry wiring.
- Potential unintended effects: stricter validation may reject previously-accepted cron shell commands unless `approved=true` is provided for medium/high risk in supervised mode.
- Guardrails/monitoring for early detection: unit coverage added for denial/approval paths; CI tool test suites.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local shell + git + gh CLI
- Workflow/plan summary (if any): policy gap closure in cron tools, targeted tests, then baseline CI-alignment commit for current main drift.
- Verification focus: security/autonomy gates and regression tests for cron tool behavior.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed

## Rollback Plan (required)

- Fast rollback command/path: revert PR merge commit (or revert commits `7b4c8b3` and `843e24a`)
- Feature flags or config toggles (if any): none
- Observable failure symptoms: cron tool operations denied unexpectedly or require explicit approval for medium/high-risk shell commands.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: policy tightening can change operational behavior for existing cron shell workflows in supervised mode.
  - Mitigation: explicit `approved=true` path documented in tool schema and covered by tests.
- Risk: shared CI baseline drift (`Cargo.lock` and rustfmt in `src/service/mod.rs`) can obscure functional diffs.
  - Mitigation: isolated `chore(ci)` commit keeps baseline alignment separate from security behavior commit.
