### PR TITLE
fix(ci): publish multi-arch Docker images and stabilize release tags

### DIFF
--- a/.github/workflows/main-branch-flow.md
+++ b/.github/workflows/main-branch-flow.md
@@ -143,7 +143,7 @@ Workflow: `.github/workflows/pub-docker-img.yml`
    - `latest` + SHA tag (`sha-<12 chars>`) for `main`
    - semantic tag from pushed git tag (`vX.Y.Z`) + SHA tag for tag pushes
    - branch name + SHA tag for non-`main` manual dispatch refs
-5. Multi-platform publish is used for tag pushes (`linux/amd64,linux/arm64`), while `main` publish stays `linux/amd64`.
+5. Multi-platform publish is used for both `main` and tag pushes (`linux/amd64,linux/arm64`).
 6. Typical runtime in recent sample: ~139.9s.
 7. Result: pushed image tags under `ghcr.io/<owner>/<repo>`.
 

--- a/.github/workflows/pub-docker-img.yml
+++ b/.github/workflows/pub-docker-img.yml
@@ -75,6 +75,8 @@ jobs:
                   tags: zeroclaw-pr-smoke:latest
                   labels: ${{ steps.meta.outputs.labels || '' }}
                   platforms: linux/amd64
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
 
             - name: Verify image
               run: docker run --rm zeroclaw-pr-smoke:latest --version
@@ -83,7 +85,7 @@ jobs:
         name: Build and Push Docker Image
         if: (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))) && github.repository == 'zeroclaw-labs/zeroclaw'
         runs-on: blacksmith-2vcpu-ubuntu-2404
-        timeout-minutes: 25
+        timeout-minutes: 45
         permissions:
             contents: read
             packages: write
@@ -128,7 +130,9 @@ jobs:
                   context: .
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
-                  platforms: ${{ startsWith(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+                  platforms: linux/amd64,linux/arm64
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
 
             - name: Set GHCR package visibility to public
               shell: bash


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: Docker publish currently resolves to `linux/amd64` only for `latest`, and release tag publishes have shown cancellation risk before finishing multi-arch output.
- Why it matters: ARM users (Apple Silicon, ARM servers, edge devices) cannot reliably pull runnable images, and missing version manifests harms release reproducibility.
- What changed: Docker publish now always targets `linux/amd64,linux/arm64` for both `main` and `v*` tag pushes; publish timeout increased from 25 to 45 minutes; build cache wiring (`type=gha`) was added; workflow docs were updated to match runtime behavior.
- What did **not** change (scope boundary): No new runtime/provider/business logic, no new architectures beyond `arm64`, no registry namespace/tag naming changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high` (workflow/publish path change)
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `ci,docs`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `ci:docker`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `distinguished contributor`
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `ci`

## Linked Issue

- Closes #901
- Related #N/A
- Depends on #N/A (if stacked)
- Supersedes #N/A (if replacing older PR)

## Validation Evidence (required)

Commands and result summary:

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pub-docker-img.yml")'
rg -n '\t' .github/workflows -g '*.yml' -g '*.yaml'
./scripts/ci/docs_quality_gate.sh
/tmp/actionlint -color
```

- Evidence provided (test/log/trace/screenshot/perf): YAML parse pass, no-tabs pass, docs quality gate pass, actionlint pass; plus pre-change GHCR manifest checks confirming missing `linux/arm64` and missing `v0.1.0` manifest.
- If any command is intentionally skipped, explain why: `cargo fmt/clippy/test` skipped because this PR only touches workflow/docs files and does not modify Rust sources.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No` (existing Docker publish network path only)
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: No user data was introduced; only workflow and docs changes.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: main-branch and `v*` tag event paths both resolve to multi-arch publish target configuration; documentation now matches workflow behavior.
- Edge cases checked: release publish timeout headroom increased to avoid cancellation for slower multi-arch builds; caching configured for both smoke and publish steps.
- What was not verified: live end-to-end publish from a new release tag in this PR context (requires merge + tag event).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `.github/workflows/pub-docker-img.yml`, `.github/workflows/main-branch-flow.md`.
- Potential unintended effects: longer publish job runtime window may keep runners occupied longer during tag publishes.
- Guardrails/monitoring for early detection: existing workflow checks plus post-merge GHCR manifest inspection for `latest` and next `v*` release tag.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `gh` CLI, `actionlint`, docs quality gate.
- Workflow/plan summary (if any): investigate issue + history, verify registry state, implement targeted workflow fix, run local validation, request owner review.
- Verification focus: publish architecture matrix, release-tag stability, workflow lint/sanity.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: `git revert a0db6e94b6f815f79d7fa12126b7197bf2dc4344` on `main`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: Docker publish failures/timeouts or unexpected GHCR manifest architecture entries.

## Risks and Mitigations

- Risk: Multi-arch publish can still be slower under transient GHCR/buildx load.
- Mitigation: increased timeout + GHA cache + owner-gated workflow review.
