### PR TITLE
refactor(auth): make auth profile store async

### DIFF
--- a/src/auth/profiles.rs
+++ b/src/auth/profiles.rs
@@ -3,11 +3,12 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::thread;
 use std::time::Duration;
+use tokio::fs::{self, OpenOptions};
+use tokio::io::AsyncWriteExt;
+use tokio::time::sleep;
 
 const CURRENT_SCHEMA_VERSION: u32 = 1;
 const PROFILES_FILENAME: &str = "auth-profiles.json";
@@ -147,14 +148,14 @@ impl AuthProfilesStore {
         &self.path
     }
 
-    pub fn load(&self) -> Result<AuthProfilesData> {
-        let _lock = self.acquire_lock()?;
-        self.load_locked()
+    pub async fn load(&self) -> Result<AuthProfilesData> {
+        let _lock = self.acquire_lock().await?;
+        self.load_locked().await
     }
 
-    pub fn upsert_profile(&self, mut profile: AuthProfile, set_active: bool) -> Result<()> {
-        let _lock = self.acquire_lock()?;
-        let mut data = self.load_locked()?;
+    pub async fn upsert_profile(&self, mut profile: AuthProfile, set_active: bool) -> Result<()> {
+        let _lock = self.acquire_lock().await?;
+        let mut data = self.load_locked().await?;
 
         profile.updated_at = Utc::now();
         if let Some(existing) = data.profiles.get(&profile.id) {
@@ -169,12 +170,12 @@ impl AuthProfilesStore {
         data.profiles.insert(profile.id.clone(), profile);
         data.updated_at = Utc::now();
 
-        self.save_locked(&data)
+        self.save_locked(&data).await
     }
 
-    pub fn remove_profile(&self, profile_id: &str) -> Result<bool> {
-        let _lock = self.acquire_lock()?;
-        let mut data = self.load_locked()?;
+    pub async fn remove_profile(&self, profile_id: &str) -> Result<bool> {
+        let _lock = self.acquire_lock().await?;
+        let mut data = self.load_locked().await?;
 
         let removed = data.profiles.remove(profile_id).is_some();
         if !removed {
@@ -184,13 +185,13 @@ impl AuthProfilesStore {
         data.active_profiles
             .retain(|_, active| active != profile_id);
         data.updated_at = Utc::now();
-        self.save_locked(&data)?;
+        self.save_locked(&data).await?;
         Ok(true)
     }
 
-    pub fn set_active_profile(&self, provider: &str, profile_id: &str) -> Result<()> {
-        let _lock = self.acquire_lock()?;
-        let mut data = self.load_locked()?;
+    pub async fn set_active_profile(&self, provider: &str, profile_id: &str) -> Result<()> {
+        let _lock = self.acquire_lock().await?;
+        let mut data = self.load_locked().await?;
 
         if !data.profiles.contains_key(profile_id) {
             anyhow::bail!("Auth profile not found: {profile_id}");
@@ -199,23 +200,23 @@ impl AuthProfilesStore {
         data.active_profiles
             .insert(provider.to_string(), profile_id.to_string());
         data.updated_at = Utc::now();
-        self.save_locked(&data)
+        self.save_locked(&data).await
     }
 
-    pub fn clear_active_profile(&self, provider: &str) -> Result<()> {
-        let _lock = self.acquire_lock()?;
-        let mut data = self.load_locked()?;
+    pub async fn clear_active_profile(&self, provider: &str) -> Result<()> {
+        let _lock = self.acquire_lock().await?;
+        let mut data = self.load_locked().await?;
         data.active_profiles.remove(provider);
         data.updated_at = Utc::now();
-        self.save_locked(&data)
+        self.save_locked(&data).await
     }
 
-    pub fn update_profile<F>(&self, profile_id: &str, mut updater: F) -> Result<AuthProfile>
+    pub async fn update_profile<F>(&self, profile_id: &str, mut updater: F) -> Result<AuthProfile>
     where
         F: FnMut(&mut AuthProfile) -> Result<()>,
     {
-        let _lock = self.acquire_lock()?;
-        let mut data = self.load_locked()?;
+        let _lock = self.acquire_lock().await?;
+        let mut data = self.load_locked().await?;
 
         let profile = data
             .profiles
@@ -226,12 +227,12 @@ impl AuthProfilesStore {
         profile.updated_at = Utc::now();
         let updated_profile = profile.clone();
         data.updated_at = Utc::now();
-        self.save_locked(&data)?;
+        self.save_locked(&data).await?;
         Ok(updated_profile)
     }
 
-    fn load_locked(&self) -> Result<AuthProfilesData> {
-        let mut persisted = self.read_persisted_locked()?;
+    async fn load_locked(&self) -> Result<AuthProfilesData> {
+        let mut persisted = self.read_persisted_locked().await?;
         let mut migrated = false;
 
         let mut profiles = BTreeMap::new();
@@ -297,7 +298,7 @@ impl AuthProfilesStore {
         }
 
         if migrated {
-            self.write_persisted_locked(&persisted)?;
+            self.write_persisted_locked(&persisted).await?;
         }
 
         Ok(AuthProfilesData {
@@ -308,7 +309,7 @@ impl AuthProfilesStore {
         })
     }
 
-    fn save_locked(&self, data: &AuthProfilesData) -> Result<()> {
+    async fn save_locked(&self, data: &AuthProfilesData) -> Result<()> {
         let mut persisted = PersistedAuthProfiles {
             schema_version: CURRENT_SCHEMA_VERSION,
             updated_at: data.updated_at.to_rfc3339(),
@@ -354,15 +355,15 @@ impl AuthProfilesStore {
             );
         }
 
-        self.write_persisted_locked(&persisted)
+        self.write_persisted_locked(&persisted).await
     }
 
-    fn read_persisted_locked(&self) -> Result<PersistedAuthProfiles> {
+    async fn read_persisted_locked(&self) -> Result<PersistedAuthProfiles> {
         if !self.path.exists() {
             return Ok(PersistedAuthProfiles::default());
         }
 
-        let bytes = fs::read(&self.path).with_context(|| {
+        let bytes = fs::read(&self.path).await.with_context(|| {
             format!(
                 "Failed to read auth profile store at {}",
                 self.path.display()
@@ -396,9 +397,9 @@ impl AuthProfilesStore {
         Ok(persisted)
     }
 
-    fn write_persisted_locked(&self, persisted: &PersistedAuthProfiles) -> Result<()> {
+    async fn write_persisted_locked(&self, persisted: &PersistedAuthProfiles) -> Result<()> {
         if let Some(parent) = self.path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
+            fs::create_dir_all(parent).await.with_context(|| {
                 format!(
                     "Failed to create auth profile directory at {}",
                     parent.display()
@@ -416,14 +417,14 @@ impl AuthProfilesStore {
         );
         let tmp_path = self.path.with_file_name(tmp_name);
 
-        fs::write(&tmp_path, &json).with_context(|| {
+        fs::write(&tmp_path, &json).await.with_context(|| {
             format!(
                 "Failed to write temporary auth profile file at {}",
                 tmp_path.display()
             )
         })?;
 
-        fs::rename(&tmp_path, &self.path).with_context(|| {
+        fs::rename(&tmp_path, &self.path).await.with_context(|| {
             format!(
                 "Failed to replace auth profile store at {}",
                 self.path.display()
@@ -450,9 +451,9 @@ impl AuthProfilesStore {
         }
     }
 
-    fn acquire_lock(&self) -> Result<AuthProfileLockGuard> {
+    async fn acquire_lock(&self) -> Result<AuthProfileLockGuard> {
         if let Some(parent) = self.lock_path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
+            fs::create_dir_all(parent).await.with_context(|| {
                 format!("Failed to create lock directory at {}", parent.display())
             })?;
         }
@@ -463,9 +464,25 @@ impl AuthProfilesStore {
                 .create_new(true)
                 .write(true)
                 .open(&self.lock_path)
+                .await
             {
                 Ok(mut file) => {
-                    let _ = writeln!(file, "pid={}", std::process::id());
+                    let mut buffer = Vec::new();
+                    writeln!(&mut buffer, "pid={}", std::process::id())?;
+                    if let Err(e) = file.write_all(&buffer).await {
+                        fs::remove_file(&self.lock_path)
+                            .await
+                            .inspect(|e| {
+                                tracing::error!("Failed to remove auth profile lock file: {e:?}");
+                            })
+                            .ok();
+                        return Err(e).with_context(|| {
+                            format!(
+                                "Failed to write auth profile lock at {}",
+                                self.lock_path.display()
+                            )
+                        });
+                    }
                     return Ok(AuthProfileLockGuard {
                         lock_path: self.lock_path.clone(),
                     });
@@ -477,7 +494,7 @@ impl AuthProfilesStore {
                             self.lock_path.display()
                         );
                     }
-                    thread::sleep(Duration::from_millis(LOCK_WAIT_MS));
+                    sleep(Duration::from_millis(LOCK_WAIT_MS)).await;
                     waited = waited.saturating_add(LOCK_WAIT_MS);
                 }
                 Err(e) => {
@@ -499,7 +516,7 @@ struct AuthProfileLockGuard {
 
 impl Drop for AuthProfileLockGuard {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.lock_path);
+        let _ = std::fs::remove_file(&self.lock_path);
     }
 }
 
@@ -645,9 +662,9 @@ mod tests {
         );
         profile.account_id = Some("acct_123".into());
 
-        store.upsert_profile(profile.clone(), true).unwrap();
+        store.upsert_profile(profile.clone(), true).await.unwrap();
 
-        let data = store.load().unwrap();
+        let data = store.load().await.unwrap();
         let loaded = data.profiles.get(&profile.id).unwrap();
 
         assert_eq!(loaded.provider, "openai-codex");
@@ -673,7 +690,7 @@ mod tests {
         let store = AuthProfilesStore::new(tmp.path(), false);
 
         let profile = AuthProfile::new_token("anthropic", "default", "token-abc".into());
-        store.upsert_profile(profile, true).unwrap();
+        store.upsert_profile(profile, true).await.unwrap();
 
         let path = store.path().to_path_buf();
         assert!(path.exists());

--- a/src/main.rs
+++ b/src/main.rs
@@ -982,7 +982,9 @@ async fn handle_auth_command(auth_command: AuthCommands, config: &Config) -> Res
                         let account_id =
                             extract_openai_account_id_for_profile(&token_set.access_token);
 
-                        auth_service.store_openai_tokens(&profile, token_set, account_id, true)?;
+                        auth_service
+                            .store_openai_tokens(&profile, token_set, account_id, true)
+                            .await?;
                         clear_pending_openai_login(config);
 
                         println!("Saved profile {profile}");
@@ -1032,7 +1034,9 @@ async fn handle_auth_command(auth_command: AuthCommands, config: &Config) -> Res
                 auth::openai_oauth::exchange_code_for_tokens(&client, &code, &pkce).await?;
             let account_id = extract_openai_account_id_for_profile(&token_set.access_token);
 
-            auth_service.store_openai_tokens(&profile, token_set, account_id, true)?;
+            auth_service
+                .store_openai_tokens(&profile, token_set, account_id, true)
+                .await?;
             clear_pending_openai_login(config);
 
             println!("Saved profile {profile}");
@@ -1085,7 +1089,9 @@ async fn handle_auth_command(auth_command: AuthCommands, config: &Config) -> Res
                 auth::openai_oauth::exchange_code_for_tokens(&client, &code, &pkce).await?;
             let account_id = extract_openai_account_id_for_profile(&token_set.access_token);
 
-            auth_service.store_openai_tokens(&profile, token_set, account_id, true)?;
+            auth_service
+                .store_openai_tokens(&profile, token_set, account_id, true)
+                .await?;
             clear_pending_openai_login(config);
 
             println!("Saved profile {profile}");
@@ -1115,7 +1121,9 @@ async fn handle_auth_command(auth_command: AuthCommands, config: &Config) -> Res
                 kind.as_metadata_value().to_string(),
             );
 
-            auth_service.store_provider_token(&provider, &profile, &token, metadata, true)?;
+            auth_service
+                .store_provider_token(&provider, &profile, &token, metadata, true)
+                .await?;
             println!("Saved profile {profile}");
             println!("Active profile for {provider}: {profile}");
             Ok(())
@@ -1135,7 +1143,9 @@ async fn handle_auth_command(auth_command: AuthCommands, config: &Config) -> Res
                 kind.as_metadata_value().to_string(),
             );
 
-            auth_service.store_provider_token(&provider, &profile, &token, metadata, true)?;
+            auth_service
+                .store_provider_token(&provider, &profile, &token, metadata, true)
+                .await?;
             println!("Saved profile {profile}");
             println!("Active profile for {provider}: {profile}");
             Ok(())
@@ -1165,7 +1175,7 @@ async fn handle_auth_command(auth_command: AuthCommands, config: &Config) -> Res
 
         AuthCommands::Logout { provider, profile } => {
             let provider = auth::normalize_provider(&provider)?;
-            let removed = auth_service.remove_profile(&provider, &profile)?;
+            let removed = auth_service.remove_profile(&provider, &profile).await?;
             if removed {
                 println!("Removed auth profile {provider}:{profile}");
             } else {
@@ -1176,13 +1186,13 @@ async fn handle_auth_command(auth_command: AuthCommands, config: &Config) -> Res
 
         AuthCommands::Use { provider, profile } => {
             let provider = auth::normalize_provider(&provider)?;
-            auth_service.set_active_profile(&provider, &profile)?;
+            auth_service.set_active_profile(&provider, &profile).await?;
             println!("Active profile for {provider}: {profile}");
             Ok(())
         }
 
         AuthCommands::List => {
-            let data = auth_service.load_profiles()?;
+            let data = auth_service.load_profiles().await?;
             if data.profiles.is_empty() {
                 println!("No auth profiles configured.");
                 return Ok(());
@@ -1201,7 +1211,7 @@ async fn handle_auth_command(auth_command: AuthCommands, config: &Config) -> Res
         }
 
         AuthCommands::Status => {
-            let data = auth_service.load_profiles()?;
+            let data = auth_service.load_profiles().await?;
             if data.profiles.is_empty() {
                 println!("No auth profiles configured.");
                 return Ok(());

--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -382,7 +382,8 @@ impl OpenAiCodexProvider {
     ) -> anyhow::Result<String> {
         let profile = self
             .auth
-            .get_profile("openai-codex", self.auth_profile_override.as_deref())?;
+            .get_profile("openai-codex", self.auth_profile_override.as_deref())
+            .await?;
         let access_token = self
             .auth
             .get_valid_openai_access_token(self.auth_profile_override.as_deref())


### PR DESCRIPTION
## Summary

- Problem: Auth profile storage APIs were synchronous and required `spawn_blocking` bridges in async flows.
- Why it matters: Blocking-style profile persistence adds complexity and can increase contention in async runtime paths.
- What changed: Converted auth profile store/service operations to async I/O (`tokio::fs`), updated auth command call sites, and updated OpenAI Codex provider profile lookup to await async auth access.
- What did **not** change (scope boundary): No schema/version changes, no new config keys, no provider behavior change beyond async internal wiring.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: M` (expected)
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `core,provider`
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): `provider:openai-codex`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `refactor`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #
- Related #708
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): command output logs from local run.
- If any command is intentionally skipped, explain why: none skipped. `cargo clippy` and `cargo test` currently fail due pre-existing unrelated issues in `src/onboard/wizard.rs`, `src/channels/lark.rs`, `src/daemon/mod.rs`, `src/security/policy.rs`, `src/channels/mod.rs`, and `src/tools/proxy_config.rs`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no personal/sensitive data added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: auth profile read/write/remove/set-active and OpenAI Codex profile fetch compile-path updated for async calls.
- Edge cases checked: lock-file acquisition write path now handles async write failures and lock cleanup.
- What was not verified: manual end-to-end OAuth/login flow against live provider.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: auth profile persistence and auth command handling.
- Potential unintended effects: async file-lock timing differences under high contention.
- Guardrails/monitoring for early detection: existing auth/profile tests plus command-level error surfacing.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex CLI for diff review, validation command execution, and PR template drafting.
- Workflow/plan summary (if any): inspected patch -> ran validation matrix -> branched/committed -> prepared PR body.
- Verification focus: async conversion safety and no schema/contract drift.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): yes.
- Note to owner: I am writing the code by hand but using Codex to fill the PR template as it is quite thorough 😅

## Rollback Plan (required)

- Fast rollback command/path: revert commit `2b12941`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: auth profile commands failing to read/write tokens or active-profile updates.

## Risks and Mitigations

- Risk: async lock-file and persistence path behavior differs from previous sync path under contention.
  - Mitigation: preserve existing lock strategy/timeouts and keep failure modes explicit with contextual errors.
