### PR TITLE
feat(channel): add native Nextcloud Talk integration

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,6 +28,7 @@ Last refreshed: **February 18, 2026**.
 - [commands-reference.md](commands-reference.md)
 - [providers-reference.md](providers-reference.md)
 - [channels-reference.md](channels-reference.md)
+- [nextcloud-talk-setup.md](nextcloud-talk-setup.md)
 - [config-reference.md](config-reference.md)
 - [custom-providers.md](custom-providers.md)
 - [zai-glm-setup.md](zai-glm-setup.md)

--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -10,6 +10,7 @@ For encrypted Matrix rooms, also read the dedicated runbook:
 - Need a full config reference by channel: jump to [Per-Channel Config Examples](#4-per-channel-config-examples).
 - Need a no-response diagnosis flow: jump to [Troubleshooting Checklist](#6-troubleshooting-checklist).
 - Need Matrix encrypted-room help: use [Matrix E2EE Guide](./matrix-e2ee-guide.md).
+- Need Nextcloud Talk bot setup: use [Nextcloud Talk Setup](./nextcloud-talk-setup.md).
 - Need deployment/network assumptions (polling vs webhook): use [Network Deployment](./network-deployment.md).
 
 ## FAQ: Matrix setup passes but no reply
@@ -102,6 +103,7 @@ If `[channels_config.matrix]` is present but the binary was built without `chann
 | Matrix | sync API (supports E2EE) | No |
 | Signal | signal-cli HTTP bridge | No (local bridge endpoint) |
 | WhatsApp | webhook (Cloud API) or websocket (Web mode) | Cloud API: Yes (public HTTPS callback), Web mode: No |
+| Nextcloud Talk | webhook (`/nextcloud-talk`) | Yes (public HTTPS callback) |
 | Webhook | gateway endpoint (`/webhook`) | Usually yes |
 | Email | IMAP polling + SMTP send | No |
 | IRC | IRC socket | No |
@@ -122,7 +124,7 @@ For channels with inbound sender allowlists:
 
 Field names differ by channel:
 
-- `allowed_users` (Telegram/Discord/Slack/Mattermost/Matrix/IRC/Lark/DingTalk/QQ)
+- `allowed_users` (Telegram/Discord/Slack/Mattermost/Matrix/IRC/Lark/DingTalk/QQ/Nextcloud Talk)
 - `allowed_from` (Signal)
 - `allowed_numbers` (WhatsApp)
 - `allowed_senders` (Email)
@@ -336,7 +338,25 @@ app_secret = "qq-app-secret"
 allowed_users = ["*"]
 ```
 
-### 4.14 iMessage
+### 4.14 Nextcloud Talk
+
+```toml
+[channels_config.nextcloud_talk]
+base_url = "https://cloud.example.com"
+app_token = "nextcloud-talk-app-token"
+webhook_secret = "optional-webhook-secret"  # optional but recommended
+allowed_users = ["*"]
+```
+
+Notes:
+
+- Inbound webhook endpoint: `POST /nextcloud-talk`.
+- Signature verification uses `X-Nextcloud-Talk-Random` and `X-Nextcloud-Talk-Signature`.
+- If `webhook_secret` is set, invalid signatures are rejected with `401`.
+- `ZEROCLAW_NEXTCLOUD_TALK_WEBHOOK_SECRET` overrides config secret.
+- See [nextcloud-talk-setup.md](./nextcloud-talk-setup.md) for a full runbook.
+
+### 4.15 iMessage
 
 ```toml
 [channels_config.imessage]
@@ -411,6 +431,7 @@ rg -n "Matrix|Telegram|Discord|Slack|Mattermost|Signal|WhatsApp|Email|IRC|Lark|D
 | Lark / Feishu | `Lark: WS connected` / `Lark event callback server listening on` | `Lark WS: ignoring ... (not in allowed_users)` / `Lark: ignoring message from unauthorized user:` | `Lark: ping failed, reconnecting` / `Lark: heartbeat timeout, reconnecting` / `Lark: WS read error:` |
 | DingTalk | `DingTalk: connected and listening for messages...` | `DingTalk: ignoring message from unauthorized user:` | `DingTalk WebSocket error:` / `DingTalk: message channel closed` |
 | QQ | `QQ: connected and identified` | `QQ: ignoring C2C message from unauthorized user:` / `QQ: ignoring group message from unauthorized user:` | `QQ: received Reconnect (op 7)` / `QQ: received Invalid Session (op 9)` / `QQ: message channel closed` |
+| Nextcloud Talk (gateway) | `POST /nextcloud-talk — Nextcloud Talk bot webhook` | `Nextcloud Talk webhook signature verification failed` / `Nextcloud Talk: ignoring message from unauthorized actor:` | `Nextcloud Talk send failed:` / `LLM error for Nextcloud Talk message:` |
 | iMessage | `iMessage channel listening (AppleScript bridge)...` | (contact allowlist enforced by `allowed_contacts`) | `iMessage poll error:` |
 
 ### 7.3 Runtime supervisor keywords

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -391,6 +391,7 @@ Examples:
 - `[channels_config.telegram]`
 - `[channels_config.discord]`
 - `[channels_config.whatsapp]`
+- `[channels_config.nextcloud_talk]`
 - `[channels_config.email]`
 
 Notes:
@@ -434,6 +435,23 @@ Notes:
 
 - WhatsApp Web requires build flag `whatsapp-web`.
 - If both Cloud and Web fields are present, Cloud mode wins for backward compatibility.
+
+### `[channels_config.nextcloud_talk]`
+
+Native Nextcloud Talk bot integration (webhook receive + OCS send API).
+
+| Key | Required | Purpose |
+|---|---|---|
+| `base_url` | Yes | Nextcloud base URL (e.g. `https://cloud.example.com`) |
+| `app_token` | Yes | Bot app token used for OCS bearer auth |
+| `webhook_secret` | Optional | Enables webhook signature verification |
+| `allowed_users` | Recommended | Allowed Nextcloud actor IDs (`[]` = deny all, `"*"` = allow all) |
+
+Notes:
+
+- Webhook endpoint is `POST /nextcloud-talk`.
+- `ZEROCLAW_NEXTCLOUD_TALK_WEBHOOK_SECRET` overrides `webhook_secret` when set.
+- See [nextcloud-talk-setup.md](nextcloud-talk-setup.md) for setup and troubleshooting.
 
 ## `[hardware]`
 

--- a/docs/docs-inventory.md
+++ b/docs/docs-inventory.md
@@ -45,6 +45,7 @@ Last reviewed: **February 18, 2026**.
 | `docs/commands-reference.md` | Current Reference | users/operators |
 | `docs/providers-reference.md` | Current Reference | users/operators |
 | `docs/channels-reference.md` | Current Reference | users/operators |
+| `docs/nextcloud-talk-setup.md` | Current Guide | operators |
 | `docs/config-reference.md` | Current Reference | operators |
 | `docs/custom-providers.md` | Current Integration Guide | integration developers |
 | `docs/zai-glm-setup.md` | Current Provider Setup Guide | users/operators |

--- a/docs/network-deployment.md
+++ b/docs/network-deployment.md
@@ -11,7 +11,7 @@ This document covers deploying ZeroClaw on a Raspberry Pi or other host on your 
 | **Telegram polling** | No | ZeroClaw polls Telegram API; works from anywhere |
 | **Matrix sync (including E2EE)** | No | ZeroClaw syncs via Matrix client API; no inbound webhook required |
 | **Discord/Slack** | No | Same — outbound only |
-| **Gateway webhook** | Yes | POST /webhook, WhatsApp, etc. need a public URL |
+| **Gateway webhook** | Yes | POST /webhook, /whatsapp, /linq, /nextcloud-talk need a public URL |
 | **Gateway pairing** | Yes | If you pair clients via the gateway |
 
 **Key:** Telegram, Discord, and Slack use **long-polling** — ZeroClaw makes outbound requests. No port forwarding or public IP required.
@@ -156,7 +156,7 @@ you have a polling conflict. Stop extra instances and restart only one daemon.
 
 ---
 
-## 5. Webhook Channels (WhatsApp, Custom)
+## 5. Webhook Channels (WhatsApp, Nextcloud Talk, Custom)
 
 Webhook-based channels need a **public URL** so Meta (WhatsApp) or your client can POST events.
 

--- a/docs/nextcloud-talk-setup.md
+++ b/docs/nextcloud-talk-setup.md
@@ -1,0 +1,78 @@
+# Nextcloud Talk Setup
+
+This guide covers native Nextcloud Talk integration for ZeroClaw.
+
+## 1. What this integration does
+
+- Receives inbound Talk bot webhook events via `POST /nextcloud-talk`.
+- Verifies webhook signatures (HMAC-SHA256) when a secret is configured.
+- Sends bot replies back to Talk rooms via Nextcloud OCS API.
+
+## 2. Configuration
+
+Add this section in `~/.zeroclaw/config.toml`:
+
+```toml
+[channels_config.nextcloud_talk]
+base_url = "https://cloud.example.com"
+app_token = "nextcloud-talk-app-token"
+webhook_secret = "optional-webhook-secret"
+allowed_users = ["*"]
+```
+
+Field reference:
+
+- `base_url`: Nextcloud base URL.
+- `app_token`: Bot app token used as `Authorization: Bearer <token>` for OCS send API.
+- `webhook_secret`: Shared secret for verifying `X-Nextcloud-Talk-Signature`.
+- `allowed_users`: Allowed Nextcloud actor IDs (`[]` denies all, `"*"` allows all).
+
+Environment override:
+
+- `ZEROCLAW_NEXTCLOUD_TALK_WEBHOOK_SECRET` overrides `webhook_secret` when set.
+
+## 3. Gateway endpoint
+
+Run the daemon or gateway and expose the webhook endpoint:
+
+```bash
+zeroclaw daemon
+# or
+zeroclaw gateway --host 127.0.0.1 --port 3000
+```
+
+Configure your Nextcloud Talk bot webhook URL to:
+
+- `https://<your-public-url>/nextcloud-talk`
+
+## 4. Signature verification contract
+
+When `webhook_secret` is configured, ZeroClaw verifies:
+
+- header `X-Nextcloud-Talk-Random`
+- header `X-Nextcloud-Talk-Signature`
+
+Verification formula:
+
+- `hex(hmac_sha256(secret, random + raw_request_body))`
+
+If verification fails, the gateway returns `401 Unauthorized`.
+
+## 5. Message routing behavior
+
+- ZeroClaw ignores bot-originated webhook events (`actorType = bots`).
+- ZeroClaw ignores non-message/system events.
+- Reply routing uses the Talk room token from the webhook payload.
+
+## 6. Quick validation checklist
+
+1. Set `allowed_users = ["*"]` for first-time validation.
+2. Send a test message in the target Talk room.
+3. Confirm ZeroClaw receives and replies in the same room.
+4. Tighten `allowed_users` to explicit actor IDs.
+
+## 7. Troubleshooting
+
+- `404 Nextcloud Talk not configured`: missing `[channels_config.nextcloud_talk]`.
+- `401 Invalid signature`: mismatch in `webhook_secret`, random header, or raw-body signing.
+- No reply but webhook `200`: event filtered (bot/system/non-allowed user/non-message payload).

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -13,6 +13,7 @@ Structured reference index for commands, providers, channels, config, and integr
 
 - Custom provider endpoints: [../custom-providers.md](../custom-providers.md)
 - Z.AI / GLM provider onboarding: [../zai-glm-setup.md](../zai-glm-setup.md)
+- Nextcloud Talk bot integration: [../nextcloud-talk-setup.md](../nextcloud-talk-setup.md)
 - LangGraph-based integration patterns: [../langgraph-integration.md](../langgraph-integration.md)
 
 ## Usage

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -25,6 +25,7 @@ pub mod linq;
 #[cfg(feature = "channel-matrix")]
 pub mod matrix;
 pub mod mattermost;
+pub mod nextcloud_talk;
 pub mod qq;
 pub mod signal;
 pub mod slack;
@@ -47,6 +48,7 @@ pub use linq::LinqChannel;
 #[cfg(feature = "channel-matrix")]
 pub use matrix::MatrixChannel;
 pub use mattermost::MattermostChannel;
+pub use nextcloud_talk::NextcloudTalkChannel;
 pub use qq::QQChannel;
 pub use signal::SignalChannel;
 pub use slack::SlackChannel;
@@ -1972,6 +1974,10 @@ pub async fn handle_command(command: crate::ChannelCommands, config: &Config) ->
                 ("Signal", config.channels_config.signal.is_some()),
                 ("WhatsApp", config.channels_config.whatsapp.is_some()),
                 ("Linq", config.channels_config.linq.is_some()),
+                (
+                    "Nextcloud Talk",
+                    config.channels_config.nextcloud_talk.is_some(),
+                ),
                 ("Email", config.channels_config.email.is_some()),
                 ("IRC", config.channels_config.irc.is_some()),
                 ("Lark", config.channels_config.lark.is_some()),
@@ -2167,6 +2173,17 @@ pub async fn doctor_channels(config: Config) -> Result<()> {
                 lq.api_token.clone(),
                 lq.from_phone.clone(),
                 lq.allowed_senders.clone(),
+            )),
+        ));
+    }
+
+    if let Some(ref nc) = config.channels_config.nextcloud_talk {
+        channels.push((
+            "Nextcloud Talk",
+            Arc::new(NextcloudTalkChannel::new(
+                nc.base_url.clone(),
+                nc.app_token.clone(),
+                nc.allowed_users.clone(),
             )),
         ));
     }
@@ -2553,6 +2570,14 @@ pub async fn start_channels(config: Config) -> Result<()> {
             lq.api_token.clone(),
             lq.from_phone.clone(),
             lq.allowed_senders.clone(),
+        )));
+    }
+
+    if let Some(ref nc) = config.channels_config.nextcloud_talk {
+        channels.push(Arc::new(NextcloudTalkChannel::new(
+            nc.base_url.clone(),
+            nc.app_token.clone(),
+            nc.allowed_users.clone(),
         )));
     }
 

--- a/src/channels/nextcloud_talk.rs
+++ b/src/channels/nextcloud_talk.rs
@@ -1,0 +1,485 @@
+use super::traits::{Channel, ChannelMessage, SendMessage};
+use async_trait::async_trait;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use uuid::Uuid;
+
+/// Nextcloud Talk channel in webhook mode.
+///
+/// Incoming messages are received by the gateway endpoint `/nextcloud-talk`.
+/// Outbound replies are sent through Nextcloud Talk OCS API.
+pub struct NextcloudTalkChannel {
+    base_url: String,
+    app_token: String,
+    allowed_users: Vec<String>,
+    client: reqwest::Client,
+}
+
+impl NextcloudTalkChannel {
+    pub fn new(base_url: String, app_token: String, allowed_users: Vec<String>) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            app_token,
+            allowed_users,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    fn is_user_allowed(&self, actor_id: &str) -> bool {
+        self.allowed_users.iter().any(|u| u == "*" || u == actor_id)
+    }
+
+    fn now_unix_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    fn parse_timestamp_secs(value: Option<&serde_json::Value>) -> u64 {
+        let raw = match value {
+            Some(serde_json::Value::Number(num)) => num.as_u64(),
+            Some(serde_json::Value::String(s)) => s.trim().parse::<u64>().ok(),
+            _ => None,
+        }
+        .unwrap_or_else(Self::now_unix_secs);
+
+        // Some payloads use milliseconds.
+        if raw > 1_000_000_000_000 {
+            raw / 1000
+        } else {
+            raw
+        }
+    }
+
+    fn value_to_string(value: Option<&serde_json::Value>) -> Option<String> {
+        match value {
+            Some(serde_json::Value::String(s)) => Some(s.clone()),
+            Some(serde_json::Value::Number(n)) => Some(n.to_string()),
+            _ => None,
+        }
+    }
+
+    /// Parse a Nextcloud Talk webhook payload into channel messages.
+    ///
+    /// Relevant payload fields:
+    /// - `type` (expects `message`)
+    /// - `object.token` (room token for reply routing)
+    /// - `message.actorType`, `message.actorId`, `message.message`, `message.timestamp`
+    pub fn parse_webhook_payload(&self, payload: &serde_json::Value) -> Vec<ChannelMessage> {
+        let mut messages = Vec::new();
+
+        if let Some(event_type) = payload.get("type").and_then(|v| v.as_str()) {
+            if !event_type.eq_ignore_ascii_case("message") {
+                tracing::debug!("Nextcloud Talk: skipping non-message event: {event_type}");
+                return messages;
+            }
+        }
+
+        let Some(message_obj) = payload.get("message") else {
+            return messages;
+        };
+
+        let room_token = payload
+            .get("object")
+            .and_then(|obj| obj.get("token"))
+            .and_then(|v| v.as_str())
+            .or_else(|| message_obj.get("token").and_then(|v| v.as_str()))
+            .map(str::trim)
+            .filter(|token| !token.is_empty());
+
+        let Some(room_token) = room_token else {
+            tracing::warn!("Nextcloud Talk: missing room token in webhook payload");
+            return messages;
+        };
+
+        let actor_type = message_obj
+            .get("actorType")
+            .and_then(|v| v.as_str())
+            .or_else(|| payload.get("actorType").and_then(|v| v.as_str()))
+            .unwrap_or("");
+
+        // Ignore bot-originated messages to prevent feedback loops.
+        if actor_type.eq_ignore_ascii_case("bots") {
+            tracing::debug!("Nextcloud Talk: skipping bot-originated message");
+            return messages;
+        }
+
+        let actor_id = message_obj
+            .get("actorId")
+            .and_then(|v| v.as_str())
+            .or_else(|| payload.get("actorId").and_then(|v| v.as_str()))
+            .map(str::trim)
+            .filter(|id| !id.is_empty());
+
+        let Some(actor_id) = actor_id else {
+            tracing::warn!("Nextcloud Talk: missing actorId in webhook payload");
+            return messages;
+        };
+
+        if !self.is_user_allowed(actor_id) {
+            tracing::warn!(
+                "Nextcloud Talk: ignoring message from unauthorized actor: {actor_id}. \
+                Add to channels.nextcloud_talk.allowed_users in config.toml, \
+                or run `zeroclaw onboard --channels-only` to configure interactively."
+            );
+            return messages;
+        }
+
+        let message_type = message_obj
+            .get("messageType")
+            .and_then(|v| v.as_str())
+            .unwrap_or("comment");
+        if !message_type.eq_ignore_ascii_case("comment") {
+            tracing::debug!("Nextcloud Talk: skipping non-comment messageType: {message_type}");
+            return messages;
+        }
+
+        // Ignore pure system messages.
+        let has_system_message = message_obj
+            .get("systemMessage")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .is_some_and(|value| !value.is_empty());
+        if has_system_message {
+            tracing::debug!("Nextcloud Talk: skipping system message event");
+            return messages;
+        }
+
+        let content = message_obj
+            .get("message")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|content| !content.is_empty());
+
+        let Some(content) = content else {
+            return messages;
+        };
+
+        let message_id = Self::value_to_string(message_obj.get("id"))
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+        let timestamp = Self::parse_timestamp_secs(message_obj.get("timestamp"));
+
+        messages.push(ChannelMessage {
+            id: message_id,
+            reply_target: room_token.to_string(),
+            sender: actor_id.to_string(),
+            content: content.to_string(),
+            channel: "nextcloud_talk".to_string(),
+            timestamp,
+            thread_ts: None,
+        });
+
+        messages
+    }
+
+    async fn send_to_room(&self, room_token: &str, content: &str) -> anyhow::Result<()> {
+        let encoded_room = urlencoding::encode(room_token);
+        let url = format!(
+            "{}/ocs/v2.php/apps/spreed/api/v1/chat/{}?format=json",
+            self.base_url, encoded_room
+        );
+
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.app_token)
+            .header("OCS-APIRequest", "true")
+            .header("Accept", "application/json")
+            .json(&serde_json::json!({ "message": content }))
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            return Ok(());
+        }
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        tracing::error!("Nextcloud Talk send failed: {status} — {body}");
+        anyhow::bail!("Nextcloud Talk API error: {status}");
+    }
+}
+
+#[async_trait]
+impl Channel for NextcloudTalkChannel {
+    fn name(&self) -> &str {
+        "nextcloud_talk"
+    }
+
+    async fn send(&self, message: &SendMessage) -> anyhow::Result<()> {
+        self.send_to_room(&message.recipient, &message.content)
+            .await
+    }
+
+    async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> anyhow::Result<()> {
+        tracing::info!(
+            "Nextcloud Talk channel active (webhook mode). \
+            Configure Nextcloud Talk bot webhook to POST to your gateway's /nextcloud-talk endpoint."
+        );
+
+        // Keep task alive; incoming events are handled by the gateway webhook handler.
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+        }
+    }
+
+    async fn health_check(&self) -> bool {
+        let url = format!("{}/status.php", self.base_url);
+
+        self.client
+            .get(&url)
+            .send()
+            .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+    }
+}
+
+/// Verify Nextcloud Talk webhook signature.
+///
+/// Signature calculation (official Talk bot docs):
+/// `hex(hmac_sha256(secret, X-Nextcloud-Talk-Random + raw_body))`
+pub fn verify_nextcloud_talk_signature(
+    secret: &str,
+    random: &str,
+    body: &str,
+    signature: &str,
+) -> bool {
+    let random = random.trim();
+    if random.is_empty() {
+        tracing::warn!("Nextcloud Talk: missing X-Nextcloud-Talk-Random header");
+        return false;
+    }
+
+    let signature_hex = signature
+        .trim()
+        .strip_prefix("sha256=")
+        .unwrap_or(signature)
+        .trim();
+
+    let Ok(provided) = hex::decode(signature_hex) else {
+        tracing::warn!("Nextcloud Talk: invalid signature format");
+        return false;
+    };
+
+    let payload = format!("{random}{body}");
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(secret.as_bytes()) else {
+        return false;
+    };
+    mac.update(payload.as_bytes());
+
+    mac.verify_slice(&provided).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_channel() -> NextcloudTalkChannel {
+        NextcloudTalkChannel::new(
+            "https://cloud.example.com".into(),
+            "app-token".into(),
+            vec!["user_a".into()],
+        )
+    }
+
+    #[test]
+    fn nextcloud_talk_channel_name() {
+        let channel = make_channel();
+        assert_eq!(channel.name(), "nextcloud_talk");
+    }
+
+    #[test]
+    fn nextcloud_talk_user_allowlist_exact_and_wildcard() {
+        let channel = make_channel();
+        assert!(channel.is_user_allowed("user_a"));
+        assert!(!channel.is_user_allowed("user_b"));
+
+        let wildcard = NextcloudTalkChannel::new(
+            "https://cloud.example.com".into(),
+            "app-token".into(),
+            vec!["*".into()],
+        );
+        assert!(wildcard.is_user_allowed("any_user"));
+    }
+
+    #[test]
+    fn nextcloud_talk_parse_valid_message_payload() {
+        let channel = make_channel();
+        let payload = serde_json::json!({
+            "type": "message",
+            "object": {
+                "id": "42",
+                "token": "room-token-123",
+                "name": "Team Room",
+                "type": "room"
+            },
+            "message": {
+                "id": 77,
+                "token": "room-token-123",
+                "actorType": "users",
+                "actorId": "user_a",
+                "actorDisplayName": "User A",
+                "timestamp": 1_735_701_200,
+                "messageType": "comment",
+                "systemMessage": "",
+                "message": "Hello from Nextcloud"
+            }
+        });
+
+        let messages = channel.parse_webhook_payload(&payload);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].id, "77");
+        assert_eq!(messages[0].reply_target, "room-token-123");
+        assert_eq!(messages[0].sender, "user_a");
+        assert_eq!(messages[0].content, "Hello from Nextcloud");
+        assert_eq!(messages[0].channel, "nextcloud_talk");
+        assert_eq!(messages[0].timestamp, 1_735_701_200);
+    }
+
+    #[test]
+    fn nextcloud_talk_parse_skips_non_message_events() {
+        let channel = make_channel();
+        let payload = serde_json::json!({
+            "type": "room",
+            "object": {"token": "room-token-123"},
+            "message": {
+                "actorType": "users",
+                "actorId": "user_a",
+                "message": "Hello"
+            }
+        });
+
+        let messages = channel.parse_webhook_payload(&payload);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn nextcloud_talk_parse_skips_bot_messages() {
+        let channel = NextcloudTalkChannel::new(
+            "https://cloud.example.com".into(),
+            "app-token".into(),
+            vec!["*".into()],
+        );
+        let payload = serde_json::json!({
+            "type": "message",
+            "object": {"token": "room-token-123"},
+            "message": {
+                "actorType": "bots",
+                "actorId": "bot_1",
+                "message": "Self message"
+            }
+        });
+
+        let messages = channel.parse_webhook_payload(&payload);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn nextcloud_talk_parse_skips_unauthorized_sender() {
+        let channel = make_channel();
+        let payload = serde_json::json!({
+            "type": "message",
+            "object": {"token": "room-token-123"},
+            "message": {
+                "actorType": "users",
+                "actorId": "user_b",
+                "message": "Unauthorized"
+            }
+        });
+
+        let messages = channel.parse_webhook_payload(&payload);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn nextcloud_talk_parse_skips_system_message() {
+        let channel = NextcloudTalkChannel::new(
+            "https://cloud.example.com".into(),
+            "app-token".into(),
+            vec!["*".into()],
+        );
+        let payload = serde_json::json!({
+            "type": "message",
+            "object": {"token": "room-token-123"},
+            "message": {
+                "actorType": "users",
+                "actorId": "user_a",
+                "messageType": "comment",
+                "systemMessage": "joined",
+                "message": ""
+            }
+        });
+
+        let messages = channel.parse_webhook_payload(&payload);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn nextcloud_talk_parse_timestamp_millis_to_seconds() {
+        let channel = NextcloudTalkChannel::new(
+            "https://cloud.example.com".into(),
+            "app-token".into(),
+            vec!["*".into()],
+        );
+        let payload = serde_json::json!({
+            "type": "message",
+            "object": {"token": "room-token-123"},
+            "message": {
+                "actorType": "users",
+                "actorId": "user_a",
+                "timestamp": 1735701200123u64,
+                "message": "hello"
+            }
+        });
+
+        let messages = channel.parse_webhook_payload(&payload);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].timestamp, 1_735_701_200);
+    }
+
+    const TEST_WEBHOOK_SECRET: &str = "nextcloud_test_webhook_secret";
+
+    #[test]
+    fn nextcloud_talk_signature_verification_valid() {
+        let secret = TEST_WEBHOOK_SECRET;
+        let random = "random-seed";
+        let body = r#"{"type":"message"}"#;
+
+        let payload = format!("{random}{body}");
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(payload.as_bytes());
+        let signature = hex::encode(mac.finalize().into_bytes());
+
+        assert!(verify_nextcloud_talk_signature(
+            secret, random, body, &signature
+        ));
+    }
+
+    #[test]
+    fn nextcloud_talk_signature_verification_invalid() {
+        assert!(!verify_nextcloud_talk_signature(
+            TEST_WEBHOOK_SECRET,
+            "random-seed",
+            r#"{"type":"message"}"#,
+            "deadbeef"
+        ));
+    }
+
+    #[test]
+    fn nextcloud_talk_signature_verification_accepts_sha256_prefix() {
+        let secret = TEST_WEBHOOK_SECRET;
+        let random = "random-seed";
+        let body = r#"{"type":"message"}"#;
+
+        let payload = format!("{random}{body}");
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(payload.as_bytes());
+        let signature = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+
+        assert!(verify_nextcloud_talk_signature(
+            secret, random, body, &signature
+        ));
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,11 +9,11 @@ pub use schema::{
     DelegateAgentConfig, DiscordConfig, DockerRuntimeConfig, EmbeddingRouteConfig, GatewayConfig,
     HardwareConfig, HardwareTransport, HeartbeatConfig, HttpRequestConfig, IMessageConfig,
     IdentityConfig, LarkConfig, MatrixConfig, MemoryConfig, ModelRouteConfig, MultimodalConfig,
-    ObservabilityConfig, PeripheralBoardConfig, PeripheralsConfig, ProxyConfig, ProxyScope,
-    QueryClassificationConfig, ReliabilityConfig, ResourceLimitsConfig, RuntimeConfig,
-    SandboxBackend, SandboxConfig, SchedulerConfig, SecretsConfig, SecurityConfig, SkillsConfig,
-    SlackConfig, StorageConfig, StorageProviderConfig, StorageProviderSection, StreamMode,
-    TelegramConfig, TunnelConfig, WebSearchConfig, WebhookConfig,
+    NextcloudTalkConfig, ObservabilityConfig, PeripheralBoardConfig, PeripheralsConfig,
+    ProxyConfig, ProxyScope, QueryClassificationConfig, ReliabilityConfig, ResourceLimitsConfig,
+    RuntimeConfig, SandboxBackend, SandboxConfig, SchedulerConfig, SecretsConfig, SecurityConfig,
+    SkillsConfig, SlackConfig, StorageConfig, StorageProviderConfig, StorageProviderSection,
+    StreamMode, TelegramConfig, TunnelConfig, WebSearchConfig, WebhookConfig,
 };
 
 #[cfg(test)]
@@ -59,8 +59,16 @@ mod tests {
             port: None,
         };
 
+        let nextcloud_talk = NextcloudTalkConfig {
+            base_url: "https://cloud.example.com".into(),
+            app_token: "app-token".into(),
+            webhook_secret: None,
+            allowed_users: vec!["*".into()],
+        };
+
         assert_eq!(telegram.allowed_users.len(), 1);
         assert_eq!(discord.guild_id.as_deref(), Some("123"));
         assert_eq!(lark.app_id, "app-id");
+        assert_eq!(nextcloud_talk.base_url, "https://cloud.example.com");
     }
 }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -225,6 +225,7 @@ fn has_supervised_channels(config: &Config) -> bool {
         lark,
         dingtalk,
         linq,
+        nextcloud_talk,
         qq,
         ..
     } = &config.channels_config;
@@ -242,6 +243,7 @@ fn has_supervised_channels(config: &Config) -> bool {
         || lark.is_some()
         || dingtalk.is_some()
         || linq.is_some()
+        || nextcloud_talk.is_some()
         || qq.is_some()
 }
 
@@ -358,6 +360,18 @@ mod tests {
         config.channels_config.qq = Some(crate::config::schema::QQConfig {
             app_id: "app-id".into(),
             app_secret: "app-secret".into(),
+            allowed_users: vec!["*".into()],
+        });
+        assert!(has_supervised_channels(&config));
+    }
+
+    #[test]
+    fn detects_nextcloud_talk_as_supervised_channel() {
+        let mut config = Config::default();
+        config.channels_config.nextcloud_talk = Some(crate::config::schema::NextcloudTalkConfig {
+            base_url: "https://cloud.example.com".into(),
+            app_token: "app-token".into(),
+            webhook_secret: None,
             allowed_users: vec!["*".into()],
         });
         assert!(has_supervised_channels(&config));

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -404,6 +404,7 @@ fn check_config_semantics(config: &Config, items: &mut Vec<DiagItem>) {
         || cc.imessage.is_some()
         || cc.matrix.is_some()
         || cc.whatsapp.is_some()
+        || cc.nextcloud_talk.is_some()
         || cc.email.is_some()
         || cc.irc.is_some()
         || cc.lark.is_some()

--- a/src/main.rs
+++ b/src/main.rs
@@ -826,6 +826,7 @@ async fn main() -> Result<()> {
                 ("Discord", config.channels_config.discord.is_some()),
                 ("Slack", config.channels_config.slack.is_some()),
                 ("Webhook", config.channels_config.webhook.is_some()),
+                ("Nextcloud", config.channels_config.nextcloud_talk.is_some()),
             ] {
                 println!(
                     "  {name:9} {}",


### PR DESCRIPTION
## Summary
- add a native `nextcloud_talk` channel implementation with outbound OCS send support
- add inbound gateway webhook `/nextcloud-talk` with optional HMAC signature verification
- wire channel into config schema, startup/doctor/status flows, and daemon supervised detection
- add focused docs for setup and reference updates across channel/config/network docs

## Root Cause
Issue #1062 requested first-class Nextcloud Talk support, but ZeroClaw previously had no built-in channel path for Talk webhook ingest + reply delivery.

## What Changed
- added `src/channels/nextcloud_talk.rs` implementing channel behavior, payload parsing, allowlist checks, and signature verification helpers
- integrated Nextcloud Talk channel in `src/channels/mod.rs`
- extended config schema with `[channels_config.nextcloud_talk]` in `src/config/schema.rs` and re-exports in `src/config/mod.rs`
- added gateway state/route/handler support in `src/gateway/mod.rs`
- added daemon/doctor/status wiring in `src/daemon/mod.rs`, `src/doctor/mod.rs`, and `src/main.rs`
- added new guide `docs/nextcloud-talk-setup.md` and updated docs index/reference pages

## Validation
- `cargo test --locked --no-default-features --lib nextcloud_talk -- --nocapture` (17 passed)
- targeted lib tests for webhook signature, payload parsing, gateway handler behavior, daemon supervised-channel detection, and config serde/default behavior (all passed)
- `cargo fmt --all -- --check` currently reports an existing unrelated formatting diff in `src/onboard/wizard.rs`

## Notes
- no model-name changes were introduced in this PR
- all newly added code/docs content is English-only

Closes #1062
