### PR TITLE
fix(onboard): require explicit confirmation before overwriting existing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,9 @@ zeroclaw onboard --api-key sk-... --provider openrouter [--model "openrouter/aut
 # Or interactive wizard
 zeroclaw onboard --interactive
 
+# If config.toml already exists and you intentionally want to overwrite it
+zeroclaw onboard --force
+
 # Or quickly repair channels/allowlists only
 zeroclaw onboard --channels-only
 

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -34,8 +34,16 @@ Last verified: **February 20, 2026**.
 - `zeroclaw onboard`
 - `zeroclaw onboard --interactive`
 - `zeroclaw onboard --channels-only`
+- `zeroclaw onboard --force`
 - `zeroclaw onboard --api-key <KEY> --provider <ID> --memory <sqlite|lucid|markdown|none>`
 - `zeroclaw onboard --api-key <KEY> --provider <ID> --model <MODEL_ID> --memory <sqlite|lucid|markdown|none>`
+- `zeroclaw onboard --api-key <KEY> --provider <ID> --model <MODEL_ID> --memory <sqlite|lucid|markdown|none> --force`
+
+`onboard` safety behavior:
+
+- If `config.toml` already exists, `onboard` asks for explicit confirmation before overwrite.
+- In non-interactive environments, existing `config.toml` causes a safe refusal unless `--force` is passed.
+- Use `zeroclaw onboard --channels-only` when you only need to rotate channel tokens/allowlists.
 
 ### `agent`
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -15,12 +15,14 @@ For first-time setup and quick orientation.
 | I have an API key, want fastest setup | `zeroclaw onboard --api-key sk-... --provider openrouter` |
 | I want guided prompts | `zeroclaw onboard --interactive` |
 | Config exists, just fix channels | `zeroclaw onboard --channels-only` |
+| Config exists, I intentionally want full overwrite | `zeroclaw onboard --force` |
 | Using subscription auth | See [Subscription Auth](../../README.md#subscription-auth-openai-codex--claude-code) |
 
 ## Onboarding and Validation
 
 - Quick onboarding: `zeroclaw onboard --api-key "sk-..." --provider openrouter`
 - Interactive onboarding: `zeroclaw onboard --interactive`
+- Existing config protection: reruns require explicit confirmation (or `--force` in non-interactive flows)
 - Ollama cloud models (`:cloud`) require a remote `api_url` and API key (for example `api_url = "https://ollama.com"`).
 - Validate environment: `zeroclaw status` + `zeroclaw doctor`
 

--- a/src/integrations/mod.rs
+++ b/src/integrations/mod.rs
@@ -107,7 +107,7 @@ fn show_integration_info(config: &Config, name: &str) -> Result<()> {
             println!("  Setup:");
             println!("    1. Message @BotFather on Telegram");
             println!("    2. Create a bot and copy the token");
-            println!("    3. Run: zeroclaw onboard");
+            println!("    3. Run: zeroclaw onboard --channels-only");
             println!("    4. Start: zeroclaw channel start");
         }
         "Discord" => {
@@ -115,13 +115,13 @@ fn show_integration_info(config: &Config, name: &str) -> Result<()> {
             println!("    1. Go to https://discord.com/developers/applications");
             println!("    2. Create app → Bot → Copy token");
             println!("    3. Enable MESSAGE CONTENT intent");
-            println!("    4. Run: zeroclaw onboard");
+            println!("    4. Run: zeroclaw onboard --channels-only");
         }
         "Slack" => {
             println!("  Setup:");
             println!("    1. Go to https://api.slack.com/apps");
             println!("    2. Create app → Bot Token Scopes → Install");
-            println!("    3. Run: zeroclaw onboard");
+            println!("    3. Run: zeroclaw onboard --channels-only");
         }
         "OpenRouter" => {
             println!("  Setup:");

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,10 @@ enum Commands {
         #[arg(long)]
         interactive: bool,
 
+        /// Overwrite existing config without confirmation
+        #[arg(long)]
+        force: bool,
+
         /// Reconfigure channels only (fast repair flow)
         #[arg(long)]
         channels_only: bool,
@@ -748,6 +752,7 @@ async fn main() -> Result<()> {
     // not allowed", we run the wizard on a blocking thread via spawn_blocking.
     if let Commands::Onboard {
         interactive,
+        force,
         channels_only,
         api_key,
         provider,
@@ -756,6 +761,7 @@ async fn main() -> Result<()> {
     } = &cli.command
     {
         let interactive = *interactive;
+        let force = *force;
         let channels_only = *channels_only;
         let api_key = api_key.clone();
         let provider = provider.clone();
@@ -770,16 +776,20 @@ async fn main() -> Result<()> {
         {
             bail!("--channels-only does not accept --api-key, --provider, --model, or --memory");
         }
+        if channels_only && force {
+            bail!("--channels-only does not accept --force");
+        }
         let config = if channels_only {
             onboard::run_channels_repair_wizard().await
         } else if interactive {
-            onboard::run_wizard().await
+            onboard::run_wizard(force).await
         } else {
             onboard::run_quick_setup(
                 api_key.as_deref(),
                 provider.as_deref(),
                 model.as_deref(),
                 memory.as_deref(),
+                force,
             )
             .await
         }?;
@@ -1527,6 +1537,7 @@ mod tests {
         match cli.command {
             Commands::Onboard {
                 interactive,
+                force,
                 channels_only,
                 api_key,
                 provider,
@@ -1534,6 +1545,7 @@ mod tests {
                 ..
             } => {
                 assert!(!interactive);
+                assert!(!force);
                 assert!(!channels_only);
                 assert_eq!(provider.as_deref(), Some("openrouter"));
                 assert_eq!(model.as_deref(), Some("custom-model-946"));
@@ -1565,5 +1577,16 @@ mod tests {
             script.contains("zeroclaw"),
             "completion script should reference binary name"
         );
+    }
+
+    #[test]
+    fn onboard_cli_accepts_force_flag() {
+        let cli = Cli::try_parse_from(["zeroclaw", "onboard", "--force"])
+            .expect("onboard --force should parse");
+
+        match cli.command {
+            Commands::Onboard { force, .. } => assert!(force),
+            other => panic!("expected onboard command, got {other:?}"),
+        }
     }
 }

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeSet;
 use std::fs;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -98,7 +99,7 @@ fn has_launchable_channels(channels: &ChannelsConfig) -> bool {
 
 // ── Main wizard entry point ──────────────────────────────────────
 
-pub async fn run_wizard() -> Result<Config> {
+pub async fn run_wizard(force: bool) -> Result<Config> {
     println!("{}", style(BANNER).cyan().bold());
 
     println!(
@@ -115,6 +116,7 @@ pub async fn run_wizard() -> Result<Config> {
 
     print_step(1, 9, "Workspace Setup");
     let (workspace_dir, config_path) = setup_workspace()?;
+    ensure_onboard_overwrite_allowed(&config_path, force)?;
 
     print_step(2, 9, "AI Provider & API Key");
     let (provider, api_key, model, provider_api_url) = setup_provider(&workspace_dir)?;
@@ -332,6 +334,7 @@ pub async fn run_quick_setup(
     provider: Option<&str>,
     model_override: Option<&str>,
     memory_backend: Option<&str>,
+    force: bool,
 ) -> Result<Config> {
     let home = directories::UserDirs::new()
         .map(|u| u.home_dir().to_path_buf())
@@ -342,6 +345,7 @@ pub async fn run_quick_setup(
         provider,
         model_override,
         memory_backend,
+        force,
         &home,
     )
     .await
@@ -353,6 +357,7 @@ async fn run_quick_setup_with_home(
     provider: Option<&str>,
     model_override: Option<&str>,
     memory_backend: Option<&str>,
+    force: bool,
     home: &Path,
 ) -> Result<Config> {
     println!("{}", style(BANNER).cyan().bold());
@@ -368,6 +373,7 @@ async fn run_quick_setup_with_home(
     let workspace_dir = zeroclaw_dir.join("workspace");
     let config_path = zeroclaw_dir.join("config.toml");
 
+    ensure_onboard_overwrite_allowed(&config_path, force)?;
     fs::create_dir_all(&workspace_dir).context("Failed to create workspace directory")?;
 
     let provider_name = provider.unwrap_or("openrouter").to_string();
@@ -1614,6 +1620,42 @@ fn print_step(current: u8, total: u8, title: &str) {
 
 fn print_bullet(text: &str) {
     println!("  {} {}", style("›").cyan(), text);
+}
+
+fn ensure_onboard_overwrite_allowed(config_path: &Path, force: bool) -> Result<()> {
+    if !config_path.exists() {
+        return Ok(());
+    }
+
+    if force {
+        println!(
+            "  {} Existing config detected at {}. Proceeding because --force was provided.",
+            style("!").yellow().bold(),
+            style(config_path.display()).yellow()
+        );
+        return Ok(());
+    }
+
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        bail!(
+            "Refusing to overwrite existing config at {} in non-interactive mode. Re-run with --force if overwrite is intentional.",
+            config_path.display()
+        );
+    }
+
+    let confirmed = Confirm::new()
+        .with_prompt(format!(
+            "  Existing config found at {}. Re-running onboarding will overwrite config.toml and may create missing workspace files (including BOOTSTRAP.md). Continue?",
+            config_path.display()
+        ))
+        .default(false)
+        .interact()?;
+
+    if !confirmed {
+        bail!("Onboarding canceled: existing configuration was left unchanged.");
+    }
+
+    Ok(())
 }
 
 async fn persist_workspace_selection(config_path: &Path) -> Result<()> {
@@ -4943,6 +4985,7 @@ mod tests {
             Some("openrouter"),
             Some("custom-model-946"),
             Some("sqlite"),
+            false,
             tmp.path(),
         )
         .await
@@ -4966,6 +5009,7 @@ mod tests {
             Some("anthropic"),
             None,
             Some("sqlite"),
+            false,
             tmp.path(),
         )
         .await
@@ -4974,6 +5018,67 @@ mod tests {
         let expected = default_model_for_provider("anthropic");
         assert_eq!(config.default_provider.as_deref(), Some("anthropic"));
         assert_eq!(config.default_model.as_deref(), Some(expected.as_str()));
+    }
+
+    #[tokio::test]
+    async fn quick_setup_existing_config_requires_force_when_non_interactive() {
+        let tmp = TempDir::new().unwrap();
+        let zeroclaw_dir = tmp.path().join(".zeroclaw");
+        let config_path = zeroclaw_dir.join("config.toml");
+
+        tokio::fs::create_dir_all(&zeroclaw_dir).await.unwrap();
+        tokio::fs::write(&config_path, "default_provider = \"openrouter\"\n")
+            .await
+            .unwrap();
+
+        let err = run_quick_setup_with_home(
+            Some("sk-existing"),
+            Some("openrouter"),
+            Some("custom-model"),
+            Some("sqlite"),
+            false,
+            tmp.path(),
+        )
+        .await
+        .expect_err("quick setup should refuse overwrite without --force");
+
+        let err_text = err.to_string();
+        assert!(err_text.contains("Refusing to overwrite existing config"));
+        assert!(err_text.contains("--force"));
+    }
+
+    #[tokio::test]
+    async fn quick_setup_existing_config_overwrites_with_force() {
+        let tmp = TempDir::new().unwrap();
+        let zeroclaw_dir = tmp.path().join(".zeroclaw");
+        let config_path = zeroclaw_dir.join("config.toml");
+
+        tokio::fs::create_dir_all(&zeroclaw_dir).await.unwrap();
+        tokio::fs::write(
+            &config_path,
+            "default_provider = \"anthropic\"\ndefault_model = \"stale-model\"\n",
+        )
+        .await
+        .unwrap();
+
+        let config = run_quick_setup_with_home(
+            Some("sk-force"),
+            Some("openrouter"),
+            Some("custom-model-fresh"),
+            Some("sqlite"),
+            true,
+            tmp.path(),
+        )
+        .await
+        .expect("quick setup should overwrite existing config with --force");
+
+        assert_eq!(config.default_provider.as_deref(), Some("openrouter"));
+        assert_eq!(config.default_model.as_deref(), Some("custom-model-fresh"));
+        assert_eq!(config.api_key.as_deref(), Some("sk-force"));
+
+        let config_raw = tokio::fs::read_to_string(config.config_path).await.unwrap();
+        assert!(config_raw.contains("default_provider = \"openrouter\""));
+        assert!(config_raw.contains("default_model = \"custom-model-fresh\""));
     }
 
     // ── scaffold_workspace: basic file creation ─────────────────


### PR DESCRIPTION
## Summary
- add an explicit overwrite guard for `zeroclaw onboard` when `config.toml` already exists
- add `--force` for intentional overwrite in non-interactive flows
- reject invalid flag combination: `zeroclaw onboard --channels-only --force`
- update integration guidance to use `zeroclaw onboard --channels-only` instead of full onboarding
- document overwrite safety behavior in command/getting-started docs

## Root Cause
`onboard` always regenerated `config.toml` (and could recreate missing workspace scaffolding such as `BOOTSTRAP.md`) without a confirmation gate when a config already existed.

## Fix Details
- interactive onboarding (`zeroclaw onboard --interactive`): prompts before overwrite unless `--force`
- quick onboarding: refuses overwrite in non-interactive contexts unless `--force`
- `--force` prints an explicit acknowledgment message before proceeding
- channels-only flow remains isolated and no longer recommends full onboarding from integration info help text

## Validation
Executed in isolated worktree `/Users/chum/wt-issue-1034-deep-clean`:

- `cargo test --locked --bin zeroclaw onboard_cli_accepts_force_flag -- --nocapture` ✅
- `cargo test --locked --lib quick_setup_existing_config_requires_force_when_non_interactive -- --nocapture` ✅
- `cargo test --locked --lib quick_setup_existing_config_overwrites_with_force -- --nocapture` ✅

(There is an existing unrelated warning in `src/tools/composio.rs` about an unused variable; no failures.)

## Issue
Closes #1034