### PR TITLE
feat(config): warn on unknown config keys to prevent silent misconfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5673,6 +5673,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8043,6 +8053,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde-big-array",
+ "serde_ignored",
  "serde_json",
  "sha2",
  "shellexpand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = { version = "1.0", default-features = false, features = ["std"] }
 # Config
 directories = "6.0"
 toml = "1.0"
+serde_ignored = "0.1"
 shellexpand = "3.1"
 
 # JSON Schema generation for config export


### PR DESCRIPTION

Summary

  - Problem: serde silently ignores unknown TOML keys (e.g. [providers.ollama]). Users write invalid config sections that are quietly discarded, causing settings like api_url to never take effect — Ollama falls back to localhost with no indication of why.
  - Why it matters: This is a silent misconfiguration trap. Users believe their config is active when it's actually dropped. Violates fail-fast / explicit errors principle (CLAUDE.md §3.5).
  - What changed: Config loading now uses serde_ignored to intercept ignored fields during deserialization and emits a WARN log for each unknown key.
  - What did not change (scope boundary): No change to parsing behavior, no rejection of unknown fields, no changes to Config struct or any other module.

  Why serde_ignored over alternatives

  Approach: #[serde(deny_unknown_fields)]
  Trade-off: Hard error on unknown fields — breaks backward compatibility; existing configs with harmless extra keys
    would fail to load on upgrade ──────────────────────────────────────── Approach: Dual parse (toml::Value + Config) with recursive key diff Trade-off: Must handle nested tables, array-of-tables, flattened fields; significant code, high maintenance cost, prone to false positives ──────────────────────────────────────── Approach: serde_ignored Trade-off: Intercepts ignored paths at the serde deserialization layer — one function call, zero false positives, preserves existing behavior, only adds WARN

  serde_ignored itself: single file ~200 lines, only dependency is serde (already present), zero transitive dependency
  increase. It is the standard Rust solution for this class of problem.

  Label Snapshot (required)

  - Risk label: risk: low
  - Size label: size: XS
  - Scope labels: config
  - Module labels: config: schema
  - Contributor tier label: (auto-managed)
  - If any auto-label is incorrect: N/A

  Change Metadata

  - Change type: feature
  - Primary scope: config

  Linked Issue



  Supersede Attribution (required when Supersedes # is used)

  N/A

  Validation Evidence (required)

  cargo fmt --all -- --check    # pass
  cargo clippy --all-targets -- -D warnings  # no new warnings (pre-existing unrelated warnings only)
  cargo test --lib config::     # 150 passed, 0 failed

  - Evidence provided: CLI output
  - If any command is intentionally skipped: cargo clippy has pre-existing warnings unrelated to this PR (not in changed line range)

  Security Impact (required)

  - New permissions/capabilities? No
  - New external network calls? No
  - Secrets/tokens handling changed? No
  - File system access scope changed? No

  Privacy and Data Hygiene (required)

  - Data-hygiene status: pass
  - Redaction/anonymization notes: N/A
  - Neutral wording confirmation: Yes

  Compatibility / Migration

  - Backward compatible? Yes — unknown fields are still accepted, only a WARN log is added
  - Config/env changes? No
  - Migration needed? No

  i18n Follow-Through (required when docs or user-facing wording changes)

  - i18n follow-through triggered? No — no docs or user-facing wording changes

  Human Verification (required)

  - Verified scenarios: Added a [providers.ollama] section to config.toml, confirmed log output WARN ... Unknown config
   key ignored: "providers"
  - Edge cases checked: No unknown keys produces no WARN output; multiple unknown keys each produce one line
  - What was not verified: Not yet verified in CI environment

  Side Effects / Blast Radius (required)

  - Affected subsystems/workflows: Only the Config::load_or_init() parsing path
  - Potential unintended effects: None — behavior is fully compatible, only adds log output
  - Guardrails/monitoring: WARN-level log only, does not affect startup

  Agent Collaboration Notes (recommended)

  - Agent tools used: Claude Code
  - Workflow/plan summary: plan mode -> approve -> implement
  - Verification focus: compilation, formatting, clippy, config tests
  - Confirmation: naming + architecture boundaries followed

  Rollback Plan (required)

  - Fast rollback command/path: git revert <commit>
  - Feature flags or config toggles: None — WARN logging is always enabled
  - Observable failure symptoms: If no issues before revert, none after revert

  Risks and Mitigations

  - Risk: serde_ignored and toml crate Deserializer interface incompatibility in future versions
    - Mitigation: Both are built on the stable serde Deserializer trait; serde_ignored has no unsafe code and minimal dependencies, upgrade risk is very low
