### PR TITLE
fix(docker): unblock workspace build and auto-publish latest image

### DIFF
--- a/.github/workflows/pub-docker-img.yml
+++ b/.github/workflows/pub-docker-img.yml
@@ -2,14 +2,33 @@ name: Pub Docker Img
 
 on:
     push:
+        branches: [main]
         tags: ["v*"]
+        paths:
+            - "Dockerfile"
+            - ".dockerignore"
+            - "Cargo.toml"
+            - "Cargo.lock"
+            - "rust-toolchain.toml"
+            - "src/**"
+            - "crates/**"
+            - "benches/**"
+            - "firmware/**"
+            - "dev/config.template.toml"
+            - ".github/workflows/pub-docker-img.yml"
     pull_request:
         branches: [main]
         paths:
             - "Dockerfile"
-            - "docker-compose.yml"
-            - "dev/docker-compose.yml"
-            - "dev/sandbox/**"
+            - ".dockerignore"
+            - "Cargo.toml"
+            - "Cargo.lock"
+            - "rust-toolchain.toml"
+            - "src/**"
+            - "crates/**"
+            - "benches/**"
+            - "firmware/**"
+            - "dev/config.template.toml"
             - ".github/workflows/pub-docker-img.yml"
     workflow_dispatch:
 
@@ -61,7 +80,7 @@ jobs:
 
     publish:
         name: Build and Push Docker Image
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         runs-on: blacksmith-2vcpu-ubuntu-2404
         timeout-minutes: 25
         permissions:

--- a/docs/ci-map.md
+++ b/docs/ci-map.md
@@ -24,7 +24,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 ### Non-Blocking but Important
 
 - `.github/workflows/pub-docker-img.yml` (`Docker`)
-    - Purpose: PR Docker smoke check and publish images on tag pushes (`v*`)
+    - Purpose: PR Docker smoke check and publish images on `main` pushes (build-input paths), tag pushes (`v*`), and manual dispatch
 - `.github/workflows/sec-audit.yml` (`Security Audit`)
     - Purpose: dependency advisories (`rustsec/audit-check`, pinned SHA) and policy/license checks (`cargo deny`)
 - `.github/workflows/sec-codeql.yml` (`CodeQL Analysis`)
@@ -66,7 +66,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 ## Trigger Map
 
 - `CI`: push to `main`, PRs to `main`
-- `Docker`: tag push (`v*`), PRs touching docker/workflow files, manual dispatch
+- `Docker`: push to `main` when Docker build inputs change, tag push (`v*`), matching PRs, manual dispatch
 - `Release`: tag push (`v*`)
 - `Security Audit`: push to `main`, PRs to `main`, weekly schedule
 - `Workflow Sanity`: PR/push when `.github/workflows/**`, `.github/*.yml`, or `.github/*.yaml` change


### PR DESCRIPTION
## Summary

- Problem: Docker builder warm-cache layer fails because workspace member `crates/robot-kit` is missing during `cargo build --release --locked`.
- Why it matters: users cannot build the Docker image locally/CI, and `latest` image in registry stays stale after normal `main` pushes.
- What changed: Dockerfile now includes workspace sub-crate manifest + placeholder source in warm-cache stage, copies `crates/` in full build stage, and Docker publish workflow now runs on qualifying `main` pushes (plus tags/manual dispatch).
- What did **not** change (scope boundary): no runtime behavior, provider/channel/tool logic, or release artifact workflow semantics beyond Docker image publish triggers/tags.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high` (workflow + container publish surface)
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS` expected
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `ci,docs`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `ci:docker`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `ci`

## Linked Issue

- Closes #764
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): No
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): no superseded PR
- Trailer format check (separate lines, no escaped `\n`): Pass

## Validation Evidence (required)

Commands and result summary:

```bash
# Reproduced previous failure shape (missing workspace member manifest)
# in a minimal temp directory with only root Cargo files + dummy root targets.

# Verified fixed layering logic (manifest + placeholder target + full crates copy)
# resolves workspace parsing in both warm-cache and source-copy phases.

cargo check --locked
cargo check --locked -p zeroclaw-robot-kit
python3 - <<'PY'
import yaml
yaml.safe_load(open('.github/workflows/pub-docker-img.yml', encoding='utf-8'))
print('yaml-ok')
PY
python3 - <<'PY'
from pathlib import Path
for p in Path('.github/workflows').rglob('*.yml'):
    assert '\t' not in p.read_text(encoding='utf-8')
print('workflow-tab-check-ok')
PY
```

- Evidence provided (test/log/trace/screenshot/perf): local command logs and temp workspace reproduction trace.
- If any command is intentionally skipped, explain why: full Docker build was not runnable in this environment because local `docker` daemon calls were hanging; validated equivalent cargo/workspace layering behavior with deterministic local simulation instead.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: no personal/sensitive data introduced
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: reproduced original workspace-missing failure; validated fixed warm-cache + source-copy layering; validated cargo checks for root package and `zeroclaw-robot-kit` package.
- Edge cases checked: workflow trigger/path logic for `main` pushes, tags, PRs, and manual dispatch; tag computation behavior for `main` vs tags remains deterministic.
- What was not verified: end-to-end registry push on GitHub-hosted runner (left to CI in PR).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `Dockerfile`, `.github/workflows/pub-docker-img.yml`, CI docs.
- Potential unintended effects: increased Docker workflow frequency on `main` pushes that touch build inputs.
- Guardrails/monitoring for early detection: PR smoke remains enabled; publish still path-filtered on `main`; tags remain supported for versioned multi-arch release images.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex CLI + gh CLI + local cargo/yaml checks.
- Workflow/plan summary (if any): reproduce -> root-cause -> Dockerfile fix -> workflow trigger fix -> validate -> issue+PR.
- Verification focus: workspace manifest resolution and image publication freshness for `latest`.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert this PR commit from `main`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: if rollback is needed, Docker build may fail again on missing `crates/robot-kit` in warm-cache layer and `latest` may stop auto-refreshing on `main`.

## Risks and Mitigations

- Risk: Docker workflow runs more often on `main` than before.
  - Mitigation: path filters limit runs to Docker build inputs; PR smoke + publish logic remain deterministic.
- Risk: image tag expectations change for `latest` freshness.
  - Mitigation: `main` push now intentionally updates `latest` + `sha-*`; tag push behavior remains versioned + `sha-*`.
