### PR TITLE
fix(config): ZEROCLAW_WORKSPACE expects parent dir containing workspace

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1858,9 +1858,11 @@ pub(crate) fn persist_active_workspace_config_dir(config_dir: &Path) -> Result<(
 
 fn resolve_config_dir_for_workspace(workspace_dir: &Path) -> (PathBuf, PathBuf) {
     let workspace_config_dir = workspace_dir.to_path_buf();
-    let workspace_dir = workspace_dir.join("workspace").to_path_buf();
     if workspace_config_dir.join("config.toml").exists() {
-        return (workspace_config_dir, workspace_dir);
+        return (
+            workspace_config_dir.clone(),
+            workspace_config_dir.join("workspace"),
+        );
     }
 
     let legacy_config_dir = workspace_dir
@@ -1879,7 +1881,10 @@ fn resolve_config_dir_for_workspace(workspace_dir: &Path) -> (PathBuf, PathBuf) 
         }
     }
 
-    (workspace_config_dir, workspace_dir)
+    (
+        workspace_config_dir.clone(),
+        workspace_config_dir.join("workspace"),
+    )
 }
 
 fn decrypt_optional_secret(
@@ -3376,7 +3381,7 @@ default_temperature = 0.7
 
         let config = Config::load_or_init().unwrap();
 
-        assert_eq!(config.workspace_dir, workspace_dir);
+        assert_eq!(config.workspace_dir, workspace_dir.join("workspace"));
         assert_eq!(config.config_path, workspace_dir.join("config.toml"));
         assert!(workspace_dir.join("config.toml").exists());
 
@@ -3509,7 +3514,7 @@ default_model = "legacy-model"
 
         let config = Config::load_or_init().unwrap();
 
-        assert_eq!(config.workspace_dir, env_workspace_dir);
+        assert_eq!(config.workspace_dir, env_workspace_dir.join("workspace"));
         assert_eq!(config.config_path, env_workspace_dir.join("config.toml"));
 
         std::env::remove_var("ZEROCLAW_WORKSPACE");


### PR DESCRIPTION
When onboarding using a custom workspace path the environment generated contains a "config.toml" and "workspace" directory under the specified path, the default config also assumes "workspace_dir" is the toplevel folder containing "config.toml" and the "workspace" directory under it.

The code has inconsistent (and buggy) behavior where when specifying ZEROCLAW_WORKSPACE it would look for both "config.toml" and the "workspace" directory drectly under the env var folder, that is wrong and I believe uninteded, after onboarding with a custom folder I expect the below to work (it appears working but .md files aren't read and memory files are generated in the wrong path):
```sh
ZEROCLAW_WORKSPACE=/path/to/folder zeroclaw daemon
```
Where the above folder contains the config and workspace directory as generated by the onboarding.

~~Also updated ZEROCLAW_WORKSPACE inthe Dockerfile to reflect this change as it was specifying a wrong workspace folder (and probably wasn't reading the .md files anyways).~~

**EDIT**: Realized there was "legacy behavior", reverted Dockerfile made code work for both cases.

## Summary

Describe this PR in 2-5 bullets:

- Problem: ZEROCLAW_WORKSPACE does not work as intended
- Why it matters: Unable to run agents in custom folders
- What changed: Env var behavior
- What did **not** change (scope boundary): Nothing else

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`):low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):XS
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):config
<<<<<<< chore/labeler-spacing-trusted-tier
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`):config:ZEROCLAW_WORKSPACE
=======
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`):config
>>>>>>> main
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):experienced
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`):bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):runtime

## Linked Issue

- Closes #
- Related #417
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes
- Migration needed? No
- If yes, exact upgrade steps:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Onboarded to custom folder ran using ZEROCLAW_WORKSPACE
- Edge cases checked: no edge cases
- What was not verified: nothing else

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Nada, human created
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: None
  - Mitigation: None
