### PR TITLE
fix(onboard): correct channel selector default to 'Done' item

### DIFF
--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -2695,7 +2695,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
         let choice = Select::new()
             .with_prompt("  Connect a channel (or Done to continue)")
             .items(&options)
-            .default(11)
+            .default(options.len() - 1)
             .interact()?;
 
         match choice {


### PR DESCRIPTION
The hardcoded .default(11) became stale when Lark/Feishu was added at index 11, shifting 'Done — finish setup' to index 12. The wizard now pre-selects the wrong channel instead of 'Done'.

Use options.len() - 1 so the default always tracks the last item regardless of how many channels exist.

Fixes #913