### PR TITLE
fix(agent): log warning when native tool call arguments fail JSON parsing

### DIFF
--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -166,8 +166,14 @@ impl ToolDispatcher for NativeToolDispatcher {
             .iter()
             .map(|tc| ParsedToolCall {
                 name: tc.name.clone(),
-                arguments: serde_json::from_str(&tc.arguments)
-                    .unwrap_or_else(|_| Value::Object(serde_json::Map::new())),
+                arguments: serde_json::from_str(&tc.arguments).unwrap_or_else(|e| {
+                    tracing::warn!(
+                        tool = %tc.name,
+                        error = %e,
+                        "Failed to parse native tool call arguments as JSON; defaulting to empty object"
+                    );
+                    Value::Object(serde_json::Map::new())
+                }),
                 tool_call_id: Some(tc.id.clone()),
             })
             .collect();


### PR DESCRIPTION
## Summary

- Problem: `NativeToolDispatcher::parse_response` silently defaults to an empty `{}` object when tool call arguments fail to parse as JSON, making it difficult to diagnose LLM misbehavior.
- Why it matters: The XML-based `XmlToolDispatcher` already logs `tracing::warn!("Malformed <tool_call> JSON: {e}")` for the same failure case (dispatcher.rs:68). The native dispatcher should have observability parity.
- What changed: Added a `tracing::warn!` with tool name and parse error before falling back to the empty object default.
- What did **not** change (scope boundary): Fallback behavior is identical — invalid JSON still becomes `{}`. Only a log line is added.

## Label Snapshot (required)

- Risk label: risk: low
- Size label: size: XS
- Scope labels: agent
- Module labels: agent: dispatcher
- Contributor tier label: trusted contributor
- If any auto-label is incorrect, note requested correction: risk should be low (log-only change)

## Change Metadata

- Change type: bug
- Primary scope: agent

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check   # pass
cargo build                  # pass
```

- Evidence provided: local build passes
- If any command is intentionally skipped, explain why: `cargo test` skipped — no test runner on target device. No behavioral change to test.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: Log includes tool name and parse error only, not raw argument content
- Neutral wording confirmation: N/A

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Confirmed XML dispatcher already logs the same class of error at dispatcher.rs:68
- Confirmed log message does not include raw argument content (avoids leaking sensitive tool args)

## Rollback Plan (required)

- Revert this commit. Only a log line; behavior is identical.
- Risk: Trivial.
