### PR TITLE
chore(branch): reconcile dev for clean main promotion

### DIFF
--- a/.github/workflows/main-branch-flow.md
+++ b/.github/workflows/main-branch-flow.md
@@ -155,7 +155,7 @@ Workflow: `.github/workflows/pub-docker-img.yml`
 6. Typical runtime in recent sample: ~139.9s.
 7. Result: pushed image tags under `ghcr.io/<owner>/<repo>`.
 
-Important: Docker publish now requires a `v*` tag push; regular branch pushes do not publish images.
+Important: Docker publish now requires a `v*` tag push; regular `dev`/`main` branch pushes do not publish images.
 
 ## Release Logic
 


### PR DESCRIPTION
## Summary
- merges the rebased promotion commit onto `dev` without force-pushing protected branch history
- resolves the remaining `main-branch-flow.md` wording conflict
- prepares `dev -> main` promotion PR #1284 to merge cleanly

## Why
`dev` is protected (no force-push, PR-only updates), so rebasing #1284 head directly is not allowed.

## Validation
- local merge and conflict resolution completed
- branch pushed and ready for review/merge
