### PR TITLE
fix(config): accept 'enable' as alias for 'enabled' in ComposioConfig

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -648,7 +648,7 @@ impl Default for GatewayConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ComposioConfig {
     /// Enable Composio integration for 1000+ OAuth tools
-    #[serde(default)]
+    #[serde(default, alias = "enable")]
     pub enabled: bool,
     /// Composio API key (stored encrypted when secrets.encrypt = true)
     #[serde(default)]
@@ -4416,6 +4416,21 @@ enabled = true
         assert!(parsed.enabled);
         assert!(parsed.api_key.is_none());
         assert_eq!(parsed.entity_id, "default");
+    }
+
+    #[test]
+    async fn composio_config_enable_alias_accepted() {
+        let toml_str = r#"
+enable = true
+api_key = "test-key"
+entity_id = "default"
+"#;
+        let parsed: ComposioConfig = toml::from_str(toml_str).unwrap();
+        assert!(
+            parsed.enabled,
+            "'enable' must be accepted as alias for 'enabled' (issue #926)"
+        );
+        assert_eq!(parsed.api_key.as_deref(), Some("test-key"));
     }
 
     // ══════════════════════════════════════════════════════════


### PR DESCRIPTION
The ComposioConfig struct only accepted 'enabled' as the TOML key, but users naturally write 'enable = true' (as shown in issue #926). With serde(default), the unrecognized 'enable' key was silently ignored, leaving Composio disabled even when the user intended to enable it.

Add serde(alias = "enable") so both spellings are accepted. This resolves the root cause where OAuth flow completes but the LLM cannot establish a Composio connection because the tool was never wired up.

Closes #926