### PR TITLE
fix(tests): update test structs for new usage and hooks fields

### DIFF
--- a/benches/agent_benchmarks.rs
+++ b/benches/agent_benchmarks.rs
@@ -38,6 +38,7 @@ impl BenchProvider {
             responses: Mutex::new(vec![ChatResponse {
                 text: Some(text.into()),
                 tool_calls: vec![],
+                usage: None,
             }]),
         }
     }
@@ -52,10 +53,12 @@ impl BenchProvider {
                         name: "noop".into(),
                         arguments: "{}".into(),
                     }],
+                    usage: None,
                 },
                 ChatResponse {
                     text: Some("done".into()),
                     tool_calls: vec![],
+                    usage: None,
                 },
             ]),
         }
@@ -85,6 +88,7 @@ impl Provider for BenchProvider {
             return Ok(ChatResponse {
                 text: Some("done".into()),
                 tool_calls: vec![],
+                usage: None,
             });
         }
         Ok(guard.remove(0))
@@ -150,6 +154,7 @@ Let me know if you need more."#
                 .into(),
         ),
         tool_calls: vec![],
+        usage: None,
     };
 
     let multi_tool = ChatResponse {
@@ -166,6 +171,7 @@ Let me know if you need more."#
                 .into(),
         ),
         tool_calls: vec![],
+        usage: None,
     };
 
     c.bench_function("xml_parse_single_tool_call", |b| {
@@ -198,6 +204,7 @@ fn bench_native_parsing(c: &mut Criterion) {
                 arguments: r#"{"path": "src/main.rs"}"#.into(),
             },
         ],
+        usage: None,
     };
 
     c.bench_function("native_parse_tool_calls", |b| {

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2720,6 +2720,7 @@ mod tests {
             3,
             None,
             None,
+            None,
         )
         .await
         .expect_err("provider without vision support should fail");
@@ -2764,6 +2765,7 @@ mod tests {
             3,
             None,
             None,
+            None,
         )
         .await
         .expect_err("oversized payload must fail");
@@ -2800,6 +2802,7 @@ mod tests {
             "cli",
             &crate::config::MultimodalConfig::default(),
             3,
+            None,
             None,
             None,
         )
@@ -2920,6 +2923,7 @@ mod tests {
             "telegram",
             &crate::config::MultimodalConfig::default(),
             4,
+            None,
             None,
             None,
         )

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3254,6 +3254,7 @@ mod tests {
             provider_runtime_options: providers::ProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            hooks: None,
         };
 
         assert!(compact_sender_history(&ctx, &sender));
@@ -3789,6 +3790,7 @@ BTC is currently around $65,000 based on latest tool output."#
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
         });
 
         process_channel_message(
@@ -4071,6 +4073,7 @@ BTC is currently around $65,000 based on latest tool output."#
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
         });
 
         process_channel_message(
@@ -4155,6 +4158,7 @@ BTC is currently around $65,000 based on latest tool output."#
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
         });
 
         process_channel_message(
@@ -4532,6 +4536,7 @@ BTC is currently around $65,000 based on latest tool output."#
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: true,
             multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);
@@ -4622,6 +4627,7 @@ BTC is currently around $65,000 based on latest tool output."#
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: true,
             multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);
@@ -4752,6 +4758,7 @@ BTC is currently around $65,000 based on latest tool output."#
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
         });
 
         process_channel_message(
@@ -5434,6 +5441,7 @@ BTC is currently around $65,000 based on latest tool output."#
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
         });
 
         process_channel_message(
@@ -5979,6 +5987,7 @@ This is an example JSON object for profile settings."#;
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
         });
 
         // Simulate a photo attachment message with [IMAGE:] marker.

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -2601,7 +2601,6 @@ mod tests {
 
         let msg = ch
             .parse_update_message(&update)
-            .map(|(m, _)| m)
             .expect("message should parse");
 
         assert_eq!(msg.sender, "alice");
@@ -2629,7 +2628,6 @@ mod tests {
 
         let msg = ch
             .parse_update_message(&update)
-            .map(|(m, _)| m)
             .expect("numeric allowlist should pass");
 
         assert_eq!(msg.sender, "555");
@@ -2657,7 +2655,6 @@ mod tests {
 
         let msg = ch
             .parse_update_message(&update)
-            .map(|(m, _)| m)
             .expect("message with thread_id should parse");
 
         assert_eq!(msg.sender, "alice");
@@ -3271,7 +3268,6 @@ mod tests {
 
         let parsed = ch
             .parse_update_message(&update)
-            .map(|(m, _)| m)
             .expect("mention should parse");
         assert_eq!(parsed.content, "Hi status please");
 

--- a/src/tools/file_read.rs
+++ b/src/tools/file_read.rs
@@ -709,6 +709,7 @@ mod tests {
                     return Ok(ChatResponse {
                         text: Some("done".into()),
                         tool_calls: vec![],
+                        usage: None,
                     });
                 }
                 Ok(guard.remove(0))
@@ -767,11 +768,13 @@ mod tests {
                     name: "file_read".into(),
                     arguments: r#"{"path": "report.pdf"}"#.into(),
                 }],
+                usage: None,
             },
             // Turn 1 continued: provider sees tool result and answers
             ChatResponse {
                 text: Some("The PDF contains a greeting: Hello PDF".into()),
                 tool_calls: vec![],
+                usage: None,
             },
         ]);
 
@@ -856,10 +859,12 @@ mod tests {
                     name: "file_read".into(),
                     arguments: r#"{"path": "data.bin"}"#.into(),
                 }],
+                usage: None,
             },
             ChatResponse {
                 text: Some("The file appears to be binary data.".into()),
                 tool_calls: vec![],
+                usage: None,
             },
         ]);
 


### PR DESCRIPTION
Add missing `usage: None` to ChatResponse literals in benchmarks, agent loop tests, and file_read tests. Add missing `hooks: None` to channel context structs in channel tests. Remove obsolete `.map(|(m, _)| m)` calls in telegram tests to match updated parse_update_message return type.