### PR TITLE
fix(ci): use snake_case inputs for first-interaction action

### DIFF
--- a/.github/workflows/pr-auto-response.yml
+++ b/.github/workflows/pr-auto-response.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Greet first-time contributors
         uses: actions/first-interaction@a1db7729b356323c7988c20ed6f0d33fe31297be # v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Thanks for opening this issue.
 
             Before maintainers triage it, please confirm:
@@ -50,7 +50,7 @@ jobs:
             - Sensitive values are redacted
 
             This helps us keep issue throughput high and response latency low.
-          pr-message: |
+          pr_message: |
             Thanks for contributing to ZeroClaw.
 
             For faster review, please ensure:


### PR DESCRIPTION
## Summary

Fixes CI error in `pr-auto-response.yml` workflow.

## Problem

The `actions/first-interaction` action requires snake_case input names, but the workflow was using kebab-case:

```
Error: Input required and not supplied: issue_message
```

## Changes

| Before (kebab-case) | After (snake_case) |
|---------------------|-------------------|
| `repo-token` | `repo_token` |
| `issue-message` | `issue_message` |
| `pr-message` | `pr_message` |

## Testing

The workflow will be tested when this PR is merged and a new contributor opens an issue or PR.