### PR TITLE
feat(delegate): agentic delegate mode with safe tool-loop wiring

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -88,6 +88,15 @@ Delegate sub-agent configurations. Each key under `[agents]` defines a named sub
 | `api_key` | unset | Optional API key override (stored encrypted when `secrets.encrypt = true`) |
 | `temperature` | unset | Temperature override for the sub-agent |
 | `max_depth` | `3` | Max recursion depth for nested delegation |
+| `agentic` | `false` | Enable multi-turn tool-call loop mode for the sub-agent |
+| `allowed_tools` | `[]` | Tool allowlist for agentic mode |
+| `max_iterations` | `10` | Max tool-call iterations for agentic mode |
+
+Notes:
+
+- `agentic = false` preserves existing single prompt→response delegate behavior.
+- `agentic = true` requires at least one matching entry in `allowed_tools`.
+- The `delegate` tool is excluded from sub-agent allowlists to prevent re-entrant delegation loops.
 
 ```toml
 [agents.researcher]
@@ -95,6 +104,9 @@ provider = "openrouter"
 model = "anthropic/claude-sonnet-4-6"
 system_prompt = "You are a research assistant."
 max_depth = 2
+agentic = true
+allowed_tools = ["web_search", "http_request", "file_read"]
+max_iterations = 8
 
 [agents.coder]
 provider = "ollama"

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -208,10 +208,23 @@ pub struct DelegateAgentConfig {
     /// Max recursion depth for nested delegation
     #[serde(default = "default_max_depth")]
     pub max_depth: u32,
+    /// Enable agentic sub-agent mode (multi-turn tool-call loop).
+    #[serde(default)]
+    pub agentic: bool,
+    /// Allowlist of tool names available to the sub-agent in agentic mode.
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+    /// Maximum tool-call iterations in agentic mode.
+    #[serde(default = "default_max_tool_iterations")]
+    pub max_iterations: usize,
 }
 
 fn default_max_depth() -> u32 {
     3
+}
+
+fn default_max_tool_iterations() -> usize {
+    10
 }
 
 // ── Hardware Config (wizard-driven) ─────────────────────────────
@@ -4062,6 +4075,9 @@ tool_dispatcher = "xml"
                 api_key: Some("agent-credential".into()),
                 temperature: None,
                 max_depth: 3,
+                agentic: false,
+                allowed_tools: Vec::new(),
+                max_iterations: 10,
             },
         );
 

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -1072,6 +1072,9 @@ mod tests {
                 api_key: None,
                 temperature: None,
                 max_depth: 3,
+                agentic: false,
+                allowed_tools: Vec::new(),
+                max_iterations: 10,
             },
         );
         config.agents.insert(
@@ -1083,6 +1086,9 @@ mod tests {
                 api_key: None,
                 temperature: None,
                 max_depth: 3,
+                agentic: false,
+                allowed_tools: Vec::new(),
+                max_iterations: 10,
             },
         );
 

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -1,6 +1,8 @@
 use super::traits::{Tool, ToolResult};
+use crate::agent::loop_::run_tool_call_loop;
 use crate::config::DelegateAgentConfig;
-use crate::providers::{self, Provider};
+use crate::observability::traits::{Observer, ObserverEvent, ObserverMetric};
+use crate::providers::{self, ChatMessage, Provider};
 use crate::security::policy::ToolOperation;
 use crate::security::SecurityPolicy;
 use async_trait::async_trait;
@@ -11,6 +13,8 @@ use std::time::Duration;
 
 /// Default timeout for sub-agent provider calls.
 const DELEGATE_TIMEOUT_SECS: u64 = 120;
+/// Default timeout for agentic sub-agent runs.
+const DELEGATE_AGENTIC_TIMEOUT_SECS: u64 = 300;
 
 /// Tool that delegates a subtask to a named agent with a different
 /// provider/model configuration. Enables multi-agent workflows where
@@ -25,6 +29,10 @@ pub struct DelegateTool {
     provider_runtime_options: providers::ProviderRuntimeOptions,
     /// Depth at which this tool instance lives in the delegation chain.
     depth: u32,
+    /// Parent tool registry for agentic sub-agents.
+    parent_tools: Arc<Vec<Arc<dyn Tool>>>,
+    /// Inherited multimodal handling config for sub-agent loops.
+    multimodal_config: crate::config::MultimodalConfig,
 }
 
 impl DelegateTool {
@@ -53,6 +61,8 @@ impl DelegateTool {
             fallback_credential,
             provider_runtime_options,
             depth: 0,
+            parent_tools: Arc::new(Vec::new()),
+            multimodal_config: crate::config::MultimodalConfig::default(),
         }
     }
 
@@ -87,7 +97,21 @@ impl DelegateTool {
             fallback_credential,
             provider_runtime_options,
             depth,
+            parent_tools: Arc::new(Vec::new()),
+            multimodal_config: crate::config::MultimodalConfig::default(),
         }
+    }
+
+    /// Attach parent tools used to build sub-agent allowlist registries.
+    pub fn with_parent_tools(mut self, parent_tools: Arc<Vec<Arc<dyn Tool>>>) -> Self {
+        self.parent_tools = parent_tools;
+        self
+    }
+
+    /// Attach multimodal configuration for sub-agent tool loops.
+    pub fn with_multimodal_config(mut self, config: crate::config::MultimodalConfig) -> Self {
+        self.multimodal_config = config;
+        self
     }
 }
 
@@ -100,7 +124,7 @@ impl Tool for DelegateTool {
     fn description(&self) -> &str {
         "Delegate a subtask to a specialized agent. Use when: a task benefits from a different model \
          (e.g. fast summarization, deep reasoning, code generation). The sub-agent runs a single \
-         prompt and returns its response."
+         prompt by default; with agentic=true it can iterate with a filtered tool-call loop."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -251,6 +275,19 @@ impl Tool for DelegateTool {
 
         let temperature = agent_config.temperature.unwrap_or(0.7);
 
+        // Agentic mode: run full tool-call loop with allowlisted tools.
+        if agent_config.agentic {
+            return self
+                .execute_agentic(
+                    agent_name,
+                    agent_config,
+                    &*provider,
+                    &full_prompt,
+                    temperature,
+                )
+                .await;
+        }
+
         // Wrap the provider call in a timeout to prevent indefinite blocking
         let result = tokio::time::timeout(
             Duration::from_secs(DELEGATE_TIMEOUT_SECS),
@@ -302,10 +339,165 @@ impl Tool for DelegateTool {
     }
 }
 
+impl DelegateTool {
+    async fn execute_agentic(
+        &self,
+        agent_name: &str,
+        agent_config: &DelegateAgentConfig,
+        provider: &dyn Provider,
+        full_prompt: &str,
+        temperature: f64,
+    ) -> anyhow::Result<ToolResult> {
+        if agent_config.allowed_tools.is_empty() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Agent '{agent_name}' has agentic=true but allowed_tools is empty"
+                )),
+            });
+        }
+
+        let allowed = agent_config
+            .allowed_tools
+            .iter()
+            .map(|name| name.trim())
+            .filter(|name| !name.is_empty())
+            .collect::<std::collections::HashSet<_>>();
+
+        let sub_tools: Vec<Box<dyn Tool>> = self
+            .parent_tools
+            .iter()
+            .filter(|tool| allowed.contains(tool.name()))
+            .filter(|tool| tool.name() != "delegate")
+            .map(|tool| Box::new(ToolArcRef::new(tool.clone())) as Box<dyn Tool>)
+            .collect();
+
+        if sub_tools.is_empty() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Agent '{agent_name}' has no executable tools after filtering allowlist ({})",
+                    agent_config.allowed_tools.join(", ")
+                )),
+            });
+        }
+
+        let mut history = Vec::new();
+        if let Some(system_prompt) = agent_config.system_prompt.as_ref() {
+            history.push(ChatMessage::system(system_prompt.clone()));
+        }
+        history.push(ChatMessage::user(full_prompt.to_string()));
+
+        let noop_observer = NoopObserver;
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(DELEGATE_AGENTIC_TIMEOUT_SECS),
+            run_tool_call_loop(
+                provider,
+                &mut history,
+                &sub_tools,
+                &noop_observer,
+                &agent_config.provider,
+                &agent_config.model,
+                temperature,
+                true,
+                None,
+                "delegate",
+                &self.multimodal_config,
+                agent_config.max_iterations,
+                None,
+                None,
+            ),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(response)) => {
+                let rendered = if response.trim().is_empty() {
+                    "[Empty response]".to_string()
+                } else {
+                    response
+                };
+
+                Ok(ToolResult {
+                    success: true,
+                    output: format!(
+                        "[Agent '{agent_name}' ({provider}/{model}, agentic)]\n{rendered}",
+                        provider = agent_config.provider,
+                        model = agent_config.model
+                    ),
+                    error: None,
+                })
+            }
+            Ok(Err(e)) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Agent '{agent_name}' failed: {e}")),
+            }),
+            Err(_) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Agent '{agent_name}' timed out after {DELEGATE_AGENTIC_TIMEOUT_SECS}s"
+                )),
+            }),
+        }
+    }
+}
+
+struct ToolArcRef {
+    inner: Arc<dyn Tool>,
+}
+
+impl ToolArcRef {
+    fn new(inner: Arc<dyn Tool>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl Tool for ToolArcRef {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn description(&self) -> &str {
+        self.inner.description()
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        self.inner.parameters_schema()
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        self.inner.execute(args).await
+    }
+}
+
+struct NoopObserver;
+
+impl Observer for NoopObserver {
+    fn record_event(&self, _event: &ObserverEvent) {}
+
+    fn record_metric(&self, _metric: &ObserverMetric) {}
+
+    fn name(&self) -> &str {
+        "noop"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::providers::{ChatRequest, ChatResponse, ToolCall};
     use crate::security::{AutonomyLevel, SecurityPolicy};
+    use anyhow::anyhow;
 
     fn test_security() -> Arc<SecurityPolicy> {
         Arc::new(SecurityPolicy::default())
@@ -322,6 +514,9 @@ mod tests {
                 api_key: None,
                 temperature: Some(0.3),
                 max_depth: 3,
+                agentic: false,
+                allowed_tools: Vec::new(),
+                max_iterations: 10,
             },
         );
         agents.insert(
@@ -333,9 +528,157 @@ mod tests {
                 api_key: Some("delegate-test-credential".to_string()),
                 temperature: None,
                 max_depth: 2,
+                agentic: false,
+                allowed_tools: Vec::new(),
+                max_iterations: 10,
             },
         );
         agents
+    }
+
+    #[derive(Default)]
+    struct EchoTool;
+
+    #[async_trait]
+    impl Tool for EchoTool {
+        fn name(&self) -> &str {
+            "echo_tool"
+        }
+
+        fn description(&self) -> &str {
+            "Echoes the `value` argument."
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "value": {"type": "string"}
+                },
+                "required": ["value"]
+            })
+        }
+
+        async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+            let value = args
+                .get("value")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            Ok(ToolResult {
+                success: true,
+                output: format!("echo:{value}"),
+                error: None,
+            })
+        }
+    }
+
+    struct OneToolThenFinalProvider;
+
+    #[async_trait]
+    impl Provider for OneToolThenFinalProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            Ok("unused".to_string())
+        }
+
+        async fn chat(
+            &self,
+            request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<ChatResponse> {
+            let has_tool_message = request.messages.iter().any(|m| m.role == "tool");
+            if has_tool_message {
+                Ok(ChatResponse {
+                    text: Some("done".to_string()),
+                    tool_calls: Vec::new(),
+                })
+            } else {
+                Ok(ChatResponse {
+                    text: None,
+                    tool_calls: vec![ToolCall {
+                        id: "call_1".to_string(),
+                        name: "echo_tool".to_string(),
+                        arguments: "{\"value\":\"ping\"}".to_string(),
+                    }],
+                })
+            }
+        }
+    }
+
+    struct InfiniteToolCallProvider;
+
+    #[async_trait]
+    impl Provider for InfiniteToolCallProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            Ok("unused".to_string())
+        }
+
+        async fn chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<ChatResponse> {
+            Ok(ChatResponse {
+                text: None,
+                tool_calls: vec![ToolCall {
+                    id: "loop".to_string(),
+                    name: "echo_tool".to_string(),
+                    arguments: "{\"value\":\"x\"}".to_string(),
+                }],
+            })
+        }
+    }
+
+    struct FailingProvider;
+
+    #[async_trait]
+    impl Provider for FailingProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            Ok("unused".to_string())
+        }
+
+        async fn chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<ChatResponse> {
+            Err(anyhow!("provider boom"))
+        }
+    }
+
+    fn agentic_config(allowed_tools: Vec<String>, max_iterations: usize) -> DelegateAgentConfig {
+        DelegateAgentConfig {
+            provider: "openrouter".to_string(),
+            model: "model-test".to_string(),
+            system_prompt: Some("You are agentic.".to_string()),
+            api_key: Some("delegate-test-credential".to_string()),
+            temperature: Some(0.2),
+            max_depth: 3,
+            agentic: true,
+            allowed_tools,
+            max_iterations,
+        }
     }
 
     #[test]
@@ -440,6 +783,9 @@ mod tests {
                 api_key: None,
                 temperature: None,
                 max_depth: 3,
+                agentic: false,
+                allowed_tools: Vec::new(),
+                max_iterations: 10,
             },
         );
         let tool = DelegateTool::new(agents, None, test_security());
@@ -543,6 +889,9 @@ mod tests {
                 api_key: None,
                 temperature: None,
                 max_depth: 3,
+                agentic: false,
+                allowed_tools: Vec::new(),
+                max_iterations: 10,
             },
         );
         let tool = DelegateTool::new(agents, None, test_security());
@@ -575,6 +924,9 @@ mod tests {
                 api_key: None,
                 temperature: None,
                 max_depth: 3,
+                agentic: false,
+                allowed_tools: Vec::new(),
+                max_iterations: 10,
             },
         );
         let tool = DelegateTool::new(agents, None, test_security());
@@ -610,5 +962,133 @@ mod tests {
             .unwrap();
         assert!(!result.success);
         assert!(result.error.unwrap().contains("none configured"));
+    }
+
+    #[tokio::test]
+    async fn agentic_mode_rejects_empty_allowed_tools() {
+        let mut agents = HashMap::new();
+        agents.insert("agentic".to_string(), agentic_config(Vec::new(), 10));
+
+        let tool = DelegateTool::new(agents, None, test_security());
+        let result = tool
+            .execute(json!({"agent": "agentic", "prompt": "test"}))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("allowed_tools is empty"));
+    }
+
+    #[tokio::test]
+    async fn agentic_mode_rejects_unmatched_allowed_tools() {
+        let mut agents = HashMap::new();
+        agents.insert(
+            "agentic".to_string(),
+            agentic_config(vec!["missing_tool".to_string()], 10),
+        );
+
+        let tool = DelegateTool::new(agents, None, test_security())
+            .with_parent_tools(Arc::new(vec![Arc::new(EchoTool)]));
+        let result = tool
+            .execute(json!({"agent": "agentic", "prompt": "test"}))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("no executable tools"));
+    }
+
+    #[tokio::test]
+    async fn execute_agentic_runs_tool_call_loop_with_filtered_tools() {
+        let config = agentic_config(vec!["echo_tool".to_string()], 10);
+        let tool = DelegateTool::new(HashMap::new(), None, test_security()).with_parent_tools(
+            Arc::new(vec![
+                Arc::new(EchoTool),
+                Arc::new(DelegateTool::new(HashMap::new(), None, test_security())),
+            ]),
+        );
+
+        let provider = OneToolThenFinalProvider;
+        let result = tool
+            .execute_agentic("agentic", &config, &provider, "run", 0.2)
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(result.output.contains("(openrouter/model-test, agentic)"));
+        assert!(result.output.contains("done"));
+    }
+
+    #[tokio::test]
+    async fn execute_agentic_excludes_delegate_even_if_allowlisted() {
+        let config = agentic_config(vec!["delegate".to_string()], 10);
+        let tool = DelegateTool::new(HashMap::new(), None, test_security()).with_parent_tools(
+            Arc::new(vec![Arc::new(DelegateTool::new(
+                HashMap::new(),
+                None,
+                test_security(),
+            ))]),
+        );
+
+        let provider = OneToolThenFinalProvider;
+        let result = tool
+            .execute_agentic("agentic", &config, &provider, "run", 0.2)
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("no executable tools"));
+    }
+
+    #[tokio::test]
+    async fn execute_agentic_respects_max_iterations() {
+        let config = agentic_config(vec!["echo_tool".to_string()], 2);
+        let tool = DelegateTool::new(HashMap::new(), None, test_security())
+            .with_parent_tools(Arc::new(vec![Arc::new(EchoTool)]));
+
+        let provider = InfiniteToolCallProvider;
+        let result = tool
+            .execute_agentic("agentic", &config, &provider, "run", 0.2)
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("maximum tool iterations (2)"));
+    }
+
+    #[tokio::test]
+    async fn execute_agentic_propagates_provider_errors() {
+        let config = agentic_config(vec!["echo_tool".to_string()], 10);
+        let tool = DelegateTool::new(HashMap::new(), None, test_security())
+            .with_parent_tools(Arc::new(vec![Arc::new(EchoTool)]));
+
+        let provider = FailingProvider;
+        let result = tool
+            .execute_agentic("agentic", &config, &provider, "run", 0.2)
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("provider boom"));
     }
 }


### PR DESCRIPTION
## Summary
- add `agentic`, `allowed_tools`, and `max_iterations` to `DelegateAgentConfig` with serde defaults
- add full agentic sub-agent tool-call loop path in `DelegateTool` when `agentic = true`
- wire delegate with parent tool registry using safe Arc wrappers (no raw-pointer unsafe forwarding)
- enforce strict tool allowlist filtering and exclude `delegate` to prevent re-entrant loops
- add and extend tests for agentic execution path and tool registry wiring
- document new agent config fields in config reference

## Why
Current delegate behavior only supports one prompt -> one response. Multi-step subtasks need iterative tool calls to avoid bouncing control back to the parent LLM each step.

## Safety Notes
- no unsafe raw pointer forwarding in tool wiring
- `delegate` is excluded from sub-agent allowlists to avoid nested re-entrant delegate loops
- agentic mode remains opt-in via config (`agentic = false` default)

## Validation
- `rustup run 1.92.0 cargo check --locked --config 'build.rustc-wrapper=""' --config 'build.target-dir="/Users/chum/.tmp/zc-target-issue1047-rustup192"'`
- `rustup run 1.92.0 cargo test --locked --no-default-features --config 'build.rustc-wrapper=""' --config 'build.target-dir="/Users/chum/.tmp/zc-target-issue1047-rustup192"' tools::delegate::tests -- --nocapture`
- `rustup run 1.92.0 cargo test --locked --no-default-features --config 'build.rustc-wrapper=""' --config 'build.target-dir="/Users/chum/.tmp/zc-target-issue1047-rustup192"' config::schema::tests::config_save_encrypts_nested_credentials -- --nocapture`
- `rustup run 1.92.0 cargo test --locked --no-default-features --config 'build.rustc-wrapper=""' --config 'build.target-dir="/Users/chum/.tmp/zc-target-issue1047-rustup192"' doctor::tests::config_validation_reports_delegate_agents_in_sorted_order -- --nocapture`
- `rustup run 1.92.0 cargo test --locked --no-default-features --config 'build.rustc-wrapper=""' --config 'build.target-dir="/Users/chum/.tmp/zc-target-issue1047-rustup192"' tools::tests::all_tools_includes_delegate_when_agents_configured -- --nocapture`
- `rustup run 1.92.0 cargo test --locked --no-default-features --config 'build.rustc-wrapper=""' --config 'build.target-dir="/Users/chum/.tmp/zc-target-issue1047-rustup192"' tools::tests::all_tools_excludes_delegate_when_no_agents -- --nocapture`

Closes #1047