### PR TITLE
test(peripherals): add unit tests for peripheral module configuration and listing

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{OnceLock, RwLock};
-use tokio::fs::{self, File, OpenOptions};
+use tokio::fs::{self, OpenOptions};
+#[cfg(unix)]
+use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
 const SUPPORTED_PROXY_SERVICE_KEYS: &[&str] = &[
@@ -3373,14 +3375,16 @@ async fn sync_directory(path: &Path) -> Result<()> {
 }
 
 #[cfg(not(unix))]
-fn sync_directory(_path: &Path) -> Result<()> {
+async fn sync_directory(_path: &Path) -> Result<()> {
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs::Permissions, os::unix::fs::PermissionsExt, path::PathBuf};
+    #[cfg(unix)]
+    use std::{fs::Permissions, os::unix::fs::PermissionsExt};
+    use std::path::PathBuf;
     use tokio::sync::{Mutex, MutexGuard};
     use tokio::test;
     use tokio_stream::wrappers::ReadDirStream;


### PR DESCRIPTION
Add tests for list_configured_boards() covering enabled/disabled states and empty/non-empty board configurations. Add test verifying create_peripheral_tools() returns empty when peripherals are disabled. Addresses audit finding CRITICAL-1 for the untested peripherals module — covers all non-hardware-gated logic paths.

Fix pre-existing Windows build errors in config/schema.rs: make non-unix sync_directory async and gate unix-only imports behind #[cfg(unix)].