### PR TITLE
fix(channel): avoid false 300s timeout during multi-turn tool loops

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -332,7 +332,7 @@ Top-level channel options are configured under `channels_config`.
 
 | Key | Default | Purpose |
 |---|---|---|
-| `message_timeout_secs` | `300` | Timeout in seconds for processing a single channel message (LLM + tools) |
+| `message_timeout_secs` | `300` | Base timeout in seconds for channel message processing; runtime scales this with tool-loop depth (up to 4x) |
 
 Examples:
 
@@ -344,6 +344,8 @@ Examples:
 Notes:
 
 - Default `300s` is optimized for on-device LLMs (Ollama) which are slower than cloud APIs.
+- Runtime timeout budget is `message_timeout_secs * scale`, where `scale = min(max_tool_iterations, 4)` and a minimum of `1`.
+- This scaling avoids false timeouts when the first LLM turn is slow/retried but later tool-loop turns still need to complete.
 - If using cloud APIs (OpenAI, Anthropic, etc.), you can reduce this to `60` or lower.
 - Values below `30` are clamped to `30` to avoid immediate timeout churn.
 - When a timeout occurs, users receive: `⚠️ Request timed out while waiting for the model. Please try again.`


### PR DESCRIPTION
## Summary

### Problem
Channel mode applies a single outer timeout (`message_timeout_secs`, default 300s) to the entire tool-call loop.

### Why it matters
On slow/retried first turns (for example intermittent `error decoding response body` from provider requests), most of the 300s budget can be consumed before follow-up tool turns execute. This leads to false timeout failures in otherwise recoverable conversations.

### What changed
- Added `channel_message_timeout_budget_secs(base_timeout_secs, max_tool_iterations)` in `src/channels/mod.rs`.
- Scaled the outer timeout budget by tool loop depth with a safety cap (`min(max_tool_iterations, 4)`), while preserving `message_timeout_secs` as the base timeout.
- Updated timeout logging to include base timeout and iteration context.
- Added unit tests for scaling + defaults/cap behavior.
- Updated config/schema comments and docs so `message_timeout_secs` clearly describes base timeout vs effective channel runtime budget.

## Validation Evidence
- Local docs gate:
  - `./scripts/ci/docs_quality_gate.sh` (pass)
- GitHub checks on this PR:
  - `CI Required Gate` (pass)
  - `Build (Smoke)` (pass)
  - `Security Audit` (pass)
  - `License & Supply Chain` (pass)
- Local targeted Rust tests were executed repeatedly against this branch in an isolated worktree, but this host currently has aggressive global cargo/rustc queueing and intermittent process termination under concurrent load; CI-required checks are green and cover build/safety gates for this delta.

## Security Impact
- Security risk level: Low.
- No new secrets, permissions, or network surfaces introduced.
- Change is timeout-budget logic for channel runtime control flow and related docs/tests only.

## Privacy and Data Hygiene
- No new data collection/storage paths added.
- No changes to redaction, telemetry payload shape, or PII handling.

## Rollback Plan
1. Revert commit `0f3019d` from `main`.
2. Confirm channel timeout behavior returns to prior fixed single-budget model.
3. Re-run CI gate (`CI Required Gate`, `Build (Smoke)`, `Security Audit`).

Fixes #974
