### PR TITLE
fix(ci): use underscore input names for actions/first-interaction

### DIFF
--- a/.github/workflows/pr-auto-response.yml
+++ b/.github/workflows/pr-auto-response.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Greet first-time contributors
         uses: actions/first-interaction@a1db7729b356323c7988c20ed6f0d33fe31297be # v1
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Thanks for opening this issue.
 
             Before maintainers triage it, please confirm:
@@ -50,7 +50,7 @@ jobs:
             - Sensitive values are redacted
 
             This helps us keep issue throughput high and response latency low.
-          pr-message: |
+          pr_message: |
             Thanks for contributing to ZeroClaw.
 
             For faster review, please ensure:


### PR DESCRIPTION
## Summary

- Problem: `actions/first-interaction` job fails on every first-time contributor PR with `Error: Input required and not supplied: issue_message`
- Why it matters: The CI shows a red X on all first-time contributor PRs, creating unnecessary noise and confusion
- What changed: Renamed three hyphenated input names to underscore format (`repo-token` → `repo_token`, `issue-message` → `issue_message`, `pr-message` → `pr_message`)
- What did **not** change (scope boundary): Message content, job triggers, permissions, and all other workflow logic unchanged

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto
- Scope labels: ci
- Module labels: N/A
- Contributor tier label: auto
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): ci

## Linked Issue

- Closes # N/A
- Related # N/A
- Depends on # N/A
- Supersedes # N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```
# Workflow-only change — no Rust code modified
# Validated by reading actions/first-interaction source:
# The action uses `core.getInput('issue_message')` (underscore),
# but YAML passed `issue-message` (hyphen).
# GitHub Actions warns: "Unexpected input(s) 'repo-token', 'issue-message', 'pr-message',
#   valid inputs are ['issue_message', 'pr_message', 'repo_token']"
```

- Evidence provided: CI failure log screenshot from PR #781 showing exact error
- If any command is intentionally skipped, explain why: No Rust commands needed — YAML-only change

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No — same `GITHUB_TOKEN`, just renamed the input key
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

- Verified scenarios: confirmed `actions/first-interaction@v1` source code expects `issue_message`, `pr_message`, `repo_token` (underscores)
- Edge cases checked: verified no other workflows reference these input names
- What was not verified: cannot test `pull_request_target` workflows from fork — will verify on next first-time contributor PR

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `pr-auto-response.yml` first-interaction job only
- Potential unintended effects: none — this fixes a broken job, no working behavior changes
- Guardrails/monitoring for early detection: next first-time contributor PR will validate

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Claude Code
- Workflow/plan summary: identified from CI failure on PR #781, traced to input name mismatch
- Verification focus: action source code input expectations
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: if reverted, first-interaction job will fail again with same error

## Risks and Mitigations

None — this fixes a broken workflow with a trivial rename.