### PR TITLE
fix(security): enforce HTTPS for Composio API requests

### DIFF
--- a/src/tools/composio.rs
+++ b/src/tools/composio.rs
@@ -177,6 +177,11 @@ impl ComposioTool {
             connected_account_ref,
         );
 
+        anyhow::ensure!(
+            url.starts_with("https://"),
+            "Composio API requests must use HTTPS"
+        );
+
         let resp = self
             .client()
             .post(&url)


### PR DESCRIPTION
Add explicit HTTPS URL scheme validation before transmitting sensitive data (connected_account_id) in the Composio v3 action execution path. The URL constant already uses HTTPS, but this defense-in-depth check ensures the scheme is enforced at runtime and satisfies the rust/cleartext-transmission code scanning rule.

Resolves code-scanning alert #1.