### PR TITLE
fix: resolve all clippy warnings and fix test compilation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ venv/
 *.key
 *.pem
 credentials.json
+.worktrees/

--- a/src/memory/sqlite.rs
+++ b/src/memory/sqlite.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use chrono::Local;
 use parking_lot::Mutex;
 use rusqlite::{params, Connection};
-use std::fmt::Write;
+use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::sync::Arc;

--- a/src/observability/prometheus.rs
+++ b/src/observability/prometheus.rs
@@ -197,6 +197,10 @@ impl Observer for PrometheusObserver {
             } => {
                 self.errors.with_label_values(&[component]).inc();
             }
+            ObserverEvent::ToolCallStart { .. }
+            | ObserverEvent::TurnComplete
+            | ObserverEvent::LlmRequest { .. }
+            | ObserverEvent::LlmResponse { .. } => {}
         }
     }
 


### PR DESCRIPTION
## Summary
- **Problem:** after rebasing onto latest `main`, a small lint-compatibility delta still remained from the original clippy/test-fix batch.
- **Why it matters:** keeping these final lint-safe adjustments avoids reintroducing avoidable warnings and keeps contributor worktree hygiene practical.
- **What changed in current PR delta:**
  - add `.worktrees/` to `.gitignore`
  - switch `std::fmt::Write` import to trait-only form (`use std::fmt::Write as _;`) in `src/memory/sqlite.rs`
  - merge explicit no-op observer event arms in `src/observability/prometheus.rs`

## Validation Evidence
- ✅ `cargo fmt --all -- --check`
- ✅ CI checks for this rebased head are green (`Build (Smoke)`, `Security Audit`, `CI Required Gate`, `Intake Checks`, `License & Supply Chain`, etc.)
- ⚠️ In this local runner, long full-suite cargo jobs intermittently receive external `SIGTERM` while compiling dependency crates; no PR-specific compiler/lint diagnostic surfaced before interruption.

## Security Impact
- Permissions change: **No**
- Network surface change: **No**
- Secrets handling change: **No**
- Filesystem access change: **No**

## Privacy and Data Hygiene
- No credentials, tokens, personal data, or private URLs introduced.
- Added/updated content stays project-scoped and English.

## Compatibility
- Backward compatible: **Yes**
- Config changes: **None**
- Migration required: **No**

## Side Effects
None expected beyond lint/code-style consistency and local worktree ignore hygiene.

## Rollback Plan
Revert the single PR commit:
- `git revert <merge_or_commit_sha>`

## Risks
Low. Remaining delta is small and non-behavioral.