### PR TITLE
fix(tests): make issue #868 model-refresh regression deterministic

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1194,6 +1194,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            linq: None,
+            linq_signing_secret: None,
             observer: Arc::new(crate::observability::NoopObserver),
         };
 
@@ -1235,6 +1237,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            linq: None,
+            linq_signing_secret: None,
             observer,
         };
 

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -5357,7 +5357,8 @@ mod tests {
 
         let config = Config {
             workspace_dir: tmp.path().to_path_buf(),
-            default_provider: Some("venice".to_string()),
+            // Use a non-provider channel key to keep this test deterministic and offline.
+            default_provider: Some("imessage".to_string()),
             ..Config::default()
         };
 

--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -2172,7 +2172,7 @@ mod tests {
     }
 
     #[test]
-    fn strip_think_tags_removes_multiple_blocks() {
+    fn strip_think_tags_removes_multiple_blocks_with_surrounding_text() {
         let input = "Answer A <think>hidden 1</think> and B <think>hidden 2</think> done";
         let output = strip_think_tags(input);
         assert_eq!(output, "Answer A  and B  done");


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: `run_models_refresh_rejects_unsupported_provider` used `venice` as the unsupported provider, but Venice now supports live model discovery, making the test network-dependent and flaky.
- Why it matters: the regression test could panic on real network availability instead of validating unsupported-provider behavior, reducing CI and local test reliability.
- What changed: switched the test fixture provider to `imessage` (a non-provider channel key) so the unsupported-provider path is deterministic and fully offline.
- What changed: fixed two unrelated test-compile blockers on current `main` needed to run validation end-to-end (`AppState` fixture fields in gateway tests, duplicate test function name in compatible provider tests).
- What did **not** change (scope boundary): no runtime provider behavior, no production gateway logic, no API contract changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS` (expected)
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `tests, onboard, provider, gateway`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `onboard:wizard, provider:compatible, gateway:metrics`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #868
- Related #886
- Depends on # (if stacked): N/A
- Supersedes # (if replacing older PR): N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
./scripts/ci/rust_quality_gate.sh
cargo test --lib -- --test-threads=1
cargo test --lib onboard::wizard::tests::run_models_refresh_rejects_unsupported_provider -- --exact
cargo test --lib onboard::wizard::tests::supports_live_model_fetch_for_supported_and_unsupported_providers -- --exact
cargo test --lib strip_think_tags_removes_multiple_blocks
cargo test --lib gateway::tests::metrics_endpoint_
```

- Evidence provided (test/log/trace/screenshot/perf): local command outputs (including full `cargo test --lib` pass: 2214 passed, 0 failed).
- If any command is intentionally skipped, explain why: `cargo clippy --all-targets -- -D warnings` is not currently green on baseline due pre-existing non-correctness warnings; used repository correctness gate script (`rust_quality_gate.sh`) for required quality enforcement on this branch.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no user data touched; test-only fixtures updated.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: unsupported-provider refresh path now fails deterministically without network dependency; Venice support assertions remain valid.
- Edge cases checked: duplicate test name no longer causes compile failure; gateway metrics tests compile with current `AppState` struct fields.
- What was not verified: external live Venice API behavior (out of scope for this deterministic regression fix).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: test suite under `onboard`, `provider`, and `gateway` modules.
- Potential unintended effects: minimal; only test code paths and fixture construction changed.
- Guardrails/monitoring for early detection: full library test suite (`cargo test --lib`) executed locally.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex CLI + `gh` CLI.
- Workflow/plan summary (if any): deep issue review, isolated worktree branch, deterministic fix, comprehensive local validation, draft PR.
- Verification focus: deterministic behavior for issue #868 and full test-suite confidence.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 92accf2`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: unsupported-provider test may become flaky again if reverted to live provider assumptions.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: including compile-blocker test fixture updates could be seen as adjacent scope.
  - Mitigation: changes are minimal, test-only, and required to execute requested full validation on current mainline.
