### PR TITLE
ci(docker): align smoke caching with Blacksmith guidance

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,6 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404
         timeout-minutes: 25
         permissions:
-            actions: write
             contents: read
         steps:
             - name: Checkout repository
@@ -56,10 +55,6 @@ jobs:
                   tags: zeroclaw-pr-smoke:latest
                   labels: ${{ steps.meta.outputs.labels }}
                   platforms: linux/amd64
-                  cache-from: |
-                      type=gha,scope=zeroclaw-docker-smoke
-                  cache-to: |
-                      type=gha,mode=max,scope=zeroclaw-docker-smoke
 
             - name: Verify image
               run: docker run --rm zeroclaw-pr-smoke:latest --version


### PR DESCRIPTION
Use Blacksmith-native Docker layer caching by removing external Buildx GHA cache directives from PR smoke.

Changes:
- remove cache-from/cache-to from PR Docker Smoke
- remove unnecessary actions:write permission added only for external cache export
- keep Blacksmith setup-docker-builder + build-push-action path intact
