### PR TITLE
fix(docker): stop smoke from compiling dependencies twice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-# 1. Copy manifests to cache dependencies
-COPY Cargo.toml Cargo.lock ./
+# 1. Copy manifests and toolchain pin to cache dependencies with the same compiler
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
 # Create dummy targets declared in Cargo.toml so manifest parsing succeeds.
 RUN mkdir -p src benches \
     && echo "fn main() {}" > src/main.rs \


### PR DESCRIPTION
## Summary

- Problem: Docker smoke rebuilds most dependencies twice in a single build.
- Why it matters: PR Docker smoke runtime is dominated by redundant compilation.
- What changed: Copied `rust-toolchain.toml` in the dependency-cache layer so both cargo build steps use the same pinned toolchain.
- What did **not** change (scope boundary): No workflow trigger, permissions, or runtime behavior changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): XS
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): ci,dependencies
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): ci:docker
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): ci

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): No
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): Pass

## Validation Evidence (required)

Commands and result summary:

```bash
docker build --progress=plain -t zeroclaw-smoke-test:local .
/usr/bin/time -p docker build --progress=plain -t zeroclaw-smoke-test:local .
docker run --rm zeroclaw-smoke-test:local --version
```

- Evidence provided (test/log/trace/screenshot/perf): First build showed no second toolchain sync and removed duplicate full dependency compile; second build was fully cached (`real 0.80s`); runtime reported `zeroclaw 0.1.0`.
- If any command is intentionally skipped, explain why: Cargo fmt/clippy/test were skipped because this change only touches Docker build-layer ordering and was validated through Docker smoke path directly.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: none
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Human Verification (required)

- Verified scenarios: Local image builds successfully; image runs `--version`; warm rebuild is fully cached.
- Edge cases checked: Toolchain pin is now available in both cargo build stages.
- What was not verified: CI runtime delta on GitHub-hosted/Blacksmith runner after merge.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Docker image build only.
- Potential unintended effects: None expected beyond improved layer-cache behavior.
- Guardrails/monitoring for early detection: Docker workflow timing in Actions (`Build smoke image` step duration).

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): shell, gh CLI, docker CLI
- Workflow/plan summary (if any): Isolated slow step from run logs, patched Dockerfile to keep toolchain consistent across layers, validated with local builds.
- Verification focus: Eliminate duplicated compile path while preserving output image.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert 5a31934`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: Docker build failure in stage `builder 6/9` if toolchain file missing/unreadable.

## Risks and Mitigations

- Risk: Slightly larger invalidation surface for dependency warmup when toolchain pin changes.
  - Mitigation: This is intended; toolchain changes should invalidate the cache.
