### PR TITLE
feat(providers): add Gemini Advanced subscription support and gemini-…

### DIFF
--- a/docs/providers-reference.md
+++ b/docs/providers-reference.md
@@ -31,6 +31,7 @@ credential is not reused for fallback providers.
 | `openai` | — | No | `OPENAI_API_KEY` |
 | `ollama` | — | Yes | `OLLAMA_API_KEY` (optional) |
 | `gemini` | `google`, `google-gemini` | No | `GEMINI_API_KEY`, `GOOGLE_API_KEY` |
+| `gemini-advanced` | `gemini-sub` | No | (subscription OAuth via `zeroclaw auth login --provider gemini`) |
 | `venice` | — | No | `VENICE_API_KEY` |
 | `vercel` | `vercel-ai` | No | `VERCEL_API_KEY` |
 | `cloudflare` | `cloudflare-ai` | No | `CLOUDFLARE_API_KEY` |
@@ -76,6 +77,29 @@ credential is not reused for fallback providers.
 - API key requests use `generativelanguage.googleapis.com/v1beta`
 - Gemini CLI OAuth requests use `cloudcode-pa.googleapis.com/v1internal` with Code Assist request envelope semantics
 - Thinking models (e.g. `gemini-3-pro-preview`) are supported — internal reasoning parts are automatically filtered from the response
+
+### Gemini Advanced Notes (Subscription OAuth)
+
+- Provider ID: `gemini-advanced` (alias: `gemini-sub`)
+- Designed for users with a Google One AI Premium subscription (Gemini Advanced)
+- No API key required — authentication uses managed OAuth via `zeroclaw auth login --provider gemini`
+- Uses the same underlying `cloudcode-pa.googleapis.com/v1internal` endpoint as Gemini CLI OAuth
+- Default model: `gemini-3.1-pro`
+- Available models: `gemini-3.1-pro`, `gemini-3-pro-preview`, `gemini-2.5-pro`
+- OAuth profile is shared with the `gemini` provider (auth-profiles.json)
+
+Setup:
+
+```bash
+zeroclaw auth login --provider gemini
+```
+
+Config example:
+
+```toml
+default_provider = "gemini-advanced"
+default_model = "gemini-3.1-pro"
+```
 
 ### Ollama Vision Notes
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -349,7 +349,9 @@ pub fn normalize_provider(provider: &str) -> Result<String> {
     match normalized.as_str() {
         "openai-codex" | "openai_codex" | "codex" => Ok(OPENAI_CODEX_PROVIDER.to_string()),
         "anthropic" | "claude" | "claude-code" => Ok(ANTHROPIC_PROVIDER.to_string()),
-        "gemini" | "google" | "vertex" => Ok(GEMINI_PROVIDER.to_string()),
+        "gemini" | "google" | "vertex" | "gemini-advanced" | "gemini-sub" => {
+            Ok(GEMINI_PROVIDER.to_string())
+        }
         other if !other.is_empty() => Ok(other.to_string()),
         _ => anyhow::bail!("Provider name cannot be empty"),
     }

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -627,6 +627,7 @@ fn canonical_provider_name(provider_name: &str) -> &str {
         "grok" => "xai",
         "together" => "together-ai",
         "google" | "google-gemini" => "gemini",
+        "gemini-sub" => "gemini-advanced",
         "kimi_coding" | "kimi_for_coding" => "kimi-code",
         "nvidia-nim" | "build.nvidia.com" => "nvidia",
         "aws-bedrock" => "bedrock",
@@ -682,6 +683,7 @@ fn default_model_for_provider(provider: &str) -> String {
         "llamacpp" => "ggml-org/gpt-oss-20b-GGUF".into(),
         "sglang" | "vllm" | "osaurus" => "default".into(),
         "gemini" => "gemini-2.5-pro".into(),
+        "gemini-advanced" => "gemini-3.1-pro".into(),
         "kimi-code" => "kimi-for-coding".into(),
         "bedrock" => "anthropic.claude-sonnet-4-5-20250929-v1:0".into(),
         "nvidia" => "meta/llama-3.3-70b-instruct".into(),
@@ -1090,6 +1092,20 @@ fn curated_models_for_provider(provider_name: &str) -> Vec<(String, String)> {
             (
                 "gemini-2.5-flash-lite".to_string(),
                 "Gemini 2.5 Flash-Lite (lowest cost)".to_string(),
+            ),
+        ],
+        "gemini-advanced" => vec![
+            (
+                "gemini-3.1-pro".to_string(),
+                "Gemini 3.1 Pro (subscription, recommended)".to_string(),
+            ),
+            (
+                "gemini-3-pro-preview".to_string(),
+                "Gemini 3 Pro Preview (latest frontier reasoning)".to_string(),
+            ),
+            (
+                "gemini-2.5-pro".to_string(),
+                "Gemini 2.5 Pro (stable reasoning)".to_string(),
             ),
         ],
         _ => vec![("default".to_string(), "Default model".to_string())],
@@ -1936,6 +1952,10 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
                 "gemini",
                 "Google Gemini — Gemini 2.0 Flash & Pro (supports CLI auth)",
             ),
+            (
+                "gemini-advanced",
+                "Google Gemini Advanced — Gemini 3.1 Pro (subscription OAuth, no API key)",
+            ),
         ],
         1 => vec![
             ("groq", "Groq — ultra-fast LPU inference"),
@@ -2219,6 +2239,16 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
         }
 
         key
+    } else if canonical_provider_name(provider_name) == "gemini-advanced" {
+        // Gemini Advanced subscription: uses managed OAuth, no API key required
+        print_bullet(&format!(
+            "{} Google Gemini Advanced uses subscription OAuth — no API key needed.",
+            style("ℹ").blue().bold()
+        ));
+        print_bullet("Run: zeroclaw auth login --provider gemini");
+        print_bullet("This will authenticate using your Google account with Gemini Advanced.");
+        println!();
+        String::new() // Empty key — authentication is handled via OAuth profile
     } else if canonical_provider_name(provider_name) == "gemini" {
         // Special handling for Gemini: check for CLI auth first
         if crate::providers::gemini::GeminiProvider::has_cli_credentials() {
@@ -2667,6 +2697,7 @@ fn provider_env_var(name: &str) -> &'static str {
         "cloudflare" | "cloudflare-ai" => "CLOUDFLARE_API_KEY",
         "bedrock" | "aws-bedrock" => "AWS_ACCESS_KEY_ID",
         "gemini" => "GEMINI_API_KEY",
+        "gemini-advanced" => "GEMINI_API_KEY",
         "nvidia" | "nvidia-nim" | "build.nvidia.com" => "NVIDIA_API_KEY",
         "astrai" => "ASTRAI_API_KEY",
         _ => "API_KEY",

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -962,7 +962,7 @@ fn create_provider_with_url_and_options(
             key,
             options.reasoning_enabled,
         ))),
-        "gemini" | "google" | "google-gemini" => {
+        "gemini" | "google" | "google-gemini" | "gemini-advanced" | "gemini-sub" => {
             let state_dir = options
                 .zeroclaw_dir
                 .clone()
@@ -1480,6 +1480,12 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             aliases: &["google", "google-gemini"],
             local: false,
         },
+        ProviderInfo {
+            name: "gemini-advanced",
+            display_name: "Google Gemini Advanced (Subscription OAuth)",
+            aliases: &["gemini-sub"],
+            local: false,
+        },
         // ── OpenAI-compatible providers ──────────────────────
         ProviderInfo {
             name: "venice",
@@ -1987,6 +1993,15 @@ mod tests {
         assert!(create_provider("google-gemini", Some("test-key")).is_ok());
         // Should also work without key (will try CLI auth)
         assert!(create_provider("gemini", None).is_ok());
+    }
+
+    #[test]
+    fn factory_gemini_advanced() {
+        // Subscription provider: works with managed OAuth (no key required)
+        assert!(create_provider("gemini-advanced", None).is_ok());
+        assert!(create_provider("gemini-sub", None).is_ok());
+        // Also accepts an explicit key for API-key based access
+        assert!(create_provider("gemini-advanced", Some("test-key")).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
…3.1-pro model

Adds `gemini-advanced` (alias: `gemini-sub`) as a dedicated provider ID for users accessing Gemini through a Google One AI Premium subscription. The subscription flow uses managed OAuth (no API key required) via `zeroclaw auth login --provider gemini`, sharing the same auth-profile store as the `gemini` provider.

Changes:
- providers/mod.rs: register `gemini-advanced` and `gemini-sub` in factory (delegates to GeminiProvider::new_with_auth); add ProviderInfo entry; add factory test
- auth/mod.rs: normalize `gemini-advanced` and `gemini-sub` to GEMINI_PROVIDER in normalize_provider()
- onboard/wizard.rs: add gemini-advanced to provider selection list; add subscription OAuth key-prompt branch (no API key needed); add default model `gemini-3.1-pro`; add curated model list for gemini-advanced; normalize `gemini-sub` alias to canonical
- docs/providers-reference.md: add gemini-advanced to provider catalog; add Gemini Advanced Notes section with setup instructions

https://claude.ai/code/session_016tUTbC5vXeXAtmt2Gt3bLU

## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion):
- Problem:
- Why it matters:
- What changed:
- What did **not** change (scope boundary):

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`):
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`):
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`):
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- File system access scope changed? (`Yes/No`)
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`)
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any):
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
  - Mitigation:
