### PR TITLE
feat(ci): block workflows if binary increases beyond 20mb

### DIFF
--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -91,7 +91,9 @@ jobs:
                   toolchain: 1.92.0
             - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
             - name: Build binary (smoke check)
-              run: cargo build --locked --verbose
+              run: cargo build --profile release-fast --locked --verbose
+            - name: Check binary size
+              run: ./scripts/ci/check_binary_size.sh target/release/zeroclaw
 
     docs-only:
         name: Docs-Only Fast Path

--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -208,27 +208,7 @@ jobs:
 
             - name: Check binary size (Unix)
               if: runner.os != 'Windows'
-              run: |
-                  BIN="target/${{ matrix.target }}/release-fast/${{ matrix.artifact }}"
-                  if [ ! -f "$BIN" ]; then
-                    echo "::error::Expected binary not found: $BIN"
-                    exit 1
-                  fi
-                  SIZE=$(stat -f%z "$BIN" 2>/dev/null || stat -c%s "$BIN")
-                  SIZE_MB=$((SIZE / 1024 / 1024))
-                  echo "Binary size: ${SIZE_MB}MB ($SIZE bytes)"
-                  echo "### Binary Size: ${{ matrix.target }}" >> "$GITHUB_STEP_SUMMARY"
-                  echo "- Size: ${SIZE_MB}MB ($SIZE bytes)" >> "$GITHUB_STEP_SUMMARY"
-                  if [ "$SIZE" -gt 41943040 ]; then
-                    echo "::error::Binary exceeds 40MB safeguard (${SIZE_MB}MB)"
-                    exit 1
-                  elif [ "$SIZE" -gt 15728640 ]; then
-                    echo "::warning::Binary exceeds 15MB advisory target (${SIZE_MB}MB)"
-                  elif [ "$SIZE" -gt 5242880 ]; then
-                    echo "::warning::Binary exceeds 5MB target (${SIZE_MB}MB)"
-                  else
-                    echo "Binary size within target."
-                  fi
+              run: ./scripts/ci/check_binary_size.sh "target/${{ matrix.target }}/release-fast/${{ matrix.artifact }}" "${{ matrix.target }}"
 
             - name: Package (Unix)
               if: runner.os != 'Windows'

--- a/scripts/ci/check_binary_size.sh
+++ b/scripts/ci/check_binary_size.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Check binary file size against safeguard thresholds.
+#
+# Usage: check_binary_size.sh <binary_path> [label]
+#
+# Arguments:
+#   binary_path  Path to the binary to check (required)
+#   label        Optional label for step summary (e.g. target triple)
+#
+# Thresholds:
+#   >20MB  — hard error (safeguard)
+#   >15MB  — warning (advisory)
+#   >5MB   — warning (target)
+#
+# Writes to GITHUB_STEP_SUMMARY when the variable is set and label is provided.
+
+set -euo pipefail
+
+BIN="${1:?Usage: check_binary_size.sh <binary_path> [label]}"
+LABEL="${2:-}"
+
+if [ ! -f "$BIN" ]; then
+  echo "::error::Binary not found at $BIN"
+  exit 1
+fi
+
+# macOS stat uses -f%z, Linux stat uses -c%s
+SIZE=$(stat -f%z "$BIN" 2>/dev/null || stat -c%s "$BIN")
+SIZE_MB=$((SIZE / 1024 / 1024))
+echo "Binary size: ${SIZE_MB}MB ($SIZE bytes)"
+
+if [ -n "$LABEL" ] && [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  echo "### Binary Size: $LABEL" >> "$GITHUB_STEP_SUMMARY"
+  echo "- Size: ${SIZE_MB}MB ($SIZE bytes)" >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ "$SIZE" -gt 20971520 ]; then
+  echo "::error::Binary exceeds 20MB safeguard (${SIZE_MB}MB)"
+  exit 1
+elif [ "$SIZE" -gt 15728640 ]; then
+  echo "::warning::Binary exceeds 15MB advisory target (${SIZE_MB}MB)"
+elif [ "$SIZE" -gt 5242880 ]; then
+  echo "::warning::Binary exceeds 5MB target (${SIZE_MB}MB)"
+else
+  echo "Binary size within target."
+fi


### PR DESCRIPTION
Abstract the smoke test to run slightly faster but to also fail if the size of the binary increases beyond 20mb.
Over the last 2 days the binary size has blown up about 8x it's original size.

We want to keep the final binary small -- until it's size can be reduced through code changes, the next best thing is to prevent it from growing further through CICD