### PR TITLE
chore: add nix files for easy onboarding on the project

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,99 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1771398736,
+        "narHash": "sha256-pjV3C7VJHN0o2SvE3O6xiwraLt7bnlWIF3o7Q0BC1jk=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "0f608091816de13d92e1f4058b501028b782dddd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771353660,
+        "narHash": "sha256-yp1y55kXgaa08g/gR3CNiUdkg1JRjPYfkKtEIRNE6S8=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "09f2d468eda25a5f06ae70046357c70ae5cd77c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+  };
+
+  outputs = { flake-utils, fenix, nixpkgs, ... }:
+    let
+      nixosModule = { pkgs, ... }: {
+        nixpkgs.overlays = [ fenix.overlays.default ];
+        environment.systemPackages = [
+          (pkgs.fenix.stable.withComponents [
+            "cargo"
+            "clippy"
+            "rust-src"
+            "rustc"
+            "rustfmt"
+          ])
+          pkgs.rust-analyzer
+        ];
+      };
+    in
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ fenix.overlays.default ];
+        };
+        rustToolchain = pkgs.fenix.stable.withComponents [
+          "cargo"
+          "clippy"
+          "rust-src"
+          "rustc"
+          "rustfmt"
+        ];
+      in {
+        packages.default = fenix.packages.${system}.stable.toolchain;
+        devShells.default = pkgs.mkShell {
+          packages = [
+            rustToolchain
+            pkgs.rust-analyzer
+          ];
+        };
+      }) // {
+      nixosConfigurations = {
+        nixos = nixpkgs.lib.nixosSystem {
+          system = "x86_64-linux";
+          modules = [ nixosModule ];
+        };
+
+        nixos-aarch64 = nixpkgs.lib.nixosSystem {
+          system = "aarch64-linux";
+          modules = [ nixosModule ];
+        };
+      };
+    };
+}


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: New contributors must manually set up Nix development environment files.
- Why it matters: Friction during environment bootstrap slows onboarding and increases setup drift.
- What changed: Added `.envrc`, `flake.nix`, and `flake.lock` to provide a reproducible Nix-based dev setup.
- What did **not** change (scope boundary): No runtime, security, provider, channel, tool, or CI behavior was modified.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: M`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `dependencies,dev,onboard`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `config:nix`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `trusted contributor`
- If any auto-label is incorrect, note requested correction: None.

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `chore`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): No superseded PR.
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): Commit-level change inspection via `git show --stat`.
- If any command is intentionally skipped, explain why: Skipped in this PR creation step; no Rust source files changed.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: No sensitive runtime payloads or credentials added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `Yes`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Nix files are present and tracked in the branch.
- Edge cases checked: None beyond file presence and branch push.
- What was not verified: Local Nix shell activation and full cargo matrix.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Developer environment bootstrap for contributors using Nix/direnv.
- Potential unintended effects: Slight repository size increase due to lockfile.
- Guardrails/monitoring for early detection: Standard PR review and CI checks post-open.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `git show`, `git push`, `gh`.
- Workflow/plan summary (if any): Reviewed latest commit, pushed branch, prepared template-compliant PR body.
- Verification focus: Scope isolation and template compliance.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Confirmed for this chore-only change.

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `4ffdd437d5aea8aef4ab3c4ec46b6d75738b8692`.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Nix onboarding path fails or conflicts with contributor local tooling.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: Contributor environments may diverge if local direnv/Nix versions are incompatible.
  - Mitigation: Keep `flake.lock` committed and document supported tooling versions in follow-up docs if needed.
