### PR TITLE
feat(channels): immediate randomized ack reactions for telegram/discord/lark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ async-trait = "0.1"
 ring = "0.17"
 
 # Protobuf encode/decode (Lark WS frame codec, WhatsApp storage)
-prost = { version = "0.14", default-features = false, optional = true }
+prost = { version = "0.14", default-features = false, features = ["derive"], optional = true }
 
 # Memory / persistence
 rusqlite = { version = "0.37", features = ["bundled"] }


### PR DESCRIPTION
## Summary
- add immediate best-effort ACK reactions for inbound Telegram messages (random from `⚡️ 🦀 🙌 💪 👌 👀 👣`, uniform)
- add immediate best-effort ACK reactions for inbound Discord messages (same random pool, uniform)
- replace fixed Lark/Feishu ACK with language-aware random reactions using locale-specific pools (`zh-CN` / `zh-TW` / `en` / `ja`)
- add locale detection with unsupported-language fallback via message-text script heuristics
- preserve full Lark channel state (including `app_language` + receive mode config) in webhook handling by cloning channel state
- enable optional `prost` derive support so channel-lark tests compile and run

## Tests
- `rustfmt --edition 2021 --check src/channels/telegram.rs src/channels/discord.rs src/channels/lark.rs`
- `cargo test random_telegram_ack_reaction_is_from_pool`
- `cargo test random_discord_ack_reaction_is_from_pool`
- `cargo test telegram_ack_reaction_request_shape`
- `cargo test telegram_extract_update_message_target_parses_ids`
- `cargo test --features channel-lark lark_reaction_locale_`
- `cargo test --features channel-lark random_lark_ack_reaction_respects_detected_locale_pool`