### PR TITLE
legal: add dual MIT+Apache 2.0 license, trademark policy, and CLA

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,132 @@
+# ZeroClaw Contributor License Agreement (CLA)
+
+**Version 1.0 — February 2026**  
+**ZeroClaw Labs**
+
+---
+
+## Purpose
+
+This Contributor License Agreement ("CLA") clarifies the intellectual
+property rights granted by contributors to ZeroClaw Labs. This agreement
+protects both contributors and users of the ZeroClaw project.
+
+By submitting a contribution (pull request, patch, issue with code, or any
+other form of code submission) to the ZeroClaw repository, you agree to the
+terms of this CLA.
+
+---
+
+## 1. Definitions
+
+- **"Contribution"** means any original work of authorship, including any
+  modifications or additions to existing work, submitted to ZeroClaw Labs
+  for inclusion in the ZeroClaw project.
+
+- **"You"** means the individual or legal entity submitting a Contribution.
+
+- **"ZeroClaw Labs"** means the maintainers and organization responsible
+  for the ZeroClaw project at https://github.com/zeroclaw-labs/zeroclaw.
+
+---
+
+## 2. Grant of Copyright License
+
+You grant ZeroClaw Labs and recipients of software distributed by ZeroClaw
+Labs a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to:
+
+- Reproduce, prepare derivative works of, publicly display, publicly
+  perform, sublicense, and distribute your Contributions and derivative
+  works under **both the MIT License and the Apache License 2.0**.
+
+---
+
+## 3. Grant of Patent License
+
+You grant ZeroClaw Labs and recipients of software distributed by ZeroClaw
+Labs a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable patent license to make, have made, use, offer to sell, sell,
+import, and otherwise transfer your Contributions.
+
+This patent license applies only to patent claims licensable by you that
+are necessarily infringed by your Contribution alone or in combination with
+the ZeroClaw project.
+
+**This protects you:** if a third party files a patent claim against
+ZeroClaw that covers your Contribution, your patent license to the project
+is not revoked.
+
+---
+
+## 4. You Retain Your Rights
+
+This CLA does **not** transfer ownership of your Contribution to ZeroClaw
+Labs. You retain full copyright ownership of your Contribution. You are
+free to use your Contribution in any other project under any license.
+
+---
+
+## 5. Original Work
+
+You represent that:
+
+1. Each Contribution is your original creation, or you have sufficient
+   rights to submit it under this CLA.
+2. Your Contribution does not knowingly infringe any third-party patent,
+   copyright, trademark, or other intellectual property right.
+3. If your employer has rights to intellectual property you create, you
+   have received permission to submit the Contribution, or your employer
+   has signed a corporate CLA with ZeroClaw Labs.
+
+---
+
+## 6. No Trademark Rights
+
+This CLA does not grant you any rights to use the ZeroClaw name,
+trademarks, service marks, or logos. See TRADEMARK.md for trademark policy.
+
+---
+
+## 7. Attribution
+
+ZeroClaw Labs will maintain attribution to contributors in the repository
+commit history and NOTICE file. Your contributions are permanently and
+publicly recorded.
+
+---
+
+## 8. Dual-License Commitment
+
+All Contributions accepted into the ZeroClaw project are licensed under
+both:
+
+- **MIT License** — permissive open-source use
+- **Apache License 2.0** — patent protection and stronger IP guarantees
+
+This dual-license model ensures maximum compatibility and protection for
+the entire contributor community.
+
+---
+
+## 9. How to Agree
+
+By opening a pull request or submitting a patch to the ZeroClaw repository,
+you indicate your agreement to this CLA. No separate signature is required
+for individual contributors.
+
+For **corporate contributors** (submitting on behalf of a company or
+organization), please open an issue titled "Corporate CLA — [Company Name]"
+and a maintainer will follow up.
+
+---
+
+## 10. Questions
+
+If you have questions about this CLA, open an issue at:
+https://github.com/zeroclaw-labs/zeroclaw/issues
+
+---
+
+*This CLA is based on the Apache Individual Contributor License Agreement
+v2.0, adapted for the ZeroClaw dual-license model.*

--- a/LICENSE
+++ b/LICENSE
@@ -22,7 +22,34 @@ SOFTWARE.
 
 ================================================================================
 
+TRADEMARK NOTICE
+
+This license does not grant permission to use the trade names, trademarks,
+service marks, or product names of ZeroClaw Labs, including "ZeroClaw",
+"zeroclaw-labs", or associated logos, except as required for reasonable and
+customary use in describing the origin of the Software.
+
+Unauthorized use of the ZeroClaw name or branding to imply endorsement,
+affiliation, or origin is strictly prohibited. See TRADEMARK.md for details.
+
+================================================================================
+
+DUAL LICENSE NOTICE
+
+This software is available under a dual-license model:
+
+  1. MIT License (this file) — for open-source, research, academic, and
+     personal use. See LICENSE (this file).
+
+  2. Apache License 2.0 — for contributors and deployments requiring explicit
+     patent grants and stronger IP protection. See LICENSE-APACHE.
+
+You may choose either license for your use. Contributors submitting patches
+grant rights under both licenses. See CLA.md for the contributor agreement.
+
+================================================================================
+
 This product includes software developed by ZeroClaw Labs and contributors:
 https://github.com/zeroclaw-labs/zeroclaw/graphs/contributors
 
-See NOTICE file for full contributor attribution.
+See NOTICE for full contributor attribution.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,186 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as defined in Section 5, any work of
+      authorship, including the original version of the Work and any
+      modifications or additions to that Work or Derivative Works of the
+      Work, that is intentionally submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or designated in writing by the copyright owner as "Not a
+      Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and subsequently
+      incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any Contribution
+      incorporated within the Work constitutes direct or contributory patent
+      infringement, then any patent licenses granted to You under this License
+      for that Work shall terminate as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or as an addendum to
+          the NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Contribution, either on its own or as part of the Work.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      including "ZeroClaw", "zeroclaw-labs", or associated logos, except
+      as required for reasonable and customary use in describing the origin
+      of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may offer such
+      obligations only on Your own behalf and on Your sole responsibility,
+      not on behalf of any other Contributor, and only if You agree to
+      indemnify, defend, and hold each Contributor harmless for any
+      liability incurred by, or claims asserted against, such Contributor
+      by reason of your accepting any warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2025 ZeroClaw Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -3,12 +3,36 @@ Copyright 2025 ZeroClaw Labs
 
 This product includes software developed at ZeroClaw Labs (https://github.com/zeroclaw-labs).
 
+Official Repository
+===================
+
+The only official ZeroClaw repository is:
+https://github.com/zeroclaw-labs/zeroclaw
+
+Any other repository claiming to be ZeroClaw is unauthorized.
+See TRADEMARK.md for the full trademark policy.
+
+License
+=======
+
+This software is available under a dual-license model:
+
+  1. MIT License — see LICENSE
+  2. Apache License 2.0 — see LICENSE-APACHE
+
+You may use either license. Contributors grant rights under both.
+See CLA.md for the contributor license agreement.
+
 Contributors
 ============
 
 This NOTICE file is maintained by repository automation.
 For the latest contributor list, see the repository contributors page:
 https://github.com/zeroclaw-labs/zeroclaw/graphs/contributors
+
+All contributors retain copyright ownership of their contributions.
+Contributions are permanently attributed in the repository commit history.
+Patent rights are protected for all contributors under Apache License 2.0.
 
 Third-Party Dependencies
 ========================

--- a/README.md
+++ b/README.md
@@ -879,13 +879,42 @@ A heartfelt thank you to the communities and institutions that inspire and fuel 
 
 We're building in the open because the best ideas come from everywhere. If you're reading this, you're part of it. Welcome. 🦀❤️
 
+## ⚠️ Official Repository & Impersonation Warning
+
+**This is the only official ZeroClaw repository:**
+> https://github.com/zeroclaw-labs/zeroclaw
+
+Any other repository, organization, domain, or package claiming to be "ZeroClaw" or implying affiliation with ZeroClaw Labs is **unauthorized and not affiliated with this project**. Known unauthorized forks will be listed in [TRADEMARK.md](TRADEMARK.md).
+
+If you encounter impersonation or trademark misuse, please [open an issue](https://github.com/zeroclaw-labs/zeroclaw/issues).
+
+---
+
 ## License
 
-MIT — see [LICENSE](LICENSE) for license terms and attribution baseline
+ZeroClaw is dual-licensed for maximum openness and contributor protection:
+
+| License | Use case |
+|---|---|
+| [MIT](LICENSE) | Open-source, research, academic, personal use |
+| [Apache 2.0](LICENSE-APACHE) | Patent protection, institutional, commercial deployment |
+
+You may choose either license. **Contributors automatically grant rights under both** — see [CLA.md](CLA.md) for the full contributor agreement.
+
+### Trademark
+
+The **ZeroClaw** name and logo are trademarks of ZeroClaw Labs. This license does not grant permission to use them to imply endorsement or affiliation. See [TRADEMARK.md](TRADEMARK.md) for permitted and prohibited uses.
+
+### Contributor Protections
+
+- You **retain copyright** of your contributions
+- **Patent grant** (Apache 2.0) shields you from patent claims by other contributors
+- Your contributions are **permanently attributed** in commit history and [NOTICE](NOTICE)
+- No trademark rights are transferred by contributing
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md). Implement a trait, submit a PR:
+See [CONTRIBUTING.md](CONTRIBUTING.md) and [CLA.md](CLA.md). Implement a trait, submit a PR:
 - CI workflow guide: [docs/ci-map.md](docs/ci-map.md)
 - New `Provider` → `src/providers/`
 - New `Channel` → `src/channels/`

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,129 @@
+# ZeroClaw Trademark Policy
+
+**Effective date:** February 2026  
+**Maintained by:** ZeroClaw Labs
+
+---
+
+## Our Trademarks
+
+The following are trademarks of ZeroClaw Labs:
+
+- **ZeroClaw** (word mark)
+- **zeroclaw-labs** (organization name)
+- The ZeroClaw logo and associated visual identity
+
+These marks identify the official ZeroClaw project and distinguish it from
+unauthorized forks, derivatives, or impersonators.
+
+---
+
+## Official Repository
+
+The **only** official ZeroClaw repository is:
+
+> https://github.com/zeroclaw-labs/zeroclaw
+
+Any other repository, organization, domain, or product claiming to be
+"ZeroClaw" or implying affiliation with ZeroClaw Labs is unauthorized and
+may constitute trademark infringement.
+
+**Known unauthorized forks:**
+- `openagen/zeroclaw` — not affiliated with ZeroClaw Labs
+
+If you encounter an unauthorized use, please report it by opening an issue
+at https://github.com/zeroclaw-labs/zeroclaw/issues.
+
+---
+
+## Permitted Uses
+
+You **may** use the ZeroClaw name and marks in the following ways without
+prior written permission:
+
+1. **Attribution** — stating that your software is based on or derived from
+   ZeroClaw, provided it is clear your project is not the official ZeroClaw.
+
+2. **Descriptive reference** — referring to ZeroClaw in documentation,
+   articles, blog posts, or presentations to accurately describe the software.
+
+3. **Community discussion** — using the name in forums, issues, or social
+   media to discuss the project.
+
+4. **Fork identification** — identifying your fork as "a fork of ZeroClaw"
+   with a clear link to the official repository.
+
+---
+
+## Prohibited Uses
+
+You **may not** use the ZeroClaw name or marks in ways that:
+
+1. **Imply official endorsement** — suggest your project, product, or
+   organization is officially affiliated with or endorsed by ZeroClaw Labs.
+
+2. **Cause brand confusion** — use "ZeroClaw" as the primary name of a
+   competing or derivative product in a way that could confuse users about
+   the source.
+
+3. **Impersonate the project** — create repositories, domains, packages,
+   or accounts that could be mistaken for the official ZeroClaw project.
+
+4. **Misrepresent origin** — remove or obscure attribution to ZeroClaw Labs
+   while distributing the software or derivatives.
+
+5. **Commercial trademark use** — use the marks in commercial products,
+   services, or marketing without prior written permission from ZeroClaw Labs.
+
+---
+
+## Fork Guidelines
+
+Forks are welcome under the terms of the MIT and Apache 2.0 licenses. If
+you fork ZeroClaw, you must:
+
+- Clearly state your project is a fork of ZeroClaw
+- Link back to the official repository
+- Not use "ZeroClaw" as the primary name of your fork
+- Not imply your fork is the official or original project
+- Retain all copyright, license, and attribution notices
+
+---
+
+## Contributor Protections
+
+Contributors to the official ZeroClaw repository are protected under the
+dual MIT + Apache 2.0 license model:
+
+- **Patent grant** (Apache 2.0) — your contributions are protected from
+  patent claims by other contributors.
+- **Attribution** — your contributions are permanently recorded in the
+  repository history and NOTICE file.
+- **No trademark transfer** — contributing code does not transfer any
+  trademark rights to third parties.
+
+---
+
+## Reporting Infringement
+
+If you believe someone is infringing ZeroClaw trademarks:
+
+1. Open an issue at https://github.com/zeroclaw-labs/zeroclaw/issues
+2. Include the URL of the infringing content
+3. Describe how it violates this policy
+
+For serious or commercial infringement, contact the maintainers directly
+through the repository.
+
+---
+
+## Changes to This Policy
+
+ZeroClaw Labs reserves the right to update this policy at any time. Changes
+will be committed to the official repository with a clear commit message.
+
+---
+
+*This trademark policy is separate from and in addition to the MIT and
+Apache 2.0 software licenses. The licenses govern use of the source code;
+this policy governs use of the ZeroClaw name and brand.*


### PR DESCRIPTION
## Summary

Establishes the hybrid dual-license strategy and contributor protections for ZeroClaw Labs.

## What's included

### New files
- **`LICENSE-APACHE`** — Full Apache 2.0 license text with ZeroClaw trademark clause in section 6
- **`TRADEMARK.md`** — Defines permitted/prohibited uses of the ZeroClaw name, lists known unauthorized forks (`openagen/zeroclaw`), and documents contributor trademark protections
- **`CLA.md`** — Contributor License Agreement granting rights under both MIT and Apache 2.0, with explicit patent grant and attribution guarantees; contributors retain copyright ownership

### Updated files
- **`LICENSE`** — Added trademark notice and dual-license reference to the existing MIT file
- **`NOTICE`** — Added official repository notice, dual-license summary, and contributor protection statement
- **`README.md`** — Added impersonation warning section with official repo link, replaced single MIT badge with dual-license table, added trademark and contributor protection summary, linked CLA.md from Contributing section

## Why

- Active impersonation by `openagen/zeroclaw` — auto-syncing our main branch and siphoning traffic
- MIT alone has no trademark protection or patent grant
- Apache 2.0 adds explicit patent grant protecting contributors from patent claims
- Dual-license gives community users MIT simplicity while giving institutional/commercial users stronger IP guarantees
- CLA ensures all contributors are protected and grant rights under both licenses

## Contributor protections added

- Contributors **retain copyright** of their contributions
- **Patent grant** (Apache 2.0) shields contributors from patent claims by other contributors
- Contributions are **permanently attributed** in commit history and NOTICE
- No trademark rights are transferred by contributing