### PR TITLE
docs(build): document compilation RAM requirements and add ARM64 Linux release binary

### DIFF
--- a/docs/one-click-bootstrap.md
+++ b/docs/one-click-bootstrap.md
@@ -10,6 +10,10 @@ Last verified: **February 20, 2026**.
 brew install zeroclaw
 ```
 
+## Compilation Requirements
+
+Building from source requires approximately **2 GB of RAM + swap** and **5 GB of disk space**. Devices with less than 2 GB RAM should add swap, cross-compile, or download a [pre-built binary](https://github.com/zeroclaw-labs/zeroclaw/releases) instead. See [troubleshooting](troubleshooting.md#build-fails-with-out-of-memory-oom) for details.
+
 ## Option A (Recommended): Clone + local script
 
 ```bash


### PR DESCRIPTION
Addresses #972: users on low-RAM devices (1 GB) cannot compile from source, and no pre-built ARM Linux binary was available for the - boards the project targets.

Changes:
- README: clarify <5MB is runtime RAM; add Compilation Requirements section (2 GB RAM+swap min); add Pre-built Binaries section with download instructions
- docs/troubleshooting: add OOM build failure section with 5 workarounds (swap, CARGO_BUILD_JOBS=1, skip Matrix feature, cross-compile, pre-built binary)
- docs/one-click-bootstrap: add compilation requirements note
- pub-release.yml: add aarch64-unknown-linux-gnu to release build matrix with cross-compilation toolchain for ARM64 Linux 