### PR TITLE
feat(channels): implement typing indicator for Telegram channel

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -4,6 +4,7 @@ use crate::security::pairing::PairingGuard;
 use anyhow::Context;
 use async_trait::async_trait;
 use directories::UserDirs;
+use parking_lot::Mutex;
 use reqwest::multipart::{Form, Part};
 use std::fs;
 use std::path::Path;
@@ -235,6 +236,7 @@ pub struct TelegramChannel {
     allowed_users: Arc<RwLock<Vec<String>>>,
     pairing: Option<PairingGuard>,
     client: reqwest::Client,
+    typing_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl TelegramChannel {
@@ -256,6 +258,7 @@ impl TelegramChannel {
             allowed_users: Arc::new(RwLock::new(normalized_allowed)),
             pairing,
             client: reqwest::Client::new(),
+            typing_handle: Mutex::new(None),
         }
     }
 
@@ -1230,6 +1233,39 @@ Ensure only one `zeroclaw` process is using this bot token."
             }
         }
     }
+
+    async fn start_typing(&self, recipient: &str) -> anyhow::Result<()> {
+        self.stop_typing(recipient).await?;
+
+        let client = self.client.clone();
+        let url = self.api_url("sendChatAction");
+        let chat_id = recipient.to_string();
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let body = serde_json::json!({
+                    "chat_id": &chat_id,
+                    "action": "typing"
+                });
+                let _ = client.post(&url).json(&body).send().await;
+                // Telegram typing indicator expires after 5s; refresh at 4s
+                tokio::time::sleep(Duration::from_secs(4)).await;
+            }
+        });
+
+        let mut guard = self.typing_handle.lock();
+        *guard = Some(handle);
+
+        Ok(())
+    }
+
+    async fn stop_typing(&self, _recipient: &str) -> anyhow::Result<()> {
+        let mut guard = self.typing_handle.lock();
+        if let Some(handle) = guard.take() {
+            handle.abort();
+        }
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -1240,6 +1276,51 @@ mod tests {
     fn telegram_channel_name() {
         let ch = TelegramChannel::new("fake-token".into(), vec!["*".into()]);
         assert_eq!(ch.name(), "telegram");
+    }
+
+    #[test]
+    fn typing_handle_starts_as_none() {
+        let ch = TelegramChannel::new("fake-token".into(), vec!["*".into()]);
+        let guard = ch.typing_handle.lock();
+        assert!(guard.is_none());
+    }
+
+    #[tokio::test]
+    async fn stop_typing_clears_handle() {
+        let ch = TelegramChannel::new("fake-token".into(), vec!["*".into()]);
+
+        // Manually insert a dummy handle
+        {
+            let mut guard = ch.typing_handle.lock();
+            *guard = Some(tokio::spawn(async {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+            }));
+        }
+
+        // stop_typing should abort and clear
+        ch.stop_typing("123").await.unwrap();
+
+        let guard = ch.typing_handle.lock();
+        assert!(guard.is_none());
+    }
+
+    #[tokio::test]
+    async fn start_typing_replaces_previous_handle() {
+        let ch = TelegramChannel::new("fake-token".into(), vec!["*".into()]);
+
+        // Insert a dummy handle first
+        {
+            let mut guard = ch.typing_handle.lock();
+            *guard = Some(tokio::spawn(async {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+            }));
+        }
+
+        // start_typing should abort the old handle and set a new one
+        let _ = ch.start_typing("123").await;
+
+        let guard = ch.typing_handle.lock();
+        assert!(guard.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Problem: TelegramChannel does not override `start_typing`/`stop_typing`, using the trait's default no-op. This means the typing indicator only fires once per message (in `listen()`) and does not persist during long tool-call loops.
- Why it matters: DiscordChannel already implements persistent typing via a spawned tokio task. Telegram users should see the same "typing..." indicator while the agent processes their request.
- What changed: Added `parking_lot::Mutex<Option<JoinHandle>>` field and implemented `start_typing` (spawns a loop calling `sendChatAction` every 4s, since Telegram typing expires after 5s) and `stop_typing` (aborts the task).
- What did **not** change (scope boundary): The one-shot typing call in `listen()` is unchanged. No config changes. No trait changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `channel:telegram`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `trusted contributor`
- If any auto-label is incorrect, note requested correction: `N/A`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo build
```

- Evidence provided (test/log/trace/screenshot/perf): local build passes
- If any command is intentionally skipped, explain why: `cargo test` skipped in author environment due target-device constraints (maintainer-side full CI/local tests were executed during review)

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No` (reuses existing `sendChatAction` API already used in `listen()`)
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: `N/A`
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`

## Human Verification (required)

- Confirmed Discord channel uses the same pattern (parking_lot::Mutex + spawned task + abort)
- Confirmed Telegram typing indicator expires after 5 seconds; 4-second refresh interval is correct
- Confirmed no raw token or sensitive data in the spawned task's API call

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge_commit_sha>`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: typing indicator not persisted or stale task behavior

## Risks and Mitigations

- Risk: Single shared typing handle may switch indicators when multiple Telegram requests overlap.
  - Mitigation: This follows existing Discord channel behavior today; future per-recipient handle map can be introduced consistently across channels if concurrency policy is expanded.
