### PR TITLE
fix(docker): unblock smoke build by adding dummy bench target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # 1. Copy manifests to cache dependencies
 COPY Cargo.toml Cargo.lock ./
-# Create dummy main.rs to build dependencies
-RUN mkdir src && echo "fn main() {}" > src/main.rs
+# Create dummy targets declared in Cargo.toml so manifest parsing succeeds.
+RUN mkdir -p src benches \
+    && echo "fn main() {}" > src/main.rs \
+    && echo "fn main() {}" > benches/agent_benchmarks.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
     cargo build --release --locked
-RUN rm -rf src
+RUN rm -rf src benches
 
 # 2. Copy source code
 COPY . .


### PR DESCRIPTION
## Summary
- fix Docker builder stage failing on manifest parsing when only Cargo manifests are copied
- add a dummy benchmark file during dependency-cache warmup so declared bench targets exist

## Root Cause
- `Cargo.toml` declares benchmark `agent_benchmarks`
- Stage 1 copied only `Cargo.toml`/`Cargo.lock` and dummy `src/main.rs`
- `cargo build --release --locked` failed before source copy because benchmark path was missing in that temporary build context

## Change
- `Dockerfile`: create `benches/agent_benchmarks.rs` dummy file alongside dummy `src/main.rs` in stage 1, then clean both

## Why this is safe
- affects only dependency-cache warmup layer
- real source tree is copied and built in stage 2 as before

## Validation
- fix is targeted to the exact failure from `PR Docker Smoke` on #637.
