### PR TITLE
fix(telegram): startup probe + 409 backoff to eliminate polling conflict on restart

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -2459,26 +2459,24 @@ impl Channel for TelegramChannel {
                                     }
                                 }
                                 break; // Probe succeeded; enter the long-poll loop.
-                            } else {
-                                let error_code = data
-                                    .get("error_code")
-                                    .and_then(serde_json::Value::as_i64)
-                                    .unwrap_or_default();
-                                if error_code == 409 {
-                                    tracing::debug!(
-                                        "Startup probe: slot busy (409), retrying in 5s"
-                                    );
-                                } else {
-                                    let desc = data
-                                        .get("description")
-                                        .and_then(serde_json::Value::as_str)
-                                        .unwrap_or("unknown");
-                                    tracing::warn!(
-                                        "Startup probe: API error {error_code}: {desc}; retrying in 5s"
-                                    );
-                                }
-                                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                             }
+
+                            let error_code = data
+                                .get("error_code")
+                                .and_then(serde_json::Value::as_i64)
+                                .unwrap_or_default();
+                            if error_code == 409 {
+                                tracing::debug!("Startup probe: slot busy (409), retrying in 5s");
+                            } else {
+                                let desc = data
+                                    .get("description")
+                                    .and_then(serde_json::Value::as_str)
+                                    .unwrap_or("unknown");
+                                tracing::warn!(
+                                    "Startup probe: API error {error_code}: {desc}; retrying in 5s"
+                                );
+                            }
+                            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                         }
                     }
                 }


### PR DESCRIPTION
## Problem

Every daemon restart produces a sustained storm of 409 Telegram polling conflicts (every 2 seconds) that can last 30+ seconds. Tracked in #1281.

## Root causes

1. **No startup probe:** The polling loop starts immediately with a 30-second `getUpdates` call. If the previous daemon's poll is still active on Telegram's server (up to 30 seconds after kill), the first long-poll collides and gets 409.

2. **2-second 409 backoff:** Far shorter than the 30-second poll timeout, causing ~15 retries per minute while the conflict persists.

## Fix

**Startup probe (retry loop):** Before entering the long-poll loop, repeatedly issue `getUpdates?timeout=0` (returns immediately) until a 200 OK is received. This claims the Telegram slot before the 30-second long-poll starts. The probe retries every 5 seconds until confirmed.

**Extended 409 backoff:** 2 s → 35 s. If a 409 still occurs in the main loop (e.g. genuine dual-instance), the daemon waits long enough for the competing 30-second session to expire naturally before retrying.

## Side effects / blast radius

- Startup is slightly slower if the previous session is still active (up to 30s in the worst case, same as today but now handled gracefully by the probe instead of spamming 409)
- No behavior change for normal operation — the probe only runs once at startup

## Non-goals

- Does not fix genuinely concurrent dual-instance conflicts (those should continue to 409, now with less spam)

## Risk

Low — changes are isolated to `listen()` startup path in `src/channels/telegram.rs`. No behavior change once polling begins.

## Rollback

Revert commit `e312f73`.

Closes #1281

🤖 Generated with [Claude Code](https://claude.ai/claude-code)