### PR TITLE
fix(tools): support '*' allowed_domains wildcard for browser_open/http_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ encrypt = true                 # API keys encrypted with local key file
 
 [browser]
 enabled = false                # opt-in browser_open + browser tools
-allowed_domains = ["docs.rs"]  # required when browser is enabled
+allowed_domains = ["docs.rs"]  # required when browser is enabled ("*" allows all public domains)
 backend = "agent_browser"      # "agent_browser" (default), "rust_native", "computer_use", "auto"
 native_headless = true         # applies when backend uses rust-native
 native_webdriver_url = "http://127.0.0.1:9515" # WebDriver endpoint (chromedriver/selenium)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -214,7 +214,7 @@ Notes:
 | Key | Default | Purpose |
 |---|---|---|
 | `enabled` | `false` | Enable `browser_open` tool (opens URLs without scraping) |
-| `allowed_domains` | `[]` | Allowed domains for `browser_open` (exact or subdomain match) |
+| `allowed_domains` | `[]` | Allowed domains for `browser_open` (exact/subdomain match, or `"*"` for all public domains) |
 | `session_name` | unset | Browser session name (for agent-browser automation) |
 | `backend` | `agent_browser` | Browser automation backend: `"agent_browser"`, `"rust_native"`, `"computer_use"`, or `"auto"` |
 | `native_headless` | `true` | Headless mode for rust-native backend |
@@ -244,14 +244,15 @@ Notes:
 | Key | Default | Purpose |
 |---|---|---|
 | `enabled` | `false` | Enable `http_request` tool for API interactions |
-| `allowed_domains` | `[]` | Allowed domains for HTTP requests (exact or subdomain match) |
+| `allowed_domains` | `[]` | Allowed domains for HTTP requests (exact/subdomain match, or `"*"` for all public domains) |
 | `max_response_size` | `1000000` | Maximum response size in bytes (default: 1 MB) |
 | `timeout_secs` | `30` | Request timeout in seconds |
 
 Notes:
 
 - Deny-by-default: if `allowed_domains` is empty, all HTTP requests are rejected.
-- Use exact domain or subdomain matching (e.g. `"api.example.com"`, `"example.com"`).
+- Use exact domain or subdomain matching (e.g. `"api.example.com"`, `"example.com"`), or `"*"` to allow any public domain.
+- Local/private targets are still blocked even when `"*"` is configured.
 
 ## `[gateway]`
 

--- a/src/tools/http_request.rs
+++ b/src/tools/http_request.rs
@@ -377,6 +377,10 @@ fn extract_host(url: &str) -> anyhow::Result<String> {
 }
 
 fn host_matches_allowlist(host: &str, allowed_domains: &[String]) -> bool {
+    if allowed_domains.iter().any(|domain| domain == "*") {
+        return true;
+    }
+
     allowed_domains.iter().any(|domain| {
         host == domain
             || host
@@ -491,6 +495,22 @@ mod tests {
     fn validate_accepts_subdomain() {
         let tool = test_tool(vec!["example.com"]);
         assert!(tool.validate_url("https://api.example.com/v1").is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_wildcard_allowlist_for_public_host() {
+        let tool = test_tool(vec!["*"]);
+        assert!(tool.validate_url("https://news.ycombinator.com").is_ok());
+    }
+
+    #[test]
+    fn validate_wildcard_allowlist_still_rejects_private_host() {
+        let tool = test_tool(vec!["*"]);
+        let err = tool
+            .validate_url("https://localhost:8080")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("local/private"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR addresses the actionable bug surfaced in #1150: wildcard allowlist entries were not honored in the native web tools.

### What changed

- `http_request`: `allowed_domains = ["*"]` now allows public domains.
- `browser_open`: `allowed_domains = ["*"]` now allows public domains.
- Kept SSRF protections intact: local/private hosts are still blocked before allowlist checks.
- Added regression tests in both modules:
  - wildcard allows public hosts
  - wildcard still rejects local/private hosts
- Updated docs to describe `"*"` behavior in config reference and README sample.

### Context on MAX_TOOL_ITERATIONS

The original `MAX_TOOL_ITERATIONS` report in this issue appears already fixed on current `main`: the constant in `agent/loop_.rs` is now a default fallback when config is unset/zero, and existing channel tests verify configured limits.

## Validation

- `cargo check`
- `cargo test --lib tools::http_request::tests::`
- `cargo test --lib tools::browser_open::tests::`
- `cargo test --lib process_channel_message_respects_configured_max_tool_iterations_above_default`
- `cargo test --lib process_channel_message_reports_configured_max_tool_iterations_limit`

Closes #1150
