### PR TITLE
feat: reduce release binary size with opt-in heavy features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7607,7 +7607,6 @@ dependencies = [
  "dialoguer",
  "directories",
  "fantoccini",
- "futures",
  "futures-util",
  "glob",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,12 +88,12 @@ async-trait = "0.1"
 # HMAC-SHA256 (Zhipu/GLM JWT auth)
 ring = "0.17"
 
-# Protobuf encode/decode (Feishu WS long-connection frame codec)
-prost = { version = "0.14", default-features = false }
+# Protobuf encode/decode (Lark WS frame codec, WhatsApp storage)
+prost = { version = "0.14", default-features = false, optional = true }
 
 # Memory / persistence
 rusqlite = { version = "0.37", features = ["bundled"] }
-postgres = { version = "0.19", features = ["with-chrono-0_4"] }
+postgres = { version = "0.19", features = ["with-chrono-0_4"], optional = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
 chrono-tz = "0.10"
 cron = "0.15"
@@ -111,7 +111,6 @@ which = "7.0"
 # WebSocket client channels (Discord/Lark/DingTalk)
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
-futures = "0.3"
 regex = "1.10"
 hostname = "0.4.2"
 rustls = "0.23"
@@ -134,9 +133,9 @@ http-body-util = "0.1"
 # Use the blocking HTTP exporter client to avoid Tokio-reactor panics in
 # OpenTelemetry background batch threads when ZeroClaw emits spans/metrics from
 # non-Tokio contexts.
-opentelemetry = { version = "0.31", default-features = false, features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "metrics", "http-proto", "reqwest-blocking-client", "reqwest-rustls-webpki-roots"] }
+opentelemetry = { version = "0.31", default-features = false, features = ["trace", "metrics"], optional = true }
+opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace", "metrics"], optional = true }
+opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "metrics", "http-proto", "reqwest-blocking-client", "reqwest-rustls-webpki-roots"], optional = true }
 
 # Serial port for peripheral communication (STM32, etc.)
 tokio-serial = { version = "5", default-features = false, optional = true }
@@ -151,7 +150,6 @@ probe-rs = { version = "0.31", optional = true }
 
 # PDF extraction for datasheet RAG (optional, enable with --features rag-pdf)
 pdf-extract = { version = "0.10", optional = true }
-tokio-stream = { version = "0.1.18", features = ["full"] }
 
 # WhatsApp Web client (wa-rs) — optional, enable with --features whatsapp-web
 # Uses wa-rs for Bot and Client, wa-rs-core for storage traits, custom rusqlite backend avoids Diesel conflict.
@@ -172,9 +170,12 @@ landlock = { version = "0.4", optional = true }
 libc = "0.2"
 
 [features]
-default = ["hardware", "channel-matrix"]
+default = []
 hardware = ["nusb", "tokio-serial"]
 channel-matrix = ["dep:matrix-sdk"]
+channel-lark = ["dep:prost"]
+memory-postgres = ["dep:postgres"]
+observability-otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
 peripheral-rpi = ["rppal"]
 # Browser backend feature alias used by cfg(feature = "browser-native")
 browser-native = ["dep:fantoccini"]
@@ -190,11 +191,11 @@ probe = ["dep:probe-rs"]
 # rag-pdf = PDF ingestion for datasheet RAG
 rag-pdf = ["dep:pdf-extract"]
 # whatsapp-web = Native WhatsApp Web client with custom rusqlite storage backend
-whatsapp-web = ["dep:wa-rs", "dep:wa-rs-core", "dep:wa-rs-binary", "dep:wa-rs-proto", "dep:wa-rs-ureq-http", "dep:wa-rs-tokio-transport", "serde-big-array"]
+whatsapp-web = ["dep:wa-rs", "dep:wa-rs-core", "dep:wa-rs-binary", "dep:wa-rs-proto", "dep:wa-rs-ureq-http", "dep:wa-rs-tokio-transport", "dep:serde-big-array", "dep:prost"]
 
 [profile.release]
 opt-level = "z"      # Optimize for size
-lto = "thin"         # Lower memory use during release builds
+lto = "fat"          # Maximum cross-crate optimization for smaller binaries
 codegen-units = 1    # Serialized codegen for low-memory devices (e.g., Raspberry Pi 3 with 1GB RAM)
                      # Higher values (e.g., 8) compile faster but require more RAM during compilation
 strip = true          # Remove debug symbols
@@ -216,6 +217,7 @@ panic = "abort"
 [dev-dependencies]
 tempfile = "3.14"
 criterion = { version = "0.8", features = ["async_tokio"] }
+tokio-stream = { version = "0.1.18", default-features = false, features = ["fs"] }
 
 [[bench]]
 name = "agent_benchmarks"

--- a/docs/arduino-uno-q-setup.md
+++ b/docs/arduino-uno-q-setup.md
@@ -15,7 +15,7 @@ ZeroClaw includes everything needed for Arduino Uno Q. **Clone the repo and foll
 | Setup command | `src/peripherals/uno_q_setup.rs` | `zeroclaw peripheral setup-uno-q` deploys the Bridge via scp + arduino-app-cli |
 | Config schema | `board = "arduino-uno-q"`, `transport = "bridge"` | Supported in `config.toml` |
 
-Build with `--features hardware` (or the default features) to include Uno Q support.
+Build with `--features hardware` to include Uno Q support.
 
 ---
 
@@ -70,7 +70,7 @@ git clone https://github.com/theonlyhennygod/zeroclaw.git
 cd zeroclaw
 
 # Build (takes ~15–30 min on Uno Q)
-cargo build --release
+cargo build --release --features hardware
 
 # Install
 sudo cp target/release/zeroclaw /usr/local/bin/
@@ -87,7 +87,7 @@ brew tap messense/macos-cross-toolchains
 brew install aarch64-unknown-linux-gnu
 
 # Build
-CC_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnu-gcc cargo build --release --target aarch64-unknown-linux-gnu
+CC_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnu-gcc cargo build --release --target aarch64-unknown-linux-gnu --features hardware
 
 # Copy to Uno Q
 scp target/aarch64-unknown-linux-gnu/release/zeroclaw arduino@<UNO_Q_IP>:~/
@@ -200,7 +200,7 @@ Now when you message your Telegram bot *"Turn on the LED"* or *"Set pin 13 high"
 | 3 | `curl -sSf https://sh.rustup.rs \| sh -s -- -y && source ~/.cargo/env` |
 | 4 | `sudo apt-get install -y pkg-config libssl-dev` |
 | 5 | `git clone https://github.com/theonlyhennygod/zeroclaw.git && cd zeroclaw` |
-| 6 | `cargo build --release --no-default-features` |
+| 6 | `cargo build --release --features hardware` |
 | 7 | `zeroclaw onboard --api-key KEY --provider openrouter` |
 | 8 | Edit `~/.zeroclaw/config.toml` (add Telegram bot_token) |
 | 9 | `zeroclaw daemon --host 127.0.0.1 --port 3000` |
@@ -212,6 +212,6 @@ Now when you message your Telegram bot *"Turn on the LED"* or *"Set pin 13 high"
 
 - **"command not found: zeroclaw"** — Use full path: `/usr/local/bin/zeroclaw` or ensure `~/.cargo/bin` is in PATH.
 - **Telegram not responding** — Check bot_token, allowed_users, and that the Uno Q has internet (WiFi).
-- **Out of memory** — Use `--no-default-features` to reduce binary size; consider `compact_context = true`.
+- **Out of memory** — Keep features minimal (`--features hardware` for Uno Q); consider `compact_context = true`.
 - **GPIO commands ignored** — Ensure Bridge app is running (`zeroclaw peripheral setup-uno-q` deploys and starts it). Config must have `board = "arduino-uno-q"` and `transport = "bridge"`.
 - **LLM provider (GLM/Zhipu)** — Use `default_provider = "glm"` or `"zhipu"` with `GLM_API_KEY` in env or config. ZeroClaw uses the correct v4 endpoint.

--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -70,24 +70,30 @@ Operational notes:
 
 ## Channel Matrix
 
-### Build Feature Toggle (`channel-matrix`)
+### Build Feature Toggles (`channel-matrix`, `channel-lark`)
 
-Matrix support is controlled at compile time by the `channel-matrix` Cargo feature.
+Matrix and Lark support are controlled at compile time.
 
-- Default builds include Matrix support (`default = ["hardware", "channel-matrix"]`).
-- For faster local iteration when Matrix is not needed:
-
-```bash
-cargo check --no-default-features --features hardware
-```
-
-- To explicitly enable Matrix support in custom feature sets:
+- Default builds are lean (`default = []`) and do not include Matrix/Lark.
+- Typical local check with only hardware support:
 
 ```bash
-cargo check --no-default-features --features hardware,channel-matrix
+cargo check --features hardware
 ```
 
-If `[channels_config.matrix]` is present but the binary was built without `channel-matrix`, `zeroclaw channel list`, `zeroclaw channel doctor`, and `zeroclaw channel start` will log that Matrix is intentionally skipped for this build.
+- Enable Matrix explicitly when needed:
+
+```bash
+cargo check --features hardware,channel-matrix
+```
+
+- Enable Lark explicitly when needed:
+
+```bash
+cargo check --features hardware,channel-lark
+```
+
+If `[channels_config.matrix]` or `[channels_config.lark]` is present but the corresponding feature is not compiled in, `zeroclaw channel list`, `zeroclaw channel doctor`, and `zeroclaw channel start` will report that the channel is intentionally skipped for this build.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -69,7 +69,7 @@ CARGO_BUILD_JOBS=1 cargo build --release --locked
 1. Reduce heavy features when Matrix is not required:
 
 ```bash
-cargo build --release --locked --no-default-features --features hardware
+cargo build --release --locked --features hardware
 ```
 
 1. Cross-compile on a stronger machine and copy the binary to the target host.
@@ -100,15 +100,21 @@ The timing report is written to `target/cargo-timings/cargo-timing.html`.
 Faster local iteration (when Matrix channel is not needed):
 
 ```bash
-cargo check --no-default-features --features hardware
+cargo check
 ```
 
-This skips `channel-matrix` and can significantly reduce compile time.
+This uses the lean default feature set and can significantly reduce compile time.
 
 To build with Matrix support explicitly enabled:
 
 ```bash
-cargo check --no-default-features --features hardware,channel-matrix
+cargo check --features channel-matrix
+```
+
+To build with Matrix + Lark + hardware support:
+
+```bash
+cargo check --features hardware,channel-matrix,channel-lark
 ```
 
 Lock-contention mitigation:

--- a/src/channels/email_channel.rs
+++ b/src/channels/email_channel.rs
@@ -13,7 +13,7 @@ use async_imap::extensions::idle::IdleResponse;
 use async_imap::types::Fetch;
 use async_imap::Session;
 use async_trait::async_trait;
-use futures::TryStreamExt;
+use futures_util::TryStreamExt;
 use lettre::message::SinglePart;
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{Message, SmtpTransport, Transport};

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -20,6 +20,7 @@ pub mod discord;
 pub mod email_channel;
 pub mod imessage;
 pub mod irc;
+#[cfg(feature = "channel-lark")]
 pub mod lark;
 pub mod linq;
 #[cfg(feature = "channel-matrix")]
@@ -43,6 +44,7 @@ pub use discord::DiscordChannel;
 pub use email_channel::EmailChannel;
 pub use imessage::IMessageChannel;
 pub use irc::IrcChannel;
+#[cfg(feature = "channel-lark")]
 pub use lark::LarkChannel;
 pub use linq::LinqChannel;
 #[cfg(feature = "channel-matrix")]
@@ -2207,7 +2209,10 @@ pub async fn handle_command(command: crate::ChannelCommands, config: &Config) ->
                 ),
                 ("Email", config.channels_config.email.is_some()),
                 ("IRC", config.channels_config.irc.is_some()),
-                ("Lark", config.channels_config.lark.is_some()),
+                (
+                    "Lark",
+                    cfg!(feature = "channel-lark") && config.channels_config.lark.is_some(),
+                ),
                 ("DingTalk", config.channels_config.dingtalk.is_some()),
                 ("QQ", config.channels_config.qq.is_some()),
             ] {
@@ -2216,6 +2221,11 @@ pub async fn handle_command(command: crate::ChannelCommands, config: &Config) ->
             if !cfg!(feature = "channel-matrix") {
                 println!(
                     "  ℹ️ Matrix channel support is disabled in this build (enable `channel-matrix`)."
+                );
+            }
+            if !cfg!(feature = "channel-lark") {
+                println!(
+                    "  ℹ️ Lark channel support is disabled in this build (enable `channel-lark`)."
                 );
             }
             println!("\nTo start channels: zeroclaw channel start");
@@ -2437,8 +2447,16 @@ pub async fn doctor_channels(config: Config) -> Result<()> {
         ));
     }
 
+    #[cfg(feature = "channel-lark")]
     if let Some(ref lk) = config.channels_config.lark {
         channels.push(("Lark", Arc::new(LarkChannel::from_config(lk))));
+    }
+
+    #[cfg(not(feature = "channel-lark"))]
+    if config.channels_config.lark.is_some() {
+        tracing::warn!(
+            "Lark channel is configured but this build was compiled without `channel-lark`; skipping Lark health check."
+        );
     }
 
     if let Some(ref dt) = config.channels_config.dingtalk {
@@ -2831,8 +2849,16 @@ pub async fn start_channels(config: Config) -> Result<()> {
         })));
     }
 
+    #[cfg(feature = "channel-lark")]
     if let Some(ref lk) = config.channels_config.lark {
         channels.push(Arc::new(LarkChannel::from_config(lk)));
+    }
+
+    #[cfg(not(feature = "channel-lark"))]
+    if config.channels_config.lark.is_some() {
+        tracing::warn!(
+            "Lark channel is configured but this build was compiled without `channel-lark`; skipping Lark runtime startup."
+        );
     }
 
     if let Some(ref dt) = config.channels_config.dingtalk {

--- a/src/memory/backend.rs
+++ b/src/memory/backend.rs
@@ -52,7 +52,7 @@ const POSTGRES_PROFILE: MemoryBackendProfile = MemoryBackendProfile {
     auto_save_default: true,
     uses_sqlite_hygiene: false,
     sqlite_based: false,
-    optional_dependency: false,
+    optional_dependency: true,
 };
 
 const NONE_PROFILE: MemoryBackendProfile = MemoryBackendProfile {

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -6,6 +6,7 @@ pub mod hygiene;
 pub mod lucid;
 pub mod markdown;
 pub mod none;
+#[cfg(feature = "memory-postgres")]
 pub mod postgres;
 pub mod response_cache;
 pub mod snapshot;
@@ -21,6 +22,7 @@ pub use backend::{
 pub use lucid::LucidMemory;
 pub use markdown::MarkdownMemory;
 pub use none::NoneMemory;
+#[cfg(feature = "memory-postgres")]
 pub use postgres::PostgresMemory;
 pub use response_cache::ResponseCache;
 pub use sqlite::SqliteMemory;
@@ -29,6 +31,7 @@ pub use traits::Memory;
 pub use traits::{MemoryCategory, MemoryEntry};
 
 use crate::config::{EmbeddingRouteConfig, MemoryConfig, StorageProviderConfig};
+#[cfg(feature = "memory-postgres")]
 use anyhow::Context;
 use std::path::Path;
 use std::sync::Arc;
@@ -42,7 +45,7 @@ fn create_memory_with_builders<F, G>(
 ) -> anyhow::Result<Box<dyn Memory>>
 where
     F: FnMut() -> anyhow::Result<SqliteMemory>,
-    G: FnMut() -> anyhow::Result<PostgresMemory>,
+    G: FnMut() -> anyhow::Result<Box<dyn Memory>>,
 {
     match classify_memory_backend(backend_name) {
         MemoryBackendKind::Sqlite => Ok(Box::new(sqlite_builder()?)),
@@ -50,7 +53,7 @@ where
             let local = sqlite_builder()?;
             Ok(Box::new(LucidMemory::new(workspace_dir, local)))
         }
-        MemoryBackendKind::Postgres => Ok(Box::new(postgres_builder()?)),
+        MemoryBackendKind::Postgres => postgres_builder(),
         MemoryBackendKind::Markdown => Ok(Box::new(MarkdownMemory::new(workspace_dir))),
         MemoryBackendKind::None => Ok(Box::new(NoneMemory::new())),
         MemoryBackendKind::Unknown => {
@@ -260,9 +263,10 @@ pub fn create_memory_with_storage_and_routes(
         Ok(mem)
     }
 
+    #[cfg(feature = "memory-postgres")]
     fn build_postgres_memory(
         storage_provider: Option<&StorageProviderConfig>,
-    ) -> anyhow::Result<PostgresMemory> {
+    ) -> anyhow::Result<Box<dyn Memory>> {
         let storage_provider = storage_provider
             .context("memory backend 'postgres' requires [storage.provider.config] settings")?;
         let db_url = storage_provider
@@ -274,12 +278,22 @@ pub fn create_memory_with_storage_and_routes(
                 "memory backend 'postgres' requires [storage.provider.config].db_url (or dbURL)",
             )?;
 
-        PostgresMemory::new(
+        let memory = PostgresMemory::new(
             db_url,
             &storage_provider.schema,
             &storage_provider.table,
             storage_provider.connect_timeout_secs,
-        )
+        )?;
+        Ok(Box::new(memory))
+    }
+
+    #[cfg(not(feature = "memory-postgres"))]
+    fn build_postgres_memory(
+        _storage_provider: Option<&StorageProviderConfig>,
+    ) -> anyhow::Result<Box<dyn Memory>> {
+        anyhow::bail!(
+            "memory backend 'postgres' requested but this build was compiled without `memory-postgres`; rebuild with `--features memory-postgres`"
+        );
     }
 
     create_memory_with_builders(
@@ -461,7 +475,11 @@ mod tests {
         let error = create_memory_with_storage(&cfg, Some(&storage), tmp.path(), None)
             .err()
             .expect("postgres without db_url should be rejected");
-        assert!(error.to_string().contains("db_url"));
+        if cfg!(feature = "memory-postgres") {
+            assert!(error.to_string().contains("db_url"));
+        } else {
+            assert!(error.to_string().contains("memory-postgres"));
+        }
     }
 
     #[test]

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,6 +1,7 @@
 pub mod log;
 pub mod multi;
 pub mod noop;
+#[cfg(feature = "observability-otel")]
 pub mod otel;
 pub mod prometheus;
 pub mod traits;
@@ -11,6 +12,7 @@ pub use self::log::LogObserver;
 #[allow(unused_imports)]
 pub use self::multi::MultiObserver;
 pub use noop::NoopObserver;
+#[cfg(feature = "observability-otel")]
 pub use otel::OtelObserver;
 pub use prometheus::PrometheusObserver;
 pub use traits::{Observer, ObserverEvent};
@@ -25,6 +27,7 @@ pub fn create_observer(config: &ObservabilityConfig) -> Box<dyn Observer> {
         "log" => Box::new(LogObserver::new()),
         "prometheus" => Box::new(PrometheusObserver::new()),
         "otel" | "opentelemetry" | "otlp" => {
+            #[cfg(feature = "observability-otel")]
             match OtelObserver::new(
                 config.otel_endpoint.as_deref(),
                 config.otel_service_name.as_deref(),
@@ -43,6 +46,13 @@ pub fn create_observer(config: &ObservabilityConfig) -> Box<dyn Observer> {
                     tracing::error!("Failed to create OTel observer: {e}. Falling back to noop.");
                     Box::new(NoopObserver)
                 }
+            }
+            #[cfg(not(feature = "observability-otel"))]
+            {
+                tracing::warn!(
+                    "OpenTelemetry backend requested but this build was compiled without `observability-otel`; falling back to noop."
+                );
+                Box::new(NoopObserver)
             }
         }
         "none" | "noop" => Box::new(NoopObserver),
@@ -103,7 +113,12 @@ mod tests {
             otel_endpoint: Some("http://127.0.0.1:19999".into()),
             otel_service_name: Some("test".into()),
         };
-        assert_eq!(create_observer(&cfg).name(), "otel");
+        let expected = if cfg!(feature = "observability-otel") {
+            "otel"
+        } else {
+            "noop"
+        };
+        assert_eq!(create_observer(&cfg).name(), expected);
     }
 
     #[test]
@@ -113,7 +128,12 @@ mod tests {
             otel_endpoint: Some("http://127.0.0.1:19999".into()),
             otel_service_name: Some("test".into()),
         };
-        assert_eq!(create_observer(&cfg).name(), "otel");
+        let expected = if cfg!(feature = "observability-otel") {
+            "otel"
+        } else {
+            "noop"
+        };
+        assert_eq!(create_observer(&cfg).name(), expected);
     }
 
     #[test]
@@ -123,7 +143,12 @@ mod tests {
             otel_endpoint: Some("http://127.0.0.1:19999".into()),
             otel_service_name: Some("test".into()),
         };
-        assert_eq!(create_observer(&cfg).name(), "otel");
+        let expected = if cfg!(feature = "observability-otel") {
+            "otel"
+        } else {
+            "noop"
+        };
+        assert_eq!(create_observer(&cfg).name(), expected);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Closes #1063.

This PR reduces default release binary size by making heavy integrations explicit opt-in features and gating runtime wiring accordingly.

## What Changed
- `Cargo.toml`
  - Changed `default` features from `"hardware,channel-matrix"` to `[]`.
  - Added feature flags:
    - `channel-lark` (enables `prost`)
    - `memory-postgres` (enables `postgres`)
    - `observability-otel` (enables `opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp`)
  - Made dependencies optional: `prost`, `postgres`, `opentelemetry*`.
  - Removed direct `futures` dependency (kept `futures-util`).
  - Moved `tokio-stream` to `dev-dependencies` with minimal `fs` feature.
  - Added `prost` to `whatsapp-web` feature wiring for storage serialization.
  - Switched `[profile.release] lto` from `thin` to `fat` for maximum size optimization.
- `src/channels/mod.rs`
  - Added compile-time gating for Lark module/export.
  - `channel list` now reflects Lark feature availability.
  - `channel doctor` and `channel start` now warn and skip Lark when configured but not compiled.
- `src/observability/mod.rs`
  - Added compile-time gating for OTel module/export.
  - Observer factory falls back to `noop` with warning when OTel backend is requested but feature is not enabled.
  - Updated tests to validate both enabled/disabled feature behavior.
- `src/memory/mod.rs`, `src/memory/backend.rs`
  - Added compile-time gating for postgres module/export.
  - Memory factory returns a clear runtime error when backend is configured as `postgres` but feature is not compiled.
  - Marked postgres backend profile as `optional_dependency = true`.
  - Updated tests to account for feature-enabled/disabled behavior.
- `src/channels/email_channel.rs`
  - Replaced `futures::TryStreamExt` with `futures_util::TryStreamExt`.
- Docs
  - Updated feature-model guidance and commands:
    - `docs/channels-reference.md`
    - `docs/troubleshooting.md`
    - `docs/arduino-uno-q-setup.md`

## Binary Size Result (measured)
Measurement date: **February 20, 2026**

- Baseline binary (`target-size-baseline/release/zeroclaw`):
  - `17,452,304 bytes` (~17 MB)
- Optimized binary (`target-size-lean/release/zeroclaw`):
  - `8,020,496 bytes` (~7.6 MB)
- Reduction:
  - `9,431,808 bytes` (**54.04%** smaller)

## Verification
- `cargo fmt --all`
- `cargo check`
- `cargo check --features "hardware,channel-matrix,channel-lark,memory-postgres,observability-otel"`
- `cargo build --release` (size measurement)

## Compatibility Notes
- Existing configs that use Matrix/Lark/Postgres/OTel continue to work when the corresponding features are enabled at build time.
- Lean/default builds now intentionally skip those backends and emit explicit warnings/errors instead of silently failing.
