### PR TITLE
feat(providers): implement chat_with_history for GLM provider

### DIFF
--- a/src/providers/glm.rs
+++ b/src/providers/glm.rs
@@ -2,7 +2,7 @@
 //! The GLM API requires JWT tokens generated from the `id.secret` API key format
 //! with a custom `sign_type: "SIGN"` header, and uses `/v4/chat/completions`.
 
-use crate::providers::traits::Provider;
+use crate::providers::traits::{ChatMessage, Provider};
 use async_trait::async_trait;
 use reqwest::Client;
 use ring::hmac;
@@ -206,6 +206,53 @@ impl Provider for GlmProvider {
             .map(|c| c.message.content)
             .ok_or_else(|| anyhow::anyhow!("No response from GLM"))
     }
+
+    async fn chat_with_history(
+        &self,
+        messages: &[ChatMessage],
+        model: &str,
+        temperature: f64,
+    ) -> anyhow::Result<String> {
+        let token = self.generate_token()?;
+
+        let api_messages: Vec<Message> = messages
+            .iter()
+            .map(|m| Message {
+                role: m.role.clone(),
+                content: m.content.clone(),
+            })
+            .collect();
+
+        let request = ChatRequest {
+            model: model.to_string(),
+            messages: api_messages,
+            temperature,
+        };
+
+        let url = format!("{}/chat/completions", self.base_url);
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error = response.text().await?;
+            anyhow::bail!("GLM API error: {error}");
+        }
+
+        let chat_response: ChatResponse = response.json().await?;
+
+        chat_response
+            .choices
+            .into_iter()
+            .next()
+            .map(|c| c.message.content)
+            .ok_or_else(|| anyhow::anyhow!("No response from GLM"))
+    }
 }
 
 #[cfg(test)]
@@ -265,6 +312,19 @@ mod tests {
         let result = p
             .chat_with_system(None, "hello", "glm-4.7", 0.7)
             .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn chat_with_history_fails_without_key() {
+        let p = GlmProvider::new(None);
+        let messages = vec![
+            ChatMessage::system("You are helpful."),
+            ChatMessage::user("Hello"),
+            ChatMessage::assistant("Hi there!"),
+            ChatMessage::user("What did I say?"),
+        ];
+        let result = p.chat_with_history(&messages, "glm-4.7", 0.7).await;
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
## Summary

- Problem: `GlmProvider` only implements `chat_with_system` and relies on the trait default for `chat_with_history`, which extracts only the last user message. Multi-turn conversations lose all prior context.
- Why it matters: The GLM API (`/v4/chat/completions`) accepts full conversation history in the same format as OpenAI/OpenRouter. Not sending history means the agent cannot maintain context across tool-call loops.
- What changed: Added `chat_with_history` implementation that maps all `ChatMessage` entries to the GLM API's message format and sends the full conversation.
- What did **not** change (scope boundary): `chat_with_system` is unchanged. JWT token generation is unchanged. No config changes.

## Label Snapshot (required)

- Risk label: risk: low
- Size label: size: XS
- Scope labels: provider
- Module labels: provider: glm
- Contributor tier label: trusted contributor
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: feature
- Primary scope: provider

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check   # pass
cargo build                  # pass
```

- Evidence provided: local build passes, new test added
- If any command is intentionally skipped, explain why: `cargo test` skipped — no test runner on target device. Integration test requires live GLM API key.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (uses same endpoint as chat_with_system)
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Test messages use generic content

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Confirmed GLM API uses OpenAI-compatible message format (role + content)
- Confirmed implementation follows the same pattern as OpenRouterProvider::chat_with_history
- Confirmed chat_with_system behavior is unaffected

## Rollback Plan (required)

- Revert this commit. Falls back to trait default (last user message only).
- Risk: Trivial.