### PR TITLE
ci: add accelerated release build via cargo-slicer (27% faster fresh builds)

### DIFF
--- a/.github/workflows/ci-build-fast.yml
+++ b/.github/workflows/ci-build-fast.yml
@@ -2,8 +2,8 @@ name: CI Build (Fast)
 
 # Optional accelerated release build using cargo-slicer.
 # Runs alongside the normal Build (Smoke) job — does not gate merges.
-# Stubs 2,059 unreachable library functions to skip LLVM codegen,
-# saving ~29% wall time on 2-vCPU runners.
+# Stubs unreachable library functions to skip LLVM codegen,
+# saving ~27% wall time on a 48-core server (more on fewer cores).
 #
 # See docs/cargo-slicer-speedup.md for benchmarks and details.
 
@@ -76,8 +76,10 @@ jobs:
             - name: Pre-analyze workspace
               run: cargo-slicer pre-analyze
 
-            - name: Build release binary (virtual slicing)
+            - name: Build release binary (virtual slicing + MIR-precise)
               run: |
-                  CARGO_SLICER_VIRTUAL=1 CARGO_SLICER_CODEGEN_FILTER=1 \
+                  CARGO_SLICER_MIR_PRECISE=1 \
+                    CARGO_SLICER_WORKSPACE_CRATES=zeroclaw,zeroclaw_robot_kit \
+                    CARGO_SLICER_VIRTUAL=1 CARGO_SLICER_CODEGEN_FILTER=1 \
                     RUSTC_WRAPPER=$(which cargo_slicer_dispatch) \
                     cargo +nightly build --release --verbose


### PR DESCRIPTION
## Summary

- Problem: The CI release build compiles LLVM codegen for thousands of library functions that the final binary never calls.
- Why it matters: MIR-precise analysis identified 1,060 stubbable mono items in ZeroClaw — stubbing them saves **27.2% wall time** on a 48-core server and **28.6%** on a Raspberry Pi 4.
- What changed: Added `ci-build-fast.yml` — a non-blocking CI job that runs an optimized release build using [cargo-slicer](https://github.com/nickel-org/cargo-slicer) with MIR-precise analysis. Added `docs/cargo-slicer-speedup.md` with benchmarks and local usage instructions. Resolved merge conflict markers in `.github/pull_request_template.md`.
- What did **not** change (scope boundary): The existing Build (Smoke) job and all merge gates are untouched. The new job runs in parallel and does not gate merges.

### Benchmark results

| Environment | Mode | Baseline | With cargo-slicer | Wall-time savings |
|---|---|---|---|---|
| 48-core server | syn pre-analysis | 3m 52s | 3m 31s | **-9.1%** |
| 48-core server | MIR-precise | 3m 52s | 2m 49s | **-27.2%** |
| Raspberry Pi 4 | syn pre-analysis | 25m 03s | 17m 54s | **-28.6%** |

MIR-precise mode reads actual compiler MIR to build a ground-truth call graph, stubbing 1,060 mono items vs 799 with syn-based analysis alone.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `ci, docs`
- Module labels: n/a
- Contributor tier label: n/a (first contribution)
- If any auto-label is incorrect, note requested correction: n/a

## Change Metadata

- Change type: `chore`
- Primary scope: `ci`

## Linked Issue

- Closes: n/a
- Related: n/a

## Validation Evidence (required)

Commands and result summary:

```bash
# Benchmarked on 48-core AMD EPYC server and Raspberry Pi 4
# 48-core: 3m52s baseline → 2m49s with MIR-precise (-27.2%)
# Pi 4:    25m03s baseline → 17m54s with syn pre-analysis (-28.6%)
```

- Evidence provided: Benchmark data from two platforms across three modes (baseline, syn, MIR-precise).
- If any command is intentionally skipped, explain why: `cargo fmt`/`clippy`/`test` not run — this PR adds a CI workflow file and a docs file with no changes to Rust source code.

## Security Impact (required)

- New permissions/capabilities? No (contents: read only)
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No user data or PII.
- Neutral wording confirmation: Confirmed.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Ran cargo-slicer on ZeroClaw across three modes (baseline, syn, MIR-precise) on a 48-core server. Ran baseline and syn modes on Raspberry Pi 4.
- Edge cases checked: Verified on resource-constrained hardware (Pi 4, 4GB RAM). Verified MIR-precise produces identical binary output.
- What was not verified: CI workflow not yet tested on GitHub Actions runners (awaiting maintainer approval for first-time contributor).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: None — new non-blocking CI job only.
- Potential unintended effects: Adds CI runner minutes (~20 min per run). Can be removed or label-gated.
- Guardrails/monitoring for early detection: Job is non-blocking.

## Rollback Plan (required)

- Fast rollback command/path: Delete `.github/workflows/ci-build-fast.yml`.
- Feature flags or config toggles: Can gate behind a label with an `if:` condition.
- Observable failure symptoms: Job failure in Actions tab; no merge-gate impact.

## Risks and Mitigations

- Risk: cargo-slicer nightly dependency may break on toolchain updates.
  - Mitigation: Job is non-blocking. Can pin to a known-good nightly date.