### PR TITLE
ci(docker): allow manual dispatch for publish job

### DIFF
--- a/.github/workflows/pub-docker-img.yml
+++ b/.github/workflows/pub-docker-img.yml
@@ -80,7 +80,7 @@ jobs:
 
     publish:
         name: Build and Push Docker Image
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.repository == 'zeroclaw-labs/zeroclaw'
+        if: (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))) && github.repository == 'zeroclaw-labs/zeroclaw'
         runs-on: blacksmith-2vcpu-ubuntu-2404
         timeout-minutes: 25
         permissions:


### PR DESCRIPTION
## Summary
- allow `Pub Docker Img` publish job to run when manually triggered via `workflow_dispatch`
- keep existing publish guards for `push` to `main` and `v*` tags
- preserve upstream-repo restriction (`zeroclaw-labs/zeroclaw`)

## Validation
- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.11`

## Risk / Rollback
- Risk: low (job condition update only)
- Rollback: revert commit `9baa87b`
