### PR TITLE
test(security): strengthen token-format regression coverage

### DIFF
--- a/src/security/pairing.rs
+++ b/src/security/pairing.rs
@@ -424,7 +424,9 @@ mod tests {
 
         assert_eq!(payload.len(), 64, "Token payload should be 32 bytes in hex");
         assert!(
-            payload.chars().all(|c| c.is_ascii_hexdigit()),
+            payload
+                .chars()
+                .all(|c| c.is_ascii_digit() || matches!(c, 'a'..='f')),
             "Token payload should be lowercase hex"
         );
     }


### PR DESCRIPTION
## Summary
- **Problem:** follow-up guardrails were still weak around token-format regression checks after #754/#755.
- **Why it matters:** future refactors could accidentally loosen token-format guarantees without being caught early.
- **What changed:** strengthened `src/security/pairing.rs` test assertions to require `zc_` + exact 64-char lowercase hex payload.

## Validation Evidence
- Local:
  - `cargo build --locked` ✅
  - `cargo clippy --all-targets -- -D warnings` ❌ (pre-existing unrelated failures in `src/gateway/mod.rs`, `src/tools/memory_store.rs`, `src/memory/sqlite.rs`, `src/observability/prometheus.rs`, `src/providers/anthropic.rs`)
  - `cargo test` ❌ (pre-existing unrelated compile failures in `src/gateway/mod.rs`, `src/tools/memory_store.rs`)
- CI:
  - `Build (Smoke)` ✅
  - `CI Required Gate` ✅
  - Security workflow checks ✅

## Security Impact
- No runtime behavior changes.
- This is test-only hardening for token format invariants.
- Risk level: low.

## Privacy and Data Hygiene
- No secrets, credentials, or personal data added.
- All added/edited text is English-only and neutral.

## Rollback Plan
- Revert commit `05c6527` (and `ce92bd6` if needed) to restore prior test assertions.
- No data migration or config rollback needed.

## Linked Issue
- refs #754