### PR TITLE
ci(homebrew): harden bot auth and preflight access checks

### DIFF
--- a/.github/workflows/pub-homebrew-core.yml
+++ b/.github/workflows/pub-homebrew-core.yml
@@ -86,6 +86,7 @@ jobs:
               shell: bash
               env:
                   HOMEBREW_CORE_BOT_TOKEN: ${{ secrets.HOMEBREW_CORE_BOT_TOKEN }}
+                  GH_TOKEN: ${{ secrets.HOMEBREW_CORE_BOT_TOKEN }}
               run: |
                   set -euo pipefail
 
@@ -107,9 +108,19 @@ jobs:
                       echo "::error::HOMEBREW_CORE_BOT_FORK_REPO must be in owner/repo format."
                       exit 1
                     fi
-                    auth_header="$(printf 'x-access-token:%s' "${HOMEBREW_CORE_BOT_TOKEN}" | base64 | tr -d '\n')"
-                    git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
-                      clone --depth=1 "https://github.com/${BOT_FORK_REPO}.git" "$tmp_repo/homebrew-core"
+                    if ! command -v gh >/dev/null 2>&1; then
+                      echo "::error::gh CLI is required on the runner."
+                      exit 1
+                    fi
+                    if [[ -z "${GH_TOKEN:-}" ]]; then
+                      echo "::error::Repository secret HOMEBREW_CORE_BOT_TOKEN is missing."
+                      exit 1
+                    fi
+                    if ! gh api "repos/${BOT_FORK_REPO}" >/dev/null 2>&1; then
+                      echo "::error::HOMEBREW_CORE_BOT_TOKEN cannot access ${BOT_FORK_REPO}."
+                      exit 1
+                    fi
+                    gh repo clone "${BOT_FORK_REPO}" "$tmp_repo/homebrew-core" -- --depth=1
                   fi
 
                   repo_dir="$tmp_repo/homebrew-core"
@@ -166,9 +177,12 @@ jobs:
                   git -C "$repo_dir" config user.email "$bot_email"
                   git -C "$repo_dir" add "$FORMULA_PATH"
                   git -C "$repo_dir" commit -m "zeroclaw ${tag_version}"
-                  auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 | tr -d '\n')"
-                  git -C "$repo_dir" -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
-                    push --set-upstream origin "$branch_name"
+                  if [[ -z "${GH_TOKEN:-}" ]]; then
+                    echo "::error::Repository secret HOMEBREW_CORE_BOT_TOKEN is missing."
+                    exit 1
+                  fi
+                  gh auth setup-git
+                  git -C "$repo_dir" push --set-upstream origin "$branch_name"
 
                   pr_title="zeroclaw ${tag_version}"
                   pr_body=$(cat <<EOF


### PR DESCRIPTION
## Summary
- replace raw git header-auth clone with `gh repo clone` using `GH_TOKEN`
- add explicit preflight check (`gh api repos/<fork>`) to fail fast with a clear auth/access error
- use `gh auth setup-git` before push to make git credential flow deterministic

## Why
Homebrew publish has been failing intermittently at clone/push auth (`could not read Username for 'https://github.com'`). This change removes brittle ad-hoc credential injection and standardizes auth through GitHub CLI.

## Validation
- `actionlint .github/workflows/pub-homebrew-core.yml`

## Risk
Low-medium, scoped to Homebrew publish workflow auth path.

## Rollback
Revert this PR.
