### PR TITLE
chore(ci): pin remaining CodeQL workflow actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,16 +24,16 @@ jobs:
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v4
+              uses: github/codeql-action/init@9e907b5e64f6b83e7804b09294d44122997950d6 # v4
               with:
                   languages: rust
                   config-file: ./.github/codeql/codeql-config.yml
 
             - name: Set up Rust
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
             - name: Build
               run: cargo build --workspace --all-targets
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v4
+              uses: github/codeql-action/analyze@9e907b5e64f6b83e7804b09294d44122997950d6 # v4


### PR DESCRIPTION
## Summary

- Problem: CodeQL workflow still used mutable action references (`@v4`, `@stable`) in a security-sensitive analysis pipeline.
- Why it matters: mutable action tags weaken CI supply-chain determinism and integrity.
- What changed: pinned remaining mutable action refs in `.github/workflows/codeql.yml` to immutable commit SHAs.
- What did **not** change (scope boundary): no workflow logic, permissions, triggers, or action allowlist policy semantics were changed.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS` (expected)
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `ci,security`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `ci:codeql`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `principal contributor` (auto)
- If any auto-label is incorrect, note requested correction: `n/a`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `chore`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `ci`

## Linked Issue

- Closes #614
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `n/a`
- Integrated scope by source PR (what was materially carried forward): `n/a`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): no superseded PR code was incorporated
- Trailer format check (separate lines, no escaped `\n`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): workflow-only change; SHA values resolved via GitHub API (`github/codeql-action@v4`, `dtolnay/rust-toolchain@stable`) and applied as immutable pins.
- If any command is intentionally skipped, explain why: Rust build/test commands are skipped because no Rust/runtime code changed; CI workflow sanity + required checks will validate this PR.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: `n/a`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no personal or sensitive data added
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `n/a`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - all mutable refs in `codeql.yml` are replaced with immutable SHAs
  - existing pinned `actions/checkout` remained unchanged
- Edge cases checked:
  - no trigger/permission deltas introduced
- What was not verified:
  - full workflow execution (delegated to PR CI)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: CodeQL workflow action resolution only
- Potential unintended effects: if upstream action internals differ from expected tag behavior, workflow behavior could change
- Guardrails/monitoring for early detection: workflow sanity and CI checks on PR

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local shell + `gh` CLI
- Workflow/plan summary (if any): minimal SHA-pinning patch scoped to issue request
- Verification focus: deterministic supply-chain pinning without behavior drift
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed

## Rollback Plan (required)

- Fast rollback command/path: revert this PR commit
- Feature flags or config toggles (if any): none
- Observable failure symptoms: CodeQL workflow step resolution failure for pinned SHAs

## Risks and Mitigations

- Risk: pinned SHAs can become stale over time.
  - Mitigation: periodic dependency/action update PRs can roll pins forward deliberately.
