### PR TITLE
fix(providers): update synthetic provider base URL

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -212,8 +212,14 @@ struct QwenOauthCredentials {
 impl std::fmt::Debug for QwenOauthCredentials {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QwenOauthCredentials")
-            .field("access_token", &self.access_token.as_ref().map(|_| "[REDACTED]"))
-            .field("refresh_token", &self.refresh_token.as_ref().map(|_| "[REDACTED]"))
+            .field(
+                "access_token",
+                &self.access_token.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_ref().map(|_| "[REDACTED]"),
+            )
             .field("resource_url", &self.resource_url)
             .field("expiry_date", &self.expiry_date)
             .finish()
@@ -245,7 +251,10 @@ struct QwenOauthProviderContext {
 impl std::fmt::Debug for QwenOauthProviderContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QwenOauthProviderContext")
-            .field("credential", &self.credential.as_ref().map(|_| "[REDACTED]"))
+            .field(
+                "credential",
+                &self.credential.as_ref().map(|_| "[REDACTED]"),
+            )
             .field("base_url", &self.base_url)
             .finish()
     }
@@ -984,7 +993,7 @@ fn create_provider_with_url_and_options(
             ),
         )),
         "synthetic" => Ok(Box::new(OpenAiCompatibleProvider::new(
-            "Synthetic", "https://api.synthetic.com", key, AuthStyle::Bearer,
+            "Synthetic", "https://api.synthetic.new/openai/v1", key, AuthStyle::Bearer,
         ))),
         "opencode" | "opencode-zen" => Ok(Box::new(OpenAiCompatibleProvider::new(
             "OpenCode Zen", "https://opencode.ai/zen/v1", key, AuthStyle::Bearer,


### PR DESCRIPTION
## Summary
Fixes the hardcoded synthetic provider base URL from `https://api.synthetic.com` to `https://api.synthetic.new/openai/v1`.

## Problem
The synthetic provider was configured with an incorrect base URL which caused connection failures when users tried to use the synthetic provider.

**Why it matters**: Users attempting to use the synthetic provider would encounter connection failures without understanding why. This creates a poor user experience and prevents the provider from working out of the box.

## Solution
Updated the base URL in `src/providers/mod.rs:987` from:
- `https://api.synthetic.com`
to:
- `https://api.synthetic.new/openai/v1`

**What changed**: Single line change updating the hardcoded base URL for the synthetic provider.

## Validation Evidence
- **Local testing**: User verified that the old URL doesn't work (connection failures)
- **Workaround confirmed**: User made it work locally using custom provider syntax:
  ```toml
  default_provider = "custom:https://api.synthetic.new/openai/v1"
  default_model = "hf:moonshotai/Kimi-K2.5"
  ```
- **Compilation**: Verified the change compiles successfully
- **Tests**: No test changes needed (tests verify factory creation, not URL values)
- **Documentation**: No documentation updates needed

### Validation Commands Run
```bash
# Format check
cargo fmt --all -- --check

# Clippy check
cargo clippy --all-targets -- -D warnings

# Tests
cargo test
```

## Security Impact
**Risk Level**: Low

**Risk Assessment**: This is a URL change for a specific provider that was already broken. No security boundaries are affected.

**Mitigation**: N/A - The change only updates a hardcoded URL to the correct endpoint. No security policies or access controls are modified.

## Privacy and Data Hygiene
- [x] No personal data or sensitive information in code, commits, or PR
- [x] No real names, emails, or identifiers used
- [x] No secrets, tokens, or credentials in the change
- [x] Test data uses neutral/project-scoped identifiers only

## Rollback Plan
- **Rollback Strategy**: Revert this commit to restore the previous (non-working) URL
- **Impact of Rollback**: Users would need to use the custom provider workaround again
- **Rollback Command**: `git revert <commit-hash>`

## Risk Assessment
**Low** - This is a URL change for a specific provider that was already broken. No other providers or functionality are affected.

## Testing
- [x] Verified the change compiles
- [x] No documentation updates needed
- [x] Tests don't need updating (they verify factory creation, not URL values)