### PR TITLE
fix(release): skip blacksmith rust-cache on windows jobs

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -188,6 +188,7 @@ jobs:
                   targets: ${{ matrix.target }}
 
             - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+              if: runner.os != 'Windows'
 
             - name: Install cross-compilation toolchain (Linux)
               if: runner.os == 'Linux' && matrix.cross_compiler != ''


### PR DESCRIPTION
## Summary
- skip `useblacksmith/rust-cache` on Windows in `pub-release.yml`
- keep cache enabled for non-Windows release matrix jobs

## Why
Windows release jobs currently fail with a cache 401, which blocks tag release publishing (including `v0.1.1`).

## Risk
Low; this only removes an optional cache step on Windows.

## Rollback
Revert this PR.
