### PR TITLE
Remove pin rust version with a minimum rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/zeroclaw-labs/zeroclaw"
 readme = "README.md"
 keywords = ["ai", "agent", "cli", "assistant", "chatbot"]
 categories = ["command-line-utilities", "api-bindings"]
+rust-version = "1.87"
 
 [dependencies]
 # CLI - minimal and fast

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.92.0"


### PR DESCRIPTION
**In the original PR #201 the problem was :**
"The project requires Rust 1.86+ due [...] . Add rust-toolchain.toml to ensure reproducible builds and prevent build failures on systems with Rust 1.85.0."

So the proper way to do that was to set a minimum Rust version rather than forcing every one to use a specific rust version.