### PR TITLE
feat(onboard): preserve existing config in interactive provider updates

### DIFF
--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -41,7 +41,9 @@ Last verified: **February 20, 2026**.
 
 `onboard` safety behavior:
 
-- If `config.toml` already exists, `onboard` asks for explicit confirmation before overwrite.
+- If `config.toml` already exists and you run `--interactive`, onboarding now offers two modes:
+  - Full onboarding (overwrite `config.toml`)
+  - Provider-only update (update provider/model/API key while preserving existing channels, tunnel, memory, hooks, and other settings)
 - In non-interactive environments, existing `config.toml` causes a safe refusal unless `--force` is passed.
 - Use `zeroclaw onboard --channels-only` when you only need to rotate channel tokens/allowlists.
 


### PR DESCRIPTION
## Summary
- add interactive onboarding mode selection when `config.toml` already exists
- support provider-only update mode that preserves existing config sections
- keep full onboarding overwrite mode available (including `--force` path)
- document the new onboarding safety behavior in command reference

## Root Cause
`zeroclaw onboard --interactive` always rebuilt a fresh config object and saved it, which overwrote user-defined sections (channels/tunnel/memory/hooks/etc.) even when users only needed provider credential/model updates.

## Fix
- introduce `InteractiveOnboardingMode` with two explicit choices when config exists:
  - Full onboarding (overwrite)
  - Provider-only update (preserve existing settings)
- add `run_provider_update_wizard(...)` to load existing config, collect provider/model/api key, and update only provider-specific fields
- preserve all non-provider sections by applying targeted merge via `apply_provider_update(...)`
- keep non-interactive safety refusal and `--force` behavior for overwrite workflows

## Validation
- `cargo fmt --all --check`
- `RUSTUP_TOOLCHAIN=stable-aarch64-apple-darwin RUSTC_WRAPPER= CARGO_TARGET_DIR=/Users/chum/wt-issue-1193-deepfix-20260221-080357/.target-issue1193 /Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo check --locked`
- `RUSTUP_TOOLCHAIN=stable-aarch64-apple-darwin RUSTC_WRAPPER= CARGO_TARGET_DIR=/Users/chum/wt-issue-1193-deepfix-20260221-080357/.target-issue1193 /Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test --locked --lib onboard::wizard::tests::apply_provider_update_preserves_non_provider_settings -- --nocapture` (blocked by unrelated pre-existing lib-test compile error in `src/channels/mod.rs`: `ChannelRuntimeContext` missing `non_cli_excluded_tools`)

Closes #1193
