### PR TITLE
fix(release): run matrix build step with bash shell

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -197,6 +197,7 @@ jobs:
                   sudo apt-get install -y ${{ matrix.cross_compiler }}
 
             - name: Build release
+              shell: bash
               env:
                   LINKER_ENV: ${{ matrix.linker_env }}
                   LINKER: ${{ matrix.linker }}


### PR DESCRIPTION
## Summary
- set `shell: bash` on the `Build release` step in `pub-release.yml`

## Why
The step uses bash syntax (`if [ -n ... ]`) and fails on `windows-latest` when executed under default PowerShell.

## Risk
Low; this only sets the shell explicitly for an existing step.

## Rollback
Revert this PR.
