### PR TITLE
fix(security): enforce HTTPS for sensitive data transmission

### DIFF
--- a/src/channels/qq.rs
+++ b/src/channels/qq.rs
@@ -11,6 +11,13 @@ use uuid::Uuid;
 const QQ_API_BASE: &str = "https://api.sgroup.qq.com";
 const QQ_AUTH_URL: &str = "https://bots.qq.com/app/getAppAccessToken";
 
+fn ensure_https(url: &str) -> anyhow::Result<()> {
+    if !url.starts_with("https://") {
+        anyhow::bail!("Refusing to transmit sensitive data over non-HTTPS URL: URL scheme must be https");
+    }
+    Ok(())
+}
+
 /// Deduplication set capacity — evict half of entries when full.
 const DEDUP_CAPACITY: usize = 10_000;
 
@@ -195,6 +202,8 @@ impl Channel for QQChannel {
                 }),
             )
         };
+
+        ensure_https(&url)?;
 
         let resp = self
             .http_client()

--- a/src/tools/composio.rs
+++ b/src/tools/composio.rs
@@ -19,6 +19,13 @@ use std::sync::Arc;
 const COMPOSIO_API_BASE_V2: &str = "https://backend.composio.dev/api/v2";
 const COMPOSIO_API_BASE_V3: &str = "https://backend.composio.dev/api/v3";
 
+fn ensure_https(url: &str) -> anyhow::Result<()> {
+    if !url.starts_with("https://") {
+        anyhow::bail!("Refusing to transmit sensitive data over non-HTTPS URL: URL scheme must be https");
+    }
+    Ok(())
+}
+
 /// A tool that proxies actions to the Composio managed tool platform.
 pub struct ComposioTool {
     api_key: String,
@@ -176,6 +183,8 @@ impl ComposioTool {
             entity_id,
             connected_account_ref,
         );
+
+        ensure_https(&url)?;
 
         let resp = self
             .client()


### PR DESCRIPTION
Add URL scheme validation before HTTP requests that transmit sensitive data (account IDs, phone numbers, user IDs). All endpoints already use HTTPS URLs, but this explicit check satisfies CodeQL rust/cleartext- transmission analysis and prevents future regressions if URLs are changed.

Affected files: composio.rs, whatsapp.rs, qq.rs