### PR TITLE
feat(integrations): add list and search subcommands

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,6 +333,20 @@ pub enum MemoryCommands {
 /// Integration subcommands
 #[derive(Subcommand, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum IntegrationCommands {
+    /// List all integrations (optionally filter by category or status)
+    List {
+        /// Filter by category (e.g. "chat", "ai", "productivity")
+        #[arg(long, short)]
+        category: Option<String>,
+        /// Filter by status: active, available, coming-soon
+        #[arg(long, short)]
+        status: Option<String>,
+    },
+    /// Search integrations by keyword (matches name and description)
+    Search {
+        /// Search query
+        query: String,
+    },
     /// Show details about a specific integration
     Info {
         /// Integration name


### PR DESCRIPTION
 Summary

  - Base branch target: dev
  - Problem: zeroclaw integrations only had info <name>, making the 60+ integration catalog undiscoverable from CLI
  - Why it matters: New users have no way to browse what ZeroClaw supports without reading docs/source. The CLI help
  says "Browse 50+ integrations" but couldn't actually do it
  - What changed: Added list (with --category/--status filters) and search <query> subcommands; extracted shared
  status_icon() helper; added 9 unit tests
  - What did not change: info behavior unchanged, registry data unchanged, no new dependencies

  Label Snapshot (required)

  - Risk label: risk: low
  - Size label: size: S
  - Scope labels: integration
  - Module labels: integration: cli
  - If any auto-label is incorrect: N/A

  Change Metadata

  - Change type: feature
  - Primary scope: runtime

  Linked Issue

  - Closes #1421

  Validation Evidence (required)

  cargo fmt --all -- --check   # pass
  cargo clippy --all-targets -- -D warnings   # pass (pre-existing warnings only)
  cargo test --lib integrations   # 30/30 passed

  - Evidence provided: test output
  - If any command is intentionally skipped: N/A

  Security Impact (required)

  - New permissions/capabilities? No
  - New external network calls? No
  - Secrets/tokens handling changed? No
  - File system access scope changed? No

  Privacy and Data Hygiene (required)

  - Data-hygiene status: pass
  - Redaction/anonymization notes: N/A
  - Neutral wording confirmation: All test data uses project-scoped labels

  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  i18n Follow-Through (required when docs or user-facing wording changes)

  - i18n follow-through triggered? No (CLI subcommand only, no docs/README changes)

  Human Verification (required)

  - Verified scenarios: list (no filter, category filter, status filter, combined), search (match, no match), invalid
  filter input error messages
  - Edge cases checked: invalid category/status strings, empty search results
  - What was not verified: visual alignment on very narrow terminals

  Side Effects / Blast Radius (required)

  - Affected subsystems: integrations CLI only
  - Potential unintended effects: None — read-only, uses existing registry data
  - Guardrails: 9 new tests + all 21 existing tests pass

  Agent Collaboration Notes (recommended)

  - Agent tools used: Claude Code
  - Verification focus: compilation, clippy, fmt, unit tests
  - Confirmation: naming + architecture boundaries followed

  Rollback Plan (required)

  - Fast rollback: git revert <commit>
  - Feature flags: None needed
  - Observable failure symptoms: list/search subcommands unavailable

  Risks and Mitigations

  None — purely additive, read-only, zero new dependencies.