### PR TITLE
docs(readme): dark mode support for Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,7 +744,11 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Implement a trait, submit a PR:
 ## Star History
 
 <p align="center">
-  <a href="https://www.star-history.com/#zeroclaw-labs/zeroclaw&Date">
-    <img src="https://api.star-history.com/svg?repos=zeroclaw-labs/zeroclaw&type=Date" alt="Star History Chart" />
+  <a href="https://www.star-history.com/#zeroclaw-labs/zeroclaw&type=date&legend=top-left">
+    <picture>
+     <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=zeroclaw-labs/zeroclaw&type=date&theme=dark&legend=top-left" />
+     <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=zeroclaw-labs/zeroclaw&type=date&legend=top-left" />
+     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=zeroclaw-labs/zeroclaw&type=date&legend=top-left" />
+    </picture>
   </a>
 </p>


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: Currently Star History chart doesn't respect browser/system dark mode setting
- Why it matters: Universal theme for entire README.md page
- What changed: README.md
- What did **not** change (scope boundary): No code files were changed.

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): docs
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): docs

## Linked Issue

- Closes #747 

## Validation Evidence (required)

<img width="2551" height="1470" alt="image" src="https://github.com/user-attachments/assets/bd902529-7c6f-47e5-92d5-fddf05d1bdd9" />

- If any command is intentionally skipped, explain why: only README.md updated, no code touched.
