### PR TITLE
feat(ci): add cross-compilation smoke tests for embedded targets

### DIFF
--- a/.github/workflows/cross-compile.yml
+++ b/.github/workflows/cross-compile.yml
@@ -1,0 +1,44 @@
+name: Cross-Compilation Smoke Tests
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+    workflow_dispatch:
+
+concurrency:
+    group: cross-compile-${{ github.event.pull_request.number || github.sha }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+env:
+    CARGO_TERM_COLOR: always
+
+jobs:
+    cross-check:
+        name: Check ${{ matrix.target }}
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        timeout-minutes: 30
+        strategy:
+            fail-fast: false
+            matrix:
+                target:
+                    - aarch64-unknown-linux-musl
+                    - armv7-unknown-linux-gnueabihf
+                    - aarch64-unknown-linux-gnu
+
+        steps:
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+              with:
+                  toolchain: 1.92.0
+                  targets: ${{ matrix.target }}
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+              with:
+                  key: ${{ matrix.target }}
+
+            - name: Cargo check (cross-compile)
+              run: cargo check --locked --target ${{ matrix.target }}


### PR DESCRIPTION
Add CI workflow (.github/workflows/cross-compile.yml) that runs cargo check against targets relevant to the project's embedded and peripheral ambitions:

- aarch64-unknown-linux-musl (Raspberry Pi, ARM64 embedded)
- armv7-unknown-linux-gnueabihf (ARM32 embedded boards)
- aarch64-unknown-linux-gnu (ARM64 Linux general)

Uses cargo check --target to catch platform-specific compilation issues without requiring full cross-compilation toolchains.

Ref: https://github.com/zeroclaw-labs/zeroclaw/issues/618 (item 9)