### PR TITLE
fix(observability): avoid OTEL reactor panic with blocking exporter client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ http-body-util = "0.1"
 # OpenTelemetry — OTLP trace + metrics export
 opentelemetry = { version = "0.31", default-features = false, features = ["trace", "metrics"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "metrics", "http-proto", "reqwest-client", "reqwest-rustls-webpki-roots"] }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "metrics", "http-proto", "reqwest-blocking-client", "reqwest-rustls-webpki-roots"] }
 
 # Serial port for peripheral communication (STM32, etc.)
 tokio-serial = { version = "5", default-features = false, optional = true }


### PR DESCRIPTION
## Summary
- Switch OTLP HTTP exporter from async reqwest client to blocking reqwest client.
- This avoids Tokio-reactor panics in OpenTelemetry background exporter threads when `[observability] backend = "otel"` is enabled.

## Linked Issue
- Closes #975

## Validation
- `CARGO_TARGET_DIR=/tmp/zc-otel cargo check --no-default-features -q`
- `CARGO_TARGET_DIR=/tmp/zc-otel cargo test --no-default-features otel_observer_creation_with_valid_endpoint_succeeds -- --nocapture`

## Risk / Rollback
- Risk: low (export transport client selection only).
- Rollback: revert commit `bebce5a`.
