### PR TITLE
fix(tests): increase lucid memory test timeouts to prevent flakiness

### DIFF
--- a/src/memory/lucid.rs
+++ b/src/memory/lucid.rs
@@ -497,8 +497,8 @@ exit 1
             cmd,
             200,
             3,
-            Duration::from_millis(500),
-            Duration::from_millis(400),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
             Duration::from_secs(2),
         )
     }
@@ -588,8 +588,8 @@ exit 1
             probe_cmd,
             200,
             1,
-            Duration::from_millis(500),
-            Duration::from_millis(400),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
             Duration::from_secs(2),
         );
 
@@ -658,8 +658,8 @@ exit 1
             failing_cmd,
             200,
             99,
-            Duration::from_millis(500),
-            Duration::from_millis(400),
+            Duration::from_secs(5),
+            Duration::from_secs(5),
             Duration::from_secs(5),
         );
 


### PR DESCRIPTION
## Summary
- Lucid memory tests used 500ms/400ms recall/store timeouts for shell script execution
- Under parallel test load, bash process spawning exceeded these limits, causing the timeout to kill scripts before they wrote to marker files — consistent test failures when run with full suite
- Widened test timeouts to 5s (scripts complete in <50ms; margin absorbs OS scheduling jitter)

## Test plan
- [x] `cargo test` — 2407 passed, 0 failed (previously 3 lucid tests failed when run in parallel)
- [x] Verified stable across 3 consecutive full runs
- [x] `cargo check` — clean

## Risk and rollback
- **Risk**: Low — test-only change, no production code modified
- **Rollback**: Revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)