### PR TITLE
docs(i18n): add Vietnamese links to all locale READMEs and docs navigation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  🌐 言語: <a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a> · <a href="README.ru.md">Русский</a>
+  🌐 言語: <a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a> · <a href="README.ru.md">Русский</a> · <a href="README.vi.md">Tiếng Việt</a>
 </p>
 
 <p align="center">

--- a/README.ru.md
+++ b/README.ru.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  🌐 Языки: <a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a> · <a href="README.ru.md">Русский</a>
+  🌐 Языки: <a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a> · <a href="README.ru.md">Русский</a> · <a href="README.vi.md">Tiếng Việt</a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  🌐 语言：<a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a> · <a href="README.ru.md">Русский</a>
+  🌐 语言：<a href="README.md">English</a> · <a href="README.zh-CN.md">简体中文</a> · <a href="README.ja.md">日本語</a> · <a href="README.ru.md">Русский</a> · <a href="README.vi.md">Tiếng Việt</a>
 </p>
 
 <p align="center">

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -87,3 +87,4 @@
 - English: [README.md](README.md)
 - 简体中文: [README.zh-CN.md](README.zh-CN.md)
 - Русский: [README.ru.md](README.ru.md)
+- Tiếng Việt: [README.vi.md](README.vi.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This page is the primary entry point for the documentation system.
 
 Last refreshed: **February 18, 2026**.
 
-Localized hubs: [简体中文](README.zh-CN.md) · [日本語](README.ja.md) · [Русский](README.ru.md).
+Localized hubs: [简体中文](README.zh-CN.md) · [日本語](README.ja.md) · [Русский](README.ru.md) · [Tiếng Việt](README.vi.md).
 
 ## Start Here
 

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -87,3 +87,4 @@
 - English: [README.md](README.md)
 - 简体中文: [README.zh-CN.md](README.zh-CN.md)
 - 日本語: [README.ja.md](README.ja.md)
+- Tiếng Việt: [README.vi.md](README.vi.md)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -87,3 +87,4 @@
 - English: [README.md](README.md)
 - 日本語: [README.ja.md](README.ja.md)
 - Русский: [README.ru.md](README.ru.md)
+- Tiếng Việt: [README.vi.md](README.vi.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,10 +10,12 @@ Last refreshed: **February 18, 2026**.
 - Chinese README: [../README.zh-CN.md](../README.zh-CN.md)
 - Japanese README: [../README.ja.md](../README.ja.md)
 - Russian README: [../README.ru.md](../README.ru.md)
+- Vietnamese README: [../README.vi.md](../README.vi.md)
 - English Docs Hub: [README.md](README.md)
 - Chinese Docs Hub: [README.zh-CN.md](README.zh-CN.md)
 - Japanese Docs Hub: [README.ja.md](README.ja.md)
 - Russian Docs Hub: [README.ru.md](README.ru.md)
+- Vietnamese Docs Hub: [README.vi.md](README.vi.md)
 
 ## Collections
 

--- a/docs/docs-inventory.md
+++ b/docs/docs-inventory.md
@@ -19,10 +19,12 @@ Last reviewed: **February 18, 2026**.
 | `README.zh-CN.md` | Current Guide (localized) | Chinese readers |
 | `README.ja.md` | Current Guide (localized) | Japanese readers |
 | `README.ru.md` | Current Guide (localized) | Russian readers |
+| `README.vi.md` | Current Guide (localized) | Vietnamese readers |
 | `docs/README.md` | Current Guide (hub) | all readers |
 | `docs/README.zh-CN.md` | Current Guide (localized hub) | Chinese readers |
 | `docs/README.ja.md` | Current Guide (localized hub) | Japanese readers |
 | `docs/README.ru.md` | Current Guide (localized hub) | Russian readers |
+| `docs/README.vi.md` | Current Guide (localized hub) | Vietnamese readers |
 | `docs/SUMMARY.md` | Current Guide (unified TOC) | all readers |
 
 ## Collection Index Docs


### PR DESCRIPTION
## Summary
- Add `Tiếng Việt` entries to language selectors in `README.zh-CN.md`, `README.ja.md`, `README.ru.md`
- Add Vietnamese docs hub link to `docs/README.md` localized hubs line
- Add Vietnamese entry to "other languages" section in `docs/README.zh-CN.md`, `docs/README.ja.md`, `docs/README.ru.md`
- Add Vietnamese README + docs hub entries to `docs/SUMMARY.md` language section
- Add `README.vi.md` and `docs/README.vi.md` rows to `docs/docs-inventory.md`

## Motivation
PR #1078 merged `README.vi.md` but did not update cross-references in existing locale files. This PR completes the navigation parity required by CLAUDE.md §4.1.

## Files changed (9)
- `README.zh-CN.md` — language selector
- `README.ja.md` — language selector
- `README.ru.md` — language selector
- `docs/README.md` — localized hubs line
- `docs/README.zh-CN.md` — other languages section
- `docs/README.ja.md` — other languages section
- `docs/README.ru.md` — other languages section
- `docs/SUMMARY.md` — language entry section
- `docs/docs-inventory.md` — entry points table

## Test plan
- [ ] Verify all 5 language links render correctly in each locale README
- [ ] Verify docs hub and SUMMARY navigation includes Vietnamese
- [ ] Verify docs-inventory table lists both `README.vi.md` and `docs/README.vi.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)