### PR TITLE
docs(readme): add Homebrew install instructions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -117,6 +117,12 @@ cd zeroclaw
 
 ## クイックスタート
 
+### Homebrew（macOS/Linuxbrew）
+
+```bash
+brew install zeroclaw
+```
+
 ```bash
 git clone https://github.com/zeroclaw-labs/zeroclaw.git
 cd zeroclaw

--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts
 
 ## Quick Start
 
+### Homebrew (macOS/Linuxbrew)
+
+```bash
+brew install zeroclaw
+```
+
 ### One-click bootstrap
 
 ```bash

--- a/README.ru.md
+++ b/README.ru.md
@@ -117,6 +117,12 @@ cd zeroclaw
 
 ## Быстрый старт
 
+### Homebrew (macOS/Linuxbrew)
+
+```bash
+brew install zeroclaw
+```
+
 ```bash
 git clone https://github.com/zeroclaw-labs/zeroclaw.git
 cd zeroclaw

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -117,6 +117,12 @@ cd zeroclaw
 
 ## 快速开始
 
+### Homebrew（macOS/Linuxbrew）
+
+```bash
+brew install zeroclaw
+```
+
 ```bash
 git clone https://github.com/zeroclaw-labs/zeroclaw.git
 cd zeroclaw

--- a/docs/one-click-bootstrap.md
+++ b/docs/one-click-bootstrap.md
@@ -4,6 +4,12 @@ This page defines the fastest supported path to install and initialize ZeroClaw.
 
 Last verified: **February 18, 2026**.
 
+## Option 0: Homebrew (macOS/Linuxbrew)
+
+```bash
+brew install zeroclaw
+```
+
 ## Option A (Recommended): Clone + local script
 
 ```bash


### PR DESCRIPTION
## Summary
- add `brew install zeroclaw` install option to root README quick start
- add matching Homebrew install snippets to `README.zh-CN.md`, `README.ja.md`, and `README.ru.md`
- add Homebrew option to `docs/one-click-bootstrap.md`

## Scope
- docs-only changes
- no runtime/config/code behavior changes

## Validation
- verified updated files render and contain the new Homebrew command consistently
- no code checks required for docs-only update
