### PR TITLE
fix(skills): support SSH git remotes for skills install

### DIFF
--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -102,6 +102,8 @@ Runtime in-chat commands (Telegram/Discord while channel server is running):
 - `zeroclaw skills install <source>`
 - `zeroclaw skills remove <name>`
 
+`<source>` accepts git remotes (`https://...`, `http://...`, `ssh://...`, and `git@host:owner/repo.git`) or a local filesystem path.
+
 Skill manifests (`SKILL.toml`) support `prompts` and `[[tools]]`; both are injected into the agent system prompt at runtime, so the model can follow skill instructions without manually reading skill files.
 
 ### `migrate`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,9 +140,9 @@ Examples:
 pub enum SkillCommands {
     /// List all installed skills
     List,
-    /// Install a new skill from a URL or local path
+    /// Install a new skill from a git URL (HTTPS/SSH) or local path
     Install {
-        /// Source URL or local path
+        /// Source git URL (HTTPS/SSH) or local path
         source: String,
     },
     /// Remove an installed skill

--- a/src/main.rs
+++ b/src/main.rs
@@ -596,9 +596,9 @@ enum ChannelCommands {
 enum SkillCommands {
     /// List installed skills
     List,
-    /// Install a skill from a GitHub URL or local path
+    /// Install a skill from a git URL (HTTPS/SSH) or local path
     Install {
-        /// GitHub URL or local path
+        /// Git URL (HTTPS/SSH) or local path
         source: String,
     },
     /// Remove an installed skill


### PR DESCRIPTION
## Summary
- fix `skills install` source detection to recognize SSH git remotes in both URI (`ssh://...`) and SCP-style (`git@host:owner/repo.git`) forms
- keep local-path handling intact with stricter URL validation to avoid false positives
- add regression tests for accepted/rejected source formats
- update docs and CLI descriptions to reflect supported git source formats

## Root Cause
`skills install` only treated `http://` and `https://` as git sources, so SSH remotes fell through to the local-path branch and failed with "Source path does not exist".

## Validation
- `CARGO_TARGET_DIR=/tmp/zc-issue1030-target cargo test --locked --lib skills::tests::`
- `CARGO_TARGET_DIR=/tmp/zc-issue1030-target cargo test --locked --lib skills::symlink_tests::`
- `CARGO_TARGET_DIR=/tmp/zc-issue1030-target cargo test --locked --no-run`
- `CARGO_TARGET_DIR=/tmp/zc-issue1030-target cargo check --locked`

Closes #1030
