### PR TITLE
fix: clarify outside-workspace access via allowed_roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,9 +656,13 @@ allow_public_bind = false      # refuse 0.0.0.0 without tunnel
 
 [autonomy]
 level = "supervised"           # "readonly", "supervised", "full" (default: supervised)
-workspace_only = true          # default: true — scoped to workspace
+workspace_only = true          # default: true — reject absolute path inputs
 allowed_commands = ["git", "npm", "cargo", "ls", "cat", "grep"]
 forbidden_paths = ["/etc", "/root", "/proc", "/sys", "~/.ssh", "~/.gnupg", "~/.aws"]
+allowed_roots = []             # optional allowlist for directories outside workspace (supports "~/...")
+# Example outside-workspace access:
+# workspace_only = false
+# allowed_roots = ["~/Desktop/projects", "/opt/shared-repo"]
 
 [runtime]
 kind = "native"                # "native" or "docker"

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -267,11 +267,12 @@ Notes:
 | Key | Default | Purpose |
 |---|---|---|
 | `level` | `supervised` | `read_only`, `supervised`, or `full` |
-| `workspace_only` | `true` | restrict writes/command paths to workspace scope |
+| `workspace_only` | `true` | reject absolute path inputs unless explicitly disabled |
 | `allowed_commands` | _required for shell execution_ | allowlist of executable names |
-| `forbidden_paths` | `[]` | explicit path denylist |
-| `max_actions_per_hour` | `100` | per-policy action budget |
-| `max_cost_per_day_cents` | `1000` | per-policy spend guardrail |
+| `forbidden_paths` | built-in protected list | explicit path denylist (system paths + sensitive dotdirs by default) |
+| `allowed_roots` | `[]` | additional roots allowed outside workspace after canonicalization |
+| `max_actions_per_hour` | `20` | per-policy action budget |
+| `max_cost_per_day_cents` | `500` | per-policy spend guardrail |
 | `require_approval_for_medium_risk` | `true` | approval gate for medium-risk commands |
 | `block_high_risk_commands` | `true` | hard block for high-risk commands |
 | `auto_approve` | `[]` | tool operations always auto-approved |
@@ -280,8 +281,17 @@ Notes:
 Notes:
 
 - `level = "full"` skips medium-risk approval gating for shell execution, while still enforcing configured guardrails.
+- Access outside the workspace requires `allowed_roots`, even when `workspace_only = false`.
+- `allowed_roots` supports absolute paths, `~/...`, and workspace-relative paths.
 - Shell separator/operator parsing is quote-aware. Characters like `;` inside quoted arguments are treated as literals, not command separators.
 - Unquoted shell chaining/operators are still enforced by policy checks (`;`, `|`, `&&`, `||`, background chaining, and redirects).
+
+```toml
+[autonomy]
+workspace_only = false
+forbidden_paths = ["/etc", "/root", "/proc", "/sys", "~/.ssh", "~/.gnupg", "~/.aws"]
+allowed_roots = ["~/Desktop/projects", "/opt/shared-repo"]
+```
 
 ## `[memory]`
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1816,11 +1816,12 @@ impl Default for BuiltinHooksConfig {
 pub struct AutonomyConfig {
     /// Autonomy level: `read_only`, `supervised` (default), or `full`.
     pub level: AutonomyLevel,
-    /// Restrict file writes and command paths to the workspace directory. Default: `true`.
+    /// Restrict absolute filesystem paths to workspace-relative references. Default: `true`.
+    /// Resolved paths outside the workspace still require `allowed_roots`.
     pub workspace_only: bool,
     /// Allowlist of executable names permitted for shell execution.
     pub allowed_commands: Vec<String>,
-    /// Explicit path denylist. Default includes system-critical paths.
+    /// Explicit path denylist. Default includes system-critical paths and sensitive dotdirs.
     pub forbidden_paths: Vec<String>,
     /// Maximum actions allowed per hour per policy. Default: `100`.
     pub max_actions_per_hour: u32,
@@ -1851,6 +1852,7 @@ pub struct AutonomyConfig {
     pub always_ask: Vec<String>,
 
     /// Extra directory roots the agent may read/write outside the workspace.
+    /// Supports absolute, `~/...`, and workspace-relative entries.
     /// Resolved paths under any of these roots pass `is_resolved_path_allowed`.
     #[serde(default)]
     pub allowed_roots: Vec<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -742,6 +742,14 @@ async fn main() -> Result<()> {
             println!("Security:");
             println!("  Workspace only:    {}", config.autonomy.workspace_only);
             println!(
+                "  Allowed roots:     {}",
+                if config.autonomy.allowed_roots.is_empty() {
+                    "(none)".to_string()
+                } else {
+                    config.autonomy.allowed_roots.join(", ")
+                }
+            );
+            println!(
                 "  Allowed commands:  {}",
                 config.autonomy.allowed_commands.join(", ")
             );

--- a/src/tools/file_edit.rs
+++ b/src/tools/file_edit.rs
@@ -36,7 +36,7 @@ impl Tool for FileEditTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Relative path to the file within the workspace"
+                    "description": "Path to the file. Relative paths resolve from workspace; outside paths require policy allowlist."
                 },
                 "old_string": {
                     "type": "string",
@@ -130,10 +130,10 @@ impl Tool for FileEditTool {
             return Ok(ToolResult {
                 success: false,
                 output: String::new(),
-                error: Some(format!(
-                    "Resolved path escapes workspace: {}",
-                    resolved_parent.display()
-                )),
+                error: Some(
+                    self.security
+                        .resolved_path_violation_message(&resolved_parent),
+                ),
             });
         }
 

--- a/src/tools/file_write.rs
+++ b/src/tools/file_write.rs
@@ -31,7 +31,7 @@ impl Tool for FileWriteTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Relative path to the file within the workspace"
+                    "description": "Path to the file. Relative paths resolve from workspace; outside paths require policy allowlist."
                 },
                 "content": {
                     "type": "string",
@@ -107,10 +107,10 @@ impl Tool for FileWriteTool {
             return Ok(ToolResult {
                 success: false,
                 output: String::new(),
-                error: Some(format!(
-                    "Resolved path escapes workspace: {}",
-                    resolved_parent.display()
-                )),
+                error: Some(
+                    self.security
+                        .resolved_path_violation_message(&resolved_parent),
+                ),
             });
         }
 

--- a/src/tools/pdf_read.rs
+++ b/src/tools/pdf_read.rs
@@ -46,7 +46,7 @@ impl Tool for PdfReadTool {
             "properties": {
                 "path": {
                     "type": "string",
-                    "description": "Relative path to the PDF file within the workspace"
+                    "description": "Path to the PDF file. Relative paths resolve from workspace; outside paths require policy allowlist."
                 },
                 "max_chars": {
                     "type": "integer",
@@ -117,10 +117,10 @@ impl Tool for PdfReadTool {
             return Ok(ToolResult {
                 success: false,
                 output: String::new(),
-                error: Some(format!(
-                    "Resolved path escapes workspace: {}",
-                    resolved_path.display()
-                )),
+                error: Some(
+                    self.security
+                        .resolved_path_violation_message(&resolved_path),
+                ),
             });
         }
 


### PR DESCRIPTION
## Summary
- clarify filesystem policy behavior for outside-workspace paths with actionable `allowed_roots` guidance
- normalize `allowed_roots` entries from config (`~/...` expansion and workspace-relative roots)
- improve file tool rejection errors to explicitly point users to `[autonomy].allowed_roots`
- add policy/tool tests plus config/README documentation updates

## Root Cause
`workspace_only = false` only relaxes absolute-path input rejection. File operations still enforce canonicalized path scope (`workspace` + `allowed_roots`). The old error text (`Resolved path escapes workspace`) and docs did not explain this second gate clearly, so users could not discover the correct fix.

## Changes
- `src/security/policy.rs`
  - added path normalization helper for `~` expansion
  - normalized `allowed_roots` from config (supports absolute, `~/...`, and workspace-relative entries)
  - introduced `resolved_path_violation_message()` with explicit `allowed_roots` remediation text
  - added tests for normalization and guidance message
- `src/tools/file_read.rs`, `src/tools/file_write.rs`, `src/tools/file_edit.rs`, `src/tools/pdf_read.rs`
  - switched resolved-path denial errors to the new guidance message
  - updated tool schema path descriptions to reflect allowlist behavior
  - added regression test for outside-workspace guidance in `file_read`
- `src/config/schema.rs`
  - clarified autonomy docs/comments around `workspace_only`, `forbidden_paths`, and `allowed_roots`
- `src/main.rs`
  - surfaced `allowed_roots` in `zeroclaw status` output
- `README.md`, `docs/config-reference.md`
  - documented `allowed_roots` usage and outside-workspace example
  - aligned autonomy defaults in docs with code

## Validation
- `cargo fmt --all`
- `cargo check --locked`
- `cargo test --locked from_config_normalizes_allowed_roots -- --nocapture`
- `cargo test --locked resolved_path_violation_message_includes_allowed_roots_guidance -- --nocapture`
- `cargo test --locked file_read_outside_workspace_guides_allowed_roots -- --nocapture`
- `./scripts/ci/rust_quality_gate.sh`
- `RUST_FILES="$(git diff --name-only -- '*.rs')" ./scripts/ci/rust_strict_delta_gate.sh`
- `DOCS_FILES="$(git diff --name-only -- '*.md' '*.mdx' LICENSE '.github/pull_request_template.md')" ./scripts/ci/docs_quality_gate.sh`

Closes #1206
