### PR TITLE
fix(composio): recover connected account selection after OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,8 @@ window_allowlist = []          # optional window title/process allowlist hints
 enabled = false                # opt-in: 1000+ OAuth apps via composio.dev
 # api_key = "cmp_..."          # optional: stored encrypted when [secrets].encrypt = true
 entity_id = "default"          # default user_id for Composio tool calls
+# Runtime tip: if execute asks for connected_account_id, run composio with
+# action='list_accounts' and app='gmail' (or your toolkit) to retrieve account IDs.
 
 [identity]
 format = "openclaw"            # "openclaw" (default, markdown files) or "aieos" (JSON)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -75,6 +75,7 @@ Notes:
 - Backward compatibility: legacy `enable = true` is accepted as an alias for `enabled = true`.
 - If `enabled = false` or `api_key` is missing, the `composio` tool is not registered.
 - Typical flow: call `connect`, complete browser OAuth, then run `execute` for the desired tool action.
+- If Composio returns a missing connected-account reference error, call `list_accounts` (optionally with `app`) and pass the returned `connected_account_id` to `execute`.
 
 ## `[multimodal]`
 

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1795,7 +1795,7 @@ pub async fn start_channels(config: Config) -> Result<()> {
     if config.composio.enabled {
         tool_descs.push((
             "composio",
-            "Execute actions on 1000+ apps via Composio (Gmail, Notion, GitHub, Slack, etc.). Use action='list' to discover, 'execute' to run (optionally with connected_account_id), 'connect' to OAuth.",
+            "Execute actions on 1000+ apps via Composio (Gmail, Notion, GitHub, Slack, etc.). Use action='list' to discover actions, 'list_accounts' to retrieve connected account IDs, 'execute' to run (optionally with connected_account_id), and 'connect' for OAuth.",
         ));
     }
     tool_descs.push((


### PR DESCRIPTION
## Summary
- add `action='list_accounts'` to the Composio tool surface so account IDs can be retrieved directly in-agent
- parse and surface `connected_account_id` from Composio connect responses, and cache it by `(entity_id, app)` for immediate follow-up execute calls
- auto-resolve `connected_account_id` for execute when omitted and exactly one usable account exists for the app/entity (via `GET /api/v3/connected_accounts`)
- improve execute failure hints to guide users toward `list_accounts` when account selection is ambiguous
- update tool descriptions and docs (`README.md`, `docs/config-reference.md`) with the new account-recovery flow

## Why
Issue #926 was closed by #953, but the latest reporter log still showed post-OAuth execute repeatedly failing due to missing `connected_account_id`.
This patch addresses that remaining gap directly.

## Validation
- `CARGO_TARGET_DIR=/tmp/zc-issue926-ca-fix cargo test --lib composio -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/zc-issue926-ca-fix cargo check`
- `CARGO_TARGET_DIR=/tmp/zc-issue926-ca-fix cargo test` (fails due to pre-existing unrelated compile errors in `tests/channel_routing.rs`: missing `thread_ts` field in `ChannelMessage` initializers)

Refs #926
Follow-up context: https://github.com/zeroclaw-labs/zeroclaw/issues/926#issuecomment-3928154939