### PR TITLE
feat(config): add model_support_vision override for per-model vision …

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -25,6 +25,14 @@ Schema export command:
 | `default_provider` | `openrouter` | provider ID or alias |
 | `default_model` | `anthropic/claude-sonnet-4-6` | model routed through selected provider |
 | `default_temperature` | `0.7` | model temperature |
+| `model_support_vision` | unset (`None`) | Vision support override for active provider/model |
+
+Notes:
+
+- `model_support_vision = true` forces vision support on (e.g. Ollama running `llava`).
+- `model_support_vision = false` forces vision support off.
+- Unset keeps the provider's built-in default.
+- Environment override: `ZEROCLAW_MODEL_SUPPORT_VISION` or `MODEL_SUPPORT_VISION` (values: `true`/`false`/`1`/`0`/`yes`/`no`/`on`/`off`).
 
 ## `[observability]`
 

--- a/docs/i18n/vi/config-reference.md
+++ b/docs/i18n/vi/config-reference.md
@@ -25,6 +25,14 @@ Lệnh xuất schema:
 | `default_provider` | `openrouter` | ID hoặc bí danh provider |
 | `default_model` | `anthropic/claude-sonnet-4-6` | Model định tuyến qua provider đã chọn |
 | `default_temperature` | `0.7` | Nhiệt độ model |
+| `model_support_vision` | chưa đặt (`None`) | Ghi đè hỗ trợ vision cho provider/model đang dùng |
+
+Lưu ý:
+
+- `model_support_vision = true` bật vision (ví dụ Ollama chạy `llava`).
+- `model_support_vision = false` tắt vision.
+- Để trống giữ mặc định của provider.
+- Biến môi trường: `ZEROCLAW_MODEL_SUPPORT_VISION` hoặc `MODEL_SUPPORT_VISION` (giá trị: `true`/`false`/`1`/`0`/`yes`/`no`/`on`/`off`).
 
 ## `[observability]`
 

--- a/docs/i18n/vi/providers-reference.md
+++ b/docs/i18n/vi/providers-reference.md
@@ -94,6 +94,25 @@ Hành vi:
 - `true`: gửi `think: true`.
 - Không đặt: bỏ qua `think` và giữ nguyên mặc định của Ollama/model.
 
+### Ghi đè Vision cho Ollama
+
+Một số model Ollama hỗ trợ vision (ví dụ `llava`, `llama3.2-vision`) trong khi các model khác thì không.
+Vì ZeroClaw không thể tự động phát hiện, bạn có thể ghi đè trong `config.toml`:
+
+```toml
+default_provider = "ollama"
+default_model = "llava"
+model_support_vision = true
+```
+
+Hành vi:
+
+- `true`: bật xử lý hình ảnh đính kèm trong vòng lặp agent.
+- `false`: tắt vision ngay cả khi provider báo hỗ trợ.
+- Không đặt: dùng mặc định của provider.
+
+Biến môi trường: `ZEROCLAW_MODEL_SUPPORT_VISION=true`
+
 ### Ghi chú về Kimi Code
 
 - Provider ID: `kimi-code`

--- a/docs/providers-reference.md
+++ b/docs/providers-reference.md
@@ -151,6 +151,25 @@ Behavior:
 - `true`: sends `think: true`.
 - Unset: omits `think` and keeps Ollama/model defaults.
 
+### Ollama Vision Override
+
+Some Ollama models support vision (e.g. `llava`, `llama3.2-vision`) while others do not.
+Since ZeroClaw cannot auto-detect this, you can override it in `config.toml`:
+
+```toml
+default_provider = "ollama"
+default_model = "llava"
+model_support_vision = true
+```
+
+Behavior:
+
+- `true`: enables image attachment processing in the agent loop.
+- `false`: disables vision even if the provider reports support.
+- Unset: uses the provider's built-in default.
+
+Environment override: `ZEROCLAW_MODEL_SUPPORT_VISION=true`
+
 ### Kimi Code Notes
 
 - Provider ID: `kimi-code`

--- a/docs/vi/config-reference.md
+++ b/docs/vi/config-reference.md
@@ -25,6 +25,14 @@ Lệnh xuất schema:
 | `default_provider` | `openrouter` | ID hoặc bí danh provider |
 | `default_model` | `anthropic/claude-sonnet-4-6` | Model định tuyến qua provider đã chọn |
 | `default_temperature` | `0.7` | Nhiệt độ model |
+| `model_support_vision` | chưa đặt (`None`) | Ghi đè hỗ trợ vision cho provider/model đang dùng |
+
+Lưu ý:
+
+- `model_support_vision = true` bật vision (ví dụ Ollama chạy `llava`).
+- `model_support_vision = false` tắt vision.
+- Để trống giữ mặc định của provider.
+- Biến môi trường: `ZEROCLAW_MODEL_SUPPORT_VISION` hoặc `MODEL_SUPPORT_VISION` (giá trị: `true`/`false`/`1`/`0`/`yes`/`no`/`on`/`off`).
 
 ## `[observability]`
 

--- a/docs/vi/providers-reference.md
+++ b/docs/vi/providers-reference.md
@@ -94,6 +94,25 @@ Hành vi:
 - `true`: gửi `think: true`.
 - Không đặt: bỏ qua `think` và giữ nguyên mặc định của Ollama/model.
 
+### Ghi đè Vision cho Ollama
+
+Một số model Ollama hỗ trợ vision (ví dụ `llava`, `llama3.2-vision`) trong khi các model khác thì không.
+Vì ZeroClaw không thể tự động phát hiện, bạn có thể ghi đè trong `config.toml`:
+
+```toml
+default_provider = "ollama"
+default_model = "llava"
+model_support_vision = true
+```
+
+Hành vi:
+
+- `true`: bật xử lý hình ảnh đính kèm trong vòng lặp agent.
+- `false`: tắt vision ngay cả khi provider báo hỗ trợ.
+- Không đặt: dùng mặc định của provider.
+
+Biến môi trường: `ZEROCLAW_MODEL_SUPPORT_VISION=true`
+
 ### Ghi chú về Kimi Code
 
 - Provider ID: `kimi-code`

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2706,6 +2706,7 @@ pub async fn run(
         zeroclaw_dir: config.config_path.parent().map(std::path::PathBuf::from),
         secrets_encrypt: config.secrets.encrypt,
         reasoning_enabled: config.runtime.reasoning_enabled,
+        model_support_vision: config.model_support_vision,
     };
 
     let provider: Box<dyn Provider> = providers::create_routed_provider_with_options(
@@ -3160,6 +3161,7 @@ pub async fn process_message(config: Config, message: &str) -> Result<String> {
         zeroclaw_dir: config.config_path.parent().map(std::path::PathBuf::from),
         secrets_encrypt: config.secrets.encrypt,
         reasoning_enabled: config.runtime.reasoning_enabled,
+        model_support_vision: config.model_support_vision,
     };
     let provider: Box<dyn Provider> = providers::create_routed_provider_with_options(
         provider_name,

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2963,6 +2963,7 @@ pub async fn start_channels(config: Config) -> Result<()> {
         zeroclaw_dir: config.config_path.parent().map(std::path::PathBuf::from),
         secrets_encrypt: config.secrets.encrypt,
         reasoning_enabled: config.runtime.reasoning_enabled,
+        model_support_vision: config.model_support_vision,
     };
     let provider: Arc<dyn Provider> = Arc::from(
         create_resilient_provider_nonblocking(

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -206,6 +206,13 @@ pub struct Config {
     /// Voice transcription configuration (Whisper API via Groq).
     #[serde(default)]
     pub transcription: TranscriptionConfig,
+
+    /// Vision support override for the active provider/model.
+    /// - `None` (default): use provider's built-in default
+    /// - `Some(true)`: force vision support on (e.g. Ollama running llava)
+    /// - `Some(false)`: force vision support off
+    #[serde(default)]
+    pub model_support_vision: Option<bool>,
 }
 
 // ── Delegate Agents ──────────────────────────────────────────────
@@ -3419,6 +3426,7 @@ impl Default for Config {
             hardware: HardwareConfig::default(),
             query_classification: QueryClassificationConfig::default(),
             transcription: TranscriptionConfig::default(),
+            model_support_vision: None,
         }
     }
 }
@@ -4126,6 +4134,18 @@ impl Config {
             }
         }
 
+        // Vision support override: ZEROCLAW_MODEL_SUPPORT_VISION or MODEL_SUPPORT_VISION
+        if let Ok(flag) = std::env::var("ZEROCLAW_MODEL_SUPPORT_VISION")
+            .or_else(|_| std::env::var("MODEL_SUPPORT_VISION"))
+        {
+            let normalized = flag.trim().to_ascii_lowercase();
+            match normalized.as_str() {
+                "1" | "true" | "yes" | "on" => self.model_support_vision = Some(true),
+                "0" | "false" | "no" | "off" => self.model_support_vision = Some(false),
+                _ => {}
+            }
+        }
+
         // Web search enabled: ZEROCLAW_WEB_SEARCH_ENABLED or WEB_SEARCH_ENABLED
         if let Ok(enabled) = std::env::var("ZEROCLAW_WEB_SEARCH_ENABLED")
             .or_else(|_| std::env::var("WEB_SEARCH_ENABLED"))
@@ -4689,6 +4709,7 @@ default_temperature = 0.7
             hooks: HooksConfig::default(),
             hardware: HardwareConfig::default(),
             transcription: TranscriptionConfig::default(),
+            model_support_vision: None,
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -4772,6 +4793,24 @@ reasoning_enabled = false
 
         let parsed: Config = toml::from_str(raw).unwrap();
         assert_eq!(parsed.runtime.reasoning_enabled, Some(false));
+    }
+
+    #[test]
+    async fn model_support_vision_deserializes() {
+        let raw = r#"
+default_temperature = 0.7
+model_support_vision = true
+"#;
+
+        let parsed: Config = toml::from_str(raw).unwrap();
+        assert_eq!(parsed.model_support_vision, Some(true));
+
+        // Default (omitted) should be None
+        let raw_no_vision = r#"
+default_temperature = 0.7
+"#;
+        let parsed2: Config = toml::from_str(raw_no_vision).unwrap();
+        assert_eq!(parsed2.model_support_vision, None);
     }
 
     #[test]
@@ -4863,6 +4902,7 @@ tool_dispatcher = "xml"
             hooks: HooksConfig::default(),
             hardware: HardwareConfig::default(),
             transcription: TranscriptionConfig::default(),
+            model_support_vision: None,
         };
 
         config.save().await.unwrap();
@@ -6444,6 +6484,28 @@ default_model = "legacy-model"
         assert_eq!(config.runtime.reasoning_enabled, Some(false));
 
         std::env::remove_var("ZEROCLAW_REASONING_ENABLED");
+    }
+
+    #[test]
+    async fn env_override_model_support_vision() {
+        let _env_guard = env_override_lock().await;
+        let mut config = Config::default();
+        assert_eq!(config.model_support_vision, None);
+
+        std::env::set_var("ZEROCLAW_MODEL_SUPPORT_VISION", "true");
+        config.apply_env_overrides();
+        assert_eq!(config.model_support_vision, Some(true));
+
+        std::env::set_var("ZEROCLAW_MODEL_SUPPORT_VISION", "false");
+        config.apply_env_overrides();
+        assert_eq!(config.model_support_vision, Some(false));
+
+        std::env::set_var("ZEROCLAW_MODEL_SUPPORT_VISION", "maybe");
+        config.model_support_vision = Some(true);
+        config.apply_env_overrides();
+        assert_eq!(config.model_support_vision, Some(true));
+
+        std::env::remove_var("ZEROCLAW_MODEL_SUPPORT_VISION");
     }
 
     #[test]

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -341,6 +341,7 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
             zeroclaw_dir: config.config_path.parent().map(std::path::PathBuf::from),
             secrets_encrypt: config.secrets.encrypt,
             reasoning_enabled: config.runtime.reasoning_enabled,
+            model_support_vision: config.model_support_vision,
         },
     )?);
     let model = config

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -167,6 +167,7 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
         hardware: hardware_config,
         query_classification: crate::config::QueryClassificationConfig::default(),
         transcription: crate::config::TranscriptionConfig::default(),
+        model_support_vision: None,
     };
 
     println!(
@@ -515,6 +516,7 @@ async fn run_quick_setup_with_home(
         hardware: crate::config::HardwareConfig::default(),
         query_classification: crate::config::QueryClassificationConfig::default(),
         transcription: crate::config::TranscriptionConfig::default(),
+        model_support_vision: None,
     };
 
     config.save().await?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -675,6 +675,7 @@ pub struct ProviderRuntimeOptions {
     pub zeroclaw_dir: Option<PathBuf>,
     pub secrets_encrypt: bool,
     pub reasoning_enabled: Option<bool>,
+    pub model_support_vision: Option<bool>,
 }
 
 impl Default for ProviderRuntimeOptions {
@@ -684,6 +685,7 @@ impl Default for ProviderRuntimeOptions {
             zeroclaw_dir: None,
             secrets_encrypt: true,
             reasoning_enabled: None,
+            model_support_vision: None,
         }
     }
 }
@@ -1320,7 +1322,8 @@ pub fn create_resilient_provider_with_options(
         reliability.provider_backoff_ms,
     )
     .with_api_keys(reliability.api_keys.clone())
-    .with_model_fallbacks(reliability.model_fallbacks.clone());
+    .with_model_fallbacks(reliability.model_fallbacks.clone())
+    .with_vision_override(options.model_support_vision);
 
     Ok(Box::new(reliable))
 }
@@ -1418,11 +1421,10 @@ pub fn create_routed_provider_with_options(
         })
         .collect();
 
-    Ok(Box::new(router::RouterProvider::new(
-        providers,
-        routes,
-        default_model.to_string(),
-    )))
+    Ok(Box::new(
+        router::RouterProvider::new(providers, routes, default_model.to_string())
+            .with_vision_override(options.model_support_vision),
+    ))
 }
 
 /// Information about a supported provider for display purposes.

--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -231,6 +231,8 @@ pub struct ReliableProvider {
     key_index: AtomicUsize,
     /// Per-model fallback chains: model_name → [fallback_model_1, fallback_model_2, ...]
     model_fallbacks: HashMap<String, Vec<String>>,
+    /// Vision support override from config (`None` = defer to provider).
+    vision_override: Option<bool>,
 }
 
 impl ReliableProvider {
@@ -246,6 +248,7 @@ impl ReliableProvider {
             api_keys: Vec::new(),
             key_index: AtomicUsize::new(0),
             model_fallbacks: HashMap::new(),
+            vision_override: None,
         }
     }
 
@@ -258,6 +261,12 @@ impl ReliableProvider {
     /// Set per-model fallback chains.
     pub fn with_model_fallbacks(mut self, fallbacks: HashMap<String, Vec<String>>) -> Self {
         self.model_fallbacks = fallbacks;
+        self
+    }
+
+    /// Set vision support override from runtime config.
+    pub fn with_vision_override(mut self, vision_override: Option<bool>) -> Self {
+        self.vision_override = vision_override;
         self
     }
 
@@ -545,9 +554,11 @@ impl Provider for ReliableProvider {
     }
 
     fn supports_vision(&self) -> bool {
-        self.providers
-            .iter()
-            .any(|(_, provider)| provider.supports_vision())
+        self.vision_override.unwrap_or_else(|| {
+            self.providers
+                .iter()
+                .any(|(_, provider)| provider.supports_vision())
+        })
     }
 
     async fn chat_with_tools(
@@ -1977,5 +1988,69 @@ mod tests {
         // Primary should have been called only once (no retries)
         assert_eq!(primary_calls.load(Ordering::SeqCst), 1);
         assert_eq!(fallback_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn vision_override_forces_true() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let provider = ReliableProvider::new(
+            vec![(
+                "primary".into(),
+                Box::new(MockProvider {
+                    calls: Arc::clone(&calls),
+                    fail_until_attempt: 0,
+                    response: "ok",
+                    error: "",
+                }) as Box<dyn Provider>,
+            )],
+            1,
+            100,
+        )
+        .with_vision_override(Some(true));
+
+        // MockProvider default capabilities → vision: false
+        // Override should force true
+        assert!(provider.supports_vision());
+    }
+
+    #[test]
+    fn vision_override_forces_false() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let provider = ReliableProvider::new(
+            vec![(
+                "primary".into(),
+                Box::new(MockProvider {
+                    calls: Arc::clone(&calls),
+                    fail_until_attempt: 0,
+                    response: "ok",
+                    error: "",
+                }) as Box<dyn Provider>,
+            )],
+            1,
+            100,
+        )
+        .with_vision_override(Some(false));
+
+        assert!(!provider.supports_vision());
+    }
+
+    #[test]
+    fn vision_override_none_defers_to_provider() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let provider = ReliableProvider::new(
+            vec![(
+                "primary".into(),
+                Box::new(MockProvider {
+                    calls: Arc::clone(&calls),
+                    fail_until_attempt: 0,
+                    response: "ok",
+                    error: "",
+                }) as Box<dyn Provider>,
+            )],
+            1,
+            100,
+        );
+        // No override set → should defer to provider default (false)
+        assert!(!provider.supports_vision());
     }
 }

--- a/src/providers/router.rs
+++ b/src/providers/router.rs
@@ -23,6 +23,8 @@ pub struct RouterProvider {
     providers: Vec<(String, Box<dyn Provider>)>,
     default_index: usize,
     default_model: String,
+    /// Vision support override from config (`None` = defer to providers).
+    vision_override: Option<bool>,
 }
 
 impl RouterProvider {
@@ -66,7 +68,14 @@ impl RouterProvider {
             providers,
             default_index: 0,
             default_model,
+            vision_override: None,
         }
+    }
+
+    /// Set vision support override from runtime config.
+    pub fn with_vision_override(mut self, vision_override: Option<bool>) -> Self {
+        self.vision_override = vision_override;
+        self
     }
 
     /// Resolve a model parameter to a (provider, actual_model) pair.
@@ -159,9 +168,11 @@ impl Provider for RouterProvider {
     }
 
     fn supports_vision(&self) -> bool {
-        self.providers
-            .iter()
-            .any(|(_, provider)| provider.supports_vision())
+        self.vision_override.unwrap_or_else(|| {
+            self.providers
+                .iter()
+                .any(|(_, provider)| provider.supports_vision())
+        })
     }
 
     async fn warmup(&self) -> anyhow::Result<()> {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -316,6 +316,7 @@ pub fn all_tools_with_runtime(
                     .map(std::path::PathBuf::from),
                 secrets_encrypt: root_config.secrets.encrypt,
                 reasoning_enabled: root_config.runtime.reasoning_enabled,
+                model_support_vision: root_config.model_support_vision,
             },
         )
         .with_parent_tools(parent_tools)


### PR DESCRIPTION
Closes #1265

  `supports_vision` is currently hardcoded per-provider. The same Ollama instance can run `llava` (vision) or
  `codellama` (no vision), but the code fixes vision support at the provider level with no user override.

  This adds a top-level `model_support_vision: Option<bool>` config key — tri-state:
  - **Unset (default):** provider's built-in value, zero behavior change
  - **`true`:** force vision on (e.g. Ollama + llava)
  - **`false`:** force vision off

  Follows the exact same pattern as `reasoning_enabled`. Override is applied at the wrapper layer (`ReliableProvider` /
   `RouterProvider`) — no concrete provider code is touched.

  ## Changes

  **Config surface:**
  - Top-level `model_support_vision` field in `Config` struct with `#[serde(default)]`
  - Env override: `ZEROCLAW_MODEL_SUPPORT_VISION` / `MODEL_SUPPORT_VISION`

  **Provider wrappers (core logic):**
  - `ReliableProvider`: `vision_override` field + `with_vision_override()` builder + `supports_vision()` override
  - `RouterProvider`: same pattern

  **Wiring (1-line each):**
  - `ProviderRuntimeOptions` struct + factory functions
  - 5 construction sites: `loop_.rs`, `channels/mod.rs`, `gateway/mod.rs`, `tools/mod.rs`, `onboard/wizard.rs`

  **Docs (i18n parity):**
  - `config-reference.md` — Core Keys table
  - `providers-reference.md` — new "Ollama Vision Override" section
  - Vietnamese sync: `docs/i18n/vi/` + `docs/vi/` (4 files)

  ## Non-goals

  - Does not change any concrete provider implementation
  - Does not auto-detect model vision capability

  ## Test plan

  - [x] `cargo fmt --all -- --check`
  - [x] `cargo clippy --all-targets -- -D warnings` (no new errors)
  - [x] 5 new tests passing:
    - `model_support_vision_deserializes` — TOML parse + default None
    - `env_override_model_support_vision` — env var override + invalid value ignored
    - `vision_override_forces_true` — ReliableProvider override
    - `vision_override_forces_false` — ReliableProvider override
    - `vision_override_none_defers_to_provider` — passthrough behavior

  ## Risk and Rollback

  - **Risk:** Low. `None` default = zero behavior change for existing users.
  - **Rollback:** Revert commit. Field is `#[serde(default)]` so old configs without it will deserialize fine.