### PR TITLE
fix(tests): remove duplicate non_cli_excluded_tools initializer

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3969,7 +3969,6 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
         });
 
         process_channel_message(


### PR DESCRIPTION
## Summary
- remove duplicated `non_cli_excluded_tools` field initialization in `ChannelRuntimeContext` test setup
- restore successful `zeroclaw` lib-test compilation on `main`

## Root Cause
A test context literal in `src/channels/mod.rs` accidentally assigned `non_cli_excluded_tools` twice, which triggers Rust error `E0062` and blocks lib test compilation.

## Validation
- `cargo fmt --all --check`
- `cargo test -p zeroclaw --lib channels::tests::process_channel_message_telegram_keeps_system_instruction_at_top_only -- --test-threads=1`
- `cargo test -p zeroclaw --lib channels::tests::process_channel_message_respects_configured_max_tool_iterations_above_default -- --test-threads=1`
- `cargo test -p zeroclaw --lib channels::tests::process_channel_message_reports_configured_max_tool_iterations_limit -- --test-threads=1`
- `cargo test -p zeroclaw --lib onboard::wizard::tests::apply_provider_update_preserves_non_provider_settings -- --test-threads=1`
- `cargo test -p zeroclaw --lib onboard::wizard::tests::channel_menu_choices_include_signal -- --test-threads=1`
- `cargo test -p zeroclaw --lib tools::http_request::tests:: -- --test-threads=1`
- `cargo test -p zeroclaw --lib tools::browser_open::tests:: -- --test-threads=1`
- `cargo test -p zeroclaw --lib channels::matrix::tests:: --features channel-matrix -- --test-threads=1`