### PR TITLE
fix(channels): make system prompt channel-agnostic

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1358,9 +1358,9 @@ pub fn build_system_prompt(
     // ── 8. Channel Capabilities ─────────────────────────────────────
     prompt.push_str("## Channel Capabilities\n\n");
     prompt.push_str(
-        "- You are running as a Discord bot. You CAN and do send messages to Discord channels.\n",
+        "- You are running as a ZeroClaw AI assistant connected to a messaging channel.\n",
     );
-    prompt.push_str("- When someone messages you on Discord, your response is automatically sent back to Discord.\n");
+    prompt.push_str("- When someone messages you, your response is automatically sent back to them.\n");
     prompt.push_str("- You do NOT need to ask permission to respond — just respond directly.\n");
     prompt.push_str("- NEVER repeat, describe, or echo credentials, tokens, API keys, or secrets in your responses.\n");
     prompt.push_str("- If a tool output contains credentials, they have already been redacted — do not mention them.\n\n");


### PR DESCRIPTION
## Problem
The system prompt in `build_system_prompt` contains hardcoded Discord-specific messaging that incorrectly appears for all channel types.

## Solution
Replace Discord-specific references with generic channel messaging that works uniformly across all channel implementations.

## Changes
- Updated channel capability messages to be channel-agnostic
- Changed "Discord bot" → "ZeroClaw AI assistant connected to a messaging channel"
- Changed "messages you on Discord" → "messages you"

## Non-goals
- No changes to actual channel implementation logic
- No changes to other system prompt sections

## Risk and Rollback
- **Risk**: Low - text-only change in system prompt
- **Blast radius**: All channels will see updated messaging
- **Rollback**: Simple revert of this commit

## Testing
- [ ] Verify system prompt generation works for all channel types
- [ ] No functional behavior changes expected

## Size
XS - 2 line change