### PR TITLE
ci(policy): restrict main PR authors and target bot PRs to dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    target-branch: main
+    target-branch: dev
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
@@ -21,7 +21,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    target-branch: main
+    target-branch: dev
     open-pull-requests-limit: 1
     labels:
       - "ci"
@@ -38,7 +38,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    target-branch: main
+    target-branch: dev
     open-pull-requests-limit: 1
     labels:
       - "ci"

--- a/.github/workflows/main-branch-flow.md
+++ b/.github/workflows/main-branch-flow.md
@@ -116,10 +116,11 @@ Notes:
 ### 3) Promotion PR `dev` -> `main`
 
 1. Maintainer opens PR with head `dev` and base `main`.
-2. `main-promotion-gate.yml` runs and fails if head repo/branch is not `<this-repo>:dev`.
-3. `ci-run.yml` and `sec-audit.yml` run on the promotion PR.
-4. Maintainer merges PR once checks and review policy pass.
-5. Merge emits a `push` event on `main`.
+2. `main-promotion-gate.yml` runs and fails unless PR author is `willsarg` or `theonlyhennygod`.
+3. `main-promotion-gate.yml` also fails if head repo/branch is not `<this-repo>:dev`.
+4. `ci-run.yml` and `sec-audit.yml` run on the promotion PR.
+5. Maintainer merges PR once checks and review policy pass.
+6. Merge emits a `push` event on `main`.
 
 ### 4) Push to `dev` or `main` (including after merge)
 

--- a/.github/workflows/main-promotion-gate.yml
+++ b/.github/workflows/main-promotion-gate.yml
@@ -22,8 +22,25 @@ jobs:
                   HEAD_REF: ${{ github.head_ref }}
                   HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
                   BASE_REPO: ${{ github.repository }}
+                  PR_AUTHOR: ${{ github.event.pull_request.user.login }}
               run: |
                   set -euo pipefail
+
+                  pr_author_lc="$(echo "${PR_AUTHOR}" | tr '[:upper:]' '[:lower:]')"
+                  allowed_authors=("willsarg" "theonlyhennygod")
+
+                  is_allowed_author=false
+                  for allowed in "${allowed_authors[@]}"; do
+                    if [[ "$pr_author_lc" == "$allowed" ]]; then
+                      is_allowed_author=true
+                      break
+                    fi
+                  done
+
+                  if [[ "$is_allowed_author" != "true" ]]; then
+                    echo "::error::PRs into main are restricted to: willsarg, theonlyhennygod. PR author: ${PR_AUTHOR}. Open this PR against dev instead."
+                    exit 1
+                  fi
 
                   if [[ "$HEAD_REPO" != "$BASE_REPO" ]]; then
                     echo "::error::PRs into main must originate from ${BASE_REPO}:dev. Current head repo: ${HEAD_REPO}."
@@ -35,4 +52,4 @@ jobs:
                     exit 1
                   fi
 
-                  echo "Promotion policy satisfied: ${HEAD_REPO}:${HEAD_REF} -> main"
+                  echo "Promotion policy satisfied: author=${PR_AUTHOR}, source=${HEAD_REPO}:${HEAD_REF} -> main"

--- a/docs/ci-map.md
+++ b/docs/ci-map.md
@@ -22,7 +22,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - `.github/workflows/pr-intake-checks.yml` (`PR Intake Checks`)
     - Purpose: safe pre-CI PR checks (template completeness, added-line tabs/trailing-whitespace/conflict markers) with immediate sticky feedback comment
 - `.github/workflows/main-promotion-gate.yml` (`Main Promotion Gate`)
-    - Purpose: enforce stable-branch policy by allowing only `dev` -> `main` PR promotion
+    - Purpose: enforce stable-branch policy by allowing only `dev` -> `main` PR promotion authored by `willsarg` or `theonlyhennygod`
 
 ### Non-Blocking but Important
 
@@ -77,13 +77,13 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - `Security Audit`: push to `dev` and `main`, PRs to `dev` and `main`, weekly schedule
 - `Sec Vorpal Reviewdog`: manual dispatch only
 - `Workflow Sanity`: PR/push when `.github/workflows/**`, `.github/*.yml`, or `.github/*.yaml` change
-- `Main Promotion Gate`: PRs to `main` only; requires head branch `dev` in the same repository
+- `Main Promotion Gate`: PRs to `main` only; requires PR author `willsarg`/`theonlyhennygod` and head branch `dev` in the same repository
+- `Dependabot`: all update PRs target `dev` (not `main`)
 - `PR Intake Checks`: `pull_request_target` on opened/reopened/synchronize/edited/ready_for_review
 - `Label Policy Sanity`: PR/push when `.github/label-policy.json`, `.github/workflows/pr-labeler.yml`, or `.github/workflows/pr-auto-response.yml` changes
 - `PR Labeler`: `pull_request_target` lifecycle events
 - `PR Auto Responder`: issue opened/labeled, `pull_request_target` opened/labeled
 - `Stale PR Check`: daily schedule, manual dispatch
-- `Dependabot`: weekly dependency maintenance windows
 - `PR Hygiene`: every 12 hours schedule, manual dispatch
 
 ## Fast Triage Guide


### PR DESCRIPTION
## Summary
- enforce main promotion PR author allowlist in `main-promotion-gate.yml` (`willsarg`, `theonlyhennygod`)
- keep existing `dev -> main` source-branch enforcement
- move Dependabot update targets from `main` to `dev` for Cargo, Actions, and Docker ecosystems
- update CI/docs maps to reflect the new policy

## Behavior
- PRs to `main` by any author outside the allowlist fail promotion gate with a redirect message to open against `dev`
- Dependabot now opens PRs against `dev`

## Validation
- YAML parse check for `.github/workflows/main-promotion-gate.yml` and `.github/dependabot.yml`
