### PR TITLE
feat(providers): support reasoning_content fallback for thinking models

### DIFF
--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -460,9 +460,12 @@ mod tests {
 
     #[test]
     fn response_with_unicode() {
-        let json = r#"{"choices":[{"message":{"content":"こんにちは 🦀"}}]}"#;
+        let json = r#"{"choices":[{"message":{"content":"Hello \u03A9"}}]}"#;
         let resp: ChatResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(resp.choices[0].message.effective_content(), "こんにちは 🦀");
+        assert_eq!(
+            resp.choices[0].message.effective_content(),
+            "Hello \u{03A9}"
+        );
     }
 
     #[test]
@@ -483,9 +486,9 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    // ══════════════════════════════════════════════════════════
+    // ----------------------------------------------------------
     // Reasoning model fallback tests (reasoning_content)
-    // ══════════════════════════════════════════════════════════
+    // ----------------------------------------------------------
 
     #[test]
     fn reasoning_content_fallback_empty_content() {


### PR DESCRIPTION
## Summary

This PR adds robust fallback support for reasoning/thinking models that return text in `reasoning_content` rather than `content`.

- Adds `reasoning_content` support in both OpenAI-compatible and OpenAI providers.
- Uses `effective_content()` extraction helpers to keep behavior stable for non-thinking models.
- Includes streaming SSE fallback support.
- Adds focused fallback tests.

## Problem

Some thinking models (for example GLM/Qwen/DeepSeek variants) may return empty/null/missing `content` while still providing valid text in `reasoning_content`. Without fallback handling, the agent can return empty responses.

## Why This Matters

This breaks provider compatibility for an increasingly common model response pattern and causes user-visible empty answers even when the model produced useful output.

## Changes

### `src/providers/compatible.rs`

- Adds `reasoning_content: Option<String>` to response and streaming delta structures.
- Adds `effective_content()` helper for non-streaming extraction paths.
- Extends SSE parsing to fall back to `reasoning_content` when streaming `content` is empty/absent.
- Adds and updates focused tests for fallback behavior.

### `src/providers/openai.rs`

- Changes response `content` parsing to optional for robust fallback behavior.
- Adds `reasoning_content: Option<String>` for chat/native response structures.
- Uses `effective_content()` in extraction paths.
- Updates and extends tests accordingly.

## Validation Evidence (required)

Commands run locally:

- `cargo fmt --all`
- `cargo check --locked --lib`
- `cargo check --locked --bin zeroclaw`
- `cargo clippy --locked --lib -- -D clippy::correctness`
- `./scripts/ci/docs_quality_gate.sh`

Notes:

- `cargo test --lib` and `./scripts/ci/rust_quality_gate.sh` are currently blocked by pre-existing upstream test-compilation issues unrelated to this PR (e.g., stale constructor args in `src/gateway/mod.rs` test initializers and missing `security` arg in `src/tools/memory_store.rs` test code).
- CI checks for this PR are green, including required gate/build/security/license checks.

## Security Impact (required)

- Risk level: low.
- Change type: additive parsing fallback only.
- No new privileges, no policy broadening, no secret handling changes.
- Non-thinking models remain on the existing `content` path.

## Privacy and Data Hygiene (required)

- No new data collection, retention, or transmission paths.
- No additional logging of message payloads/secrets introduced.
- Parsing behavior changes only in provider response handling.

## Rollback Plan (required)

- Revert commits in this PR to restore previous extraction behavior.
- No schema migrations or stateful data changes required.
- Blast radius is limited to `src/providers/compatible.rs` and `src/providers/openai.rs`.
