### PR TITLE
fix(tools): log warning on invalid memory_store category

### DIFF
--- a/src/tools/memory_store.rs
+++ b/src/tools/memory_store.rs
@@ -61,7 +61,14 @@ impl Tool for MemoryStoreTool {
         let category = match args.get("category").and_then(|v| v.as_str()) {
             Some("daily") => MemoryCategory::Daily,
             Some("conversation") => MemoryCategory::Conversation,
-            _ => MemoryCategory::Core,
+            Some("core") | None => MemoryCategory::Core,
+            Some(other) => {
+                tracing::warn!(
+                    category = other,
+                    "Unknown memory category; defaulting to 'core'"
+                );
+                MemoryCategory::Core
+            }
         };
 
         match self.memory.store(key, content, category, None).await {


### PR DESCRIPTION
## Summary

- Problem: `memory_store` tool silently defaults any unrecognized category string to `"core"`. When the LLM sends a typo or invented category, the data is stored as core with no indication.
- Why it matters: Silent fallbacks violate the fail-fast principle and make it harder to diagnose unexpected LLM behavior or category misuse.
- What changed: Added explicit match arms for `"core"` and `None` (intentional defaults) and a `tracing::warn` for any unrecognized value before falling back to core.
- What did **not** change (scope boundary): Fallback behavior is identical — unknown categories still become core. Only a log line and explicit match arms are added.

## Label Snapshot (required)

- Risk label: risk: low
- Size label: size: XS
- Scope labels: tool
- Module labels: tool: memory_store
- Contributor tier label: trusted contributor
- If any auto-label is incorrect, note requested correction: risk should be low (log-only change)

## Change Metadata

- Change type: bug
- Primary scope: tool

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check   # pass
cargo build                  # pass
```

- Evidence provided: local build passes
- If any command is intentionally skipped, explain why: `cargo test` skipped — no test runner on target device. No behavioral change to test.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: Log includes the invalid category string only (not sensitive)
- Neutral wording confirmation: N/A

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Confirmed the catch-all `_` arm previously matched both valid (`"core"`, `None`) and invalid cases without distinction
- Confirmed the new match arms are exhaustive and the warning only fires for genuinely unrecognized values

## Rollback Plan (required)

- Revert this commit. Only adds a log line and explicit match arms; storage behavior is identical.
- Risk: Trivial.
