### PR TITLE
docs: clarify MCP setup is outside onboard wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,9 @@ zeroclaw onboard --force
 # Or quickly repair channels/allowlists only
 zeroclaw onboard --channels-only
 
+# Note: onboarding configures ZeroClaw provider/model/channel/memory settings.
+# MCP server registration is managed outside this wizard by your MCP-capable runtime/client.
+
 # Chat
 zeroclaw agent -m "Hello, ZeroClaw!"
 
@@ -804,6 +807,7 @@ ZeroClaw supports [Osaurus](https://github.com/dinoki-ai/osaurus) as a first-cla
 - Provider ID: `osaurus`
 - Default endpoint: `http://localhost:1337/v1`
 - API key defaults to `"osaurus"` but is optional
+- MCP server setup is managed in Osaurus itself; `zeroclaw onboard` does not register MCP servers
 
 Example setup:
 

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -47,6 +47,7 @@ Last verified: **February 21, 2026**.
   - Provider-only update (update provider/model/API key while preserving existing channels, tunnel, memory, hooks, and other settings)
 - In non-interactive environments, existing `config.toml` causes a safe refusal unless `--force` is passed.
 - Use `zeroclaw onboard --channels-only` when you only need to rotate channel tokens/allowlists.
+- `onboard` does not register MCP servers; configure MCP server connections in your MCP-capable runtime/client.
 
 ### `agent`
 

--- a/docs/providers-reference.md
+++ b/docs/providers-reference.md
@@ -123,6 +123,7 @@ credential is not reused for fallback providers.
 - [Osaurus](https://github.com/dinoki-ai/osaurus) is a unified AI edge runtime for macOS (Apple Silicon) that combines local MLX inference with cloud provider proxying through a single endpoint.
 - Supports multiple API formats simultaneously: OpenAI-compatible (`/v1/chat/completions`), Anthropic (`/messages`), Ollama (`/chat`), and Open Responses (`/v1/responses`).
 - Built-in MCP (Model Context Protocol) support for tool and context server connectivity.
+- MCP server registration is handled by Osaurus; ZeroClaw onboarding does not manage MCP server entries.
 - Local models run via MLX (Llama, Qwen, Gemma, GLM, Phi, Nemotron, and others); cloud models are proxied transparently.
 
 ### Bedrock Notes


### PR DESCRIPTION
## Summary
- clarify that `zeroclaw onboard` configures provider/model/channel/memory but does not register MCP servers
- add explicit MCP setup notes in README onboarding flow and Osaurus section
- mirror the same clarification in command and provider references

## Validation
- ran docs quality gate in changed-lines mode
- result: no blocking markdown issues on changed lines
- note: repository has pre-existing non-blocking markdown issues outside changed lines

## Why
This removes ambiguity for users expecting MCP server registration to be part of the onboarding wizard.
