### PR TITLE
fix(ci): use grouped redirect for GITHUB_OUTPUT writes in pub-release

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -109,10 +109,12 @@ jobs:
                     fi
                   fi
 
-                  echo "release_ref=${release_ref}" >> "$GITHUB_OUTPUT"
-                  echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
-                  echo "publish_release=${publish_release}" >> "$GITHUB_OUTPUT"
-                  echo "draft_release=${draft_release}" >> "$GITHUB_OUTPUT"
+                  {
+                    echo "release_ref=${release_ref}"
+                    echo "release_tag=${release_tag}"
+                    echo "publish_release=${publish_release}"
+                    echo "draft_release=${draft_release}"
+                  } >> "$GITHUB_OUTPUT"
 
                   {
                     echo "### Release Context"


### PR DESCRIPTION
Replace individual >> redirects with a single grouped { ... } >> block to resolve shellcheck SC2129 and satisfy actionlint.
Fixes a few broken workflows