### PR TITLE
fix(security): remove sensitive fields from Debug impls

### DIFF
--- a/src/auth/profiles.rs
+++ b/src/auth/profiles.rs
@@ -51,7 +51,7 @@ impl TokenSet {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct AuthProfile {
     pub id: String,
     pub provider: String,
@@ -69,6 +69,21 @@ pub struct AuthProfile {
     pub metadata: BTreeMap<String, String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+}
+
+impl std::fmt::Debug for AuthProfile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthProfile")
+            .field("id", &self.id)
+            .field("provider", &self.provider)
+            .field("profile_name", &self.profile_name)
+            .field("kind", &self.kind)
+            .field("workspace_id", &self.workspace_id)
+            .field("metadata", &self.metadata)
+            .field("created_at", &self.created_at)
+            .field("updated_at", &self.updated_at)
+            .finish_non_exhaustive()
+    }
 }
 
 impl AuthProfile {

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -31,6 +31,16 @@ pub struct MatrixChannel {
     http_client: Client,
 }
 
+impl std::fmt::Debug for MatrixChannel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MatrixChannel")
+            .field("homeserver", &self.homeserver)
+            .field("room_id", &self.room_id)
+            .field("allowed_users", &self.allowed_users)
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct SyncResponse {
     next_batch: String,

--- a/src/channels/qq.rs
+++ b/src/channels/qq.rs
@@ -192,10 +192,14 @@ impl Channel for QQChannel {
                 }),
             )
         } else {
-            let user_id = message
+            let raw_uid = message
                 .recipient
                 .strip_prefix("user:")
                 .unwrap_or(&message.recipient);
+            let user_id: String = raw_uid
+                .chars()
+                .filter(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
             (
                 format!("{QQ_API_BASE}/v2/users/{user_id}/messages"),
                 json!({

--- a/src/channels/whatsapp_storage.rs
+++ b/src/channels/whatsapp_storage.rs
@@ -1092,6 +1092,8 @@ impl DeviceStoreTrait for RusqliteStore {
             bytes
         };
 
+        // Safety: device account data is stored to DB only; to_store_err! converts
+        // rusqlite errors without logging parameter values.
         let account = device.account.as_ref().map(|a| a.encode_to_vec());
 
         to_store_err!(execute: conn.execute(

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -100,8 +100,7 @@ impl std::fmt::Debug for ResolvedEmbeddingConfig {
             .field("provider", &self.provider)
             .field("model", &self.model)
             .field("dimensions", &self.dimensions)
-            .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/memory/traits.rs
+++ b/src/memory/traits.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 /// A single memory entry
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct MemoryEntry {
     pub id: String,
     pub key: String,
@@ -11,6 +11,19 @@ pub struct MemoryEntry {
     pub timestamp: String,
     pub session_id: Option<String>,
     pub score: Option<f64>,
+}
+
+impl std::fmt::Debug for MemoryEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryEntry")
+            .field("id", &self.id)
+            .field("key", &self.key)
+            .field("content", &self.content)
+            .field("category", &self.category)
+            .field("timestamp", &self.timestamp)
+            .field("score", &self.score)
+            .finish_non_exhaustive()
+    }
 }
 
 /// Memory categories for organization

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -216,17 +216,9 @@ struct QwenOauthCredentials {
 impl std::fmt::Debug for QwenOauthCredentials {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QwenOauthCredentials")
-            .field(
-                "access_token",
-                &self.access_token.as_ref().map(|_| "[REDACTED]"),
-            )
-            .field(
-                "refresh_token",
-                &self.refresh_token.as_ref().map(|_| "[REDACTED]"),
-            )
             .field("resource_url", &self.resource_url)
             .field("expiry_date", &self.expiry_date)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -255,12 +247,8 @@ struct QwenOauthProviderContext {
 impl std::fmt::Debug for QwenOauthProviderContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QwenOauthProviderContext")
-            .field(
-                "credential",
-                &self.credential.as_ref().map(|_| "[REDACTED]"),
-            )
             .field("base_url", &self.base_url)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/tools/browser.rs
+++ b/src/tools/browser.rs
@@ -34,13 +34,12 @@ impl std::fmt::Debug for ComputerUseConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ComputerUseConfig")
             .field("endpoint", &self.endpoint)
-            .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
             .field("timeout_ms", &self.timeout_ms)
             .field("allow_remote_endpoint", &self.allow_remote_endpoint)
             .field("window_allowlist", &self.window_allowlist)
             .field("max_coordinate_x", &self.max_coordinate_x)
             .field("max_coordinate_y", &self.max_coordinate_y)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
Resolve 18 CodeQL cleartext-logging/cleartext-transmission alerts by removing sensitive data from Debug output entirely rather than redacting.

Changes:
- memory/mod.rs: omit api_key from ResolvedEmbeddingConfig Debug
- tools/browser.rs: omit api_key from ComputerUseConfig Debug
- providers/mod.rs: omit access_token/refresh_token from QwenOauthCredentials Debug, credential from QwenOauthProviderContext
- memory/traits.rs: custom Debug for MemoryEntry omitting session_id
- auth/profiles.rs: custom Debug for AuthProfile omitting token, token_set, account_id
- channels/matrix.rs: add Debug impl for MatrixChannel omitting access_token
- channels/qq.rs: sanitize user_id before URL interpolation
- channels/whatsapp_storage.rs: document false-positive analysis