### PR TITLE
fix(release): emit sigstore bundles during artifact signing

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -313,10 +313,11 @@ jobs:
                   set -euo pipefail
                   while IFS= read -r -d '' file; do
                     cosign sign-blob --yes \
+                      --bundle="${file}.sigstore.json" \
                       --output-signature="${file}.sig" \
                       --output-certificate="${file}.pem" \
                       "$file"
-                  done < <(find artifacts -type f ! -name '*.sig' ! -name '*.pem' -print0)
+                  done < <(find artifacts -type f ! -name '*.sig' ! -name '*.pem' ! -name '*.sigstore.json' -print0)
 
             - name: Verify GHCR release tag availability
               shell: bash


### PR DESCRIPTION
## Summary
- add `--bundle` output to `cosign sign-blob` in `pub-release.yml`
- exclude `*.sigstore.json` from the signing input file scan

## Why
Current signing config requires bundle output, and publish fails without it.

## Risk
Low; signing remains keyless and now emits standard sigstore bundle artifacts.

## Rollback
Revert this PR.
