### PR TITLE
Change channel ID to 'discord' in message structure

### DIFF
--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -406,7 +406,7 @@ impl Channel for DiscordChannel {
                             channel_id.clone()
                         },
                         content: clean_content,
-                        channel: channel_id,
+                        channel: "discord".to_string(),
                         timestamp: std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
                             .unwrap_or_default()


### PR DESCRIPTION
ChannelMessage.channel is used as a lookup key to retrieve the channel implementation by name (channels_by_name.get(&msg.channel)). The Discord listen method was incorrectly setting it to the Discord snowflake channel ID, causing the lookup to return None and silently dropping all outbound replies. The reply_target field (which holds the snowflake ID and is used as the actual API routing target in send) was already correct