### PR TITLE
feat(channels): support message interruption on rapid sender input

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2070,6 +2070,12 @@ pub struct ChannelsConfig {
     /// Default: 300s for on-device LLMs (Ollama) which are slower than cloud APIs.
     #[serde(default = "default_channel_message_timeout_secs")]
     pub message_timeout_secs: u64,
+    /// When true, a new message from the same sender cancels any in-flight LLM
+    /// request for that sender. The interrupted message content is preserved in
+    /// conversation history so the new request sees full context.
+    /// Default: false.
+    #[serde(default)]
+    pub interrupt_on_new_message: bool,
 }
 
 fn default_channel_message_timeout_secs() -> u64 {
@@ -2096,6 +2102,7 @@ impl Default for ChannelsConfig {
             dingtalk: None,
             qq: None,
             message_timeout_secs: default_channel_message_timeout_secs(),
+            interrupt_on_new_message: false,
         }
     }
 }
@@ -3537,6 +3544,7 @@ default_temperature = 0.7
                 dingtalk: None,
                 qq: None,
                 message_timeout_secs: 300,
+                interrupt_on_new_message: false,
             },
             memory: MemoryConfig::default(),
             storage: StorageConfig::default(),
@@ -4060,6 +4068,7 @@ allowed_users = ["@ops:matrix.org"]
             dingtalk: None,
             qq: None,
             message_timeout_secs: 300,
+            interrupt_on_new_message: false,
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();
@@ -4237,6 +4246,7 @@ channel_id = "C123"
             dingtalk: None,
             qq: None,
             message_timeout_secs: 300,
+            interrupt_on_new_message: false,
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();


### PR DESCRIPTION
## Summary

- Problem: When a user sends multiple messages rapidly (e.g. forwards an image then sends "summarize this"), the bot processes each message independently — the second request lacks context from the first, and the first produces an unnecessary reply.
- Why it matters: Common in Telegram and similar platforms where forwarding + follow-up is a natural pattern; the redundant/context-less replies create a poor user experience.
- What changed: Added `interrupt_on_new_message` config flag (default false). When enabled, a new message from the same sender cancels the in-flight LLM request via `CancellationToken`, preserves the interrupted message in conversation history, and cleans up typing indicators.
- What did not change (scope boundary): Default behavior is unchanged (flag defaults to false). Different senders never affect each other. No new crate dependencies — uses existing `tokio_util::sync::CancellationToken` already imported in the project.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: M`
- Scope labels: `channel`, `config`, `runtime`
- Module labels: `channel:dispatch`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Closes #857
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings  # pass (8 pre-existing upstream warnings, 0 introduced by this PR)
cargo test   # 2311 passed, 2 failed (both pre-existing on upstream/main, 0 introduced by this PR)
```

- Evidence provided: 3 new unit tests covering interrupt-enabled same-sender cancellation, interrupt-disabled parallel processing, and cross-sender isolation. All 3 pass.
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: No identity-like wording used.

## Compatibility / Migration

- Backward compatible? Yes — `interrupt_on_new_message` defaults to `false`, preserving existing behavior.
- Config/env changes? Yes — new optional `interrupt_on_new_message` field in `[channels_config]`.
- Migration needed? No — `#[serde(default)]` means existing configs work without changes.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: interrupt-enabled same-sender cancellation, interrupt-disabled parallel processing, cross-sender isolation
- Edge cases checked: rapid sequential messages from same sender, concurrent messages from different senders, history preservation after cancellation, typing indicator cleanup
- What was not verified: live Telegram/Discord end-to-end testing (no credentials available)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `run_message_dispatch_loop` now wraps `process_channel_message` in `process_channel_message_cancellable`; this applies universally but the cancellation path is only active when `interrupt_on_new_message = true`.
- Potential unintended effects: None expected — when the flag is false (default), the `CancellationToken` is never cancelled and `active_senders` map stays empty.
- Guardrails/monitoring for early detection: Console log when cancellation occurs for debugging.

## Agent Collaboration Notes (recommended)

N/A

## Rollback Plan (required)

- Fast rollback command/path: Set `interrupt_on_new_message = false` (or remove the key entirely — serde default is false).
- Feature flags or config toggles (if any): `interrupt_on_new_message` in `[channels_config]` is itself the toggle.
- Observable failure symptoms: If broken, messages from same sender may be silently dropped or history may not accumulate correctly — visible through missing bot replies.

## Risks and Mitigations

- Risk: Cancellation race — if `cancel()` fires just as the LLM response arrives, the reply could be partially sent.
  - Mitigation: `tokio::select!` guarantees only one branch executes; once the cancelled branch runs, `process_channel_message` is dropped and its future is never polled again.
- Risk: History grows unbounded if many messages are interrupted in sequence.
  - Mitigation: History is trimmed to `MAX_CHANNEL_HISTORY` in the cancelled branch, same as normal message processing.
