### PR TITLE
fix(onboard): complete NVIDIA NIM onboarding and live model discovery

### DIFF
--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -71,6 +71,8 @@ Last verified: **February 18, 2026**.
 - `zeroclaw models refresh --provider <ID>`
 - `zeroclaw models refresh --force`
 
+`models refresh` currently supports live catalog refresh for provider IDs: `openrouter`, `openai`, `anthropic`, `groq`, `mistral`, `deepseek`, `xai`, `together-ai`, `gemini`, `ollama`, `astrai`, `venice`, `fireworks`, `cohere`, `moonshot`, `glm`, `zai`, `qwen`, and `nvidia`.
+
 ### `channel`
 
 - `zeroclaw channel list`

--- a/docs/providers-reference.md
+++ b/docs/providers-reference.md
@@ -59,6 +59,20 @@ Runtime resolution order is:
 - Default onboarding model: `kimi-for-coding` (alternative: `kimi-k2.5`)
 - Runtime auto-adds `User-Agent: KimiCLI/0.77` for compatibility.
 
+### NVIDIA NIM Notes
+
+- Canonical provider ID: `nvidia`
+- Aliases: `nvidia-nim`, `build.nvidia.com`
+- Base API URL: `https://integrate.api.nvidia.com/v1`
+- Model discovery: `zeroclaw models refresh --provider nvidia`
+
+Recommended starter model IDs (verified against NVIDIA API catalog on February 18, 2026):
+
+- `meta/llama-3.3-70b-instruct`
+- `deepseek-ai/deepseek-v3.2`
+- `nvidia/llama-3.3-nemotron-super-49b-v1.5`
+- `nvidia/llama-3.1-nemotron-ultra-253b-v1`
+
 ## Custom Endpoints
 
 - OpenAI-compatible endpoint:


### PR DESCRIPTION
## Summary
This patch completes NVIDIA NIM onboarding coverage end-to-end and fixes gaps that made issue #780 still reproducible in non-interactive/provider-override paths.

## Root cause
NVIDIA support existed in provider factory and parts of interactive onboarding, but several onboarding/model-discovery paths were incomplete:
- `nvidia-nim` / `build.nvidia.com` aliases were not normalized by onboarding model helpers.
- default model fallback for NVIDIA provider paths could resolve to a non-NVIDIA model.
- curated onboarding model catalog did not include a dedicated NVIDIA branch.
- `zeroclaw models refresh` did not include NVIDIA in live model discovery.

## What changed
- Normalized onboarding aliases: `nvidia-nim`, `build.nvidia.com` -> `nvidia`.
- Added NVIDIA default model for quick/non-interactive setup.
- Added NVIDIA curated model catalog and updated interactive NVIDIA starter model list.
- Enabled NVIDIA live model discovery via `https://integrate.api.nvidia.com/v1/models`.
- Added/updated onboarding tests for NVIDIA defaults, alias normalization, curated catalog, and live-fetch support.
- Added docs updates:
  - `docs/providers-reference.md` (NVIDIA NIM notes + starter IDs)
  - `docs/commands-reference.md` (live model refresh support matrix)

## Model ID verification
NVIDIA model IDs in this patch were verified against NVIDIA’s official model catalog (`docs.api.nvidia.com`) on **February 18, 2026**.

## Validation
- ✅ `cargo fmt --all -- --check`
- ⚠️ `cargo clippy --all-targets -- -D warnings` currently fails on pre-existing repository-wide warnings unrelated to this patch.
- ⚠️ Full `cargo test` in this environment is impacted by command-session SIGTERM limits during long Rust link phases; targeted verification and code-path review completed for changed onboarding logic.

## Issue link
- Fixes #780