### PR TITLE
ci(homebrew): prefer HOMEBREW_UPSTREAM_PR_TOKEN with fallback

### DIFF
--- a/.github/workflows/pub-homebrew-core.yml
+++ b/.github/workflows/pub-homebrew-core.yml
@@ -85,8 +85,8 @@ jobs:
               id: patch_formula
               shell: bash
               env:
-                  HOMEBREW_CORE_BOT_TOKEN: ${{ secrets.HOMEBREW_CORE_BOT_TOKEN }}
-                  GH_TOKEN: ${{ secrets.HOMEBREW_CORE_BOT_TOKEN }}
+                  HOMEBREW_CORE_BOT_TOKEN: ${{ secrets.HOMEBREW_UPSTREAM_PR_TOKEN || secrets.HOMEBREW_CORE_BOT_TOKEN }}
+                  GH_TOKEN: ${{ secrets.HOMEBREW_UPSTREAM_PR_TOKEN || secrets.HOMEBREW_CORE_BOT_TOKEN }}
               run: |
                   set -euo pipefail
 
@@ -163,7 +163,7 @@ jobs:
               if: ${{ inputs.dry_run == false }}
               shell: bash
               env:
-                  GH_TOKEN: ${{ secrets.HOMEBREW_CORE_BOT_TOKEN }}
+                  GH_TOKEN: ${{ secrets.HOMEBREW_UPSTREAM_PR_TOKEN || secrets.HOMEBREW_CORE_BOT_TOKEN }}
               run: |
                   set -euo pipefail
 


### PR DESCRIPTION
Use HOMEBREW_UPSTREAM_PR_TOKEN when present, fallback to HOMEBREW_CORE_BOT_TOKEN for compatibility.\n\nThis unblocks Homebrew publish runs where the new secret name is used.