### PR TITLE
feat: add remote docker image pull support

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,9 @@ cd zeroclaw
 
 # Optional: run bootstrap + onboarding fully in Docker
 ./bootstrap.sh --docker
+
+# Optional: in --docker mode, skip local image build and use local tag or pull fallback image
+./bootstrap.sh --docker --skip-build
 ```
 
 Remote one-liner (review first in security-sensitive environments):

--- a/README.vi.md
+++ b/README.vi.md
@@ -233,6 +233,9 @@ cd zeroclaw
 
 # Tùy chọn: chạy bootstrap + onboarding hoàn toàn trong Docker
 ./bootstrap.sh --docker
+
+# Tùy chọn: ở chế độ --docker, bỏ qua build image local và dùng tag local hoặc pull image fallback
+./bootstrap.sh --docker --skip-build
 ```
 
 Cài từ xa bằng một lệnh (nên xem trước nếu môi trường nhạy cảm về bảo mật):

--- a/docs/one-click-bootstrap.md
+++ b/docs/one-click-bootstrap.md
@@ -95,6 +95,10 @@ If you run Option B outside a repository checkout, the bootstrap script automati
 This builds a local ZeroClaw image and launches onboarding inside a container while
 persisting config/workspace to `./.zeroclaw-docker`.
 
+If you add `--skip-build`, bootstrap skips local image build. It first tries the local
+Docker tag (`ZEROCLAW_DOCKER_IMAGE`, default: `zeroclaw-bootstrap:local`); if missing,
+it pulls `ghcr.io/zeroclaw-labs/zeroclaw:latest` and tags it locally before running.
+
 ### Quick onboarding (non-interactive)
 
 ```bash
@@ -117,7 +121,7 @@ ZEROCLAW_API_KEY="sk-..." ZEROCLAW_PROVIDER="openrouter" ./bootstrap.sh --onboar
 
 - `--install-system-deps`
 - `--install-rust`
-- `--skip-build`
+- `--skip-build` (in `--docker` mode: use local image if present, otherwise pull `ghcr.io/zeroclaw-labs/zeroclaw:latest`)
 - `--skip-install`
 - `--provider <id>`
 


### PR DESCRIPTION
This pull request improves the Docker onboarding experience by adding a new option to skip building the Docker image locally and instead use an existing local image or pull a fallback image from a remote registry. The documentation and help text are updated to reflect this new workflow, making onboarding more flexible and robust, especially in environments where building images locally is not feasible.

**Docker onboarding improvements:**

* Added support for `--skip-build` in Docker mode: if the local image (`ZEROCLAW_DOCKER_IMAGE`, default: `zeroclaw-bootstrap:local`) is not found, the script now pulls the official fallback image (`ghcr.io/zeroclaw-labs/zeroclaw:latest`) and tags it locally before running. [[1]](diffhunk://#diff-ad8a239f2d9110a9929810a189865ad0515e31355df3088588fccbb94879ce4fL565-R567) [[2]](diffhunk://#diff-ad8a239f2d9110a9929810a189865ad0515e31355df3088588fccbb94879ce4fR587-R599)

**Documentation updates:**

* Updated `README.md`, `README.vi.md`, and `docs/one-click-bootstrap.md` to document the new `--skip-build` option in Docker mode, including details on image selection and fallback behavior. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236-R238) [[2]](diffhunk://#diff-301d8c84eee3cf002a75a53a34ea5cb1ef2c03891ff71bfa43dd5483c913d126R236-R238) [[3]](diffhunk://#diff-1ce779458dab6c31c6527e547c26bb8159dee8df203c4995279c96d3a5a492d3R98-R101) [[4]](diffhunk://#diff-1ce779458dab6c31c6527e547c26bb8159dee8df203c4995279c96d3a5a492d3L120-R124)
* Clarified the help text in `scripts/bootstrap.sh` to specify that `--skip-build` skips both the Rust build and Docker image build steps.## Summary

Describe this PR in 2-5 bullets:

- Problem: Add a new option to skip building the Docker image locally and instead use an existing local image or pull a fallback image from a remote registry.
- Why it matters: it helps prevent low performance device with extremely low ram and cpu overhead to install without having to build the image itself
- What changed: Slight changes in documentation and bootstraps script
- What did **not** change (scope boundary): other core functionality

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): medium
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): XS
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): onboard
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): none
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`):
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- File system access scope changed? (`Yes/No`)
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any):
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: None
  - Mitigation:
