### PR TITLE
fix(onboard): add Signal to interactive channel setup

### DIFF
--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -1,6 +1,6 @@
 use crate::config::schema::{
     default_nostr_relays, DingTalkConfig, IrcConfig, LarkReceiveMode, LinqConfig, NostrConfig,
-    QQConfig, StreamMode, WhatsAppConfig,
+    QQConfig, SignalConfig, StreamMode, WhatsAppConfig,
 };
 use crate::config::{
     AutonomyConfig, BrowserConfig, ChannelsConfig, ComposioConfig, Config, DiscordConfig,
@@ -2923,6 +2923,47 @@ fn setup_memory() -> Result<MemoryConfig> {
 
 // ── Step 3: Channels ────────────────────────────────────────────
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ChannelMenuChoice {
+    Telegram,
+    Discord,
+    Slack,
+    IMessage,
+    Matrix,
+    Signal,
+    WhatsApp,
+    Linq,
+    Irc,
+    Webhook,
+    DingTalk,
+    QqOfficial,
+    LarkFeishu,
+    Nostr,
+    Done,
+}
+
+const CHANNEL_MENU_CHOICES: &[ChannelMenuChoice] = &[
+    ChannelMenuChoice::Telegram,
+    ChannelMenuChoice::Discord,
+    ChannelMenuChoice::Slack,
+    ChannelMenuChoice::IMessage,
+    ChannelMenuChoice::Matrix,
+    ChannelMenuChoice::Signal,
+    ChannelMenuChoice::WhatsApp,
+    ChannelMenuChoice::Linq,
+    ChannelMenuChoice::Irc,
+    ChannelMenuChoice::Webhook,
+    ChannelMenuChoice::DingTalk,
+    ChannelMenuChoice::QqOfficial,
+    ChannelMenuChoice::LarkFeishu,
+    ChannelMenuChoice::Nostr,
+    ChannelMenuChoice::Done,
+];
+
+fn channel_menu_choices() -> &'static [ChannelMenuChoice] {
+    CHANNEL_MENU_CHOICES
+}
+
 #[allow(clippy::too_many_lines)]
 fn setup_channels() -> Result<ChannelsConfig> {
     print_bullet("Channels let you talk to ZeroClaw from anywhere.");
@@ -2930,39 +2971,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
     println!();
 
     let mut config = ChannelsConfig::default();
-    #[derive(Clone, Copy)]
-    enum ChannelMenuChoice {
-        Telegram,
-        Discord,
-        Slack,
-        IMessage,
-        Matrix,
-        WhatsApp,
-        Linq,
-        Irc,
-        Webhook,
-        DingTalk,
-        QqOfficial,
-        LarkFeishu,
-        Nostr,
-        Done,
-    }
-    let menu_choices = [
-        ChannelMenuChoice::Telegram,
-        ChannelMenuChoice::Discord,
-        ChannelMenuChoice::Slack,
-        ChannelMenuChoice::IMessage,
-        ChannelMenuChoice::Matrix,
-        ChannelMenuChoice::WhatsApp,
-        ChannelMenuChoice::Linq,
-        ChannelMenuChoice::Irc,
-        ChannelMenuChoice::Webhook,
-        ChannelMenuChoice::DingTalk,
-        ChannelMenuChoice::QqOfficial,
-        ChannelMenuChoice::LarkFeishu,
-        ChannelMenuChoice::Nostr,
-        ChannelMenuChoice::Done,
-    ];
+    let menu_choices = channel_menu_choices();
 
     loop {
         let options: Vec<String> = menu_choices
@@ -3006,6 +3015,14 @@ fn setup_channels() -> Result<ChannelsConfig> {
                         "✅ connected"
                     } else {
                         "— self-hosted chat"
+                    }
+                ),
+                ChannelMenuChoice::Signal => format!(
+                    "Signal     {}",
+                    if config.signal.is_some() {
+                        "✅ connected"
+                    } else {
+                        "— signal-cli daemon bridge"
                     }
                 ),
                 ChannelMenuChoice::WhatsApp => format!(
@@ -3567,6 +3584,102 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     room_id,
                     allowed_users,
                 });
+            }
+            ChannelMenuChoice::Signal => {
+                // ── Signal ──
+                println!();
+                println!(
+                    "  {} {}",
+                    style("Signal Setup").white().bold(),
+                    style("— signal-cli daemon bridge").dim()
+                );
+                print_bullet("1. Run signal-cli daemon with HTTP enabled (default port 8686).");
+                print_bullet("2. Ensure your Signal account is registered in signal-cli.");
+                print_bullet("3. Optionally scope to DMs only or to a specific group.");
+                println!();
+
+                let http_url: String = Input::new()
+                    .with_prompt("  signal-cli HTTP URL")
+                    .default("http://127.0.0.1:8686".into())
+                    .interact_text()?;
+
+                if http_url.trim().is_empty() {
+                    println!("  {} Skipped — HTTP URL required", style("→").dim());
+                    continue;
+                }
+
+                let account: String = Input::new()
+                    .with_prompt("  Account number (E.164, e.g. +1234567890)")
+                    .interact_text()?;
+
+                if account.trim().is_empty() {
+                    println!("  {} Skipped — account number required", style("→").dim());
+                    continue;
+                }
+
+                let scope_options = [
+                    "All messages (DMs + groups)",
+                    "DM only",
+                    "Specific group ID",
+                ];
+                let scope_choice = Select::new()
+                    .with_prompt("  Message scope")
+                    .items(scope_options)
+                    .default(0)
+                    .interact()?;
+
+                let group_id = match scope_choice {
+                    1 => Some("dm".to_string()),
+                    2 => {
+                        let group_input: String =
+                            Input::new().with_prompt("  Group ID").interact_text()?;
+                        let group_input = group_input.trim().to_string();
+                        if group_input.is_empty() {
+                            println!("  {} Skipped — group ID required", style("→").dim());
+                            continue;
+                        }
+                        Some(group_input)
+                    }
+                    _ => None,
+                };
+
+                let allowed_from_raw: String = Input::new()
+                    .with_prompt(
+                        "  Allowed sender numbers (comma-separated +1234567890, or * for all)",
+                    )
+                    .default("*".into())
+                    .interact_text()?;
+
+                let allowed_from = if allowed_from_raw.trim() == "*" {
+                    vec!["*".into()]
+                } else {
+                    allowed_from_raw
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                };
+
+                let ignore_attachments = Confirm::new()
+                    .with_prompt("  Ignore attachment-only messages?")
+                    .default(false)
+                    .interact()?;
+
+                let ignore_stories = Confirm::new()
+                    .with_prompt("  Ignore incoming stories?")
+                    .default(true)
+                    .interact()?;
+
+                config.signal = Some(SignalConfig {
+                    http_url: http_url.trim_end_matches('/').to_string(),
+                    account: account.trim().to_string(),
+                    group_id,
+                    allowed_from,
+                    ignore_attachments,
+                    ignore_stories,
+                });
+
+                println!("  {} Signal configured", style("✅").green().bold());
             }
             ChannelMenuChoice::WhatsApp => {
                 // ── WhatsApp ──
@@ -4454,6 +4567,9 @@ fn setup_channels() -> Result<ChannelsConfig> {
     if config.matrix.is_some() {
         active.push("Matrix");
     }
+    if config.signal.is_some() {
+        active.push("Signal");
+    }
     if config.whatsapp.is_some() {
         active.push("WhatsApp");
     }
@@ -4984,20 +5100,47 @@ fn print_summary(config: &Config) {
     if config.channels_config.slack.is_some() {
         channels.push("Slack");
     }
+    if config.channels_config.mattermost.is_some() {
+        channels.push("Mattermost");
+    }
     if config.channels_config.imessage.is_some() {
         channels.push("iMessage");
     }
     if config.channels_config.matrix.is_some() {
         channels.push("Matrix");
     }
+    if config.channels_config.signal.is_some() {
+        channels.push("Signal");
+    }
+    if config.channels_config.whatsapp.is_some() {
+        channels.push("WhatsApp");
+    }
+    if config.channels_config.linq.is_some() {
+        channels.push("Linq");
+    }
+    if config.channels_config.nextcloud_talk.is_some() {
+        channels.push("Nextcloud Talk");
+    }
     if config.channels_config.email.is_some() {
         channels.push("Email");
+    }
+    if config.channels_config.irc.is_some() {
+        channels.push("IRC");
     }
     if config.channels_config.webhook.is_some() {
         channels.push("Webhook");
     }
     if config.channels_config.lark.is_some() {
         channels.push("Lark");
+    }
+    if config.channels_config.dingtalk.is_some() {
+        channels.push("DingTalk");
+    }
+    if config.channels_config.qq.is_some() {
+        channels.push("QQ");
+    }
+    if config.channels_config.nostr.is_some() {
+        channels.push("Nostr");
     }
     println!(
         "    {} Channels:      {}",
@@ -6405,10 +6548,26 @@ mod tests {
     }
 
     #[test]
-    fn launchable_channels_include_mattermost_and_qq() {
+    fn channel_menu_choices_include_signal() {
+        assert!(channel_menu_choices().contains(&ChannelMenuChoice::Signal));
+    }
+
+    #[test]
+    fn launchable_channels_include_signal_mattermost_and_qq() {
         let mut channels = ChannelsConfig::default();
         assert!(!has_launchable_channels(&channels));
 
+        channels.signal = Some(crate::config::schema::SignalConfig {
+            http_url: "http://127.0.0.1:8686".into(),
+            account: "+1234567890".into(),
+            group_id: None,
+            allowed_from: vec!["*".into()],
+            ignore_attachments: false,
+            ignore_stories: true,
+        });
+        assert!(has_launchable_channels(&channels));
+
+        channels.signal = None;
         channels.mattermost = Some(crate::config::schema::MattermostConfig {
             url: "https://mattermost.example.com".into(),
             bot_token: "token".into(),


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Problem: `zeroclaw channel list` shows Signal, but `zeroclaw onboard --interactive` had no Signal option.
- Why it matters: This mismatch confuses users and blocks interactive setup for a listed channel.
- What changed: Added Signal to interactive channel menu, implemented Signal setup prompts, and updated wizard channel summaries for consistency.
- What did **not** change (scope boundary): No channel runtime behavior changes, no transport protocol changes, no provider/model changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `onboard,channel`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `onboard: interactive wizard`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #1208
- Related # N/A
- Depends on # N/A
- Supersedes # N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all
RUSTUP_TOOLCHAIN=stable-aarch64-apple-darwin RUSTC_WRAPPER= CARGO_TARGET_DIR=/Users/chum/wt-issue-1208-deepfix-20260221-083320/.target-issue1208 /Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo check --locked
RUSTUP_TOOLCHAIN=stable-aarch64-apple-darwin RUSTC_WRAPPER= CARGO_TARGET_DIR=/Users/chum/wt-issue-1208-deepfix-20260221-083320/.target-issue1208 /Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test --locked --lib onboard::wizard::tests::channel_menu_choices_include_signal -- --nocapture
RUSTUP_TOOLCHAIN=stable-aarch64-apple-darwin RUSTC_WRAPPER= CARGO_TARGET_DIR=/Users/chum/wt-issue-1208-deepfix-20260221-083320/.target-issue1208 /Users/chum/.rustup/toolchains/stable-aarch64-apple-darwin/bin/cargo test --locked --lib onboard::wizard::tests::launchable_channels_include_signal_mattermost_and_qq -- --nocapture
BASE_SHA=$(git merge-base origin/main HEAD) RUST_FILES='src/onboard/wizard.rs' CARGO_TARGET_DIR=/Users/chum/wt-issue-1208-deepfix-20260221-083320/.target-issue1208 ./scripts/ci/rust_strict_delta_gate.sh
cargo fmt --all --check
```

- Evidence provided (test/log/trace/screenshot/perf):
  - New regression test ensures interactive menu choices include Signal.
  - Existing launchability test now also verifies Signal launchability path.
  - Strict delta gate reported no blocking lint issues on changed Rust lines.
- If any command is intentionally skipped, explain why:
  - Full `cargo test` suite not rerun due scope (single wizard module) and long-running global cargo/rustc lock contention from concurrent host builds.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no user data changes; no secrets added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - Signal is present in interactive onboarding channel menu.
  - Signal configuration fields are collected and persisted in wizard flow.
  - Wizard summaries include Signal and other configured channels consistently.
- Edge cases checked:
  - DM-only and specific group scope options for Signal.
  - Empty required Signal fields are rejected with explicit guidance.
- What was not verified:
  - Live signal-cli daemon connectivity to a real Signal account in this run.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: onboarding wizard channel selection + setup summary output.
- Potential unintended effects: minor UX text/order differences in channel menu and summary.
- Guardrails/monitoring for early detection: unit tests added for menu coverage and launchability.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex CLI shell workflow.
- Workflow/plan summary (if any): issue claim -> isolated worktree -> root-cause triage -> targeted fix -> validation -> ready promotion.
- Verification focus: onboarding/menu consistency with channel list, regression safety.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `72e0aad`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: Signal missing again from `onboard --interactive` menu.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: wizard prompt flow complexity increases slightly.
  - Mitigation: dedicated regression test + scoped channel branch logic.
