### PR TITLE
docs: add architecture, subscription auth, and memory system sections to multilingual READMEs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -142,6 +142,106 @@ zeroclaw gateway
 zeroclaw daemon
 ```
 
+## Subscription Auth（OpenAI Codex / Claude Code）
+
+ZeroClaw はサブスクリプションベースのネイティブ認証プロファイルをサポートしています（マルチアカウント対応、保存時暗号化）。
+
+- 保存先: `~/.zeroclaw/auth-profiles.json`
+- 暗号化キー: `~/.zeroclaw/.secret_key`
+- Profile ID 形式: `<provider>:<profile_name>`（例: `openai-codex:work`）
+
+OpenAI Codex OAuth（ChatGPT サブスクリプション）:
+
+```bash
+# サーバー/ヘッドレス環境向け推奨
+zeroclaw auth login --provider openai-codex --device-code
+
+# ブラウザ/コールバックフロー（ペーストフォールバック付き）
+zeroclaw auth login --provider openai-codex --profile default
+zeroclaw auth paste-redirect --provider openai-codex --profile default
+
+# 確認 / リフレッシュ / プロファイル切替
+zeroclaw auth status
+zeroclaw auth refresh --provider openai-codex --profile default
+zeroclaw auth use --provider openai-codex --profile work
+```
+
+Claude Code / Anthropic setup-token:
+
+```bash
+# サブスクリプション/setup token の貼り付け（Authorization header モード）
+zeroclaw auth paste-token --provider anthropic --profile default --auth-kind authorization
+
+# エイリアスコマンド
+zeroclaw auth setup-token --provider anthropic --profile default
+```
+
+Subscription auth で agent を実行:
+
+```bash
+zeroclaw agent --provider openai-codex -m "hello"
+zeroclaw agent --provider openai-codex --auth-profile openai-codex:work -m "hello"
+
+# Anthropic は API key と auth token の両方の環境変数をサポート:
+# ANTHROPIC_AUTH_TOKEN, ANTHROPIC_OAUTH_TOKEN, ANTHROPIC_API_KEY
+zeroclaw agent --provider anthropic -m "hello"
+```
+
+## アーキテクチャ
+
+すべてのサブシステムは **Trait** — 設定変更だけで実装を差し替え可能、コード変更不要。
+
+<p align="center">
+  <img src="docs/architecture.svg" alt="ZeroClaw アーキテクチャ" width="900" />
+</p>
+
+| サブシステム | Trait | 内蔵実装 | 拡張方法 |
+|-------------|-------|----------|----------|
+| **AI モデル** | `Provider` | `zeroclaw providers` で確認（現在 28 個の組み込み + エイリアス、カスタムエンドポイント対応） | `custom:https://your-api.com`（OpenAI 互換）または `anthropic-custom:https://your-api.com` |
+| **チャネル** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Email, IRC, Lark, DingTalk, QQ, Webhook | 任意のメッセージ API |
+| **メモリ** | `Memory` | SQLite ハイブリッド検索, PostgreSQL バックエンド, Lucid ブリッジ, Markdown ファイル, 明示的 `none` バックエンド, スナップショット/復元, オプション応答キャッシュ | 任意の永続化バックエンド |
+| **ツール** | `Tool` | shell/file/memory, cron/schedule, git, pushover, browser, http_request, screenshot/image_info, composio (opt-in), delegate, ハードウェアツール | 任意の機能 |
+| **オブザーバビリティ** | `Observer` | Noop, Log, Multi | Prometheus, OTel |
+| **ランタイム** | `RuntimeAdapter` | Native, Docker（サンドボックス） | adapter 経由で追加可能；未対応の kind は即座にエラー |
+| **セキュリティ** | `SecurityPolicy` | Gateway ペアリング, サンドボックス, allowlist, レート制限, ファイルシステムスコープ, 暗号化シークレット | — |
+| **アイデンティティ** | `IdentityConfig` | OpenClaw (markdown), AIEOS v1.1 (JSON) | 任意の ID フォーマット |
+| **トンネル** | `Tunnel` | None, Cloudflare, Tailscale, ngrok, Custom | 任意のトンネルバイナリ |
+| **ハートビート** | Engine | HEARTBEAT.md 定期タスク | — |
+| **スキル** | Loader | TOML マニフェスト + SKILL.md インストラクション | コミュニティスキルパック |
+| **インテグレーション** | Registry | 9 カテゴリ、70 件以上の連携 | プラグインシステム |
+
+### ランタイムサポート（現状）
+
+- ✅ 現在サポート: `runtime.kind = "native"` または `runtime.kind = "docker"`
+- 🚧 計画中（未実装）: WASM / エッジランタイム
+
+未対応の `runtime.kind` が設定された場合、ZeroClaw は native へのサイレントフォールバックではなく、明確なエラーで終了します。
+
+### メモリシステム（フルスタック検索エンジン）
+
+すべて自社実装、外部依存ゼロ — Pinecone、Elasticsearch、LangChain 不要:
+
+| レイヤー | 実装 |
+|---------|------|
+| **ベクトル DB** | Embeddings を SQLite に BLOB として保存、コサイン類似度検索 |
+| **キーワード検索** | FTS5 仮想テーブル、BM25 スコアリング |
+| **ハイブリッドマージ** | カスタム重み付きマージ関数（`vector.rs`） |
+| **Embeddings** | `EmbeddingProvider` trait — OpenAI、カスタム URL、または noop |
+| **チャンキング** | 行ベースの Markdown チャンカー（見出し構造保持） |
+| **キャッシュ** | SQLite `embedding_cache` テーブル、LRU エビクション |
+| **安全な再インデックス** | FTS5 再構築 + 欠落ベクトルの再埋め込みをアトミックに実行 |
+
+Agent はツール経由でメモリの呼び出し・保存・管理を自動的に行います。
+
+```toml
+[memory]
+backend = "sqlite"             # "sqlite", "lucid", "postgres", "markdown", "none"
+auto_save = true
+embedding_provider = "none"    # "none", "openai", "custom:https://..."
+vector_weight = 0.7
+keyword_weight = 0.3
+```
+
 ## セキュリティのデフォルト
 
 - Gateway の既定バインド: `127.0.0.1:3000`

--- a/README.ru.md
+++ b/README.ru.md
@@ -142,6 +142,106 @@ zeroclaw gateway
 zeroclaw daemon
 ```
 
+## Subscription Auth (OpenAI Codex / Claude Code)
+
+ZeroClaw поддерживает нативные профили авторизации на основе подписки (мультиаккаунт, шифрование при хранении).
+
+- Файл хранения: `~/.zeroclaw/auth-profiles.json`
+- Ключ шифрования: `~/.zeroclaw/.secret_key`
+- Формат Profile ID: `<provider>:<profile_name>` (пример: `openai-codex:work`)
+
+OpenAI Codex OAuth (подписка ChatGPT):
+
+```bash
+# Рекомендуется для серверов/headless-окружений
+zeroclaw auth login --provider openai-codex --device-code
+
+# Браузерный/callback-поток с paste-фолбэком
+zeroclaw auth login --provider openai-codex --profile default
+zeroclaw auth paste-redirect --provider openai-codex --profile default
+
+# Проверка / обновление / переключение профиля
+zeroclaw auth status
+zeroclaw auth refresh --provider openai-codex --profile default
+zeroclaw auth use --provider openai-codex --profile work
+```
+
+Claude Code / Anthropic setup-token:
+
+```bash
+# Вставка subscription/setup token (режим Authorization header)
+zeroclaw auth paste-token --provider anthropic --profile default --auth-kind authorization
+
+# Команда-алиас
+zeroclaw auth setup-token --provider anthropic --profile default
+```
+
+Запуск agent с subscription auth:
+
+```bash
+zeroclaw agent --provider openai-codex -m "hello"
+zeroclaw agent --provider openai-codex --auth-profile openai-codex:work -m "hello"
+
+# Anthropic поддерживает и API key, и auth token через переменные окружения:
+# ANTHROPIC_AUTH_TOKEN, ANTHROPIC_OAUTH_TOKEN, ANTHROPIC_API_KEY
+zeroclaw agent --provider anthropic -m "hello"
+```
+
+## Архитектура
+
+Каждая подсистема — это **Trait**: меняйте реализации через конфигурацию, без изменения кода.
+
+<p align="center">
+  <img src="docs/architecture.svg" alt="Архитектура ZeroClaw" width="900" />
+</p>
+
+| Подсистема | Trait | Встроенные реализации | Расширение |
+|-----------|-------|---------------------|------------|
+| **AI-модели** | `Provider` | Каталог через `zeroclaw providers` (сейчас 28 встроенных + алиасы, плюс пользовательские endpoint) | `custom:https://your-api.com` (OpenAI-совместимый) или `anthropic-custom:https://your-api.com` |
+| **Каналы** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Email, IRC, Lark, DingTalk, QQ, Webhook | Любой messaging API |
+| **Память** | `Memory` | SQLite гибридный поиск, PostgreSQL-бэкенд, Lucid-мост, Markdown-файлы, явный `none`-бэкенд, snapshot/hydrate, опциональный кэш ответов | Любой persistence-бэкенд |
+| **Инструменты** | `Tool` | shell/file/memory, cron/schedule, git, pushover, browser, http_request, screenshot/image_info, composio (opt-in), delegate, аппаратные инструменты | Любая функциональность |
+| **Наблюдаемость** | `Observer` | Noop, Log, Multi | Prometheus, OTel |
+| **Runtime** | `RuntimeAdapter` | Native, Docker (sandbox) | Через adapter; неподдерживаемые kind завершаются с ошибкой |
+| **Безопасность** | `SecurityPolicy` | Gateway pairing, sandbox, allowlist, rate limits, scoping файловой системы, шифрование секретов | — |
+| **Идентификация** | `IdentityConfig` | OpenClaw (markdown), AIEOS v1.1 (JSON) | Любой формат идентификации |
+| **Туннели** | `Tunnel` | None, Cloudflare, Tailscale, ngrok, Custom | Любой tunnel-бинарник |
+| **Heartbeat** | Engine | HEARTBEAT.md — периодические задачи | — |
+| **Навыки** | Loader | TOML-манифесты + SKILL.md-инструкции | Пакеты навыков сообщества |
+| **Интеграции** | Registry | 70+ интеграций в 9 категориях | Плагинная система |
+
+### Поддержка runtime (текущая)
+
+- ✅ Поддерживается сейчас: `runtime.kind = "native"` или `runtime.kind = "docker"`
+- 🚧 Запланировано, но ещё не реализовано: WASM / edge-runtime
+
+При указании неподдерживаемого `runtime.kind` ZeroClaw завершается с явной ошибкой, а не молча откатывается к native.
+
+### Система памяти (полнофункциональный поисковый движок)
+
+Полностью собственная реализация, ноль внешних зависимостей — без Pinecone, Elasticsearch, LangChain:
+
+| Уровень | Реализация |
+|---------|-----------|
+| **Векторная БД** | Embeddings хранятся как BLOB в SQLite, поиск по косинусному сходству |
+| **Поиск по ключевым словам** | Виртуальные таблицы FTS5 со скорингом BM25 |
+| **Гибридное слияние** | Пользовательская взвешенная функция слияния (`vector.rs`) |
+| **Embeddings** | Trait `EmbeddingProvider` — OpenAI, пользовательский URL или noop |
+| **Чанкинг** | Построчный Markdown-чанкер с сохранением заголовков |
+| **Кэширование** | Таблица `embedding_cache` в SQLite с LRU-вытеснением |
+| **Безопасная переиндексация** | Атомарная перестройка FTS5 + повторное встраивание отсутствующих векторов |
+
+Agent автоматически вспоминает, сохраняет и управляет памятью через инструменты.
+
+```toml
+[memory]
+backend = "sqlite"             # "sqlite", "lucid", "postgres", "markdown", "none"
+auto_save = true
+embedding_provider = "none"    # "none", "openai", "custom:https://..."
+vector_weight = 0.7
+keyword_weight = 0.3
+```
+
 ## Важные security-дефолты
 
 - Gateway по умолчанию: `127.0.0.1:3000`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -147,6 +147,106 @@ zeroclaw gateway
 zeroclaw daemon
 ```
 
+## Subscription Auth（OpenAI Codex / Claude Code）
+
+ZeroClaw 现已支持基于订阅的原生鉴权配置（多账号、静态加密存储）。
+
+- 配置文件：`~/.zeroclaw/auth-profiles.json`
+- 加密密钥：`~/.zeroclaw/.secret_key`
+- Profile ID 格式：`<provider>:<profile_name>`（例：`openai-codex:work`）
+
+OpenAI Codex OAuth（ChatGPT 订阅）：
+
+```bash
+# 推荐用于服务器/无显示器环境
+zeroclaw auth login --provider openai-codex --device-code
+
+# 浏览器/回调流程，支持粘贴回退
+zeroclaw auth login --provider openai-codex --profile default
+zeroclaw auth paste-redirect --provider openai-codex --profile default
+
+# 检查 / 刷新 / 切换 profile
+zeroclaw auth status
+zeroclaw auth refresh --provider openai-codex --profile default
+zeroclaw auth use --provider openai-codex --profile work
+```
+
+Claude Code / Anthropic setup-token：
+
+```bash
+# 粘贴订阅/setup token（Authorization header 模式）
+zeroclaw auth paste-token --provider anthropic --profile default --auth-kind authorization
+
+# 别名命令
+zeroclaw auth setup-token --provider anthropic --profile default
+```
+
+使用 subscription auth 运行 agent：
+
+```bash
+zeroclaw agent --provider openai-codex -m "hello"
+zeroclaw agent --provider openai-codex --auth-profile openai-codex:work -m "hello"
+
+# Anthropic 同时支持 API key 和 auth token 环境变量：
+# ANTHROPIC_AUTH_TOKEN, ANTHROPIC_OAUTH_TOKEN, ANTHROPIC_API_KEY
+zeroclaw agent --provider anthropic -m "hello"
+```
+
+## 架构
+
+每个子系统都是一个 **Trait** — 通过配置切换即可更换实现，无需修改代码。
+
+<p align="center">
+  <img src="docs/architecture.svg" alt="ZeroClaw 架构图" width="900" />
+</p>
+
+| 子系统 | Trait | 内置实现 | 扩展方式 |
+|--------|-------|----------|----------|
+| **AI 模型** | `Provider` | 通过 `zeroclaw providers` 查看（当前 28 个内置 + 别名，以及自定义端点） | `custom:https://your-api.com`（OpenAI 兼容）或 `anthropic-custom:https://your-api.com` |
+| **通道** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Email, IRC, Lark, DingTalk, QQ, Webhook | 任意消息 API |
+| **记忆** | `Memory` | SQLite 混合搜索, PostgreSQL 后端, Lucid 桥接, Markdown 文件, 显式 `none` 后端, 快照/恢复, 可选响应缓存 | 任意持久化后端 |
+| **工具** | `Tool` | shell/file/memory, cron/schedule, git, pushover, browser, http_request, screenshot/image_info, composio (opt-in), delegate, 硬件工具 | 任意能力 |
+| **可观测性** | `Observer` | Noop, Log, Multi | Prometheus, OTel |
+| **运行时** | `RuntimeAdapter` | Native, Docker（沙箱） | 通过 adapter 添加；不支持的类型会快速失败 |
+| **安全** | `SecurityPolicy` | Gateway 配对, 沙箱, allowlist, 速率限制, 文件系统作用域, 加密密钥 | — |
+| **身份** | `IdentityConfig` | OpenClaw (markdown), AIEOS v1.1 (JSON) | 任意身份格式 |
+| **隧道** | `Tunnel` | None, Cloudflare, Tailscale, ngrok, Custom | 任意隧道工具 |
+| **心跳** | Engine | HEARTBEAT.md 定期任务 | — |
+| **技能** | Loader | TOML 清单 + SKILL.md 指令 | 社区技能包 |
+| **集成** | Registry | 9 个分类下 70+ 集成 | 插件系统 |
+
+### 运行时支持（当前）
+
+- ✅ 当前支持：`runtime.kind = "native"` 或 `runtime.kind = "docker"`
+- 🚧 计划中，尚未实现：WASM / 边缘运行时
+
+配置了不支持的 `runtime.kind` 时，ZeroClaw 会以明确的错误退出，而非静默回退到 native。
+
+### 记忆系统（全栈搜索引擎）
+
+全部自研，零外部依赖 — 无需 Pinecone、Elasticsearch、LangChain：
+
+| 层级 | 实现 |
+|------|------|
+| **向量数据库** | Embeddings 以 BLOB 存储于 SQLite，余弦相似度搜索 |
+| **关键词搜索** | FTS5 虚拟表，BM25 评分 |
+| **混合合并** | 自定义加权合并函数（`vector.rs`） |
+| **Embeddings** | `EmbeddingProvider` trait — OpenAI、自定义 URL 或 noop |
+| **分块** | 基于行的 Markdown 分块器，保留标题结构 |
+| **缓存** | SQLite `embedding_cache` 表，LRU 淘汰策略 |
+| **安全重索引** | 原子化重建 FTS5 + 重新嵌入缺失向量 |
+
+Agent 通过工具自动进行记忆的回忆、保存和管理。
+
+```toml
+[memory]
+backend = "sqlite"             # "sqlite", "lucid", "postgres", "markdown", "none"
+auto_save = true
+embedding_provider = "none"    # "none", "openai", "custom:https://..."
+vector_weight = 0.7
+keyword_weight = 0.3
+```
+
 ## 安全默认行为（关键）
 
 - Gateway 默认绑定：`127.0.0.1:3000`


### PR DESCRIPTION
The English README contains architecture overview (diagram + trait table), subscription auth setup (OAuth flow + examples), and memory system design (vector + FTS5 hybrid search) sections that were missing from the Chinese, Japanese, and Russian translations.

This closes the content parity gap identified in the documentation audit, ensuring non-English speakers have access to the same critical architectural context and setup guidance.