### PR TITLE
feat: add stdout-safe shell completions command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,6 +797,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7670,6 +7679,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "clap_complete",
  "console",
  "criterion",
  "cron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["command-line-utilities", "api-bindings"]
 [dependencies]
 # CLI - minimal and fast
 clap = { version = "4.5", features = ["derive"] }
+clap_complete = "4.5"
 
 # Async runtime - feature-optimized for size
 tokio = { version = "1.42", default-features = false, features = ["rt-multi-thread", "macros", "time", "net", "io-util", "sync", "process", "io-std", "fs", "signal"] }

--- a/README.md
+++ b/README.md
@@ -297,6 +297,10 @@ zeroclaw daemon
 zeroclaw status
 zeroclaw auth status
 
+# Generate shell completions (stdout only, safe to source directly)
+source <(zeroclaw completions bash)
+zeroclaw completions zsh > ~/.zfunc/_zeroclaw
+
 # Run system diagnostics
 zeroclaw doctor
 
@@ -882,6 +886,7 @@ See [aieos.org](https://aieos.org) for the full schema and live examples.
 | `integrations` | Inspect integration setup details |
 | `skills` | List/install/remove skills |
 | `migrate` | Import data from other runtimes (`migrate openclaw`) |
+| `completions` | Generate shell completion scripts (`bash`, `fish`, `zsh`, `powershell`, `elvish`) |
 | `hardware` | USB discover/introspect/info commands |
 | `peripheral` | Manage and flash hardware peripherals |
 

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -2,7 +2,7 @@
 
 This reference is derived from the current CLI surface (`zeroclaw --help`).
 
-Last verified: **February 19, 2026**.
+Last verified: **February 20, 2026**.
 
 ## Top-Level Commands
 
@@ -23,6 +23,7 @@ Last verified: **February 19, 2026**.
 | `skills` | List/install/remove skills |
 | `migrate` | Import from external runtimes (currently OpenClaw) |
 | `config` | Export machine-readable config schema |
+| `completions` | Generate shell completion scripts to stdout |
 | `hardware` | Discover and introspect USB hardware |
 | `peripheral` | Configure and flash peripherals |
 
@@ -124,6 +125,16 @@ Skill manifests (`SKILL.toml`) support `prompts` and `[[tools]]`; both are injec
 - `zeroclaw config schema`
 
 `config schema` prints a JSON Schema (draft 2020-12) for the full `config.toml` contract to stdout.
+
+### `completions`
+
+- `zeroclaw completions bash`
+- `zeroclaw completions fish`
+- `zeroclaw completions zsh`
+- `zeroclaw completions powershell`
+- `zeroclaw completions elvish`
+
+`completions` is stdout-only by design so scripts can be sourced directly without log/warning contamination.
 
 ### `hardware`
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: ZeroClaw did not expose a shell-completion command, and completion output would be unsafe to source if any logger/config warning reached stdout.
- Why it matters: `source <(zeroclaw completions bash)` fails when non-script text appears on stdout.
- What changed: added `zeroclaw completions <bash|fish|zsh|powershell|elvish>` using `clap_complete`, with an early-return execution path before logging/config initialization so output remains stdout-only completion script content.
- What did **not** change (scope boundary): no automatic installation/writing of completion files; users/package managers keep ownership of install paths.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `tool,docs,tests,dependencies`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `tool: shell`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto
- If any auto-label is incorrect, note requested correction: n/a

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #993
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): n/a
- Integrated scope by source PR (what was materially carried forward): n/a
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): n/a
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): n/a
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): n/a

## Validation Evidence (required)

Commands and result summary:

```bash
# Full bin test suite (no-default-features path)
CARGO_QUEUE_BYPASS=1 CARGO_QUEUE_ALLOW_BYPASS=1 RUSTUP_TOOLCHAIN=1.92.0-aarch64-apple-darwin \
  cargo test --no-default-features --bin zeroclaw \
  --config 'build.rustc-wrapper=""' \
  --config 'build.target-dir="/Users/chum/wt-issue-993-shell-completions-20260220/target-issue993-direct2"'

# New completion-path tests
cargo test --no-default-features --bin zeroclaw completions_ --config ...
cargo test --no-default-features --bin zeroclaw completion_generation_ --config ...

# Compile validation
cargo check --no-default-features --bin zeroclaw --config ...

# Formatting check on touched file (repo-wide fmt currently has pre-existing drift in unrelated files)
rustfmt --check --config skip_children=true src/main.rs
```

- Evidence provided (test/log/trace/screenshot/perf): full test run passed (`2386 passed; 0 failed`), focused completion tests passed, compile check passed.
- If any command is intentionally skipped, explain why: `cargo fmt --all -- --check` was executed and reports pre-existing formatting drift in unrelated files outside this issue scope; this PR keeps scope focused and does not include unrelated formatting churn.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: n/a

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no sensitive payloads added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: n/a

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - `zeroclaw completions <shell>` argument parsing for all supported shells.
  - completion generation includes binary name and is emitted via dedicated writer path.
  - command dispatch path returns before logging/config bootstrap to prevent output contamination.
- Edge cases checked:
  - unsupported shell values rejected by clap value enum.
  - completion command remains docs-aligned across README and command reference.
- What was not verified:
  - shell-specific installation paths/package-manager integration (out of scope by issue design).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: CLI command parsing/dispatch, docs command reference.
- Potential unintended effects: minimal; only new subcommand path added, existing command paths unchanged.
- Guardrails/monitoring for early detection: unit tests for parse and generation, plus full bin test suite pass.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `gh`, local cargo/rustfmt toolchain.
- Workflow/plan summary (if any): issue triage -> isolated worktree -> implementation -> full test/compile validation -> docs updates -> draft PR.
- Verification focus: stdout-only completion generation and command-path isolation from logger/config side effects.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `f2e91ff` (or PR rollback) to remove `completions` command and dependency.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: completion command unavailable or output contamination if reverted incorrectly.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: completion generation path could accidentally regress to logging/config-initialized flow in future refactors.
  - Mitigation: explicit early-return branch in `main` and dedicated tests around completion command parsing/output generation.
