### PR TITLE
fix(ci): sync release publishing with GHCR and add runbook

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -3,21 +3,129 @@ name: Pub Release
 on:
     push:
         tags: ["v*"]
+    workflow_dispatch:
+        inputs:
+            release_ref:
+                description: "Git ref (branch, tag, or SHA) to build"
+                required: false
+                default: "main"
+                type: string
+            publish_release:
+                description: "Publish a GitHub release (false = verification build only)"
+                required: false
+                default: false
+                type: boolean
+            release_tag:
+                description: "Existing release tag (required when publish_release=true), e.g. v0.1.1"
+                required: false
+                default: ""
+                type: string
+            draft:
+                description: "Create release as draft (manual publish only)"
+                required: false
+                default: true
+                type: boolean
+    schedule:
+        # Weekly release-readiness verification on default branch (no publish)
+        - cron: "17 8 * * 1"
 
 concurrency:
-    group: release
+    group: release-${{ github.ref || github.run_id }}
     cancel-in-progress: false
 
 permissions:
     contents: write
+    packages: read
     id-token: write # Required for cosign keyless signing via OIDC
 
 env:
     CARGO_TERM_COLOR: always
 
 jobs:
+    prepare:
+        name: Prepare Release Context
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        outputs:
+            release_ref: ${{ steps.vars.outputs.release_ref }}
+            release_tag: ${{ steps.vars.outputs.release_tag }}
+            publish_release: ${{ steps.vars.outputs.publish_release }}
+            draft_release: ${{ steps.vars.outputs.draft_release }}
+        steps:
+            - name: Resolve release inputs
+              id: vars
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  event_name="${GITHUB_EVENT_NAME}"
+                  publish_release="false"
+                  draft_release="false"
+                  semver_pattern='^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'
+
+                  if [[ "$event_name" == "push" ]]; then
+                    release_ref="${GITHUB_REF_NAME}"
+                    release_tag="${GITHUB_REF_NAME}"
+                    publish_release="true"
+                  elif [[ "$event_name" == "workflow_dispatch" ]]; then
+                    release_ref="${{ inputs.release_ref }}"
+                    publish_release="${{ inputs.publish_release }}"
+                    draft_release="${{ inputs.draft }}"
+
+                    if [[ "$publish_release" == "true" ]]; then
+                      release_tag="${{ inputs.release_tag }}"
+                      if [[ -z "$release_tag" ]]; then
+                        echo "::error::release_tag is required when publish_release=true"
+                        exit 1
+                      fi
+                      release_ref="$release_tag"
+                    else
+                      release_tag="verify-${GITHUB_SHA::12}"
+                    fi
+                  else
+                    # schedule
+                    release_ref="main"
+                    release_tag="verify-${GITHUB_SHA::12}"
+                  fi
+
+                  if [[ "$publish_release" == "true" ]]; then
+                    if [[ ! "$release_tag" =~ $semver_pattern ]]; then
+                      echo "::error::release_tag must match semver-like format (vX.Y.Z[-suffix])"
+                      exit 1
+                    fi
+                    if ! git ls-remote --exit-code --tags "https://github.com/${GITHUB_REPOSITORY}.git" "refs/tags/${release_tag}" >/dev/null; then
+                      echo "::error::Tag ${release_tag} does not exist on origin. Push the tag first, then rerun manual publish."
+                      exit 1
+                    fi
+
+                    # Guardrail: release tags must resolve to commits already reachable from main.
+                    tmp_repo="$(mktemp -d)"
+                    trap 'rm -rf "$tmp_repo"' EXIT
+                    git -C "$tmp_repo" init -q
+                    git -C "$tmp_repo" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+                    git -C "$tmp_repo" fetch --quiet --filter=blob:none origin main "refs/tags/${release_tag}:refs/tags/${release_tag}"
+                    if ! git -C "$tmp_repo" merge-base --is-ancestor "refs/tags/${release_tag}" "origin/main"; then
+                      echo "::error::Tag ${release_tag} is not reachable from origin/main. Release tags must be cut from main."
+                      exit 1
+                    fi
+                  fi
+
+                  echo "release_ref=${release_ref}" >> "$GITHUB_OUTPUT"
+                  echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
+                  echo "publish_release=${publish_release}" >> "$GITHUB_OUTPUT"
+                  echo "draft_release=${draft_release}" >> "$GITHUB_OUTPUT"
+
+                  {
+                    echo "### Release Context"
+                    echo "- event: ${event_name}"
+                    echo "- release_ref: ${release_ref}"
+                    echo "- release_tag: ${release_tag}"
+                    echo "- publish_release: ${publish_release}"
+                    echo "- draft_release: ${draft_release}"
+                  } >> "$GITHUB_STEP_SUMMARY"
+
     build-release:
         name: Build ${{ matrix.target }}
+        needs: [prepare]
         runs-on: ${{ matrix.os }}
         timeout-minutes: 40
         strategy:
@@ -69,9 +177,12 @@ jobs:
 
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  ref: ${{ needs.prepare.outputs.release_ref }}
 
             - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
               with:
+                  toolchain: 1.92.0
                   targets: ${{ matrix.target }}
 
             - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
@@ -136,13 +247,53 @@ jobs:
                   path: zeroclaw-${{ matrix.target }}.${{ matrix.archive_ext }}
                   retention-days: 7
 
+    verify-artifacts:
+        name: Verify Artifact Set
+        needs: [prepare, build-release]
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        steps:
+            - name: Download all artifacts
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  path: artifacts
+
+            - name: Validate expected archives
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  expected=(
+                    "zeroclaw-x86_64-unknown-linux-gnu.tar.gz"
+                    "zeroclaw-aarch64-unknown-linux-gnu.tar.gz"
+                    "zeroclaw-armv7-unknown-linux-gnueabihf.tar.gz"
+                    "zeroclaw-x86_64-apple-darwin.tar.gz"
+                    "zeroclaw-aarch64-apple-darwin.tar.gz"
+                    "zeroclaw-x86_64-pc-windows-msvc.zip"
+                  )
+
+                  missing=0
+                  for file in "${expected[@]}"; do
+                    if ! find artifacts -type f -name "$file" -print -quit | grep -q .; then
+                      echo "::error::Missing release archive: $file"
+                      missing=1
+                    fi
+                  done
+
+                  if [ "$missing" -ne 0 ]; then
+                    exit 1
+                  fi
+
+                  echo "All expected release archives are present."
+
     publish:
         name: Publish Release
-        needs: build-release
+        if: needs.prepare.outputs.publish_release == 'true'
+        needs: [prepare, verify-artifacts]
         runs-on: blacksmith-2vcpu-ubuntu-2404
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  ref: ${{ needs.prepare.outputs.release_ref }}
 
             - name: Download all artifacts
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -173,19 +324,56 @@ jobs:
               uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
 
             - name: Sign artifacts with cosign (keyless)
+              shell: bash
               run: |
-                  for file in artifacts/**/*; do
-                    [ -f "$file" ] || continue
+                  set -euo pipefail
+                  while IFS= read -r -d '' file; do
                     cosign sign-blob --yes \
                       --oidc-issuer=https://token.actions.githubusercontent.com \
                       --output-signature="${file}.sig" \
                       --output-certificate="${file}.pem" \
                       "$file"
+                  done < <(find artifacts -type f ! -name '*.sig' ! -name '*.pem' -print0)
+
+            - name: Verify GHCR release tag availability
+              shell: bash
+              env:
+                  RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+              run: |
+                  set -euo pipefail
+                  repo="${GITHUB_REPOSITORY,,}"
+                  manifest_url="https://ghcr.io/v2/${repo}/manifests/${RELEASE_TAG}"
+                  accept_header="application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json"
+                  max_attempts=18
+                  sleep_seconds=20
+
+                  for attempt in $(seq 1 "$max_attempts"); do
+                    code="$(curl -sS -o /tmp/ghcr-release-manifest.json -w "%{http_code}" \
+                      -u "${GITHUB_ACTOR}:${{ secrets.GITHUB_TOKEN }}" \
+                      -H "Accept: ${accept_header}" \
+                      "${manifest_url}" || true)"
+
+                    if [ "$code" = "200" ]; then
+                      echo "GHCR release tag is available: ${repo}:${RELEASE_TAG}"
+                      exit 0
+                    fi
+
+                    if [ "$attempt" -lt "$max_attempts" ]; then
+                      echo "Waiting for GHCR tag ${repo}:${RELEASE_TAG} (attempt ${attempt}/${max_attempts}, HTTP ${code})..."
+                      sleep "$sleep_seconds"
+                    fi
                   done
+
+                  echo "::error::GHCR tag ${repo}:${RELEASE_TAG} was not available before release publish timeout."
+                  cat /tmp/ghcr-release-manifest.json || true
+                  exit 1
 
             - name: Create GitHub Release
               uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
               with:
+                  tag_name: ${{ needs.prepare.outputs.release_tag }}
+                  target_commitish: ${{ needs.prepare.outputs.release_ref }}
+                  draft: ${{ needs.prepare.outputs.draft_release == 'true' }}
                   generate_release_notes: true
                   files: |
                       artifacts/**/*

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -37,6 +37,7 @@ Last refreshed: **February 18, 2026**.
 
 - [operations/README.md](operations/README.md)
 - [operations-runbook.md](operations-runbook.md)
+- [release-process.md](release-process.md)
 - [troubleshooting.md](troubleshooting.md)
 - [network-deployment.md](network-deployment.md)
 - [mattermost-setup.md](mattermost-setup.md)

--- a/docs/ci-map.md
+++ b/docs/ci-map.md
@@ -30,7 +30,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - `.github/workflows/sec-codeql.yml` (`CodeQL Analysis`)
     - Purpose: scheduled/manual static analysis for security findings
 - `.github/workflows/pub-release.yml` (`Release`)
-    - Purpose: build tagged release artifacts and publish GitHub releases
+    - Purpose: build release artifacts in verification mode (manual/scheduled) and publish GitHub releases on tag push or manual publish mode
 - `.github/workflows/pr-label-policy-check.yml` (`Label Policy Sanity`)
     - Purpose: validate shared contributor-tier policy in `.github/label-policy.json` and ensure label workflows consume that policy
 - `.github/workflows/test-rust-build.yml` (`Rust Reusable Job`)
@@ -67,7 +67,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 
 - `CI`: push to `main`, PRs to `main`
 - `Docker`: push to `main` when Docker build inputs change, tag push (`v*`), matching PRs, manual dispatch
-- `Release`: tag push (`v*`)
+- `Release`: tag push (`v*`), weekly schedule (verification-only), manual dispatch (verification or publish)
 - `Security Audit`: push to `main`, PRs to `main`, weekly schedule
 - `Workflow Sanity`: PR/push when `.github/workflows/**`, `.github/*.yml`, or `.github/*.yaml` change
 - `PR Intake Checks`: `pull_request_target` on opened/reopened/synchronize/edited/ready_for_review
@@ -82,7 +82,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 
 1. `CI Required Gate` failing: start with `.github/workflows/ci-run.yml`.
 2. Docker failures on PRs: inspect `.github/workflows/pub-docker-img.yml` `pr-smoke` job.
-3. Release failures on tags: inspect `.github/workflows/pub-release.yml`.
+3. Release failures (tag/manual/scheduled): inspect `.github/workflows/pub-release.yml` and the `prepare` job outputs.
 4. Security failures: inspect `.github/workflows/sec-audit.yml` and `deny.toml`.
 5. Workflow syntax/lint failures: inspect `.github/workflows/workflow-sanity.yml`.
 6. PR intake failures: inspect `.github/workflows/pr-intake-checks.yml` sticky comment and run logs.
@@ -93,6 +93,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 ## Maintenance Rules
 
 - Keep merge-blocking checks deterministic and reproducible (`--locked` where applicable).
+- Follow `docs/release-process.md` for verify-before-publish release cadence and tag discipline.
 - Keep merge-blocking rust quality policy aligned across `.github/workflows/ci-run.yml`, `dev/ci.sh`, and `.githooks/pre-push` (`./scripts/ci/rust_quality_gate.sh` + `./scripts/ci/rust_strict_delta_gate.sh`).
 - Use `./scripts/ci/rust_strict_delta_gate.sh` (or `./dev/ci.sh lint-delta`) as the incremental strict merge gate for changed Rust lines.
 - Run full strict lint audits regularly via `./scripts/ci/rust_quality_gate.sh --strict` (for example through `./dev/ci.sh lint-strict`) and track cleanup in focused PRs.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -5,6 +5,7 @@ For operators running ZeroClaw in persistent or production-like environments.
 ## Core Operations
 
 - Day-2 runbook: [../operations-runbook.md](../operations-runbook.md)
+- Release runbook: [../release-process.md](../release-process.md)
 - Troubleshooting matrix: [../troubleshooting.md](../troubleshooting.md)
 - Safe network/gateway deployment: [../network-deployment.md](../network-deployment.md)
 - Mattermost setup (channel-specific): [../mattermost-setup.md](../mattermost-setup.md)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,112 @@
+# ZeroClaw Release Process
+
+This runbook defines the maintainers' standard release flow.
+
+Last verified: **February 20, 2026**.
+
+## Release Goals
+
+- Keep releases predictable and repeatable.
+- Publish only from code already in `main`.
+- Verify multi-target artifacts before publish.
+- Keep release cadence regular even with high PR volume.
+
+## Standard Cadence
+
+- Patch/minor releases: weekly or bi-weekly.
+- Emergency security fixes: out-of-band.
+- Never wait for very large commit batches to accumulate.
+
+## Workflow Contract
+
+Release automation lives in:
+
+- `.github/workflows/pub-release.yml`
+
+Modes:
+
+- Tag push `v*`: publish mode.
+- Manual dispatch: verification-only or publish mode.
+- Weekly schedule: verification-only mode.
+
+Publish-mode guardrails:
+
+- Tag must match semver-like format `vX.Y.Z[-suffix]`.
+- Tag must already exist on origin.
+- Tag commit must be reachable from `origin/main`.
+- Matching GHCR image tag (`ghcr.io/<owner>/<repo>:<tag>`) must be available before GitHub Release publish completes.
+- Artifacts are verified before publish.
+
+## Maintainer Procedure
+
+### 1) Preflight on `main`
+
+1. Ensure required checks are green on latest `main`.
+2. Confirm no high-priority incidents or known regressions are open.
+3. Confirm installer and Docker workflows are healthy on recent `main` commits.
+
+### 2) Run verification build (no publish)
+
+Run `Pub Release` manually:
+
+- `publish_release`: `false`
+- `release_ref`: `main`
+
+Expected outcome:
+
+- Full target matrix builds successfully.
+- `verify-artifacts` confirms all expected archives exist.
+- No GitHub Release is published.
+
+### 3) Cut release tag
+
+From a clean local checkout synced to `origin/main`:
+
+```bash
+scripts/release/cut_release_tag.sh vX.Y.Z --push
+```
+
+This script enforces:
+
+- clean working tree
+- `HEAD == origin/main`
+- non-duplicate tag
+- semver-like tag format
+
+### 4) Monitor publish run
+
+After tag push, monitor:
+
+1. `Pub Release` publish mode
+2. `Pub Docker Img` publish job
+
+Expected publish outputs:
+
+- release archives
+- `SHA256SUMS`
+- `CycloneDX` and `SPDX` SBOMs
+- cosign signatures/certificates
+- GitHub Release notes + assets
+
+### 5) Post-release validation
+
+1. Verify GitHub Release assets are downloadable.
+2. Verify GHCR tags for the released version and `latest`.
+3. Verify install paths that rely on release assets (for example bootstrap binary download).
+
+## Emergency / Recovery Path
+
+If tag-push release fails after artifacts are validated:
+
+1. Fix workflow or packaging issue on `main`.
+2. Re-run manual `Pub Release` in publish mode with:
+   - `publish_release=true`
+   - `release_tag=<existing tag>`
+   - `release_ref` is automatically pinned to `release_tag` in publish mode
+3. Re-validate released assets.
+
+## Operational Notes
+
+- Keep release changes small and reversible.
+- Prefer one release issue/checklist per version so handoff is clear.
+- Avoid publishing from ad-hoc feature branches.

--- a/scripts/release/cut_release_tag.sh
+++ b/scripts/release/cut_release_tag.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/release/cut_release_tag.sh <tag> [--push]
+
+Create an annotated release tag from the current checkout.
+
+Requirements:
+- tag must match vX.Y.Z (optional suffix like -rc.1)
+- working tree must be clean
+- HEAD must match origin/main
+- tag must not already exist locally or on origin
+
+Options:
+  --push   Push the tag to origin after creating it
+USAGE
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 1
+fi
+
+TAG="$1"
+PUSH_TAG="false"
+if [[ $# -eq 2 ]]; then
+  if [[ "$2" != "--push" ]]; then
+    usage
+    exit 1
+  fi
+  PUSH_TAG="true"
+fi
+
+SEMVER_PATTERN='^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'
+if [[ ! "$TAG" =~ $SEMVER_PATTERN ]]; then
+  echo "error: tag must match vX.Y.Z or vX.Y.Z-suffix (received: $TAG)" >&2
+  exit 1
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: run this script inside the git repository" >&2
+  exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "error: working tree is not clean; commit or stash changes first" >&2
+  exit 1
+fi
+
+echo "Fetching origin/main and tags..."
+git fetch --quiet origin main --tags
+
+HEAD_SHA="$(git rev-parse HEAD)"
+MAIN_SHA="$(git rev-parse origin/main)"
+if [[ "$HEAD_SHA" != "$MAIN_SHA" ]]; then
+  echo "error: HEAD ($HEAD_SHA) is not origin/main ($MAIN_SHA)." >&2
+  echo "hint: checkout/update main before cutting a release tag." >&2
+  exit 1
+fi
+
+if git show-ref --tags --verify --quiet "refs/tags/$TAG"; then
+  echo "error: tag already exists locally: $TAG" >&2
+  exit 1
+fi
+
+if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+  echo "error: tag already exists on origin: $TAG" >&2
+  exit 1
+fi
+
+MESSAGE="zeroclaw $TAG"
+git tag -a "$TAG" -m "$MESSAGE"
+echo "Created annotated tag: $TAG"
+
+if [[ "$PUSH_TAG" == "true" ]]; then
+  git push origin "$TAG"
+  echo "Pushed tag to origin: $TAG"
+  echo "GitHub release pipeline will run via .github/workflows/pub-release.yml"
+else
+  echo "Next step: git push origin $TAG"
+fi


### PR DESCRIPTION
## Summary
- expand release workflow to support verify-only/manual/scheduled modes
- enforce publish guardrails (valid tag, tag exists, tag reachable from main)
- gate GitHub release publish on matching GHCR tag availability
- add release process runbook and release tag helper script
- update CI/release docs to reflect the new flow

## Validation
- workflow YAML parse check passed for all workflows
- workflow tab check passed
- bash syntax check passed for scripts/release/cut_release_tag.sh

## Risk / Rollback
- Risk: low-medium (workflow behavior and docs)
- Rollback: revert this PR commit to restore prior release workflow behavior