### PR TITLE
fix(provider): disable native tool calling for MiniMax

### DIFF
--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -33,6 +33,9 @@ pub struct OpenAiCompatibleProvider {
     /// to the first `user` message, then drop the system messages.
     /// Required for providers that reject `role: system` (e.g. MiniMax).
     merge_system_into_user: bool,
+    /// Whether this provider supports OpenAI-style native tool calling.
+    /// When false, tools are injected into the system prompt as text.
+    native_tool_calling: bool,
 }
 
 /// How the provider expects the API key to be sent.
@@ -54,7 +57,7 @@ impl OpenAiCompatibleProvider {
         auth_style: AuthStyle,
     ) -> Self {
         Self::new_with_options(
-            name, base_url, credential, auth_style, false, true, None, false,
+            name, base_url, credential, auth_style, false, true, None, false, true,
         )
     }
 
@@ -74,6 +77,7 @@ impl OpenAiCompatibleProvider {
             true,
             None,
             false,
+            true,
         )
     }
 
@@ -86,7 +90,7 @@ impl OpenAiCompatibleProvider {
         auth_style: AuthStyle,
     ) -> Self {
         Self::new_with_options(
-            name, base_url, credential, auth_style, false, false, None, false,
+            name, base_url, credential, auth_style, false, false, None, false, true,
         )
     }
 
@@ -110,6 +114,7 @@ impl OpenAiCompatibleProvider {
             true,
             Some(user_agent),
             false,
+            true,
         )
     }
 
@@ -130,6 +135,7 @@ impl OpenAiCompatibleProvider {
             true,
             Some(user_agent),
             false,
+            true,
         )
     }
 
@@ -142,7 +148,7 @@ impl OpenAiCompatibleProvider {
         auth_style: AuthStyle,
     ) -> Self {
         Self::new_with_options(
-            name, base_url, credential, auth_style, false, false, None, true,
+            name, base_url, credential, auth_style, false, false, None, true, false,
         )
     }
 
@@ -155,6 +161,7 @@ impl OpenAiCompatibleProvider {
         supports_responses_fallback: bool,
         user_agent: Option<&str>,
         merge_system_into_user: bool,
+        native_tool_calling: bool,
     ) -> Self {
         Self {
             name: name.to_string(),
@@ -165,6 +172,7 @@ impl OpenAiCompatibleProvider {
             supports_responses_fallback,
             user_agent: user_agent.map(ToString::to_string),
             merge_system_into_user,
+            native_tool_calling,
         }
     }
 
@@ -1124,7 +1132,7 @@ impl OpenAiCompatibleProvider {
 impl Provider for OpenAiCompatibleProvider {
     fn capabilities(&self) -> crate::providers::traits::ProviderCapabilities {
         crate::providers::traits::ProviderCapabilities {
-            native_tool_calling: true,
+            native_tool_calling: self.native_tool_calling,
             vision: self.supports_vision,
         }
     }
@@ -2383,6 +2391,22 @@ mod tests {
         let caps = <OpenAiCompatibleProvider as Provider>::capabilities(&p);
         assert!(caps.native_tool_calling);
         assert!(caps.vision);
+    }
+
+    #[test]
+    fn minimax_provider_disables_native_tool_calling() {
+        let p = OpenAiCompatibleProvider::new_merge_system_into_user(
+            "MiniMax",
+            "https://api.minimax.chat/v1",
+            Some("k"),
+            AuthStyle::Bearer,
+        );
+        let caps = <OpenAiCompatibleProvider as Provider>::capabilities(&p);
+        assert!(
+            !caps.native_tool_calling,
+            "MiniMax should use prompt-guided tool calling, not native"
+        );
+        assert!(!caps.vision);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: MiniMax API does not support OpenAI-style native tool definitions (`tools` parameter). Sending them causes 500 Internal Server Error on every request, making MiniMax completely unusable when tools are configured.
- Why it matters: MiniMax provider is workflow-blocked for all users with tools enabled.
- What changed: Added `native_tool_calling` field to `OpenAiCompatibleProvider`; MiniMax (via `new_merge_system_into_user`) sets it to `false`, falling back to prompt-guided tool calling.
- What did **not** change: All other providers remain `native_tool_calling: true`. No behavioral change for non-MiniMax providers.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `provider`
- Module labels: `provider: minimax`
- Contributor tier label: N/A
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `provider`

## Linked Issue

- Closes #1387

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo test -p zeroclaw --lib providers::compatible
# test result: ok. 74 passed; 0 failed; 0 ignored
```

- Evidence provided: all 74 compatible provider tests pass, including new `minimax_provider_disables_native_tool_calling` test
- Full `cargo fmt`, `cargo clippy`, `cargo test` deferred to CI

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes — MiniMax previously always failed with 500 when tools were present; this fix makes it work.
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (code-only change)

## Human Verification (required)

- Verified scenarios: MiniMax provider reports `native_tool_calling: false`; all other providers report `true`
- Edge cases checked: `new_merge_system_into_user` is the only constructor setting `native_tool_calling: false`
- What was not verified: End-to-end MiniMax prompt-guided tool calling quality (model capability dependent)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: MiniMax provider tool calling path only
- Potential unintended effects: Prompt-guided tool calling may be less reliable than native (model capability limitation, not a code issue)
- Guardrails/monitoring: Agent loop already has fallback XML/markdown tool call parsing (`parse_tool_calls`)

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (code review, test execution)
- Workflow/plan summary: Traced full code path from error → provider capabilities → agent loop tool dispatch → API request body
- Verification focus: Confirmed MiniMax `chat()` override honors `native_tool_calling` via agent loop `use_native_tools` flag
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None needed; revert restores previous (broken) behavior
- Observable failure symptoms: MiniMax 500 errors return if reverted

## Risks and Mitigations

- Risk: MiniMax M2.5 may not reliably follow prompt-guided tool calling XML format
  - Mitigation: This is a model capability limitation, not a code bug. The alternative (native tools) causes 500 errors, so prompt-guided is strictly better.