### PR TITLE
fix(provider): align qwen oauth alias with qwen base-url mapping

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -604,7 +604,7 @@ fn moonshot_base_url(name: &str) -> Option<&'static str> {
 }
 
 fn qwen_base_url(name: &str) -> Option<&'static str> {
-    if is_qwen_cn_alias(name) {
+    if is_qwen_cn_alias(name) || is_qwen_oauth_alias(name) {
         Some(QWEN_CN_BASE_URL)
     } else if is_qwen_intl_alias(name) {
         Some(QWEN_INTL_BASE_URL)


### PR DESCRIPTION
## Summary
This patch fixes a provider alias inconsistency discovered during deep post-merge regression checks.

## Problem
`is_qwen_alias("qwen-code")` returns true (via OAuth alias), but `qwen_base_url("qwen-code")` returned `None`.
That caused `providers::tests::regional_endpoint_aliases_map_to_expected_urls` to fail.

## Change
- Treat Qwen OAuth aliases as CN fallback in `qwen_base_url()`:
  - `is_qwen_cn_alias(name) || is_qwen_oauth_alias(name) -> QWEN_CN_BASE_URL`

This is safe because dedicated Qwen OAuth provider construction remains handled by the earlier `is_qwen_oauth_alias` branch in `create_provider_with_options`.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --lib providers::tests::regional_endpoint_aliases_map_to_expected_urls`
- `cargo test -q`
