### PR TITLE
ci(docker): speed up PR smoke builds on Blacksmith

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,7 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404
         timeout-minutes: 25
         permissions:
+            actions: write
             contents: read
         steps:
             - name: Checkout repository
@@ -50,9 +51,15 @@ jobs:
                   context: .
                   push: false
                   load: true
+                  provenance: false
+                  sbom: false
                   tags: zeroclaw-pr-smoke:latest
                   labels: ${{ steps.meta.outputs.labels }}
                   platforms: linux/amd64
+                  cache-from: |
+                      type=gha,scope=zeroclaw-docker-smoke
+                  cache-to: |
+                      type=gha,mode=max,scope=zeroclaw-docker-smoke
 
             - name: Verify image
               run: docker run --rm zeroclaw-pr-smoke:latest --version


### PR DESCRIPTION
## Summary
- add explicit Buildx GHA cache import/export to PR Docker smoke
- disable provenance and sbom generation on smoke image builds
- keep release publish behavior unchanged (tags-only)

## Why
PR smoke is one of the more expensive CI checks. The current build action reports cache state as unset, so this enables a durable cache backend for smoke runs.

## Validation plan
- compare PR Docker Smoke duration on this PR against recent baseline
- confirm build still verifies image with 
