### PR TITLE
chore(licenses): allow BSL-1.0 in cargo-deny policy

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,7 @@ allow = [
     "MPL-2.0",
     "CDLA-Permissive-2.0",
     "0BSD",
+    "BSL-1.0",
 ]
 unused-allowed-license = "allow"
 


### PR DESCRIPTION
## Summary
- add `BSL-1.0` to `deny.toml` license allowlist for cargo-deny

## Why
- PR #816 introduces `matrix-sdk` dependency chain that includes `xxhash-rust` (`BSL-1.0`)
- current `License & Supply Chain` check fails only because this license is not explicitly allowed yet

## Scope
- minimal policy-only update (`deny.toml`)
- no runtime/codepath behavior changes

## Validation
- CI target to unblock: `Sec Audit / License & Supply Chain`

## Related
- #816
