### PR TITLE
fix(channel): remove HEARTBEAT.md from channel system prompt

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -488,14 +488,7 @@ fn load_openclaw_bootstrap_files(
         "The following workspace files define your identity, behavior, and context. They are ALREADY injected below—do NOT suggest reading them with file_read.\n\n",
     );
 
-    let bootstrap_files = [
-        "AGENTS.md",
-        "SOUL.md",
-        "TOOLS.md",
-        "IDENTITY.md",
-        "USER.md",
-        "HEARTBEAT.md",
-    ];
+    let bootstrap_files = ["AGENTS.md", "SOUL.md", "TOOLS.md", "IDENTITY.md", "USER.md"];
 
     for filename in &bootstrap_files {
         inject_workspace_file(prompt, workspace_dir, filename, max_chars_per_file);
@@ -518,7 +511,7 @@ fn load_openclaw_bootstrap_files(
 /// 2. Safety — guardrail reminder
 /// 3. Skills — compact list with paths (loaded on-demand)
 /// 4. Workspace — working directory
-/// 5. Bootstrap files — AGENTS, SOUL, TOOLS, IDENTITY, USER, HEARTBEAT, BOOTSTRAP, MEMORY
+/// 5. Bootstrap files — AGENTS, SOUL, TOOLS, IDENTITY, USER, BOOTSTRAP, MEMORY
 /// 6. Date & Time — timezone for cache stability
 /// 7. Runtime — host, OS, model
 ///
@@ -2004,7 +1997,13 @@ mod tests {
         assert!(prompt.contains("### USER.md"), "missing USER.md");
         assert!(prompt.contains("### AGENTS.md"), "missing AGENTS.md");
         assert!(prompt.contains("### TOOLS.md"), "missing TOOLS.md");
-        assert!(prompt.contains("### HEARTBEAT.md"), "missing HEARTBEAT.md");
+        // HEARTBEAT.md is intentionally excluded from channel prompts — it's only
+        // relevant to the heartbeat worker and causes LLMs to emit spurious
+        // "HEARTBEAT_OK" acknowledgments in channel conversations.
+        assert!(
+            !prompt.contains("### HEARTBEAT.md"),
+            "HEARTBEAT.md should not be in channel prompt"
+        );
         assert!(prompt.contains("### MEMORY.md"), "missing MEMORY.md");
         assert!(prompt.contains("User likes Rust"), "missing MEMORY content");
     }


### PR DESCRIPTION
## Summary

- Problem: Channel conversations (Telegram, etc.) include `HEARTBEAT.md` in the system prompt, causing the LLM to emit spurious "HEARTBEAT_OK" text at the start of responses
- Why it matters: Users see meaningless "HEARTBEAT_OK" before every response, making the bot appear broken
- What changed: Removed `HEARTBEAT.md` from the channel bootstrap file list; updated test to assert exclusion
- What did **not** change (scope boundary): Agent prompt (`src/agent/prompt.rs`) still includes `HEARTBEAT.md` — correct for agent/heartbeat contexts. Heartbeat engine reads it directly from disk, unaffected.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto
- Scope labels: channel, heartbeat
- Module labels: `channel:telegram`
- Contributor tier label: auto
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): channel

## Linked Issue

- Closes # N/A — discovered during live Telegram testing
- Related # N/A
- Depends on # N/A
- Supersedes # N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check        # OK (no formatting issues)
./scripts/ci/rust_quality_gate.sh # OK (clippy correctness clean, pre-existing pedantic warnings only)
cargo test --bin zeroclaw prompt_injects_workspace  # 1 passed
cargo test --bin zeroclaw prompt_missing_file        # 1 passed
```

- Evidence provided (test/log/trace/screenshot/perf): test output above; manual verification of service restart with all health checks green
- If any command is intentionally skipped, explain why: `cargo test --locked` full suite not run due to pre-existing compilation errors in unrelated modules (gateway/mod.rs AppState, tools/memory_store.rs arity) that exist on main

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes — channel conversations simply stop including HEARTBEAT.md content
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: rebuilt release binary, restarted service via launchctl, all 6 health components green including channel:telegram
- Edge cases checked: HEARTBEAT.md file still exists on disk — confirmed `inject_workspace_file` simply skips it since it's no longer in the bootstrap list
- What was not verified: end-to-end Telegram message exchange (user can test)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: channel system prompt only (slightly smaller — one fewer bootstrap section)
- Potential unintended effects: none — HEARTBEAT.md has no channel-relevant content
- Guardrails/monitoring for early detection: heartbeat worker unaffected (reads file directly); agent CLI unaffected (separate prompt builder)

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Claude Code
- Workflow/plan summary: traced HEARTBEAT_OK origin → found HEARTBEAT.md injected into channel prompt → removed from bootstrap list → updated test
- Verification focus: prompt construction tests, service health checks
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`, rebuild, restart service
- Feature flags or config toggles (if any): none needed — this is a bug fix
- Observable failure symptoms: if HEARTBEAT.md was actually needed in channels (it isn't), heartbeat-related instructions would be missing from channel LLM calls

## Risks and Mitigations

None — HEARTBEAT.md has no channel-relevant content. The heartbeat engine reads it independently from disk.