### PR TITLE
fix(agent): skip interactive approval in daemon/cron context

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -174,6 +174,7 @@ async fn run_agent_job(
                 model_override,
                 config.default_temperature,
                 vec![],
+                false,
             )
             .await
         }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -197,7 +197,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
             let prompt = format!("[Heartbeat Task] {task}");
             let temp = config.default_temperature;
             if let Err(e) =
-                crate::agent::run(config.clone(), Some(prompt), None, None, temp, vec![]).await
+                crate::agent::run(config.clone(), Some(prompt), None, None, temp, vec![], false).await
             {
                 crate::health::mark_component_error("heartbeat", e.to_string());
                 tracing::warn!("Heartbeat task failed: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -667,7 +667,7 @@ async fn main() -> Result<()> {
             model,
             temperature,
             peripheral,
-        } => agent::run(config, message, provider, model, temperature, peripheral)
+        } => agent::run(config, message, provider, model, temperature, peripheral, true)
             .await
             .map(|_| ()),
 


### PR DESCRIPTION
## Supersedes
- #1106 by @AllenHyang

## Summary
- Daemon heartbeat and cron tasks call `agent::run()` which hardcoded `channel_name: "cli"` and always created an `ApprovalManager`, causing `[Y]es / [N]o / [A]lways` stdin prompts on the unattended daemon terminal (238 occurrences observed in production logs)
- Add `interactive: bool` parameter to `agent::run()`: CLI passes `true` (preserving approval flow), daemon/cron pass `false` (no `ApprovalManager`, channel marked as `"daemon"`)

## Integrated Scope
- From #1106: the `interactive` parameter approach and daemon/cron caller updates

## Changes (4 files, +14/-7)
- `src/agent/loop_.rs`: add `interactive: bool` param; gate `ApprovalManager` creation and `channel_name` on it
- `src/main.rs`: pass `interactive: true` (CLI)
- `src/daemon/mod.rs`: pass `interactive: false` (heartbeat)
- `src/cron/scheduler.rs`: pass `interactive: false` (cron jobs)

## Validation Evidence
- `cargo check` — clean (no new warnings)
- `git diff origin/main...HEAD --stat` confirms only 4 files touched
- Previous PR #1106 was closed for scope hygiene (300+ files in diff); this PR is focused to the 4 relevant files only

## Security Impact
- No security policy changes; approval flow for CLI is preserved exactly as-is
- Daemon/cron already auto-approved non-CLI channels (`ApprovalResponse::Yes` for non-"cli"); this change skips creating the `ApprovalManager` entirely, which is strictly equivalent

## Privacy and Data Hygiene
- No PII, credentials, or sensitive data involved

## Risk and Rollback
- **Risk**: Low — only affects daemon/cron code path; CLI behavior unchanged
- **Blast radius**: `agent::run()` signature change touches 3 callers (main.rs, daemon/mod.rs, cron/scheduler.rs)
- **Rollback**: Revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)