### PR TITLE
fix(release): remove duplicate SHA256SUMS asset upload

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -373,6 +373,5 @@ jobs:
                   generate_release_notes: true
                   files: |
                       artifacts/**/*
-                      artifacts/SHA256SUMS
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- remove duplicate `SHA256SUMS` file entry from release asset upload list

## Why
`artifacts/**/*` already includes `SHA256SUMS`; listing it again can cause action-gh-release asset update errors.

## Risk
Low; release workflow-only, single-line change.
