### PR TITLE
fix(gemini): derive OAuth refresh client id from Gemini CLI token

### DIFF
--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -7,6 +7,7 @@
 use crate::auth::AuthService;
 use crate::providers::traits::{ChatMessage, ChatResponse, Provider, TokenUsage};
 use async_trait::async_trait;
+use base64::Engine;
 use directories::UserDirs;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -251,10 +252,15 @@ impl GenerateContentResponse {
 #[derive(Debug, Deserialize)]
 struct GeminiCliOAuthCreds {
     access_token: Option<String>,
+    #[serde(alias = "idToken")]
+    id_token: Option<String>,
     refresh_token: Option<String>,
+    #[serde(alias = "clientId")]
     client_id: Option<String>,
+    #[serde(alias = "clientSecret")]
     client_secret: Option<String>,
     /// Unix milliseconds expiry (used by newer Gemini CLI versions).
+    #[serde(alias = "expiryDate")]
     expiry_date: Option<i64>,
     /// RFC 3339 expiry string (used by older Gemini CLI versions).
     expiry: Option<String>,
@@ -305,16 +311,7 @@ fn refresh_gemini_cli_token(
         .build()
         .unwrap_or_else(|_| reqwest::blocking::Client::new());
 
-    let mut form: Vec<(&str, String)> = vec![
-        ("grant_type", "refresh_token".to_string()),
-        ("refresh_token", refresh_token.to_string()),
-    ];
-    if let Some(id) = client_id.and_then(GeminiProvider::normalize_non_empty) {
-        form.push(("client_id", id));
-    }
-    if let Some(secret) = client_secret.and_then(GeminiProvider::normalize_non_empty) {
-        form.push(("client_secret", secret));
-    }
+    let form = build_oauth_refresh_form(refresh_token, client_id, client_secret);
 
     let response = client
         .post(GOOGLE_TOKEN_ENDPOINT)
@@ -359,6 +356,50 @@ fn refresh_gemini_cli_token(
         access_token,
         expiry_millis,
     })
+}
+
+fn build_oauth_refresh_form(
+    refresh_token: &str,
+    client_id: Option<&str>,
+    client_secret: Option<&str>,
+) -> Vec<(&'static str, String)> {
+    let mut form = vec![
+        ("grant_type", "refresh_token".to_string()),
+        ("refresh_token", refresh_token.to_string()),
+    ];
+    if let Some(id) = client_id.and_then(GeminiProvider::normalize_non_empty) {
+        form.push(("client_id", id));
+    }
+    if let Some(secret) = client_secret.and_then(GeminiProvider::normalize_non_empty) {
+        form.push(("client_secret", secret));
+    }
+    form
+}
+
+fn extract_client_id_from_id_token(id_token: &str) -> Option<String> {
+    let payload = id_token.split('.').nth(1)?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(payload))
+        .ok()?;
+
+    #[derive(Deserialize)]
+    struct IdTokenClaims {
+        aud: Option<String>,
+        azp: Option<String>,
+    }
+
+    let claims: IdTokenClaims = serde_json::from_slice(&decoded).ok()?;
+    claims
+        .aud
+        .as_deref()
+        .and_then(GeminiProvider::normalize_non_empty)
+        .or_else(|| {
+            claims
+                .azp
+                .as_deref()
+                .and_then(GeminiProvider::normalize_non_empty)
+        })
 }
 
 /// Async version of token refresh for use during runtime (inside tokio context).
@@ -565,12 +606,19 @@ impl GeminiProvider {
             .access_token
             .and_then(|token| Self::normalize_non_empty(&token))?;
 
-        let client_id = Self::load_non_empty_env("GEMINI_OAUTH_CLIENT_ID").or_else(|| {
-            creds
-                .client_id
-                .as_deref()
-                .and_then(Self::normalize_non_empty)
-        });
+        let id_token_client_id = creds
+            .id_token
+            .as_deref()
+            .and_then(extract_client_id_from_id_token);
+
+        let client_id = Self::load_non_empty_env("GEMINI_OAUTH_CLIENT_ID")
+            .or_else(|| {
+                creds
+                    .client_id
+                    .as_deref()
+                    .and_then(Self::normalize_non_empty)
+            })
+            .or(id_token_client_id);
         let client_secret = Self::load_non_empty_env("GEMINI_OAUTH_CLIENT_SECRET").or_else(|| {
             creds
                 .client_secret
@@ -1290,6 +1338,84 @@ mod tests {
     }
 
     #[test]
+    fn oauth_refresh_form_uses_provided_client_credentials() {
+        let form = build_oauth_refresh_form("refresh-token", Some("client-id"), Some("secret"));
+        let map: std::collections::HashMap<_, _> = form.into_iter().collect();
+        assert_eq!(map.get("grant_type"), Some(&"refresh_token".to_string()));
+        assert_eq!(map.get("refresh_token"), Some(&"refresh-token".to_string()));
+        assert_eq!(map.get("client_id"), Some(&"client-id".to_string()));
+        assert_eq!(map.get("client_secret"), Some(&"secret".to_string()));
+    }
+
+    #[test]
+    fn oauth_refresh_form_omits_client_credentials_when_missing() {
+        let form = build_oauth_refresh_form("refresh-token", None, None);
+        let map: std::collections::HashMap<_, _> = form.into_iter().collect();
+        assert!(map.get("client_id").is_none());
+        assert!(map.get("client_secret").is_none());
+    }
+
+    #[test]
+    fn extract_client_id_from_id_token_prefers_aud_claim() {
+        let payload = serde_json::json!({
+            "aud": "aud-client-id",
+            "azp": "azp-client-id"
+        });
+        let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&payload).unwrap());
+        let token = format!("header.{payload_b64}.sig");
+
+        assert_eq!(
+            extract_client_id_from_id_token(&token),
+            Some("aud-client-id".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_client_id_from_id_token_uses_azp_when_aud_missing() {
+        let payload = serde_json::json!({
+            "azp": "azp-client-id"
+        });
+        let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&payload).unwrap());
+        let token = format!("header.{payload_b64}.sig");
+
+        assert_eq!(
+            extract_client_id_from_id_token(&token),
+            Some("azp-client-id".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_client_id_from_id_token_returns_none_for_invalid_tokens() {
+        assert_eq!(extract_client_id_from_id_token("invalid"), None);
+        assert_eq!(extract_client_id_from_id_token("a.b.c"), None);
+    }
+
+    #[test]
+    fn try_load_cli_token_derives_client_id_from_id_token_when_missing() {
+        let payload = serde_json::json!({ "aud": "derived-client-id" });
+        let payload_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&payload).unwrap());
+        let id_token = format!("header.{payload_b64}.sig");
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let json = format!(
+            r#"{{
+                "access_token": "ya29.test-access",
+                "refresh_token": "1//test-refresh",
+                "id_token": "{id_token}"
+            }}"#
+        );
+        std::fs::write(file.path(), json).unwrap();
+
+        let path = file.path().to_path_buf();
+        let state = GeminiProvider::try_load_gemini_cli_token(Some(&path)).unwrap();
+        assert_eq!(state.client_id.as_deref(), Some("derived-client-id"));
+        assert_eq!(state.client_secret, None);
+    }
+
+    #[test]
     fn provider_creates_without_key() {
         let provider = GeminiProvider::new(None);
         // May pick up env vars; just verify it doesn't panic
@@ -1654,6 +1780,24 @@ mod tests {
         assert_eq!(creds.refresh_token.as_deref(), Some("1//test-refresh"));
         assert_eq!(creds.expiry_date, Some(4102444800000));
         assert!(creds.expiry.is_none());
+    }
+
+    #[test]
+    fn creds_deserialize_accepts_camel_case_fields() {
+        let json = r#"{
+            "access_token": "ya29.test-token",
+            "idToken": "header.payload.sig",
+            "refresh_token": "1//test-refresh",
+            "clientId": "test-client-id",
+            "clientSecret": "test-client-secret",
+            "expiryDate": 4102444800000
+        }"#;
+
+        let creds: GeminiCliOAuthCreds = serde_json::from_str(json).unwrap();
+        assert_eq!(creds.id_token.as_deref(), Some("header.payload.sig"));
+        assert_eq!(creds.client_id.as_deref(), Some("test-client-id"));
+        assert_eq!(creds.client_secret.as_deref(), Some("test-client-secret"));
+        assert_eq!(creds.expiry_date, Some(4102444800000));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- fix Gemini CLI OAuth refresh when `oauth_creds.json` omits `client_id`/`client_secret`
- derive fallback `client_id` from `id_token` claims (`aud` then `azp`) instead of hardcoded OAuth literals
- keep env/file credential precedence and expand serde aliases for camelCase Gemini CLI fields
- add regression tests for refresh-form behavior, `id_token` parsing edge cases, and token-state loading

## Root Cause
ZeroClaw attempted token refresh without a resolvable `client_id` when Gemini CLI credentials lacked explicit client fields. Google OAuth refresh then returned HTTP 400 `invalid_request` with `Could not determine client ID from request`.

## Testing
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/zc1424-target cargo test --lib providers::gemini::tests:: -- --nocapture`

Closes #1424
