### PR TITLE
test: stabilize cron shell capture and gemini warmup noop

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -10,6 +10,7 @@ use crate::security::SecurityPolicy;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use futures_util::{stream, StreamExt};
+use std::process::Stdio;
 use std::sync::Arc;
 use tokio::process::Command;
 use tokio::time::{self, Duration};
@@ -429,6 +430,9 @@ async fn run_job_command_with_timeout(
         .arg("-lc")
         .arg(&job.command)
         .current_dir(&config.workspace_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .kill_on_drop(true)
         .spawn()
     {

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -689,7 +689,10 @@ mod tests {
 
     #[tokio::test]
     async fn warmup_without_key_is_noop() {
-        let provider = GeminiProvider::new(None);
+        let provider = GeminiProvider {
+            auth: None,
+            client: Client::new(),
+        };
         let result = provider.warmup().await;
         assert!(result.is_ok());
     }


### PR DESCRIPTION
## Summary
This PR is a follow-up hardening pass after #746.

It removes nondeterminism from 5 previously failing `cargo test --lib` cases:
- 4 cron scheduler command-execution tests
- 1 Gemini warmup no-auth test

## Why it matters
These tests were intermittently flaky because process IO capture and auth source selection were environment-sensitive. Stabilizing them improves CI confidence and keeps regressions detectable.

## What changed
- `src/cron/scheduler.rs`
  - Force deterministic command IO for cron shell jobs:
    - `stdin = null`
    - `stdout = piped`
    - `stderr = piped`
- `src/providers/gemini.rs`
  - In `warmup_without_key_is_noop`, construct an explicit unauthenticated provider (`auth: None`) instead of calling `GeminiProvider::new(None)`, which may resolve ambient credentials.

## Validation Evidence
### Commands run
- `cargo test --lib run_job_command_success`
- `cargo test --lib run_job_command_failure`
- `cargo test --lib execute_job_with_retry_recovers_after_first_failure`
- `cargo test --lib execute_job_with_retry_exhausts_attempts`
- `cargo test --lib warmup_without_key_is_noop`
- `cargo test --lib`
- `cargo test --locked`
- `./scripts/ci/docs_quality_gate.sh` (no docs changed; skipped)

### Results
- Targeted regressions: pass
- `cargo test --lib`: pass (2044 passed, 0 failed)
- `cargo test --locked`: pass (unit/integration/doc tests all green)

## Security Impact
- Risk level: low to medium (test-stability and execution-capture hardening only; no policy broadening).
- No new privileges, secrets, or network surfaces introduced.
- Cron command execution remains gated by existing `SecurityPolicy` checks.

## Privacy and Data Hygiene
- No new data collection or retention paths.
- No personal/sensitive data handling changes.
- Logging shape is unchanged except deterministic capture behavior in test-affected command paths.

## Rollback Plan
- Revert this PR commit to restore prior behavior.
- Rollback scope is limited to two files:
  - `src/cron/scheduler.rs`
  - `src/providers/gemini.rs`

## Issue Link
Related to #746.