### PR TITLE
docs(env): add missing environment variables to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@ PROVIDER=openrouter
 # Workspace directory override
 # ZEROCLAW_WORKSPACE=/path/to/workspace
 
+# Reasoning mode (enables extended thinking for supported models)
+# ZEROCLAW_REASONING_ENABLED=false
+# REASONING_ENABLED=false
+
 # ── Provider-Specific API Keys ────────────────────────────────
 # OpenRouter
 # OPENROUTER_API_KEY=sk-or-v1-...
@@ -62,6 +66,22 @@ PROVIDER=openrouter
 # ZEROCLAW_GATEWAY_PORT=3000
 # ZEROCLAW_GATEWAY_HOST=127.0.0.1
 # ZEROCLAW_ALLOW_PUBLIC_BIND=false
+
+# ── Storage ─────────────────────────────────────────────────
+# Backend override for persistent storage (default: sqlite)
+# ZEROCLAW_STORAGE_PROVIDER=sqlite
+# ZEROCLAW_STORAGE_DB_URL=postgres://localhost/zeroclaw
+# ZEROCLAW_STORAGE_CONNECT_TIMEOUT_SECS=5
+
+# ── Proxy ──────────────────────────────────────────────────
+# Forward provider/service traffic through an HTTP(S) proxy.
+# ZEROCLAW_PROXY_ENABLED=false
+# ZEROCLAW_HTTP_PROXY=http://proxy.example.com:8080
+# ZEROCLAW_HTTPS_PROXY=http://proxy.example.com:8080
+# ZEROCLAW_ALL_PROXY=socks5://proxy.example.com:1080
+# ZEROCLAW_NO_PROXY=localhost,127.0.0.1
+# ZEROCLAW_PROXY_SCOPE=zeroclaw          # environment|zeroclaw|services
+# ZEROCLAW_PROXY_SERVICES=openai,anthropic
 
 # ── Optional Integrations ────────────────────────────────────
 # Pushover notifications (`pushover` tool)


### PR DESCRIPTION
Add env vars from apply_env_overrides() that were absent from .env.example:

- ZEROCLAW_REASONING_ENABLED / REASONING_ENABLED (reasoning mode)
- ZEROCLAW_STORAGE_PROVIDER (storage backend override)
- ZEROCLAW_STORAGE_DB_URL (remote storage connection URL)
- ZEROCLAW_STORAGE_CONNECT_TIMEOUT_SECS (storage connect timeout)
- ZEROCLAW_PROXY_ENABLED (proxy toggle)
- ZEROCLAW_HTTP_PROXY (HTTP proxy URL)
- ZEROCLAW_HTTPS_PROXY (HTTPS proxy URL)
- ZEROCLAW_ALL_PROXY (SOCKS/universal proxy URL)
- ZEROCLAW_NO_PROXY (proxy bypass list)
- ZEROCLAW_PROXY_SCOPE (proxy scope: environment|zeroclaw|services)
- ZEROCLAW_PROXY_SERVICES (service selector for scoped proxy)

Resolves audit finding §6.3.