### PR TITLE
fix(gemini): handle thinking model response parts correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Legacy values are still decrypted for backward compatibility but should be migrated.
 
 ### Fixed
+- **Gemini thinking model support** — Responses from thinking models (e.g. `gemini-3-pro-preview`)
+  are now handled correctly. The provider skips internal reasoning parts (`thought: true`) and
+  signature parts (`thoughtSignature`), extracting only the final answer text. Falls back to
+  thinking content when no non-thinking response is available.
 - **Onboarding channel menu dispatch** now uses an enum-backed selector instead of hard-coded
   numeric match arms, preventing duplicated pattern arms and related `unreachable pattern`
   compiler warnings in `src/onboard/wizard.rs`.

--- a/docs/providers-reference.md
+++ b/docs/providers-reference.md
@@ -64,6 +64,7 @@ credential is not reused for fallback providers.
 - Auth can come from `GEMINI_API_KEY`, `GOOGLE_API_KEY`, or Gemini CLI OAuth cache (`~/.gemini/oauth_creds.json`)
 - API key requests use `generativelanguage.googleapis.com/v1beta`
 - Gemini CLI OAuth requests use `cloudcode-pa.googleapis.com/v1internal` with Code Assist request envelope semantics
+- Thinking models (e.g. `gemini-3-pro-preview`) are supported — internal reasoning parts are automatically filtered from the response
 
 ### Ollama Vision Notes
 


### PR DESCRIPTION
## Summary

- Gemini thinking models (e.g. `gemini-3-pro-preview`) return response parts with `thought: true` (internal reasoning) and `thoughtSignature` (opaque signature blob). The current extraction logic takes the first part, which is the thinking part, returning reasoning text instead of the actual answer — or failing with "error decoding response body" when the response structure doesn't match expectations.
- Adds `thought` field to `ResponsePart`, implements `effective_text()` on `CandidateContent` to skip thinking/signature parts, updates extraction to use it.
- Makes `Candidate.content` optional to guard against candidates with no content (e.g. safety-filtered responses).
- 7 new inline tests covering thinking, non-thinking, fallback, empty, multi-part, signature-only, and internal API (cloudcode-pa) responses.
- Non-thinking models are completely unaffected.

## Problem

When using `gemini-3-pro-preview` (or other thinking-enabled Gemini models), the API returns parts like:

```json
{
  "candidates": [{
    "content": {
      "parts": [
        {"thought": true, "text": "Let me reason about this..."},
        {"text": "The actual answer."},
        {"thoughtSignature": "base64blob..."}
      ]
    }
  }]
}
```

The previous code blindly took `.parts.into_iter().next()`, which returned the thinking part instead of the answer. Parts with only `thoughtSignature` (no `text`) were noise that could cause empty responses.

## Changes

### `src/providers/gemini.rs`

- `ResponsePart`: adds `thought: bool` field (`#[serde(default)]`) to detect reasoning parts
- `Candidate`: makes `content` optional (`Option<CandidateContent>`) for robustness
- `CandidateContent::effective_text()`: new method following the `effective_content()` pattern from OpenAI provider — skips `thought: true` parts, skips signature-only parts, concatenates non-thinking text, falls back to thinking text if that's all that's available
- `send_generate_content`: uses `effective_text()` instead of `.parts.into_iter().next().and_then(|p| p.text)`

### `CHANGELOG.md`

- Entry under `[Unreleased] > Fixed`

### `docs/providers-reference.md`

- Note about thinking model support in Gemini Notes section

## Validation Evidence

- `cargo check --lib` — compiles clean (no new warnings)
- `cargo clippy` — no issues in `gemini.rs`
- `cargo fmt` — no formatting issues in changed files
- Note: `cargo test --lib` is blocked by a pre-existing compilation error in `src/agent/loop_.rs:3603` (missing 8th arg to `build_system_prompt_with_mode`) — unrelated to this PR

## Security Impact

- Risk level: **low**
- Change type: additive response parsing only
- No new privileges, no policy changes, no secret handling changes
- Non-thinking models remain on the existing code path

## Rollback Plan

- Revert this commit to restore previous extraction behavior
- No schema or config changes, no stateful data migration required

🤖 Generated with [Claude Code](https://claude.com/claude-code)