### PR TITLE
perf(memory): cap LIKE-fallback keyword count for query cache efficiency

### DIFF
--- a/src/memory/sqlite.rs
+++ b/src/memory/sqlite.rs
@@ -461,10 +461,16 @@ impl Memory for SqliteMemory {
             }
         }
 
-        // If hybrid returned nothing, fall back to LIKE search
+        // If hybrid returned nothing, fall back to LIKE search.
+        // Cap keyword count to bound the number of distinct SQL shapes
+        // so the query cache (prepared-statement cache) stays effective.
         if results.is_empty() {
-            let keywords: Vec<String> =
-                query.split_whitespace().map(|w| format!("%{w}%")).collect();
+            const MAX_LIKE_KEYWORDS: usize = 8;
+            let keywords: Vec<String> = query
+                .split_whitespace()
+                .take(MAX_LIKE_KEYWORDS)
+                .map(|w| format!("%{w}%"))
+                .collect();
             if !keywords.is_empty() {
                 let conditions: Vec<String> = keywords
                     .iter()


### PR DESCRIPTION
Problem:
The LIKE-fallback path in recall() builds SQL strings dynamically via format!() with one pair of conditions per keyword. Because the query shape changes for every unique keyword count, SQLite's prepared statement cache cannot reuse compiled queries — each new keyword count produces a unique SQL string that must be re-parsed and compiled.

Fix:
Cap the number of keywords processed in the LIKE fallback to 8 using .take(MAX_LIKE_KEYWORDS). This bounds the number of distinct query shapes to 8, making the prepared statement cache effective. Excess keywords beyond 8 are dropped, which is acceptable because the LIKE fallback is already a last-resort path (only reached when both FTS5 and vector search return no results).

Note: there is no SQL injection risk from the format!() usage since all values are bound as parameters, but the cache miss is a real performance concern for repeated queries.

Ref: zeroclaw-labs/zeroclaw#710 (Item 6)