### PR TITLE
feat(channels): add /new command to clear conversation history

### DIFF
--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -44,10 +44,12 @@ When running `zeroclaw channel start` (or daemon mode), Telegram and Discord now
 - `/models <provider>` — switch provider for the current sender session
 - `/model` — show current model and cached model IDs (if available)
 - `/model <model-id>` — switch model for the current sender session
+- `/new` — clear conversation history and start a fresh session
 
 Notes:
 
-- Switching clears only that sender's in-memory conversation history to avoid cross-model context contamination.
+- Switching provider or model clears only that sender's in-memory conversation history to avoid cross-model context contamination.
+- `/new` clears the sender's conversation history without changing provider or model selection.
 - Model cache previews come from `zeroclaw models refresh --provider <ID>`.
 - These are runtime chat commands, not CLI subcommands.
 

--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -88,6 +88,7 @@ Runtime in-chat commands (Telegram/Discord while channel server is running):
 - `/models <provider>`
 - `/model`
 - `/model <model-id>`
+- `/new`
 
 `add/remove` currently route you back to managed setup/manual config paths (not full declarative mutators yet).
 

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -85,6 +85,7 @@ enum ChannelRuntimeCommand {
     SetProvider(String),
     ShowModel,
     SetModel(String),
+    NewSession,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -179,6 +180,7 @@ fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRun
                 Some(ChannelRuntimeCommand::SetModel(model))
             }
         }
+        "/new" => Some(ChannelRuntimeCommand::NewSession),
         _ => None,
     }
 }
@@ -424,6 +426,10 @@ async fn handle_runtime_command_if_needed(
                     current.provider
                 )
             }
+        }
+        ChannelRuntimeCommand::NewSession => {
+            clear_sender_history(ctx, &sender_key);
+            "Conversation history cleared. Starting fresh.".to_string()
         }
     };
 


### PR DESCRIPTION
## Summary

- Problem: No way to clear stale conversation history on Telegram/Discord without switching model/provider
- Why it matters: Stale context accumulates in the 50-message history buffer, causing hallucinations and referencing outdated information from prior conversations
- What changed: Added `/new` runtime command that clears the sender's conversation history
- What did **not** change (scope boundary): Provider/model selection, route overrides, system prompt injection, history buffer size

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel:telegram`, `channel:discord`
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Related: #1350 (datetime injection — complements stale context mitigation)

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass (pre-existing issue in compatible.rs, not from this PR)
cargo clippy -- -D warnings -A deprecated  # pass (pre-existing issues in other files, none in channels/mod.rs)
cargo build                  # pass
```

- Evidence provided: successful build
- `cargo test` skipped: test runner unavailable on Pi (aarch64). No new logic branches — the change follows the exact same pattern as existing SetProvider/SetModel handlers.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Build compiles, code follows existing command pattern exactly
- Edge cases checked: `/new` with trailing text (ignored by parser since no args consumed), `/new@botname` (handled by existing bot-suffix stripping)
- What was not verified: Live Telegram/Discord end-to-end (no test instance on Pi)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Telegram and Discord in-chat command handling only
- Potential unintended effects: None — only clears the calling sender's history, no effect on other senders or route selections
- Guardrails/monitoring for early detection: Confirmation message sent back to user on success

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (read, edit, bash)
- Workflow/plan summary: Add enum variant, parse case, match handler — mirrors existing SetProvider/SetModel pattern
- Verification focus: Build success, pattern consistency with existing commands
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None needed — additive change
- Observable failure symptoms: `/new` command not recognized or no response

## Risks and Mitigations

- Risk: None — minimal additive change following established patterns
