### PR TITLE
fix(discord): use channel name for reply routing instead of discord channel ID

### DIFF
--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -406,7 +406,7 @@ impl Channel for DiscordChannel {
                             channel_id.clone()
                         },
                         content: clean_content,
-                        channel: channel_id,
+                        channel: "discord".to_string(),
                         timestamp: std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
                             .unwrap_or_default()


### PR DESCRIPTION
## Problem

Discord channel replies are silently dropped. The bot receives messages, generates LLM responses, but never sends them back to Discord.

## Root Cause

In `src/channels/discord.rs` line 409, the `ChannelMessage.channel` field is set to the numeric Discord channel ID (e.g. `"1466566015440650374"`) instead of the literal string `"discord"`.

When `process_channel_message()` in `src/channels/mod.rs:189` does:

```rust
let target_channel = ctx.channels_by_name.get(&msg.channel).cloned();
```

...it looks up the Discord channel ID in a map keyed by channel names like `"discord"`, `"telegram"`, `"slack"`. The lookup returns `None`, so `target_channel` is `None`, and the reply send block at line 239-246 is skipped entirely.

No error is logged because the "Reply" print at line 234 fires before the send attempt, and the `if let Some(channel)` guard silently skips when `None`.

## Fix

One line: set `channel: "discord".to_string()` to match every other channel implementation.

Every other channel already does this correctly:
- telegram: `channel: "telegram".to_string()`
- slack: `channel: "slack".to_string()`
- whatsapp, matrix, signal, irc, imessage, lark, dingtalk, qq, email, mattermost -- all use their channel name string

Discord was the only outlier.

## Testing

Tested on a live instance (Debian thin client, Claude Opus via Anthropic-compatible proxy). Before the fix: bot processed messages and logged replies but Discord never received them. After the fix: replies show up in both DMs and server channels.

## Risk

Low. Single line change, isolated to Discord channel, no behavioral change for any other channel.