### PR TITLE
fix(lark): use valid Feishu API emoji_type keys for ack reactions

### DIFF
--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -14,37 +14,19 @@ const FEISHU_WS_BASE_URL: &str = "https://open.feishu.cn";
 const LARK_BASE_URL: &str = "https://open.larksuite.com/open-apis";
 const LARK_WS_BASE_URL: &str = "https://open.larksuite.com";
 
-const LARK_ACK_REACTIONS_ZH_CN: &[&str] = &["OK", "加油", "鼓掌", "碰拳", "看", "奋斗", "强"];
+/// Feishu/Lark API emoji_type keys for message reactions.
+/// These must match the API's enum values exactly (case-sensitive).
+/// Reference: https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce
+const LARK_ACK_REACTIONS_ZH_CN: &[&str] =
+    &["OK", "MUSCLE", "APPLAUSE", "FISTBUMP", "GLANCE", "STRIVE", "THUMBSUP"];
 const LARK_ACK_REACTIONS_ZH_TW: &[&str] = &[
-    "我看行",
-    "OK",
-    "加油",
-    "鼓掌",
-    "碰拳",
-    "看",
-    "奮鬥",
-    "強",
-    "很 OK",
+    "LGTM", "OK", "MUSCLE", "APPLAUSE", "FISTBUMP", "GLANCE", "STRIVE", "THUMBSUP", "DONE",
 ];
 const LARK_ACK_REACTIONS_EN: &[&str] = &[
-    "LooksGoodToMe",
-    "OK",
-    "Praise",
-    "Determined",
-    "Glance",
-    "FistBump",
-    "Applaud",
-    "FightOn",
+    "LGTM", "OK", "PRAISE", "MUSCLE", "GLANCE", "FISTBUMP", "APPLAUSE", "STRIVE",
 ];
 const LARK_ACK_REACTIONS_JA: &[&str] = &[
-    "いいと思う",
-    "OK",
-    "よくできた",
-    "頑張る",
-    "見る",
-    "グータッチ",
-    "拍手",
-    "頑張れ",
+    "LGTM", "OK", "PRAISE", "MUSCLE", "GLANCE", "FISTBUMP", "APPLAUSE", "STRIVE",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: Lark ack reactions fail with Feishu API error `231001: reaction type is invalid`. The locale-aware reaction lists introduced in #1284 use display names (e.g. `"加油"`, `"鼓掌"`, `"Applaud"`) which are not valid Feishu API `emoji_type` enum values.
- Why it matters: Every incoming message triggers a failed reaction request, producing warn-level log noise and no visible emoji feedback to users.
- What changed: Replaced all reaction type strings with the API's documented enum keys (`MUSCLE`, `APPLAUSE`, `FISTBUMP`, `STRIVE`, `LGTM`, `PRAISE`, etc.) as defined in the [Feishu emoji reference](https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce).
- What did **not** change (scope boundary): Locale detection logic, reaction selection logic, and the reaction API call path are untouched. Only the string constants were corrected.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: lark`
- Contributor tier label: N/A
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check    # pass
cargo check --features channel-lark  # pass
```

- Evidence provided: compilation check, live deployment verification (reactions now succeed on Feishu)
- If any command is intentionally skipped: Test suite not affected — reaction constants are not covered by existing unit tests

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes — fixes broken behavior, no config changes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Deployed fixed binary to live daemon, sent messages in Feishu — emoji reactions now appear correctly
- Edge cases checked: N/A — string constant replacement only
- What was not verified: Lark (international) endpoint reactions (only Feishu CN tested)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Lark ack reaction on message receive
- Potential unintended effects: None — same emoji set, just correct API keys
- Guardrails/monitoring: Reaction failures logged at warn level; success is silent

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (Opus 4.6)
- Verification focus: Live deployment verification on Feishu
- Confirmation: naming + architecture boundaries followed: Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>`
- Feature flags or config toggles: N/A
- Observable failure symptoms: If reverted, `231001 reaction type is invalid` errors return in daemon logs

## Risks and Mitigations

- Risk: Some emoji keys may not be available on all Feishu tenant configurations
  - Mitigation: All keys used (`OK`, `MUSCLE`, `APPLAUSE`, `THUMBSUP`, etc.) are standard Feishu platform emojis documented in the official API reference