### PR TITLE
fix(onboard,skills): resolve workspace layout mismatch and open-skills detection

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -3178,7 +3178,7 @@ pub(crate) async fn persist_active_workspace_config_dir(config_dir: &Path) -> Re
     Ok(())
 }
 
-fn resolve_config_dir_for_workspace(workspace_dir: &Path) -> (PathBuf, PathBuf) {
+pub(crate) fn resolve_config_dir_for_workspace(workspace_dir: &Path) -> (PathBuf, PathBuf) {
     let workspace_config_dir = workspace_dir.to_path_buf();
     if workspace_config_dir.join("config.toml").exists() {
         return (
@@ -3207,6 +3207,17 @@ fn resolve_config_dir_for_workspace(workspace_dir: &Path) -> (PathBuf, PathBuf) 
         workspace_config_dir.clone(),
         workspace_config_dir.join("workspace"),
     )
+}
+
+/// Resolve the current runtime config/workspace directories for onboarding flows.
+///
+/// This mirrors the same precedence used by `Config::load_or_init()`:
+/// `ZEROCLAW_CONFIG_DIR` > `ZEROCLAW_WORKSPACE` > active workspace marker > defaults.
+pub(crate) async fn resolve_runtime_dirs_for_onboarding() -> Result<(PathBuf, PathBuf)> {
+    let (default_zeroclaw_dir, default_workspace_dir) = default_config_and_workspace_dirs()?;
+    let (config_dir, workspace_dir, _) =
+        resolve_runtime_config_dirs(&default_zeroclaw_dir, &default_workspace_dir).await?;
+    Ok((config_dir, workspace_dir))
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary
- fix onboarding workspace path resolution so defaults match runtime env/config resolution (prevents duplicate workspace directories in mixed container setups)
- make quick setup honor `ZEROCLAW_WORKSPACE` / `ZEROCLAW_CONFIG_DIR` precedence used by runtime config loading
- update open-skills discovery to prefer modern `open-skills/skills/<name>/SKILL.md` layout and avoid loading repository docs as skills
- add regression test coverage for env-driven quick-setup layout and open-skills nested-directory loading

## Root Cause
- `onboard` was choosing workspace paths from a local home-based heuristic instead of the same resolution pipeline used at runtime, so container env defaults could diverge between onboarding and daemon startup.
- open-skills loader scanned repo-root markdown files and therefore could treat `CONTRIBUTING.md`-style docs as runnable skills when using the current open-skills repository structure.

## Validation
- `cargo fmt --all`
- `cargo test -p zeroclaw --lib onboard::wizard::tests::quick_setup_ -- --test-threads=1`
- `cargo test -p zeroclaw --lib skills::tests::load_skills_with_config_reads_open_skills_dir_without_network -- --test-threads=1`
- `cargo test -p zeroclaw --lib skills::tests:: -- --test-threads=1`
- `cargo test -p zeroclaw --lib config::schema::tests::resolve_runtime_config_dirs_uses_env_workspace_first -- --test-threads=1`

Closes #1214
Closes #1215