### PR TITLE
fix: use dnf5-compatible group install syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Example sample (macOS arm64, measured on February 18, 2026):
 
 1. **Build essentials:**
    - **Linux (Debian/Ubuntu):** `sudo apt install build-essential pkg-config`
-   - **Linux (Fedora/RHEL):** `sudo dnf groupinstall "Development Tools" && sudo dnf install pkg-config`
+   - **Linux (Fedora/RHEL):** `sudo dnf group install development-tools && sudo dnf install pkg-config`
    - **macOS:** Install Xcode Command Line Tools: `xcode-select --install`
 
 2. **Rust toolchain:**

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -74,7 +74,7 @@ install_system_deps() {
         run_privileged apt-get update -qq
         run_privileged apt-get install -y build-essential pkg-config git curl
       elif have_cmd dnf; then
-        run_privileged dnf groupinstall -y "Development Tools"
+        run_privileged dnf group install -y development-tools
         run_privileged dnf install -y pkg-config git curl
       else
         warn "Unsupported Linux distribution. Install compiler toolchain + pkg-config + git + curl manually."


### PR DESCRIPTION
## Summary

- Problem: `dnf groupinstall "Development Tools"` fails on dnf5 (Fedora 41+) — legacy alias removed and quoted group name not recognized
- Why it matters: Fedora users cannot bootstrap the project with documented instructions
- What changed: `README.md` and `scripts/bootstrap.sh` now use `dnf group install development-tools`
- What did **not** change (scope boundary): No other distro commands, no script logic changes

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `docs`, `scripts`
- Module labels: N/A
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `docs`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
bash -n scripts/bootstrap.sh  # syntax check passes
```

- Evidence provided: `bash -n` syntax validation
- If any command is intentionally skipped, explain why: `cargo fmt`/`clippy`/`test` not relevant — no Rust code changed

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes — `dnf group install` works on both dnf4 and dnf5
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: `sudo dnf group install development-tools` succeeds on Fedora 43 (dnf5)
- Edge cases checked: `dnf groupinstall "Development Tools"` confirmed broken on dnf5
- What was not verified: dnf4 (RHEL/older Fedora) — `dnf group install` is valid on dnf4 per docs

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Bootstrap script for Fedora/RHEL users, README instructions
- Potential unintended effects: None
- Guardrails/monitoring for early detection: N/A

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Grep for `dnf` references, fix both occurrences
- Verification focus: Correct subcommand syntax and group ID for dnf5
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None
- Observable failure symptoms: Bootstrap script fails on Fedora with dnf5

## Risks and Mitigations

- Risk: None