### PR TITLE
fix(telegram): send image attachments when finalizing draft messages

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -2155,28 +2155,62 @@ impl Channel for TelegramChannel {
         // Clean up rate-limit tracking for this chat
         self.last_draft_edit.lock().remove(&chat_id);
 
+        // Parse attachments before processing
+        let (text_without_markers, attachments) = parse_attachment_markers(text);
+
+        // Parse message ID once for reuse
+        let msg_id = match message_id.parse::<i64>() {
+            Ok(id) => Some(id),
+            Err(e) => {
+                tracing::warn!("Invalid Telegram message_id '{message_id}': {e}");
+                None
+            }
+        };
+
+        // If we have attachments, delete the draft and send fresh messages
+        // (Telegram editMessageText can't add attachments)
+        if !attachments.is_empty() {
+            // Delete the draft message
+            if let Some(id) = msg_id {
+                let _ = self
+                    .client
+                    .post(self.api_url("deleteMessage"))
+                    .json(&serde_json::json!({
+                        "chat_id": chat_id,
+                        "message_id": id,
+                    }))
+                    .send()
+                    .await;
+            }
+
+            // Send text without markers
+            if !text_without_markers.is_empty() {
+                self.send_text_chunks(&text_without_markers, &chat_id, thread_id.as_deref())
+                    .await?;
+            }
+
+            // Send attachments
+            for attachment in &attachments {
+                self.send_attachment(&chat_id, thread_id.as_deref(), attachment)
+                    .await?;
+            }
+
+            return Ok(());
+        }
+
         // If text exceeds limit, delete draft and send as chunked messages
         if text.len() > TELEGRAM_MAX_MESSAGE_LENGTH {
-            let msg_id = match message_id.parse::<i64>() {
-                Ok(id) => id,
-                Err(e) => {
-                    tracing::warn!("Invalid Telegram message_id '{message_id}': {e}");
-                    return self
-                        .send_text_chunks(text, &chat_id, thread_id.as_deref())
-                        .await;
-                }
-            };
-
-            // Delete the draft
-            let _ = self
-                .client
-                .post(self.api_url("deleteMessage"))
-                .json(&serde_json::json!({
-                    "chat_id": chat_id,
-                    "message_id": msg_id,
-                }))
-                .send()
-                .await;
+            if let Some(id) = msg_id {
+                let _ = self
+                    .client
+                    .post(self.api_url("deleteMessage"))
+                    .json(&serde_json::json!({
+                        "chat_id": chat_id,
+                        "message_id": id,
+                    }))
+                    .send()
+                    .await;
+            }
 
             // Fall back to chunked send
             return self
@@ -2184,20 +2218,16 @@ impl Channel for TelegramChannel {
                 .await;
         }
 
-        let msg_id = match message_id.parse::<i64>() {
-            Ok(id) => id,
-            Err(e) => {
-                tracing::warn!("Invalid Telegram message_id '{message_id}': {e}");
-                return self
-                    .send_text_chunks(text, &chat_id, thread_id.as_deref())
-                    .await;
-            }
+        let Some(id) = msg_id else {
+            return self
+                .send_text_chunks(text, &chat_id, thread_id.as_deref())
+                .await;
         };
 
         // Try editing with HTML formatting
         let body = serde_json::json!({
             "chat_id": chat_id,
-            "message_id": msg_id,
+            "message_id": id,
             "text": Self::markdown_to_telegram_html(text),
             "parse_mode": "HTML",
         });
@@ -2216,7 +2246,7 @@ impl Channel for TelegramChannel {
         // Markdown failed — retry without parse_mode
         let plain_body = serde_json::json!({
             "chat_id": chat_id,
-            "message_id": msg_id,
+            "message_id": id,
             "text": text,
         });
 


### PR DESCRIPTION
## Summary

### Problem
When using Telegram streaming mode, the finalize_draft function would only edit the message text via editMessageText API. This meant image attachments marked with [IMAGE:path] syntax were never actually sent to users - only the text content was delivered.

### Why it matters
Users could not receive screenshots from browser automation or any image attachments when using Telegram as a channel. The warning "Telegram finalize_draft edit failed; falling back to sendMessage" would appear, but images were still lost.

### What changed
Modified finalize_draft in src/channels/telegram.rs to:
1. Parse attachment markers ([IMAGE:...], [DOCUMENT:...], etc.) from responses
2. Delete the draft message when attachments are present
3. Send text content without markers via send_text_chunks
4. Send each attachment via appropriate Telegram API

## Validation Evidence

### Commands run
```bash
cargo build --release
cargo test telegram --lib
```

### Test results
- Browser screenshot tool generates image correctly
- [IMAGE:path] marker is parsed correctly
- Draft message is deleted before sending attachments
- Image is delivered to Telegram chat
- Text + image combined responses work correctly

## Security Impact

### Risk level
Low - No new external inputs or attack surface introduced.

### Mitigation
- Uses existing send_photo, send_document methods
- Path validation already exists in send_attachment method

## Privacy and Data Hygiene

### Status
No privacy concerns. No new data collection or storage.

## Rollback Plan

If issues are detected:
1. Revert commit: git revert 9dd5667
2. Rebuild and restart daemon

---

Fixes: Telegram finalize_draft warning when sending images
