### PR TITLE
chore(release): bump version to v0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7989,7 +7989,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclaw"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- bump crate version from `0.1.5` to `0.1.6` in `Cargo.toml`
- align lockfile package entry for `zeroclaw` to `0.1.6`

## Why
Prepare the repository for a clean `v0.1.6` tag/release after recent CI/Homebrew workflow fixes.

## Risk
Low. Metadata-only release version bump.

## Rollback
Revert this PR.
