### PR TITLE
docs(channel): add Linq to documentation and feature matrix

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -198,7 +198,7 @@ zeroclaw agent --provider anthropic -m "hello"
 | サブシステム | Trait | 内蔵実装 | 拡張方法 |
 |-------------|-------|----------|----------|
 | **AI モデル** | `Provider` | `zeroclaw providers` で確認（現在 28 個の組み込み + エイリアス、カスタムエンドポイント対応） | `custom:https://your-api.com`（OpenAI 互換）または `anthropic-custom:https://your-api.com` |
-| **チャネル** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Email, IRC, Lark, DingTalk, QQ, Webhook | 任意のメッセージ API |
+| **チャネル** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Linq, Email, IRC, Lark, DingTalk, QQ, Webhook | 任意のメッセージ API |
 | **メモリ** | `Memory` | SQLite ハイブリッド検索, PostgreSQL バックエンド, Lucid ブリッジ, Markdown ファイル, 明示的 `none` バックエンド, スナップショット/復元, オプション応答キャッシュ | 任意の永続化バックエンド |
 | **ツール** | `Tool` | shell/file/memory, cron/schedule, git, pushover, browser, http_request, screenshot/image_info, composio (opt-in), delegate, ハードウェアツール | 任意の機能 |
 | **オブザーバビリティ** | `Observer` | Noop, Log, Multi | Prometheus, OTel |

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Every subsystem is a **trait** — swap implementations with a config change, ze
 | Subsystem | Trait | Ships with | Extend |
 |-----------|-------|------------|--------|
 | **AI Models** | `Provider` | Provider catalog via `zeroclaw providers` (currently 29 built-ins + aliases, plus custom endpoints) | `custom:https://your-api.com` (OpenAI-compatible) or `anthropic-custom:https://your-api.com` |
-| **Channels** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Email, IRC, Lark, DingTalk, QQ, Webhook | Any messaging API |
+| **Channels** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Linq, Email, IRC, Lark, DingTalk, QQ, Webhook | Any messaging API |
 | **Memory** | `Memory` | SQLite hybrid search, PostgreSQL backend (configurable storage provider), Lucid bridge, Markdown files, explicit `none` backend, snapshot/hydrate, optional response cache | Any persistence backend |
 | **Tools** | `Tool` | shell/file/memory, cron/schedule, git, pushover, browser, http_request, screenshot/image_info, composio (opt-in), delegate, hardware tools | Any capability |
 | **Observability** | `Observer` | Noop, Log, Multi | Prometheus, OTel |

--- a/README.ru.md
+++ b/README.ru.md
@@ -198,7 +198,7 @@ zeroclaw agent --provider anthropic -m "hello"
 | Подсистема | Trait | Встроенные реализации | Расширение |
 |-----------|-------|---------------------|------------|
 | **AI-модели** | `Provider` | Каталог через `zeroclaw providers` (сейчас 28 встроенных + алиасы, плюс пользовательские endpoint) | `custom:https://your-api.com` (OpenAI-совместимый) или `anthropic-custom:https://your-api.com` |
-| **Каналы** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Email, IRC, Lark, DingTalk, QQ, Webhook | Любой messaging API |
+| **Каналы** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Linq, Email, IRC, Lark, DingTalk, QQ, Webhook | Любой messaging API |
 | **Память** | `Memory` | SQLite гибридный поиск, PostgreSQL-бэкенд, Lucid-мост, Markdown-файлы, явный `none`-бэкенд, snapshot/hydrate, опциональный кэш ответов | Любой persistence-бэкенд |
 | **Инструменты** | `Tool` | shell/file/memory, cron/schedule, git, pushover, browser, http_request, screenshot/image_info, composio (opt-in), delegate, аппаратные инструменты | Любая функциональность |
 | **Наблюдаемость** | `Observer` | Noop, Log, Multi | Prometheus, OTel |

--- a/README.vi.md
+++ b/README.vi.md
@@ -386,7 +386,7 @@ Mọi hệ thống con đều là **trait** — chỉ cần đổi cấu hình, 
 | Hệ thống con | Trait | Đi kèm sẵn | Mở rộng |
 |-----------|-------|------------|--------|
 | **Mô hình AI** | `Provider` | Danh mục provider qua `zeroclaw providers` (hiện có 28 built-in + alias, cộng endpoint tùy chỉnh) | `custom:https://your-api.com` (tương thích OpenAI) hoặc `anthropic-custom:https://your-api.com` |
-| **Channel** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Email, IRC, Lark, DingTalk, QQ, Webhook | Bất kỳ messaging API nào |
+| **Channel** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Linq, Email, IRC, Lark, DingTalk, QQ, Webhook | Bất kỳ messaging API nào |
 | **Memory** | `Memory` | SQLite hybrid search, PostgreSQL backend (storage provider có thể cấu hình), Lucid bridge, Markdown files, backend `none` tường minh, snapshot/hydrate, response cache tùy chọn | Bất kỳ persistence backend nào |
 | **Tool** | `Tool` | shell/file/memory, cron/schedule, git, pushover, browser, http_request, screenshot/image_info, composio (opt-in), delegate, hardware tools | Bất kỳ khả năng nào |
 | **Observability** | `Observer` | Noop, Log, Multi | Prometheus, OTel |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -203,7 +203,7 @@ zeroclaw agent --provider anthropic -m "hello"
 | 子系统 | Trait | 内置实现 | 扩展方式 |
 |--------|-------|----------|----------|
 | **AI 模型** | `Provider` | 通过 `zeroclaw providers` 查看（当前 28 个内置 + 别名，以及自定义端点） | `custom:https://your-api.com`（OpenAI 兼容）或 `anthropic-custom:https://your-api.com` |
-| **通道** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Email, IRC, Lark, DingTalk, QQ, Webhook | 任意消息 API |
+| **通道** | `Channel` | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Linq, Email, IRC, Lark, DingTalk, QQ, Webhook | 任意消息 API |
 | **记忆** | `Memory` | SQLite 混合搜索, PostgreSQL 后端, Lucid 桥接, Markdown 文件, 显式 `none` 后端, 快照/恢复, 可选响应缓存 | 任意持久化后端 |
 | **工具** | `Tool` | shell/file/memory, cron/schedule, git, pushover, browser, http_request, screenshot/image_info, composio (opt-in), delegate, 硬件工具 | 任意能力 |
 | **可观测性** | `Observer` | Noop, Log, Multi | Prometheus, OTel |

--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -116,6 +116,7 @@ If `[channels_config.matrix]` or `[channels_config.lark]` is present but the cor
 | Lark/Feishu | websocket (default) or webhook | Webhook mode only |
 | DingTalk | stream mode | No |
 | QQ | bot gateway | No |
+| Linq | webhook (`/linq`) | Yes (public HTTPS callback) |
 | iMessage | local integration | No |
 
 ---
@@ -133,7 +134,7 @@ Field names differ by channel:
 - `allowed_users` (Telegram/Discord/Slack/Mattermost/Matrix/IRC/Lark/DingTalk/QQ/Nextcloud Talk)
 - `allowed_from` (Signal)
 - `allowed_numbers` (WhatsApp)
-- `allowed_senders` (Email)
+- `allowed_senders` (Email/Linq)
 - `allowed_contacts` (iMessage)
 
 ---
@@ -362,7 +363,26 @@ Notes:
 - `ZEROCLAW_NEXTCLOUD_TALK_WEBHOOK_SECRET` overrides config secret.
 - See [nextcloud-talk-setup.md](./nextcloud-talk-setup.md) for a full runbook.
 
-### 4.15 iMessage
+### 4.15 Linq
+
+```toml
+[channels_config.linq]
+api_token = "linq-partner-api-token"
+from_phone = "+15551234567"
+signing_secret = "optional-webhook-signing-secret"  # optional but recommended
+allowed_senders = ["*"]
+```
+
+Notes:
+
+- Linq uses the Partner V3 API for iMessage, RCS, and SMS.
+- Inbound webhook endpoint: `POST /linq`.
+- Signature verification uses `X-Webhook-Signature` (HMAC-SHA256) and `X-Webhook-Timestamp`.
+- If `signing_secret` is set, invalid or stale (>300s) signatures are rejected.
+- `ZEROCLAW_LINQ_SIGNING_SECRET` overrides config secret.
+- `allowed_senders` uses E.164 phone number format (e.g. `+1234567890`).
+
+### 4.16 iMessage
 
 ```toml
 [channels_config.imessage]

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -394,6 +394,7 @@ Examples:
 - `[channels_config.telegram]`
 - `[channels_config.discord]`
 - `[channels_config.whatsapp]`
+- `[channels_config.linq]`
 - `[channels_config.nextcloud_talk]`
 - `[channels_config.email]`
 
@@ -438,6 +439,24 @@ Notes:
 
 - WhatsApp Web requires build flag `whatsapp-web`.
 - If both Cloud and Web fields are present, Cloud mode wins for backward compatibility.
+
+### `[channels_config.linq]`
+
+Linq Partner V3 API integration for iMessage, RCS, and SMS.
+
+| Key | Required | Purpose |
+|---|---|---|
+| `api_token` | Yes | Linq Partner API bearer token |
+| `from_phone` | Yes | Phone number to send from (E.164 format) |
+| `signing_secret` | Optional | Webhook signing secret for HMAC-SHA256 signature verification |
+| `allowed_senders` | Recommended | Allowed inbound phone numbers (`[]` = deny all, `"*"` = allow all) |
+
+Notes:
+
+- Webhook endpoint is `POST /linq`.
+- `ZEROCLAW_LINQ_SIGNING_SECRET` overrides `signing_secret` when set.
+- Signatures use `X-Webhook-Signature` and `X-Webhook-Timestamp` headers; stale timestamps (>300s) are rejected.
+- See [channels-reference.md](channels-reference.md) for full config examples.
 
 ### `[channels_config.nextcloud_talk]`
 


### PR DESCRIPTION
## Summary
- Add Linq channel to architecture feature matrix in all READMEs (EN/ZH/JA/RU/VI)
- Add Linq delivery mode row, allowlist field, and config example (section 4.15) in `docs/channels-reference.md`
- Add `[channels_config.linq]` config key table in `docs/config-reference.md`

## Context
Linq channel code is fully implemented (`src/channels/linq.rs`, config schema, gateway `/linq` endpoint, onboarding wizard) but was missing from user-facing documentation. This PR closes that documentation gap.

## Validation
- No code changes — docs only
- Verified EN/ZH/JA/RU/VI README parity
- Verified channels-reference.md section numbering consistency (4.15 Linq, 4.16 iMessage)

## Risk and Rollback
- Risk: low (docs-only)
- Rollback: revert commit

## Test plan
- [x] Verify markdown renders correctly on GitHub
- [x] Verify channels-reference.md section links work
- [x] Verify config-reference.md table renders correctly