### PR TITLE
ci(release): add bot-owned Homebrew publish workflow

### DIFF
--- a/.github/workflows/main-branch-flow.md
+++ b/.github/workflows/main-branch-flow.md
@@ -16,7 +16,7 @@ Use this with:
 | PR activity (`pull_request`) | `ci-run.yml`, `sec-audit.yml`, `main-promotion-gate.yml` (for `main` PRs), plus path-scoped workflows |
 | Push to `dev`/`main` | `ci-run.yml`, `sec-audit.yml`, plus path-scoped workflows |
 | Tag push (`v*`) | `pub-release.yml` publish mode, `pub-docker-img.yml` publish job |
-| Scheduled/manual | `pub-release.yml` verification mode, `sec-codeql.yml`, `feature-matrix.yml`, `test-fuzz.yml`, `pr-check-stale.yml`, `pr-check-status.yml`, `sync-contributors.yml`, `test-benchmarks.yml`, `test-e2e.yml` |
+| Scheduled/manual | `pub-release.yml` verification mode, `pub-homebrew-core.yml` (manual), `sec-codeql.yml`, `feature-matrix.yml`, `test-fuzz.yml`, `pr-check-stale.yml`, `pr-check-status.yml`, `sync-contributors.yml`, `test-benchmarks.yml`, `test-e2e.yml` |
 
 ## Runtime and Docker Matrix
 
@@ -34,6 +34,7 @@ Observed averages below are from recent completed runs (sampled from GitHub Acti
 | `pub-docker-img.yml` (`pull_request`) | Docker build-input PR changes | 240.4s | Yes | Yes | No |
 | `pub-docker-img.yml` (`push`) | tag push `v*` | 139.9s | Yes | No | Yes |
 | `pub-release.yml` | Tag push `v*` (publish) + manual/scheduled verification (no publish) | N/A in recent sample | No | No | No |
+| `pub-homebrew-core.yml` | Manual workflow dispatch only | N/A in recent sample | No | No | No |
 
 Notes:
 
@@ -167,10 +168,17 @@ Workflow: `.github/workflows/pub-release.yml`
    - Manual dispatch -> verification-only or publish mode (input-driven).
    - Weekly schedule -> verification-only mode.
 2. `prepare` resolves release context (`release_ref`, `release_tag`, publish/draft mode) and validates manual publish inputs.
+   - publish mode enforces `release_tag` == `Cargo.toml` version at the tag commit.
 3. `build-release` builds matrix artifacts across Linux/macOS/Windows targets.
 4. `verify-artifacts` enforces presence of all expected archives before any publish attempt.
 5. In publish mode, workflow generates SBOM (`CycloneDX` + `SPDX`), `SHA256SUMS`, keyless cosign signatures, and verifies GHCR release-tag availability.
 6. In publish mode, workflow creates/updates the GitHub Release for the resolved tag and commit-ish.
+
+Manual Homebrew formula flow:
+
+1. Run `.github/workflows/pub-homebrew-core.yml` with `release_tag=vX.Y.Z`.
+2. Use `dry_run=true` first to validate formula patch and metadata.
+3. Use `dry_run=false` to push from bot fork and open `homebrew-core` PR.
 
 ## Merge/Policy Notes
 

--- a/.github/workflows/pub-homebrew-core.yml
+++ b/.github/workflows/pub-homebrew-core.yml
@@ -1,0 +1,194 @@
+name: Pub Homebrew Core
+
+on:
+    workflow_dispatch:
+        inputs:
+            release_tag:
+                description: "Existing release tag to publish (vX.Y.Z)"
+                required: true
+                type: string
+            dry_run:
+                description: "Patch formula only (no push/PR)"
+                required: false
+                default: true
+                type: boolean
+
+concurrency:
+    group: homebrew-core-${{ github.run_id }}
+    cancel-in-progress: false
+
+permissions:
+    contents: read
+
+jobs:
+    publish-homebrew-core:
+        name: Publish Homebrew Core PR
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        env:
+            UPSTREAM_REPO: Homebrew/homebrew-core
+            FORMULA_PATH: Formula/z/zeroclaw.rb
+            RELEASE_TAG: ${{ inputs.release_tag }}
+            DRY_RUN: ${{ inputs.dry_run }}
+            BOT_FORK_REPO: ${{ vars.HOMEBREW_CORE_BOT_FORK_REPO }}
+            BOT_EMAIL: ${{ vars.HOMEBREW_CORE_BOT_EMAIL }}
+        steps:
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  fetch-depth: 0
+
+            - name: Validate release tag and version alignment
+              id: release_meta
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  semver_pattern='^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'
+                  if [[ ! "$RELEASE_TAG" =~ $semver_pattern ]]; then
+                    echo "::error::release_tag must match semver-like format (vX.Y.Z[-suffix])."
+                    exit 1
+                  fi
+
+                  if ! git rev-parse "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+                    git fetch --tags origin
+                  fi
+
+                  tag_version="${RELEASE_TAG#v}"
+                  cargo_version="$(git show "${RELEASE_TAG}:Cargo.toml" | sed -n 's/^version = "\([^"]*\)"/\1/p' | head -n1)"
+                  if [[ -z "$cargo_version" ]]; then
+                    echo "::error::Unable to read Cargo.toml version from tag ${RELEASE_TAG}."
+                    exit 1
+                  fi
+                  if [[ "$cargo_version" != "$tag_version" ]]; then
+                    echo "::error::Tag ${RELEASE_TAG} does not match Cargo.toml version (${cargo_version})."
+                    echo "::error::Bump Cargo.toml first, then publish Homebrew."
+                    exit 1
+                  fi
+
+                  tarball_url="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${RELEASE_TAG}.tar.gz"
+                  tarball_sha="$(curl -fsSL "$tarball_url" | sha256sum | awk '{print $1}')"
+
+                  {
+                    echo "tag_version=$tag_version"
+                    echo "tarball_url=$tarball_url"
+                    echo "tarball_sha=$tarball_sha"
+                  } >> "$GITHUB_OUTPUT"
+
+                  {
+                    echo "### Release Metadata"
+                    echo "- release_tag: ${RELEASE_TAG}"
+                    echo "- cargo_version: ${cargo_version}"
+                    echo "- tarball_sha256: ${tarball_sha}"
+                    echo "- dry_run: ${DRY_RUN}"
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Patch Homebrew formula
+              id: patch_formula
+              shell: bash
+              env:
+                  HOMEBREW_CORE_BOT_TOKEN: ${{ secrets.HOMEBREW_CORE_BOT_TOKEN }}
+              run: |
+                  set -euo pipefail
+
+                  tmp_repo="$(mktemp -d)"
+                  echo "tmp_repo=$tmp_repo" >> "$GITHUB_OUTPUT"
+
+                  if [[ "$DRY_RUN" == "true" ]]; then
+                    git clone --depth=1 "https://github.com/${UPSTREAM_REPO}.git" "$tmp_repo/homebrew-core"
+                  else
+                    if [[ -z "${BOT_FORK_REPO}" ]]; then
+                      echo "::error::Repository variable HOMEBREW_CORE_BOT_FORK_REPO is required when dry_run=false."
+                      exit 1
+                    fi
+                    if [[ -z "${HOMEBREW_CORE_BOT_TOKEN}" ]]; then
+                      echo "::error::Repository secret HOMEBREW_CORE_BOT_TOKEN is required when dry_run=false."
+                      exit 1
+                    fi
+                    if [[ "$BOT_FORK_REPO" != */* ]]; then
+                      echo "::error::HOMEBREW_CORE_BOT_FORK_REPO must be in owner/repo format."
+                      exit 1
+                    fi
+                    git clone --depth=1 "https://x-access-token:${HOMEBREW_CORE_BOT_TOKEN}@github.com/${BOT_FORK_REPO}.git" "$tmp_repo/homebrew-core"
+                  fi
+
+                  repo_dir="$tmp_repo/homebrew-core"
+                  formula_file="$repo_dir/$FORMULA_PATH"
+                  if [[ ! -f "$formula_file" ]]; then
+                    echo "::error::Formula file not found: $FORMULA_PATH"
+                    exit 1
+                  fi
+
+                  if [[ "$DRY_RUN" == "false" ]]; then
+                    git -C "$repo_dir" remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
+                    git -C "$repo_dir" fetch --depth=1 upstream master
+                    branch_name="zeroclaw-${RELEASE_TAG}-${GITHUB_RUN_ID}"
+                    git -C "$repo_dir" checkout -B "$branch_name" upstream/master
+                    echo "branch_name=$branch_name" >> "$GITHUB_OUTPUT"
+                  fi
+
+                  tarball_url="${{ steps.release_meta.outputs.tarball_url }}"
+                  tarball_sha="${{ steps.release_meta.outputs.tarball_sha }}"
+
+                  perl -0pi -e "s|^  url \".*\"|  url \"${tarball_url}\"|m" "$formula_file"
+                  perl -0pi -e "s|^  sha256 \".*\"|  sha256 \"${tarball_sha}\"|m" "$formula_file"
+                  perl -0pi -e "s|^  license \".*\"|  license \"Apache-2.0 OR MIT\"|m" "$formula_file"
+                  perl -0pi -e 's|^  head "https://github\.com/zeroclaw-labs/zeroclaw\.git".*|  head "https://github.com/zeroclaw-labs/zeroclaw.git"|m' "$formula_file"
+
+                  git -C "$repo_dir" diff -- "$FORMULA_PATH" > "$tmp_repo/formula.diff"
+                  if [[ ! -s "$tmp_repo/formula.diff" ]]; then
+                    echo "::error::No formula changes generated. Nothing to publish."
+                    exit 1
+                  fi
+
+                  {
+                    echo "### Formula Diff"
+                    echo '```diff'
+                    cat "$tmp_repo/formula.diff"
+                    echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Push branch and open Homebrew PR
+              if: ${{ inputs.dry_run == false }}
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ secrets.HOMEBREW_CORE_BOT_TOKEN }}
+              run: |
+                  set -euo pipefail
+
+                  repo_dir="${{ steps.patch_formula.outputs.tmp_repo }}/homebrew-core"
+                  branch_name="${{ steps.patch_formula.outputs.branch_name }}"
+                  tag_version="${{ steps.release_meta.outputs.tag_version }}"
+                  fork_owner="${BOT_FORK_REPO%%/*}"
+                  bot_email="${BOT_EMAIL:-${fork_owner}@users.noreply.github.com}"
+
+                  git -C "$repo_dir" config user.name "$fork_owner"
+                  git -C "$repo_dir" config user.email "$bot_email"
+                  git -C "$repo_dir" add "$FORMULA_PATH"
+                  git -C "$repo_dir" commit -m "zeroclaw ${tag_version}"
+                  git -C "$repo_dir" push --set-upstream origin "$branch_name"
+
+                  pr_title="zeroclaw ${tag_version}"
+                  pr_body=$(cat <<EOF
+                  Automated formula bump from ZeroClaw release workflow.
+
+                  - Release tag: ${RELEASE_TAG}
+                  - Source tarball: ${{ steps.release_meta.outputs.tarball_url }}
+                  - Source sha256: ${{ steps.release_meta.outputs.tarball_sha }}
+                  EOF
+                  )
+
+                  gh pr create \
+                    --repo "$UPSTREAM_REPO" \
+                    --base master \
+                    --head "${fork_owner}:${branch_name}" \
+                    --title "$pr_title" \
+                    --body "$pr_body"
+
+            - name: Summary output
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  if [[ "$DRY_RUN" == "true" ]]; then
+                    echo "Dry run complete: formula diff generated, no push/PR performed."
+                  else
+                    echo "Publish complete: branch pushed and PR opened from bot fork."
+                  fi

--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -107,6 +107,19 @@ jobs:
                       echo "::error::Tag ${release_tag} is not reachable from origin/main. Release tags must be cut from main."
                       exit 1
                     fi
+
+                    # Guardrail: release tag and Cargo package version must stay aligned.
+                    tag_version="${release_tag#v}"
+                    cargo_version="$(git -C "$tmp_repo" show "refs/tags/${release_tag}:Cargo.toml" | sed -n 's/^version = "\([^"]*\)"/\1/p' | head -n1)"
+                    if [[ -z "$cargo_version" ]]; then
+                      echo "::error::Unable to read Cargo package version from ${release_tag}:Cargo.toml"
+                      exit 1
+                    fi
+                    if [[ "$cargo_version" != "$tag_version" ]]; then
+                      echo "::error::Tag ${release_tag} does not match Cargo.toml version (${cargo_version})."
+                      echo "::error::Bump Cargo.toml version first, then create/publish the matching tag."
+                      exit 1
+                    fi
                   fi
 
                   {

--- a/docs/ci-map.md
+++ b/docs/ci-map.md
@@ -37,6 +37,9 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
     - Noise control: excludes common test/fixture paths and test file patterns by default (`include_tests=false`)
 - `.github/workflows/pub-release.yml` (`Release`)
     - Purpose: build release artifacts in verification mode (manual/scheduled) and publish GitHub releases on tag push or manual publish mode
+- `.github/workflows/pub-homebrew-core.yml` (`Pub Homebrew Core`)
+    - Purpose: manual, bot-owned Homebrew core formula bump PR flow for tagged releases
+    - Guardrail: release tag must match `Cargo.toml` version
 - `.github/workflows/pr-label-policy-check.yml` (`Label Policy Sanity`)
     - Purpose: validate shared contributor-tier policy in `.github/label-policy.json` and ensure label workflows consume that policy
 - `.github/workflows/test-rust-build.yml` (`Rust Reusable Job`)
@@ -74,6 +77,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - `CI`: push to `dev` and `main`, PRs to `dev` and `main`
 - `Docker`: tag push (`v*`) for publish, matching PRs to `dev`/`main` for smoke build, manual dispatch for smoke only
 - `Release`: tag push (`v*`), weekly schedule (verification-only), manual dispatch (verification or publish)
+- `Pub Homebrew Core`: manual dispatch only
 - `Security Audit`: push to `dev` and `main`, PRs to `dev` and `main`, weekly schedule
 - `Sec Vorpal Reviewdog`: manual dispatch only
 - `Workflow Sanity`: PR/push when `.github/workflows/**`, `.github/*.yml`, or `.github/*.yaml` change
@@ -91,12 +95,13 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 1. `CI Required Gate` failing: start with `.github/workflows/ci-run.yml`.
 2. Docker failures on PRs: inspect `.github/workflows/pub-docker-img.yml` `pr-smoke` job.
 3. Release failures (tag/manual/scheduled): inspect `.github/workflows/pub-release.yml` and the `prepare` job outputs.
-4. Security failures: inspect `.github/workflows/sec-audit.yml` and `deny.toml`.
-5. Workflow syntax/lint failures: inspect `.github/workflows/workflow-sanity.yml`.
-6. PR intake failures: inspect `.github/workflows/pr-intake-checks.yml` sticky comment and run logs.
-7. Label policy parity failures: inspect `.github/workflows/pr-label-policy-check.yml`.
-8. Docs failures in CI: inspect `docs-quality` job logs in `.github/workflows/ci-run.yml`.
-9. Strict delta lint failures in CI: inspect `lint-strict-delta` job logs and compare with `BASE_SHA` diff scope.
+4. Homebrew formula publish failures: inspect `.github/workflows/pub-homebrew-core.yml` summary output and bot token/fork variables.
+5. Security failures: inspect `.github/workflows/sec-audit.yml` and `deny.toml`.
+6. Workflow syntax/lint failures: inspect `.github/workflows/workflow-sanity.yml`.
+7. PR intake failures: inspect `.github/workflows/pr-intake-checks.yml` sticky comment and run logs.
+8. Label policy parity failures: inspect `.github/workflows/pr-label-policy-check.yml`.
+9. Docs failures in CI: inspect `docs-quality` job logs in `.github/workflows/ci-run.yml`.
+10. Strict delta lint failures in CI: inspect `lint-strict-delta` job logs and compare with `BASE_SHA` diff scope.
 
 ## Maintenance Rules
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -22,6 +22,7 @@ Last verified: **February 21, 2026**.
 Release automation lives in:
 
 - `.github/workflows/pub-release.yml`
+- `.github/workflows/pub-homebrew-core.yml` (manual Homebrew formula PR, bot-owned)
 
 Modes:
 
@@ -93,6 +94,26 @@ Expected publish outputs:
 1. Verify GitHub Release assets are downloadable.
 2. Verify GHCR tags for the released version (`vX.Y.Z`) and release commit SHA tag (`sha-<12>`).
 3. Verify install paths that rely on release assets (for example bootstrap binary download).
+
+### 6) Publish Homebrew Core formula (bot-owned)
+
+Run `Pub Homebrew Core` manually:
+
+- `release_tag`: `vX.Y.Z`
+- `dry_run`: `true` first, then `false`
+
+Required repository settings for non-dry-run:
+
+- secret: `HOMEBREW_CORE_BOT_TOKEN` (token from a dedicated bot account, not a personal maintainer account)
+- variable: `HOMEBREW_CORE_BOT_FORK_REPO` (for example `zeroclaw-release-bot/homebrew-core`)
+- optional variable: `HOMEBREW_CORE_BOT_EMAIL`
+
+Workflow guardrails:
+
+- release tag must match `Cargo.toml` version
+- formula source URL and SHA256 are updated from the tagged tarball
+- formula license is normalized to `Apache-2.0 OR MIT`
+- PR is opened from the bot fork into `Homebrew/homebrew-core:master`
 
 ## Emergency / Recovery Path
 


### PR DESCRIPTION
## Summary
- add manual Pub Homebrew Core workflow for bot-owned formula bumps
- enforce release tag to Cargo version alignment in Pub Release
- update release/CI flow docs for the Homebrew publish path

## Why
- remove personal-account dependency for Homebrew publication
- prevent tag/version drift from breaking Homebrew and release consistency

## Risk
- workflow-only and docs-only changes; no runtime behavior changes