### PR TITLE
fix(build): remove stale rust-toolchain.toml reference from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
-# 1. Copy manifests and toolchain pin to cache dependencies with the same compiler
-COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+# 1. Copy manifests to cache dependencies
+COPY Cargo.toml Cargo.lock ./
 COPY crates/robot-kit/Cargo.toml crates/robot-kit/Cargo.toml
 # Create dummy targets declared in Cargo.toml so manifest parsing succeeds.
 RUN mkdir -p src benches crates/robot-kit/src \


### PR DESCRIPTION
## Summary

- **Problem:** Docker builds fail immediately with `"/rust-toolchain.toml": not found` because the Dockerfile still references a file that was deleted in commit c15280c.
- **Why it matters:** No one can build the Docker image from the current `main` branch — the build fails at the COPY step before compilation even begins. This blocks all container-based deployments and local Docker development workflows.
- **What changed:** Removed `rust-toolchain.toml` from the `COPY` line in the Dockerfile (line 16) and updated the accompanying comment to reflect the current state. The Rust version pin now lives in `Cargo.toml` as `rust-version = "1.87"` (set in commit c15280c), so the toolchain file is no longer needed.
- **What did **not** change (scope boundary):** No changes to source code, tests, CI workflows, config, or any other files. The `pub-docker-img.yml` workflow also has stale `rust-toolchain.toml` path triggers (lines 12, 25) but those are a separate CI hygiene concern and intentionally excluded from this PR to keep scope focused.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`): `dev`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): N/A
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `ci`

## Linked Issue

- Closes # N/A (no existing issue for this regression)
- Related # N/A
- Depends on # N/A
- Supersedes # N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A — this PR does not supersede any other PR.

## Validation Evidence (required)

Commands and result summary:

The change is Dockerfile-only (no Rust source changes), so `cargo fmt`, `cargo clippy`, and `cargo test` are not applicable to the fix itself. Validation was done by building the Docker image before and after the fix:

**Before fix (upstream main):**
```
COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
ERROR: "/rust-toolchain.toml": not found
```

**After fix:**
```
docker build --no-cache -t zeroclaw:latest .
# Build completes successfully — full compilation, strip, and multi-stage copy all pass.
# Container starts and runs the daemon with channels connected.
```

- Evidence provided (test/log/trace/screenshot/perf): Successful Docker build and container startup verified locally.
- If any command is intentionally skipped, explain why: `cargo fmt/clippy/test` skipped — this PR changes only the Dockerfile, not Rust source code. No Rust compilation behavior is affected.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: No data involved — Dockerfile build instruction change only.
- Neutral wording confirmation: Confirmed — no identity-like wording present.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Full `docker build --no-cache` from clean upstream main + this fix. Container starts successfully with `daemon` command, connects to Discord and Mattermost channels.
- Edge cases checked: Confirmed the ESP32 firmware crate has its own `rust-toolchain.toml` at `firmware/zeroclaw-esp32/rust-toolchain.toml` — that file is unaffected and correctly referenced in its own docs.
- What was not verified: The `dev` stage of the multi-stage Dockerfile (we use the `release` stage). The `dev` stage does not reference `rust-toolchain.toml` so no issue expected.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Docker image build only. The `pub-docker-img.yml` workflow will benefit since it can now build successfully.
- Potential unintended effects: None — removing a reference to a nonexistent file cannot break anything that currently works.
- Guardrails/monitoring for early detection: CI Docker build job will validate the fix.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): OpenCode (Claude) for codebase search, diff verification, and PR authoring.
- Workflow/plan summary (if any): Discovered the broken Docker build while rebuilding the container after pulling latest upstream. Traced root cause to commit c15280c which deleted `rust-toolchain.toml` but did not update the Dockerfile. Applied minimal fix.
- Verification focus: Docker build success, no unrelated file changes, no scope creep.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes — single-concern fix, no unrelated modules touched.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>` — single commit, clean revert.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: If reverted, Docker builds will fail again with `"/rust-toolchain.toml": not found`.

## Risks and Mitigations

- Risk: None. This removes a reference to a file that no longer exists. The build is currently broken without this fix.