### PR TITLE
fix(channel): use only standard Telegram reaction emojis

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -16,7 +16,7 @@ const TELEGRAM_MAX_MESSAGE_LENGTH: usize = 4096;
 /// Reserve space for continuation markers added by send_text_chunks:
 /// worst case is "(continued)\n\n" + chunk + "\n\n(continues...)" = 30 extra chars
 const TELEGRAM_CONTINUATION_OVERHEAD: usize = 30;
-const TELEGRAM_ACK_REACTIONS: &[&str] = &["⚡️", "🦀", "🙌", "💪", "👌", "👀", "👣"];
+const TELEGRAM_ACK_REACTIONS: &[&str] = &["⚡️", "🙌", "💪", "👌", "👀"];
 
 /// Metadata for an incoming document or photo attachment.
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
The previous emoji set included unsupported reactions (🦀, 👣) that Telegram API rejects with REACTION_INVALID error in some chat contexts. Remove these while keeping the working emojis.

Before: `["⚡️", "🦀", "🙌", "💪", "👌", "👀", "👣"]`
After:  `["⚡️", "🙌", "💪", "👌", "👀"]`

Fixes warning: REACTION_INVALID 400 Bad Request

## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): `dev`
- Problem: Telegram bot logs WARN with "REACTION_INVALID 400 Bad Request" when trying to add ACK reactions using non-standard emojis (🦀, 👣)
- Why it matters: Pollutes logs with warnings; reactions don't appear for users in some chat contexts
- What changed: Removed unsupported emojis (`🦀`, `👣`) from reaction list, keeping working ones (`⚡️`, `🙌`, `💪`, `👌`, `👀`)
- What did **not** change (scope boundary): Reaction logic, random selection, ACK behavior, or any other channel code

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `channel: telegram`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): (auto-managed)
- If any auto-label is incorrect, note requested correction: None

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes # (none - trivial fix)
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): `cargo fmt` passes; trivial single-line change
- If any command is intentionally skipped, explain why: `clippy` and `test` skipped - no functional logic changes, only emoji constants changed

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: No personal/sensitive data added
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): No identity-like wording needed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Telegram reactions (⚡️, 🙌, 💪, 👌, 👀) work across all chat types (private, group, supergroup)
- Edge cases checked: N/A - using conservative standard emoji set universally supported by Telegram
- What was not verified: N/A

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Telegram channel only (`src/channels/telegram.rs`)
- Potential unintended effects: None - standard emojis are universally supported
- Guardrails/monitoring for early detection: Warning log will no longer appear

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): None
- Workflow/plan summary (if any): Simple constant replacement
- Verification focus: Emoji selection limited to standard Telegram reactions
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert 3b261f2`
- Feature flags or config toggles (if any): None
- Observable failure symptoms: None expected - if issues arise, reactions simply won't appear (same as before fix)

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: None
  - Mitigation: N/A
