### PR TITLE
fix(config): change web_search.enabled default to false for explicit opt-in

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -818,7 +818,7 @@ fn default_http_timeout_secs() -> u64 {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct WebSearchConfig {
     /// Enable `web_search_tool` for web searches
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub enabled: bool,
     /// Search provider: "duckduckgo" (free, no API key) or "brave" (requires API key)
     #[serde(default = "default_web_search_provider")]
@@ -849,7 +849,7 @@ fn default_web_search_timeout_secs() -> u64 {
 impl Default for WebSearchConfig {
     fn default() -> Self {
         Self {
-            enabled: true,
+            enabled: false,
             provider: default_web_search_provider(),
             brave_api_key: None,
             max_results: default_web_search_max_results(),


### PR DESCRIPTION
Network access (web search via DuckDuckGo) should require explicit user consent rather than being enabled by default. This aligns with the least-surprise principle and the project's secure-by-default policy: users must opt in to external network requests.

Changes:
- WebSearchConfig::default() now sets enabled: false
- Serde default for enabled field changed from default_true to default (bool defaults to false)