### PR TITLE
ci(release): add SBOM generation with syft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,10 +98,21 @@ jobs:
               with:
                   path: artifacts
 
+            - name: Install syft
+              run: |
+                  curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
+
+            - name: Generate SBOM (CycloneDX)
+              run: |
+                  syft dir:. --source-name zeroclaw -o cyclonedx-json=artifacts/zeroclaw.cdx.json -o spdx-json=artifacts/zeroclaw.spdx.json
+                  echo "### SBOM Generated" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- CycloneDX: zeroclaw.cdx.json" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- SPDX: zeroclaw.spdx.json" >> "$GITHUB_STEP_SUMMARY"
+
             - name: Generate SHA256 checksums
               run: |
                   cd artifacts
-                  find . -type f \( -name '*.tar.gz' -o -name '*.zip' \) -exec sha256sum {} + | sed 's|  \./[^/]*/|  |' > SHA256SUMS
+                  find . -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.cdx.json' -o -name '*.spdx.json' \) -exec sha256sum {} + | sed 's|  \./[^/]*/|  |' > SHA256SUMS
                   echo "Generated checksums:"
                   cat SHA256SUMS
 


### PR DESCRIPTION
Generate CycloneDX and SPDX Software Bill of Materials during release builds. SBOMs are included in release artifacts and covered by SHA256 checksums and cosign signatures.

Addresses item #5 in #618.