### PR TITLE
fix(matrix): persist e2ee keys across daemon restarts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tokio-util = { version = "0.7", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "multipart", "stream", "socks"] }
 
 # Matrix client + E2EE decryption
-matrix-sdk = { version = "0.16", optional = true, default-features = false, features = ["e2e-encryption", "rustls-tls", "markdown"] }
+matrix-sdk = { version = "0.16", optional = true, default-features = false, features = ["e2e-encryption", "rustls-tls", "markdown", "sqlite"] }
 
 # Serialization
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2594,13 +2594,14 @@ fn collect_configured_channels(
     if let Some(ref mx) = config.channels_config.matrix {
         channels.push(ConfiguredChannel {
             display_name: "Matrix",
-            channel: Arc::new(MatrixChannel::new_with_session_hint(
+            channel: Arc::new(MatrixChannel::new_with_session_hint_and_zeroclaw_dir(
                 mx.homeserver.clone(),
                 mx.access_token.clone(),
                 mx.room_id.clone(),
                 mx.allowed_users.clone(),
                 mx.user_id.clone(),
                 mx.device_id.clone(),
+                config.config_path.parent().map(|path| path.to_path_buf()),
             )),
         });
     }
@@ -3869,6 +3870,7 @@ BTC is currently around $65,000 based on latest tool output."#
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: false,
+            non_cli_excluded_tools: Arc::new(Vec::new()),
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
         });


### PR DESCRIPTION
## Summary
- configure Matrix SDK with a persistent SQLite store path under the active ZeroClaw config directory (`<config_dir>/state/matrix`)
- create the Matrix store directory before client build to ensure deterministic persistence setup
- pass config directory context from channel runtime wiring into `MatrixChannel`
- add regression tests for Matrix persistence path derivation
- fix one test runtime-context initializer to include the current `non_cli_excluded_tools` field under `channel-matrix` test builds

## Root Cause
`MatrixSdkClient::builder()` was created without persistent store configuration, so E2EE state/keys were kept in memory only. After daemon restart, the same `device_id` could conflict with missing local key material.

## Validation
- `cargo --config 'build.rustc-wrapper=""' check -q`
- `cargo --config 'build.rustc-wrapper=""' check --features channel-matrix -q`
- `cargo --config 'build.rustc-wrapper=""' test --lib channels::matrix::tests:: --features channel-matrix -- --nocapture`
- `cargo --config 'build.rustc-wrapper=""' test --lib channels::tests::process_channel_message_telegram_does_not_persist_tool_summary_prefix --features channel-matrix -- --nocapture`

## Behavior Notes
- Matrix channel state now persists under `~/.zeroclaw/state/matrix` (or the active profile config directory equivalent) by default.
- This is backward-compatible for existing configs; no new user-facing config keys are required.

Closes #1103
