### PR TITLE
fix: stabilize scheduler command tests and remove clippy debt

### DIFF
--- a/src/observability/prometheus.rs
+++ b/src/observability/prometheus.rs
@@ -197,10 +197,6 @@ impl Observer for PrometheusObserver {
             } => {
                 self.errors.with_label_values(&[component]).inc();
             }
-            ObserverEvent::ToolCallStart { .. }
-            | ObserverEvent::TurnComplete
-            | ObserverEvent::LlmRequest { .. }
-            | ObserverEvent::LlmResponse { .. } => {}
         }
     }
 


### PR DESCRIPTION
## Summary
This follow-up hardening patch (related to #761) fixes the remaining unstable test behavior and removes the clippy debt found during post-fix validation.

## Root causes
1. `run_job_command_with_timeout` did not pipe stdout/stderr, so scheduler tests could not assert captured output reliably.
2. `warmup_without_key_is_noop` depended on ambient environment auth when using `GeminiProvider::new(None)`.
3. Several clippy warnings remained in adjacent modules and blocked `-D warnings` quality gates.

## Changes
- Pipe child process stdout/stderr in scheduler command execution.
- Make Gemini warmup test deterministic by constructing a provider with explicit `auth: None`.
- Apply targeted clippy cleanups:
  - collapse nested `if` in streaming loop
  - replace `or_insert_with(Vec::new)` with `or_default()`
  - replace `push_str(format!(...))` with `write!`
  - merge identical match arms in observability and anthropic provider code

## Validation
- `cargo fmt --all -- --check`
- `cargo test --locked --lib cron::scheduler::tests::`
- `cargo test --locked --lib providers::gemini::tests::`
- `cargo clippy --locked --lib -- -D warnings`

`cargo clippy --all-targets` is intermittently terminated by this execution environment (`SIGTERM`) while checking the root crate, but the modified and related test/quality scopes above are green.

## Issue link
Related to #761
