### PR TITLE
fix(lark): refresh tenant token on Feishu 99991663 responses

### DIFF
--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -312,6 +312,12 @@ The wizard now includes a dedicated **Lark/Feishu** step with:
 - receive mode selection (`websocket` or `webhook`)
 - optional webhook verification token prompt (recommended for stronger callback authenticity checks)
 
+Runtime token behavior:
+
+- `tenant_access_token` is cached with a refresh deadline based on `expire`/`expires_in` from the auth response.
+- send requests automatically retry once after token invalidation when Feishu/Lark returns either HTTP `401` or business error code `99991663` (`Invalid access token`).
+- if the retry still returns token-invalid responses, the send call fails with the upstream status/body for easier troubleshooting.
+
 ### 4.12 DingTalk
 
 ```toml


### PR DESCRIPTION
## Summary
- fix Lark/Feishu tenant token lifecycle so cached `tenant_access_token` is refreshed before expiry
- treat Feishu business error `code=99991663` as token-invalid (in addition to HTTP 401) and retry send once with a fresh token
- validate Lark send success by both HTTP status and response business code
- document runtime token refresh/retry behavior in channel docs

## Root cause
Lark channel cached tenant token indefinitely and only retried on HTTP 401.
Feishu often returns HTTP 200 with body `code=99991663` for expired/invalid access token, so retry logic never executed and the channel stayed broken until restart.

## What changed
- replace token cache type with value + refresh deadline metadata
- derive refresh deadline from `expire` / `expires_in` (with skew + fallback TTL)
- add response helpers to detect token-invalid body code and enforce business-level send success
- in `send`, retry once after cache invalidation when response is HTTP 401 or `code=99991663`
- add focused unit tests for token refresh decision, TTL extraction, refresh deadline, and send response validation
- add docs note in `docs/channels-reference.md` for runtime token behavior

## Validation
- `cargo fmt -- src/channels/lark.rs`
- attempted focused test run:
  - `cargo test lark_ensure_send_success_rejects_non_zero_code -- --exact --nocapture`
- local test execution is currently blocked by unrelated existing test compile issues on `main`:
  - `src/cron/scheduler.rs` tests use `test_config(&tmp)` without `.await`
  - `src/gateway/mod.rs` test imports `rand::Rng` but calls `.random()` (requires `RngExt`)
  - these are outside this issue scope and pre-existing

Closes #1049
