### PR TITLE
fix(security): change pairing lockout to per-client accounting

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -629,7 +629,7 @@ impl TelegramChannel {
 
         if let Some(code) = Self::extract_bind_code(text) {
             if let Some(pairing) = self.pairing.as_ref() {
-                match pairing.try_pair(code).await {
+                match pairing.try_pair(code, &normalized_username).await {
                     Ok(Some(_token)) => {
                         let bind_identity = normalized_sender_id.clone().or_else(|| {
                             if normalized_username.is_empty() || normalized_username == "unknown" {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -610,7 +610,7 @@ async fn handle_pair(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
 
-    match state.pairing.try_pair(code).await {
+    match state.pairing.try_pair(code, &rate_key).await {
         Ok(Some(token)) => {
             tracing::info!("🔐 New client paired successfully");
             if let Err(err) = persist_pairing_tokens(state.config.clone(), &state.pairing).await {
@@ -1457,7 +1457,7 @@ mod tests {
 
         let guard = PairingGuard::new(true, &[]);
         let code = guard.pairing_code().unwrap();
-        let token = guard.try_pair(&code).await.unwrap().unwrap();
+        let token = guard.try_pair(&code, "test-client").await.unwrap().unwrap();
         assert!(guard.is_authenticated(&token));
 
         let shared_config = Arc::new(Mutex::new(config));


### PR DESCRIPTION
Replace global failed-attempt counter with per-client tracking keyed by client identity. This prevents one attacker from locking out all legitimate clients via brute-force pairing attempts.

- Replace global (u32, Option<Instant>) with HashMap<String, (u32, Option<Instant>)>
- Add MAX_LOCKOUT_CLIENTS (1000) cardinality bound with expiry-based eviction
- Update try_pair signature to accept client_id parameter
- Update all call sites (gateway, telegram channel)
- Add lockout_is_per_client_not_global regression test

Resolves zeroclaw-labs/zeroclaw#603