### PR TITLE
fix(provider): clamp gpt-5-codex reasoning effort

### DIFF
--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -175,6 +175,9 @@ fn clamp_reasoning_effort(model: &str, effort: &str) -> String {
     if (id.starts_with("gpt-5.2") || id.starts_with("gpt-5.3")) && effort == "minimal" {
         return "low".to_string();
     }
+    if id.starts_with("gpt-5-codex") && effort == "xhigh" {
+        return "high".to_string();
+    }
     if id == "gpt-5.1" && effort == "xhigh" {
         return "high".to_string();
     }
@@ -560,6 +563,10 @@ mod tests {
         );
         assert_eq!(
             clamp_reasoning_effort("gpt-5.1", "xhigh"),
+            "high".to_string()
+        );
+        assert_eq!(
+            clamp_reasoning_effort("gpt-5-codex", "xhigh"),
             "high".to_string()
         );
         assert_eq!(


### PR DESCRIPTION
## Summary
`gpt-5-codex` rejects `reasoning.effort="xhigh"` and supports only `low|medium|high`.
This patch clamps `xhigh -> high` for `gpt-5-codex` model ids before request dispatch.

## Why
Issue #1124 reports runtime 400 failures from Codex responses API when default effort resolves to `xhigh`.

## What Changed
- update `clamp_reasoning_effort` in `src/providers/openai_codex.rs`
- add test assertion for `gpt-5-codex` + `xhigh` -> `high`

## Validation
- attempted local test: `cargo test clamp_reasoning_effort_adjusts_known_models --lib`
- local environment blocker: `cargo` binary unavailable in this runner (`/bin/bash: cargo: command not found`)
- rely on GitHub CI for validation in this draft PR

Closes #1124
