### PR TITLE
feat(provider): add first-class llama.cpp provider flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Every subsystem is a **trait** — swap implementations with a config change, ze
 
 | Subsystem | Trait | Ships with | Extend |
 |-----------|-------|------------|--------|
-| **AI Models** | `Provider` | Provider catalog via `zeroclaw providers` (currently 28 built-ins + aliases, plus custom endpoints) | `custom:https://your-api.com` (OpenAI-compatible) or `anthropic-custom:https://your-api.com` |
+| **AI Models** | `Provider` | Provider catalog via `zeroclaw providers` (currently 29 built-ins + aliases, plus custom endpoints) | `custom:https://your-api.com` (OpenAI-compatible) or `anthropic-custom:https://your-api.com` |
 | **Channels** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Email, IRC, Lark, DingTalk, QQ, Webhook | Any messaging API |
 | **Memory** | `Memory` | SQLite hybrid search, PostgreSQL backend (configurable storage provider), Lucid bridge, Markdown files, explicit `none` backend, snapshot/hydrate, optional response cache | Any persistence backend |
 | **Tools** | `Tool` | shell/file/memory, cron/schedule, git, pushover, browser, http_request, screenshot/image_info, composio (opt-in), delegate, hardware tools | Any capability |
@@ -721,6 +721,26 @@ default_provider = "ollama"
 default_model = "qwen3:cloud"
 api_url = "https://ollama.com"
 api_key = "ollama_api_key_here"
+```
+
+### llama.cpp Server Endpoint
+
+ZeroClaw now supports `llama-server` as a first-class local provider:
+
+- Provider ID: `llamacpp` (alias: `llama.cpp`)
+- Default endpoint: `http://localhost:8080/v1`
+- API key is optional unless your server is started with `--api-key`
+
+Example setup:
+
+```bash
+llama-server -hf ggml-org/gpt-oss-20b-GGUF --jinja -c 133000 --host 127.0.0.1 --port 8033
+```
+
+```toml
+default_provider = "llamacpp"
+api_url = "http://127.0.0.1:8033/v1"
+default_model = "ggml-org/gpt-oss-20b-GGUF"
 ```
 
 ### Custom Provider Endpoints

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -2,7 +2,7 @@
 
 This reference is derived from the current CLI surface (`zeroclaw --help`).
 
-Last verified: **February 19, 2026**.
+Last verified: **February 20, 2026**.
 
 ## Top-Level Commands
 
@@ -74,7 +74,7 @@ Last verified: **February 19, 2026**.
 - `zeroclaw models refresh --provider <ID>`
 - `zeroclaw models refresh --force`
 
-`models refresh` currently supports live catalog refresh for provider IDs: `openrouter`, `openai`, `anthropic`, `groq`, `mistral`, `deepseek`, `xai`, `together-ai`, `gemini`, `ollama`, `astrai`, `venice`, `fireworks`, `cohere`, `moonshot`, `glm`, `zai`, `qwen`, and `nvidia`.
+`models refresh` currently supports live catalog refresh for provider IDs: `openrouter`, `openai`, `anthropic`, `groq`, `mistral`, `deepseek`, `xai`, `together-ai`, `gemini`, `ollama`, `llamacpp`, `astrai`, `venice`, `fireworks`, `cohere`, `moonshot`, `glm`, `zai`, `qwen`, and `nvidia`.
 
 ### `channel`
 

--- a/docs/custom-providers.md
+++ b/docs/custom-providers.md
@@ -46,6 +46,38 @@ export API_KEY="your-api-key"
 zeroclaw agent
 ```
 
+## llama.cpp Server (Recommended Local Setup)
+
+ZeroClaw includes a first-class local provider for `llama-server`:
+
+- Provider ID: `llamacpp` (alias: `llama.cpp`)
+- Default endpoint: `http://localhost:8080/v1`
+- API key is optional unless `llama-server` is started with `--api-key`
+
+Start a local server (example):
+
+```bash
+llama-server -hf ggml-org/gpt-oss-20b-GGUF --jinja -c 133000 --host 127.0.0.1 --port 8033
+```
+
+Then configure ZeroClaw:
+
+```toml
+default_provider = "llamacpp"
+api_url = "http://127.0.0.1:8033/v1"
+default_model = "ggml-org/gpt-oss-20b-GGUF"
+default_temperature = 0.7
+```
+
+Quick validation:
+
+```bash
+zeroclaw models refresh --provider llamacpp
+zeroclaw agent -m "hello"
+```
+
+You do not need to export `ZEROCLAW_API_KEY=dummy` for this flow.
+
 ## Testing Configuration
 
 Verify your custom endpoint:
@@ -88,10 +120,11 @@ curl -sS https://your-api.com/models \
 
 ## Examples
 
-### Local LLM Server
+### Local LLM Server (Generic Custom Endpoint)
 
 ```toml
-default_provider = "custom:http://localhost:8080"
+default_provider = "custom:http://localhost:8080/v1"
+api_key = "your-api-key-if-required"
 default_model = "local-model"
 ```
 

--- a/docs/providers-reference.md
+++ b/docs/providers-reference.md
@@ -2,7 +2,7 @@
 
 This document maps provider IDs, aliases, and credential environment variables.
 
-Last verified: **February 19, 2026**.
+Last verified: **February 20, 2026**.
 
 ## How to List Providers
 
@@ -54,6 +54,7 @@ credential is not reused for fallback providers.
 | `cohere` | — | No | `COHERE_API_KEY` |
 | `copilot` | `github-copilot` | No | (use config/`API_KEY` fallback with GitHub token) |
 | `lmstudio` | `lm-studio` | Yes | (optional; local by default) |
+| `llamacpp` | `llama.cpp` | Yes | `LLAMACPP_API_KEY` (optional; only if server auth is enabled) |
 | `nvidia` | `nvidia-nim`, `build.nvidia.com` | No | `NVIDIA_API_KEY` |
 
 ### Gemini Notes
@@ -69,6 +70,13 @@ credential is not reused for fallback providers.
 - Vision input is supported through user message image markers: ``[IMAGE:<source>]``.
 - After multimodal normalization, ZeroClaw sends image payloads through Ollama's native `messages[].images` field.
 - If a non-vision provider is selected, ZeroClaw returns a structured capability error instead of silently ignoring images.
+
+### llama.cpp Server Notes
+
+- Provider ID: `llamacpp` (alias: `llama.cpp`)
+- Default endpoint: `http://localhost:8080/v1`
+- API key is optional by default; set `LLAMACPP_API_KEY` only when `llama-server` is started with `--api-key`.
+- Model discovery: `zeroclaw models refresh --provider llamacpp`
 
 ### Bedrock Notes
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -833,6 +833,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "cloudflare" | "cloudflare-ai" => vec!["CLOUDFLARE_API_KEY"],
         "ovhcloud" | "ovh" => vec!["OVH_AI_ENDPOINTS_ACCESS_TOKEN"],
         "astrai" => vec!["ASTRAI_API_KEY"],
+        "llamacpp" | "llama.cpp" => vec!["LLAMACPP_API_KEY"],
         _ => vec![],
     };
 
@@ -1072,6 +1073,22 @@ fn create_provider_with_url_and_options(
                 "LM Studio",
                 "http://localhost:1234/v1",
                 Some(lm_studio_key),
+                AuthStyle::Bearer,
+            )))
+        }
+        "llamacpp" | "llama.cpp" => {
+            let base_url = api_url
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or("http://localhost:8080/v1");
+            let llama_cpp_key = key
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or("llama.cpp");
+            Ok(Box::new(OpenAiCompatibleProvider::new(
+                "llama.cpp",
+                base_url,
+                Some(llama_cpp_key),
                 AuthStyle::Bearer,
             )))
         }
@@ -1517,6 +1534,12 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             local: true,
         },
         ProviderInfo {
+            name: "llamacpp",
+            display_name: "llama.cpp server",
+            aliases: &["llama.cpp"],
+            local: true,
+        },
+        ProviderInfo {
             name: "nvidia",
             display_name: "NVIDIA NIM",
             aliases: &["nvidia-nim", "build.nvidia.com"],
@@ -1949,6 +1972,13 @@ mod tests {
         assert!(create_provider("lmstudio", None).is_ok());
     }
 
+    #[test]
+    fn factory_llamacpp() {
+        assert!(create_provider("llamacpp", Some("key")).is_ok());
+        assert!(create_provider("llama.cpp", Some("key")).is_ok());
+        assert!(create_provider("llamacpp", None).is_ok());
+    }
+
     // ── Extended ecosystem ───────────────────────────────────
 
     #[test]
@@ -2297,6 +2327,7 @@ mod tests {
             "qwen-us",
             "qwen-code",
             "lmstudio",
+            "llamacpp",
             "groq",
             "mistral",
             "xai",


### PR DESCRIPTION
## Summary
- add first-class `llamacpp` provider support (alias: `llama.cpp`) with default local endpoint and optional `LLAMACPP_API_KEY`
- improve onboarding for local/private tier: canonical alias handling, llama.cpp endpoint prompt, optional key UX, curated models, and keyless-local summary handling
- fix model refresh endpoint resolution so llama.cpp uses the user-configured endpoint (`api_url`) instead of always assuming `http://localhost:8080/v1`
- update provider/docs references and command docs to include llama.cpp support and usage guidance

## Root Cause
Issue #1006 exposed that users had to force custom-provider workarounds for llama.cpp and that model refresh logic was not robust for non-default local llama.cpp endpoints.

## Validation
- `cargo test --locked llamacpp -- --nocapture`
- `cargo test --locked provider_supports_keyless_local_usage_for_local_providers -- --exact --nocapture`
- `cargo test --locked resolve_live_models_endpoint_ -- --nocapture`
- `cargo test --locked models_endpoint_for_provider_supports_additional_openai_compatible_providers -- --exact --nocapture`

All passed on Rust 1.92 toolchain with isolated Cargo target/cache.

## Model / Provider Verification
- verified referenced Hugging Face model pages return HTTP 200:
  - `ggml-org/gpt-oss-20b-GGUF`
  - `bartowski/Llama-3.3-70B-Instruct-GGUF`
  - `Qwen/Qwen2.5-Coder-7B-Instruct-GGUF`
- verified llama.cpp server docs for `/v1/models`, `/v1/chat/completions`, and `--api-key` behavior.

Closes #1006