### PR TITLE
fix(provider): preserve reasoning_content in tool-call conversation history

### DIFF
--- a/benches/agent_benchmarks.rs
+++ b/benches/agent_benchmarks.rs
@@ -39,6 +39,7 @@ impl BenchProvider {
                 text: Some(text.into()),
                 tool_calls: vec![],
                 usage: None,
+                reasoning_content: None,
             }]),
         }
     }
@@ -54,11 +55,13 @@ impl BenchProvider {
                         arguments: "{}".into(),
                     }],
                     usage: None,
+                    reasoning_content: None,
                 },
                 ChatResponse {
                     text: Some("done".into()),
                     tool_calls: vec![],
                     usage: None,
+                    reasoning_content: None,
                 },
             ]),
         }
@@ -89,6 +92,7 @@ impl Provider for BenchProvider {
                 text: Some("done".into()),
                 tool_calls: vec![],
                 usage: None,
+                reasoning_content: None,
             });
         }
         Ok(guard.remove(0))
@@ -155,6 +159,7 @@ Let me know if you need more."#
         ),
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     };
 
     let multi_tool = ChatResponse {
@@ -172,6 +177,7 @@ Let me know if you need more."#
         ),
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     };
 
     c.bench_function("xml_parse_single_tool_call", |b| {
@@ -205,6 +211,7 @@ fn bench_native_parsing(c: &mut Criterion) {
             },
         ],
         usage: None,
+        reasoning_content: None,
     };
 
     c.bench_function("native_parse_tool_calls", |b| {

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -518,6 +518,7 @@ impl Agent {
             self.history.push(ConversationMessage::AssistantToolCalls {
                 text: response.text.clone(),
                 tool_calls: response.tool_calls.clone(),
+                reasoning_content: response.reasoning_content.clone(),
             });
 
             let results = self.execute_tools(&calls).await;
@@ -651,6 +652,7 @@ mod tests {
                     text: Some("done".into()),
                     tool_calls: vec![],
                     usage: None,
+                    reasoning_content: None,
                 });
             }
             Ok(guard.remove(0))
@@ -689,6 +691,7 @@ mod tests {
                 text: Some("hello".into()),
                 tool_calls: vec![],
                 usage: None,
+                reasoning_content: None,
             }]),
         });
 
@@ -728,11 +731,13 @@ mod tests {
                         arguments: "{}".into(),
                     }],
                     usage: None,
+                    reasoning_content: None,
                 },
                 crate::providers::ChatResponse {
                     text: Some("done".into()),
                     tool_calls: vec![],
                     usage: None,
+                    reasoning_content: None,
                 },
             ]),
         });

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -94,6 +94,7 @@ impl Provider for ScriptedProvider {
                 text: Some("done".into()),
                 tool_calls: vec![],
                 usage: None,
+                reasoning_content: None,
             });
         }
         Ok(guard.remove(0))
@@ -330,6 +331,7 @@ fn tool_response(calls: Vec<ToolCall>) -> ChatResponse {
         text: Some(String::new()),
         tool_calls: calls,
         usage: None,
+        reasoning_content: None,
     }
 }
 
@@ -339,6 +341,7 @@ fn text_response(text: &str) -> ChatResponse {
         text: Some(text.into()),
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     }
 }
 
@@ -350,6 +353,7 @@ fn xml_tool_response(name: &str, args: &str) -> ChatResponse {
         )),
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     }
 }
 
@@ -739,6 +743,7 @@ async fn turn_handles_empty_text_response() {
         text: Some(String::new()),
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     }]));
 
     let mut agent = build_agent_with(provider, vec![], Box::new(NativeToolDispatcher));
@@ -753,6 +758,7 @@ async fn turn_handles_none_text_response() {
         text: None,
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     }]));
 
     let mut agent = build_agent_with(provider, vec![], Box::new(NativeToolDispatcher));
@@ -777,6 +783,7 @@ async fn turn_preserves_text_alongside_tool_calls() {
                 arguments: r#"{"message": "hi"}"#.into(),
             }],
             usage: None,
+            reasoning_content: None,
         },
         text_response("Here are the results"),
     ]));
@@ -1014,6 +1021,7 @@ async fn native_dispatcher_handles_stringified_arguments() {
             arguments: r#"{"message": "hello"}"#.into(),
         }],
         usage: None,
+        reasoning_content: None,
     };
 
     let (_, calls) = dispatcher.parse_response(&response);
@@ -1040,6 +1048,7 @@ fn xml_dispatcher_handles_nested_json() {
         ),
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     };
 
     let dispatcher = XmlToolDispatcher;
@@ -1058,6 +1067,7 @@ fn xml_dispatcher_handles_empty_tool_call_tag() {
         text: Some("<tool_call>\n</tool_call>\nSome text".into()),
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     };
 
     let dispatcher = XmlToolDispatcher;
@@ -1072,6 +1082,7 @@ fn xml_dispatcher_handles_unclosed_tool_call() {
         text: Some("Before\n<tool_call>\n{\"name\": \"shell\"}".into()),
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     };
 
     let dispatcher = XmlToolDispatcher;
@@ -1097,6 +1108,7 @@ fn conversation_message_serialization_roundtrip() {
                 name: "shell".into(),
                 arguments: "{}".into(),
             }],
+            reasoning_content: None,
         },
         ConversationMessage::ToolResults(vec![ToolResultMessage {
             tool_call_id: "tc1".into(),
@@ -1119,10 +1131,12 @@ fn conversation_message_serialization_roundtrip() {
                 ConversationMessage::AssistantToolCalls {
                     text: a_text,
                     tool_calls: a_calls,
+                    ..
                 },
                 ConversationMessage::AssistantToolCalls {
                     text: b_text,
                     tool_calls: b_calls,
+                    ..
                 },
             ) => {
                 assert_eq!(a_text, b_text);
@@ -1219,6 +1233,7 @@ fn xml_dispatcher_converts_history_to_provider_messages() {
                 name: "shell".into(),
                 arguments: "{}".into(),
             }],
+            reasoning_content: None,
         },
         ConversationMessage::ToolResults(vec![ToolResultMessage {
             tool_call_id: "tc1".into(),

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -412,6 +412,7 @@ impl AnthropicProvider {
             },
             tool_calls,
             usage,
+            reasoning_content: None,
         }
     }
 

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -784,6 +784,7 @@ impl BedrockProvider {
             },
             tool_calls,
             usage,
+            reasoning_content: None,
         }
     }
 

--- a/src/providers/copilot.rs
+++ b/src/providers/copilot.rs
@@ -378,6 +378,7 @@ impl CopilotProvider {
             text: choice.message.content,
             tool_calls,
             usage,
+            reasoning_content: None,
         })
     }
 

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -1221,6 +1221,7 @@ impl Provider for GeminiProvider {
             text: Some(text),
             tool_calls: Vec::new(),
             usage,
+            reasoning_content: None,
         })
     }
 

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -641,6 +641,7 @@ impl Provider for OllamaProvider {
                 text,
                 tool_calls,
                 usage,
+                reasoning_content: None,
             });
         }
 
@@ -659,6 +660,7 @@ impl Provider for OllamaProvider {
                     )),
                     tool_calls: vec![],
                     usage,
+                    reasoning_content: None,
                 });
             }
             tracing::warn!("Ollama returned empty content with no tool calls");
@@ -667,6 +669,7 @@ impl Provider for OllamaProvider {
             text: Some(content),
             tool_calls: vec![],
             usage,
+            reasoning_content: None,
         })
     }
 
@@ -713,6 +716,7 @@ impl Provider for OllamaProvider {
             text: Some(text),
             tool_calls: vec![],
             usage: None,
+            reasoning_content: None,
         })
     }
 }

--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -1670,6 +1670,7 @@ mod tests {
                 text: Some(self.response_text.to_string()),
                 tool_calls: self.tool_calls.clone(),
                 usage: None,
+                reasoning_content: None,
             })
         }
     }
@@ -1862,6 +1863,7 @@ mod tests {
                 text: Some(self.response_text.to_string()),
                 tool_calls: vec![],
                 usage: None,
+                reasoning_content: None,
             })
         }
     }

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -601,6 +601,7 @@ mod tests {
                     text: Some("done".to_string()),
                     tool_calls: Vec::new(),
                     usage: None,
+                    reasoning_content: None,
                 })
             } else {
                 Ok(ChatResponse {
@@ -611,6 +612,7 @@ mod tests {
                         arguments: "{\"value\":\"ping\"}".to_string(),
                     }],
                     usage: None,
+                    reasoning_content: None,
                 })
             }
         }
@@ -644,6 +646,7 @@ mod tests {
                     arguments: "{\"value\":\"x\"}".to_string(),
                 }],
                 usage: None,
+                reasoning_content: None,
             })
         }
     }

--- a/src/tools/file_read.rs
+++ b/src/tools/file_read.rs
@@ -744,6 +744,7 @@ mod tests {
                         text: Some("done".into()),
                         tool_calls: vec![],
                         usage: None,
+                        reasoning_content: None,
                     });
                 }
                 Ok(guard.remove(0))
@@ -803,12 +804,14 @@ mod tests {
                     arguments: r#"{"path": "report.pdf"}"#.into(),
                 }],
                 usage: None,
+                reasoning_content: None,
             },
             // Turn 1 continued: provider sees tool result and answers
             ChatResponse {
                 text: Some("The PDF contains a greeting: Hello PDF".into()),
                 tool_calls: vec![],
                 usage: None,
+                reasoning_content: None,
             },
         ]);
 
@@ -894,11 +897,13 @@ mod tests {
                     arguments: r#"{"path": "data.bin"}"#.into(),
                 }],
                 usage: None,
+                reasoning_content: None,
             },
             ChatResponse {
                 text: Some("The file appears to be binary data.".into()),
                 tool_calls: vec![],
                 usage: None,
+                reasoning_content: None,
             },
         ]);
 

--- a/tests/agent_e2e.rs
+++ b/tests/agent_e2e.rs
@@ -65,6 +65,7 @@ impl Provider for MockProvider {
                 text: Some("done".into()),
                 tool_calls: vec![],
                 usage: None,
+                reasoning_content: None,
             });
         }
         Ok(guard.remove(0))
@@ -190,6 +191,7 @@ impl Provider for RecordingProvider {
                 text: Some("done".into()),
                 tool_calls: vec![],
                 usage: None,
+                reasoning_content: None,
             });
         }
         Ok(guard.remove(0))
@@ -238,6 +240,7 @@ fn text_response(text: &str) -> ChatResponse {
         text: Some(text.into()),
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     }
 }
 
@@ -246,6 +249,7 @@ fn tool_response(calls: Vec<ToolCall>) -> ChatResponse {
         text: Some(String::new()),
         tool_calls: calls,
         usage: None,
+        reasoning_content: None,
     }
 }
 
@@ -370,6 +374,7 @@ async fn e2e_xml_dispatcher_tool_call() {
             ),
             tool_calls: vec![],
             usage: None,
+            reasoning_content: None,
         },
         text_response("XML tool executed"),
     ]));

--- a/tests/agent_loop_robustness.rs
+++ b/tests/agent_loop_robustness.rs
@@ -60,6 +60,7 @@ impl Provider for MockProvider {
                 text: Some("done".into()),
                 tool_calls: vec![],
                 usage: None,
+                reasoning_content: None,
             });
         }
         Ok(guard.remove(0))
@@ -181,6 +182,7 @@ fn text_response(text: &str) -> ChatResponse {
         text: Some(text.into()),
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     }
 }
 
@@ -189,6 +191,7 @@ fn tool_response(calls: Vec<ToolCall>) -> ChatResponse {
         text: Some(String::new()),
         tool_calls: calls,
         usage: None,
+        reasoning_content: None,
     }
 }
 
@@ -357,6 +360,7 @@ async fn agent_handles_empty_provider_response() {
         text: Some(String::new()),
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     }]));
 
     let mut agent = build_agent(provider, vec![Box::new(EchoTool)]);
@@ -371,6 +375,7 @@ async fn agent_handles_none_text_response() {
         text: None,
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     }]));
 
     let mut agent = build_agent(provider, vec![Box::new(EchoTool)]);

--- a/tests/provider_schema.rs
+++ b/tests/provider_schema.rs
@@ -154,6 +154,7 @@ fn chat_response_text_only() {
         text: Some("Hello world".into()),
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     };
 
     assert_eq!(resp.text_or_empty(), "Hello world");
@@ -170,6 +171,7 @@ fn chat_response_with_tool_calls() {
             arguments: "{}".into(),
         }],
         usage: None,
+        reasoning_content: None,
     };
 
     assert!(resp.has_tool_calls());
@@ -183,6 +185,7 @@ fn chat_response_text_or_empty_handles_none() {
         text: None,
         tool_calls: vec![],
         usage: None,
+        reasoning_content: None,
     };
 
     assert_eq!(resp.text_or_empty(), "");
@@ -205,6 +208,7 @@ fn chat_response_multiple_tool_calls() {
             },
         ],
         usage: None,
+        reasoning_content: None,
     };
 
     assert!(resp.has_tool_calls());


### PR DESCRIPTION
## Summary

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): `dev`
- Problem: Thinking/reasoning models (Kimi K2.5, GLM-4.7, DeepSeek-R1) return a `reasoning_content` field in assistant messages with tool calls. ZeroClaw silently drops this field when constructing conversation history. When the history is sent back to the provider API, the provider rejects the request with HTTP 400: `"thinking is enabled but reasoning_content is missing in assistant tool call message"`.
- Why it matters: Any user of a thinking model with tool-calling enabled hits a hard crash on the second agent loop iteration, making these models completely unusable with ZeroClaw.
- What changed: Added `reasoning_content: Option<String>` as an opaque pass-through field at every layer of the pipeline — `ChatResponse`, `ConversationMessage::AssistantToolCalls`, `NativeMessage` structs in compatible/openai/openrouter providers, parse/convert/build functions in providers and agent loop, and the tool dispatcher. The field uses `#[serde(skip_serializing_if = "Option::is_none")]` so it is invisible for non-thinking models.
- What did **not** change (scope boundary): No behavioral changes for non-thinking models. No new config keys, no new dependencies, no changes to security/gateway/runtime. The field is purely pass-through with no interpretation or transformation.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: M`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `provider`, `agent`, `tool`, `tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `provider: compatible`, `provider: openai`, `provider: openrouter`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `provider`

## Linked Issue

- Closes #1327
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

N/A — not superseding any PR.

## Validation Evidence (required)

Commands and result summary:

```bash
# Format check — clean
cargo fmt --all -- --check
# Exit 0, no diffs

# Compilation with tests and benches — clean (only pre-existing warnings)
cargo check --tests --benches
# Exit 0, only pre-existing unused-import warnings from upstream main

# Full test suite — all pass
cargo test
# 2857 tests passed, 0 failures

# Targeted new tests — all 39 new reasoning_content tests pass
cargo test reasoning_content
# 39 tests passed (x2 for lib+bin targets = 78 runs), 0 failures

# Docker image build — success
docker build --target dev -t zeroclaw:dev-combined .

# Live E2E validation with GLM-4.7 thinking model
# Container started with daemon command, Discord + Mattermost channels connected
# Two multi-turn tool call conversations completed without 400 errors
```

- Evidence provided (test/log/trace/screenshot/perf): Unit tests (39 new), full test suite (2857 pass), Docker build, live E2E with GLM-4.7
- If any command is intentionally skipped, explain why: `cargo clippy --all-targets -- -D warnings` skipped because upstream `main` (v0.1.5, commit 13daa87) has 30+ pre-existing clippy errors unrelated to this change. This PR introduces zero new warnings.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: No personal or sensitive data in any code, tests, or comments. All test fixtures use neutral project-scoped values.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Confirmed — all test names and values are impersonal and system-focused.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes — `reasoning_content` is `Option<String>` with `skip_serializing_if`, so existing serialized data without this field deserializes to `None` and serializes identically to before.
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No — this is a code-only bug fix with no docs or user-facing wording changes.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Live E2E with GLM-4.7 thinking model — two multi-turn conversations with tool calls completed successfully. Container ran with `daemon` command, Discord and Mattermost channels connected.
- Edge cases checked: Non-thinking models (no `reasoning_content` in response) — field is `None`, not serialized, zero behavior change. Models returning `reasoning_content: null` explicitly — deserialized as `None`. Empty string `reasoning_content` — passed through faithfully.
- What was not verified: Other thinking models (Kimi K2.5, DeepSeek-R1) — not tested live, but the fix is provider-agnostic and opaque pass-through.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `providers` (compatible, openai, openrouter — parse and convert functions), `agent` (loop history building, dispatcher, agent orchestration), `tools` (delegate, file_read — mechanical `None` additions to `ChatResponse` constructions)
- Potential unintended effects: None anticipated — the field is purely additive and `Option`-wrapped. Non-thinking model paths are unchanged (field is `None` throughout).
- Guardrails/monitoring for early detection: 39 new targeted unit tests covering round-trip preservation, `None` pass-through, JSON serialization/deserialization, and conditional inclusion in outgoing payloads.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): OpenCode (Claude) for implementation, testing, and validation
- Workflow/plan summary (if any): Traced the `reasoning_content` field through every layer of the pipeline (API response parsing → ChatResponse → ConversationMessage → history JSON → outgoing NativeMessage), identified all drop points, added the field at each layer with `Option<String>` + `skip_serializing_if`, wrote comprehensive tests, validated in Docker with live E2E.
- Verification focus: Round-trip fidelity of `reasoning_content` through the full pipeline, zero regression for non-thinking models.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes — used existing trait/struct patterns, no cross-module coupling, no new dependencies, Rust naming conventions followed.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit-sha>` — single commit, clean revert.
- Feature flags or config toggles (if any): None needed — the change is additive and backward compatible.
- Observable failure symptoms: If rollback is needed, the symptom is the original bug: 400 errors from thinking model APIs when tool calls are involved in conversation history.

## Risks and Mitigations

- Risk: A provider returns an unexpected type for `reasoning_content` (e.g., object instead of string).
  - Mitigation: Field is typed as `Option<String>` with serde deserialization — non-string values will deserialize to `None` (with default serde behavior), which is the safe fallback. No crash path.