### PR TITLE
ci(dependabot): add Docker ecosystem monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,20 @@ updates:
         update-types:
           - minor
           - patch
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: main
+    open-pull-requests-limit: 3
+    labels:
+      - "ci"
+      - "dependencies"
+    groups:
+      docker-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Problem: The Dependabot configuration monitors Cargo and GitHub Actions dependencies but does not track Docker base image updates. Stale base images in the Dockerfile can accumulate unpatched vulnerabilities.

Solution: Add a Docker package-ecosystem entry to dependabot.yml that proposes weekly base image updates, grouped by minor/patch, with a 3-PR concurrency limit. Labels (ci, dependencies) match the existing GitHub Actions ecosystem entry for consistent triage routing.

Testing: Validated YAML syntax. Dependabot will activate automatically on the next scheduled scan after merge.

Ref: zeroclaw-labs/zeroclaw#618 (item 1 — Dependency Update Automation)