### PR TITLE
ci(cache): migrate Rust dependency caching to Blacksmith

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -26,7 +26,7 @@ jobs:
             - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
               with:
                   toolchain: 1.92.0
-            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
 
             - name: Run benchmarks
               run: cargo bench --locked 2>&1 | tee benchmark_output.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
               with:
                   toolchain: 1.92.0
                   components: rustfmt, clippy
-            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
             - name: Run rust quality gate
               run: ./scripts/ci/rust_quality_gate.sh
 
@@ -72,7 +72,7 @@ jobs:
               with:
                   toolchain: 1.92.0
                   components: clippy
-            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
             - name: Run strict lint delta gate
               env:
                   BASE_SHA: ${{ needs.changes.outputs.base_sha }}
@@ -89,7 +89,7 @@ jobs:
             - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
               with:
                   toolchain: 1.92.0
-            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
             - name: Run tests
               run: cargo test --locked --verbose
 
@@ -105,7 +105,7 @@ jobs:
             - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
               with:
                   toolchain: 1.92.0
-            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
             - name: Build release binary
               run: cargo build --release --locked --verbose
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,6 @@ jobs:
             - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
               with:
                   toolchain: 1.92.0
-            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
             - name: Run integration / E2E tests
               run: cargo test --test agent_e2e --locked --verbose

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -49,7 +49,7 @@ jobs:
               with:
                   toolchain: 1.92.0
 
-            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
               with:
                   key: features-${{ matrix.name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
               with:
                   targets: ${{ matrix.target }}
 
-            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
 
             - name: Build release
               run: cargo build --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/rust-reusable.yml
+++ b/.github/workflows/rust-reusable.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Restore Rust cache
         if: inputs.use_cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
 
       - name: Run command
         shell: bash

--- a/docs/actions-source-policy.md
+++ b/docs/actions-source-policy.md
@@ -15,7 +15,6 @@ Selected allowlist patterns:
 - `actions/*` (covers `actions/cache`, `actions/checkout`, `actions/upload-artifact`, `actions/download-artifact`, and other first-party actions)
 - `docker/*`
 - `dtolnay/rust-toolchain@*`
-- `Swatinem/rust-cache@*`
 - `DavidAnson/markdownlint-cli2-action@*`
 - `lycheeverse/lychee-action@*`
 - `EmbarkStudios/cargo-deny-action@*`
@@ -75,6 +74,8 @@ If encountered, add only the specific trusted missing action, rerun, and documen
 
 Latest sweep notes:
 
+- 2026-02-17: Rust dependency cache migrated from `Swatinem/rust-cache` to `useblacksmith/rust-cache`
+    - No new allowlist pattern required (`useblacksmith/*` already allowlisted)
 - 2026-02-16: Hidden dependency discovered in `release.yml`: `sigstore/cosign-installer@...`
     - Added allowlist pattern: `sigstore/cosign-installer@*`
 - 2026-02-16: Blacksmith migration blocked workflow execution


### PR DESCRIPTION
## Summary
- replace  with  across workflows
- keep pinned SHAs for supply-chain consistency
- update actions source policy notes to reflect migration

## Scope
Updated:
- 
- 
- 
- 
- 
- 
- 

## Allowlist impact
No new allowlist pattern required ( already allowlisted).
