### PR TITLE
feat(nix): add nix package to build zeroclaw

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     nixpkgs.url = "nixpkgs/nixos-unstable";
   };
 
-  outputs = { flake-utils, fenix, nixpkgs, ... }:
+  outputs = { self, flake-utils, fenix, nixpkgs, ... }:
     let
       nixosModule = { pkgs, ... }: {
         nixpkgs.overlays = [ fenix.overlays.default ];
@@ -37,8 +37,20 @@
           "rustc"
           "rustfmt"
         ];
+        zeroclaw = pkgs.rustPlatform.buildRustPackage {
+          pname = "zeroclaw";
+          version = (pkgs.lib.importTOML ./Cargo.toml).package.version;
+          src = self;
+          doCheck = false;
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+        };
       in {
-        packages.default = fenix.packages.${system}.stable.toolchain;
+        packages = {
+          default = zeroclaw;
+          zeroclaw = zeroclaw;
+        };
         devShells.default = pkgs.mkShell {
           packages = [
             rustToolchain


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): dev
- Problem: a Nix flake was added in #897 but primarily to create a dev shell (basically a Nix container that has all the dependencies needed for a developer to work on the project). a Nix flake can also package the actual software so that others using Nix can inherit it. this PR adds that package.
- Why it matters: it makes it easy to build and install as system software on Nix-based systems
- What changed: basic Rust packaging common to Nix was used to setup a package and export it from the flake
- What did **not** change (scope boundary): anything related to the app or its normal Rust packaging; only Nix was affected

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): core, dependencies, dev, ci
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): config: nix
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): feature
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): multi

## Linked Issue

- Closes #
- Related #
- Depends on #897  
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`) N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`) N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): See below
- If any command is intentionally skipped, explain why: No Rust files were changed

```
commit fab1eee4576bad505646a384726dbcd475bd7e25 (HEAD -> nix-flake-package, fork/nix-flake-package)
Author: slimepop6 <>
Date:   Sun Feb 22 02:04:06 2026 -0800

    feat(nix): add nix package to build zeroclaw

 flake.nix | 17 +++++++++++++++--
 1 file changed, 15 insertions(+), 2 deletions(-)
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- New external network calls? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- File system access scope changed? (`Yes/No`) No
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: No sensitive data added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`) No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`) N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`) N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`) N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Nix package can be built `nix build .#`, ran `nix run .#`, and imported into another flake and added to a system `inputs.zeroclaw.packages.x86_64-linux.zeroclaw`
- Edge cases checked: None other than noted scenarios
- What was not verified: Zeroclaw behavior (because no source files in Rust were changed)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Nix packaging
- Potential unintended effects: Maaaaaybe it increases reviewer burden if a lot of people start submitting Nix module files to make it easier to configure on Nix systems? Not really sure otherwise 
- Guardrails/monitoring for early detection: 

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Cursor
- Workflow/plan summary (if any): Agent was told to build a Rust package into the Nix flake. I manually edited the code to source the version and Cargo.lock automatically to prevent desync between Cargo.toml/Cargo.lock and flake.nix.
- Verification focus: Manually running in terminal
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Most of this was done manually, and those docs are huge, but I believe I have followed them

## Rollback Plan (required)

- Fast rollback command/path: Revert this PR
- Feature flags or config toggles (if any): N/A
- Observable failure symptoms: Nix flake fails to build

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: None
  - Mitigation: None
