### PR TITLE
fix(channels/lark): use valid emoji_type for message reactions

### DIFF
--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -14,46 +14,13 @@ const FEISHU_WS_BASE_URL: &str = "https://open.feishu.cn";
 const LARK_BASE_URL: &str = "https://open.larksuite.com/open-apis";
 const LARK_WS_BASE_URL: &str = "https://open.larksuite.com";
 
-const LARK_ACK_REACTIONS_ZH_CN: &[&str] = &["OK", "加油", "鼓掌", "碰拳", "看", "奋斗", "强"];
-const LARK_ACK_REACTIONS_ZH_TW: &[&str] = &[
-    "我看行",
+// Lark/Feishu message reaction emoji_type constants.
+const LARK_ACK_REACTIONS: &[&str] = &[
     "OK",
-    "加油",
-    "鼓掌",
-    "碰拳",
-    "看",
-    "奮鬥",
-    "強",
-    "很 OK",
+    "StatusReading",
+    "Status_PrivateMessage",
+    "Typing",
 ];
-const LARK_ACK_REACTIONS_EN: &[&str] = &[
-    "LooksGoodToMe",
-    "OK",
-    "Praise",
-    "Determined",
-    "Glance",
-    "FistBump",
-    "Applaud",
-    "FightOn",
-];
-const LARK_ACK_REACTIONS_JA: &[&str] = &[
-    "いいと思う",
-    "OK",
-    "よくできた",
-    "頑張る",
-    "見る",
-    "グータッチ",
-    "拍手",
-    "頑張れ",
-];
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum LarkAckLocale {
-    ZhCn,
-    ZhTw,
-    En,
-    Ja,
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum LarkPlatform {
@@ -1153,189 +1120,12 @@ fn random_from_pool(pool: &'static [&'static str]) -> &'static str {
     pool[pick_uniform_index(pool.len())]
 }
 
-fn lark_ack_pool(locale: LarkAckLocale) -> &'static [&'static str] {
-    match locale {
-        LarkAckLocale::ZhCn => LARK_ACK_REACTIONS_ZH_CN,
-        LarkAckLocale::ZhTw => LARK_ACK_REACTIONS_ZH_TW,
-        LarkAckLocale::En => LARK_ACK_REACTIONS_EN,
-        LarkAckLocale::Ja => LARK_ACK_REACTIONS_JA,
-    }
-}
-
-fn map_locale_tag(tag: &str) -> Option<LarkAckLocale> {
-    let normalized = tag.trim().to_ascii_lowercase().replace('-', "_");
-    if normalized.is_empty() {
-        return None;
-    }
-
-    if normalized.starts_with("ja") {
-        return Some(LarkAckLocale::Ja);
-    }
-    if normalized.starts_with("en") {
-        return Some(LarkAckLocale::En);
-    }
-    if normalized.contains("hant")
-        || normalized.starts_with("zh_tw")
-        || normalized.starts_with("zh_hk")
-        || normalized.starts_with("zh_mo")
-    {
-        return Some(LarkAckLocale::ZhTw);
-    }
-    if normalized.starts_with("zh") {
-        return Some(LarkAckLocale::ZhCn);
-    }
-    None
-}
-
-fn find_locale_hint(value: &serde_json::Value) -> Option<String> {
-    match value {
-        serde_json::Value::Object(map) => {
-            for key in [
-                "locale",
-                "language",
-                "lang",
-                "i18n_locale",
-                "user_locale",
-                "locale_id",
-            ] {
-                if let Some(locale) = map.get(key).and_then(serde_json::Value::as_str) {
-                    return Some(locale.to_string());
-                }
-            }
-
-            for child in map.values() {
-                if let Some(locale) = find_locale_hint(child) {
-                    return Some(locale);
-                }
-            }
-            None
-        }
-        serde_json::Value::Array(items) => {
-            for child in items {
-                if let Some(locale) = find_locale_hint(child) {
-                    return Some(locale);
-                }
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
-fn detect_locale_from_post_content(content: &str) -> Option<LarkAckLocale> {
-    let parsed = serde_json::from_str::<serde_json::Value>(content).ok()?;
-    let obj = parsed.as_object()?;
-    for key in obj.keys() {
-        if let Some(locale) = map_locale_tag(key) {
-            return Some(locale);
-        }
-    }
-    None
-}
-
-fn is_japanese_kana(ch: char) -> bool {
-    matches!(
-        ch as u32,
-        0x3040..=0x309F | // Hiragana
-        0x30A0..=0x30FF | // Katakana
-        0x31F0..=0x31FF // Katakana Phonetic Extensions
-    )
-}
-
-fn is_cjk_han(ch: char) -> bool {
-    matches!(
-        ch as u32,
-        0x3400..=0x4DBF | // CJK Extension A
-        0x4E00..=0x9FFF // CJK Unified Ideographs
-    )
-}
-
-fn is_traditional_only_han(ch: char) -> bool {
-    matches!(
-        ch,
-        '奮' | '鬥'
-            | '強'
-            | '體'
-            | '國'
-            | '臺'
-            | '萬'
-            | '與'
-            | '為'
-            | '這'
-            | '學'
-            | '機'
-            | '開'
-            | '裡'
-    )
-}
-
-fn is_simplified_only_han(ch: char) -> bool {
-    matches!(
-        ch,
-        '奋' | '斗'
-            | '强'
-            | '体'
-            | '国'
-            | '台'
-            | '万'
-            | '与'
-            | '为'
-            | '这'
-            | '学'
-            | '机'
-            | '开'
-            | '里'
-    )
-}
-
-fn detect_locale_from_text(text: &str) -> Option<LarkAckLocale> {
-    if text.chars().any(is_japanese_kana) {
-        return Some(LarkAckLocale::Ja);
-    }
-    if text.chars().any(is_traditional_only_han) {
-        return Some(LarkAckLocale::ZhTw);
-    }
-    if text.chars().any(is_simplified_only_han) {
-        return Some(LarkAckLocale::ZhCn);
-    }
-    if text.chars().any(is_cjk_han) {
-        return Some(LarkAckLocale::ZhCn);
-    }
-    None
-}
-
-fn detect_lark_ack_locale(
-    payload: Option<&serde_json::Value>,
-    fallback_text: &str,
-) -> LarkAckLocale {
-    if let Some(payload) = payload {
-        if let Some(locale) = find_locale_hint(payload).and_then(|hint| map_locale_tag(&hint)) {
-            return locale;
-        }
-
-        let message_content = payload
-            .pointer("/message/content")
-            .and_then(serde_json::Value::as_str)
-            .or_else(|| {
-                payload
-                    .pointer("/event/message/content")
-                    .and_then(serde_json::Value::as_str)
-            });
-
-        if let Some(locale) = message_content.and_then(detect_locale_from_post_content) {
-            return locale;
-        }
-    }
-
-    detect_locale_from_text(fallback_text).unwrap_or(LarkAckLocale::En)
-}
-
+/// Returns a random reaction emoji type from the standard Lark/Feishu reaction pool.
 fn random_lark_ack_reaction(
-    payload: Option<&serde_json::Value>,
-    fallback_text: &str,
+    _payload: Option<&serde_json::Value>,
+    _fallback_text: &str,
 ) -> &'static str {
-    let locale = detect_lark_ack_locale(payload, fallback_text);
-    random_from_pool(lark_ack_pool(locale))
+    random_from_pool(LARK_ACK_REACTIONS)
 }
 
 /// Flatten a Feishu `post` rich-text message to plain text.
@@ -1942,99 +1732,19 @@ mod tests {
     }
 
     #[test]
-    fn lark_reaction_locale_explicit_language_tags() {
-        assert_eq!(map_locale_tag("zh-CN"), Some(LarkAckLocale::ZhCn));
-        assert_eq!(map_locale_tag("zh_TW"), Some(LarkAckLocale::ZhTw));
-        assert_eq!(map_locale_tag("zh-Hant"), Some(LarkAckLocale::ZhTw));
-        assert_eq!(map_locale_tag("en-US"), Some(LarkAckLocale::En));
-        assert_eq!(map_locale_tag("ja-JP"), Some(LarkAckLocale::Ja));
-        assert_eq!(map_locale_tag("fr-FR"), None);
-    }
-
-    #[test]
-    fn lark_reaction_locale_prefers_explicit_payload_locale() {
-        let payload = serde_json::json!({
-            "sender": {
-                "locale": "ja-JP"
-            },
-            "message": {
-                "content": "{\"text\":\"hello\"}"
-            }
-        });
-        assert_eq!(
-            detect_lark_ack_locale(Some(&payload), "你好，世界"),
-            LarkAckLocale::Ja
+    fn random_lark_ack_reaction_returns_valid_emoji_type() {
+        let selected = random_lark_ack_reaction(None, "hello");
+        assert!(
+            LARK_ACK_REACTIONS.contains(&selected),
+            "selected reaction should be in the reaction pool"
         );
-    }
 
-    #[test]
-    fn lark_reaction_locale_unsupported_payload_falls_back_to_text_script() {
-        let payload = serde_json::json!({
-            "sender": {
-                "locale": "fr-FR"
-            },
-            "message": {
-                "content": "{\"text\":\"頑張れ\"}"
-            }
-        });
-        assert_eq!(
-            detect_lark_ack_locale(Some(&payload), "頑張ってください"),
-            LarkAckLocale::Ja
-        );
-    }
-
-    #[test]
-    fn lark_reaction_locale_detects_simplified_and_traditional_text() {
-        assert_eq!(
-            detect_lark_ack_locale(None, "继续奋斗，今天很强"),
-            LarkAckLocale::ZhCn
-        );
-        assert_eq!(
-            detect_lark_ack_locale(None, "繼續奮鬥，今天很強"),
-            LarkAckLocale::ZhTw
-        );
-    }
-
-    #[test]
-    fn lark_reaction_locale_defaults_to_english_for_unsupported_text() {
-        assert_eq!(
-            detect_lark_ack_locale(None, "Bonjour tout le monde"),
-            LarkAckLocale::En
-        );
-    }
-
-    #[test]
-    fn random_lark_ack_reaction_respects_detected_locale_pool() {
-        let payload = serde_json::json!({
-            "sender": {
-                "locale": "zh-CN"
-            }
-        });
-        let selected = random_lark_ack_reaction(Some(&payload), "hello");
-        assert!(LARK_ACK_REACTIONS_ZH_CN.contains(&selected));
-
-        let payload = serde_json::json!({
-            "sender": {
-                "locale": "zh-TW"
-            }
-        });
-        let selected = random_lark_ack_reaction(Some(&payload), "hello");
-        assert!(LARK_ACK_REACTIONS_ZH_TW.contains(&selected));
-
-        let payload = serde_json::json!({
-            "sender": {
-                "locale": "en-US"
-            }
-        });
-        let selected = random_lark_ack_reaction(Some(&payload), "hello");
-        assert!(LARK_ACK_REACTIONS_EN.contains(&selected));
-
-        let payload = serde_json::json!({
-            "sender": {
-                "locale": "ja-JP"
-            }
-        });
-        let selected = random_lark_ack_reaction(Some(&payload), "hello");
-        assert!(LARK_ACK_REACTIONS_JA.contains(&selected));
+        // Verify all reactions are valid emoji types
+        for reaction in LARK_ACK_REACTIONS {
+            assert!(
+                !reaction.is_empty(),
+                "emoji_type should not be empty"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: Lark/Feishu API returns "reaction type is invalid" error (code 231001) when adding message reactions because the code used invalid localized emoji strings (e.g., "加油", "鼓掌") instead of standard `emoji_type` identifiers
- Why it matters: The acknowledgment reaction feature was non-functional for Lark users, preventing visual confirmation that messages were received
- What changed: Replaced invalid emoji strings with valid standard `emoji_type` identifiers and simplified the reaction pool. Remove relevant outdated code and tests. Check doc: https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce
  -  Now the reaction pool is ["OK", "StatusReading", "Status_PrivateMessage", "Typing"]
  <img width="104" height="96" alt="image" src="https://github.com/user-attachments/assets/f33f6a95-6ef4-44c8-92e6-88651b43ed9f" />
  <img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/c6854546-62f8-4662-ba72-b8b63359e6cf" />
  <img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/6a95c416-eb42-4b08-bf15-98c014fa34ea" />
    <img width="96" height="96" alt="image" src="https://github.com/user-attachments/assets/e5f89822-89bc-4679-b1ad-77607e032b5f" />


- What did **not** change: Message handling logic, reaction trigger conditions, best-effort failure handling

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `channel`
- Module labels: `channel: lark`
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes: N/A
- Related: N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check      # ✓ passed
cargo clippy --all-targets -- -D warnings  # ✓ passed
cargo check                     # ✓ passed
```

- Evidence provided: compilation success, no functional behavior changes (emoji selection is random from valid pool)

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: N/A

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No` (internal emoji_type identifiers, user-facing behavior unchanged)

## Human Verification (required)

- Verified scenarios: Code compiles successfully, emoji_type format matches official API documentation
- Edge cases checked: Empty message_id handling (unchanged), token refresh on 401 (unchanged)
- What was not verified: Live API testing (requires actual Lark credentials)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Lark/Feishu channel message acknowledgment reactions only
- Potential unintended effects: None expected (reaction is best-effort and failures are silently logged)
- Guardrails/monitoring for early detection: Existing warn-level logging for reaction failures

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>` or restore previous version of `src/channels/lark.rs`
- Feature flags or config toggles: None
- Observable failure symptoms: Continued "reaction type is invalid" warnings in logs

## Risks and Mitigations

None. This is a straightforward bug fix replacing invalid emoji strings with valid API identifiers.

## Security & Compatibility

- No new permissions, network calls, or secrets handling changes
- Backward compatible, no config changes, no migration needed