### PR TITLE
fix(config): add missing "date" to AutonomyConfig default allowed_commands

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1819,6 +1819,7 @@ impl Default for AutonomyConfig {
                 "wc".into(),
                 "head".into(),
                 "tail".into(),
+                "date".into(),
             ],
             forbidden_paths: vec![
                 "/etc".into(),


### PR DESCRIPTION
## Summary

- Problem: `SecurityPolicy::default()` (policy.rs:114) includes `"date"` in its `allowed_commands` list, but `AutonomyConfig::default()` (schema.rs:1809-1822) omits it. Since `SecurityPolicy::from_config()` copies `allowed_commands` from `AutonomyConfig`, the `date` command is effectively blocked at runtime despite the `SecurityPolicy` unit test asserting it is allowed.
- Why it matters: Agents cannot check the current date/time without users manually adding `"date"` to their config. The existing test (`policy.rs:893 — assert!(p.is_command_allowed("date"))`) passes only because it uses `SecurityPolicy::default()` directly, masking the runtime behavior gap.
- What changed: Added `"date".into()` to `AutonomyConfig::default().allowed_commands` to restore parity with `SecurityPolicy::default()`. One line, one file.
- What did **not** change (scope boundary): No changes to `SecurityPolicy::default()`, risk classification, command validation logic, tests, other config defaults, or any other file.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): risk: low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): size: XS
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): config
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): config: autonomy
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): experienced contributor
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): config

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
# cargo fmt — PASS
cargo fmt --all -- --check

# cargo clippy / cargo test — pre-existing upstream compile errors
# in unrelated files (telegram.rs, file_read.rs, gateway/mod.rs).
# This PR changes only the default value of a Vec<String> in schema.rs.
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): Format check passes. The existing test `policy.rs:893` (`assert!(p.is_command_allowed("date"))`) already validates `date` is allowed when using `SecurityPolicy::default()` — this PR aligns `AutonomyConfig::default()` to match.
- If any command is intentionally skipped, explain why: clippy/test blocked by pre-existing upstream compile errors in unrelated files. This change is a single default-value addition with no logic changes.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No — `date` is already classified as Low risk in `command_risk_level()` and already present in `SecurityPolicy::default()`. This PR only aligns the config default to match.
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: No personal data in changed file.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes — purely additive. Users who already have `"date"` in their config are unaffected. Users without a custom `allowed_commands` list gain `date` in the default.
- Config/env changes? (`Yes/No`): Yes — `date` is added to the default `allowed_commands` list. No user action required.
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: No docs changes — one-line default value fix.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Confirmed `SecurityPolicy::default()` includes `"date"` at policy.rs:114 while `AutonomyConfig::default()` omits it. Confirmed `SecurityPolicy::from_config()` copies from `AutonomyConfig`, making the omission the effective runtime behavior.
- Edge cases checked: Users with custom `allowed_commands` in config.toml are unaffected (their list overrides the default entirely).
- What was not verified: Full cargo test suite (blocked by pre-existing upstream compile errors).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Default shell command allowlist only.
- Potential unintended effects: None — `date` is read-only and already classified as Low risk.
- Guardrails/monitoring for early detection: Existing test `policy.rs:893` already asserts `date` is allowed.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): OpenCode (Claude) for investigation and implementation
- Workflow/plan summary (if any): Discovered discrepancy while investigating a user report that the agent couldn't access date/time. Traced through shell.rs -> policy.rs -> schema.rs to identify the config default gap.
- Verification focus: Parity between SecurityPolicy::default() and AutonomyConfig::default()
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes — single-concern fix, one file, one line.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>`
- Feature flags or config toggles (if any): Users can remove `"date"` from their `allowed_commands` config to restore previous behavior.
- Observable failure symptoms: If reverted, agents using default config would be unable to run `date` (same as current behavior).

## Risks and Mitigations

- Risk: None. `date` is a read-only command with no side effects, already present in `SecurityPolicy::default()` and classified as Low risk.
  - Mitigation: Existing test coverage at policy.rs:893.