### PR TITLE
fix(config): HttpRequestConfig::default() zero-initializes numeric fields

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -978,7 +978,7 @@ impl Default for BrowserConfig {
 /// HTTP request tool configuration (`[http_request]` section).
 ///
 /// Deny-by-default: if `allowed_domains` is empty, all HTTP requests are rejected.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct HttpRequestConfig {
     /// Enable `http_request` tool for API interactions
     #[serde(default)]
@@ -992,6 +992,17 @@ pub struct HttpRequestConfig {
     /// Request timeout in seconds (default: 30)
     #[serde(default = "default_http_timeout_secs")]
     pub timeout_secs: u64,
+}
+
+impl Default for HttpRequestConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            allowed_domains: vec![],
+            max_response_size: default_http_max_response_size(),
+            timeout_secs: default_http_timeout_secs(),
+        }
+    }
 }
 
 fn default_http_max_response_size() -> usize {
@@ -3920,6 +3931,15 @@ mod tests {
     use tokio_stream::StreamExt;
 
     // ── Defaults ─────────────────────────────────────────────
+
+    #[test]
+    async fn http_request_config_default_has_correct_values() {
+        let cfg = HttpRequestConfig::default();
+        assert_eq!(cfg.timeout_secs, 30);
+        assert_eq!(cfg.max_response_size, 1_000_000);
+        assert!(!cfg.enabled);
+        assert!(cfg.allowed_domains.is_empty());
+    }
 
     #[test]
     async fn config_default_has_sane_values() {

--- a/src/tools/http_request.rs
+++ b/src/tools/http_request.rs
@@ -114,8 +114,14 @@ impl HttpRequestTool {
         headers: Vec<(String, String)>,
         body: Option<&str>,
     ) -> anyhow::Result<reqwest::Response> {
+        let timeout_secs = if self.timeout_secs == 0 {
+            tracing::warn!("http_request: timeout_secs is 0, using safe default of 30s");
+            30
+        } else {
+            self.timeout_secs
+        };
         let builder = reqwest::Client::builder()
-            .timeout(Duration::from_secs(self.timeout_secs))
+            .timeout(Duration::from_secs(timeout_secs))
             .connect_timeout(Duration::from_secs(10))
             .redirect(reqwest::redirect::Policy::none());
         let builder = crate::config::apply_runtime_proxy_to_builder(builder, "tool.http_request");


### PR DESCRIPTION
## Summary

- **Problem**: `HttpRequestConfig` derives `Default`, giving `timeout_secs=0` and `max_response_size=0`. Onboarding wizard writes these to `config.toml`.
- **Why it matters**: `Duration::from_secs(0)` causes every `http_request` call to fail immediately and silently.
- **What changed**: Manual `impl Default` delegating to serde helper functions; zero-guard with `tracing::warn!` in `execute_request`; regression test.
- **What did not change**: `wizard.rs` (fixed automatically), field semantics, docs (already correct).

> **Note**: I noticed #1192 was assigned to @theonlyhennygod — happy to close this PR if you'd prefer to keep that assignment. My fix is ready if it's useful.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: (auto-managed)
- Scope labels: `config`, `tool`
- Module labels: `config: http_request`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `config`

## Linked Issue

- Closes #1192

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check      # pass
cargo clippy --all-targets -- -D warnings  # pre-existing warnings on main, none introduced by this PR
cargo test http_request_config_default_has_correct_values  # 1 passed
```

- Evidence provided: regression test passes locally.
- If any command is intentionally skipped, explain why: full `cargo clippy` has pre-existing warnings on current main (unrelated to this change). No new warnings introduced by this PR.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: pass

## Compatibility / Migration

- Backward compatible? Yes — bug fix, aligns behavior with documented defaults.
- Config/env changes? No
- Migration needed? No. Operators with broken configs should manually set `timeout_secs = 30` and `max_response_size = 1000000`.

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: `HttpRequestConfig::default()` returns `timeout_secs=30`, `max_response_size=1_000_000`; regression test passes; `cargo build` clean.
- Edge cases checked: zero-guard in `execute_request` emits `tracing::warn!` and falls back to 30s for any pre-existing broken config.
- What was not verified: live `zeroclaw onboard` end-to-end write (requires full onboarding environment).

## Side Effects / Blast Radius (required)

- Affected subsystems: all call sites of `HttpRequestConfig::default()` (wizard ×2, schema fixtures ×3, tools/mod.rs ×1) now receive correct values automatically.
- Potential unintended effects: none — fix aligns behavior with already-documented defaults.
- Guardrails/monitoring: zero-guard in `execute_request` as safety net for any pre-existing broken configs.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow: identified root cause via code search, implemented manual `impl Default` following `MultimodalConfig` pattern, added zero-guard and regression test.
- Confirmation: naming + architecture boundaries followed per `AGENTS.md` + `CONTRIBUTING.md`.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 71ed8e3`
- Feature flags or config toggles: none
- Observable failure symptoms: `http_request` tool calls time out immediately after onboarding.

## Risks and Mitigations

None. Fix aligns `Default` with already-documented intended values; no behavior change for correctly configured systems.