### PR TITLE
refactor(lib): restrict internal module visibility to pub(crate)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,41 +39,41 @@ use clap::Subcommand;
 use serde::{Deserialize, Serialize};
 
 pub mod agent;
-pub mod approval;
-pub mod auth;
+pub(crate) mod approval;
+pub(crate) mod auth;
 pub mod channels;
 pub mod config;
-pub mod cost;
-pub mod cron;
-pub mod daemon;
-pub mod doctor;
+pub(crate) mod cost;
+pub(crate) mod cron;
+pub(crate) mod daemon;
+pub(crate) mod doctor;
 pub mod gateway;
-pub mod hardware;
-pub mod health;
-pub mod heartbeat;
-pub mod identity;
-pub mod integrations;
+pub(crate) mod hardware;
+pub(crate) mod health;
+pub(crate) mod heartbeat;
+pub(crate) mod identity;
+pub(crate) mod integrations;
 pub mod memory;
-pub mod migration;
-pub mod multimodal;
+pub(crate) mod migration;
+pub(crate) mod multimodal;
 pub mod observability;
-pub mod onboard;
+pub(crate) mod onboard;
 pub mod peripherals;
 pub mod providers;
 pub mod rag;
 pub mod runtime;
-pub mod security;
-pub mod service;
-pub mod skills;
+pub(crate) mod security;
+pub(crate) mod service;
+pub(crate) mod skills;
 pub mod tools;
-pub mod tunnel;
-pub mod util;
+pub(crate) mod tunnel;
+pub(crate) mod util;
 
 pub use config::Config;
 
 /// Service management subcommands
 #[derive(Subcommand, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum ServiceCommands {
+pub(crate) enum ServiceCommands {
     /// Install daemon service unit for auto-start and restart
     Install,
     /// Start daemon service
@@ -88,7 +88,7 @@ pub enum ServiceCommands {
 
 /// Channel management subcommands
 #[derive(Subcommand, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum ChannelCommands {
+pub(crate) enum ChannelCommands {
     /// List all configured channels
     List,
     /// Start all configured channels (handled in main.rs for async)
@@ -116,7 +116,7 @@ pub enum ChannelCommands {
 
 /// Skills management subcommands
 #[derive(Subcommand, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum SkillCommands {
+pub(crate) enum SkillCommands {
     /// List all installed skills
     List,
     /// Install a new skill from a URL or local path
@@ -133,7 +133,7 @@ pub enum SkillCommands {
 
 /// Migration subcommands
 #[derive(Subcommand, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum MigrateCommands {
+pub(crate) enum MigrateCommands {
     /// Import memory from an `OpenClaw` workspace into this `ZeroClaw` workspace
     Openclaw {
         /// Optional path to `OpenClaw` workspace (defaults to ~/.openclaw/workspace)
@@ -148,7 +148,7 @@ pub enum MigrateCommands {
 
 /// Cron subcommands
 #[derive(Subcommand, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum CronCommands {
+pub(crate) enum CronCommands {
     /// List all scheduled tasks
     List,
     /// Add a new scheduled task
@@ -218,7 +218,7 @@ pub enum CronCommands {
 
 /// Integration subcommands
 #[derive(Subcommand, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub enum IntegrationCommands {
+pub(crate) enum IntegrationCommands {
     /// Show details about a specific integration
     Info {
         /// Integration name


### PR DESCRIPTION
Restrict 19 internal-only modules from pub to pub(crate) in lib.rs, reducing the public API surface of the library crate.

Modules kept pub (used by integration tests, benchmarks, or are documented extension points per AGENTS.md):
  agent, channels, config, gateway, memory, observability,
  peripherals, providers, rag, runtime, tools

Modules restricted to pub(crate) (not imported via zeroclaw:: by any external consumer):
  approval, auth, cost, cron, daemon, doctor, hardware, health,
  heartbeat, identity, integrations, migration, multimodal, onboard,
  security, service, skills, tunnel, util

Also restrict 6 command enums (ServiceCommands, ChannelCommands, SkillCommands, MigrateCommands, CronCommands, IntegrationCommands) to pub(crate) — main.rs defines its own copies and does not import these from the library crate. HardwareCommands and PeripheralCommands remain pub as main.rs imports them via zeroclaw::.