### PR TITLE
fix(channels): harden WhatsApp Web mode and align docs/onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,37 @@ For non-text replies, ZeroClaw can send Telegram attachments when the assistant 
 
 Paths can be local files (for example `/tmp/screenshot.png`) or HTTPS URLs.
 
-### WhatsApp Business Cloud API Setup
+### WhatsApp Setup
+
+ZeroClaw supports two WhatsApp backends:
+
+- **WhatsApp Web mode** (QR / pair code, no Meta Business API required)
+- **WhatsApp Business Cloud API mode** (official Meta webhook flow)
+
+#### WhatsApp Web mode (recommended for personal/self-hosted use)
+
+1. **Build with WhatsApp Web support:**
+   ```bash
+   cargo build --features whatsapp-web
+   ```
+
+2. **Configure ZeroClaw:**
+   ```toml
+   [channels_config.whatsapp]
+   session_path = "~/.zeroclaw/state/whatsapp-web/session.db"
+   pair_phone = "15551234567"   # optional; omit to use QR flow
+   pair_code = ""               # optional custom pair code
+   allowed_numbers = ["+1234567890"]  # E.164 format, or ["*"] for all
+   ```
+
+3. **Start channels/daemon and link device:**
+   - Run `zeroclaw channel start` (or `zeroclaw daemon`).
+   - Follow terminal pairing output (QR or pair code).
+   - In WhatsApp on phone: **Settings → Linked Devices**.
+
+4. **Test:** Send a message from an allowed number and verify the agent replies.
+
+#### WhatsApp Business Cloud API mode
 
 WhatsApp uses Meta's Cloud API with webhooks (push-based, not polling):
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -356,6 +356,34 @@ Notes:
 
 See detailed channel matrix and allowlist behavior in [channels-reference.md](channels-reference.md).
 
+### `[channels_config.whatsapp]`
+
+WhatsApp supports two backends under one config table.
+
+Cloud API mode (Meta webhook):
+
+| Key | Required | Purpose |
+|---|---|---|
+| `access_token` | Yes | Meta Cloud API bearer token |
+| `phone_number_id` | Yes | Meta phone number ID |
+| `verify_token` | Yes | Webhook verification token |
+| `app_secret` | Optional | Enables webhook signature verification (`X-Hub-Signature-256`) |
+| `allowed_numbers` | Recommended | Allowed inbound numbers (`[]` = deny all, `"*"` = allow all) |
+
+WhatsApp Web mode (native client):
+
+| Key | Required | Purpose |
+|---|---|---|
+| `session_path` | Yes | Persistent SQLite session path |
+| `pair_phone` | Optional | Pair-code flow phone number (digits only) |
+| `pair_code` | Optional | Custom pair code (otherwise auto-generated) |
+| `allowed_numbers` | Recommended | Allowed inbound numbers (`[]` = deny all, `"*"` = allow all) |
+
+Notes:
+
+- WhatsApp Web requires build flag `whatsapp-web`.
+- If both Cloud and Web fields are present, Cloud mode wins for backward compatibility.
+
 ## `[hardware]`
 
 Hardware wizard configuration for physical-world access (STM32, probe, serial).

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2061,6 +2061,11 @@ pub async fn doctor_channels(config: Config) -> Result<()> {
     }
 
     if let Some(ref wa) = config.channels_config.whatsapp {
+        if wa.is_ambiguous_config() {
+            tracing::warn!(
+                "WhatsApp config has both phone_number_id and session_path set; preferring Cloud API mode. Remove one selector to avoid ambiguity."
+            );
+        }
         // Runtime negotiation: detect backend type from config
         match wa.backend_type() {
             "cloud" => {
@@ -2450,6 +2455,11 @@ pub async fn start_channels(config: Config) -> Result<()> {
     }
 
     if let Some(ref wa) = config.channels_config.whatsapp {
+        if wa.is_ambiguous_config() {
+            tracing::warn!(
+                "WhatsApp config has both phone_number_id and session_path set; preferring Cloud API mode. Remove one selector to avoid ambiguity."
+            );
+        }
         // Runtime negotiation: detect backend type from config
         match wa.backend_type() {
             "cloud" => {


### PR DESCRIPTION
## Summary
This PR deepens the existing WhatsApp Web implementation and closes core gaps from #965 so the feature is usable, safer, and documented end-to-end.

### What changed
- Fixed `whatsapp-web` feature build blocker by populating `ChannelMessage.thread_ts` in WhatsApp Web inbound events.
- Enforced allowlist semantics in WhatsApp Web to match channel policy (`[]` means deny-all, `"*"` means allow-all).
- Improved inbound handling:
  - Ignore empty/non-text payloads.
  - Reply target now uses the originating chat JID (DM/group-safe routing).
- Improved outbound handling:
  - Allowlist checks apply to plain phone-number recipients.
  - Direct JID recipients bypass phone-number allowlist normalization checks.
- Added ambiguity detection for WhatsApp config (`phone_number_id` + `session_path` both set).
  - Runtime logs explicit warning and preserves backward-compatible cloud precedence.
- Extended onboarding wizard with WhatsApp mode selection:
  - WhatsApp Web (QR/pair-code) flow
  - WhatsApp Business Cloud API flow
- Updated docs for dual backend support:
  - README setup section
  - channel reference mode matrix/behavior
  - config reference keys and precedence notes
- Normalized new/updated logs/comments to English-only wording.

## Root cause
The original implementation was partial: compile contract drift (`thread_ts`), policy mismatch around allowlists, ambiguous config behavior not surfaced, and onboarding/docs still mostly Cloud API-centric.

## Validation
### Build
- `cargo check --no-default-features --features whatsapp-web`

### Targeted tests
- `cargo test --no-default-features --features whatsapp-web whatsapp_web_ -- --nocapture`
  - `channels::whatsapp_web::tests::*` passed in both `lib` and `bin` targets.
- `cargo test --no-default-features --features whatsapp-web whatsapp_config_backend_type_ -- --nocapture`
  - `config::schema::tests::whatsapp_config_backend_type_cloud_precedence_when_ambiguous`
  - `config::schema::tests::whatsapp_config_backend_type_web`
  - passed in both `lib` and `bin` targets.

## Notes
- Existing warnings seen in this repository (unused imports/vars outside this diff) are unchanged by this PR.

Closes #965
