### PR TITLE
test: add unit tests for audit-07 coverage gaps

### DIFF
--- a/src/tools/file_read.rs
+++ b/src/tools/file_read.rs
@@ -973,4 +973,21 @@ mod tests {
 
         let _ = tokio::fs::remove_dir_all(&workspace).await;
     }
+
+    #[tokio::test]
+    async fn file_read_blocks_null_byte_in_path() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_read_null_byte");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let tool = FileReadTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({"path": "test\0evil.txt"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("not allowed"));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
 }

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -1,0 +1,323 @@
+//! Config Schema Boundary Tests
+//!
+//! Validates: config defaults, backward compatibility, invalid input rejection,
+//! and gateway/security/agent config boundary conditions.
+
+use zeroclaw::config::{
+    AutonomyConfig, ChannelsConfig, Config, GatewayConfig, SecurityConfig,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invalid value fail-fast
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn config_unknown_keys_parse_without_error() {
+    let toml_str = r#"
+default_temperature = 0.7
+totally_unknown_key = "should be ignored"
+another_fake = 42
+"#;
+    let parsed: Config = toml::from_str(toml_str).expect("unknown keys should be ignored");
+    assert!((parsed.default_temperature - 0.7).abs() < f64::EPSILON);
+}
+
+#[test]
+fn config_wrong_type_for_port_fails() {
+    let toml_str = r#"
+[gateway]
+port = "not_a_number"
+"#;
+    let result: Result<Config, _> = toml::from_str(toml_str);
+    assert!(result.is_err(), "string for u16 port should fail to parse");
+}
+
+#[test]
+fn config_wrong_type_for_temperature_fails() {
+    let toml_str = r#"
+default_temperature = "hot"
+"#;
+    let result: Result<Config, _> = toml::from_str(toml_str);
+    assert!(
+        result.is_err(),
+        "string for f64 temperature should fail to parse"
+    );
+}
+
+#[test]
+fn config_negative_port_fails() {
+    let toml_str = r#"
+[gateway]
+port = -1
+"#;
+    let result: Result<Config, _> = toml::from_str(toml_str);
+    assert!(result.is_err(), "negative port should fail for u16");
+}
+
+#[test]
+fn config_overflow_port_fails() {
+    let toml_str = r#"
+[gateway]
+port = 99999
+"#;
+    let result: Result<Config, _> = toml::from_str(toml_str);
+    assert!(result.is_err(), "port > 65535 should fail for u16");
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GatewayConfig boundary tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn gateway_config_defaults_are_secure() {
+    let gw = GatewayConfig::default();
+    assert_eq!(gw.port, 3000);
+    assert_eq!(gw.host, "127.0.0.1");
+    assert!(gw.require_pairing, "pairing should be required by default");
+    assert!(
+        !gw.allow_public_bind,
+        "public bind should be denied by default"
+    );
+    assert!(
+        !gw.trust_forwarded_headers,
+        "forwarded headers should be untrusted by default"
+    );
+}
+
+#[test]
+fn gateway_config_rate_limit_defaults() {
+    let gw = GatewayConfig::default();
+    assert_eq!(gw.pair_rate_limit_per_minute, 10);
+    assert_eq!(gw.webhook_rate_limit_per_minute, 60);
+    assert_eq!(gw.rate_limit_max_keys, 10_000);
+}
+
+#[test]
+fn gateway_config_idempotency_defaults() {
+    let gw = GatewayConfig::default();
+    assert_eq!(gw.idempotency_ttl_secs, 300);
+    assert_eq!(gw.idempotency_max_keys, 10_000);
+}
+
+#[test]
+fn gateway_config_toml_roundtrip() {
+    let mut gw = GatewayConfig::default();
+    gw.port = 8080;
+    gw.host = "0.0.0.0".into();
+    gw.require_pairing = false;
+    gw.pair_rate_limit_per_minute = 5;
+
+    let toml_str = toml::to_string(&gw).expect("gateway config should serialize");
+    let parsed: GatewayConfig = toml::from_str(&toml_str).expect("should deserialize back");
+
+    assert_eq!(parsed.port, 8080);
+    assert_eq!(parsed.host, "0.0.0.0");
+    assert!(!parsed.require_pairing);
+    assert_eq!(parsed.pair_rate_limit_per_minute, 5);
+}
+
+#[test]
+fn gateway_config_missing_section_uses_defaults() {
+    let toml_str = r#"
+default_temperature = 0.5
+"#;
+    let parsed: Config = toml::from_str(toml_str).expect("missing gateway section should parse");
+    assert_eq!(parsed.gateway.port, 3000);
+    assert_eq!(parsed.gateway.host, "127.0.0.1");
+    assert!(parsed.gateway.require_pairing);
+    assert!(!parsed.gateway.allow_public_bind);
+}
+
+#[test]
+fn gateway_config_partial_section_fills_defaults() {
+    let toml_str = r#"
+default_temperature = 0.7
+
+[gateway]
+port = 9090
+"#;
+    let parsed: Config = toml::from_str(toml_str).expect("partial gateway should parse");
+    assert_eq!(parsed.gateway.port, 9090);
+    assert_eq!(parsed.gateway.host, "127.0.0.1");
+    assert!(parsed.gateway.require_pairing);
+    assert_eq!(parsed.gateway.pair_rate_limit_per_minute, 10);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SecurityConfig boundary tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn security_config_defaults() {
+    let sec = SecurityConfig::default();
+    assert!(
+        sec.sandbox.enabled.is_none(),
+        "sandbox enabled should auto-detect (None) by default"
+    );
+    assert!(sec.audit.enabled, "audit should be enabled by default");
+}
+
+#[test]
+fn security_config_toml_roundtrip() {
+    let mut sec = SecurityConfig::default();
+    sec.sandbox.enabled = Some(true);
+    sec.audit.max_size_mb = 200;
+
+    let toml_str = toml::to_string(&sec).expect("SecurityConfig should serialize");
+    let parsed: SecurityConfig = toml::from_str(&toml_str).expect("should deserialize back");
+
+    assert_eq!(parsed.sandbox.enabled, Some(true));
+    assert_eq!(parsed.audit.max_size_mb, 200);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AutonomyConfig boundary tests (security policy via Config.autonomy)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn autonomy_config_default_is_supervised() {
+    let autonomy = AutonomyConfig::default();
+    assert_eq!(
+        format!("{:?}", autonomy.level),
+        "Supervised",
+        "default autonomy should be Supervised"
+    );
+}
+
+#[test]
+fn autonomy_config_default_max_actions_per_hour() {
+    let autonomy = AutonomyConfig::default();
+    assert!(
+        autonomy.max_actions_per_hour > 0,
+        "max_actions_per_hour should be positive"
+    );
+}
+
+#[test]
+fn autonomy_config_default_workspace_only() {
+    let autonomy = AutonomyConfig::default();
+    assert!(
+        autonomy.workspace_only,
+        "workspace_only should default to true"
+    );
+}
+
+#[test]
+fn autonomy_config_toml_roundtrip() {
+    let mut config = Config::default();
+    config.autonomy.max_actions_per_hour = 50;
+    config.autonomy.workspace_only = false;
+
+    let toml_str = toml::to_string(&config).expect("config should serialize");
+    let parsed: Config = toml::from_str(&toml_str).expect("should deserialize back");
+
+    assert_eq!(parsed.autonomy.max_actions_per_hour, 50);
+    assert!(!parsed.autonomy.workspace_only);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backward compatibility
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn config_empty_toml_requires_temperature() {
+    let result: Result<Config, _> = toml::from_str("");
+    assert!(
+        result.is_err(),
+        "empty TOML should fail because default_temperature is required"
+    );
+}
+
+#[test]
+fn config_minimal_toml_with_temperature_uses_defaults() {
+    let toml_str = "default_temperature = 0.7\n";
+    let parsed: Config = toml::from_str(toml_str).expect("minimal TOML should parse");
+    assert_eq!(parsed.agent.max_tool_iterations, 10);
+    assert_eq!(parsed.gateway.port, 3000);
+}
+
+#[test]
+fn config_only_temperature_parses() {
+    let toml_str = "default_temperature = 1.2\n";
+    let parsed: Config = toml::from_str(toml_str).expect("temperature-only TOML should parse");
+    assert!((parsed.default_temperature - 1.2).abs() < f64::EPSILON);
+    assert_eq!(parsed.agent.max_tool_iterations, 10);
+}
+
+#[test]
+fn config_extra_unknown_keys_ignored() {
+    let toml_str = r#"
+default_temperature = 0.5
+future_feature = true
+[some_future_section]
+value = 123
+"#;
+    let parsed: Config =
+        toml::from_str(toml_str).expect("unknown keys and sections should be ignored");
+    assert!((parsed.default_temperature - 0.5).abs() < f64::EPSILON);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config merging edge cases
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn config_multiple_channels_coexist() {
+    let toml_str = r#"
+default_temperature = 0.7
+
+[channels_config]
+cli = true
+
+[channels_config.telegram]
+bot_token = "test_token"
+allowed_users = ["zeroclaw_user"]
+
+[channels_config.discord]
+bot_token = "test_token"
+"#;
+    let parsed: Config = toml::from_str(toml_str).expect("multi-channel config should parse");
+    assert!(parsed.channels_config.telegram.is_some());
+    assert!(parsed.channels_config.discord.is_some());
+    assert!(parsed.channels_config.slack.is_none());
+}
+
+#[test]
+fn config_nested_optional_sections_default_when_absent() {
+    let toml_str = "default_temperature = 0.7\n";
+    let parsed: Config = toml::from_str(toml_str).expect("minimal TOML should parse");
+    assert!(parsed.channels_config.telegram.is_none());
+    assert!(!parsed.composio.enabled);
+    assert!(parsed.composio.api_key.is_none());
+    assert!(!parsed.browser.enabled);
+}
+
+#[test]
+fn config_channels_default_cli_enabled() {
+    let channels = ChannelsConfig::default();
+    assert!(channels.cli, "CLI channel should be enabled by default");
+}
+
+#[test]
+fn config_channels_all_optional_channels_none_by_default() {
+    let channels = ChannelsConfig::default();
+    assert!(channels.telegram.is_none());
+    assert!(channels.discord.is_none());
+    assert!(channels.slack.is_none());
+    assert!(channels.matrix.is_none());
+    assert!(channels.webhook.is_none());
+}
+
+#[test]
+fn config_memory_defaults_when_section_absent() {
+    let toml_str = "default_temperature = 0.7\n";
+    let parsed: Config = toml::from_str(toml_str).expect("minimal TOML should parse");
+    let mem = &parsed.memory;
+    assert!(!mem.backend.is_empty());
+    assert!(!mem.embedding_provider.is_empty());
+    let weight_sum = mem.vector_weight + mem.keyword_weight;
+    assert!(
+        (weight_sum - 1.0).abs() < 0.01,
+        "vector + keyword weights should sum to ~1.0"
+    );
+}

--- a/tests/provider_resolution.rs
+++ b/tests/provider_resolution.rs
@@ -8,7 +8,7 @@
 //! credential wiring, and auth header format.
 
 use zeroclaw::providers::compatible::{AuthStyle, OpenAiCompatibleProvider};
-use zeroclaw::providers::{create_provider, create_provider_with_url};
+use zeroclaw::providers::{create_provider, create_provider_with_options, create_provider_with_url};
 
 /// Helper: assert provider creation succeeds
 fn assert_provider_ok(name: &str, key: Option<&str>, url: Option<&str>) {
@@ -240,5 +240,233 @@ fn convenience_factory_ollama_no_key() {
         result.is_ok(),
         "ollama should not require api key: {}",
         result.err().map(|e| e.to_string()).unwrap_or_default()
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Primary providers with custom implementations
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn factory_resolves_openrouter_provider() {
+    assert_provider_ok("openrouter", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_gemini_provider() {
+    assert_provider_ok("gemini", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_bedrock_provider() {
+    assert_provider_ok("bedrock", None, None);
+}
+
+#[test]
+fn factory_resolves_copilot_provider() {
+    assert_provider_ok("copilot", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_synthetic_provider() {
+    assert_provider_ok("synthetic", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_openai_codex_provider() {
+    let options = zeroclaw::providers::ProviderRuntimeOptions::default();
+    let result = create_provider_with_options("openai-codex", None, &options);
+    assert!(
+        result.is_ok(),
+        "openai-codex provider should resolve: {}",
+        result.err().map(|e| e.to_string()).unwrap_or_default()
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OpenAI-compatible ecosystem providers
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn factory_resolves_venice_provider() {
+    assert_provider_ok("venice", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_cohere_provider() {
+    assert_provider_ok("cohere", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_opencode_provider() {
+    assert_provider_ok("opencode", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_astrai_provider() {
+    assert_provider_ok("astrai", Some("test-key"), None);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// China region providers
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn factory_resolves_moonshot_provider() {
+    assert_provider_ok("moonshot", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_glm_provider() {
+    assert_provider_ok("glm", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_qwen_provider() {
+    assert_provider_ok("qwen", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_doubao_provider() {
+    assert_provider_ok("doubao", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_qianfan_provider() {
+    assert_provider_ok("qianfan", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_minimax_provider() {
+    assert_provider_ok("minimax", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_kimi_code_provider() {
+    assert_provider_ok("kimi-code", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_zai_provider() {
+    assert_provider_ok("zai", Some("test-key"), None);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Local/self-hosted providers
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn factory_resolves_lmstudio_provider() {
+    assert_provider_ok("lmstudio", None, None);
+}
+
+#[test]
+fn factory_resolves_llamacpp_provider() {
+    assert_provider_ok("llamacpp", None, None);
+}
+
+#[test]
+fn factory_resolves_vllm_provider() {
+    assert_provider_ok("vllm", None, None);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cloud AI endpoints
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn factory_resolves_vercel_provider() {
+    assert_provider_ok("vercel", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_cloudflare_provider() {
+    assert_provider_ok("cloudflare", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_nvidia_provider() {
+    assert_provider_ok("nvidia", Some("test-key"), None);
+}
+
+#[test]
+fn factory_resolves_ovhcloud_provider() {
+    assert_provider_ok("ovhcloud", Some("test-key"), None);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Alias resolution tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn factory_google_alias_resolves_to_gemini() {
+    assert_provider_ok("google", Some("test-key"), None);
+}
+
+#[test]
+fn factory_google_gemini_alias_resolves_to_gemini() {
+    assert_provider_ok("google-gemini", Some("test-key"), None);
+}
+
+#[test]
+fn factory_aws_bedrock_alias_resolves_to_bedrock() {
+    assert_provider_ok("aws-bedrock", None, None);
+}
+
+#[test]
+fn factory_github_copilot_alias_resolves_to_copilot() {
+    assert_provider_ok("github-copilot", Some("test-key"), None);
+}
+
+#[test]
+fn factory_vercel_ai_alias_resolves_to_vercel() {
+    assert_provider_ok("vercel-ai", Some("test-key"), None);
+}
+
+#[test]
+fn factory_cloudflare_ai_alias_resolves_to_cloudflare() {
+    assert_provider_ok("cloudflare-ai", Some("test-key"), None);
+}
+
+#[test]
+fn factory_opencode_zen_alias_resolves_to_opencode() {
+    assert_provider_ok("opencode-zen", Some("test-key"), None);
+}
+
+#[test]
+fn factory_lm_studio_alias_resolves_to_lmstudio() {
+    assert_provider_ok("lm-studio", None, None);
+}
+
+#[test]
+fn factory_llama_cpp_alias_resolves_to_llamacpp() {
+    assert_provider_ok("llama.cpp", None, None);
+}
+
+#[test]
+fn factory_nvidia_nim_alias_resolves_to_nvidia() {
+    assert_provider_ok("nvidia-nim", Some("test-key"), None);
+}
+
+#[test]
+fn factory_build_nvidia_com_alias_resolves_to_nvidia() {
+    assert_provider_ok("build.nvidia.com", Some("test-key"), None);
+}
+
+#[test]
+fn factory_ovh_alias_resolves_to_ovhcloud() {
+    assert_provider_ok("ovh", Some("test-key"), None);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Custom endpoint tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn factory_anthropic_custom_endpoint_resolves() {
+    assert_provider_ok(
+        "anthropic-custom:https://api.example.com",
+        Some("test-key"),
+        None,
     );
 }


### PR DESCRIPTION
Add 81 new tests addressing audit-07 findings across 4 areas:

Provider factory resolution (42 tests):
- Cover all 25+ untested providers and aliases in factory
- Test openrouter, gemini, bedrock, copilot, china region, local, cloud AI, and custom endpoint providers

Config schema boundaries (26 tests):
- Invalid value fail-fast (wrong types, overflow port)
- Gateway, security, autonomy config defaults and roundtrips
- Backward compatibility (unknown keys, partial sections)
- Nested optional section defaults

Gateway rate limiter boundaries (8 tests):
- Window expiry and re-allow after cooldown
- Independent key tracking
- Exact max_keys boundary eviction
- Pair vs webhook independence
- Concurrent access thread safety
- Rapid burst then cooldown pattern

Tool error paths (5 tests):
- Null byte in path rejection for file_read and file_edit
- Shell nonexistent command, stderr capture, action budget exhaustion