### PR TITLE
fix(security): enforce schedule cron and command policy gates

### DIFF
--- a/src/tools/schedule.rs
+++ b/src/tools/schedule.rs
@@ -549,6 +549,100 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rate_limit_blocks_create_action() {
+        let tmp = TempDir::new().unwrap();
+        let config = Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            autonomy: crate::config::AutonomyConfig {
+                level: AutonomyLevel::Full,
+                max_actions_per_hour: 0,
+                ..Default::default()
+            },
+            ..Config::default()
+        };
+        tokio::fs::create_dir_all(&config.workspace_dir)
+            .await
+            .unwrap();
+        let security = Arc::new(SecurityPolicy::from_config(
+            &config.autonomy,
+            &config.workspace_dir,
+        ));
+        let tool = ScheduleTool::new(security, config);
+
+        let blocked = tool
+            .execute(json!({
+                "action": "create",
+                "expression": "*/5 * * * *",
+                "command": "echo blocked-by-rate-limit"
+            }))
+            .await
+            .unwrap();
+        assert!(!blocked.success);
+        assert!(blocked
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Rate limit exceeded"));
+
+        let list = tool.execute(json!({"action": "list"})).await.unwrap();
+        assert!(list.success);
+        assert!(list.output.contains("No scheduled jobs"));
+    }
+
+    #[tokio::test]
+    async fn rate_limit_blocks_cancel_and_keeps_job() {
+        let tmp = TempDir::new().unwrap();
+        let config = Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            autonomy: crate::config::AutonomyConfig {
+                level: AutonomyLevel::Full,
+                max_actions_per_hour: 1,
+                ..Default::default()
+            },
+            ..Config::default()
+        };
+        tokio::fs::create_dir_all(&config.workspace_dir)
+            .await
+            .unwrap();
+        let security = Arc::new(SecurityPolicy::from_config(
+            &config.autonomy,
+            &config.workspace_dir,
+        ));
+        let tool = ScheduleTool::new(security, config);
+
+        let create = tool
+            .execute(json!({
+                "action": "create",
+                "expression": "*/5 * * * *",
+                "command": "echo keep-me"
+            }))
+            .await
+            .unwrap();
+        assert!(create.success);
+        let id = create.output.split_whitespace().nth(3).unwrap();
+
+        let cancel = tool
+            .execute(json!({"action": "cancel", "id": id}))
+            .await
+            .unwrap();
+        assert!(!cancel.success);
+        assert!(cancel
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("Rate limit exceeded"));
+
+        let get = tool
+            .execute(json!({"action": "get", "id": id}))
+            .await
+            .unwrap();
+        assert!(get.success);
+        assert!(get.output.contains("echo keep-me"));
+    }
+
+    #[tokio::test]
     async fn unknown_action_returns_failure() {
         let (_tmp, config, security) = test_setup().await;
         let tool = ScheduleTool::new(security, config);


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: `schedule` mutating create/add/once paths did not honor `cron.enabled` and persisted shell commands without command-policy validation/approval gates.
- Why it matters: this creates policy bypass risk (feature-flag drift and unsupervised medium/high-risk shell scheduling).
- What changed: added `cron.enabled` mutation guard in `schedule`, added command validation via `validate_command_execution(..., approved)` for create-like actions, added `approved` schema parameter, and added regression tests for cron-disabled, disallowed command, and supervised approval-required behavior.
- What did **not** change (scope boundary): no scheduler execution semantics change, no cron storage schema change, no non-schedule tool behavior change.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto-managed/read-only
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `cron,security,tool,tests`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `tool:schedule,security:policy`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed/read-only
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `security`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `security`

## Linked Issue

- Closes #600
- Related #599
- Depends on # (if stacked): none
- Supersedes # (if replacing older PR): none

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- `cargo fmt --all -- --check`: pass
- `cargo clippy --locked --all-targets -- -D warnings`: pass
- `cargo test --locked schedule::tests::`: pass
- `cargo test --locked`: fails on unrelated existing baseline test in `memory::lucid` (`recall_handles_lucid_cold_start_delay_within_timeout`)
- Evidence provided (test/log/trace/screenshot/perf): local test/clippy logs
- If any command is intentionally skipped, explain why: none skipped

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no personal/sensitive data introduced
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `No` (intentional security tightening)
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: schedule create/add/once blocked when `cron.enabled=false`; disallowed command is rejected; medium-risk command requires `approved=true` in supervised mode.
- Edge cases checked: missing/invalid scheduling parameter combinations, readonly mutation block, list/get non-mutating behavior unchanged.
- What was not verified: live end-to-end scheduled execution across external provider integrations.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `schedule` tool mutation paths.
- Potential unintended effects: previously accepted schedule commands in supervised mode may now require explicit approval.
- Guardrails/monitoring for early detection: added unit tests for policy denial/approval paths.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local shell + git + gh CLI
- Workflow/plan summary (if any): checked for existing contributor PRs for issue #600 (none), implemented policy guards and tests, then applied CI baseline alignment commit.
- Verification focus: schedule policy parity with cron/shell guardrails.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed

## Rollback Plan (required)

- Fast rollback command/path: revert commits `c1e102b` and `bfb83d1`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: schedule create/add/once rejected with `cron is disabled` or command approval-required errors.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: stricter validation can interrupt existing supervised workflows that relied on implicit approval.
  - Mitigation: explicit `approved=true` pathway and test coverage.
- Risk: CI baseline drift can obscure functional review.
  - Mitigation: isolated `chore(ci)` commit separates baseline alignment from functional security changes.
