### PR TITLE
fix(security): make schedule tool honor cron.enabled and command policy

### DIFF
--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -69,6 +69,11 @@ Last verified: **February 20, 2026**.
 - `zeroclaw cron pause <id>`
 - `zeroclaw cron resume <id>`
 
+Notes:
+
+- Mutating schedule/cron actions require `cron.enabled = true`.
+- Shell command payloads for schedule creation (`create` / `add` / `once`) are validated by security command policy before job persistence.
+
 ### `models`
 
 - `zeroclaw models refresh`

--- a/src/tools/schedule.rs
+++ b/src/tools/schedule.rs
@@ -55,6 +55,11 @@ impl Tool for ScheduleTool {
                     "type": "string",
                     "description": "Shell command to execute. Required for create/add/once."
                 },
+                "approved": {
+                    "type": "boolean",
+                    "description": "Set true to explicitly approve medium/high-risk shell commands in supervised mode",
+                    "default": false
+                },
                 "id": {
                     "type": "string",
                     "description": "Task ID. Required for get/cancel/remove/pause/resume."
@@ -83,7 +88,11 @@ impl Tool for ScheduleTool {
                 if let Some(blocked) = self.enforce_mutation_allowed(action) {
                     return Ok(blocked);
                 }
-                self.handle_create_like(action, &args)
+                let approved = args
+                    .get("approved")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false);
+                self.handle_create_like(action, &args, approved)
             }
             "cancel" | "remove" => {
                 if let Some(blocked) = self.enforce_mutation_allowed(action) {
@@ -128,6 +137,16 @@ impl Tool for ScheduleTool {
 
 impl ScheduleTool {
     fn enforce_mutation_allowed(&self, action: &str) -> Option<ToolResult> {
+        if !self.config.cron.enabled {
+            return Some(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "cron is disabled by config (cron.enabled=false); cannot perform '{action}'"
+                )),
+            });
+        }
+
         if !self.security.can_act() {
             return Some(ToolResult {
                 success: false,
@@ -219,12 +238,25 @@ impl ScheduleTool {
         }
     }
 
-    fn handle_create_like(&self, action: &str, args: &serde_json::Value) -> Result<ToolResult> {
+    fn handle_create_like(
+        &self,
+        action: &str,
+        args: &serde_json::Value,
+        approved: bool,
+    ) -> Result<ToolResult> {
         let command = args
             .get("command")
             .and_then(|value| value.as_str())
             .filter(|value| !value.trim().is_empty())
             .ok_or_else(|| anyhow::anyhow!("Missing or empty 'command' parameter"))?;
+
+        if let Err(reason) = self.security.validate_command_execution(command, approved) {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(reason),
+            });
+        }
 
         let expression = args.get("expression").and_then(|value| value.as_str());
         let delay = args.get("delay").and_then(|value| value.as_str());
@@ -524,5 +556,116 @@ mod tests {
         let result = tool.execute(json!({"action": "explode"})).await.unwrap();
         assert!(!result.success);
         assert!(result.error.as_deref().unwrap().contains("Unknown action"));
+    }
+
+    #[tokio::test]
+    async fn mutating_actions_fail_when_cron_disabled() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        config.cron.enabled = false;
+        std::fs::create_dir_all(&config.workspace_dir).unwrap();
+        let security = Arc::new(SecurityPolicy::from_config(
+            &config.autonomy,
+            &config.workspace_dir,
+        ));
+        let tool = ScheduleTool::new(security, config);
+
+        let create = tool
+            .execute(json!({
+                "action": "create",
+                "expression": "*/5 * * * *",
+                "command": "echo hello"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!create.success);
+        assert!(create
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("cron is disabled"));
+    }
+
+    #[tokio::test]
+    async fn create_blocks_disallowed_command() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        config.autonomy.level = AutonomyLevel::Supervised;
+        config.autonomy.allowed_commands = vec!["echo".into()];
+        std::fs::create_dir_all(&config.workspace_dir).unwrap();
+        let security = Arc::new(SecurityPolicy::from_config(
+            &config.autonomy,
+            &config.workspace_dir,
+        ));
+        let tool = ScheduleTool::new(security, config);
+
+        let result = tool
+            .execute(json!({
+                "action": "create",
+                "expression": "*/5 * * * *",
+                "command": "curl https://example.com"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("not allowed"));
+    }
+
+    #[tokio::test]
+    async fn medium_risk_create_requires_approval() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            ..Config::default()
+        };
+        config.autonomy.level = AutonomyLevel::Supervised;
+        config.autonomy.allowed_commands = vec!["touch".into()];
+        std::fs::create_dir_all(&config.workspace_dir).unwrap();
+        let security = Arc::new(SecurityPolicy::from_config(
+            &config.autonomy,
+            &config.workspace_dir,
+        ));
+        let tool = ScheduleTool::new(security, config);
+
+        let denied = tool
+            .execute(json!({
+                "action": "create",
+                "expression": "*/5 * * * *",
+                "command": "touch schedule-policy-test"
+            }))
+            .await
+            .unwrap();
+        assert!(!denied.success);
+        assert!(denied
+            .error
+            .as_deref()
+            .unwrap_or_default()
+            .contains("explicit approval"));
+
+        let approved = tool
+            .execute(json!({
+                "action": "create",
+                "expression": "*/5 * * * *",
+                "command": "touch schedule-policy-test",
+                "approved": true
+            }))
+            .await
+            .unwrap();
+        assert!(approved.success, "{:?}", approved.error);
     }
 }


### PR DESCRIPTION
## Summary
- enforce `cron.enabled` for all mutating schedule actions (`create/add/once/cancel/remove/pause/resume`)
- enforce command execution policy before persisting schedule jobs for `create/add/once`
- add explicit `approved` argument support for supervised command approval flow
- add regression tests covering cron flag gating, disallowed command blocking, and approval requirements
- document the schedule/cron mutation and command-policy rules in command reference docs

## Root Cause
The schedule tool create-like paths inserted jobs directly without checking:
- feature flag state (`cron.enabled`)
- command execution policy (`validate_command_execution`)

This allowed policy bypass and behavior drift from expected security controls.

## Validation
- `cargo test --lib --no-default-features tools::schedule::tests:: -- --nocapture --test-threads=1`
  - result: `9 passed; 0 failed`

Closes #600
