### PR TITLE
fix(config): preserve explicit custom provider when legacy PROVIDER is set

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -20,6 +20,19 @@ Schema export command:
 | `default_model` | `anthropic/claude-sonnet-4-6` | model routed through selected provider |
 | `default_temperature` | `0.7` | model temperature |
 
+## Environment Provider Overrides
+
+Provider selection can also be controlled by environment variables. Precedence is:
+
+1. `ZEROCLAW_PROVIDER` (explicit override, always wins when non-empty)
+2. `PROVIDER` (legacy fallback, only applied when config provider is unset or still `openrouter`)
+3. `default_provider` in `config.toml`
+
+Operational note for container users:
+
+- If your `config.toml` sets an explicit custom provider like `custom:https://.../v1`, a default `PROVIDER=openrouter` from Docker/container env will no longer replace it.
+- Use `ZEROCLAW_PROVIDER` when you intentionally want runtime env to override a non-default configured provider.
+
 ## `[agent]`
 
 | Key | Default | Purpose |

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1194,6 +1194,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            linq: None,
+            linq_signing_secret: None,
             observer: Arc::new(crate::observability::NoopObserver),
         };
 
@@ -1235,6 +1237,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            linq: None,
+            linq_signing_secret: None,
             observer,
         };
 


### PR DESCRIPTION
## Summary

This fixes a regression where custom OpenAI-compatible providers could be unintentionally replaced by container defaults from `PROVIDER`, causing auth failures (e.g. OpenRouter 401) even when `default_provider = "custom:https://.../v1"` was explicitly configured.

### Root cause

`Config::apply_env_overrides()` treated `PROVIDER` as an unconditional fallback override whenever `ZEROCLAW_PROVIDER` was unset. In Docker/Podman setups, `PROVIDER=openrouter` commonly exists by default and could override a non-default provider set in `config.toml`.

### What changed

- Keep `ZEROCLAW_PROVIDER` as the explicit high-priority override.
- Restrict legacy `PROVIDER` behavior so it is only applied when config provider is unset or still default (`openrouter`).
- Add regression tests for provider override precedence.
- Document env provider override precedence in config reference docs.

## Files changed

- `src/config/schema.rs`
- `src/gateway/mod.rs` (test state struct completeness for current `AppState` fields)
- `docs/config-reference.md`

## Validation

Executed targeted tests for this regression and adjacent behavior:

- `cargo test -q --lib env_override_`
- `cargo test -q --lib metrics_endpoint_returns_hint_when_prometheus_is_disabled`
- `cargo test -q --lib metrics_endpoint_renders_prometheus_output`

All passed.

## Impact

- Explicit custom providers in `config.toml` are no longer silently replaced by legacy `PROVIDER` defaults.
- Operators can still force runtime override with `ZEROCLAW_PROVIDER`.

Fixes #834
