### PR TITLE
fix(security): deny unapproved tool calls on non-CLI channels

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1001,11 +1001,13 @@ pub(crate) async fn run_tool_call_loop(
                         arguments: call.arguments.clone(),
                     };
 
-                    // Only prompt interactively on CLI; auto-approve on other channels.
+                    // On CLI, prompt interactively. On other channels where
+                    // interactive approval is not possible, deny the call to
+                    // respect the supervised autonomy setting.
                     let decision = if channel_name == "cli" {
                         mgr.prompt_cli(&request)
                     } else {
-                        ApprovalResponse::Yes
+                        ApprovalResponse::No
                     };
 
                     mgr.record_decision(&call.name, &call.arguments, decision, channel_name);


### PR DESCRIPTION
## Summary

- Problem: When `autonomy = "supervised"`, the approval gate only works on CLI. On Telegram and all other channels, every tool call is silently auto-approved — completely bypassing supervised mode
- Why it matters: High-risk tools like `shell` execute without any oversight on non-CLI channels, defeating the purpose of supervised autonomy
- What changed: On non-CLI channels, tool calls that require approval are now denied (with a denial message fed back to the LLM) instead of auto-approved
- What did **not** change (scope boundary): CLI interactive approval unchanged; tools in `auto_approve` config list still execute freely; `autonomy = "full"` bypasses all approval as before

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: XS`
- Scope labels: `security`, `agent`
- Module labels: `agent: loop`

## Change Metadata

- Change type: `security`
- Primary scope: `security`

## Linked Issue

N/A

## Validation Evidence (required)

```bash
cargo build    # pass
```

- Evidence provided: build passes
- If any command is intentionally skipped, explain why: `cargo test` unavailable on Pi

## Security Impact (required)

- New permissions/capabilities? No — strictly reduces permissions on non-CLI channels
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- Risk and mitigation: This is a security-tightening change. Tools that were previously auto-approved on Telegram will now be denied unless they are in the `auto_approve` config list. Users who rely on supervised mode with Telegram should add needed tools to `auto_approve` or switch to `autonomy = "full"`

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Behavior change — supervised mode on non-CLI channels will now deny tool calls that previously auto-approved
- Config/env changes? No new config; users may need to expand `auto_approve` list
- Migration needed? No schema change; behavioral adjustment documented above

## Human Verification (required)

- Verified scenarios: `needs_approval` returns true -> denied on non-CLI; `needs_approval` returns false (auto_approve list) -> still allowed
- Edge cases checked: `autonomy = "full"` never calls `needs_approval`, unaffected; CLI path unchanged
- What was not verified: Live Telegram interaction with supervised mode

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: All non-CLI channels (Telegram, Discord, etc.) when `autonomy = "supervised"`
- Potential unintended effects: Tools that worked before on Telegram may now be denied — this is intentional and matches the expected behavior of supervised mode
- Guardrails/monitoring for early detection: Denial messages appear in LLM tool results and audit log

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: Set `autonomy = "full"` to restore auto-approve behavior
- Observable failure symptoms: LLM reports tools are denied on Telegram

## Risks and Mitigations

- Risk: Users on supervised mode may find Telegram tool usage broken until they configure `auto_approve`
  - Mitigation: Clear denial message; easy config fix; `autonomy = "full"` as escape hatch