### PR TITLE
fix(prompt): include actual date and time in system prompt

### DIFF
--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -211,8 +211,8 @@ impl PromptSection for DateTimeSection {
     fn build(&self, _ctx: &PromptContext<'_>) -> Result<String> {
         let now = Local::now();
         Ok(format!(
-            "## Current Date & Time\n\nTimezone: {}",
-            now.format("%Z")
+            "## Current Date & Time\n\n{}",
+            now.format("%Y-%m-%d %H:%M %Z")
         ))
     }
 }

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1028,8 +1028,11 @@ pub fn build_system_prompt(
 
     // ── 6. Date & Time ──────────────────────────────────────────
     let now = chrono::Local::now();
-    let tz = now.format("%Z").to_string();
-    let _ = writeln!(prompt, "## Current Date & Time\n\nTimezone: {tz}\n");
+    let _ = writeln!(
+        prompt,
+        "## Current Date & Time\n\n{}\n",
+        now.format("%Y-%m-%d %H:%M %Z")
+    );
 
     // ── 7. Runtime ──────────────────────────────────────────────
     let host =


### PR DESCRIPTION
## Summary

- Problem: "Current Date & Time" section only output timezone abbreviation (e.g. "EST"), not the actual date or time
- Why it matters: LLM cannot answer time-related questions ("what day is it?", "remind me tomorrow") or handle time-sensitive context
- What changed: Output `YYYY-MM-DD HH:MM TZ` format in both `channels/mod.rs` and `agent/prompt.rs`
- What did **not** change (scope boundary): Section header unchanged, chrono dependency already present

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`, `agent`
- Module labels: `channel: mod`, `agent: prompt`

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

N/A

## Validation Evidence (required)

```bash
cargo build    # pass
```

- Evidence provided: build passes
- If any command is intentionally skipped, explain why: `cargo test` unavailable on Pi

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Format string produces expected output (e.g. "2026-02-19 20:30 EST")
- Edge cases checked: Both code paths updated (channel and Agent prompt)
- What was not verified: LLM behavior with new date awareness

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: System prompt for all channels and CLI
- Potential unintended effects: System prompt changes slightly each minute (timestamp); negligible impact on prompt caching
- Guardrails/monitoring for early detection: N/A

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Observable failure symptoms: N/A

## Risks and Mitigations

- Risk: None