### PR TITLE
fix: route heartbeat outputs to configured channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,9 @@ allowed_workspace_roots = []   # optional allowlist for workspace mount validati
 [heartbeat]
 enabled = false
 interval_minutes = 30
+message = "Check London time"     # optional fallback task when HEARTBEAT.md has no `- ` entries
+target = "telegram"               # optional announce channel: telegram, discord, slack, mattermost
+to = "123456789"                  # optional target recipient/chat/channel id
 
 [tunnel]
 provider = "none"              # "none", "cloudflare", "tailscale", "ngrok", "custom"

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2287,6 +2287,15 @@ pub struct HeartbeatConfig {
     pub enabled: bool,
     /// Interval in minutes between heartbeat pings. Default: `30`.
     pub interval_minutes: u32,
+    /// Optional fallback task text when `HEARTBEAT.md` has no task entries.
+    #[serde(default)]
+    pub message: Option<String>,
+    /// Optional delivery channel for heartbeat output (for example: `telegram`).
+    #[serde(default, alias = "channel")]
+    pub target: Option<String>,
+    /// Optional delivery recipient/chat identifier (required when `target` is set).
+    #[serde(default, alias = "recipient")]
+    pub to: Option<String>,
 }
 
 impl Default for HeartbeatConfig {
@@ -2294,6 +2303,9 @@ impl Default for HeartbeatConfig {
         Self {
             enabled: false,
             interval_minutes: 30,
+            message: None,
+            target: None,
+            to: None,
         }
     }
 }
@@ -4588,6 +4600,26 @@ mod tests {
         let h = HeartbeatConfig::default();
         assert!(!h.enabled);
         assert_eq!(h.interval_minutes, 30);
+        assert!(h.message.is_none());
+        assert!(h.target.is_none());
+        assert!(h.to.is_none());
+    }
+
+    #[test]
+    async fn heartbeat_config_parses_delivery_aliases() {
+        let raw = r#"
+enabled = true
+interval_minutes = 10
+message = "Ping"
+channel = "telegram"
+recipient = "42"
+"#;
+        let parsed: HeartbeatConfig = toml::from_str(raw).unwrap();
+        assert!(parsed.enabled);
+        assert_eq!(parsed.interval_minutes, 10);
+        assert_eq!(parsed.message.as_deref(), Some("Ping"));
+        assert_eq!(parsed.target.as_deref(), Some("telegram"));
+        assert_eq!(parsed.to.as_deref(), Some("42"));
     }
 
     #[test]
@@ -4697,6 +4729,9 @@ default_temperature = 0.7
             heartbeat: HeartbeatConfig {
                 enabled: true,
                 interval_minutes: 15,
+                message: Some("Check London time".into()),
+                target: Some("telegram".into()),
+                to: Some("123456".into()),
             },
             cron: CronConfig::default(),
             channels_config: ChannelsConfig {
@@ -4764,6 +4799,12 @@ default_temperature = 0.7
         assert_eq!(parsed.runtime.kind, "docker");
         assert!(parsed.heartbeat.enabled);
         assert_eq!(parsed.heartbeat.interval_minutes, 15);
+        assert_eq!(
+            parsed.heartbeat.message.as_deref(),
+            Some("Check London time")
+        );
+        assert_eq!(parsed.heartbeat.target.as_deref(), Some("telegram"));
+        assert_eq!(parsed.heartbeat.to.as_deref(), Some("123456"));
         assert!(parsed.channels_config.telegram.is_some());
         assert_eq!(
             parsed.channels_config.telegram.unwrap().bot_token,

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -296,6 +296,15 @@ async fn deliver_if_configured(config: &Config, job: &CronJob, output: &str) -> 
         .as_deref()
         .ok_or_else(|| anyhow::anyhow!("delivery.to is required for announce mode"))?;
 
+    deliver_announcement(config, channel, target, output).await
+}
+
+pub(crate) async fn deliver_announcement(
+    config: &Config,
+    channel: &str,
+    target: &str,
+    output: &str,
+) -> Result<()> {
     match channel.to_ascii_lowercase().as_str() {
         "telegram" => {
             let tg = config

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -181,6 +181,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
         config.workspace_dir.clone(),
         observer,
     );
+    let delivery = heartbeat_delivery_target(&config)?;
 
     let interval_mins = config.heartbeat.interval_minutes.max(5);
     let mut interval = tokio::time::interval(Duration::from_secs(u64::from(interval_mins) * 60));
@@ -188,7 +189,8 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
     loop {
         interval.tick().await;
 
-        let tasks = engine.collect_tasks().await?;
+        let file_tasks = engine.collect_tasks().await?;
+        let tasks = heartbeat_tasks_for_tick(file_tasks, config.heartbeat.message.as_deref());
         if tasks.is_empty() {
             continue;
         }
@@ -196,7 +198,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
         for task in tasks {
             let prompt = format!("[Heartbeat Task] {task}");
             let temp = config.default_temperature;
-            if let Err(e) = crate::agent::run(
+            match crate::agent::run(
                 config.clone(),
                 Some(prompt),
                 None,
@@ -207,13 +209,113 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
             )
             .await
             {
-                crate::health::mark_component_error("heartbeat", e.to_string());
-                tracing::warn!("Heartbeat task failed: {e}");
-            } else {
-                crate::health::mark_component_ok("heartbeat");
+                Ok(output) => {
+                    crate::health::mark_component_ok("heartbeat");
+                    let announcement = if output.trim().is_empty() {
+                        "heartbeat task executed".to_string()
+                    } else {
+                        output
+                    };
+                    if let Some((channel, target)) = &delivery {
+                        if let Err(e) = crate::cron::scheduler::deliver_announcement(
+                            &config,
+                            channel,
+                            target,
+                            &announcement,
+                        )
+                        .await
+                        {
+                            crate::health::mark_component_error(
+                                "heartbeat",
+                                format!("delivery failed: {e}"),
+                            );
+                            tracing::warn!("Heartbeat delivery failed: {e}");
+                        }
+                    }
+                }
+                Err(e) => {
+                    crate::health::mark_component_error("heartbeat", e.to_string());
+                    tracing::warn!("Heartbeat task failed: {e}");
+                }
             }
         }
     }
+}
+
+fn heartbeat_tasks_for_tick(
+    file_tasks: Vec<String>,
+    fallback_message: Option<&str>,
+) -> Vec<String> {
+    if !file_tasks.is_empty() {
+        return file_tasks;
+    }
+
+    fallback_message
+        .map(str::trim)
+        .filter(|message| !message.is_empty())
+        .map(|message| vec![message.to_string()])
+        .unwrap_or_default()
+}
+
+fn heartbeat_delivery_target(config: &Config) -> Result<Option<(String, String)>> {
+    let channel = config
+        .heartbeat
+        .target
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let target = config
+        .heartbeat
+        .to
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+
+    match (channel, target) {
+        (None, None) => Ok(None),
+        (Some(_), None) => anyhow::bail!("heartbeat.to is required when heartbeat.target is set"),
+        (None, Some(_)) => anyhow::bail!("heartbeat.target is required when heartbeat.to is set"),
+        (Some(channel), Some(target)) => {
+            validate_heartbeat_channel_config(config, channel)?;
+            Ok(Some((channel.to_string(), target.to_string())))
+        }
+    }
+}
+
+fn validate_heartbeat_channel_config(config: &Config, channel: &str) -> Result<()> {
+    match channel.to_ascii_lowercase().as_str() {
+        "telegram" => {
+            if config.channels_config.telegram.is_none() {
+                anyhow::bail!(
+                    "heartbeat.target is set to telegram but channels_config.telegram is not configured"
+                );
+            }
+        }
+        "discord" => {
+            if config.channels_config.discord.is_none() {
+                anyhow::bail!(
+                    "heartbeat.target is set to discord but channels_config.discord is not configured"
+                );
+            }
+        }
+        "slack" => {
+            if config.channels_config.slack.is_none() {
+                anyhow::bail!(
+                    "heartbeat.target is set to slack but channels_config.slack is not configured"
+                );
+            }
+        }
+        "mattermost" => {
+            if config.channels_config.mattermost.is_none() {
+                anyhow::bail!(
+                    "heartbeat.target is set to mattermost but channels_config.mattermost is not configured"
+                );
+            }
+        }
+        other => anyhow::bail!("unsupported heartbeat.target channel: {other}"),
+    }
+
+    Ok(())
 }
 
 fn has_supervised_channels(config: &Config) -> bool {
@@ -352,5 +454,91 @@ mod tests {
             allowed_users: vec!["*".into()],
         });
         assert!(has_supervised_channels(&config));
+    }
+
+    #[test]
+    fn heartbeat_tasks_use_file_tasks_when_available() {
+        let tasks =
+            heartbeat_tasks_for_tick(vec!["From file".to_string()], Some("Fallback from config"));
+        assert_eq!(tasks, vec!["From file".to_string()]);
+    }
+
+    #[test]
+    fn heartbeat_tasks_fall_back_to_config_message() {
+        let tasks = heartbeat_tasks_for_tick(vec![], Some("  check london time  "));
+        assert_eq!(tasks, vec!["check london time".to_string()]);
+    }
+
+    #[test]
+    fn heartbeat_tasks_ignore_empty_fallback_message() {
+        let tasks = heartbeat_tasks_for_tick(vec![], Some("   "));
+        assert!(tasks.is_empty());
+    }
+
+    #[test]
+    fn heartbeat_delivery_target_none_when_unset() {
+        let config = Config::default();
+        let target = heartbeat_delivery_target(&config).unwrap();
+        assert!(target.is_none());
+    }
+
+    #[test]
+    fn heartbeat_delivery_target_requires_to_field() {
+        let mut config = Config::default();
+        config.heartbeat.target = Some("telegram".into());
+        let err = heartbeat_delivery_target(&config).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("heartbeat.to is required when heartbeat.target is set"));
+    }
+
+    #[test]
+    fn heartbeat_delivery_target_requires_target_field() {
+        let mut config = Config::default();
+        config.heartbeat.to = Some("123456".into());
+        let err = heartbeat_delivery_target(&config).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("heartbeat.target is required when heartbeat.to is set"));
+    }
+
+    #[test]
+    fn heartbeat_delivery_target_rejects_unsupported_channel() {
+        let mut config = Config::default();
+        config.heartbeat.target = Some("email".into());
+        config.heartbeat.to = Some("ops@example.com".into());
+        let err = heartbeat_delivery_target(&config).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("unsupported heartbeat.target channel"));
+    }
+
+    #[test]
+    fn heartbeat_delivery_target_requires_channel_configuration() {
+        let mut config = Config::default();
+        config.heartbeat.target = Some("telegram".into());
+        config.heartbeat.to = Some("123456".into());
+        let err = heartbeat_delivery_target(&config).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("channels_config.telegram is not configured"));
+    }
+
+    #[test]
+    fn heartbeat_delivery_target_accepts_telegram_configuration() {
+        let mut config = Config::default();
+        config.heartbeat.target = Some("telegram".into());
+        config.heartbeat.to = Some("123456".into());
+        config.channels_config.telegram = Some(crate::config::TelegramConfig {
+            bot_token: "bot-token".into(),
+            allowed_users: vec![],
+            stream_mode: crate::config::StreamMode::default(),
+            draft_update_interval_ms: 1000,
+            interrupt_on_new_message: false,
+            mention_only: false,
+        });
+
+        let target = heartbeat_delivery_target(&config).unwrap();
+        assert_eq!(target, Some(("telegram".to_string(), "123456".to_string())));
     }
 }

--- a/src/heartbeat/engine.rs
+++ b/src/heartbeat/engine.rs
@@ -248,6 +248,7 @@ mod tests {
             HeartbeatConfig {
                 enabled: true,
                 interval_minutes: 30,
+                ..HeartbeatConfig::default()
             },
             dir.clone(),
             observer,
@@ -273,6 +274,7 @@ mod tests {
             HeartbeatConfig {
                 enabled: true,
                 interval_minutes: 30,
+                ..HeartbeatConfig::default()
             },
             dir.clone(),
             observer,
@@ -290,6 +292,7 @@ mod tests {
             HeartbeatConfig {
                 enabled: false,
                 interval_minutes: 30,
+                ..HeartbeatConfig::default()
             },
             std::env::temp_dir(),
             observer,


### PR DESCRIPTION
## Summary
- add heartbeat delivery fields (`message`, `target`, `to`) to `HeartbeatConfig` with backward-compatible aliases
- route heartbeat agent output through channel delivery (telegram/discord/slack/mattermost) using shared cron delivery logic
- add fallback behavior so heartbeat runs `heartbeat.message` when `HEARTBEAT.md` has no task bullets
- validate heartbeat delivery config at runtime startup (`target/to` pairing, supported channel, channel configured)
- document the new heartbeat options in README

## Validation
- `cargo fmt --all`
- `rustup run stable cargo test --locked`
- `rustup run stable ./scripts/ci/rust_quality_gate.sh`
- `BASE_SHA=2c57c89f9ebe53e40518d38b1f8f8492fa2c7b95 rustup run stable ./scripts/ci/rust_strict_delta_gate.sh`

Closes #1415
