### PR TITLE
ci(homebrew): fix bot fork auth clone path

### DIFF
--- a/.github/workflows/pub-homebrew-core.yml
+++ b/.github/workflows/pub-homebrew-core.yml
@@ -94,23 +94,23 @@ jobs:
 
                   if [[ "$DRY_RUN" == "true" ]]; then
                     git clone --depth=1 "https://github.com/${UPSTREAM_REPO}.git" "$tmp_repo/homebrew-core"
-                else
-                  if [[ -z "${BOT_FORK_REPO}" ]]; then
-                    echo "::error::Repository variable HOMEBREW_CORE_BOT_FORK_REPO is required when dry_run=false."
-                    exit 1
-                  fi
+                  else
+                    if [[ -z "${BOT_FORK_REPO}" ]]; then
+                      echo "::error::Repository variable HOMEBREW_CORE_BOT_FORK_REPO is required when dry_run=false."
+                      exit 1
+                    fi
                     if [[ -z "${HOMEBREW_CORE_BOT_TOKEN}" ]]; then
                       echo "::error::Repository secret HOMEBREW_CORE_BOT_TOKEN is required when dry_run=false."
                       exit 1
                     fi
-                  if [[ "$BOT_FORK_REPO" != */* ]]; then
-                    echo "::error::HOMEBREW_CORE_BOT_FORK_REPO must be in owner/repo format."
-                    exit 1
+                    if [[ "$BOT_FORK_REPO" != */* ]]; then
+                      echo "::error::HOMEBREW_CORE_BOT_FORK_REPO must be in owner/repo format."
+                      exit 1
+                    fi
+                    auth_header="$(printf 'x-access-token:%s' "${HOMEBREW_CORE_BOT_TOKEN}" | base64 | tr -d '\n')"
+                    git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+                      clone --depth=1 "https://github.com/${BOT_FORK_REPO}.git" "$tmp_repo/homebrew-core"
                   fi
-                  auth_header="$(printf 'x-access-token:%s' "${HOMEBREW_CORE_BOT_TOKEN}" | base64 | tr -d '\n')"
-                  git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
-                    clone --depth=1 "https://github.com/${BOT_FORK_REPO}.git" "$tmp_repo/homebrew-core"
-                fi
 
                   repo_dir="$tmp_repo/homebrew-core"
                   formula_file="$repo_dir/$FORMULA_PATH"


### PR DESCRIPTION
## Summary
- switch non-dry-run clone auth from URL-embedded token to GitHub `extraheader` auth
- validate `HOMEBREW_CORE_BOT_FORK_REPO` format before clone
- fix shell block indentation in `Patch Homebrew formula` so workflow YAML parses reliably

## Why
`Pub Homebrew Core` failed with `URL rejected: Bad hostname` when token characters were interpreted in the clone URL.

## Validation
- `actionlint .github/workflows/pub-homebrew-core.yml`
- workflow_dispatch dry-run on branch succeeded: https://github.com/zeroclaw-labs/zeroclaw/actions/runs/22269032683

## Risk
Low, scoped to `.github/workflows/pub-homebrew-core.yml`.

## Rollback
Revert this PR commit pair.
