### PR TITLE
perf: eliminate unnecessary heap allocations across agent loop, memory and channels

### DIFF
--- a/src/channels/email_channel.rs
+++ b/src/channels/email_channel.rs
@@ -154,7 +154,14 @@ impl EmailChannel {
                 _ => {}
             }
         }
-        result.split_whitespace().collect::<Vec<_>>().join(" ")
+        let mut normalized = String::with_capacity(result.len());
+        for word in result.split_whitespace() {
+            if !normalized.is_empty() {
+                normalized.push(' ');
+            }
+            normalized.push_str(word);
+        }
+        normalized
     }
 
     /// Extract the sender address from a parsed email

--- a/src/channels/irc.rs
+++ b/src/channels/irc.rs
@@ -163,12 +163,17 @@ fn split_message(message: &str, max_bytes: usize) -> Vec<String> {
 
     // Guard against max_bytes == 0 to prevent infinite loop
     if max_bytes == 0 {
-        let full: String = message
+        let mut full = String::new();
+        for l in message
             .lines()
             .map(|l| l.trim_end_matches('\r'))
             .filter(|l| !l.is_empty())
-            .collect::<Vec<_>>()
-            .join(" ");
+        {
+            if !full.is_empty() {
+                full.push(' ');
+            }
+            full.push_str(l);
+        }
         if full.is_empty() {
             chunks.push(String::new());
         } else {


### PR DESCRIPTION
- Replace clone()+clear() with std::mem::take() in chunker (items 1, 6)
- Add Vec::with_capacity() hints in chunker split functions (item 2)
- Replace collect::<Vec<_>>().join() with direct iteration in IRC and email channels (item 3)
- Share heading strings via Rc<str> instead of cloning per chunk (item 5)
- Use borrowed references in provider tool spec types to avoid cloning name/description/parameters per tool per request (item 7)

Closes #712