### PR TITLE
fix(ci): enforce public GHCR visibility for docker image pulls

### DIFF
--- a/.github/workflows/pub-docker-img.yml
+++ b/.github/workflows/pub-docker-img.yml
@@ -129,3 +129,64 @@ jobs:
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   platforms: ${{ startsWith(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+
+            - name: Set GHCR package visibility to public
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  set -euo pipefail
+                  owner="${GITHUB_REPOSITORY_OWNER,,}"
+                  repo="${GITHUB_REPOSITORY#*/}"
+
+                  # Package path can be either "<repo>" or URL-encoded "<owner>/<repo>".
+                  candidates=(
+                    "$repo"
+                    "${owner}%2F${repo}"
+                  )
+
+                  for pkg in "${candidates[@]}"; do
+                    code="$(curl -sS -o /tmp/ghcr-visibility.json -w "%{http_code}" \
+                      -X PATCH \
+                      -H "Authorization: Bearer ${GH_TOKEN}" \
+                      -H "Accept: application/vnd.github+json" \
+                      -H "X-GitHub-Api-Version: 2022-11-28" \
+                      "https://api.github.com/orgs/${owner}/packages/container/${pkg}/visibility" \
+                      -d '{"visibility":"public"}' || true)"
+
+                    if [ "$code" = "200" ] || [ "$code" = "204" ]; then
+                      echo "GHCR package visibility is public for ${pkg}."
+                      exit 0
+                    fi
+
+                    echo "Attempt for ${pkg} returned HTTP ${code}."
+                    cat /tmp/ghcr-visibility.json || true
+                  done
+
+                  echo "::error::Failed to set GHCR package visibility to public."
+                  exit 1
+
+            - name: Verify anonymous GHCR pull access
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  token_resp="$(curl -sS "https://ghcr.io/token?scope=repository:${GITHUB_REPOSITORY}:pull")"
+                  token="$(echo "$token_resp" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
+
+                  if [ -z "$token" ]; then
+                    echo "::error::Anonymous GHCR token request failed: $token_resp"
+                    exit 1
+                  fi
+
+                  code="$(curl -sS -o /tmp/ghcr-manifest.json -w "%{http_code}" \
+                    -H "Authorization: Bearer ${token}" \
+                    -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json" \
+                    "https://ghcr.io/v2/${GITHUB_REPOSITORY}/manifests/latest")"
+
+                  if [ "$code" != "200" ]; then
+                    echo "::error::Anonymous manifest pull failed with HTTP ${code}"
+                    cat /tmp/ghcr-manifest.json || true
+                    exit 1
+                  fi
+
+                  echo "Anonymous GHCR pull access verified."


### PR DESCRIPTION
## Summary
- enforce GHCR container package visibility to `public` in `Pub Docker Img` publish job
- fail publish job if visibility update cannot be applied
- add explicit anonymous pull verification (`token` + `manifests/latest`) so regressions are caught immediately in CI

## Why
Issue #745 reports unauthorized pulls from `ghcr.io/zeroclaw-labs/zeroclaw:latest`. Publishing alone is not sufficient when package visibility drifts private.

## Validation
- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:1.7.11`

## Risk / Rollback
- Risk: medium (publish job now fails if package visibility/auth state is wrong)
- Rollback: revert commit `a9509a8`
