### PR TITLE
fix(channel): replace hardcoded Discord bot text with generic channel text

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1042,10 +1042,7 @@ pub fn build_system_prompt(
 
     // ── 8. Channel Capabilities ─────────────────────────────────────
     prompt.push_str("## Channel Capabilities\n\n");
-    prompt.push_str(
-        "- You are running as a Discord bot. You CAN and do send messages to Discord channels.\n",
-    );
-    prompt.push_str("- When someone messages you on Discord, your response is automatically sent back to Discord.\n");
+    prompt.push_str("- You are running as a messaging bot. Your response is automatically sent back to the user's channel.\n");
     prompt.push_str("- You do NOT need to ask permission to respond — just respond directly.\n");
     prompt.push_str("- NEVER repeat, describe, or echo credentials, tokens, API keys, or secrets in your responses.\n");
     prompt.push_str("- If a tool output contains credentials, they have already been redacted — do not mention them.\n\n");
@@ -2950,8 +2947,8 @@ mod tests {
             "missing Channel Capabilities section"
         );
         assert!(
-            prompt.contains("running as a Discord bot"),
-            "missing Discord context"
+            prompt.contains("running as a messaging bot"),
+            "missing channel context"
         );
         assert!(
             prompt.contains("NEVER repeat, describe, or echo credentials"),


### PR DESCRIPTION
## Summary

- Problem: Channel Capabilities section in `build_system_prompt()` hardcodes "You are running as a Discord bot" for ALL channels including Telegram
- Why it matters: LLM misidentifies itself and may reference Discord-specific features when running on Telegram or other channels
- What changed: Replaced Discord-specific text with generic "messaging bot" wording; updated corresponding test assertion
- What did **not** change (scope boundary): Per-channel delivery instructions (`channel_delivery_instructions()`) unchanged, system prompt structure unchanged

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: mod`
- Contributor tier label: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

N/A

## Validation Evidence (required)

```bash
cargo build    # pass
```

- Evidence provided: build passes, test assertion updated
- If any command is intentionally skipped, explain why: `cargo test` unavailable on Pi

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: System prompt no longer mentions Discord when used on Telegram
- Edge cases checked: Discord channel still gets correct behavior via `channel_delivery_instructions()`
- What was not verified: Live multi-channel test

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: System prompt for all channels
- Potential unintended effects: None
- Guardrails/monitoring for early detection: N/A

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: N/A
- Observable failure symptoms: N/A

## Risks and Mitigations

- Risk: None