### PR TITLE
feat(skills): add compact prompt injection mode for low-context models

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,9 +946,10 @@ Community `open-skills` sync is disabled by default. Enable it explicitly in `co
 [skills]
 open_skills_enabled = true
 # open_skills_dir = "/path/to/open-skills"  # optional
+# prompt_injection_mode = "compact"          # optional: use for low-context local models
 ```
 
-You can also override at runtime with `ZEROCLAW_OPEN_SKILLS_ENABLED` and `ZEROCLAW_OPEN_SKILLS_DIR`.
+You can also override at runtime with `ZEROCLAW_OPEN_SKILLS_ENABLED`, `ZEROCLAW_OPEN_SKILLS_DIR`, and `ZEROCLAW_SKILLS_PROMPT_MODE` (`full` or `compact`).
 
 ## Development
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -134,6 +134,7 @@ Notes:
 |---|---|---|
 | `open_skills_enabled` | `false` | Opt-in loading/sync of community `open-skills` repository |
 | `open_skills_dir` | unset | Optional local path for `open-skills` (defaults to `$HOME/open-skills` when enabled) |
+| `prompt_injection_mode` | `full` | Skill prompt verbosity: `full` (inline instructions/tools) or `compact` (name/description/location only) |
 
 Notes:
 
@@ -141,7 +142,9 @@ Notes:
 - Environment overrides:
   - `ZEROCLAW_OPEN_SKILLS_ENABLED` accepts `1/0`, `true/false`, `yes/no`, `on/off`.
   - `ZEROCLAW_OPEN_SKILLS_DIR` overrides the repository path when non-empty.
+  - `ZEROCLAW_SKILLS_PROMPT_MODE` accepts `full` or `compact`.
 - Precedence for enable flag: `ZEROCLAW_OPEN_SKILLS_ENABLED` → `skills.open_skills_enabled` in `config.toml` → default `false`.
+- `prompt_injection_mode = "compact"` is recommended on low-context local models to reduce startup prompt size while keeping skill files available on demand.
 
 ## `[composio]`
 

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -30,6 +30,7 @@ pub struct Agent {
     workspace_dir: std::path::PathBuf,
     identity_config: crate::config::IdentityConfig,
     skills: Vec<crate::skills::Skill>,
+    skills_prompt_mode: crate::config::SkillsPromptInjectionMode,
     auto_save: bool,
     history: Vec<ConversationMessage>,
     classification_config: crate::config::QueryClassificationConfig,
@@ -50,6 +51,7 @@ pub struct AgentBuilder {
     workspace_dir: Option<std::path::PathBuf>,
     identity_config: Option<crate::config::IdentityConfig>,
     skills: Option<Vec<crate::skills::Skill>>,
+    skills_prompt_mode: Option<crate::config::SkillsPromptInjectionMode>,
     auto_save: Option<bool>,
     classification_config: Option<crate::config::QueryClassificationConfig>,
     available_hints: Option<Vec<String>>,
@@ -71,6 +73,7 @@ impl AgentBuilder {
             workspace_dir: None,
             identity_config: None,
             skills: None,
+            skills_prompt_mode: None,
             auto_save: None,
             classification_config: None,
             available_hints: None,
@@ -142,6 +145,14 @@ impl AgentBuilder {
         self
     }
 
+    pub fn skills_prompt_mode(
+        mut self,
+        skills_prompt_mode: crate::config::SkillsPromptInjectionMode,
+    ) -> Self {
+        self.skills_prompt_mode = Some(skills_prompt_mode);
+        self
+    }
+
     pub fn auto_save(mut self, auto_save: bool) -> Self {
         self.auto_save = Some(auto_save);
         self
@@ -197,6 +208,7 @@ impl AgentBuilder {
                 .unwrap_or_else(|| std::path::PathBuf::from(".")),
             identity_config: self.identity_config.unwrap_or_default(),
             skills: self.skills.unwrap_or_default(),
+            skills_prompt_mode: self.skills_prompt_mode.unwrap_or_default(),
             auto_save: self.auto_save.unwrap_or(false),
             history: Vec::new(),
             classification_config: self.classification_config.unwrap_or_default(),
@@ -312,6 +324,7 @@ impl Agent {
                 &config.workspace_dir,
                 config,
             ))
+            .skills_prompt_mode(config.skills.prompt_injection_mode)
             .auto_save(config.memory.auto_save)
             .build()
     }
@@ -350,6 +363,7 @@ impl Agent {
             model_name: &self.model_name,
             tools: &self.tools,
             skills: &self.skills,
+            skills_prompt_mode: self.skills_prompt_mode,
             identity_config: Some(&self.identity_config),
             dispatcher_instructions: &instructions,
         };

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1561,6 +1561,7 @@ pub async fn run(
         Some(&config.identity),
         bootstrap_max_chars,
         native_tools,
+        config.skills.prompt_injection_mode,
     );
 
     // Append structured tool-use instructions with schemas (only for non-native providers)
@@ -1928,6 +1929,7 @@ pub async fn process_message(config: Config, message: &str) -> Result<String> {
         Some(&config.identity),
         bootstrap_max_chars,
         native_tools,
+        config.skills.prompt_injection_mode,
     );
     if !native_tools {
         system_prompt.push_str(&build_tool_instructions(&tools_registry));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -12,8 +12,9 @@ pub use schema::{
     NextcloudTalkConfig, ObservabilityConfig, PeripheralBoardConfig, PeripheralsConfig,
     ProxyConfig, ProxyScope, QueryClassificationConfig, ReliabilityConfig, ResourceLimitsConfig,
     RuntimeConfig, SandboxBackend, SandboxConfig, SchedulerConfig, SecretsConfig, SecurityConfig,
-    SkillsConfig, SlackConfig, StorageConfig, StorageProviderConfig, StorageProviderSection,
-    StreamMode, TelegramConfig, TunnelConfig, WebSearchConfig, WebhookConfig,
+    SkillsConfig, SkillsPromptInjectionMode, SlackConfig, StorageConfig, StorageProviderConfig,
+    StorageProviderSection, StreamMode, TelegramConfig, TunnelConfig, WebSearchConfig,
+    WebhookConfig,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add a configurable `[skills].prompt_injection_mode` with two modes: `full` (default) and `compact`
- thread the selected skills prompt mode through system-prompt assembly (`channels` + `agent prompt builder`)
- add compact-mode coverage in `skills`, `channels`, `agent::prompt`, and config env override tests
- document config and env override (`ZEROCLAW_SKILLS_PROMPT_MODE`) in README + config reference

## Problem
Issue #1066 reported severe startup system-prompt growth after full skill-text injection, which can consume most of the context window on low-context local models.

## Why It Matters
When startup prompt usage is too high, local deployments have little room for user/task context, causing degraded quality or unusable sessions.

## What Changed
- `src/config/schema.rs`
  - added `SkillsPromptInjectionMode` enum: `full` | `compact`
  - added `skills.prompt_injection_mode` to `SkillsConfig` (default `full`)
  - added env override: `ZEROCLAW_SKILLS_PROMPT_MODE`
- `src/skills/mod.rs`
  - added `skills_to_prompt_with_mode(...)`
  - retained `skills_to_prompt(...)` as backward-compatible full-mode wrapper
  - compact mode now emits only skill metadata (`name`, `description`, `location`) and explicitly instructs load-on-demand
- `src/channels/mod.rs`, `src/agent/prompt.rs`, `src/agent/agent.rs`, `src/agent/loop_.rs`
  - wired mode through all prompt construction paths
- `README.md`, `docs/config-reference.md`
  - documented new config and env option

## Validation Evidence (required)
Commands executed successfully in isolated build context with pinned compiler path:

```bash
rustfmt --check src/agent/prompt.rs src/channels/mod.rs src/config/schema.rs src/skills/mod.rs
RUSTC=$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/rustc \
RUSTDOC=$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/rustdoc \
CARGO_BUILD_RUSTC_WRAPPER= RUSTC_WRAPPER= SCCACHE_DISABLE=1 \
$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/cargo check --locked

RUSTC=$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/rustc \
RUSTDOC=$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/rustdoc \
CARGO_BUILD_RUSTC_WRAPPER= RUSTC_WRAPPER= SCCACHE_DISABLE=1 \
$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/cargo test --locked skills_to_prompt_compact_mode_omits_instructions_and_tools

RUSTC=$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/rustc \
RUSTDOC=$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/rustdoc \
CARGO_BUILD_RUSTC_WRAPPER= RUSTC_WRAPPER= SCCACHE_DISABLE=1 \
$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/cargo test --locked prompt_skills_compact_mode_omits_instructions_and_tools

RUSTC=$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/rustc \
RUSTDOC=$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/rustdoc \
CARGO_BUILD_RUSTC_WRAPPER= RUSTC_WRAPPER= SCCACHE_DISABLE=1 \
$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/cargo test --locked skills_section_compact_mode_omits_instructions_and_tools

RUSTC=$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/rustc \
RUSTDOC=$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/rustdoc \
CARGO_BUILD_RUSTC_WRAPPER= RUSTC_WRAPPER= SCCACHE_DISABLE=1 \
$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/cargo test --locked env_override_open_skills_enabled_and_dir

RUSTC=$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/rustc \
RUSTDOC=$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/rustdoc \
CARGO_BUILD_RUSTC_WRAPPER= RUSTC_WRAPPER= SCCACHE_DISABLE=1 \
$HOME/.rustup/toolchains/1.92.0-aarch64-apple-darwin/bin/cargo test --locked env_override_open_skills_enabled_invalid_value_keeps_existing_value
```

Results:
- all listed commands completed successfully
- compact-mode and env-override behaviors pass targeted coverage

## Security Impact (required)
- no new network surface, secrets flow, or privilege path added
- change is limited to prompt composition policy and config parsing
- invalid env values are ignored safely (existing behavior preserved)

## Privacy and Data Hygiene (required)
- no new logging of sensitive data
- no personal data added to code, docs, tests, or examples
- no local/private artifacts included in commit

## Rollback Plan (required)
- revert this PR commit if needed
- runtime fallback remains available by setting `skills.prompt_injection_mode = "full"` or `ZEROCLAW_SKILLS_PROMPT_MODE=full`
- default remains `full`, so rollback risk is low

Closes #1066