### PR TITLE
fix(skills): inject skill prompts and tools into agent system prompt

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1097,12 +1097,13 @@ pub fn build_system_prompt(
         prompt.push_str("## Available Skills\n\n");
         prompt.push_str("<available_skills>\n");
         for skill in skills {
+            let escaped_name = xml_escape(&skill.name);
+            let escaped_description = xml_escape(&skill.description);
             let _ = writeln!(prompt, "  <skill>");
-            let _ = writeln!(prompt, "    <name>{}</name>", skill.name);
+            let _ = writeln!(prompt, "    <name>{escaped_name}</name>");
             let _ = writeln!(
                 prompt,
-                "    <description>{}</description>",
-                skill.description
+                "    <description>{escaped_description}</description>"
             );
             let location = skill.location.clone().unwrap_or_else(|| {
                 workspace_dir
@@ -1110,14 +1111,18 @@ pub fn build_system_prompt(
                     .join(&skill.name)
                     .join("SKILL.md")
             });
-            let _ = writeln!(prompt, "    <location>{}</location>", location.display());
+            let escaped_location = xml_escape(&location.display().to_string());
+            let _ = writeln!(prompt, "    <location>{escaped_location}</location>");
             if !skill.tools.is_empty() {
                 let _ = writeln!(prompt, "    <tools>");
                 for tool in &skill.tools {
+                    let escaped_tool_name = xml_escape(&tool.name);
+                    let escaped_tool_kind = xml_escape(&tool.kind);
+                    let escaped_tool_description = xml_escape(&tool.description);
                     let _ = writeln!(
                         prompt,
                         "      <tool name=\"{}\" kind=\"{}\">{}</tool>",
-                        tool.name, tool.kind, tool.description
+                        escaped_tool_name, escaped_tool_kind, escaped_tool_description
                     );
                 }
                 let _ = writeln!(prompt, "    </tools>");
@@ -1125,9 +1130,8 @@ pub fn build_system_prompt(
             if !skill.prompts.is_empty() {
                 let _ = writeln!(prompt, "    <instructions>");
                 for p in &skill.prompts {
-                    prompt.push_str("      ");
-                    prompt.push_str(p);
-                    prompt.push('\n');
+                    let escaped_prompt = xml_escape(p);
+                    let _ = writeln!(prompt, "      {escaped_prompt}");
                 }
                 let _ = writeln!(prompt, "    </instructions>");
             }
@@ -1209,10 +1213,19 @@ pub fn build_system_prompt(
     prompt.push_str("- If a tool output contains credentials, they have already been redacted — do not mention them.\n\n");
 
     if prompt.is_empty() {
-        "You are ZeroClaw, a fast and efficient AI assistant built in Rust. Be helpful, concise, and direct.".to_string()
+        "You are ZeroClaw, a fast and efficient AI assistant built in Rust. Be helpful, concise, and direct."
+            .to_string()
     } else {
         prompt
     }
+}
+
+fn xml_escape(raw: &str) -> String {
+    raw.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
 }
 
 /// Inject a single workspace file into the prompt with truncation and missing-file markers.
@@ -3312,6 +3325,40 @@ mod tests {
             "skill tool should be inlined"
         );
         assert!(prompt.contains("<tools>"), "should have tools block");
+    }
+
+    #[test]
+    fn prompt_skills_escape_reserved_xml_chars() {
+        let ws = make_workspace();
+        let skills = vec![crate::skills::Skill {
+            name: "code<review>&".into(),
+            description: "Review \"unsafe\" and 'risky' bits".into(),
+            version: "1.0.0".into(),
+            author: None,
+            tags: vec![],
+            tools: vec![crate::skills::SkillTool {
+                name: "run\"linter\"".into(),
+                description: "Run <lint> & report".into(),
+                kind: "shell&exec".into(),
+                command: "cargo clippy".into(),
+                args: std::collections::HashMap::new(),
+            }],
+            prompts: vec!["Use <tool_call> and & keep output \"safe\"".into()],
+            location: None,
+        }];
+
+        let prompt = build_system_prompt(ws.path(), "model", &[], &skills, None, None);
+
+        assert!(prompt.contains("<name>code&lt;review&gt;&amp;</name>"));
+        assert!(prompt.contains(
+            "<description>Review &quot;unsafe&quot; and &apos;risky&apos; bits</description>"
+        ));
+        assert!(
+            prompt.contains(
+                "<tool name=\"run&quot;linter&quot;\" kind=\"shell&amp;exec\">Run &lt;lint&gt; &amp; report</tool>"
+            )
+        );
+        assert!(prompt.contains("Use &lt;tool_call&gt; and &amp; keep output &quot;safe&quot;"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Problem: Skill prompts and tool definitions from SKILL.toml are parsed correctly but never injected into the agent's system prompt. Both prompt-building paths only emit metadata (name, description, location), telling the LLM to read the file on demand — which often fails.
- Why it matters: Skills are effectively broken. The agent doesn't receive skill instructions and must attempt manual file reads that fail due to path resolution issues.
- What changed: Both prompt builders now inline `<instructions>` and `<tools>` XML blocks inside each `<skill>` element, so the agent receives full skill context without extra tool calls.
- What did **not** change (scope boundary): Skill loading/parsing, skill CLI commands, tool execution, and all other prompt sections are unchanged.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `skills`, `agent`, `channel`
- Module labels: `skills:prompt-injection`
- Contributor tier label: `trusted contributor`
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `multi` (agent + channel prompt builders)

## Linked Issue

- Closes #877

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```
cargo fmt --all -- --check  # pass (pre-existing issue in compatible.rs, not from this PR)
cargo clippy -- -D warnings -A deprecated  # pass (4 pre-existing warnings in daemon/onboard/providers/tools, none in changed files)
cargo build  # pass
```

- Evidence provided: build succeeds, no new warnings or errors in changed files
- If any command is intentionally skipped, explain why: `cargo test` unavailable on target platform (Raspberry Pi aarch64, no test runner). CI will run tests.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: test uses neutral project-scoped labels only

## Compatibility / Migration

- Backward compatible? Yes — skills that previously relied on the on-demand read pattern will now work better since prompts are available directly.
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Created 3 skills (personal-trainer, cook, thesis-focus) with SKILL.toml prompts and tools. Before this fix, agent attempted manual fileread of SKILL.toml and failed. After fix, prompts are inline in system prompt.
- Edge cases checked: Skills with no prompts (empty vec), skills with no tools (empty vec), skills with both.
- What was not verified: `cargo test` (not available on Pi).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: System prompt generation for both channel-based and agent-based invocations. Prompts will be slightly larger due to inline skill content.
- Potential unintended effects: Increased system prompt token usage proportional to number of skills and prompt length. For typical setups (2-5 skills), this is negligible.
- Guardrails/monitoring for early detection: Existing bootstrap max chars truncation still applies to other prompt sections.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (code search, editing, build validation)
- Workflow/plan summary: Traced both prompt-building paths, identified that `skills_to_prompt()` in skills/mod.rs was dead code, applied the inline injection pattern consistently to both paths.
- Verification focus: Build success, no new clippy/fmt warnings in changed files.
- Confirmation: naming + architecture boundaries followed (AGENTS.md + CONTRIBUTING.md): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>` — single commit, clean revert.
- Feature flags or config toggles (if any): None
- Observable failure symptoms: If reverted, skills go back to on-demand loading (broken behavior). If the fix itself causes issues, system prompt would contain unexpected content — observable via agent response quality.

## Risks and Mitigations

- Risk: Large skill prompts could increase system prompt size significantly.
  - Mitigation: Typical skill prompts are 500-2000 chars. Even with 5 skills, this adds ~10K chars — well within context limits. A future enhancement could add a size threshold for on-demand loading of very large prompts.