### PR TITLE
docs(docs): close #774 follow-up gaps in IA and multilingual docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,7 @@ API_KEY=your-api-key-here
 # Default provider/model (can be overridden by CLI flags)
 PROVIDER=openrouter
 # ZEROCLAW_PROVIDER=openrouter
-# ZEROCLAW_MODEL=anthropic/claude-sonnet-4-20250514
+# ZEROCLAW_MODEL=anthropic/claude-sonnet-4-6
 # ZEROCLAW_TEMPERATURE=0.7
 
 # Workspace directory override

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -14,6 +14,9 @@
 | ワンコマンドで導入したい | [one-click-bootstrap.md](one-click-bootstrap.md) |
 | コマンドを用途別に確認したい | [commands-reference.md](commands-reference.md) |
 | 設定キーと既定値を確認したい | [config-reference.md](config-reference.md) |
+| カスタム Provider / endpoint を追加したい | [custom-providers.md](custom-providers.md) |
+| Z.AI / GLM Provider を設定したい | [zai-glm-setup.md](zai-glm-setup.md) |
+| LangGraph ツール連携を使いたい | [langgraph-integration.md](langgraph-integration.md) |
 | 日常運用（runbook）を確認したい | [operations-runbook.md](operations-runbook.md) |
 | インストール/実行トラブルを解決したい | [troubleshooting.md](troubleshooting.md) |
 | 統合 TOC から探したい | [SUMMARY.md](SUMMARY.md) |
@@ -48,6 +51,9 @@
 - [providers-reference.md](providers-reference.md)
 - [channels-reference.md](channels-reference.md)
 - [config-reference.md](config-reference.md)
+- [custom-providers.md](custom-providers.md)
+- [zai-glm-setup.md](zai-glm-setup.md)
+- [langgraph-integration.md](langgraph-integration.md)
 - [operations-runbook.md](operations-runbook.md)
 - [troubleshooting.md](troubleshooting.md)
 
@@ -65,6 +71,7 @@
 
 - [security/README.md](security/README.md)
 - [agnostic-security.md](agnostic-security.md)
+- [frictionless-security.md](frictionless-security.md)
 - [sandboxing.md](sandboxing.md)
 - [resource-limits.md](resource-limits.md)
 - [audit-logging.md](audit-logging.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,9 @@ Localized hubs: [简体中文](README.zh-CN.md) · [日本語](README.ja.md) · 
 | Bootstrap in one command | [one-click-bootstrap.md](one-click-bootstrap.md) |
 | Find commands by task | [commands-reference.md](commands-reference.md) |
 | Check config defaults and keys quickly | [config-reference.md](config-reference.md) |
+| Configure custom providers/endpoints | [custom-providers.md](custom-providers.md) |
+| Configure Z.AI / GLM provider | [zai-glm-setup.md](zai-glm-setup.md) |
+| Use LangGraph integration patterns | [langgraph-integration.md](langgraph-integration.md) |
 | Operate runtime (day-2 runbook) | [operations-runbook.md](operations-runbook.md) |
 | Troubleshoot install/runtime/channel issues | [troubleshooting.md](troubleshooting.md) |
 | Browse docs by category | [SUMMARY.md](SUMMARY.md) |
@@ -48,6 +51,9 @@ Localized hubs: [简体中文](README.zh-CN.md) · [日本語](README.ja.md) · 
 - [providers-reference.md](providers-reference.md) — provider IDs, aliases, credential env vars
 - [channels-reference.md](channels-reference.md) — channel capabilities and setup paths
 - [config-reference.md](config-reference.md) — high-signal config keys and secure defaults
+- [custom-providers.md](custom-providers.md) — custom provider/base URL integration templates
+- [zai-glm-setup.md](zai-glm-setup.md) — Z.AI/GLM setup and endpoint matrix
+- [langgraph-integration.md](langgraph-integration.md) — fallback integration for model/tool-calling edge cases
 - [operations-runbook.md](operations-runbook.md) — day-2 runtime operations and rollback flow
 - [troubleshooting.md](troubleshooting.md) — common failure signatures and recovery steps
 

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -14,6 +14,9 @@
 | Установить одной командой | [one-click-bootstrap.md](one-click-bootstrap.md) |
 | Найти команды по задаче | [commands-reference.md](commands-reference.md) |
 | Проверить ключи конфигурации и дефолты | [config-reference.md](config-reference.md) |
+| Подключить кастомный provider / endpoint | [custom-providers.md](custom-providers.md) |
+| Настроить provider Z.AI / GLM | [zai-glm-setup.md](zai-glm-setup.md) |
+| Использовать интеграцию LangGraph | [langgraph-integration.md](langgraph-integration.md) |
 | Операционный runbook (day-2) | [operations-runbook.md](operations-runbook.md) |
 | Быстро устранить типовые проблемы | [troubleshooting.md](troubleshooting.md) |
 | Открыть общий TOC docs | [SUMMARY.md](SUMMARY.md) |
@@ -48,6 +51,9 @@
 - [providers-reference.md](providers-reference.md)
 - [channels-reference.md](channels-reference.md)
 - [config-reference.md](config-reference.md)
+- [custom-providers.md](custom-providers.md)
+- [zai-glm-setup.md](zai-glm-setup.md)
+- [langgraph-integration.md](langgraph-integration.md)
 - [operations-runbook.md](operations-runbook.md)
 - [troubleshooting.md](troubleshooting.md)
 
@@ -65,6 +71,7 @@
 
 - [security/README.md](security/README.md)
 - [agnostic-security.md](agnostic-security.md)
+- [frictionless-security.md](frictionless-security.md)
 - [sandboxing.md](sandboxing.md)
 - [resource-limits.md](resource-limits.md)
 - [audit-logging.md](audit-logging.md)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -14,6 +14,9 @@
 | 一键安装与初始化 | [one-click-bootstrap.md](one-click-bootstrap.md) |
 | 按任务找命令 | [commands-reference.md](commands-reference.md) |
 | 快速查看配置默认值与关键项 | [config-reference.md](config-reference.md) |
+| 接入自定义 Provider / endpoint | [custom-providers.md](custom-providers.md) |
+| 配置 Z.AI / GLM Provider | [zai-glm-setup.md](zai-glm-setup.md) |
+| 使用 LangGraph 工具调用集成 | [langgraph-integration.md](langgraph-integration.md) |
 | 进行日常运维（runbook） | [operations-runbook.md](operations-runbook.md) |
 | 快速排查安装/运行问题 | [troubleshooting.md](troubleshooting.md) |
 | 统一目录导航 | [SUMMARY.md](SUMMARY.md) |
@@ -48,6 +51,9 @@
 - [providers-reference.md](providers-reference.md)
 - [channels-reference.md](channels-reference.md)
 - [config-reference.md](config-reference.md)
+- [custom-providers.md](custom-providers.md)
+- [zai-glm-setup.md](zai-glm-setup.md)
+- [langgraph-integration.md](langgraph-integration.md)
 - [operations-runbook.md](operations-runbook.md)
 - [troubleshooting.md](troubleshooting.md)
 
@@ -65,6 +71,7 @@
 
 - [security/README.md](security/README.md)
 - [agnostic-security.md](agnostic-security.md)
+- [frictionless-security.md](frictionless-security.md)
 - [sandboxing.md](sandboxing.md)
 - [resource-limits.md](resource-limits.md)
 - [audit-logging.md](audit-logging.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -22,13 +22,16 @@ Last refreshed: **February 18, 2026**.
 - [getting-started/README.md](getting-started/README.md)
 - [one-click-bootstrap.md](one-click-bootstrap.md)
 
-### 2) Command/Config References
+### 2) Command/Config References & Integrations
 
 - [reference/README.md](reference/README.md)
 - [commands-reference.md](commands-reference.md)
 - [providers-reference.md](providers-reference.md)
 - [channels-reference.md](channels-reference.md)
 - [config-reference.md](config-reference.md)
+- [custom-providers.md](custom-providers.md)
+- [zai-glm-setup.md](zai-glm-setup.md)
+- [langgraph-integration.md](langgraph-integration.md)
 
 ### 3) Operations & Deployment
 
@@ -55,6 +58,9 @@ Last refreshed: **February 18, 2026**.
 - [adding-boards-and-tools.md](adding-boards-and-tools.md)
 - [nucleo-setup.md](nucleo-setup.md)
 - [arduino-uno-q-setup.md](arduino-uno-q-setup.md)
+- [datasheets/nucleo-f401re.md](datasheets/nucleo-f401re.md)
+- [datasheets/arduino-uno.md](datasheets/arduino-uno.md)
+- [datasheets/esp32.md](datasheets/esp32.md)
 
 ### 6) Contribution & CI
 

--- a/docs/docs-inventory.md
+++ b/docs/docs-inventory.md
@@ -46,6 +46,9 @@ Last reviewed: **February 18, 2026**.
 | `docs/providers-reference.md` | Current Reference | users/operators |
 | `docs/channels-reference.md` | Current Reference | users/operators |
 | `docs/config-reference.md` | Current Reference | operators |
+| `docs/custom-providers.md` | Current Integration Guide | integration developers |
+| `docs/zai-glm-setup.md` | Current Provider Setup Guide | users/operators |
+| `docs/langgraph-integration.md` | Current Integration Guide | integration developers |
 | `docs/operations-runbook.md` | Current Guide | operators |
 | `docs/troubleshooting.md` | Current Guide | users/operators |
 | `docs/network-deployment.md` | Current Guide | operators |
@@ -54,7 +57,9 @@ Last reviewed: **February 18, 2026**.
 | `docs/arduino-uno-q-setup.md` | Current Guide | hardware builders |
 | `docs/nucleo-setup.md` | Current Guide | hardware builders |
 | `docs/hardware-peripherals-design.md` | Current Design Spec | hardware contributors |
-| `docs/langgraph-integration.md` | Current Integration Guide | integration developers |
+| `docs/datasheets/nucleo-f401re.md` | Current Hardware Reference | hardware builders |
+| `docs/datasheets/arduino-uno.md` | Current Hardware Reference | hardware builders |
+| `docs/datasheets/esp32.md` | Current Hardware Reference | hardware builders |
 
 ## Policy / Process Docs
 

--- a/docs/hardware/README.md
+++ b/docs/hardware/README.md
@@ -11,4 +11,7 @@ For board integration, firmware flow, and peripheral architecture.
 
 ## Datasheets
 
-- Board/chip datasheets: [../datasheets](../datasheets)
+- Datasheet index: [../datasheets](../datasheets)
+- STM32 Nucleo-F401RE: [../datasheets/nucleo-f401re.md](../datasheets/nucleo-f401re.md)
+- Arduino Uno: [../datasheets/arduino-uno.md](../datasheets/arduino-uno.md)
+- ESP32: [../datasheets/esp32.md](../datasheets/esp32.md)

--- a/docs/langgraph-integration.md
+++ b/docs/langgraph-integration.md
@@ -132,7 +132,7 @@ agent = create_agent(
 
 ```python
 agent = create_agent(
-    model="anthropic/claude-3.5-sonnet",
+    model="anthropic/claude-sonnet-4-6",
     api_key="your-openrouter-key",
     base_url="https://openrouter.ai/api/v1"
 )

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,6 +1,6 @@
 # Reference Catalogs
 
-Structured reference index for commands, providers, channels, and config.
+Structured reference index for commands, providers, channels, config, and integration guides.
 
 ## Core References
 
@@ -9,6 +9,14 @@ Structured reference index for commands, providers, channels, and config.
 - Channel setup + allowlists: [../channels-reference.md](../channels-reference.md)
 - Config defaults and keys: [../config-reference.md](../config-reference.md)
 
+## Provider & Integration Extensions
+
+- Custom provider endpoints: [../custom-providers.md](../custom-providers.md)
+- Z.AI / GLM provider onboarding: [../zai-glm-setup.md](../zai-glm-setup.md)
+- LangGraph-based integration patterns: [../langgraph-integration.md](../langgraph-integration.md)
+
 ## Usage
 
-Use this collection when you need precise CLI/config details rather than step-by-step tutorials.
+Use this collection when you need precise CLI/config details or provider integration patterns rather than step-by-step tutorials.
+
+When adding a new reference/integration doc, make sure it is linked in both [../SUMMARY.md](../SUMMARY.md) and [../docs-inventory.md](../docs-inventory.md).


### PR DESCRIPTION
## Summary

- Problem: several documentation surfaces introduced in PR #771 were not fully connected through `README -> docs hub -> SUMMARY -> category indexes`, creating discoverability gaps for provider/integration and hardware datasheet docs.
- Why it matters: issue #774 is the follow-up tracker for docs IA consistency and multilingual parity; missing links increase onboarding friction and make docs drift harder to detect.
- What changed: added missing cross-links in `docs/SUMMARY.md`, `docs/reference/README.md`, `docs/hardware/README.md`, `docs/docs-inventory.md`, and all docs hubs (`docs/README*.md`); aligned stale model examples to `anthropic/claude-sonnet-4-6` in `.env.example` and `docs/langgraph-integration.md`.
- What did **not** change (scope boundary): no runtime behavior, no Rust source changes, no workflow/security policy logic changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `docs,scripts`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `docs:navigation`, `docs:inventory`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `docs`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `docs`

## Linked Issue

- Closes #774
- Related #771
- Depends on # (if stacked): N/A
- Supersedes # (if replacing older PR): N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
bash -n bootstrap.sh scripts/bootstrap.sh scripts/install.sh
BASE_SHA=$(git merge-base origin/main HEAD) DOCS_FILES="$(git diff --name-only $(git merge-base origin/main HEAD) HEAD | awk '/\.md$/ || /\.mdx$/ || $0=="LICENSE" || $0==".github\/pull_request_template.md" {print}')" ./scripts/ci/docs_quality_gate.sh
BASE_SHA=$(git merge-base origin/main HEAD) DOCS_FILES="$(git diff --name-only $(git merge-base origin/main HEAD) HEAD | awk '/\.md$/ || /\.mdx$/ || $0=="LICENSE" || $0==".github\/pull_request_template.md" {print}')" ./scripts/ci/docs_links_gate.sh
```

- Result summary:
  - `bash -n`: pass
  - `docs_quality_gate`: pass (0 markdownlint errors on changed files)
  - `docs_links_gate`: pass (0 errors)
  - Summary coverage check: pass (all docs files covered in `docs/SUMMARY.md`, excluding `SUMMARY.md` self-reference)
  - Localized docs-hub parity check: pass (`custom-providers`, `zai-glm-setup`, `langgraph-integration`, `frictionless-security` present in all `docs/README*.md`)
  - Stale model-string check: pass (`claude-sonnet-4-20250514`/`claude-3.5-sonnet` removed from touched surfaces)
- Evidence provided (test/log/trace/screenshot/perf): local command logs captured in this PR workflow
- If any command is intentionally skipped, explain why: none

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no personal/sensitive data added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No` (example strings only)
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: docs route completeness and multilingual hub parity checks
- Edge cases checked: missing-reference surfaces (`custom-providers`, `zai-glm-setup`, `langgraph-integration`, datasheets) now visible via index/summary/hubs
- What was not verified: none

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: docs navigation, docs inventory, model example snippets in docs/config examples
- Potential unintended effects: markdown lint regressions or stale links if typo introduced
- Guardrails/monitoring for early detection: docs quality/link checks and manual grep parity checks

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `gh`, local shell checks, repository-wide docs parity checks
- Workflow/plan summary (if any): issue triage -> docs gap analysis -> targeted link/model consistency patch -> validation
- Verification focus: README/docs hub/SUMMARY/category/index parity and stale model example cleanup
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: revert commit `86efa2d` on this branch
- Feature flags or config toggles (if any): none
- Observable failure symptoms: missing docs links or markdown lint/link-gate failures

## Risks and Mitigations

- Risk: incomplete docs parity across localized hubs if one locale drifts.
  - Mitigation: synchronized updates across all `docs/README*.md` plus validation checks.
- Risk: stale model examples reintroduced in future docs edits.
  - Mitigation: standardized to `anthropic/claude-sonnet-4-6` in touched examples and validated against Anthropic official models/deprecations docs.
