### PR TITLE
Fix skill prompts/tools injection into system prompt (#877)

### DIFF
--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -102,6 +102,8 @@ Runtime in-chat commands (Telegram/Discord while channel server is running):
 - `zeroclaw skills install <source>`
 - `zeroclaw skills remove <name>`
 
+Skill manifests (`SKILL.toml`) support `prompts` and `[[tools]]`; both are injected into the agent system prompt at runtime, so the model can follow skill instructions without manually reading skill files.
+
 ### `migrate`
 
 - `zeroclaw migrate openclaw [--source <path>] [--dry-run]`

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1158,7 +1158,7 @@ fn load_openclaw_bootstrap_files(
 /// Follows the `OpenClaw` framework structure by default:
 /// 1. Tooling — tool list + descriptions
 /// 2. Safety — guardrail reminder
-/// 3. Skills — compact list with paths (loaded on-demand)
+/// 3. Skills — full skill instructions and tool metadata
 /// 4. Workspace — working directory
 /// 5. Bootstrap files — AGENTS, SOUL, TOOLS, IDENTITY, USER, BOOTSTRAP, MEMORY
 /// 6. Date & Time — timezone for cache stability
@@ -1235,52 +1235,10 @@ pub fn build_system_prompt(
          - When in doubt, ask before acting externally.\n\n",
     );
 
-    // ── 3. Skills (inline prompts + tools) ──────────────────────
+    // ── 3. Skills (full instructions + tool metadata) ───────────
     if !skills.is_empty() {
-        prompt.push_str("## Available Skills\n\n");
-        prompt.push_str("<available_skills>\n");
-        for skill in skills {
-            let escaped_name = xml_escape(&skill.name);
-            let escaped_description = xml_escape(&skill.description);
-            let _ = writeln!(prompt, "  <skill>");
-            let _ = writeln!(prompt, "    <name>{escaped_name}</name>");
-            let _ = writeln!(
-                prompt,
-                "    <description>{escaped_description}</description>"
-            );
-            let location = skill.location.clone().unwrap_or_else(|| {
-                workspace_dir
-                    .join("skills")
-                    .join(&skill.name)
-                    .join("SKILL.md")
-            });
-            let escaped_location = xml_escape(&location.display().to_string());
-            let _ = writeln!(prompt, "    <location>{escaped_location}</location>");
-            if !skill.tools.is_empty() {
-                let _ = writeln!(prompt, "    <tools>");
-                for tool in &skill.tools {
-                    let escaped_tool_name = xml_escape(&tool.name);
-                    let escaped_tool_kind = xml_escape(&tool.kind);
-                    let escaped_tool_description = xml_escape(&tool.description);
-                    let _ = writeln!(
-                        prompt,
-                        "      <tool name=\"{}\" kind=\"{}\">{}</tool>",
-                        escaped_tool_name, escaped_tool_kind, escaped_tool_description
-                    );
-                }
-                let _ = writeln!(prompt, "    </tools>");
-            }
-            if !skill.prompts.is_empty() {
-                let _ = writeln!(prompt, "    <instructions>");
-                for p in &skill.prompts {
-                    let escaped_prompt = xml_escape(p);
-                    let _ = writeln!(prompt, "      {escaped_prompt}");
-                }
-                let _ = writeln!(prompt, "    </instructions>");
-            }
-            let _ = writeln!(prompt, "  </skill>");
-        }
-        prompt.push_str("</available_skills>\n\n");
+        prompt.push_str(&crate::skills::skills_to_prompt(skills, workspace_dir));
+        prompt.push_str("\n\n");
     }
 
     // ── 4. Workspace ────────────────────────────────────────────
@@ -1361,14 +1319,6 @@ pub fn build_system_prompt(
     } else {
         prompt
     }
-}
-
-fn xml_escape(raw: &str) -> String {
-    raw.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-        .replace('\'', "&apos;")
 }
 
 /// Inject a single workspace file into the prompt with truncation and missing-file markers.
@@ -3656,7 +3606,7 @@ mod tests {
     }
 
     #[test]
-    fn prompt_skills_inline_prompts_and_tools() {
+    fn prompt_skills_include_instructions_and_tools() {
         let ws = make_workspace();
         let skills = vec![crate::skills::Skill {
             name: "code-review".into(),
@@ -3665,13 +3615,13 @@ mod tests {
             author: None,
             tags: vec![],
             tools: vec![crate::skills::SkillTool {
-                name: "run_linter".into(),
-                description: "Run linter on code".into(),
+                name: "lint".into(),
+                description: "Run static checks".into(),
                 kind: "shell".into(),
                 command: "cargo clippy".into(),
-                args: std::collections::HashMap::new(),
+                args: HashMap::new(),
             }],
-            prompts: vec!["When reviewing code, check for common bugs and style issues.".into()],
+            prompts: vec!["Always run cargo test before final response.".into()],
             location: None,
         }];
 
@@ -3681,21 +3631,13 @@ mod tests {
         assert!(prompt.contains("<name>code-review</name>"));
         assert!(prompt.contains("<description>Review code for bugs</description>"));
         assert!(prompt.contains("SKILL.md</location>"));
-        // Skill prompts should be inlined
-        assert!(
-            prompt.contains("When reviewing code, check for common bugs"),
-            "skill prompt should be inlined in system prompt"
-        );
-        assert!(
-            prompt.contains("<instructions>"),
-            "should have instructions block"
-        );
-        // Skill tools should be inlined
-        assert!(
-            prompt.contains("run_linter"),
-            "skill tool should be inlined"
-        );
-        assert!(prompt.contains("<tools>"), "should have tools block");
+        assert!(prompt.contains("<instructions>"));
+        assert!(prompt
+            .contains("<instruction>Always run cargo test before final response.</instruction>"));
+        assert!(prompt.contains("<tools>"));
+        assert!(prompt.contains("<name>lint</name>"));
+        assert!(prompt.contains("<kind>shell</kind>"));
+        assert!(!prompt.contains("loaded on demand"));
     }
 
     #[test]
@@ -3712,7 +3654,7 @@ mod tests {
                 description: "Run <lint> & report".into(),
                 kind: "shell&exec".into(),
                 command: "cargo clippy".into(),
-                args: std::collections::HashMap::new(),
+                args: HashMap::new(),
             }],
             prompts: vec!["Use <tool_call> and & keep output \"safe\"".into()],
             location: None,
@@ -3724,12 +3666,12 @@ mod tests {
         assert!(prompt.contains(
             "<description>Review &quot;unsafe&quot; and &apos;risky&apos; bits</description>"
         ));
-        assert!(
-            prompt.contains(
-                "<tool name=\"run&quot;linter&quot;\" kind=\"shell&amp;exec\">Run &lt;lint&gt; &amp; report</tool>"
-            )
-        );
-        assert!(prompt.contains("Use &lt;tool_call&gt; and &amp; keep output &quot;safe&quot;"));
+        assert!(prompt.contains("<name>run&quot;linter&quot;</name>"));
+        assert!(prompt.contains("<description>Run &lt;lint&gt; &amp; report</description>"));
+        assert!(prompt.contains("<kind>shell&amp;exec</kind>"));
+        assert!(prompt.contains(
+            "<instruction>Use &lt;tool_call&gt; and &amp; keep output &quot;safe&quot;</instruction>"
+        ));
     }
 
     #[test]

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -354,39 +354,84 @@ fn extract_description(content: &str) -> String {
         .to_string()
 }
 
-/// Build a system prompt addition from all loaded skills
-pub fn skills_to_prompt(skills: &[Skill]) -> String {
+fn append_xml_escaped(out: &mut String, text: &str) {
+    for ch in text.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(ch),
+        }
+    }
+}
+
+fn write_xml_text_element(out: &mut String, indent: usize, tag: &str, value: &str) {
+    for _ in 0..indent {
+        out.push(' ');
+    }
+    out.push('<');
+    out.push_str(tag);
+    out.push('>');
+    append_xml_escaped(out, value);
+    out.push_str("</");
+    out.push_str(tag);
+    out.push_str(">\n");
+}
+
+/// Build the "Available Skills" system prompt section with full skill instructions.
+pub fn skills_to_prompt(skills: &[Skill], workspace_dir: &Path) -> String {
     use std::fmt::Write;
 
     if skills.is_empty() {
         return String::new();
     }
 
-    let mut prompt = String::from("\n## Active Skills\n\n");
+    let mut prompt = String::from(
+        "## Available Skills\n\n\
+         Skill instructions and tool metadata are preloaded below.\n\
+         Follow these instructions directly; do not read skill files at runtime unless the user asks.\n\n\
+         <available_skills>\n",
+    );
 
     for skill in skills {
-        let _ = writeln!(prompt, "### {} (v{})", skill.name, skill.version);
-        let _ = writeln!(prompt, "{}", skill.description);
+        let _ = writeln!(prompt, "  <skill>");
+        write_xml_text_element(&mut prompt, 4, "name", &skill.name);
+        write_xml_text_element(&mut prompt, 4, "description", &skill.description);
+
+        let location = skill.location.clone().unwrap_or_else(|| {
+            workspace_dir
+                .join("skills")
+                .join(&skill.name)
+                .join("SKILL.md")
+        });
+        write_xml_text_element(&mut prompt, 4, "location", &location.display().to_string());
+
+        if !skill.prompts.is_empty() {
+            let _ = writeln!(prompt, "    <instructions>");
+            for instruction in &skill.prompts {
+                write_xml_text_element(&mut prompt, 6, "instruction", instruction);
+            }
+            let _ = writeln!(prompt, "    </instructions>");
+        }
 
         if !skill.tools.is_empty() {
-            prompt.push_str("Tools:\n");
+            let _ = writeln!(prompt, "    <tools>");
             for tool in &skill.tools {
-                let _ = writeln!(
-                    prompt,
-                    "- **{}**: {} ({})",
-                    tool.name, tool.description, tool.kind
-                );
+                let _ = writeln!(prompt, "      <tool>");
+                write_xml_text_element(&mut prompt, 8, "name", &tool.name);
+                write_xml_text_element(&mut prompt, 8, "description", &tool.description);
+                write_xml_text_element(&mut prompt, 8, "kind", &tool.kind);
+                let _ = writeln!(prompt, "      </tool>");
             }
+            let _ = writeln!(prompt, "    </tools>");
         }
 
-        for p in &skill.prompts {
-            prompt.push_str(p);
-            prompt.push('\n');
-        }
-
-        prompt.push('\n');
+        let _ = writeln!(prompt, "  </skill>");
     }
 
+    prompt.push_str("</available_skills>");
     prompt
 }
 
@@ -683,7 +728,7 @@ command = "echo hello"
 
     #[test]
     fn skills_to_prompt_empty() {
-        let prompt = skills_to_prompt(&[]);
+        let prompt = skills_to_prompt(&[], Path::new("/tmp"));
         assert!(prompt.is_empty());
     }
 
@@ -699,9 +744,10 @@ command = "echo hello"
             prompts: vec!["Do the thing.".to_string()],
             location: None,
         }];
-        let prompt = skills_to_prompt(&skills);
-        assert!(prompt.contains("test"));
-        assert!(prompt.contains("Do the thing"));
+        let prompt = skills_to_prompt(&skills, Path::new("/tmp"));
+        assert!(prompt.contains("<available_skills>"));
+        assert!(prompt.contains("<name>test</name>"));
+        assert!(prompt.contains("<instruction>Do the thing.</instruction>"));
     }
 
     #[test]
@@ -889,11 +935,32 @@ description = "Bare minimum"
             prompts: vec![],
             location: None,
         }];
-        let prompt = skills_to_prompt(&skills);
+        let prompt = skills_to_prompt(&skills, Path::new("/tmp"));
         assert!(prompt.contains("weather"));
-        assert!(prompt.contains("get_weather"));
-        assert!(prompt.contains("Fetch forecast"));
-        assert!(prompt.contains("shell"));
+        assert!(prompt.contains("<name>get_weather</name>"));
+        assert!(prompt.contains("<description>Fetch forecast</description>"));
+        assert!(prompt.contains("<kind>shell</kind>"));
+    }
+
+    #[test]
+    fn skills_to_prompt_escapes_xml_content() {
+        let skills = vec![Skill {
+            name: "xml<skill>".to_string(),
+            description: "A & B".to_string(),
+            version: "1.0.0".to_string(),
+            author: None,
+            tags: vec![],
+            tools: vec![],
+            prompts: vec!["Use <tool> & check \"quotes\".".to_string()],
+            location: None,
+        }];
+
+        let prompt = skills_to_prompt(&skills, Path::new("/tmp"));
+        assert!(prompt.contains("<name>xml&lt;skill&gt;</name>"));
+        assert!(prompt.contains("<description>A &amp; B</description>"));
+        assert!(prompt.contains(
+            "<instruction>Use &lt;tool&gt; &amp; check &quot;quotes&quot;.</instruction>"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- inject full skill instructions (`prompts`) and skill tool metadata into the system prompt instead of metadata-only skill stubs
- unify both prompt construction paths (`channels::build_system_prompt` and `agent::prompt::SkillsSection`) through a shared renderer in `src/skills/mod.rs`
- escape XML-sensitive characters in injected skill content to keep prompt XML blocks well-formed
- update prompt tests to assert instruction/tool inclusion and remove stale on-demand loading expectation
- add docs note in `docs/commands-reference.md` clarifying `SKILL.toml` `prompts` / `[[tools]]` injection behavior
- align `tests/channel_routing.rs` with the current `ChannelMessage` shape (`thread_ts`) so full test builds remain green

## Testing
- `cargo check`
- `cargo check --no-default-features`
- `cargo test`
- `cargo test --no-default-features`
- `cargo test --no-default-features skills_to_prompt -- --nocapture`
- `cargo test --no-default-features prompt_skills_include_instructions_and_tools -- --nocapture`
- `cargo test --no-default-features skills_section_includes_instructions_and_tools -- --nocapture`
- `cargo test --no-default-features native_tool_spec_deserializes_from_openai_format -- --nocapture`

Closes #877