### PR TITLE
feat(onboard): add signup URL, model catalog, and live fetch for Astrai

### DIFF
--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -774,6 +774,7 @@ fn supports_live_model_fetch(provider_name: &str) -> bool {
             | "together-ai"
             | "gemini"
             | "ollama"
+            | "astrai"
     )
 }
 
@@ -1020,6 +1021,9 @@ fn fetch_live_models_for_provider(provider_name: &str, api_key: &str) -> Result<
                     "deepseek-v3.1:cloud".to_string(),
                 ]
             }
+        }
+        "astrai" => {
+            fetch_openai_compatible_models("https://as-trai.com/v1/models", api_key.as_deref())?
         }
         _ => Vec::new(),
     };
@@ -1648,6 +1652,7 @@ fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String, Optio
                 "nvidia" | "nvidia-nim" | "build.nvidia.com" => "https://build.nvidia.com/",
                 "bedrock" => "https://console.aws.amazon.com/iam",
                 "gemini" => "https://aistudio.google.com/app/apikey",
+                "astrai" => "https://as-trai.com",
                 _ => "",
             }
         };
@@ -1808,6 +1813,16 @@ fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String, Optio
             ),
             ("gemini-1.5-pro", "Gemini 1.5 Pro (best quality)"),
             ("gemini-1.5-flash", "Gemini 1.5 Flash (balanced)"),
+        ],
+        "astrai" => vec![
+            ("auto", "Auto — Astrai best execution routing (recommended)"),
+            ("gpt-4o", "GPT-4o (OpenAI via Astrai)"),
+            (
+                "claude-sonnet-4.5",
+                "Claude Sonnet 4.5 (Anthropic via Astrai)",
+            ),
+            ("deepseek-v3", "DeepSeek V3 (best value via Astrai)"),
+            ("llama-3.3-70b", "Llama 3.3 70B (open source via Astrai)"),
         ],
         _ => vec![("default", "Default model")],
     };
@@ -4596,6 +4611,7 @@ mod tests {
         assert!(supports_live_model_fetch("grok"));
         assert!(supports_live_model_fetch("together"));
         assert!(supports_live_model_fetch("ollama"));
+        assert!(supports_live_model_fetch("astrai"));
         assert!(!supports_live_model_fetch("venice"));
     }
 


### PR DESCRIPTION
## Summary
- **Signup URL**: Users now see `Get your API key at: https://as-trai.com` during onboarding (previously blank)
- **Curated model list**: 5 models including `auto` (best execution routing), GPT-4o, Claude Sonnet 4.5, DeepSeek V3, Llama 3.3 70B
- **Live model fetch**: Added Astrai to `supports_live_model_fetch` and `fetch_live_models_for_provider` — queries the OpenAI-compatible `/v1/models` endpoint when a key is present

## Context
Follow-up to #486 (Astrai provider integration). The initial PR added factory wiring and env var support, but the onboarding wizard had no signup URL, no curated models (fell to generic "Default model"), and no live model discovery. This made the Astrai option effectively dead in onboarding — users had nowhere to get a key and no model choices.

## Test plan
- [x] `cargo test -p zeroclaw onboard` — all 39 tests pass
- [x] `cargo test -p zeroclaw factory_astrai` — provider factory test passes
- [x] `cargo fmt --all -- --check` — no formatting issues in wizard.rs
- [x] New `supports_live_model_fetch("astrai")` assertion added to existing test

## Risk and Rollback
- **Risk**: Low — additive only, no behavior changes for other providers
- **Rollback**: Revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)