### PR TITLE
ci(policy): enforce willsarg-only edits for root license files

### DIFF
--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -229,8 +229,6 @@ jobs:
 
             - name: Enforce owner-only edits for root license files
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-              env:
-                  LICENSE_FILE_OWNER_LOGINS: ${{ vars.LICENSE_FILE_OWNER_LOGINS }}
               with:
                   script: |
                     const script = require('./.github/workflows/scripts/ci_license_file_owner_guard.js');

--- a/.github/workflows/scripts/ci_license_file_owner_guard.js
+++ b/.github/workflows/scripts/ci_license_file_owner_guard.js
@@ -11,12 +11,7 @@ module.exports = async ({ github, context, core }) => {
     return;
   }
 
-  const baseOwners = ["willsarg"];
-  const configuredOwners = (process.env.LICENSE_FILE_OWNER_LOGINS || "")
-    .split(",")
-    .map((login) => login.trim().toLowerCase())
-    .filter(Boolean);
-  const ownerAllowlist = [...new Set([...baseOwners, ...configuredOwners])];
+  const ownerAllowlist = ["willsarg"];
 
   if (ownerAllowlist.length === 0) {
     core.setFailed("License owner allowlist is empty.");


### PR DESCRIPTION
## Summary
- enforce strict root license ownership to `willsarg` only
- remove `LICENSE_FILE_OWNER_LOGINS` variable override path

## Why
Policy requirement is explicit single-owner control over root license files.

## Risk
Low; policy-only workflow/script change.
