### PR TITLE
fix(slack): support wildcard/all-channel listen when channel_id is unset

### DIFF
--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -177,9 +177,14 @@ mention_only = false
 [channels_config.slack]
 bot_token = "xoxb-..."
 app_token = "xapp-..."             # optional
-channel_id = "C1234567890"         # optional
+channel_id = "C1234567890"         # optional: single channel; omit or "*" for all accessible channels
 allowed_users = ["*"]
 ```
+
+Slack listen behavior:
+
+- `channel_id = "C123..."`: listen only on that channel.
+- `channel_id = "*"` or omitted: auto-discover and listen across all accessible channels.
 
 ### 4.4 Mattermost
 
@@ -462,7 +467,7 @@ rg -n "Matrix|Telegram|Discord|Slack|Mattermost|Signal|WhatsApp|Email|IRC|Lark|D
 |---|---|---|---|
 | Telegram | `Telegram channel listening for messages...` | `Telegram: ignoring message from unauthorized user:` | `Telegram poll error:` / `Telegram parse error:` / `Telegram polling conflict (409):` |
 | Discord | `Discord: connected and identified` | `Discord: ignoring message from unauthorized user:` | `Discord: received Reconnect (op 7)` / `Discord: received Invalid Session (op 9)` |
-| Slack | `Slack channel listening on #` | `Slack: ignoring message from unauthorized user:` | `Slack poll error:` / `Slack parse error:` |
+| Slack | `Slack channel listening on #` / `Slack channel_id not set (or '*'); listening across all accessible channels.` | `Slack: ignoring message from unauthorized user:` | `Slack poll error:` / `Slack parse error:` / `Slack channel discovery failed:` |
 | Mattermost | `Mattermost channel listening on` | `Mattermost: ignoring message from unauthorized user:` | `Mattermost poll error:` / `Mattermost parse error:` |
 | Matrix | `Matrix channel listening on room` / `Matrix room ... is encrypted; E2EE decryption is enabled via matrix-sdk.` | `Matrix whoami failed; falling back to configured session hints for E2EE session restore:` / `Matrix whoami failed while resolving listener user_id; using configured user_id hint:` | `Matrix sync error: ... retrying...` |
 | Signal | `Signal channel listening via SSE on` | (allowlist checks are enforced by `allowed_from`) | `Signal SSE returned ...` / `Signal SSE connect error:` |

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2466,6 +2466,7 @@ pub struct SlackConfig {
     /// Slack app-level token for Socket Mode (xapp-...).
     pub app_token: Option<String>,
     /// Optional channel ID to restrict the bot to a single channel.
+    /// Omit (or set `"*"`) to listen across all accessible channels.
     pub channel_id: Option<String>,
     /// Allowed Slack user IDs. Empty = deny all.
     #[serde(default)]

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -3306,7 +3306,9 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     .interact_text()?;
 
                 let channel: String = Input::new()
-                    .with_prompt("  Default channel ID (optional, Enter to skip)")
+                    .with_prompt(
+                        "  Default channel ID (optional, Enter to skip for all accessible channels; '*' also means all)",
+                    )
                     .allow_empty(true)
                     .interact_text()?;
 


### PR DESCRIPTION
## Summary

This fixes the Slack onboarding/config contract mismatch where `channel_id` was documented as optional but runtime listening hard-failed without it.

### What changed

1. `SlackChannel::listen` now supports all-channel listening when `channel_id` is omitted or set to `"*"`.
2. Added Slack channel auto-discovery via `conversations.list` with periodic refresh.
3. Maintains per-channel message watermarks (`last_ts`) to avoid cross-channel duplicate/ordering issues.
4. Improved Slack polling diagnostics for discovery/history API errors.
5. Updated onboarding prompt and config/docs wording to explicitly document:
   - single-channel mode (`channel_id = "C..."`)
   - all-accessible-channels mode (`channel_id = "*"` or omitted)
6. Added unit tests for wildcard/blank channel-id normalization and channel list extraction behavior.

## Root cause

`SlackConfig.channel_id` is `Option<String>` and onboarding labels it optional, but `listen()` previously required it at runtime (`Slack channel_id required for listening`).

## Validation

### Passed

- `cargo fmt --all --check`
- `cargo check --locked`

### Blocked by pre-existing repository baseline test failures (unrelated to this diff)

Running targeted `cargo test` currently fails due existing compile errors in other modules/tests, including:

- `src/agent/loop_.rs` (missing `hooks` arg in `run_tool_call_loop` test calls)
- `src/channels/mod.rs` (missing `hooks` field in `ChannelRuntimeContext` initializers in tests)
- `src/channels/telegram.rs` (tuple/type mismatch in test mappings)
- `src/tools/file_read.rs` (missing `usage` field in `ChatResponse` test initializers)

These failures are present outside the Slack fix scope.

## Issue linkage

Closes #1175
