### PR TITLE
fix(release): remove conflicting cosign oidc issuer override

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -313,7 +313,6 @@ jobs:
                   set -euo pipefail
                   while IFS= read -r -d '' file; do
                     cosign sign-blob --yes \
-                      --oidc-issuer=https://token.actions.githubusercontent.com \
                       --output-signature="${file}.sig" \
                       --output-certificate="${file}.pem" \
                       "$file"


### PR DESCRIPTION
## Summary
- remove `--oidc-issuer` from `cosign sign-blob` in `pub-release.yml`

## Why
The publish job fails with: `cannot specify service URLs and use signing config`.
This keeps keyless signing but avoids conflicting explicit service URL override.

## Risk
Low; signing remains enabled and still uses OIDC/keyless flow.

## Rollback
Revert this PR.
