### PR TITLE
fix(runtime): resolve reply_target compile regression

### DIFF
--- a/examples/custom_channel.rs
+++ b/examples/custom_channel.rs
@@ -13,7 +13,7 @@ pub struct ChannelMessage {
     pub id: String,
     pub sender: String,
     /// Channel-specific reply address (e.g. Telegram chat_id, Discord channel_id).
-    pub reply_to: String,
+    pub reply_target: String,
     pub content: String,
     pub channel: String,
     pub timestamp: u64,
@@ -97,7 +97,7 @@ impl Channel for TelegramChannel {
                         let channel_msg = ChannelMessage {
                             id: msg["message_id"].to_string(),
                             sender,
-                            reply_to: chat_id,
+                            reply_target: chat_id,
                             content: msg["text"].as_str().unwrap_or("").to_string(),
                             channel: "telegram".into(),
                             timestamp: msg["date"].as_u64().unwrap_or(0),

--- a/src/channels/irc.rs
+++ b/src/channels/irc.rs
@@ -551,7 +551,7 @@ impl Channel for IrcChannel {
                     // Determine reply target: if sent to a channel, reply to channel;
                     // if DM (target == our nick), reply to sender
                     let is_channel = target.starts_with('#') || target.starts_with('&');
-                    let reply_to = if is_channel {
+                    let reply_target = if is_channel {
                         target.to_string()
                     } else {
                         sender_nick.to_string()
@@ -566,7 +566,7 @@ impl Channel for IrcChannel {
                     let channel_msg = ChannelMessage {
                         id: format!("irc_{}_{seq}", chrono::Utc::now().timestamp_millis()),
                         sender: sender_nick.to_string(),
-                        reply_target: reply_to,
+                        reply_target,
                         content,
                         channel: "irc".to_string(),
                         timestamp: std::time::SystemTime::now()

--- a/tests/reply_target_field_regression.rs
+++ b/tests/reply_target_field_regression.rs
@@ -1,0 +1,70 @@
+//! Regression guard for ChannelMessage field naming consistency.
+//!
+//! This test prevents accidental reintroduction of the removed `reply_to` field
+//! in Rust source code where `reply_target` must be used.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const SCAN_PATHS: &[&str] = &["src", "examples"];
+const FORBIDDEN_PATTERNS: &[&str] = &[".reply_to", "reply_to:"];
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("Failed to read directory {}: {err}", dir.display()));
+
+    for entry in entries {
+        let entry =
+            entry.unwrap_or_else(|err| panic!("Failed to read entry in {}: {err}", dir.display()));
+        let path = entry.path();
+
+        if path.is_dir() {
+            collect_rs_files(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+#[test]
+fn source_does_not_use_legacy_reply_to_field() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut rust_files = Vec::new();
+
+    for relative in SCAN_PATHS {
+        collect_rs_files(&root.join(relative), &mut rust_files);
+    }
+
+    rust_files.sort();
+
+    let mut violations = Vec::new();
+
+    for file_path in rust_files {
+        let content = fs::read_to_string(&file_path).unwrap_or_else(|err| {
+            panic!("Failed to read source file {}: {err}", file_path.display())
+        });
+
+        for (line_idx, line) in content.lines().enumerate() {
+            for pattern in FORBIDDEN_PATTERNS {
+                if line.contains(pattern) {
+                    let rel = file_path
+                        .strip_prefix(root)
+                        .unwrap_or(&file_path)
+                        .display()
+                        .to_string();
+                    violations.push(format!(
+                        "{rel}:{} contains forbidden pattern `{pattern}`: {}",
+                        line_idx + 1,
+                        line.trim()
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "Found legacy `reply_to` field usage:\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
## Summary
- **Problem:** residual legacy `reply_to` naming remained after `ChannelMessage` migrated to `reply_target`, creating drift risk and potential compile/runtime confusion in channel code and examples.
- **Why it matters:** future refactors/cherry-picks could accidentally reintroduce invalid `ChannelMessage` field usage and break builds or behavior.
- **What changed:** standardized remaining legacy naming to `reply_target` and added a regression guard test that scans `src/` and `examples/` for legacy field-access/initializer patterns.

## Root Cause Analysis
- `ChannelMessage` was migrated from `reply_to` to `reply_target`, but legacy naming remained in a few places (including an example and local identifier naming).
- Even when these leftovers do not always break compilation directly, they increase drift risk and make accidental reintroduction of invalid field usage much more likely in future refactors/cherry-picks.

## Validation Evidence
- ✅ `cargo fmt --all -- --check`
- ✅ `CARGO_TARGET_DIR=/tmp/zc-issue761-target cargo check --locked -j 4`
- ✅ `CARGO_TARGET_DIR=/tmp/zc-issue761-target cargo build --release --locked -j 4`
- ✅ `CARGO_TARGET_DIR=/tmp/zc-issue761-target cargo test --locked --test reply_target_field_regression`
- ⚠️ `cargo clippy --locked --all-targets -- -D warnings` reports existing baseline failures outside this patch scope (`src/agent/loop_.rs`, `src/channels/mod.rs`, `src/memory/sqlite.rs`, `src/observability/prometheus.rs`, `src/providers/anthropic.rs`).
- ⚠️ `cargo test --locked -j 4` may include unrelated pre-existing failures in cron/gemini tests on current baseline.

## Security Impact
- Security risk level: **low**.
- This patch does not expand privileges, policies, or external IO boundaries.
- The regression test reduces correctness drift risk by preventing a known legacy field pattern from re-entering runtime channel code paths.

## Privacy and Data Hygiene
- No personal data, credentials, tokens, or private endpoints introduced.
- Test assertions and messages remain project-scoped and identity-neutral.

## Rollback Plan
- Revert commit: `fix(channels): enforce reply_target naming consistency`.
- Rollback impact: removes the naming cleanup and regression guard, restoring prior behavior only.
- Verification after rollback: run `cargo check --locked -j 4` to confirm baseline parity.

## Issue Link
Closes #761