### PR TITLE
perf(cron): wrap record_run INSERT+DELETE in explicit transaction

### DIFF
--- a/src/cron/store.rs
+++ b/src/cron/store.rs
@@ -293,7 +293,12 @@ pub fn record_run(
     duration_ms: i64,
 ) -> Result<()> {
     with_connection(config, |conn| {
-        conn.execute(
+        // Wrap INSERT + pruning DELETE in an explicit transaction so that
+        // if the DELETE fails, the INSERT is rolled back and the run table
+        // cannot grow unboundedly.
+        let tx = conn.unchecked_transaction()?;
+
+        tx.execute(
             "INSERT INTO cron_runs (job_id, started_at, finished_at, status, output, duration_ms)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             params![
@@ -308,7 +313,7 @@ pub fn record_run(
         .context("Failed to insert cron run")?;
 
         let keep = i64::from(config.cron.max_run_history.max(1));
-        conn.execute(
+        tx.execute(
             "DELETE FROM cron_runs
              WHERE job_id = ?1
                AND id NOT IN (
@@ -320,6 +325,8 @@ pub fn record_run(
             params![job_id, keep],
         )
         .context("Failed to prune cron run history")?;
+
+        tx.commit().context("Failed to commit cron run transaction")?;
         Ok(())
     })
 }


### PR DESCRIPTION
Problem:
In record_run(), an INSERT into cron_runs followed by a pruning DELETE ran as separate implicit transactions. If the INSERT succeeded but the DELETE failed (e.g., due to disk pressure or lock contention), the run table would grow unboundedly since the pruning step was lost while the new row persisted.

Fix:
Wrap both statements in an explicit transaction using conn.unchecked_transaction(). If either statement fails, the entire transaction is rolled back, maintaining the invariant that the run history stays bounded by max_run_history.

Ref: zeroclaw-labs/zeroclaw#710 (Item 5)