### PR TITLE
ci(docker): publish images only on tag pushes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,6 @@ name: Docker
 
 on:
     push:
-        branches: [main]
         tags: ["v*"]
     pull_request:
         branches: [main]
@@ -60,7 +59,7 @@ jobs:
 
     publish:
         name: Build and Push Docker Image
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         runs-on: blacksmith-2vcpu-ubuntu-2404
         timeout-minutes: 25
         permissions:


### PR DESCRIPTION
## Summary
- limit Docker publish workflow to tag pushes only
- keep PR Docker smoke behavior unchanged

## Why
- avoid unnecessary image publish runs on every merge to main
- reduce CI runtime and cost while preserving release image publishing

## Validation
- reviewed  trigger and job guard
