### PR TITLE
fix: route vercel provider to AI Gateway endpoint

### DIFF
--- a/docs/providers-reference.md
+++ b/docs/providers-reference.md
@@ -2,7 +2,7 @@
 
 This document maps provider IDs, aliases, and credential environment variables.
 
-Last verified: **February 20, 2026**.
+Last verified: **February 21, 2026**.
 
 ## How to List Providers
 
@@ -59,6 +59,14 @@ credential is not reused for fallback providers.
 | `vllm` | — | Yes | `VLLM_API_KEY` (optional) |
 | `osaurus` | — | Yes | `OSAURUS_API_KEY` (optional; defaults to `"osaurus"`) |
 | `nvidia` | `nvidia-nim`, `build.nvidia.com` | No | `NVIDIA_API_KEY` |
+
+### Vercel AI Gateway Notes
+
+- Provider ID: `vercel` (alias: `vercel-ai`)
+- Base API URL: `https://ai-gateway.vercel.sh/v1`
+- Authentication: `VERCEL_API_KEY`
+- Vercel AI Gateway usage does not require a project deployment.
+- If you see `DEPLOYMENT_NOT_FOUND`, verify the provider is targeting the gateway endpoint above instead of `https://api.vercel.ai`.
 
 ### Gemini Notes
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -72,6 +72,7 @@ const QWEN_OAUTH_DEFAULT_CLIENT_ID: &str = "f0304373b74a44d2b584a3fb70ca9e56";
 const QWEN_OAUTH_CREDENTIAL_FILE: &str = ".qwen/oauth_creds.json";
 const ZAI_GLOBAL_BASE_URL: &str = "https://api.z.ai/api/coding/paas/v4";
 const ZAI_CN_BASE_URL: &str = "https://open.bigmodel.cn/api/coding/paas/v4";
+const VERCEL_AI_GATEWAY_BASE_URL: &str = "https://ai-gateway.vercel.sh/v1";
 
 pub(crate) fn is_minimax_intl_alias(name: &str) -> bool {
     matches!(
@@ -969,7 +970,10 @@ fn create_provider_with_url_and_options(
             "Venice", "https://api.venice.ai", key, AuthStyle::Bearer,
         ))),
         "vercel" | "vercel-ai" => Ok(Box::new(OpenAiCompatibleProvider::new(
-            "Vercel AI Gateway", "https://api.vercel.ai", key, AuthStyle::Bearer,
+            "Vercel AI Gateway",
+            VERCEL_AI_GATEWAY_BASE_URL,
+            key,
+            AuthStyle::Bearer,
         ))),
         "cloudflare" | "cloudflare-ai" => Ok(Box::new(OpenAiCompatibleProvider::new(
             "Cloudflare AI Gateway",
@@ -1968,6 +1972,14 @@ mod tests {
     fn factory_vercel() {
         assert!(create_provider("vercel", Some("key")).is_ok());
         assert!(create_provider("vercel-ai", Some("key")).is_ok());
+    }
+
+    #[test]
+    fn vercel_gateway_base_url_matches_public_gateway_endpoint() {
+        assert_eq!(
+            VERCEL_AI_GATEWAY_BASE_URL,
+            "https://ai-gateway.vercel.sh/v1"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- fix Vercel provider default OpenAI-compatible base URL to the public Vercel AI Gateway endpoint (`https://ai-gateway.vercel.sh/v1`)
- add a regression test to keep the gateway base URL pinned to the public endpoint
- document Vercel AI Gateway endpoint and `DEPLOYMENT_NOT_FOUND` troubleshooting in providers reference docs

## Root Cause
ZeroClaw configured the `vercel`/`vercel-ai` provider against `https://api.vercel.ai`, which is not the AI Gateway endpoint used for OpenAI-compatible chat requests. This mismatch could surface `DEPLOYMENT_NOT_FOUND` for normal gateway usage.

## Validation
- `cargo fmt --all --check`
- `rustup run stable cargo check --locked`
- `rustup run stable cargo test factory_vercel`
- `rustup run stable cargo test vercel_gateway_base_url_matches_public_gateway_endpoint`
- `./scripts/ci/rust_quality_gate.sh`
- `RUST_FILES="$(git diff --name-only -- '*.rs')" ./scripts/ci/rust_strict_delta_gate.sh`
- `DOCS_FILES="$(git diff --name-only -- '*.md' '*.mdx' LICENSE '.github/pull_request_template.md')" ./scripts/ci/docs_quality_gate.sh`

Closes #1222