### PR TITLE
docs(i18n): add Vietnamese translations for docs hub and key references

### DIFF
--- a/docs/README.vi.md
+++ b/docs/README.vi.md
@@ -1,0 +1,92 @@
+# Tài liệu ZeroClaw (Tiếng Việt)
+
+Trang này là điểm vào tiếng Việt cho hệ thống tài liệu.
+
+Đồng bộ lần cuối: **2026-02-20**.
+
+> Lưu ý: Tên lệnh, khóa cấu hình và đường dẫn API giữ nguyên tiếng Anh. Nội dung chi tiết lấy tài liệu tiếng Anh làm chuẩn.
+
+## Tra cứu nhanh
+
+| Tôi muốn… | Xem tài liệu |
+|---|---|
+| Cài đặt và chạy nhanh | [../README.vi.md](../README.vi.md) / [../README.md](../README.md) |
+| Cài đặt bằng một lệnh | [one-click-bootstrap.md](one-click-bootstrap.md) |
+| Tìm lệnh theo tác vụ | [commands-reference.md](commands-reference.md) |
+| Kiểm tra giá trị mặc định và khóa cấu hình | [config-reference.md](config-reference.md) |
+| Kết nối provider / endpoint tùy chỉnh | [custom-providers.md](custom-providers.md) |
+| Cấu hình Z.AI / GLM provider | [zai-glm-setup.md](zai-glm-setup.md) |
+| Sử dụng tích hợp LangGraph | [langgraph-integration.md](langgraph-integration.md) |
+| Vận hành hàng ngày (runbook) | [operations-runbook.md](operations-runbook.md) |
+| Khắc phục sự cố cài đặt/chạy/kênh | [troubleshooting.md](troubleshooting.md) |
+| Cấu hình Matrix phòng mã hóa (E2EE) | [matrix-e2ee-guide.md](matrix-e2ee-guide.md) |
+| Duyệt tài liệu theo danh mục | [SUMMARY.md](SUMMARY.md) |
+| Xem bản chụp PR/Issue | [project-triage-snapshot-2026-02-18.md](project-triage-snapshot-2026-02-18.md) |
+
+## Cây quyết định 10 giây (xem trước)
+
+- Cài đặt lần đầu hoặc khởi động nhanh → [getting-started/README.md](getting-started/README.md)
+- Cần tra cứu lệnh CLI / khóa cấu hình → [reference/README.md](reference/README.md)
+- Cần vận hành / triển khai sản phẩm → [operations/README.md](operations/README.md)
+- Gặp lỗi hoặc hồi quy → [troubleshooting.md](troubleshooting.md)
+- Tìm hiểu bảo mật và lộ trình → [security/README.md](security/README.md)
+- Làm việc với bo mạch / thiết bị ngoại vi → [hardware/README.md](hardware/README.md)
+- Đóng góp / review / quy trình CI → [contributing/README.md](contributing/README.md)
+- Xem toàn bộ bản đồ tài liệu → [SUMMARY.md](SUMMARY.md)
+
+## Duyệt theo danh mục (khuyến nghị)
+
+- Bắt đầu: [getting-started/README.md](getting-started/README.md)
+- Tra cứu: [reference/README.md](reference/README.md)
+- Vận hành & triển khai: [operations/README.md](operations/README.md)
+- Bảo mật: [security/README.md](security/README.md)
+- Phần cứng & ngoại vi: [hardware/README.md](hardware/README.md)
+- Đóng góp & CI: [contributing/README.md](contributing/README.md)
+- Ảnh chụp dự án: [project/README.md](project/README.md)
+
+## Theo vai trò
+
+### Người dùng / Vận hành
+
+- [commands-reference.md](commands-reference.md) — tra cứu lệnh theo tác vụ
+- [providers-reference.md](providers-reference.md) — ID provider, bí danh, biến môi trường xác thực
+- [channels-reference.md](channels-reference.md) — khả năng kênh và hướng dẫn thiết lập
+- [matrix-e2ee-guide.md](matrix-e2ee-guide.md) — thiết lập phòng mã hóa Matrix (E2EE)
+- [config-reference.md](config-reference.md) — khóa cấu hình quan trọng và giá trị mặc định an toàn
+- [custom-providers.md](custom-providers.md) — mẫu tích hợp provider / base URL tùy chỉnh
+- [zai-glm-setup.md](zai-glm-setup.md) — thiết lập Z.AI/GLM và ma trận endpoint
+- [langgraph-integration.md](langgraph-integration.md) — tích hợp dự phòng cho model/tool-calling
+- [operations-runbook.md](operations-runbook.md) — vận hành runtime hàng ngày và quy trình rollback
+- [troubleshooting.md](troubleshooting.md) — dấu hiệu lỗi thường gặp và cách khắc phục
+
+### Người đóng góp / Bảo trì
+
+- [../CONTRIBUTING.md](../CONTRIBUTING.md)
+- [pr-workflow.md](pr-workflow.md)
+- [reviewer-playbook.md](reviewer-playbook.md)
+- [ci-map.md](ci-map.md)
+- [actions-source-policy.md](actions-source-policy.md)
+
+### Bảo mật / Độ tin cậy
+
+> Lưu ý: Mục này bao gồm tài liệu đề xuất/lộ trình, có thể chứa lệnh hoặc cấu hình giả định. Để biết hành vi hiện tại, xem [config-reference.md](config-reference.md), [operations-runbook.md](operations-runbook.md) và [troubleshooting.md](troubleshooting.md) trước.
+
+- [security/README.md](security/README.md)
+- [agnostic-security.md](agnostic-security.md)
+- [frictionless-security.md](frictionless-security.md)
+- [sandboxing.md](sandboxing.md)
+- [audit-logging.md](audit-logging.md)
+- [resource-limits.md](resource-limits.md)
+- [security-roadmap.md](security-roadmap.md)
+
+## Quản lý & phân loại tài liệu
+
+- Mục lục thống nhất (TOC): [SUMMARY.md](SUMMARY.md)
+- Danh mục và phân loại tài liệu: [docs-inventory.md](docs-inventory.md)
+
+## Ngôn ngữ khác
+
+- English: [README.md](README.md)
+- 简体中文: [README.zh-CN.md](README.zh-CN.md)
+- 日本語: [README.ja.md](README.ja.md)
+- Русский: [README.ru.md](README.ru.md)

--- a/docs/commands-reference.vi.md
+++ b/docs/commands-reference.vi.md
@@ -1,0 +1,160 @@
+# Tham khảo lệnh ZeroClaw
+
+Tài liệu này dựa trên giao diện CLI hiện tại (`zeroclaw --help`).
+
+Xác minh lần cuối: **2026-02-20**.
+
+## Lệnh cấp cao nhất
+
+| Lệnh | Mục đích |
+|---|---|
+| `onboard` | Khởi tạo workspace/config nhanh hoặc tương tác |
+| `agent` | Chạy chat tương tác hoặc chế độ gửi tin nhắn đơn |
+| `gateway` | Khởi động gateway webhook và HTTP WhatsApp |
+| `daemon` | Khởi động runtime có giám sát (gateway + channels + heartbeat/scheduler tùy chọn) |
+| `service` | Quản lý vòng đời dịch vụ cấp hệ điều hành |
+| `doctor` | Chạy chẩn đoán và kiểm tra trạng thái |
+| `status` | Hiển thị cấu hình và tóm tắt hệ thống |
+| `cron` | Quản lý tác vụ định kỳ |
+| `models` | Làm mới danh mục model của provider |
+| `providers` | Liệt kê ID provider, bí danh và provider đang dùng |
+| `channel` | Quản lý kênh và kiểm tra sức khỏe kênh |
+| `integrations` | Kiểm tra chi tiết tích hợp |
+| `skills` | Liệt kê/cài đặt/gỡ bỏ skills |
+| `migrate` | Nhập dữ liệu từ runtime khác (hiện hỗ trợ OpenClaw) |
+| `config` | Xuất schema cấu hình dạng máy đọc được |
+| `completions` | Tạo script tự hoàn thành cho shell ra stdout |
+| `hardware` | Phát hiện và kiểm tra phần cứng USB |
+| `peripheral` | Cấu hình và nạp firmware thiết bị ngoại vi |
+
+## Nhóm lệnh
+
+### `onboard`
+
+- `zeroclaw onboard`
+- `zeroclaw onboard --interactive`
+- `zeroclaw onboard --channels-only`
+- `zeroclaw onboard --api-key <KEY> --provider <ID> --memory <sqlite|lucid|markdown|none>`
+- `zeroclaw onboard --api-key <KEY> --provider <ID> --model <MODEL_ID> --memory <sqlite|lucid|markdown|none>`
+
+### `agent`
+
+- `zeroclaw agent`
+- `zeroclaw agent -m "Hello"`
+- `zeroclaw agent --provider <ID> --model <MODEL> --temperature <0.0-2.0>`
+- `zeroclaw agent --peripheral <board:path>`
+
+### `gateway` / `daemon`
+
+- `zeroclaw gateway [--host <HOST>] [--port <PORT>]`
+- `zeroclaw daemon [--host <HOST>] [--port <PORT>]`
+
+### `service`
+
+- `zeroclaw service install`
+- `zeroclaw service start`
+- `zeroclaw service stop`
+- `zeroclaw service restart`
+- `zeroclaw service status`
+- `zeroclaw service uninstall`
+
+### `cron`
+
+- `zeroclaw cron list`
+- `zeroclaw cron add <expr> [--tz <IANA_TZ>] <command>`
+- `zeroclaw cron add-at <rfc3339_timestamp> <command>`
+- `zeroclaw cron add-every <every_ms> <command>`
+- `zeroclaw cron once <delay> <command>`
+- `zeroclaw cron remove <id>`
+- `zeroclaw cron pause <id>`
+- `zeroclaw cron resume <id>`
+
+### `models`
+
+- `zeroclaw models refresh`
+- `zeroclaw models refresh --provider <ID>`
+- `zeroclaw models refresh --force`
+
+`models refresh` hiện hỗ trợ làm mới danh mục trực tiếp cho các provider: `openrouter`, `openai`, `anthropic`, `groq`, `mistral`, `deepseek`, `xai`, `together-ai`, `gemini`, `ollama`, `astrai`, `venice`, `fireworks`, `cohere`, `moonshot`, `glm`, `zai`, `qwen` và `nvidia`.
+
+### `channel`
+
+- `zeroclaw channel list`
+- `zeroclaw channel start`
+- `zeroclaw channel doctor`
+- `zeroclaw channel bind-telegram <IDENTITY>`
+- `zeroclaw channel add <type> <json>`
+- `zeroclaw channel remove <name>`
+
+Lệnh trong chat khi runtime đang chạy (Telegram/Discord):
+
+- `/models`
+- `/models <provider>`
+- `/model`
+- `/model <model-id>`
+
+Channel runtime cũng theo dõi `config.toml` và tự động áp dụng thay đổi cho:
+- `default_provider`
+- `default_model`
+- `default_temperature`
+- `api_key` / `api_url` (cho provider mặc định)
+- `reliability.*` cài đặt retry của provider
+
+`add/remove` hiện chuyển hướng về thiết lập có hướng dẫn / cấu hình thủ công (chưa hỗ trợ đầy đủ mutator khai báo).
+
+### `integrations`
+
+- `zeroclaw integrations info <name>`
+
+### `skills`
+
+- `zeroclaw skills list`
+- `zeroclaw skills install <source>`
+- `zeroclaw skills remove <name>`
+
+`<source>` chấp nhận git remote (`https://...`, `http://...`, `ssh://...` và `git@host:owner/repo.git`) hoặc đường dẫn cục bộ.
+
+Skill manifest (`SKILL.toml`) hỗ trợ `prompts` và `[[tools]]`; cả hai được đưa vào system prompt của agent khi chạy, giúp model có thể tuân theo hướng dẫn skill mà không cần đọc thủ công.
+
+### `migrate`
+
+- `zeroclaw migrate openclaw [--source <path>] [--dry-run]`
+
+### `config`
+
+- `zeroclaw config schema`
+
+`config schema` xuất JSON Schema (draft 2020-12) cho toàn bộ hợp đồng `config.toml` ra stdout.
+
+### `completions`
+
+- `zeroclaw completions bash`
+- `zeroclaw completions fish`
+- `zeroclaw completions zsh`
+- `zeroclaw completions powershell`
+- `zeroclaw completions elvish`
+
+`completions` chỉ xuất ra stdout để script có thể được source trực tiếp mà không bị lẫn log/cảnh báo.
+
+### `hardware`
+
+- `zeroclaw hardware discover`
+- `zeroclaw hardware introspect <path>`
+- `zeroclaw hardware info [--chip <chip_name>]`
+
+### `peripheral`
+
+- `zeroclaw peripheral list`
+- `zeroclaw peripheral add <board> <path>`
+- `zeroclaw peripheral flash [--port <serial_port>]`
+- `zeroclaw peripheral setup-uno-q [--host <ip_or_host>]`
+- `zeroclaw peripheral flash-nucleo`
+
+## Mẹo kiểm tra
+
+Để xác minh nhanh tài liệu với binary hiện tại:
+
+```bash
+zeroclaw --help
+zeroclaw <command> --help
+```

--- a/docs/config-reference.vi.md
+++ b/docs/config-reference.vi.md
@@ -1,0 +1,519 @@
+# Tham khảo cấu hình ZeroClaw (Dành cho vận hành)
+
+Đây là tài liệu tham khảo ngắn gọn về các mục cấu hình thường dùng và giá trị mặc định.
+
+Xác minh lần cuối: **2026-02-19**.
+
+Thứ tự tìm đường dẫn config khi khởi động:
+
+1. Biến `ZEROCLAW_WORKSPACE` (nếu được đặt)
+2. Marker `~/.zeroclaw/active_workspace.toml` (nếu có)
+3. Mặc định `~/.zeroclaw/config.toml`
+
+ZeroClaw ghi log đường dẫn config đã giải quyết khi khởi động ở mức `INFO`:
+
+- `Config loaded` với các trường: `path`, `workspace`, `source`, `initialized`
+
+Lệnh xuất schema:
+
+- `zeroclaw config schema` (xuất JSON Schema draft 2020-12 ra stdout)
+
+## Khóa chính
+
+| Khóa | Mặc định | Ghi chú |
+|---|---|---|
+| `default_provider` | `openrouter` | ID hoặc bí danh provider |
+| `default_model` | `anthropic/claude-sonnet-4-6` | Model định tuyến qua provider đã chọn |
+| `default_temperature` | `0.7` | Nhiệt độ model |
+
+## `[observability]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `backend` | `none` | Backend quan sát: `none`, `noop`, `log`, `prometheus`, `otel`, `opentelemetry` hoặc `otlp` |
+| `otel_endpoint` | `http://localhost:4318` | Endpoint OTLP HTTP khi backend là `otel` |
+| `otel_service_name` | `zeroclaw` | Tên dịch vụ gửi đến OTLP collector |
+
+Lưu ý:
+
+- `backend = "otel"` dùng OTLP HTTP export với blocking exporter client để span và metric có thể được gửi an toàn từ context ngoài Tokio.
+- Bí danh `opentelemetry` và `otlp` trỏ đến cùng backend OTel.
+
+Ví dụ:
+
+```toml
+[observability]
+backend = "otel"
+otel_endpoint = "http://localhost:4318"
+otel_service_name = "zeroclaw"
+```
+
+## Ghi đè provider qua biến môi trường
+
+Chọn provider cũng có thể điều khiển qua biến môi trường. Thứ tự ưu tiên:
+
+1. `ZEROCLAW_PROVIDER` (ghi đè tường minh, luôn thắng khi có giá trị)
+2. `PROVIDER` (dự phòng kiểu cũ, chỉ áp dụng khi provider trong config chưa đặt hoặc vẫn là `openrouter`)
+3. `default_provider` trong `config.toml`
+
+Lưu ý cho người dùng container:
+
+- Nếu `config.toml` đặt provider tùy chỉnh như `custom:https://.../v1`, biến `PROVIDER=openrouter` mặc định từ Docker/container sẽ không thay thế nó.
+- Dùng `ZEROCLAW_PROVIDER` khi cố ý muốn biến môi trường ghi đè provider đã cấu hình.
+
+## `[agent]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `compact_context` | `false` | Khi bật: bootstrap_max_chars=6000, rag_chunk_limit=2. Dùng cho model 13B trở xuống |
+| `max_tool_iterations` | `10` | Số vòng lặp tool-call tối đa mỗi tin nhắn trên CLI, gateway và channels |
+| `max_history_messages` | `50` | Số tin nhắn lịch sử tối đa giữ lại mỗi phiên |
+| `parallel_tools` | `false` | Bật thực thi tool song song trong một lượt |
+| `tool_dispatcher` | `auto` | Chiến lược dispatch tool |
+
+Lưu ý:
+
+- Đặt `max_tool_iterations = 0` sẽ dùng giá trị mặc định an toàn `10`.
+- Nếu tin nhắn kênh vượt giá trị này, runtime trả về: `Agent exceeded maximum tool iterations (<value>)`.
+- Trong vòng lặp tool của CLI, gateway và channel, các lời gọi tool độc lập được thực thi đồng thời mặc định khi không cần phê duyệt; thứ tự kết quả giữ ổn định.
+- `parallel_tools` áp dụng cho API `Agent::turn()`. Không ảnh hưởng đến vòng lặp runtime của CLI, gateway hay channel.
+
+## `[agents.<name>]`
+
+Cấu hình agent phụ (sub-agent). Mỗi khóa dưới `[agents]` định nghĩa một agent phụ có tên mà agent chính có thể ủy quyền.
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `provider` | _bắt buộc_ | Tên provider (ví dụ `"ollama"`, `"openrouter"`, `"anthropic"`) |
+| `model` | _bắt buộc_ | Tên model cho agent phụ |
+| `system_prompt` | chưa đặt | System prompt tùy chỉnh cho agent phụ (tùy chọn) |
+| `api_key` | chưa đặt | API key tùy chỉnh (mã hóa khi `secrets.encrypt = true`) |
+| `temperature` | chưa đặt | Temperature tùy chỉnh cho agent phụ |
+| `max_depth` | `3` | Độ sâu đệ quy tối đa cho ủy quyền lồng nhau |
+| `agentic` | `false` | Bật chế độ vòng lặp tool-call nhiều lượt cho agent phụ |
+| `allowed_tools` | `[]` | Danh sách tool được phép ở chế độ agentic |
+| `max_iterations` | `10` | Số vòng tool-call tối đa cho chế độ agentic |
+
+Lưu ý:
+
+- `agentic = false` giữ nguyên hành vi ủy quyền prompt→response đơn lượt.
+- `agentic = true` yêu cầu ít nhất một mục khớp trong `allowed_tools`.
+- Tool `delegate` bị loại khỏi allowlist của agent phụ để tránh vòng lặp ủy quyền.
+
+```toml
+[agents.researcher]
+provider = "openrouter"
+model = "anthropic/claude-sonnet-4-6"
+system_prompt = "You are a research assistant."
+max_depth = 2
+agentic = true
+allowed_tools = ["web_search", "http_request", "file_read"]
+max_iterations = 8
+
+[agents.coder]
+provider = "ollama"
+model = "qwen2.5-coder:32b"
+temperature = 0.2
+```
+
+## `[runtime]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `reasoning_enabled` | chưa đặt (`None`) | Ghi đè toàn cục cho reasoning/thinking trên provider hỗ trợ |
+
+Lưu ý:
+
+- `reasoning_enabled = false` tắt tường minh reasoning phía provider cho provider hỗ trợ (hiện tại `ollama`, qua trường `think: false`).
+- `reasoning_enabled = true` yêu cầu reasoning tường minh (`think: true` trên `ollama`).
+- Để trống giữ mặc định của provider.
+
+## `[skills]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `open_skills_enabled` | `false` | Cho phép tải/đồng bộ kho `open-skills` cộng đồng |
+| `open_skills_dir` | chưa đặt | Đường dẫn cục bộ cho `open-skills` (mặc định `$HOME/open-skills` khi bật) |
+
+Lưu ý:
+
+- Mặc định an toàn: ZeroClaw **không** clone hay đồng bộ `open-skills` trừ khi `open_skills_enabled = true`.
+- Ghi đè qua biến môi trường:
+  - `ZEROCLAW_OPEN_SKILLS_ENABLED` chấp nhận `1/0`, `true/false`, `yes/no`, `on/off`.
+  - `ZEROCLAW_OPEN_SKILLS_DIR` ghi đè đường dẫn kho khi có giá trị.
+- Thứ tự ưu tiên: `ZEROCLAW_OPEN_SKILLS_ENABLED` → `skills.open_skills_enabled` trong `config.toml` → mặc định `false`.
+
+## `[composio]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `enabled` | `false` | Bật công cụ OAuth do Composio quản lý |
+| `api_key` | chưa đặt | API key Composio cho tool `composio` |
+| `entity_id` | `default` | `user_id` mặc định gửi khi gọi connect/execute |
+
+Lưu ý:
+
+- Tương thích ngược: `enable = true` kiểu cũ được chấp nhận như bí danh cho `enabled = true`.
+- Nếu `enabled = false` hoặc thiếu `api_key`, tool `composio` không được đăng ký.
+- ZeroClaw yêu cầu Composio v3 tools với `toolkit_versions=latest` và thực thi với `version="latest"` để tránh bản tool mặc định cũ.
+- Luồng thông thường: gọi `connect`, hoàn tất OAuth trên trình duyệt, rồi chạy `execute` cho hành động mong muốn.
+- Nếu Composio trả lỗi thiếu connected-account, gọi `list_accounts` (tùy chọn với `app`) và truyền `connected_account_id` trả về cho `execute`.
+
+## `[cost]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `enabled` | `false` | Bật theo dõi chi phí |
+| `daily_limit_usd` | `10.00` | Giới hạn chi tiêu hàng ngày (USD) |
+| `monthly_limit_usd` | `100.00` | Giới hạn chi tiêu hàng tháng (USD) |
+| `warn_at_percent` | `80` | Cảnh báo khi chi tiêu đạt tỷ lệ phần trăm này |
+| `allow_override` | `false` | Cho phép vượt ngân sách khi dùng cờ `--override` |
+
+Lưu ý:
+
+- Khi `enabled = true`, runtime theo dõi ước tính chi phí mỗi yêu cầu và áp dụng giới hạn ngày/tháng.
+- Tại ngưỡng `warn_at_percent`, cảnh báo được gửi nhưng yêu cầu vẫn tiếp tục.
+- Khi đạt giới hạn, yêu cầu bị từ chối trừ khi `allow_override = true` và cờ `--override` được truyền.
+
+## `[identity]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `format` | `openclaw` | Định dạng danh tính: `"openclaw"` (mặc định) hoặc `"aieos"` |
+| `aieos_path` | chưa đặt | Đường dẫn file AIEOS JSON (tương đối với workspace) |
+| `aieos_inline` | chưa đặt | AIEOS JSON nội tuyến (thay thế cho đường dẫn file) |
+
+Lưu ý:
+
+- Dùng `format = "aieos"` với `aieos_path` hoặc `aieos_inline` để tải tài liệu danh tính AIEOS / OpenClaw.
+- Chỉ nên đặt một trong hai `aieos_path` hoặc `aieos_inline`; `aieos_path` được ưu tiên.
+
+## `[multimodal]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `max_images` | `4` | Số marker ảnh tối đa mỗi yêu cầu |
+| `max_image_size_mb` | `5` | Giới hạn kích thước ảnh trước khi mã hóa base64 |
+| `allow_remote_fetch` | `false` | Cho phép tải ảnh từ URL `http(s)` trong marker |
+
+Lưu ý:
+
+- Runtime chấp nhận marker ảnh trong tin nhắn với cú pháp: ``[IMAGE:<source>]``.
+- Nguồn hỗ trợ:
+  - Đường dẫn file cục bộ (ví dụ ``[IMAGE:/tmp/screenshot.png]``)
+- Data URI (ví dụ ``[IMAGE:data:image/png;base64,...]``)
+- URL từ xa chỉ khi `allow_remote_fetch = true`
+- Kiểu MIME cho phép: `image/png`, `image/jpeg`, `image/webp`, `image/gif`, `image/bmp`.
+- Khi provider đang dùng không hỗ trợ vision, yêu cầu thất bại với lỗi capability có cấu trúc (`capability=vision`) thay vì bỏ qua ảnh.
+
+## `[browser]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `enabled` | `false` | Bật tool `browser_open` (mở URL, không thu thập dữ liệu) |
+| `allowed_domains` | `[]` | Tên miền cho phép cho `browser_open` (khớp chính xác hoặc subdomain) |
+| `session_name` | chưa đặt | Tên phiên trình duyệt (cho tự động hóa agent-browser) |
+| `backend` | `agent_browser` | Backend tự động hóa: `"agent_browser"`, `"rust_native"`, `"computer_use"` hoặc `"auto"` |
+| `native_headless` | `true` | Chế độ headless cho backend rust-native |
+| `native_webdriver_url` | `http://127.0.0.1:9515` | URL endpoint WebDriver cho backend rust-native |
+| `native_chrome_path` | chưa đặt | Đường dẫn Chrome/Chromium tùy chọn cho backend rust-native |
+
+### `[browser.computer_use]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `endpoint` | `http://127.0.0.1:8787/v1/actions` | Endpoint sidecar cho hành động computer-use (chuột/bàn phím/screenshot cấp OS) |
+| `api_key` | chưa đặt | Bearer token tùy chọn cho sidecar computer-use (mã hóa khi lưu) |
+| `timeout_ms` | `15000` | Thời gian chờ mỗi hành động (mili giây) |
+| `allow_remote_endpoint` | `false` | Cho phép endpoint từ xa/công khai cho sidecar |
+| `window_allowlist` | `[]` | Danh sách cho phép tiêu đề cửa sổ/tiến trình gửi đến sidecar |
+| `max_coordinate_x` | chưa đặt | Giới hạn trục X cho hành động dựa trên tọa độ (tùy chọn) |
+| `max_coordinate_y` | chưa đặt | Giới hạn trục Y cho hành động dựa trên tọa độ (tùy chọn) |
+
+Lưu ý:
+
+- Khi `backend = "computer_use"`, agent ủy quyền hành động trình duyệt cho sidecar tại `computer_use.endpoint`.
+- `allow_remote_endpoint = false` (mặc định) từ chối mọi endpoint không phải loopback để tránh lộ ra ngoài.
+- Dùng `window_allowlist` để giới hạn cửa sổ OS mà sidecar có thể tương tác.
+
+## `[http_request]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `enabled` | `false` | Bật tool `http_request` cho tương tác API |
+| `allowed_domains` | `[]` | Tên miền cho phép (khớp chính xác hoặc subdomain) |
+| `max_response_size` | `1000000` | Kích thước response tối đa (byte, mặc định: 1 MB) |
+| `timeout_secs` | `30` | Thời gian chờ yêu cầu (giây) |
+
+Lưu ý:
+
+- Mặc định từ chối tất cả: nếu `allowed_domains` rỗng, mọi yêu cầu HTTP bị từ chối.
+- Dùng khớp tên miền chính xác hoặc subdomain (ví dụ `"api.example.com"`, `"example.com"`).
+
+## `[gateway]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `host` | `127.0.0.1` | Địa chỉ bind |
+| `port` | `3000` | Cổng lắng nghe gateway |
+| `require_pairing` | `true` | Yêu cầu ghép nối trước khi xác thực bearer |
+| `allow_public_bind` | `false` | Chặn lộ public do vô ý |
+
+## `[autonomy]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `level` | `supervised` | `read_only`, `supervised` hoặc `full` |
+| `workspace_only` | `true` | Giới hạn ghi/lệnh trong phạm vi workspace |
+| `allowed_commands` | _bắt buộc để chạy shell_ | Danh sách lệnh được phép |
+| `forbidden_paths` | `[]` | Danh sách đường dẫn bị cấm |
+| `max_actions_per_hour` | `100` | Ngân sách hành động mỗi giờ |
+| `max_cost_per_day_cents` | `1000` | Giới hạn chi tiêu mỗi ngày (cent) |
+| `require_approval_for_medium_risk` | `true` | Yêu cầu phê duyệt cho lệnh rủi ro trung bình |
+| `block_high_risk_commands` | `true` | Chặn cứng lệnh rủi ro cao |
+| `auto_approve` | `[]` | Thao tác tool luôn được tự động phê duyệt |
+| `always_ask` | `[]` | Thao tác tool luôn yêu cầu phê duyệt |
+
+Lưu ý:
+
+- `level = "full"` bỏ qua phê duyệt rủi ro trung bình cho shell execution, nhưng vẫn áp dụng guardrail đã cấu hình.
+- Phân tích toán tử/dấu phân cách shell nhận biết dấu ngoặc kép. Ký tự như `;` trong đối số được trích dẫn được xử lý là ký tự, không phải dấu phân cách lệnh.
+- Toán tử chuỗi shell không trích dẫn vẫn được kiểm tra bởi policy (`;`, `|`, `&&`, `||`, chạy nền và chuyển hướng).
+
+## `[memory]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `backend` | `sqlite` | `sqlite`, `lucid`, `markdown`, `none` |
+| `auto_save` | `true` | Chỉ lưu đầu vào người dùng (đầu ra assistant bị loại) |
+| `embedding_provider` | `none` | `none`, `openai` hoặc endpoint tùy chỉnh |
+| `embedding_model` | `text-embedding-3-small` | ID model embedding, hoặc tuyến `hint:<name>` |
+| `embedding_dimensions` | `1536` | Kích thước vector mong đợi cho model embedding đã chọn |
+| `vector_weight` | `0.7` | Trọng số vector trong xếp hạng kết hợp |
+| `keyword_weight` | `0.3` | Trọng số từ khóa trong xếp hạng kết hợp |
+
+Lưu ý:
+
+- Chèn ngữ cảnh memory bỏ qua khóa auto-save `assistant_resp*` kiểu cũ để tránh tóm tắt do model tạo bị coi là sự thật.
+
+## `[[model_routes]]` và `[[embedding_routes]]`
+
+Dùng route hint để tích hợp giữ tên ổn định trong khi model ID thay đổi.
+
+### `[[model_routes]]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `hint` | _bắt buộc_ | Tên hint tác vụ (ví dụ `"reasoning"`, `"fast"`, `"code"`, `"summarize"`) |
+| `provider` | _bắt buộc_ | Provider đích (phải khớp tên provider đã biết) |
+| `model` | _bắt buộc_ | Model sử dụng với provider đó |
+| `api_key` | chưa đặt | API key tùy chỉnh cho provider của route này (tùy chọn) |
+
+### `[[embedding_routes]]`
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `hint` | _bắt buộc_ | Tên route hint (ví dụ `"semantic"`, `"archive"`, `"faq"`) |
+| `provider` | _bắt buộc_ | Embedding provider (`"none"`, `"openai"` hoặc `"custom:<url>"`) |
+| `model` | _bắt buộc_ | Model embedding sử dụng với provider đó |
+| `dimensions` | chưa đặt | Ghi đè kích thước embedding cho route này (tùy chọn) |
+| `api_key` | chưa đặt | API key tùy chỉnh cho provider của route này (tùy chọn) |
+
+```toml
+[memory]
+embedding_model = "hint:semantic"
+
+[[model_routes]]
+hint = "reasoning"
+provider = "openrouter"
+model = "provider/model-id"
+
+[[embedding_routes]]
+hint = "semantic"
+provider = "openai"
+model = "text-embedding-3-small"
+dimensions = 1536
+```
+
+Chiến lược nâng cấp:
+
+1. Giữ hint ổn định (`hint:reasoning`, `hint:semantic`).
+2. Chỉ cập nhật `model = "...phiên-bản-mới..."` trong mục route.
+3. Kiểm tra bằng `zeroclaw doctor` trước khi khởi động lại/triển khai.
+
+## `[query_classification]`
+
+Định tuyến model hint tự động — ánh xạ tin nhắn người dùng đến hint `[[model_routes]]` dựa trên mẫu nội dung.
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `enabled` | `false` | Bật phân loại truy vấn tự động |
+| `rules` | `[]` | Quy tắc phân loại (đánh giá theo thứ tự ưu tiên) |
+
+Mỗi rule trong `rules`:
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `hint` | _bắt buộc_ | Phải khớp giá trị hint trong `[[model_routes]]` |
+| `keywords` | `[]` | Khớp chuỗi con không phân biệt hoa thường |
+| `patterns` | `[]` | Khớp chuỗi chính xác phân biệt hoa thường (cho code fence, từ khóa như `"fn "`) |
+| `min_length` | chưa đặt | Chỉ khớp nếu độ dài tin nhắn ≥ N ký tự |
+| `max_length` | chưa đặt | Chỉ khớp nếu độ dài tin nhắn ≤ N ký tự |
+| `priority` | `0` | Rule ưu tiên cao hơn được kiểm tra trước |
+
+```toml
+[query_classification]
+enabled = true
+
+[[query_classification.rules]]
+hint = "reasoning"
+keywords = ["explain", "analyze", "why"]
+min_length = 200
+priority = 10
+
+[[query_classification.rules]]
+hint = "fast"
+keywords = ["hi", "hello", "thanks"]
+max_length = 50
+priority = 5
+```
+
+## `[channels_config]`
+
+Tùy chọn kênh cấp cao nằm dưới `channels_config`.
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `message_timeout_secs` | `300` | Thời gian chờ cơ bản (giây) cho xử lý tin nhắn kênh; runtime tự điều chỉnh theo độ sâu tool-loop (lên đến 4x) |
+
+Ví dụ:
+
+- `[channels_config.telegram]`
+- `[channels_config.discord]`
+- `[channels_config.whatsapp]`
+- `[channels_config.email]`
+
+Lưu ý:
+
+- Mặc định `300s` tối ưu cho LLM chạy cục bộ (Ollama) vốn chậm hơn cloud API.
+- Ngân sách timeout runtime là `message_timeout_secs * scale`, trong đó `scale = min(max_tool_iterations, 4)` và tối thiểu `1`.
+- Việc điều chỉnh này tránh timeout sai khi lượt LLM đầu chậm/retry nhưng các lượt tool-loop sau vẫn cần hoàn tất.
+- Nếu dùng cloud API (OpenAI, Anthropic, v.v.), có thể giảm xuống `60` hoặc thấp hơn.
+- Giá trị dưới `30` bị giới hạn thành `30` để tránh timeout liên tục.
+- Khi timeout xảy ra, người dùng nhận: `⚠️ Request timed out while waiting for the model. Please try again.`
+- Hành vi ngắt chỉ Telegram được điều khiển bằng `channels_config.telegram.interrupt_on_new_message` (mặc định `false`).
+  Khi bật, tin nhắn mới từ cùng người gửi trong cùng chat sẽ hủy yêu cầu đang xử lý và giữ ngữ cảnh người dùng bị ngắt.
+- Khi `zeroclaw channel start` đang chạy, thay đổi `default_provider`, `default_model`, `default_temperature`, `api_key`, `api_url` và `reliability.*` được áp dụng nóng từ `config.toml` ở tin nhắn tiếp theo.
+
+Xem ma trận kênh và hành vi allowlist chi tiết tại [channels-reference.md](channels-reference.md).
+
+### `[channels_config.whatsapp]`
+
+WhatsApp hỗ trợ hai backend dưới cùng một bảng config.
+
+Chế độ Cloud API (webhook Meta):
+
+| Khóa | Bắt buộc | Mục đích |
+|---|---|---|
+| `access_token` | Có | Bearer token Meta Cloud API |
+| `phone_number_id` | Có | ID số điện thoại Meta |
+| `verify_token` | Có | Token xác minh webhook |
+| `app_secret` | Tùy chọn | Bật xác minh chữ ký webhook (`X-Hub-Signature-256`) |
+| `allowed_numbers` | Khuyến nghị | Số điện thoại cho phép gửi đến (`[]` = từ chối tất cả, `"*"` = cho phép tất cả) |
+
+Chế độ WhatsApp Web (client gốc):
+
+| Khóa | Bắt buộc | Mục đích |
+|---|---|---|
+| `session_path` | Có | Đường dẫn phiên SQLite lưu trữ lâu dài |
+| `pair_phone` | Tùy chọn | Số điện thoại cho luồng pair-code (chỉ chữ số) |
+| `pair_code` | Tùy chọn | Mã pair tùy chỉnh (nếu không sẽ tự tạo) |
+| `allowed_numbers` | Khuyến nghị | Số điện thoại cho phép gửi đến (`[]` = từ chối tất cả, `"*"` = cho phép tất cả) |
+
+Lưu ý:
+
+- WhatsApp Web yêu cầu build flag `whatsapp-web`.
+- Nếu cả Cloud lẫn Web đều có cấu hình, Cloud được ưu tiên để tương thích ngược.
+
+## `[hardware]`
+
+Cấu hình hardware wizard cho truy cập vật lý (STM32, probe, serial).
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `enabled` | `false` | Bật truy cập phần cứng |
+| `transport` | `none` | Chế độ truyền: `"none"`, `"native"`, `"serial"` hoặc `"probe"` |
+| `serial_port` | chưa đặt | Đường dẫn cổng serial (ví dụ `"/dev/ttyACM0"`) |
+| `baud_rate` | `115200` | Tốc độ baud serial |
+| `probe_target` | chưa đặt | Chip đích cho probe (ví dụ `"STM32F401RE"`) |
+| `workspace_datasheets` | `false` | Bật RAG datasheet workspace (đánh chỉ mục PDF schematic để AI tra cứu chân) |
+
+Lưu ý:
+
+- Dùng `transport = "serial"` với `serial_port` cho kết nối USB-serial.
+- Dùng `transport = "probe"` với `probe_target` cho nạp qua debug-probe (ví dụ ST-Link).
+- Xem [hardware-peripherals-design.md](hardware-peripherals-design.md) để biết chi tiết giao thức.
+
+## `[peripherals]`
+
+Cấu hình bo mạch ngoại vi cấp cao. Bo mạch trở thành tool agent khi được bật.
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `enabled` | `false` | Bật hỗ trợ ngoại vi (bo mạch trở thành tool agent) |
+| `boards` | `[]` | Danh sách cấu hình bo mạch |
+| `datasheet_dir` | chưa đặt | Đường dẫn tài liệu datasheet (tương đối workspace) cho RAG |
+
+Mỗi mục trong `boards`:
+
+| Khóa | Mặc định | Mục đích |
+|---|---|---|
+| `board` | _bắt buộc_ | Loại bo mạch: `"nucleo-f401re"`, `"rpi-gpio"`, `"esp32"`, v.v. |
+| `transport` | `serial` | Kiểu truyền: `"serial"`, `"native"`, `"websocket"` |
+| `path` | chưa đặt | Đường dẫn serial: `"/dev/ttyACM0"`, `"/dev/ttyUSB0"` |
+| `baud` | `115200` | Tốc độ baud cho serial |
+
+```toml
+[peripherals]
+enabled = true
+datasheet_dir = "docs/datasheets"
+
+[[peripherals.boards]]
+board = "nucleo-f401re"
+transport = "serial"
+path = "/dev/ttyACM0"
+baud = 115200
+
+[[peripherals.boards]]
+board = "rpi-gpio"
+transport = "native"
+```
+
+Lưu ý:
+
+- Đặt file `.md`/`.txt` datasheet đặt tên theo bo mạch (ví dụ `nucleo-f401re.md`, `rpi-gpio.md`) trong `datasheet_dir` cho RAG.
+- Xem [hardware-peripherals-design.md](hardware-peripherals-design.md) để biết giao thức bo mạch và ghi chú firmware.
+
+## Giá trị mặc định liên quan bảo mật
+
+- Allowlist kênh mặc định từ chối tất cả (`[]` nghĩa là từ chối tất cả)
+- Gateway mặc định yêu cầu ghép nối
+- Mặc định chặn public bind
+
+## Lệnh kiểm tra
+
+Sau khi chỉnh config:
+
+```bash
+zeroclaw status
+zeroclaw doctor
+zeroclaw channel doctor
+zeroclaw service restart
+```
+
+## Tài liệu liên quan
+
+- [channels-reference.md](channels-reference.md)
+- [providers-reference.md](providers-reference.md)
+- [operations-runbook.md](operations-runbook.md)
+- [troubleshooting.md](troubleshooting.md)

--- a/docs/getting-started/README.vi.md
+++ b/docs/getting-started/README.vi.md
@@ -1,0 +1,29 @@
+# Tài liệu Bắt đầu
+
+Dành cho cài đặt lần đầu và làm quen nhanh.
+
+## Lộ trình bắt đầu
+
+1. Tổng quan và khởi động nhanh: [../../README.vi.md](../../README.vi.md)
+2. Cài đặt một lệnh và chế độ bootstrap kép: [../one-click-bootstrap.md](../one-click-bootstrap.md)
+3. Tìm lệnh theo tác vụ: [../commands-reference.md](../commands-reference.md)
+
+## Chọn hướng đi
+
+| Tình huống | Lệnh |
+|----------|---------|
+| Có API key, muốn cài nhanh nhất | `zeroclaw onboard --api-key sk-... --provider openrouter` |
+| Muốn được hướng dẫn từng bước | `zeroclaw onboard --interactive` |
+| Đã có config, chỉ cần sửa kênh | `zeroclaw onboard --channels-only` |
+| Dùng xác thực subscription | Xem [Subscription Auth](../../README.vi.md#subscription-auth-openai-codex--claude-code) |
+
+## Thiết lập và kiểm tra
+
+- Thiết lập nhanh: `zeroclaw onboard --api-key "sk-..." --provider openrouter`
+- Thiết lập tương tác: `zeroclaw onboard --interactive`
+- Kiểm tra môi trường: `zeroclaw status` + `zeroclaw doctor`
+
+## Tiếp theo
+
+- Vận hành runtime: [../operations/README.md](../operations/README.md)
+- Tra cứu tham khảo: [../reference/README.md](../reference/README.md)

--- a/docs/one-click-bootstrap.vi.md
+++ b/docs/one-click-bootstrap.vi.md
@@ -1,0 +1,134 @@
+# Cài đặt một lệnh
+
+Trang này hướng dẫn cách cài đặt và khởi tạo ZeroClaw nhanh nhất.
+
+Xác minh lần cuối: **2026-02-20**.
+
+## Cách 0: Homebrew (macOS/Linuxbrew)
+
+```bash
+brew install zeroclaw
+```
+
+## Cách A (Khuyến nghị): Clone + chạy script cục bộ
+
+```bash
+git clone https://github.com/zeroclaw-labs/zeroclaw.git
+cd zeroclaw
+./bootstrap.sh
+```
+
+Mặc định script sẽ:
+
+1. `cargo build --release --locked`
+2. `cargo install --path . --force --locked`
+
+### Kiểm tra tài nguyên và binary dựng sẵn
+
+Build từ mã nguồn thường yêu cầu tối thiểu:
+
+- **2 GB RAM + swap**
+- **6 GB dung lượng trống**
+
+Khi tài nguyên hạn chế, bootstrap sẽ thử tải binary dựng sẵn trước.
+
+```bash
+./bootstrap.sh --prefer-prebuilt
+```
+
+Chỉ dùng binary dựng sẵn, báo lỗi nếu không tìm thấy bản phù hợp:
+
+```bash
+./bootstrap.sh --prebuilt-only
+```
+
+Bỏ qua binary dựng sẵn, buộc build từ mã nguồn:
+
+```bash
+./bootstrap.sh --force-source-build
+```
+
+## Bootstrap kép
+
+Mặc định là **chỉ ứng dụng** (build/cài ZeroClaw), yêu cầu Rust toolchain sẵn có.
+
+Với máy mới, bật bootstrap môi trường:
+
+```bash
+./bootstrap.sh --install-system-deps --install-rust
+```
+
+Lưu ý:
+
+- `--install-system-deps` cài các thành phần biên dịch/build cần thiết (có thể cần `sudo`).
+- `--install-rust` cài Rust qua `rustup` nếu chưa có.
+- `--prefer-prebuilt` thử tải binary dựng sẵn trước, nếu không có thì build từ nguồn.
+- `--prebuilt-only` tắt phương án build từ nguồn.
+- `--force-source-build` tắt hoàn toàn phương án binary dựng sẵn.
+
+## Cách B: Lệnh từ xa một dòng
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/bootstrap.sh | bash
+```
+
+Với môi trường yêu cầu bảo mật cao, nên dùng Cách A để kiểm tra script trước khi chạy.
+
+Tương thích ngược:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/install.sh | bash
+```
+
+Endpoint cũ này ưu tiên chuyển tiếp đến `scripts/bootstrap.sh`, nếu không có thì dùng cài đặt từ nguồn kiểu cũ.
+
+Nếu chạy Cách B ngoài thư mục repo, bootstrap script sẽ tự clone workspace tạm, build, cài đặt rồi dọn dẹp.
+
+## Chế độ thiết lập tùy chọn
+
+### Thiết lập trong container (Docker)
+
+```bash
+./bootstrap.sh --docker
+```
+
+Lệnh này build image ZeroClaw cục bộ và chạy thiết lập trong container, lưu config/workspace vào `./.zeroclaw-docker`.
+
+### Thiết lập nhanh (không tương tác)
+
+```bash
+./bootstrap.sh --onboard --api-key "sk-..." --provider openrouter
+```
+
+Hoặc dùng biến môi trường:
+
+```bash
+ZEROCLAW_API_KEY="sk-..." ZEROCLAW_PROVIDER="openrouter" ./bootstrap.sh --onboard
+```
+
+### Thiết lập tương tác
+
+```bash
+./bootstrap.sh --interactive-onboard
+```
+
+## Các cờ hữu ích
+
+- `--install-system-deps`
+- `--install-rust`
+- `--skip-build`
+- `--skip-install`
+- `--provider <id>`
+
+Xem tất cả tùy chọn:
+
+```bash
+./bootstrap.sh --help
+```
+
+## Tài liệu liên quan
+
+- [README.md](../README.md)
+- [commands-reference.md](commands-reference.md)
+- [providers-reference.md](providers-reference.md)
+- [channels-reference.md](channels-reference.md)

--- a/docs/troubleshooting.vi.md
+++ b/docs/troubleshooting.vi.md
@@ -1,0 +1,241 @@
+# Khắc phục sự cố ZeroClaw
+
+Hướng dẫn này tập trung vào các lỗi cài đặt/chạy thường gặp và cách giải quyết nhanh.
+
+Xác minh lần cuối: **2026-02-20**.
+
+## Cài đặt / Bootstrap
+
+### Không tìm thấy `cargo`
+
+Biểu hiện:
+
+- bootstrap thoát với lỗi `cargo is not installed`
+
+Khắc phục:
+
+```bash
+./bootstrap.sh --install-rust
+```
+
+Hoặc cài từ <https://rustup.rs/>.
+
+### Thiếu thư viện hệ thống để build
+
+Biểu hiện:
+
+- build thất bại do lỗi trình biên dịch hoặc `pkg-config`
+
+Khắc phục:
+
+```bash
+./bootstrap.sh --install-system-deps
+```
+
+### Build thất bại trên máy ít RAM / ít dung lượng
+
+Biểu hiện:
+
+- `cargo build --release` bị kill (`signal: 9`, OOM killer, hoặc `cannot allocate memory`)
+- Build vẫn lỗi sau khi thêm swap vì hết dung lượng ổ đĩa
+
+Nguyên nhân:
+
+- Bộ nhớ khi chạy (<5MB cho thao tác thông thường) khác với bộ nhớ khi biên dịch.
+- Build đầy đủ từ mã nguồn có thể cần **2 GB RAM + swap** và **6+ GB dung lượng trống**.
+- Bật swap trên ổ nhỏ có thể tránh OOM RAM nhưng vẫn lỗi vì hết dung lượng.
+
+Cách tốt nhất cho máy hạn chế tài nguyên:
+
+```bash
+./bootstrap.sh --prefer-prebuilt
+```
+
+Chế độ chỉ dùng binary (không build từ nguồn):
+
+```bash
+./bootstrap.sh --prebuilt-only
+```
+
+Nếu bắt buộc phải build từ nguồn trên máy yếu:
+
+1. Chỉ thêm swap nếu còn đủ dung lượng cho cả swap lẫn kết quả build.
+1. Giới hạn số luồng build:
+
+```bash
+CARGO_BUILD_JOBS=1 cargo build --release --locked
+```
+
+1. Bỏ bớt feature nặng khi không cần Matrix:
+
+```bash
+cargo build --release --locked --no-default-features --features hardware
+```
+
+1. Cross-compile trên máy mạnh hơn rồi copy binary sang máy đích.
+
+### Build rất chậm hoặc có vẻ bị treo
+
+Biểu hiện:
+
+- `cargo check` / `cargo build` dừng lâu ở `Checking zeroclaw`
+- Lặp lại thông báo `Blocking waiting for file lock on package cache` hoặc `build directory`
+
+Nguyên nhân trong ZeroClaw:
+
+- Thư viện Matrix E2EE (`matrix-sdk`, `ruma`, `vodozemac`) lớn và tốn thời gian kiểm tra kiểu.
+- TLS + crypto native build script (`aws-lc-sys`, `ring`) tăng thời gian biên dịch đáng kể.
+- `rusqlite` với SQLite tích hợp biên dịch mã C cục bộ.
+- Chạy nhiều cargo job/worktree song song gây tranh chấp file lock.
+
+Kiểm tra nhanh:
+
+```bash
+cargo check --timings
+cargo tree -d
+```
+
+Báo cáo thời gian được ghi tại `target/cargo-timings/cargo-timing.html`.
+
+Lặp nhanh hơn khi không cần kênh Matrix:
+
+```bash
+cargo check --no-default-features --features hardware
+```
+
+Lệnh này bỏ qua `channel-matrix` và giảm đáng kể thời gian biên dịch.
+
+Build với Matrix:
+
+```bash
+cargo check --no-default-features --features hardware,channel-matrix
+```
+
+Giảm tranh chấp lock:
+
+```bash
+pgrep -af "cargo (check|build|test)|cargo check|cargo build|cargo test"
+```
+
+Dừng các cargo job không liên quan trước khi build.
+
+### Không tìm thấy lệnh `zeroclaw` sau cài đặt
+
+Biểu hiện:
+
+- Cài đặt thành công nhưng shell không tìm thấy `zeroclaw`
+
+Khắc phục:
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"
+which zeroclaw
+```
+
+Thêm vào shell profile nếu cần giữ lâu dài.
+
+## Runtime / Gateway
+
+### Không kết nối được gateway
+
+Kiểm tra:
+
+```bash
+zeroclaw status
+zeroclaw doctor
+```
+
+Xác minh `~/.zeroclaw/config.toml`:
+
+- `[gateway].host` (mặc định `127.0.0.1`)
+- `[gateway].port` (mặc định `3000`)
+- `allow_public_bind` chỉ bật khi cố ý mở truy cập LAN/public
+
+### Lỗi ghép nối / xác thực webhook
+
+Kiểm tra:
+
+1. Đảm bảo đã hoàn tất ghép nối (luồng `/pair`)
+2. Đảm bảo bearer token còn hiệu lực
+3. Chạy lại chẩn đoán:
+
+```bash
+zeroclaw doctor
+```
+
+## Sự cố kênh
+
+### Telegram xung đột: `terminated by other getUpdates request`
+
+Nguyên nhân:
+
+- Nhiều poller dùng chung bot token
+
+Khắc phục:
+
+- Chỉ giữ một runtime đang chạy cho token đó
+- Dừng các tiến trình `zeroclaw daemon` / `zeroclaw channel start` thừa
+
+### Kênh không khỏe trong `channel doctor`
+
+Kiểm tra:
+
+```bash
+zeroclaw channel doctor
+```
+
+Sau đó xác minh thông tin xác thực và trường allowlist cho từng kênh trong config.
+
+## Chế độ dịch vụ
+
+### Dịch vụ đã cài nhưng không chạy
+
+Kiểm tra:
+
+```bash
+zeroclaw service status
+```
+
+Khôi phục:
+
+```bash
+zeroclaw service stop
+zeroclaw service start
+```
+
+Xem log trên Linux:
+
+```bash
+journalctl --user -u zeroclaw.service -f
+```
+
+## Tương thích cài đặt cũ
+
+Cả hai cách vẫn hoạt động:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/install.sh | bash
+```
+
+`install.sh` là điểm vào tương thích, chuyển tiếp/dự phòng về hành vi bootstrap.
+
+## Vẫn chưa giải quyết được?
+
+Thu thập và đính kèm các thông tin sau khi tạo issue:
+
+```bash
+zeroclaw --version
+zeroclaw status
+zeroclaw doctor
+zeroclaw channel doctor
+```
+
+Kèm thêm: hệ điều hành, cách cài đặt, và đoạn config đã ẩn bí mật.
+
+## Tài liệu liên quan
+
+- [operations-runbook.md](operations-runbook.md)
+- [one-click-bootstrap.md](one-click-bootstrap.md)
+- [channels-reference.md](channels-reference.md)
+- [network-deployment.md](network-deployment.md)

--- a/python/README.vi.md
+++ b/python/README.vi.md
@@ -1,0 +1,154 @@
+# zeroclaw-tools
+
+Gói Python đồng hành cho [ZeroClaw](https://github.com/zeroclaw-labs/zeroclaw) — gọi công cụ dựa trên LangGraph cho thực thi agent LLM nhất quán.
+
+## Tại sao cần gói này?
+
+Một số nhà cung cấp LLM (đặc biệt là GLM-5/Zhipu và các model tương tự) có hành vi gọi công cụ không nhất quán khi dùng lời gọi dạng văn bản. Gói này cung cấp phương pháp dựa trên LangGraph mang lại:
+
+- **Gọi công cụ nhất quán** trên mọi provider tương thích OpenAI
+- **Vòng lặp công cụ tự động** — tiếp tục gọi cho đến khi hoàn tất tác vụ
+- **Dễ mở rộng** — thêm công cụ mới bằng decorator `@tool`
+- **Không phụ thuộc framework** — hoạt động với mọi API tương thích OpenAI
+
+## Cài đặt
+
+```bash
+pip install zeroclaw-tools
+```
+
+Kèm tích hợp Discord:
+
+```bash
+pip install zeroclaw-tools[discord]
+```
+
+## Bắt đầu nhanh
+
+### Agent cơ bản
+
+```python
+import asyncio
+from zeroclaw_tools import create_agent, shell, file_read, file_write
+from langchain_core.messages import HumanMessage
+
+async def main():
+    # Tạo agent với công cụ
+    agent = create_agent(
+        tools=[shell, file_read, file_write],
+        model="glm-5",
+        api_key="your-api-key",
+        base_url="https://api.z.ai/api/coding/paas/v4"
+    )
+
+    # Thực thi tác vụ
+    result = await agent.ainvoke({
+        "messages": [HumanMessage(content="List files in /tmp directory")]
+    })
+
+    print(result["messages"][-1].content)
+
+asyncio.run(main())
+```
+
+### Dùng qua CLI
+
+```bash
+# Đặt biến môi trường
+export API_KEY="your-api-key"
+export API_BASE="https://api.z.ai/api/coding/paas/v4"
+
+# Chạy CLI
+zeroclaw-tools "List files in the current directory"
+
+# Chế độ tương tác (không cần tin nhắn)
+zeroclaw-tools -i
+```
+
+### Bot Discord
+
+```python
+import os
+from zeroclaw_tools.integrations import DiscordBot
+
+bot = DiscordBot(
+    token=os.environ["DISCORD_TOKEN"],
+    guild_id=123456789,
+    allowed_users=["123456789"]
+)
+
+bot.run()
+```
+
+## Công cụ có sẵn
+
+| Công cụ | Mô tả |
+|------|-------------|
+| `shell` | Thực thi lệnh shell |
+| `file_read` | Đọc nội dung file |
+| `file_write` | Ghi nội dung vào file |
+| `web_search` | Tìm kiếm web (cần Brave API key) |
+| `http_request` | Gửi yêu cầu HTTP |
+| `memory_store` | Lưu dữ liệu vào bộ nhớ |
+| `memory_recall` | Truy xuất dữ liệu đã lưu |
+
+## Tạo công cụ tùy chỉnh
+
+```python
+from zeroclaw_tools import tool
+
+@tool
+def my_custom_tool(query: str) -> str:
+    """Mô tả công cụ này làm gì."""
+    # Viết logic tại đây
+    return f"Result for: {query}"
+
+# Dùng với agent
+agent = create_agent(tools=[my_custom_tool])
+```
+
+## Tương thích provider
+
+Hoạt động với mọi provider tương thích OpenAI:
+
+- **Z.AI / GLM-5** — `https://api.z.ai/api/coding/paas/v4`
+- **OpenRouter** — `https://openrouter.ai/api/v1`
+- **Groq** — `https://api.groq.com/openai/v1`
+- **DeepSeek** — `https://api.deepseek.com`
+- **Ollama** — `http://localhost:11434/v1`
+- **Và nhiều hơn nữa...**
+
+## Kiến trúc
+
+```
+┌─────────────────────────────────────────────┐
+│              Ứng dụng của bạn               │
+├─────────────────────────────────────────────┤
+│           zeroclaw-tools Agent              │
+│  ┌─────────────────────────────────────┐   │
+│  │         LangGraph StateGraph         │   │
+│  │    ┌───────────┐    ┌──────────┐    │   │
+│  │    │   Agent   │───▶│   Tools  │    │   │
+│  │    │   Node    │◀───│   Node   │    │   │
+│  │    └───────────┘    └──────────┘    │   │
+│  └─────────────────────────────────────┘   │
+├─────────────────────────────────────────────┤
+│     Nhà cung cấp LLM tương thích OpenAI    │
+└─────────────────────────────────────────────┘
+```
+
+## So sánh với Rust ZeroClaw
+
+| Tính năng | Rust ZeroClaw | zeroclaw-tools |
+|---------|---------------|----------------|
+| **Kích thước binary** | ~3.4 MB | Gói Python |
+| **Bộ nhớ** | <5 MB | ~50 MB |
+| **Thời gian khởi động** | <10ms | ~500ms |
+| **Độ nhất quán công cụ** | Phụ thuộc model | LangGraph đảm bảo |
+| **Khả năng mở rộng** | Rust traits | Python decorators |
+
+Dùng **Rust ZeroClaw** cho triển khai biên (edge) trong sản phẩm. Dùng **zeroclaw-tools** khi cần đảm bảo tính nhất quán gọi công cụ hoặc tích hợp hệ sinh thái Python.
+
+## Giấy phép
+
+MIT License — xem [LICENSE](../LICENSE)


### PR DESCRIPTION
## Summary
- Create Vietnamese translations (`.vi.md`) for 7 key documentation files
- Translation style: natural idiomatic Vietnamese (thuần Việt), technical terms/commands/paths kept in English

## New files (7)
| File | Source |
|---|---|
| `docs/README.vi.md` | `docs/README.md` (docs hub) |
| `docs/commands-reference.vi.md` | `docs/commands-reference.md` |
| `docs/config-reference.vi.md` | `docs/config-reference.md` |
| `docs/troubleshooting.vi.md` | `docs/troubleshooting.md` |
| `docs/one-click-bootstrap.vi.md` | `docs/one-click-bootstrap.md` |
| `docs/getting-started/README.vi.md` | `docs/getting-started/README.md` |
| `python/README.vi.md` | `python/README.md` |

## Translation guidelines
- Natural Vietnamese phrasing, avoiding word-by-word translation
- Command names, config keys, API paths, code blocks kept in English
- Internal links point to English source docs (consistent with zh-CN/ja/ru pattern)
- "Other languages" section includes all 5 supported locales

## Test plan
- [ ] Verify all `.vi.md` files render correctly on GitHub
- [ ] Verify internal links resolve to correct targets
- [ ] Spot-check translation quality against source docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)