### PR TITLE
fix(ci): make cargo-slicer fast-build resilient to nightly API drift

### DIFF
--- a/.github/workflows/ci-build-fast.yml
+++ b/.github/workflows/ci-build-fast.yml
@@ -63,23 +63,46 @@ jobs:
                   cache-targets: true
 
             - name: Install cargo-slicer
+              id: install_slicer
+              shell: bash
               run: |
-                  cargo install cargo-slicer --locked 2>/dev/null \
-                    || cargo install cargo-slicer
-                  cargo +nightly install cargo-slicer --profile release-rustc \
+                  set -euo pipefail
+
+                  if cargo install cargo-slicer --version "$CARGO_SLICER_VERSION" --locked 2>/dev/null \
+                    || cargo install cargo-slicer --version "$CARGO_SLICER_VERSION"; then
+                    echo "slicer_ready=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "::warning::Unable to install cargo-slicer CLI; using fallback nightly release build."
+                    echo "slicer_ready=false" >> "$GITHUB_OUTPUT"
+                    echo "driver_ready=false" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  if cargo +nightly install cargo-slicer --version "$CARGO_SLICER_VERSION" --profile release-rustc \
                     --bin cargo-slicer-rustc --bin cargo_slicer_dispatch \
                     --features rustc-driver --locked 2>/dev/null \
-                    || cargo +nightly install cargo-slicer --profile release-rustc \
+                    || cargo +nightly install cargo-slicer --version "$CARGO_SLICER_VERSION" --profile release-rustc \
                       --bin cargo-slicer-rustc --bin cargo_slicer_dispatch \
-                      --features rustc-driver
+                      --features rustc-driver; then
+                    echo "driver_ready=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "::warning::cargo-slicer rustc-driver install failed (nightly rustc API drift); using fallback nightly release build."
+                    echo "driver_ready=false" >> "$GITHUB_OUTPUT"
+                  fi
 
             - name: Pre-analyze workspace
+              if: steps.install_slicer.outputs.slicer_ready == 'true'
               run: cargo-slicer pre-analyze
 
             - name: Build release binary (virtual slicing + MIR-precise)
+              if: steps.install_slicer.outputs.driver_ready == 'true'
               run: |
                   CARGO_SLICER_MIR_PRECISE=1 \
                     CARGO_SLICER_WORKSPACE_CRATES=zeroclaw,zeroclaw_robot_kit \
                     CARGO_SLICER_VIRTUAL=1 CARGO_SLICER_CODEGEN_FILTER=1 \
                     RUSTC_WRAPPER=$(which cargo_slicer_dispatch) \
                     cargo +nightly build --release --verbose
+
+            - name: Fallback release build (no slicer wrapper)
+              if: steps.install_slicer.outputs.driver_ready != 'true'
+              run: cargo +nightly build --release --verbose

--- a/docs/cargo-slicer-speedup.md
+++ b/docs/cargo-slicer-speedup.md
@@ -14,7 +14,13 @@ All measurements are clean `cargo +nightly build --release`. MIR-precise mode re
 
 ## CI Integration
 
-The workflow [`.github/workflows/ci-build-fast.yml`](../.github/workflows/ci-build-fast.yml) runs an accelerated release build alongside the standard one. It does not gate merges — it runs in parallel as a non-blocking check.
+The workflow [`.github/workflows/ci-build-fast.yml`](../.github/workflows/ci-build-fast.yml) runs an accelerated release build alongside the standard one. It does not gate merges and runs in parallel as a non-blocking check.
+
+CI uses a resilient two-path strategy:
+- **Fast path**: install `cargo-slicer` plus the `rustc-driver` binaries and run the MIR-precise sliced build.
+- **Fallback path**: if `rustc-driver` install fails (for example due to nightly `rustc` API drift), run a plain `cargo +nightly build --release` instead of failing the check.
+
+This keeps the check useful and green while preserving acceleration whenever the toolchain is compatible.
 
 ## Local Usage
 


### PR DESCRIPTION
## Summary
- make `CI Build (Fast)` resilient when `cargo-slicer` rustc-driver install breaks on nightly rustc internals
- keep fast path when both CLI and rustc-driver binaries install successfully
- add fallback path to run plain `cargo +nightly build --release` when rustc-driver install fails
- document the fallback behavior in `docs/cargo-slicer-speedup.md`

## Why
`Build (Fast — cargo-slicer)` currently turns red on rustc API drift (`FileName::prefer_local`), even when project code is healthy. This keeps the check useful and stable.

Closes #1249