### PR TITLE
fix(channels): include date and time in system prompt datetime section

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2171,8 +2171,12 @@ pub fn build_system_prompt_with_mode(
 
     // ── 6. Date & Time ──────────────────────────────────────────
     let now = chrono::Local::now();
-    let tz = now.format("%Z").to_string();
-    let _ = writeln!(prompt, "## Current Date & Time\n\nTimezone: {tz}\n");
+    let _ = writeln!(
+        prompt,
+        "## Current Date & Time\n\n{} ({})\n",
+        now.format("%Y-%m-%d %H:%M:%S"),
+        now.format("%Z")
+    );
 
     // ── 7. Runtime ──────────────────────────────────────────────
     let host =


### PR DESCRIPTION
## Problem

The `Current Date & Time` section in `build_system_prompt_with_mode` only emitted the timezone string:

```
## Current Date & Time

Timezone: +08:00
```

No actual date or time values were included, causing the AI to hallucinate incorrect dates when asked about the current time (e.g. answering "2025年1月2日" when the actual date was 2026-02-21).

## Change

Emit the full datetime instead:

```
## Current Date & Time

2026-02-21 14:08:51 (+08:00)
```

**File:** `src/channels/mod.rs` — `build_system_prompt_with_mode`, Date & Time section (section 6)

## Verification

Tested before and after with `zeroclaw agent -m "現在幾點？今天日期？"`:

- **Before:** AI responded with a hallucinated date over a year off
- **After:** AI correctly reported the current date and time

## Non-goals

- Does not change `src/agent/prompt.rs` `DateTimeSection` (already correct)
- Does not change timezone format

## Risk and Rollback

- Risk: Low — single-line logic change in prompt construction, no API/config/schema impact
- Rollback: Revert this commit