### PR TITLE
ci(security): add manual Vorpal reviewdog workflow

### DIFF
--- a/.github/workflows/sec-vorpal-reviewdog.yml
+++ b/.github/workflows/sec-vorpal-reviewdog.yml
@@ -1,0 +1,179 @@
+name: Sec Vorpal Reviewdog
+
+on:
+    workflow_dispatch:
+        inputs:
+            scan_scope:
+                description: "File selection mode when source_path is empty"
+                required: true
+                type: choice
+                default: changed
+                options:
+                    - changed
+                    - all
+            base_ref:
+                description: "Base branch/ref for changed diff mode"
+                required: true
+                type: string
+                default: main
+            source_path:
+                description: "Optional comma-separated file paths to scan (overrides scan_scope)"
+                required: false
+                type: string
+            include_tests:
+                description: "Include test/fixture files in scan selection"
+                required: true
+                type: choice
+                default: "false"
+                options:
+                    - "false"
+                    - "true"
+            folders_to_ignore:
+                description: "Optional comma-separated path prefixes to ignore"
+                required: false
+                type: string
+                default: target,node_modules,web/dist,.venv,venv
+            reporter:
+                description: "Reviewdog reporter mode"
+                required: true
+                type: choice
+                default: github-pr-check
+                options:
+                    - github-pr-check
+                    - github-pr-review
+            filter_mode:
+                description: "Reviewdog filter mode"
+                required: true
+                type: choice
+                default: file
+                options:
+                    - added
+                    - diff_context
+                    - file
+                    - nofilter
+            level:
+                description: "Reviewdog severity level"
+                required: true
+                type: choice
+                default: error
+                options:
+                    - info
+                    - warning
+                    - error
+            fail_on_error:
+                description: "Fail workflow when Vorpal reports findings"
+                required: true
+                type: choice
+                default: "false"
+                options:
+                    - "false"
+                    - "true"
+            reviewdog_flags:
+                description: "Optional extra reviewdog flags"
+                required: false
+                type: string
+
+concurrency:
+    group: sec-vorpal-reviewdog-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+    checks: write
+    pull-requests: write
+
+jobs:
+    vorpal:
+        name: Vorpal Reviewdog Scan
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        timeout-minutes: 20
+        steps:
+            - name: Checkout
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+            - name: Resolve source paths
+              id: sources
+              shell: bash
+              env:
+                  INPUT_SOURCE_PATH: ${{ inputs.source_path }}
+                  INPUT_SCAN_SCOPE: ${{ inputs.scan_scope }}
+                  INPUT_BASE_REF: ${{ inputs.base_ref }}
+                  INPUT_INCLUDE_TESTS: ${{ inputs.include_tests }}
+              run: |
+                  set -euo pipefail
+
+                  strip_space() {
+                      local value="$1"
+                      value="${value//$'\n'/}"
+                      value="${value//$'\r'/}"
+                      value="${value// /}"
+                      echo "$value"
+                  }
+
+                  source_override="$(strip_space "${INPUT_SOURCE_PATH}")"
+                  if [ -n "${source_override}" ]; then
+                      normalized="$(echo "${INPUT_SOURCE_PATH}" | tr '\n' ',' | sed -E 's/[[:space:]]+//g; s/,+/,/g; s/^,|,$//g')"
+                      if [ -n "${normalized}" ]; then
+                          echo "scan=true" >> "${GITHUB_OUTPUT}"
+                          echo "source_path=${normalized}" >> "${GITHUB_OUTPUT}"
+                          echo "selection=manual" >> "${GITHUB_OUTPUT}"
+                          exit 0
+                      fi
+                  fi
+
+                  include_ext='\.(py|js|jsx|ts|tsx)$'
+                  exclude_paths='^(target/|node_modules/|web/node_modules/|dist/|web/dist/|\.venv/|venv/)'
+                  exclude_tests='(^|/)(test|tests|__tests__|fixtures|mocks|examples)/|(^|/)test_helpers/|(_test\.py$)|(^|/)test_.*\.py$|(\.spec\.(ts|tsx|js|jsx)$)|(\.test\.(ts|tsx|js|jsx)$)'
+
+                  if [ "${INPUT_SCAN_SCOPE}" = "all" ]; then
+                      candidate_files="$(git ls-files)"
+                  else
+                      base_ref="${INPUT_BASE_REF#refs/heads/}"
+                      base_ref="${base_ref#origin/}"
+                      if git fetch --no-tags --depth=1 origin "${base_ref}" >/dev/null 2>&1; then
+                          if merge_base="$(git merge-base HEAD "origin/${base_ref}" 2>/dev/null)"; then
+                              candidate_files="$(git diff --name-only --diff-filter=ACMR "${merge_base}"...HEAD)"
+                          else
+                              echo "Unable to resolve merge-base for origin/${base_ref}; falling back to tracked files."
+                              candidate_files="$(git ls-files)"
+                          fi
+                      else
+                          echo "Unable to fetch origin/${base_ref}; falling back to tracked files."
+                          candidate_files="$(git ls-files)"
+                      fi
+                  fi
+
+                  source_files="$(printf '%s\n' "${candidate_files}" | sed '/^$/d' | grep -E "${include_ext}" | grep -Ev "${exclude_paths}" || true)"
+                  if [ "${INPUT_INCLUDE_TESTS}" != "true" ] && [ -n "${source_files}" ]; then
+                      source_files="$(printf '%s\n' "${source_files}" | grep -Ev "${exclude_tests}" || true)"
+                  fi
+                  if [ -z "${source_files}" ]; then
+                      echo "scan=false" >> "${GITHUB_OUTPUT}"
+                      echo "source_path=" >> "${GITHUB_OUTPUT}"
+                      echo "selection=none" >> "${GITHUB_OUTPUT}"
+                      exit 0
+                  fi
+
+                  source_path="$(printf '%s\n' "${source_files}" | paste -sd, -)"
+                  echo "scan=true" >> "${GITHUB_OUTPUT}"
+                  echo "source_path=${source_path}" >> "${GITHUB_OUTPUT}"
+                  echo "selection=auto-${INPUT_SCAN_SCOPE}" >> "${GITHUB_OUTPUT}"
+
+            - name: No supported files to scan
+              if: steps.sources.outputs.scan != 'true'
+              shell: bash
+              run: |
+                  echo "No supported files selected for Vorpal scan (extensions: .py .js .jsx .ts .tsx)."
+
+            - name: Run Vorpal with reviewdog
+              if: steps.sources.outputs.scan == 'true'
+              uses: Checkmarx/vorpal-reviewdog-github-action@8cc292f337a2f1dea581b4f4bd73852e7becb50d # v1.2.0
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  source_path: ${{ steps.sources.outputs.source_path }}
+                  folders_to_ignore: ${{ inputs.folders_to_ignore }}
+                  reporter: ${{ inputs.reporter }}
+                  filter_mode: ${{ inputs.filter_mode }}
+                  level: ${{ inputs.level }}
+                  fail_on_error: ${{ inputs.fail_on_error }}
+                  reviewdog_flags: ${{ inputs.reviewdog_flags }}

--- a/docs/actions-source-policy.md
+++ b/docs/actions-source-policy.md
@@ -22,6 +22,7 @@ Selected allowlist patterns:
 - `rhysd/actionlint@*`
 - `softprops/action-gh-release@*`
 - `sigstore/cosign-installer@*`
+- `Checkmarx/vorpal-reviewdog-github-action@*`
 - `useblacksmith/*` (Blacksmith self-hosted runner infrastructure)
 
 ## Change Control Export
@@ -74,6 +75,9 @@ If encountered, add only the specific trusted missing action, rerun, and documen
 
 Latest sweep notes:
 
+- 2026-02-21: Added manual Vorpal reviewdog workflow for targeted secure-coding checks on supported file types
+    - Added allowlist pattern: `Checkmarx/vorpal-reviewdog-github-action@*`
+    - Workflow uses pinned source: `Checkmarx/vorpal-reviewdog-github-action@8cc292f337a2f1dea581b4f4bd73852e7becb50d` (v1.2.0)
 - 2026-02-17: Rust dependency cache migrated from `Swatinem/rust-cache` to `useblacksmith/rust-cache`
     - No new allowlist pattern required (`useblacksmith/*` already allowlisted)
 - 2026-02-16: Hidden dependency discovered in `release.yml`: `sigstore/cosign-installer@...`

--- a/docs/ci-map.md
+++ b/docs/ci-map.md
@@ -29,6 +29,9 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
     - Purpose: dependency advisories (`rustsec/audit-check`, pinned SHA) and policy/license checks (`cargo deny`)
 - `.github/workflows/sec-codeql.yml` (`CodeQL Analysis`)
     - Purpose: scheduled/manual static analysis for security findings
+- `.github/workflows/sec-vorpal-reviewdog.yml` (`Sec Vorpal Reviewdog`)
+    - Purpose: manual secure-coding feedback scan for supported non-Rust files (`.py`, `.js`, `.jsx`, `.ts`, `.tsx`) using reviewdog annotations
+    - Noise control: excludes common test/fixture paths and test file patterns by default (`include_tests=false`)
 - `.github/workflows/pub-release.yml` (`Release`)
     - Purpose: build release artifacts in verification mode (manual/scheduled) and publish GitHub releases on tag push or manual publish mode
 - `.github/workflows/pr-label-policy-check.yml` (`Label Policy Sanity`)
@@ -69,6 +72,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - `Docker`: push to `main` when Docker build inputs change, tag push (`v*`), matching PRs, manual dispatch
 - `Release`: tag push (`v*`), weekly schedule (verification-only), manual dispatch (verification or publish)
 - `Security Audit`: push to `main`, PRs to `main`, weekly schedule
+- `Sec Vorpal Reviewdog`: manual dispatch only
 - `Workflow Sanity`: PR/push when `.github/workflows/**`, `.github/*.yml`, or `.github/*.yaml` change
 - `PR Intake Checks`: `pull_request_target` on opened/reopened/synchronize/edited/ready_for_review
 - `Label Policy Sanity`: PR/push when `.github/label-policy.json`, `.github/workflows/pr-labeler.yml`, or `.github/workflows/pr-auto-response.yml` changes


### PR DESCRIPTION
## Summary
- add a manual security workflow at `.github/workflows/sec-vorpal-reviewdog.yml` using pinned `Checkmarx/vorpal-reviewdog-github-action@8cc292f337a2f1dea581b4f4bd73852e7becb50d` (v1.2.0)
- scope default scanning to supported non-Rust files in this repo (`.py`, `.js`, `.jsx`, `.ts`, `.tsx`)
- reduce false positives by excluding test/fixture paths and test filename patterns by default (`include_tests=false`)
- document workflow behavior in `docs/ci-map.md`
- document Actions allowlist impact in `docs/actions-source-policy.md`

## Allowlist Impact
- Added action source pattern: `Checkmarx/vorpal-reviewdog-github-action@*`

## Risk
- Low to medium: new workflow is `workflow_dispatch` only (manual, non-blocking)

## Rollback
- Revert this PR commit to remove the workflow and allowlist/doc updates
