### PR TITLE
ci: add gitleaks secrets scanning

### DIFF
--- a/.github/workflows/secrets-scanning.yml
+++ b/.github/workflows/secrets-scanning.yml
@@ -1,0 +1,47 @@
+name: Secrets Scanning
+
+on:
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
+
+concurrency:
+    group: secrets-scan-${{ github.event.pull_request.number || github.sha }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+
+jobs:
+    gitleaks:
+        name: Gitleaks Secret Scan
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        timeout-minutes: 10
+        steps:
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  fetch-depth: 0
+
+            - name: Install gitleaks
+              run: |
+                  curl -sSfL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_8.24.3_linux_x64.tar.gz \
+                    | tar xz -C /usr/local/bin gitleaks
+                  gitleaks version
+
+            - name: Run gitleaks (PR diff)
+              if: github.event_name == 'pull_request'
+              run: |
+                  gitleaks detect \
+                    --source . \
+                    --log-opts "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" \
+                    --verbose \
+                    --exit-code 1
+
+            - name: Run gitleaks (push full scan)
+              if: github.event_name == 'push'
+              run: |
+                  gitleaks detect \
+                    --source . \
+                    --verbose \
+                    --exit-code 1


### PR DESCRIPTION
Add CI-time secrets scanning with gitleaks to catch accidentally committed credentials, tokens, or API keys. PR builds scan only the diff; push builds scan the full repository.

Addresses item #16 in #618.