### PR TITLE
feat(heartbeat): add channel delivery for heartbeat reports

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2641,12 +2641,12 @@ fn classify_health_result(
     }
 }
 
-struct ConfiguredChannel {
-    display_name: &'static str,
-    channel: Arc<dyn Channel>,
+pub(crate) struct ConfiguredChannel {
+    pub(crate) display_name: &'static str,
+    pub(crate) channel: Arc<dyn Channel>,
 }
 
-fn collect_configured_channels(
+pub(crate) fn collect_configured_channels(
     config: &Config,
     _matrix_skip_context: &str,
 ) -> Vec<ConfiguredChannel> {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2286,6 +2286,13 @@ pub struct HeartbeatConfig {
     pub enabled: bool,
     /// Interval in minutes between heartbeat pings. Default: `30`.
     pub interval_minutes: u32,
+    /// Channel to deliver heartbeat results to (e.g. `"lark"`, `"telegram"`, `"discord"`).
+    /// When set together with `target`, heartbeat output is sent to this channel after each run.
+    #[serde(default)]
+    pub channel: Option<String>,
+    /// Recipient / chat ID for heartbeat delivery (channel-specific).
+    #[serde(default)]
+    pub target: Option<String>,
 }
 
 impl Default for HeartbeatConfig {
@@ -2293,6 +2300,8 @@ impl Default for HeartbeatConfig {
         Self {
             enabled: false,
             interval_minutes: 30,
+            channel: None,
+            target: None,
         }
     }
 }
@@ -4639,6 +4648,7 @@ default_temperature = 0.7
             heartbeat: HeartbeatConfig {
                 enabled: true,
                 interval_minutes: 15,
+                ..Default::default()
             },
             cron: CronConfig::default(),
             channels_config: ChannelsConfig {

--- a/src/heartbeat/engine.rs
+++ b/src/heartbeat/engine.rs
@@ -248,6 +248,7 @@ mod tests {
             HeartbeatConfig {
                 enabled: true,
                 interval_minutes: 30,
+                ..Default::default()
             },
             dir.clone(),
             observer,
@@ -273,6 +274,7 @@ mod tests {
             HeartbeatConfig {
                 enabled: true,
                 interval_minutes: 30,
+                ..Default::default()
             },
             dir.clone(),
             observer,
@@ -290,6 +292,7 @@ mod tests {
             HeartbeatConfig {
                 enabled: false,
                 interval_minutes: 30,
+                ..Default::default()
             },
             std::env::temp_dir(),
             observer,


### PR DESCRIPTION
## Summary

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): `main`
- Problem: Heartbeat tasks execute silently — operators have no way to receive periodic status reports through their configured messaging channels.
- Why it matters: For autonomous agents running as daemons, heartbeat visibility is critical for operational awareness without manually checking logs.
- What changed: Added two optional config fields (`channel`, `target`) to `HeartbeatConfig`; after each heartbeat tick the worker now collects task results and delivers a summary report to the specified channel.
- What did **not** change (scope boundary): Heartbeat task collection, parsing, scheduling logic, and the agent execution path are untouched. No new dependencies added.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels: `heartbeat`, `daemon`, `config`, `channel`
- Module labels: `heartbeat: delivery`, `daemon: heartbeat-worker`
- Contributor tier label: N/A (first upstream PR)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi` (heartbeat + daemon + config + channel)

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A — not superseding any PR.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check    # ✅ pass
cargo clippy --bin zeroclaw --features channel-lark -- -D warnings  # ✅ no new warnings (pre-existing warnings in unrelated files)
cargo test --features channel-lark -- daemon heartbeat  # ✅ 32/32 passed
```

- Evidence provided: compilation check, fmt, clippy, focused test run
- If any command is intentionally skipped, explain why: Full `cargo clippy --all-targets` has 48 pre-existing errors in `onboard/wizard.rs` and other unrelated files; binary target clippy is clean for our changes.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (reuses existing channel `send()` path)
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No user data in code; heartbeat report contains only task names (already user-authored in HEARTBEAT.md) and status.
- Neutral wording confirmation: Yes — all identifiers use project-native labels.

## Compatibility / Migration

- Backward compatible? Yes — new fields use `#[serde(default)]` with `Option<String>` defaulting to `None`; existing configs work unchanged.
- Config/env changes? Yes — two new optional fields: `[heartbeat].channel` and `[heartbeat].target`.
- Migration needed? No — delivery is opt-in; omitting both fields preserves current behavior exactly.

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No — no docs or user-facing wording changes in this PR.

## Human Verification (required)

- Verified scenarios: Compilation, test suite, config backward compatibility (default values).
- Edge cases checked: Missing `channel` or `target` (delivery disabled gracefully), unknown channel name (logged warning, delivery skipped), case-insensitive channel name matching.
- What was not verified: End-to-end delivery to a live Lark/Telegram channel (requires running daemon with real credentials).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `daemon/mod.rs` heartbeat worker loop, `channels/mod.rs` visibility (`pub(crate)` for `collect_configured_channels`).
- Potential unintended effects: `collect_configured_channels` is now `pub(crate)` — other crate-internal code could call it, but this is intentional and safe.
- Guardrails/monitoring for early detection: Delivery failures are logged at `warn` level; heartbeat health status continues to reflect task execution outcome independent of delivery.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (Opus 4.6)
- Workflow/plan summary: Read existing heartbeat + daemon + channel code → add config fields → wire delivery in heartbeat worker → validate
- Verification focus: Compilation, test pass, backward compatibility, no security surface changes
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>` — single commit, clean revert.
- Feature flags or config toggles: Delivery is opt-in via `channel` + `target` config fields; removing them from config.toml disables delivery instantly.
- Observable failure symptoms: If delivery channel misconfigured, `warn` log: "Heartbeat delivery channel '...' not found"; if send fails, `warn` log: "Heartbeat delivery to channel failed".

## Risks and Mitigations

- Risk: `collect_configured_channels` instantiates all configured channels to find the heartbeat one — slight overhead at worker startup.
  - Mitigation: Called once at worker init, not per tick. Overhead is negligible compared to heartbeat interval (minutes).