### PR TITLE
fix(agent): stabilize tool-call loop dedupe and fallback tool_call_id mapping

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1209,6 +1209,7 @@ fn parse_glm_shortened_body(body: &str) -> Option<ParsedToolCall> {
             return Some(ParsedToolCall {
                 name: tool_name.to_string(),
                 arguments: serde_json::Value::Object(args),
+                tool_call_id: None,
             });
         }
     }
@@ -1239,6 +1240,7 @@ fn parse_glm_shortened_body(body: &str) -> Option<ParsedToolCall> {
             return Some(ParsedToolCall {
                 name: tool_name.to_string(),
                 arguments: serde_json::Value::Object(args),
+                tool_call_id: None,
             });
         }
     }
@@ -1264,6 +1266,7 @@ fn parse_glm_shortened_body(body: &str) -> Option<ParsedToolCall> {
         return Some(ParsedToolCall {
             name: tool_name.to_string(),
             arguments,
+            tool_call_id: None,
         });
     }
 


### PR DESCRIPTION
## Summary
This PR stabilizes the agent tool-call loop by addressing two high-impact failure modes:

1. Duplicate parsed tool calls were being executed repeatedly in a single turn.
2. In native-tool mode, fallback-parsed OpenAI-style JSON tool calls could lose `tool_call_id` mapping.

Fixes #1242.

## What changed
- Added per-turn deduplication in `run_tool_call_loop` for identical tool calls using canonicalized `(tool_name, args_json)` signatures.
- Extended `ParsedToolCall` to carry `tool_call_id`.
- Propagated tool-call IDs through:
  - parsed JSON tool-call extraction (`id`, `tool_call_id`, `call_id` aliases)
  - native structured tool-call parsing (`ToolCall.id`)
  - execution staging and result emission
- Added native fallback history bridge:
  - when provider is in native mode and fallback-parsed calls contain IDs,
    assistant/tool history is emitted in native-compatible JSON/`role=tool` format.
- Added regression tests covering:
  - duplicate-call suppression
  - fallback native `tool_call_id` preservation
  - parser-level ID extraction for alias formats

## Why this is safe
- Dedupe scope is limited to **same turn + same tool + same canonical arguments**.
- Non-native providers keep existing prompt-wrapper history behavior.
- Native fallback upgrade is only activated when parsed calls have complete IDs.

## Validation
### Completed
- `cargo fmt`

### Blocked locally (environment)
Attempting to run targeted tests was blocked by a local Rust toolchain/cache issue unrelated to this patch:
- `error[E0514]: found crate \`quote\` compiled by an incompatible version of rustc`
- surfaced while compiling `axum-macros`

CI should provide authoritative pass/fail for test execution.
