### PR TITLE
fix(provider): surface API key rotation as ineffective warning

### DIFF
--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -311,10 +311,12 @@ impl Provider for ReliableProvider {
                             // On rate-limit, try rotating API key
                             if rate_limited && !non_retryable_rate_limit {
                                 if let Some(new_key) = self.rotate_key() {
-                                    tracing::info!(
+                                    tracing::warn!(
                                         provider = provider_name,
                                         error = %error_detail,
-                                        "Rate limited, rotated API key (key ending ...{})",
+                                        "Rate limited; key rotation selected key ending ...{} \
+                                         but cannot apply (Provider trait has no set_api_key). \
+                                         Retrying with original key.",
                                         &new_key[new_key.len().saturating_sub(4)..]
                                     );
                                 }
@@ -419,10 +421,12 @@ impl Provider for ReliableProvider {
 
                             if rate_limited && !non_retryable_rate_limit {
                                 if let Some(new_key) = self.rotate_key() {
-                                    tracing::info!(
+                                    tracing::warn!(
                                         provider = provider_name,
                                         error = %error_detail,
-                                        "Rate limited, rotated API key (key ending ...{})",
+                                        "Rate limited; key rotation selected key ending ...{} \
+                                         but cannot apply (Provider trait has no set_api_key). \
+                                         Retrying with original key.",
                                         &new_key[new_key.len().saturating_sub(4)..]
                                     );
                                 }
@@ -527,10 +531,12 @@ impl Provider for ReliableProvider {
 
                             if rate_limited && !non_retryable_rate_limit {
                                 if let Some(new_key) = self.rotate_key() {
-                                    tracing::info!(
+                                    tracing::warn!(
                                         provider = provider_name,
                                         error = %error_detail,
-                                        "Rate limited, rotated API key (key ending ...{})",
+                                        "Rate limited; key rotation selected key ending ...{} \
+                                         but cannot apply (Provider trait has no set_api_key). \
+                                         Retrying with original key.",
                                         &new_key[new_key.len().saturating_sub(4)..]
                                     );
                                 }


### PR DESCRIPTION
## Summary

- Problem: `rotate_key()` selects the next API key in the round-robin and logs an info message implying rotation worked, but the key is never applied to the underlying Provider (trait has no `set_api_key` method)
- Why it matters: Operators who configure multiple API keys for rate-limit resilience get a misleading log suggesting rotation is active, when retries actually keep hitting the same key
- What changed: Changed log level from `info` to `warn` and message explicitly states the key cannot be applied due to Provider trait limitation
- What did **not** change (scope boundary): `rotate_key()` logic, round-robin indexing, Provider trait — this is a transparency fix, not an implementation fix

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `provider`
- Module labels: `provider: reliable`

## Change Metadata

- Change type: `bug`
- Primary scope: `provider`

## Linked Issue

N/A

## Validation Evidence (required)

```bash
cargo build    # pass
```

- Evidence provided: build passes
- If any command is intentionally skipped, explain why: `cargo test` unavailable on Pi

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Warning message is clear about the limitation
- Edge cases checked: Both `chat_with_system` and `chat` code paths updated (replace_all)
- What was not verified: Live rate-limit scenario

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: ReliableProvider retry logging
- Potential unintended effects: None
- Guardrails/monitoring for early detection: warn-level logs are more visible

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Observable failure symptoms: N/A

## Risks and Mitigations

- Risk: None — log-only change