### PR TITLE
fix(ci): avoid push false-fail on workflow-owner gate

### DIFF
--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -234,7 +234,7 @@ jobs:
 
                   if [ "${{ needs.changes.outputs.docs_only }}" = "true" ]; then
                     echo "workflow_owner_approval=${workflow_owner_result}"
-                    if [ "$workflow_changed" = "true" ] && [ "$workflow_owner_result" != "success" ]; then
+                    if [ "$event_name" = "pull_request" ] && [ "$workflow_changed" = "true" ] && [ "$workflow_owner_result" != "success" ]; then
                       echo "Workflow files changed but workflow owner approval gate did not pass."
                       exit 1
                     fi
@@ -249,7 +249,7 @@ jobs:
                   if [ "$rust_changed" != "true" ]; then
                     echo "rust_changed=false (non-rust fast path)"
                     echo "workflow_owner_approval=${workflow_owner_result}"
-                    if [ "$workflow_changed" = "true" ] && [ "$workflow_owner_result" != "success" ]; then
+                    if [ "$event_name" = "pull_request" ] && [ "$workflow_changed" = "true" ] && [ "$workflow_owner_result" != "success" ]; then
                       echo "Workflow files changed but workflow owner approval gate did not pass."
                       exit 1
                     fi
@@ -273,7 +273,7 @@ jobs:
                   echo "docs=${docs_result}"
                   echo "workflow_owner_approval=${workflow_owner_result}"
 
-                  if [ "$workflow_changed" = "true" ] && [ "$workflow_owner_result" != "success" ]; then
+                  if [ "$event_name" = "pull_request" ] && [ "$workflow_changed" = "true" ] && [ "$workflow_owner_result" != "success" ]; then
                     echo "Workflow files changed but workflow owner approval gate did not pass."
                     exit 1
                   fi


### PR DESCRIPTION
## Summary
- fix `CI Required Gate` to enforce workflow-owner approval only on `pull_request` events
- keep workflow-owner policy unchanged for workflow-changing PRs
- prevent false failures on `push` runs where `workflow-owner-approval` is intentionally `skipped`

## Why It Matters
After merging the cargo-slicer fallback hardening, `main` push CI started failing because:
- `workflow_changed=true`
- `workflow-owner-approval` job is PR-only, so it is `skipped` on push
- `CI Required Gate` treated `skipped` as failure even for push events

This patch restores correct semantics: PRs still require owner approval for workflow changes, push runs do not.

## Validation Evidence
- reviewed failing run: `22258067949` (`CI Run`)
- confirmed failure line: `workflow_owner_approval=skipped` followed by `Workflow files changed but workflow owner approval gate did not pass.`
- verified patch updates all three owner-gate checks in `.github/workflows/ci-run.yml`

## Security Impact
- no runtime behavior changes
- no secret handling changes
- no permission broadening

## Privacy and Data Hygiene
- no data collection changes
- no PII flow changes

## Rollback Plan
1. Revert this PR commit.
2. Re-run CI on `main`.
