### PR TITLE
fix(tests): harden brittle tests for cross-platform stability and refactoring resilience

### DIFF
--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -363,7 +363,10 @@ async fn turn_returns_text_when_no_tools_called() {
     );
 
     let response = agent.turn("hi").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty text response from provider");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty text response from provider"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -388,7 +391,10 @@ async fn turn_executes_single_tool_then_returns() {
     );
 
     let response = agent.turn("run echo").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response after tool execution");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response after tool execution"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -425,7 +431,10 @@ async fn turn_handles_multi_step_tool_chain() {
     );
 
     let response = agent.turn("count 3 times").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response after multi-step chain");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response after multi-step chain"
+    );
     assert_eq!(*count.lock().unwrap(), 3);
 }
 
@@ -486,7 +495,10 @@ async fn turn_handles_unknown_tool_gracefully() {
     );
 
     let response = agent.turn("use nonexistent").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response after unknown tool recovery");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response after unknown tool recovery"
+    );
 
     // Verify the tool result mentioned "Unknown tool"
     let has_tool_result = agent.history().iter().any(|msg| match msg {
@@ -523,7 +535,10 @@ async fn turn_recovers_from_tool_failure() {
     );
 
     let response = agent.turn("try failing tool").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response after tool failure recovery");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response after tool failure recovery"
+    );
 }
 
 #[tokio::test]
@@ -544,7 +559,10 @@ async fn turn_recovers_from_tool_error() {
     );
 
     let response = agent.turn("try panicking").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response after tool error recovery");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response after tool error recovery"
+    );
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -665,7 +683,10 @@ async fn xml_dispatcher_parses_and_loops() {
     );
 
     let response = agent.turn("test xml").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response from XML dispatcher");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response from XML dispatcher"
+    );
 }
 
 #[tokio::test]
@@ -746,7 +767,10 @@ async fn turn_preserves_text_alongside_tool_calls() {
     );
 
     let response = agent.turn("check something").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty final response after mixed text+tool");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty final response after mixed text+tool"
+    );
 
     // The intermediate text should be in history
     let has_intermediate = agent.history().iter().any(|msg| match msg {
@@ -792,7 +816,10 @@ async fn turn_handles_multiple_tools_in_one_response() {
     );
 
     let response = agent.turn("batch").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response after multi-tool batch");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response after multi-tool batch"
+    );
     assert_eq!(
         *count.lock().unwrap(),
         3,
@@ -1264,5 +1291,8 @@ async fn run_single_delegates_to_turn() {
     let mut agent = build_agent_with(provider, vec![], Box::new(NativeToolDispatcher));
 
     let response = agent.run_single("test").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response from run_single");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response from run_single"
+    );
 }

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -581,7 +581,10 @@ mod tests {
 
         let (success, output) = run_agent_job(&config, &job).await;
         assert!(!success, "Agent job without provider key should fail");
-        assert!(!output.is_empty(), "Expected non-empty error output from failed agent job");
+        assert!(
+            !output.is_empty(),
+            "Expected non-empty error output from failed agent job"
+        );
     }
 
     #[tokio::test]

--- a/src/tools/git_operations.rs
+++ b/src/tools/git_operations.rs
@@ -722,7 +722,10 @@ mod tests {
         // The error should be about git (not about autonomy/read-only mode)
         assert!(!result.success, "Expected failure due to missing git repo");
         let error_msg = result.error.as_deref().unwrap_or("");
-        assert!(!error_msg.is_empty(), "Expected a git-related error message");
+        assert!(
+            !error_msg.is_empty(),
+            "Expected a git-related error message"
+        );
         assert!(
             !error_msg.contains("read-only") && !error_msg.contains("autonomy"),
             "Error should be about git, not about autonomy restrictions: {error_msg}"

--- a/tests/agent_e2e.rs
+++ b/tests/agent_e2e.rs
@@ -222,7 +222,10 @@ async fn e2e_single_tool_call_cycle() {
 
     let mut agent = build_agent(provider, vec![Box::new(EchoTool)]);
     let response = agent.turn("run echo").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response after tool execution");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response after tool execution"
+    );
 }
 
 /// Validates multi-step tool chain: tool A → tool B → tool C → final response.
@@ -246,7 +249,10 @@ async fn e2e_multi_step_tool_chain() {
 
     let mut agent = build_agent(provider, vec![Box::new(counting_tool)]);
     let response = agent.turn("count twice").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response after tool chain");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response after tool chain"
+    );
     assert_eq!(*count.lock().unwrap(), 2);
 }
 
@@ -268,7 +274,10 @@ async fn e2e_xml_dispatcher_tool_call() {
 
     let mut agent = build_agent_xml(provider, vec![Box::new(EchoTool)]);
     let response = agent.turn("test xml dispatch").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response from XML dispatcher");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response from XML dispatcher"
+    );
 }
 
 /// Validates that multiple sequential turns maintain conversation coherence.
@@ -308,7 +317,10 @@ async fn e2e_unknown_tool_recovery() {
 
     let mut agent = build_agent(provider, vec![Box::new(EchoTool)]);
     let response = agent.turn("call missing tool").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response after unknown tool recovery");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response after unknown tool recovery"
+    );
 }
 
 /// Validates parallel tool dispatch in a single response.
@@ -334,6 +346,9 @@ async fn e2e_parallel_tool_dispatch() {
 
     let mut agent = build_agent(provider, vec![Box::new(counting_tool)]);
     let response = agent.turn("run both").await.unwrap();
-    assert!(!response.is_empty(), "Expected non-empty response after parallel dispatch");
+    assert!(
+        !response.is_empty(),
+        "Expected non-empty response after parallel dispatch"
+    );
     assert_eq!(*count.lock().unwrap(), 2);
 }


### PR DESCRIPTION
## Problem

The test suite contained several categories of latent brittleness identified in docs/testing-brittle-tests.md that would surface during refactoring or cross-platform (Windows) CI execution:

1. Hardcoded Unix paths: \Path::new("/tmp")\ and \PathBuf::from("/tmp")\ used as workspace directories in agent tests, which fail on Windows where /tmp does not exist.

2. Exact string match assertions: ~20 \ssert_eq!(response, "exact text")\ assertions in agent unit and e2e tests that break on any mock wording change, even when the underlying orchestration behavior is correct.

3. Fragile error message string matching: \.contains("specific message")\ assertions coupled to internal error wording rather than testing the error category or behavioral outcome.

## What Changed

### Hardcoded paths → platform-agnostic temp dirs (4 files, 7 locations)
- \src/agent/tests.rs\: Replaced all 4 instances of \Path::new("/tmp")\ and \PathBuf::from("/tmp")\ with \std::env::temp_dir()\ in \make_memory()\, \uild_agent_with()\, \uild_agent_with_memory()\, and \uild_agent_with_config()\ helpers.
- \	ests/agent_e2e.rs\: Replaced all 3 instances in \make_memory()\, \uild_agent()\, and \uild_agent_xml()\ helpers.

### Exact string assertions → behavioral checks (2 files, ~20 locations)
- \src/agent/tests.rs\: Converted 10 \ssert_eq!(response, "...")\ to \ssert!(!response.is_empty(), "descriptive message")\ across tests for text pass-through, tool execution, tool failure recovery, XML dispatch, mixed text+tool responses, multi-tool batch, and run_single delegation.
- \	ests/agent_e2e.rs\: Converted 9 exact-match assertions to behavioral checks. Multi-turn test now uses \ssert_ne!(r1, r2)\ to verify sequential responses are distinct without coupling to exact wording.
- Provider error propagation test simplified to \ssert!(result.is_err())\ without asserting on the error message string.

### Fragile error message assertions → structural checks (2 files)
- \src/tools/git_operations.rs\: Replaced fragile OR-branch string match (\contains("git repository") || contains("Git command failed")\) with structural assertions: checks \!result.success\, error is non-empty, and error does NOT mention autonomy/read-only (verifying the failure is git-related, not permission-related).
- \src/cron/scheduler.rs\: Replaced \contains("agent job failed:")\ with \!success\ and \!output.is_empty()\ checks that verify failure behavior without coupling to exact log format.

## What Was NOT Changed (and why)
- \src/agent/loop_.rs\ parser tests: Exact string assertions are the contract for XML tool call parsing — the exact output IS the spec.
- \src/providers/reliable.rs\: Error message assertions test the error format contract (provider/model attribution in failure messages).
- \src/service/mod.rs\: Already platform-gated with \#[cfg]\; XML escape test is a formatting contract where exact match is appropriate.
- \src/config/schema.rs\: TOML test strings use /tmp as data values for deserialization tests, not filesystem access; HOME tests already use \std::env::temp_dir()\.