### PR TITLE
fix(providers): disable Responses API fallback for NVIDIA NIM

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1171,7 +1171,7 @@ fn create_provider_with_url_and_options(
             )))
         }
         "nvidia" | "nvidia-nim" | "build.nvidia.com" => Ok(Box::new(
-            OpenAiCompatibleProvider::new(
+            OpenAiCompatibleProvider::new_no_responses_fallback(
                 "NVIDIA NIM",
                 "https://integrate.api.nvidia.com/v1",
                 key,


### PR DESCRIPTION
## Summary

**Problem:** NVIDIA NIM API (`integrate.api.nvidia.com`) does not support the OpenAI Responses API endpoint (`/v1/responses`). When a chat completions request returns a non-success status, zeroclaw falls back to `/v1/responses`, which also 404s, producing a confusing double-failure error.

**Why it matters:** All NVIDIA NIM models are unusable with zeroclaw — every failed request triggers an unnecessary Responses API fallback that also fails, masking the real error.

**What changed:** One-line fix in `src/providers/mod.rs` — the NVIDIA provider now uses `OpenAiCompatibleProvider::new_no_responses_fallback()` instead of `OpenAiCompatibleProvider::new()`, matching the approach already used for GLM and other chat-completions-only providers.

## Validation Evidence

- Built from source on macOS arm64 (`make build`)
- Ran `zeroclaw agent --model minimaxai/minimax-m2.1 -m "Say hello"` — successful response
- Ran `zeroclaw agent --model qwen/qwen3.5-397b-a17b -m "Say hello"` — successful response
- Ran `zeroclaw agent --model moonshotai/kimi-k2.5 -m "Say hello"` — successful response
- Ran batch workloads (multiple concurrent `zeroclaw agent` workers) against NVIDIA NIM for extended periods without provider errors

## Security Impact

- **Risk:** None
- **Mitigation:** N/A — this change only disables an unsupported API fallback path for the NVIDIA provider. No new endpoints, credentials, or authentication flows are introduced.

## Privacy and Data Hygiene

- No change to data handling, logging, or storage
- No new PII collection or processing
- No change to telemetry or observability paths

## Rollback Plan

Revert the single-line change in `src/providers/mod.rs`:
```diff
- OpenAiCompatibleProvider::new_no_responses_fallback(
+ OpenAiCompatibleProvider::new(
```

## Test plan
- [x] Confirmed NVIDIA NIM provider works after the fix with multiple models
- [x] Built from source on macOS arm64, ran `zeroclaw agent` with `default_provider = "nvidia"`
- [x] Extended batch workload testing with concurrent workers

Fixes #1282