### PR TITLE
fix(token): update token generation to use rand::rng() to resolve dep…

### DIFF
--- a/src/security/pairing.rs
+++ b/src/security/pairing.rs
@@ -176,14 +176,14 @@ fn generate_code() -> String {
 
 /// Generate a cryptographically-adequate bearer token with 256-bit entropy.
 ///
-/// Uses `rand::thread_rng()` which is backed by the OS CSPRNG
+/// Uses `rand::rng()` which is backed by the OS CSPRNG
 /// (/dev/urandom on Linux, BCryptGenRandom on Windows, SecRandomCopyBytes
 /// on macOS). The 32 random bytes (256 bits) are hex-encoded for a
 /// 64-character token, providing 256 bits of entropy.
 fn generate_token() -> String {
     use rand::RngCore;
     let mut bytes = [0u8; 32];
-    rand::thread_rng().fill_bytes(&mut bytes);
+    rand::rng().fill_bytes(&mut bytes);
     format!("zc_{}", hex::encode(bytes))
 }
 


### PR DESCRIPTION
Addresses warning coming from compiler: 
❯ rspberrypi@localhost:~/zeroclaw$ cargo build --release --locked                                        
  warning: use of deprecated function `rand::thread_rng`: Renamed to `rng`                             
     --> src/security/pairing.rs:186:11                                                                      |                                                                                                
  186 |     rand::thread_rng().fill_bytes(&mut bytes);                                                       |           ^^^^^^^^^^                                                                           
      |                                                                                                
      = note: `#[warn(deprecated)]` on by default 