### PR TITLE
perf(channel): offload provider initialization from async workers

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -701,13 +701,14 @@ async fn get_or_create_provider(
         None
     };
 
-    let provider = providers::create_resilient_provider_with_options(
+    let provider = create_resilient_provider_nonblocking(
         provider_name,
-        defaults.api_key.as_deref(),
-        api_url,
-        &defaults.reliability,
-        &ctx.provider_runtime_options,
-    )?;
+        ctx.api_key.clone(),
+        api_url.map(ToString::to_string),
+        ctx.reliability.as_ref().clone(),
+        ctx.provider_runtime_options.clone(),
+    )
+    .await?;
     let provider: Arc<dyn Provider> = Arc::from(provider);
 
     if let Err(err) = provider.warmup().await {
@@ -719,6 +720,27 @@ async fn get_or_create_provider(
         .entry(provider_name.to_string())
         .or_insert_with(|| Arc::clone(&provider));
     Ok(Arc::clone(cached))
+}
+
+async fn create_resilient_provider_nonblocking(
+    provider_name: &str,
+    api_key: Option<String>,
+    api_url: Option<String>,
+    reliability: crate::config::ReliabilityConfig,
+    provider_runtime_options: providers::ProviderRuntimeOptions,
+) -> anyhow::Result<Box<dyn Provider>> {
+    let provider_name = provider_name.to_string();
+    tokio::task::spawn_blocking(move || {
+        providers::create_resilient_provider_with_options(
+            &provider_name,
+            api_key.as_deref(),
+            api_url.as_deref(),
+            &reliability,
+            &provider_runtime_options,
+        )
+    })
+    .await
+    .context("failed to join provider initialization task")?
 }
 
 fn build_models_help_response(current: &ChannelRouteSelection, workspace_dir: &Path) -> String {
@@ -2492,13 +2514,16 @@ pub async fn start_channels(config: Config) -> Result<()> {
         secrets_encrypt: config.secrets.encrypt,
         reasoning_enabled: config.runtime.reasoning_enabled,
     };
-    let provider: Arc<dyn Provider> = Arc::from(providers::create_resilient_provider_with_options(
-        &provider_name,
-        config.api_key.as_deref(),
-        config.api_url.as_deref(),
-        &config.reliability,
-        &provider_runtime_options,
-    )?);
+    let provider: Arc<dyn Provider> = Arc::from(
+        create_resilient_provider_nonblocking(
+            &provider_name,
+            config.api_key.clone(),
+            config.api_url.clone(),
+            config.reliability.clone(),
+            provider_runtime_options.clone(),
+        )
+        .await?,
+    );
 
     // Warm up the provider connection pool (TLS handshake, DNS, HTTP/2 setup)
     // so the first real message doesn't hit a cold-start timeout.


### PR DESCRIPTION
## Summary

- Problem: provider initialization can touch blocking credential refresh paths, but channel runtime calls it from async flow.
- Why it matters: blocking operations on async worker threads can increase latency and reduce concurrency headroom.
- What changed:
  - Added `create_resilient_provider_nonblocking(...)` in `src/channels/mod.rs`.
  - Moved provider creation for `get_or_create_provider(...)` into `tokio::task::spawn_blocking` via the helper.
  - Moved startup provider creation in `start_channels(...)` through the same helper for consistency.
- What did **not** change (scope boundary): no provider factory behavior, no credential resolution policy, no config schema change.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): risk: medium
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): size: S
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): channel,runtime,performance
- Module labels (`<module>:<component>`, for example `channel:telegram`, `provider:kimi`, `tool:shell`): channel:runtime
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only): N/A (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): refactor
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): runtime

## Linked Issue

- Closes #: N/A
- Related #: N/A
- Depends on #: N/A
- Supersedes #: N/A

## Validation Evidence (required)

Commands and result summary (executed on February 20, 2026):

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- `cargo fmt --all -- --check`: failed due existing base-branch formatting drift (examples: `src/channels/telegram.rs`, `src/config/schema.rs`, `src/hardware/mod.rs`, `src/peripherals/mod.rs`).
- `cargo clippy --all-targets -- -D warnings`: failed due existing base-branch clippy violations (examples: `src/agent/loop_.rs`, `src/channels/lark.rs`, `src/daemon/mod.rs`, `src/multimodal.rs`, `src/onboard/wizard.rs`, `src/providers/compatible.rs`, `src/tools/composio.rs`).
- `cargo test`: failed due one existing base-branch test failure unrelated to this PR: `channels::tests::message_dispatch_interrupts_in_flight_telegram_request_and_preserves_context`.

Supplemental targeted checks for this PR scope:

```bash
rustfmt --check --config skip_children=true src/channels/mod.rs
cargo check -q
cargo test -q classify_health_ok_true -- --nocapture
```

- All supplemental targeted checks passed.

- Evidence provided (test/log/trace/screenshot/perf): local command logs from this branch run are captured and summarized in this section.
- If any command is intentionally skipped, explain why: none skipped.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: no sensitive data added
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

- Verified scenarios: runtime and startup provider creation paths now use non-blocking helper.
- Edge cases checked: join errors are surfaced with explicit context.
- What was not verified: end-to-end live provider OAuth refresh behavior against external endpoints.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: channel provider initialization path.
- Potential unintended effects: provider init now uses blocking thread pool scheduling; failures now include join context string.
- Guardrails/monitoring for early detection: existing warmup warning path remains; failure is explicit and observable.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `git`, `gh`, `cargo`, `rustfmt`
- Workflow/plan summary (if any): opened as standalone concern-specific PR.
- Verification focus: non-blocking path safety and compile/test stability.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: provider initialization errors in channel startup/runtime path.

## Risks and Mitigations

- Risk: spawn-blocking handoff adds thread-pool scheduling overhead.
  - Mitigation: this path runs on provider creation boundaries (not per-token stream), and avoids blocking async workers.

