### PR TITLE
fix(provider): address Astrai onboarding follow-ups from #486

### DIFF
--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -1384,6 +1384,10 @@ fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String, Optio
         2 => vec![
             ("vercel", "Vercel AI Gateway"),
             ("cloudflare", "Cloudflare AI Gateway"),
+            (
+                "astrai",
+                "Astrai — compliant AI routing (PII stripping, cost optimization)",
+            ),
             ("bedrock", "Amazon Bedrock — AWS managed models"),
         ],
         3 => vec![
@@ -1988,6 +1992,7 @@ fn provider_env_var(name: &str) -> &'static str {
         "bedrock" | "aws-bedrock" => "AWS_ACCESS_KEY_ID",
         "gemini" => "GEMINI_API_KEY",
         "nvidia" | "nvidia-nim" | "build.nvidia.com" => "NVIDIA_API_KEY",
+        "astrai" => "ASTRAI_API_KEY",
         _ => "API_KEY",
     }
 }
@@ -4779,6 +4784,7 @@ mod tests {
         assert_eq!(provider_env_var("nvidia"), "NVIDIA_API_KEY");
         assert_eq!(provider_env_var("nvidia-nim"), "NVIDIA_API_KEY"); // alias
         assert_eq!(provider_env_var("build.nvidia.com"), "NVIDIA_API_KEY"); // alias
+        assert_eq!(provider_env_var("astrai"), "ASTRAI_API_KEY");
     }
 
     #[test]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1347,6 +1347,7 @@ mod tests {
             "cohere",
             "copilot",
             "nvidia",
+            "astrai",
         ];
         for name in providers {
             assert!(


### PR DESCRIPTION
## Summary

- Problem: Review on #486 identified 4 gaps — Astrai missing from all-providers test, onboarding env var mapping, provider selection list, and env var unit test
- Why it matters: Keeps runtime support and onboarding UX aligned for the new Astrai provider
- What changed: Added Astrai to factory test list, `provider_env_var()`, onboarding Gateway tier, and env var assertion
- What did **not** change (scope boundary): No changes to provider factory, traits, config schema, or any runtime behavior

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `provider`
- Module labels: `provider:astrai`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `fix`
- Primary scope: `provider`

## Linked Issue

- Closes: N/A
- Related: #486 (review follow-ups from @chumyin)

## Validation Evidence (required)

```bash
cargo fmt --all -- --check                          # ✅ clean (our files pass; pre-existing diffs in benches/screenshot.rs/agent_e2e.rs untouched)
cargo clippy --all-targets -- -D clippy::correctness  # ✅ pass
cargo test --lib -- factory_all_providers factory_astrai provider_env_var  # ✅ 4 passed, 0 failed
```

- Evidence provided: local `fmt`, `clippy`, targeted `test` results
- If any command is intentionally skipped: Full `cargo test` not re-run (only touched test + onboarding code; targeted tests cover all changes)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Uses project-native naming only

## Compatibility / Migration

- Backward compatible? Yes — purely additive
- Config/env changes? No (env var already supported at runtime from #486)
- Migration needed? No

## Human Verification (required)

- Verified scenarios: `factory_all_providers` now includes astrai; `provider_env_var("astrai")` returns `ASTRAI_API_KEY`; astrai appears in onboarding Gateway tier
- Edge cases checked: Unknown provider still falls back to `API_KEY`
- What was not verified: Interactive onboarding wizard flow (requires TTY)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `src/providers/mod.rs` (test only), `src/onboard/wizard.rs` (env var mapping + provider list + test)
- Potential unintended effects: None — additive test + onboarding wiring
- Guardrails/monitoring for early detection: Existing test suite

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Addressed all 4 inline review comments from @chumyin on #486
- Verification focus: Targeted test runs for all modified code paths
- Confirmation: naming + architecture boundaries followed: Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <sha>`
- Feature flags or config toggles: N/A
- Observable failure symptoms: Test failure in `factory_all_providers` or `provider_env_var_known_providers`

## Risks and Mitigations

- Risk: None — additive test and onboarding changes only