### PR TITLE
ci: add changelog automation with git-cliff

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,46 @@
+name: Changelog
+
+on:
+    push:
+        tags: ["v*"]
+
+concurrency:
+    group: changelog
+    cancel-in-progress: false
+
+permissions:
+    contents: write
+
+jobs:
+    generate:
+        name: Generate Changelog
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        timeout-minutes: 10
+        steps:
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  fetch-depth: 0
+
+            - name: Install git-cliff
+              run: |
+                  curl -sSfL https://github.com/orhun/git-cliff/releases/latest/download/git-cliff-x86_64-unknown-linux-gnu.tar.gz \
+                    | tar xz -C /usr/local/bin --strip-components=1 git-cliff-x86_64-unknown-linux-gnu/git-cliff
+                  git-cliff --version
+
+            - name: Generate changelog
+              run: |
+                  git-cliff --config cliff.toml --output CHANGELOG.md
+                  echo "### Changelog Generated" >> "$GITHUB_STEP_SUMMARY"
+                  echo "Changelog updated for tag ${GITHUB_REF_NAME}" >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Commit changelog
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add CHANGELOG.md
+                  if git diff --cached --quiet; then
+                    echo "No changelog changes to commit."
+                  else
+                    git commit -m "docs: update changelog for ${GITHUB_REF_NAME}"
+                    git push origin HEAD:main
+                  fi

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,66 @@
+# git-cliff configuration for ZeroClaw
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """# Changelog
+
+All notable changes to ZeroClaw will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""
+body = """
+{%- macro remote_url() -%}
+  https://github.com/zeroclaw-labs/zeroclaw
+{%- endmacro -%}
+
+{% if version -%}
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits
+| filter(attribute="scope")
+| sort(attribute="scope") %}
+- **{{ commit.scope }}**: {{ commit.message }}
+  {%- if commit.breaking %} (**BREAKING**){% endif %}
+{%- endfor -%}
+{% for commit in commits %}
+{%- if not commit.scope %}
+- {{ commit.message }}
+  {%- if commit.breaking %} (**BREAKING**){% endif %}
+{%- endif -%}
+{%- endfor -%}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "Added" },
+    { message = "^fix", group = "Fixed" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Changed" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^security", group = "Security" },
+    { body = ".*security", group = "Security" },
+]
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "v[0-9].*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "newest"


### PR DESCRIPTION
Add git-cliff configuration and workflow to auto-generate CHANGELOG.md from conventional commit messages on release tags.

Addresses item #13 in #618.