### PR TITLE
feat(lark): add immediate ack emoji reaction on message receive

### DIFF
--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -13,6 +13,7 @@ const FEISHU_BASE_URL: &str = "https://open.feishu.cn/open-apis";
 const FEISHU_WS_BASE_URL: &str = "https://open.feishu.cn";
 const LARK_BASE_URL: &str = "https://open.larksuite.com/open-apis";
 const LARK_WS_BASE_URL: &str = "https://open.larksuite.com";
+const ACK_REACTION_EMOJI_TYPE: &str = "SMILE";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Feishu WebSocket long-connection: pbbp2.proto frame codec
@@ -215,6 +216,110 @@ impl LarkChannel {
 
     fn send_message_url(&self) -> String {
         format!("{}/im/v1/messages?receive_id_type=chat_id", self.api_base())
+    }
+
+    fn message_reaction_url(&self, message_id: &str) -> String {
+        format!("{}/im/v1/messages/{message_id}/reactions", self.api_base())
+    }
+
+    async fn post_message_reaction_with_token(
+        &self,
+        message_id: &str,
+        token: &str,
+    ) -> anyhow::Result<reqwest::Response> {
+        let url = self.message_reaction_url(message_id);
+        let body = serde_json::json!({
+            "reaction_type": {
+                "emoji_type": ACK_REACTION_EMOJI_TYPE
+            }
+        });
+
+        let response = self
+            .http_client()
+            .post(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json; charset=utf-8")
+            .json(&body)
+            .send()
+            .await?;
+
+        Ok(response)
+    }
+
+    /// Best-effort "received" signal for incoming messages.
+    /// Failures are logged and never block normal message handling.
+    async fn try_add_ack_reaction(&self, message_id: &str) {
+        if message_id.is_empty() {
+            return;
+        }
+
+        let mut token = match self.get_tenant_access_token().await {
+            Ok(token) => token,
+            Err(err) => {
+                tracing::warn!("Lark: failed to fetch token for reaction: {err}");
+                return;
+            }
+        };
+
+        let mut retried = false;
+        loop {
+            let response = match self
+                .post_message_reaction_with_token(message_id, &token)
+                .await
+            {
+                Ok(resp) => resp,
+                Err(err) => {
+                    tracing::warn!("Lark: failed to add reaction for {message_id}: {err}");
+                    return;
+                }
+            };
+
+            if response.status().as_u16() == 401 && !retried {
+                self.invalidate_token().await;
+                token = match self.get_tenant_access_token().await {
+                    Ok(new_token) => new_token,
+                    Err(err) => {
+                        tracing::warn!(
+                            "Lark: failed to refresh token for reaction on {message_id}: {err}"
+                        );
+                        return;
+                    }
+                };
+                retried = true;
+                continue;
+            }
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let err_body = response.text().await.unwrap_or_default();
+                tracing::warn!(
+                    "Lark: add reaction failed for {message_id}: status={status}, body={err_body}"
+                );
+                return;
+            }
+
+            let payload: serde_json::Value = match response.json().await {
+                Ok(v) => v,
+                Err(err) => {
+                    tracing::warn!(
+                        "Lark: add reaction decode failed for {message_id}: {err}"
+                    );
+                    return;
+                }
+            };
+
+            let code = payload.get("code").and_then(|v| v.as_i64()).unwrap_or(-1);
+            if code != 0 {
+                let msg = payload
+                    .get("msg")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown error");
+                tracing::warn!(
+                    "Lark: add reaction returned code={code} for {message_id}: {msg}"
+                );
+            }
+            return;
+        }
     }
 
     /// POST /callback/ws/endpoint → (wss_url, client_config)
@@ -463,6 +568,8 @@ impl LarkChannel {
                     if lark_msg.chat_type == "group" && !should_respond_in_group(&lark_msg.mentions) {
                         continue;
                     }
+
+                    self.try_add_ack_reaction(&lark_msg.message_id).await;
 
                     let channel_msg = ChannelMessage {
                         id: Uuid::new_v4().to_string(),
@@ -751,6 +858,15 @@ impl LarkChannel {
 
             // Parse event messages
             let messages = state.channel.parse_event_payload(&payload);
+            if !messages.is_empty() {
+                if let Some(message_id) = payload
+                    .pointer("/event/message/message_id")
+                    .and_then(|m| m.as_str())
+                {
+                    state.channel.try_add_ack_reaction(message_id).await;
+                }
+            }
+
             for msg in messages {
                 if state.tx.send(msg).await.is_err() {
                     tracing::warn!("Lark: message channel closed");
@@ -1267,5 +1383,21 @@ mod tests {
         let msgs = ch.parse_event_payload(&payload);
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].sender, "ou_user");
+    }
+
+    #[test]
+    fn lark_reaction_url_matches_region() {
+        let ch_cn = make_channel();
+        assert_eq!(
+            ch_cn.message_reaction_url("om_test_message_id"),
+            "https://open.feishu.cn/open-apis/im/v1/messages/om_test_message_id/reactions"
+        );
+
+        let mut ch_intl = make_channel();
+        ch_intl.use_feishu = false;
+        assert_eq!(
+            ch_intl.message_reaction_url("om_test_message_id"),
+            "https://open.larksuite.com/open-apis/im/v1/messages/om_test_message_id/reactions"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: Lark/Feishu incoming messages had no immediate in-channel acknowledgment signal when a message was received.
- Why it matters: A quick ack reaction improves receive-path visibility and operator confidence while preserving normal message processing.
- What changed: Added best-effort ack emoji reaction on receive in `src/channels/lark.rs` for both websocket and webhook paths, plus URL-region unit coverage.
- What did **not** change (scope boundary): No new permission model, no blocking behavior on reaction failure, and no cross-channel behavior changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `channel: lark`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes # none
- Related # none
- Depends on # (if stacked) none
- Supersedes # (if replacing older PR) none

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): not applicable
- Integrated scope by source PR (what was materially carried forward): not applicable
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): not applicable
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): not applicable
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): not applicable

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
  - `cargo +1.92.0-aarch64-apple-darwin test lark_reaction_url_matches_region --lib` (pass)
  - `./scripts/ci/rust_quality_gate.sh` (fail: `cargo fmt --all -- --check` reports formatting diffs on current branch snapshot)
  - `./scripts/ci/rust_strict_delta_gate.sh` (pass: no blocking strict lint issues on changed Rust lines)
  - `./scripts/ci/docs_quality_gate.sh` (pass/skip: no docs files detected)
- If any command is intentionally skipped, explain why:
  - none

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `Yes` (Lark reaction API call on receive path)
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation:
  - Risk: added outbound API call during receive path.
  - Mitigation: best-effort non-blocking behavior; reaction failure does not interrupt normal message dispatch/processing.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no personal/sensitive payloads added to code, docs, or tests.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: not applicable

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - region-specific reaction URL generation via unit test
  - reaction path is best-effort and non-blocking by design
- Edge cases checked:
  - webhook and websocket receive paths both include ack trigger point
  - reaction failure does not stop message handling path
- What was not verified:
  - full integration verification against live tenant/API in this PR thread

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `src/channels/lark.rs` receive path only
- Potential unintended effects: additional API request volume to Lark reaction endpoint
- Guardrails/monitoring for early detection: rely on existing channel/runtime logs and error reporting for reaction failures (non-blocking)

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local coding assistant for implementation and PR drafting
- Workflow/plan summary (if any): implement helper -> wire receive paths -> add focused unit test
- Verification focus: URL-region correctness and non-blocking failure path
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed

## Rollback Plan (required)

- Fast rollback command/path: revert commit `cf6bbb7` (or revert this PR) to restore prior receive behavior
- Feature flags or config toggles (if any): none
- Observable failure symptoms: unexpected reaction API errors/latency without message-delivery regression

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: added outbound reaction call may increase external API dependency on receive path.
  - Mitigation: keep call best-effort and non-blocking; preserve message handling continuity on failure.
