### PR TITLE
fix(release): make v0.1.2 publish robust and attach dual-license files

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -273,7 +273,7 @@ jobs:
         if: needs.prepare.outputs.publish_release == 'true'
         needs: [prepare, verify-artifacts]
         runs-on: blacksmith-2vcpu-ubuntu-2404
-        timeout-minutes: 15
+        timeout-minutes: 45
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               with:
@@ -297,10 +297,16 @@ jobs:
                     echo "- SPDX: zeroclaw.spdx.json"
                   } >> "$GITHUB_STEP_SUMMARY"
 
+            - name: Attach license and notice files
+              run: |
+                  cp LICENSE artifacts/LICENSE
+                  cp LICENSE-APACHE artifacts/LICENSE-APACHE
+                  cp NOTICE artifacts/NOTICE
+
             - name: Generate SHA256 checksums
               run: |
                   cd artifacts
-                  find . -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.cdx.json' -o -name '*.spdx.json' \) -exec sha256sum {} + | sed 's|  \./[^/]*/|  |' > SHA256SUMS
+                  find . -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.cdx.json' -o -name '*.spdx.json' -o -name 'LICENSE' -o -name 'LICENSE-APACHE' -o -name 'NOTICE' \) -exec sha256sum {} + | sed 's|  \./[^/]*/|  |' > SHA256SUMS
                   echo "Generated checksums:"
                   cat SHA256SUMS
 
@@ -328,7 +334,7 @@ jobs:
                   repo="${GITHUB_REPOSITORY,,}"
                   manifest_url="https://ghcr.io/v2/${repo}/manifests/${RELEASE_TAG}"
                   accept_header="application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json"
-                  max_attempts=18
+                  max_attempts=75
                   sleep_seconds=20
 
                   for attempt in $(seq 1 "$max_attempts"); do
@@ -363,7 +369,6 @@ jobs:
               uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
               with:
                   tag_name: ${{ needs.prepare.outputs.release_tag }}
-                  target_commitish: ${{ needs.prepare.outputs.release_ref }}
                   draft: ${{ needs.prepare.outputs.draft_release == 'true' }}
                   generate_release_notes: true
                   files: |


### PR DESCRIPTION
## Summary
- remove invalid `target_commitish` assignment that used tag names
- extend GHCR tag wait window so release publish does not race docker push
- attach `LICENSE`, `LICENSE-APACHE`, and `NOTICE` to release artifacts and checksums

## Why
`v0.1.2` release publish failed due a GHCR timing race and 422 `target_commitish` validation.

## Risk
Low; workflow-only change scoped to release publish path.

## Rollback
Revert this PR.
