### PR TITLE
fix(channel): use native tool calling to preserve conversation context

### DIFF
--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -497,6 +497,53 @@ impl Provider for AnthropicProvider {
         true
     }
 
+    async fn chat_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: &[serde_json::Value],
+        model: &str,
+        temperature: f64,
+    ) -> anyhow::Result<ProviderChatResponse> {
+        // Convert OpenAI-format tool JSON to ToolSpec so we can reuse the
+        // existing `chat()` method which handles full message history,
+        // system prompt extraction, caching, and Anthropic native formatting.
+        let tool_specs: Vec<ToolSpec> = tools
+            .iter()
+            .filter_map(|t| {
+                let func = t.get("function").or_else(|| {
+                    tracing::warn!("Skipping malformed tool definition (missing 'function' key)");
+                    None
+                })?;
+                let name = func.get("name").and_then(|n| n.as_str()).or_else(|| {
+                    tracing::warn!("Skipping tool with missing or non-string 'name'");
+                    None
+                })?;
+                Some(ToolSpec {
+                    name: name.to_string(),
+                    description: func
+                        .get("description")
+                        .and_then(|d| d.as_str())
+                        .unwrap_or("")
+                        .to_string(),
+                    parameters: func
+                        .get("parameters")
+                        .cloned()
+                        .unwrap_or(serde_json::json!({"type": "object"})),
+                })
+            })
+            .collect();
+
+        let request = ProviderChatRequest {
+            messages,
+            tools: if tool_specs.is_empty() {
+                None
+            } else {
+                Some(&tool_specs)
+            },
+        };
+        self.chat(request, model, temperature).await
+    }
+
     async fn warmup(&self) -> anyhow::Result<()> {
         if let Some(credential) = self.credential.as_ref() {
             let mut request = self
@@ -1104,5 +1151,168 @@ mod tests {
         let provider = AnthropicProvider::new(None);
         let result = provider.warmup().await;
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn convert_messages_preserves_multi_turn_history() {
+        let messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: "You are helpful.".to_string(),
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "gen a 2 sum in golang".to_string(),
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "```go\nfunc twoSum(nums []int) {}\n```".to_string(),
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "what's meaning of make here?".to_string(),
+            },
+        ];
+
+        let (system, native_msgs) = AnthropicProvider::convert_messages(&messages);
+
+        // System prompt extracted
+        assert!(system.is_some());
+        // All 3 non-system messages preserved in order
+        assert_eq!(native_msgs.len(), 3);
+        assert_eq!(native_msgs[0].role, "user");
+        assert_eq!(native_msgs[1].role, "assistant");
+        assert_eq!(native_msgs[2].role, "user");
+    }
+
+    /// Integration test: spin up a mock Anthropic API server, call chat_with_tools
+    /// with a multi-turn conversation + tools, and verify the request body contains
+    /// ALL conversation turns and native tool definitions.
+    #[tokio::test]
+    async fn chat_with_tools_sends_full_history_and_native_tools() {
+        use axum::{routing::post, Json, Router};
+        use std::sync::{Arc, Mutex};
+        use tokio::net::TcpListener;
+
+        // Captured request body for assertion
+        let captured: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+        let captured_clone = captured.clone();
+
+        let app = Router::new().route(
+            "/v1/messages",
+            post(move |Json(body): Json<serde_json::Value>| {
+                let cap = captured_clone.clone();
+                async move {
+                    *cap.lock().unwrap() = Some(body);
+                    // Return a minimal valid Anthropic response
+                    Json(serde_json::json!({
+                        "id": "msg_test",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "The make function creates a map."}],
+                        "model": "claude-opus-4-6",
+                        "stop_reason": "end_turn",
+                        "usage": {"input_tokens": 100, "output_tokens": 20}
+                    }))
+                }
+            }),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        // Create provider pointing at mock server
+        let provider = AnthropicProvider {
+            credential: Some("test-key".to_string()),
+            base_url: format!("http://{addr}"),
+        };
+
+        // Multi-turn conversation: system → user (Go code) → assistant (code response) → user (follow-up)
+        let messages = vec![
+            ChatMessage::system("You are a helpful assistant."),
+            ChatMessage::user("gen a 2 sum in golang"),
+            ChatMessage::assistant("```go\nfunc twoSum(nums []int, target int) []int {\n    m := make(map[int]int)\n    for i, n := range nums {\n        if j, ok := m[target-n]; ok {\n            return []int{j, i}\n        }\n        m[n] = i\n    }\n    return nil\n}\n```"),
+            ChatMessage::user("what's meaning of make here?"),
+        ];
+
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "shell",
+                "description": "Run a shell command",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string"}
+                    },
+                    "required": ["command"]
+                }
+            }
+        })];
+
+        let result = provider
+            .chat_with_tools(&messages, &tools, "claude-opus-4-6", 0.7)
+            .await;
+        assert!(result.is_ok(), "chat_with_tools failed: {:?}", result.err());
+
+        let body = captured
+            .lock()
+            .unwrap()
+            .take()
+            .expect("No request captured");
+
+        // Verify system prompt extracted to top-level field
+        let system = &body["system"];
+        assert!(
+            system.to_string().contains("helpful assistant"),
+            "System prompt missing: {system}"
+        );
+
+        // Verify ALL conversation turns present in messages array
+        let msgs = body["messages"].as_array().expect("messages not an array");
+        assert_eq!(
+            msgs.len(),
+            3,
+            "Expected 3 messages (2 user + 1 assistant), got {}",
+            msgs.len()
+        );
+
+        // Turn 1: user with Go request
+        assert_eq!(msgs[0]["role"], "user");
+        let turn1_text = msgs[0]["content"].to_string();
+        assert!(
+            turn1_text.contains("2 sum"),
+            "Turn 1 missing Go request: {turn1_text}"
+        );
+
+        // Turn 2: assistant with Go code
+        assert_eq!(msgs[1]["role"], "assistant");
+        let turn2_text = msgs[1]["content"].to_string();
+        assert!(
+            turn2_text.contains("make(map[int]int)"),
+            "Turn 2 missing Go code: {turn2_text}"
+        );
+
+        // Turn 3: user follow-up
+        assert_eq!(msgs[2]["role"], "user");
+        let turn3_text = msgs[2]["content"].to_string();
+        assert!(
+            turn3_text.contains("meaning of make"),
+            "Turn 3 missing follow-up: {turn3_text}"
+        );
+
+        // Verify native tools are present
+        let api_tools = body["tools"].as_array().expect("tools not an array");
+        assert_eq!(api_tools.len(), 1);
+        assert_eq!(api_tools[0]["name"], "shell");
+        assert!(
+            api_tools[0]["input_schema"].is_object(),
+            "Missing input_schema"
+        );
+
+        server_handle.abort();
     }
 }


### PR DESCRIPTION
## Summary

- **Problem:** Telegram follow-up messages lost conversation context. When a user sent "gen a 2 sum in golang" followed by "what's meaning of make here?", the model ignored the prior turn because (1) `AnthropicProvider` didn't override `chat_with_tools()`, causing the default trait impl to drop all history, and (2) the 34k system prompt (including redundant XML tool schemas) drowned out the ~460 chars of actual conversation.
- **Why it matters:** Multi-turn conversation is a core UX expectation for chat channels. Without it, every message is treated as a standalone query.
- **What changed:** Override `chat_with_tools()` on `AnthropicProvider` to convert OpenAI-format tool JSON → native `ToolSpec` and delegate to `chat()` which preserves full message history. Skip `build_tool_instructions()` XML protocol when the provider supports native tools (system prompt drops from ~34k to ~17k). Added integration tests for both the provider-level and channel-level conversation history preservation.
- **What did not change:** Non-native-tool providers still get the full XML protocol. The `build_tool_instructions()` function itself is unchanged. No changes to tool execution, memory, or gateway.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: M`
- Scope labels: `channel`, `provider`, `agent`
- Module labels: `channel:telegram`, `provider:anthropic`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `multi` (channel + provider + agent)

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #97

## Supersede Attribution (required when `Supersedes #` is used)

- N/A — #97 was my own earlier PR on the same branch; this is a rebased continuation, not a supersede of another contributor's work.

## Validation Evidence (required)

```bash
# Format — our 3 files pass; pre-existing failures in qq.rs, whatsapp.rs, gateway/mod.rs, composio.rs exist on main
cargo fmt --all -- --check  # ✓ (our files clean)

# Compile — clean (1 pre-existing warning in wizard.rs)
cargo check                 # ✓

# Clippy — our code clean; pre-existing errors in gateway/mod.rs (missing linq fields) and proxy_config.rs exist on main
cargo clippy --all-targets -- -D warnings  # ✓ (our files clean)

# Tests — test compilation blocked by pre-existing gateway::AppState error on main (missing linq, linq_signing_secret fields)
# Verified by checking out main and confirming identical failure
cargo test --locked          # blocked by pre-existing main issue
```

- Evidence provided: Compilation passes. Pre-existing test compilation failure on `main` (gateway `AppState` missing `linq` fields) blocks `cargo test` for all branches including main itself.
- If any command is intentionally skipped: `cargo test` cannot run due to pre-existing test compilation error on main. Verified by `git checkout main && cargo test` showing identical failure.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: Test data uses neutral identifiers (`alice`, `test-model`, `test-key`)
- Neutral wording confirmation: All test fixtures use project-neutral labels

## Compatibility / Migration

- Backward compatible? Yes — non-native-tool providers are unaffected (XML protocol still emitted for them)
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios:
  - End-to-end Telegram test: sent "gen a 2 sum in golang", received Go code, sent "what's meaning of make here?", model correctly referenced `make(map[int]int)` from prior turn
  - Verified system prompt reduced from ~34k to ~17k chars
  - Verified tool calling still works via shell tool invocation
- Edge cases checked:
  - First message (no history) works correctly
  - Provider without native tool support still gets XML protocol
- What was not verified: Other channels (Discord, Slack, etc.) — they share the same code path

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: System prompt generation (all channels using native-tool providers get shorter prompts), `AnthropicProvider` now has `chat_with_tools` override
- Potential unintended effects: If a provider incorrectly reports `supports_native_tools() = true`, it would lose the XML protocol fallback. Currently only Anthropic reports true, and it genuinely supports native tools.
- Guardrails/monitoring: The conditional is explicit (`if !provider.supports_native_tools()`), and the XML protocol function is unchanged — easy to revert by removing the condition.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Diagnosed root cause via code tracing → implemented provider override + system prompt optimization → code review → rebase on latest main → verification
- Verification focus: Multi-turn conversation context preservation
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>` — single-concern change, clean revert
- Feature flags or config toggles: None needed — the fix is in the default code path
- Observable failure symptoms: If reverted, follow-up messages will again lose context (model treats each message independently)

## Risks and Mitigations

- Risk: Non-Anthropic providers that report `supports_native_tools() = true` in the future must also implement `chat_with_tools()` properly.
  - Mitigation: The default trait impl of `chat_with_tools` falls back to `chat_with_history`, which is the pre-existing behavior. New providers would need to explicitly opt in.