### PR TITLE
fix(tool): harden content_search parsing, safety, and registry coverage

### DIFF
--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -423,6 +423,7 @@ mod tests {
         );
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(names.contains(&"browser_open"));
+        assert!(names.contains(&"content_search"));
         assert!(names.contains(&"model_routing_config"));
         assert!(names.contains(&"pushover"));
         assert!(names.contains(&"proxy_config"));
@@ -438,6 +439,7 @@ mod tests {
         assert!(names.contains(&"file_write"));
         assert!(names.contains(&"file_edit"));
         assert!(names.contains(&"glob_search"));
+        assert!(names.contains(&"content_search"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Problem: the initial `content_search` implementation (from #1240) worked functionally but had edge-case correctness gaps in parsing and truncation behavior.
- Why it matters: this tool is a core code-navigation primitive; edge-case miscounts or truncation panics reduce reliability under real-world search output.
- What changed:
  - validate `output_mode` explicitly (reject invalid values instead of silently treating as `content`)
  - replace byte-slice truncation with UTF-8 boundary-safe truncation (`truncate_utf8`) to prevent panic on multibyte boundaries
  - improve content-mode parsing to distinguish match lines vs context lines and avoid counting separators (`--`) as matches
  - harden count-mode parsing (`path:count`) with robust parsing helper
  - return `No matches found.` when formatted output is empty after filtering
  - assert `content_search` registration in both default and full tool registries (`src/tools/mod.rs` tests)
  - add focused unit tests for new edge behavior
- What did **not** change (scope boundary): no new dependencies, no shell permission expansion, no non-tool subsystem behavior changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `runtime,tool,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `tool: content_search`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `runtime`

## Linked Issue

- Closes #1239
- Related #
- Depends on # (if stacked)
- Supersedes #1240

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
  - `#1240 by @reidliu41`
- Integrated scope by source PR (what was materially carried forward):
  - carried forward the initial `content_search` tool implementation and tool registration.
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `Yes`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N.A.
- Trailer format check (separate lines, no escaped `\\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
./scripts/ci/rust_quality_gate.sh
./scripts/ci/rust_strict_delta_gate.sh
cargo test --lib tools::content_search::tests -- --nocapture
cargo check
```

- Evidence provided (test/log/trace/screenshot/perf): local command outputs captured; `content_search` suite reports `22 passed; 0 failed`.
- If any command is intentionally skipped, explain why: none.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N.A.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: tests use temporary directories and synthetic content only.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N.A.

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N.A.
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N.A.
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N.A.
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: no docs/runtime contract text changed in this patch.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - normal content search
  - `files_with_matches` and `count` output modes
  - invalid `output_mode` rejection path
  - multiline fallback behavior when `rg` is unavailable
  - symlink escape safety test path
- Edge cases checked:
  - UTF-8-safe truncation boundary handling
  - context output should not overcount separator/context lines as matches
  - colon-containing path parsing in count mode
- What was not verified:
  - remote hosted CI signal is still pending at PR update time

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `src/tools/content_search.rs`, tool registry tests in `src/tools/mod.rs`
- Potential unintended effects: stricter `output_mode` validation now rejects previously tolerated invalid values (intentional)
- Guardrails/monitoring for early detection: strict delta gate + focused tool tests

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `gh`, local CI scripts, cargo test/check
- Workflow/plan summary (if any): deep triage -> hardening patch -> focused tests -> quality gates -> draft PR
- Verification focus: output correctness, safety boundaries, registry coverage
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert 80e46cca`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: inaccurate content_search summaries or invalid output-mode handling regressions

## Risks and Mitigations

- Risk: stricter validation may reject malformed legacy caller payloads that previously fell through to default behavior.
  - Mitigation: error message is explicit and schema already advertises valid enum values; callers can correct quickly.

Co-authored-by: Reid <61492567+reidliu41@users.noreply.github.com>