### PR TITLE
fix(errors): improve config error messages with section paths and remediation hints

### DIFF
--- a/src/channels/linq.rs
+++ b/src/channels/linq.rs
@@ -125,7 +125,8 @@ impl LinqChannel {
         if !self.is_sender_allowed(&normalized_from) {
             tracing::warn!(
                 "Linq: ignoring message from unauthorized sender: {normalized_from}. \
-                Add to allowed_senders in config.toml."
+                Add to channels.linq.allowed_senders in config.toml, \
+                or run `zeroclaw onboard --channels-only` to configure interactively."
             );
             return messages;
         }

--- a/src/channels/whatsapp.rs
+++ b/src/channels/whatsapp.rs
@@ -99,7 +99,8 @@ impl WhatsAppChannel {
                     if !self.is_number_allowed(&normalized_from) {
                         tracing::warn!(
                             "WhatsApp: ignoring message from unauthorized number: {normalized_from}. \
-                            Add to allowed_numbers in config.toml, then run `zeroclaw onboard --channels-only`."
+                            Add to channels.whatsapp.allowed_numbers in config.toml, \
+                            or run `zeroclaw onboard --channels-only` to configure interactively."
                         );
                         continue;
                     }

--- a/src/tools/web_search_tool.rs
+++ b/src/tools/web_search_tool.rs
@@ -219,7 +219,10 @@ impl Tool for WebSearchTool {
         let result = match self.provider.as_str() {
             "duckduckgo" | "ddg" => self.search_duckduckgo(query).await?,
             "brave" => self.search_brave(query).await?,
-            _ => anyhow::bail!("Unknown search provider: {}", self.provider),
+            _ => anyhow::bail!(
+                "Unknown search provider: '{}'. Set tools.web_search.provider to 'duckduckgo' or 'brave' in config.toml",
+                self.provider
+            ),
         };
 
         Ok(ToolResult {


### PR DESCRIPTION
Improve vague error messages in channel initialization and tool setup to include specific config key paths and remediation steps, matching the quality standard set by proxy validation errors.

Changes:
- telegram.rs: Include [channels.telegram] section path and required fields (bot_token, allowed_users) in missing-config error; add onboard hint; specify channels.telegram.allowed_users in pairing message; improve parse error context
- whatsapp.rs: Specify channels.whatsapp.allowed_numbers key path in unauthorized-number warning
- linq.rs: Specify channels.linq.allowed_senders key path in unauthorized-sender warning; add onboard hint
- web_search_tool.rs: Include tools.web_search.provider config path and valid values in unknown-provider error

Addresses API surface audit §8.2 (config context in error messages).