### PR TITLE
fix(agent): inject full datetime into system prompt and allow date command

### DIFF
--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -348,4 +348,25 @@ mod tests {
         assert!(prompt.contains("test_tool"));
         assert!(prompt.contains("instr"));
     }
+
+    #[test]
+    fn datetime_section_includes_timestamp_and_timezone() {
+        let tools: Vec<Box<dyn Tool>> = vec![];
+        let ctx = PromptContext {
+            workspace_dir: Path::new("/tmp"),
+            model_name: "test-model",
+            tools: &tools,
+            skills: &[],
+            identity_config: None,
+            dispatcher_instructions: "instr",
+        };
+
+        let rendered = DateTimeSection.build(&ctx).unwrap();
+        assert!(rendered.starts_with("## Current Date & Time\n\n"));
+
+        let payload = rendered.trim_start_matches("## Current Date & Time\n\n");
+        assert!(payload.chars().any(|c| c.is_ascii_digit()));
+        assert!(payload.contains(" ("));
+        assert!(payload.ends_with(')'));
+    }
 }

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -691,6 +691,7 @@ mod tests {
         assert!(p.is_command_allowed("cargo build --release"));
         assert!(p.is_command_allowed("cat file.txt"));
         assert!(p.is_command_allowed("grep -r pattern ."));
+        assert!(p.is_command_allowed("date"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Three related agent UX issues found during MiniMax channel testing:

### 1. Wrong/hallucinated dates in responses

`DateTimeSection` in `src/agent/prompt.rs` injected only the timezone string into the system prompt — not the actual date or time. Models have no reliable way to know the current date from training data alone, so they hallucinate or return stale dates from their training cutoff.

**Example observed:** Agent responded "I cannot directly execute the `date` command (blocked by security policy)" and then gave an incorrect date from its training data.

### 2. `date` command rejected by security policy

The `date` shell command was absent from the default `allowed_commands` list in `SecurityPolicy`. When a model attempted to call `shell({"command": "date"})` as a fallback to get the current time, `is_command_allowed()` returned `false` and the tool returned an error message. The model then surfaced this error to the user verbatim.

`date` is a read-only, side-effect-free command with no security risk. Its absence from the allowlist was an oversight.

## Changes

**`src/agent/prompt.rs`**
- `DateTimeSection::build()` now injects the full timestamp: `YYYY-MM-DD HH:MM:SS (TZ)` instead of just `Timezone: TZ`

**`src/security/policy.rs`**
- Add `"date"` to the default `allowed_commands` list in `SecurityPolicy::default()`

## Non-goals

- Not changing the autonomy model or risk classification
- Not adding new config keys or feature flags
- Not modifying any other allowed commands

## Risk

**Low.**

- The datetime prompt change only affects how the system prompt is constructed; no API surface changes.
- Adding `"date"` to the allowlist only relaxes one read-only command with no side effects. It does not affect any access control boundary.

## Rollback

Revert this commit.

## Validation

- `cargo fmt --all -- --check`: passes
- `cargo test`: 2154 passed, same pre-existing failures, no regressions
- Manual: agent now responds with the correct current date without needing to call any shell command