### PR TITLE
fix(security): enforce HTTPS for WhatsApp send requests

### DIFF
--- a/src/channels/whatsapp.rs
+++ b/src/channels/whatsapp.rs
@@ -148,6 +148,11 @@ impl Channel for WhatsAppChannel {
             self.endpoint_id
         );
 
+        anyhow::ensure!(
+            url.starts_with("https://"),
+            "WhatsApp API requests must use HTTPS"
+        );
+
         // Normalize recipient (remove leading + if present for API)
         let to = message
             .recipient


### PR DESCRIPTION
Add explicit HTTPS URL scheme validation before transmitting sensitive data (phone_number_id, access_token) in the WhatsApp channel send path. The URL template already uses HTTPS, but this defense-in-depth check ensures the scheme is enforced at runtime and satisfies the rust/cleartext-transmission code scanning rule.

Resolves code-scanning alert #2.