### PR TITLE
fix(agent): implement actual concurrent tool execution

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -400,11 +400,8 @@ impl Agent {
             return results;
         }
 
-        let mut results = Vec::with_capacity(calls.len());
-        for call in calls {
-            results.push(self.execute_tool_call(call).await);
-        }
-        results
+        let futs: Vec<_> = calls.iter().map(|call| self.execute_tool_call(call)).collect();
+        futures::future::join_all(futs).await
     }
 
     fn classify_model(&self, user_message: &str) -> String {


### PR DESCRIPTION
## Summary

- Problem: Both the `parallel_tools = true` and `false` branches in `execute_tools()` ran identical sequential `for` loops — no concurrent execution ever happened
- Why it matters: Multi-tool responses are slower than necessary when parallelism is configured but not working
- What changed: Use `futures::future::join_all` to execute tool calls concurrently when `parallel_tools` is enabled
- What did **not** change (scope boundary): Sequential path unchanged, no new dependencies (futures already in Cargo.toml), tool execution logic unchanged

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `agent`
- Module labels: `agent: agent`

## Change Metadata

- Change type: `bug`
- Primary scope: `agent`

## Linked Issue

N/A

## Validation Evidence (required)

```bash
cargo build    # pass
```

- Evidence provided: build passes
- If any command is intentionally skipped, explain why: `cargo test` unavailable on Pi

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (same tool calls, just concurrent)
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes — only affects behavior when `parallel_tools = true`
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: `join_all` collects futures and awaits them concurrently, preserving order
- Edge cases checked: Single tool call (join_all with one future is equivalent to sequential); empty calls (join_all returns empty vec)
- What was not verified: Live multi-tool concurrent execution with timing measurement

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Agent struct tool execution when `parallel_tools = true`
- Potential unintended effects: Concurrent tool execution may surface race conditions in tools that have shared state (unlikely for current tool set)
- Guardrails/monitoring for early detection: Default is `parallel_tools = false`, so opt-in only

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>` or set `parallel_tools = false`
- Observable failure symptoms: Tool execution errors if concurrent access causes issues

## Risks and Mitigations

- Risk: Tools with shared mutable state could race when run concurrently
  - Mitigation: Default is sequential; parallel is opt-in; existing tools use Arc/Mutex for shared state