### PR TITLE
docs: enhance getting-started, hardware, and project collection indexes

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -8,6 +8,15 @@ For first-time setup and quick orientation.
 2. One-click setup and dual bootstrap mode: [../one-click-bootstrap.md](../one-click-bootstrap.md)
 3. Find commands by tasks: [../commands-reference.md](../commands-reference.md)
 
+## Choose Your Path
+
+| Scenario | Command |
+|----------|---------|
+| I have an API key, want fastest setup | `zeroclaw onboard --api-key sk-... --provider openrouter` |
+| I want guided prompts | `zeroclaw onboard --interactive` |
+| Config exists, just fix channels | `zeroclaw onboard --channels-only` |
+| Using subscription auth | See [Subscription Auth](../../README.md#subscription-auth-openai-codex--claude-code) |
+
 ## Onboarding and Validation
 
 - Quick onboarding: `zeroclaw onboard --api-key "sk-..." --provider openrouter`

--- a/docs/hardware/README.md
+++ b/docs/hardware/README.md
@@ -2,6 +2,8 @@
 
 For board integration, firmware flow, and peripheral architecture.
 
+ZeroClaw's hardware subsystem enables direct control of microcontrollers and peripherals via the `Peripheral` trait. Each board exposes tools for GPIO, ADC, and sensor operations, allowing agent-driven hardware interaction on boards like STM32 Nucleo, Raspberry Pi, and ESP32. See [hardware-peripherals-design.md](../hardware-peripherals-design.md) for the full architecture.
+
 ## Entry Points
 
 - Architecture and peripheral model: [../hardware-peripherals-design.md](../hardware-peripherals-design.md)

--- a/docs/project/README.md
+++ b/docs/project/README.md
@@ -8,6 +8,10 @@ Time-bound project status snapshots for planning documentation and operations wo
 
 ## Scope
 
-Use snapshots to understand changing PR/issue pressure and prioritize doc maintenance.
+Project snapshots are time-bound assessments of open PRs, issues, and documentation health. Use these to:
 
-For stable classification of docs intent, use [../docs-inventory.md](../docs-inventory.md).
+- Identify documentation gaps driven by feature work
+- Prioritize docs maintenance alongside code changes
+- Track evolving PR/issue pressure over time
+
+For stable documentation classification (not time-bound), use [docs-inventory.md](../docs-inventory.md).


### PR DESCRIPTION
Adds onboarding decision tree to getting-started/README.md so users can quickly identify the right setup command for their situation.

Adds hardware vision overview to hardware/README.md explaining the Peripheral trait and supported board types.

Expands project/README.md with scope explanation describing the purpose of project snapshots and how they relate to documentation maintenance.