### PR TITLE
ci(docker): publish images only on v* tags

### DIFF
--- a/.github/workflows/pub-docker-img.yml
+++ b/.github/workflows/pub-docker-img.yml
@@ -2,20 +2,7 @@ name: Pub Docker Img
 
 on:
     push:
-        branches: [main]
         tags: ["v*"]
-        paths:
-            - "Dockerfile"
-            - ".dockerignore"
-            - "Cargo.toml"
-            - "Cargo.lock"
-            - "rust-toolchain.toml"
-            - "src/**"
-            - "crates/**"
-            - "benches/**"
-            - "firmware/**"
-            - "dev/config.template.toml"
-            - ".github/workflows/pub-docker-img.yml"
     pull_request:
         branches: [main]
         paths:
@@ -78,7 +65,7 @@ jobs:
 
     publish:
         name: Build and Push Docker Image
-        if: (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')))) && github.repository == 'zeroclaw-labs/zeroclaw'
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'zeroclaw-labs/zeroclaw'
         runs-on: blacksmith-2vcpu-ubuntu-2404
         timeout-minutes: 45
         permissions:
@@ -105,17 +92,13 @@ jobs:
                   set -euo pipefail
                   IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
                   SHA_TAG="${IMAGE}:sha-${GITHUB_SHA::12}"
-
-                  if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-                    TAG_NAME="${GITHUB_REF#refs/tags/}"
-                    TAGS="${IMAGE}:${TAG_NAME},${SHA_TAG}"
-                  elif [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-                    TAGS="${IMAGE}:latest,${SHA_TAG}"
-                  else
-                    BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-                    BRANCH_NAME="${BRANCH_NAME//\//-}"
-                    TAGS="${IMAGE}:${BRANCH_NAME},${SHA_TAG}"
+                  if [[ "${GITHUB_REF}" != refs/tags/v* ]]; then
+                    echo "::error::Docker publish is restricted to v* tag pushes."
+                    exit 1
                   fi
+
+                  TAG_NAME="${GITHUB_REF#refs/tags/}"
+                  TAGS="${IMAGE}:${TAG_NAME},${SHA_TAG}"
 
                   echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
@@ -169,6 +152,7 @@ jobs:
               shell: bash
               run: |
                   set -euo pipefail
+                  TAG_NAME="${GITHUB_REF#refs/tags/}"
                   token_resp="$(curl -sS "https://ghcr.io/token?scope=repository:${GITHUB_REPOSITORY}:pull")"
                   token="$(echo "$token_resp" | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')"
 
@@ -180,7 +164,7 @@ jobs:
                   code="$(curl -sS -o /tmp/ghcr-manifest.json -w "%{http_code}" \
                     -H "Authorization: Bearer ${token}" \
                     -H "Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json" \
-                    "https://ghcr.io/v2/${GITHUB_REPOSITORY}/manifests/latest")"
+                    "https://ghcr.io/v2/${GITHUB_REPOSITORY}/manifests/${TAG_NAME}")"
 
                   if [ "$code" != "200" ]; then
                     echo "::error::Anonymous manifest pull failed with HTTP ${code}"

--- a/docs/ci-map.md
+++ b/docs/ci-map.md
@@ -13,7 +13,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - `.github/workflows/ci-run.yml` (`CI`)
     - Purpose: Rust validation (`cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D clippy::correctness`, strict delta lint gate on changed Rust lines, `test`, release build smoke) + docs quality checks when docs change (`markdownlint` blocks only issues on changed lines; link check scans only links added on changed lines)
     - Additional behavior: PRs that change `.github/workflows/**` require at least one approving review from a login in `WORKFLOW_OWNER_LOGINS` (repository variable fallback: `theonlyhennygod,willsarg`)
-    - Additional behavior: PRs that change root license files (`LICENSE`, `LICENSE-APACHE`) must be authored by a login in `LICENSE_FILE_OWNER_LOGINS` (repository variable fallback: `willsarg`)
+    - Additional behavior: PRs that change root license files (`LICENSE`, `LICENSE-APACHE`) must be authored by `willsarg`
     - Additional behavior: lint gates run before `test`/`build`; when lint/docs gates fail on PRs, CI posts an actionable feedback comment with failing gate names and local fix commands
     - Merge gate: `CI Required Gate`
 - `.github/workflows/workflow-sanity.yml` (`Workflow Sanity`)
@@ -25,7 +25,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 ### Non-Blocking but Important
 
 - `.github/workflows/pub-docker-img.yml` (`Docker`)
-    - Purpose: PR Docker smoke check and publish images on `main` pushes (build-input paths), tag pushes (`v*`), and manual dispatch
+    - Purpose: PR Docker smoke check and publish images on tag pushes (`v*`) only
 - `.github/workflows/sec-audit.yml` (`Security Audit`)
     - Purpose: dependency advisories (`rustsec/audit-check`, pinned SHA) and policy/license checks (`cargo deny`)
 - `.github/workflows/sec-codeql.yml` (`CodeQL Analysis`)
@@ -70,7 +70,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 ## Trigger Map
 
 - `CI`: push to `main`, PRs to `main`
-- `Docker`: push to `main` when Docker build inputs change, tag push (`v*`), matching PRs, manual dispatch
+- `Docker`: tag push (`v*`) for publish, matching PRs for smoke build, manual dispatch for smoke only
 - `Release`: tag push (`v*`), weekly schedule (verification-only), manual dispatch (verification or publish)
 - `Security Audit`: push to `main`, PRs to `main`, weekly schedule
 - `Sec Vorpal Reviewdog`: manual dispatch only

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -2,7 +2,7 @@
 
 This runbook defines the maintainers' standard release flow.
 
-Last verified: **February 20, 2026**.
+Last verified: **February 21, 2026**.
 
 ## Release Goals
 
@@ -91,7 +91,7 @@ Expected publish outputs:
 ### 5) Post-release validation
 
 1. Verify GitHub Release assets are downloadable.
-2. Verify GHCR tags for the released version and `latest`.
+2. Verify GHCR tags for the released version (`vX.Y.Z`) and release commit SHA tag (`sha-<12>`).
 3. Verify install paths that rely on release assets (for example bootstrap binary download).
 
 ## Emergency / Recovery Path


### PR DESCRIPTION
## Summary
- restrict Docker publish job to `push` events on `refs/tags/v*` only
- remove `main`-push and `workflow_dispatch` publish paths
- verify GHCR manifest access on the release tag being pushed (not `latest`)
- update workflow/docs references to match tag-only publish behavior

## Why
Prevent routine `main` pushes from publishing container images; only explicit version tags should publish release images.

## Risk
Low to medium. Affects Docker release cadence and publish triggers only.

## Rollback
Revert this PR to restore `main` push Docker publishing.
