### PR TITLE
feat(tools): add Perplexity Search API as web search provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,3 +117,8 @@ PROVIDER=openrouter
 # Optional: Brave Search (requires API key from https://brave.com/search/api)
 # WEB_SEARCH_PROVIDER=brave
 # BRAVE_API_KEY=your-brave-search-api-key
+#
+# Optional: Perplexity Search (requires API key from https://www.perplexity.ai/settings/api)
+# Note: PERPLEXITY_API_KEY is shared with the Perplexity LLM provider above.
+# WEB_SEARCH_PROVIDER=perplexity
+# PERPLEXITY_API_KEY=pplx-...

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -312,6 +312,43 @@ Notes:
 - Use exact domain or subdomain matching (e.g. `"api.example.com"`, `"example.com"`), or `"*"` to allow any public domain.
 - Local/private targets are still blocked even when `"*"` is configured.
 
+## `[web_search]`
+
+| Key | Default | Purpose |
+|---|---|---|
+| `enabled` | `false` | Enable `web_search_tool` for web searches |
+| `provider` | `"duckduckgo"` | Search provider: `"duckduckgo"`, `"brave"`, or `"perplexity"` |
+| `brave_api_key` | — | Brave Search API key (required if `provider = "brave"`) |
+| `perplexity_api_key` | — | Perplexity Search API key (required if `provider = "perplexity"`) |
+| `max_results` | `5` | Maximum results per search (1–10) |
+| `timeout_secs` | `15` | Request timeout in seconds |
+
+Environment variable overrides:
+
+| Variable (preferred) | Fallback | Field |
+|---|---|---|
+| `ZEROCLAW_WEB_SEARCH_PROVIDER` | `WEB_SEARCH_PROVIDER` | `provider` |
+| `ZEROCLAW_BRAVE_API_KEY` | `BRAVE_API_KEY` | `brave_api_key` |
+| `ZEROCLAW_PERPLEXITY_API_KEY` | `PERPLEXITY_API_KEY` | `perplexity_api_key` |
+| `ZEROCLAW_WEB_SEARCH_MAX_RESULTS` | `WEB_SEARCH_MAX_RESULTS` | `max_results` |
+| `ZEROCLAW_WEB_SEARCH_TIMEOUT_SECS` | `WEB_SEARCH_TIMEOUT_SECS` | `timeout_secs` |
+
+Notes:
+
+- `duckduckgo` is free and requires no API key.
+- `brave` requires a key from <https://brave.com/search/api>. Returns structured results (title, URL, description).
+- `perplexity` requires a key from <https://www.perplexity.ai/settings/api>. Uses `POST /search` and returns structured results (title, URL, snippet). The `PERPLEXITY_API_KEY` env var is shared with the Perplexity LLM provider.
+- API keys are encrypted at rest via `SecretStore`.
+
+```toml
+[web_search]
+enabled = true
+provider = "perplexity"
+perplexity_api_key = "pplx-..."  # encrypted at rest
+max_results = 5
+timeout_secs = 15
+```
+
 ## `[gateway]`
 
 | Key | Default | Purpose |

--- a/docs/i18n/vi/langgraph-integration.md
+++ b/docs/i18n/vi/langgraph-integration.md
@@ -85,7 +85,7 @@ asyncio.run(main())
 
 | Tool | Mô tả |
 |------|-------|
-| `web_search` | Tìm kiếm web (yêu cầu `BRAVE_API_KEY`) |
+| `web_search` | Tìm kiếm web (DuckDuckGo miễn phí; hoặc `BRAVE_API_KEY` / `PERPLEXITY_API_KEY`) |
 | `http_request` | Thực hiện HTTP request |
 | `memory_store` | Lưu dữ liệu vào bộ nhớ lâu dài |
 | `memory_recall` | Truy xuất dữ liệu đã lưu |
@@ -179,7 +179,8 @@ bot.run()
 ```bash
 # Set environment variables
 export API_KEY="your-key"
-export BRAVE_API_KEY="your-brave-key"  # Optional, for web search
+export BRAVE_API_KEY="your-brave-key"          # Tùy chọn, cho Brave web search
+export PERPLEXITY_API_KEY="your-perplexity-key"  # Tùy chọn, cho Perplexity web search
 
 # Single message
 zeroclaw-tools "What is the current date?"

--- a/docs/langgraph-integration.md
+++ b/docs/langgraph-integration.md
@@ -85,7 +85,7 @@ asyncio.run(main())
 
 | Tool | Description |
 |------|-------------|
-| `web_search` | Search the web (requires `BRAVE_API_KEY`) |
+| `web_search` | Search the web (DuckDuckGo free; or `BRAVE_API_KEY` / `PERPLEXITY_API_KEY`) |
 | `http_request` | Make HTTP requests |
 | `memory_store` | Store data in persistent memory |
 | `memory_recall` | Recall stored data |
@@ -179,7 +179,8 @@ bot.run()
 ```bash
 # Set environment variables
 export API_KEY="your-key"
-export BRAVE_API_KEY="your-brave-key"  # Optional, for web search
+export BRAVE_API_KEY="your-brave-key"          # Optional, for Brave web search
+export PERPLEXITY_API_KEY="your-perplexity-key"  # Optional, for Perplexity web search
 
 # Single message
 zeroclaw-tools "What is the current date?"

--- a/docs/vi/langgraph-integration.md
+++ b/docs/vi/langgraph-integration.md
@@ -85,7 +85,7 @@ asyncio.run(main())
 
 | Tool | Mô tả |
 |------|-------|
-| `web_search` | Tìm kiếm web (yêu cầu `BRAVE_API_KEY`) |
+| `web_search` | Tìm kiếm web (DuckDuckGo miễn phí; hoặc `BRAVE_API_KEY` / `PERPLEXITY_API_KEY`) |
 | `http_request` | Thực hiện HTTP request |
 | `memory_store` | Lưu dữ liệu vào bộ nhớ lâu dài |
 | `memory_recall` | Truy xuất dữ liệu đã lưu |
@@ -179,7 +179,8 @@ bot.run()
 ```bash
 # Set environment variables
 export API_KEY="your-key"
-export BRAVE_API_KEY="your-brave-key"  # Optional, for web search
+export BRAVE_API_KEY="your-brave-key"          # Tùy chọn, cho Brave web search
+export PERPLEXITY_API_KEY="your-perplexity-key"  # Tùy chọn, cho Perplexity web search
 
 # Single message
 zeroclaw-tools "What is the current date?"

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1027,12 +1027,16 @@ pub struct WebSearchConfig {
     /// Enable `web_search_tool` for web searches
     #[serde(default)]
     pub enabled: bool,
-    /// Search provider: "duckduckgo" (free, no API key) or "brave" (requires API key)
+    /// Search provider: "duckduckgo" (free, no API key), "brave" (requires API key),
+    /// or "perplexity" (requires API key)
     #[serde(default = "default_web_search_provider")]
     pub provider: String,
     /// Brave Search API key (required if provider is "brave")
     #[serde(default)]
     pub brave_api_key: Option<String>,
+    /// Perplexity Search API key (required if provider is "perplexity")
+    #[serde(default)]
+    pub perplexity_api_key: Option<String>,
     /// Maximum results per search (1-10)
     #[serde(default = "default_web_search_max_results")]
     pub max_results: usize,
@@ -1059,6 +1063,7 @@ impl Default for WebSearchConfig {
             enabled: false,
             provider: default_web_search_provider(),
             brave_api_key: None,
+            perplexity_api_key: None,
             max_results: default_web_search_max_results(),
             timeout_secs: default_web_search_timeout_secs(),
         }
@@ -3858,6 +3863,12 @@ impl Config {
 
             decrypt_optional_secret(
                 &store,
+                &mut config.web_search.perplexity_api_key,
+                "config.web_search.perplexity_api_key",
+            )?;
+
+            decrypt_optional_secret(
+                &store,
                 &mut config.storage.provider.config.db_url,
                 "config.storage.provider.config.db_url",
             )?;
@@ -4197,6 +4208,16 @@ impl Config {
             }
         }
 
+        // Perplexity API key: ZEROCLAW_PERPLEXITY_API_KEY or PERPLEXITY_API_KEY
+        if let Ok(api_key) = std::env::var("ZEROCLAW_PERPLEXITY_API_KEY")
+            .or_else(|_| std::env::var("PERPLEXITY_API_KEY"))
+        {
+            let api_key = api_key.trim();
+            if !api_key.is_empty() {
+                self.web_search.perplexity_api_key = Some(api_key.to_string());
+            }
+        }
+
         // Web search max results: ZEROCLAW_WEB_SEARCH_MAX_RESULTS or WEB_SEARCH_MAX_RESULTS
         if let Ok(max_results) = std::env::var("ZEROCLAW_WEB_SEARCH_MAX_RESULTS")
             .or_else(|_| std::env::var("WEB_SEARCH_MAX_RESULTS"))
@@ -4339,6 +4360,12 @@ impl Config {
             &store,
             &mut config_to_save.web_search.brave_api_key,
             "config.web_search.brave_api_key",
+        )?;
+
+        encrypt_optional_secret(
+            &store,
+            &mut config_to_save.web_search.perplexity_api_key,
+            "config.web_search.perplexity_api_key",
         )?;
 
         encrypt_optional_secret(

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -271,6 +271,7 @@ pub fn all_tools_with_runtime(
         tool_arcs.push(Arc::new(WebSearchTool::new(
             root_config.web_search.provider.clone(),
             root_config.web_search.brave_api_key.clone(),
+            root_config.web_search.perplexity_api_key.clone(),
             root_config.web_search.max_results,
             root_config.web_search.timeout_secs,
         )));

--- a/src/tools/web_search_tool.rs
+++ b/src/tools/web_search_tool.rs
@@ -5,10 +5,12 @@ use serde_json::json;
 use std::time::Duration;
 
 /// Web search tool for searching the internet.
-/// Supports multiple providers: DuckDuckGo (free), Brave (requires API key).
+/// Supports multiple providers: DuckDuckGo (free), Brave (requires API key),
+/// Perplexity (requires API key).
 pub struct WebSearchTool {
     provider: String,
     brave_api_key: Option<String>,
+    perplexity_api_key: Option<String>,
     max_results: usize,
     timeout_secs: u64,
 }
@@ -17,12 +19,14 @@ impl WebSearchTool {
     pub fn new(
         provider: String,
         brave_api_key: Option<String>,
+        perplexity_api_key: Option<String>,
         max_results: usize,
         timeout_secs: u64,
     ) -> Self {
         Self {
             provider: provider.trim().to_lowercase(),
             brave_api_key,
+            perplexity_api_key,
             max_results: max_results.clamp(1, 10),
             timeout_secs: timeout_secs.max(1),
         }
@@ -162,6 +166,74 @@ impl WebSearchTool {
 
         Ok(lines.join("\n"))
     }
+
+    async fn search_perplexity(&self, query: &str) -> anyhow::Result<String> {
+        let api_key = self
+            .perplexity_api_key
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Perplexity API key not configured"))?;
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(self.timeout_secs))
+            .build()?;
+
+        let body = serde_json::json!({
+            "query": query,
+            "max_results": self.max_results,
+        });
+
+        let response = client
+            .post("https://api.perplexity.ai/search")
+            .header("Accept", "application/json")
+            .header("Authorization", format!("Bearer {}", api_key))
+            .json(&body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            anyhow::bail!(
+                "Perplexity search failed with status: {}",
+                response.status()
+            );
+        }
+
+        let json: serde_json::Value = response.json().await?;
+        self.parse_perplexity_results(&json, query)
+    }
+
+    fn parse_perplexity_results(
+        &self,
+        json: &serde_json::Value,
+        query: &str,
+    ) -> anyhow::Result<String> {
+        let results = json
+            .get("results")
+            .and_then(|r| r.as_array())
+            .ok_or_else(|| anyhow::anyhow!("Invalid Perplexity API response"))?;
+
+        if results.is_empty() {
+            return Ok(format!("No results found for: {}", query));
+        }
+
+        let mut lines = vec![format!("Search results for: {} (via Perplexity)", query)];
+
+        for (i, result) in results.iter().take(self.max_results).enumerate() {
+            let title = result
+                .get("title")
+                .and_then(|t| t.as_str())
+                .unwrap_or("No title");
+            let url = result.get("url").and_then(|u| u.as_str()).unwrap_or("");
+            let snippet = result.get("snippet").and_then(|s| s.as_str()).unwrap_or("");
+
+            lines.push(format!("{}. {}", i + 1, title));
+            lines.push(format!("   {}", url));
+            if !snippet.is_empty() {
+                lines.push(format!("   {}", snippet));
+            }
+        }
+
+        Ok(lines.join("\n"))
+    }
 }
 
 fn decode_ddg_redirect_url(raw_url: &str) -> String {
@@ -219,8 +291,9 @@ impl Tool for WebSearchTool {
         let result = match self.provider.as_str() {
             "duckduckgo" | "ddg" => self.search_duckduckgo(query).await?,
             "brave" => self.search_brave(query).await?,
+            "perplexity" => self.search_perplexity(query).await?,
             _ => anyhow::bail!(
-                "Unknown search provider: '{}'. Set tools.web_search.provider to 'duckduckgo' or 'brave' in config.toml",
+                "Unknown search provider: '{}'. Set tools.web_search.provider to 'duckduckgo', 'brave', or 'perplexity' in config.toml",
                 self.provider
             ),
         };
@@ -239,19 +312,19 @@ mod tests {
 
     #[test]
     fn test_tool_name() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         assert_eq!(tool.name(), "web_search_tool");
     }
 
     #[test]
     fn test_tool_description() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         assert!(tool.description().contains("Search the web"));
     }
 
     #[test]
     fn test_parameters_schema() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let schema = tool.parameters_schema();
         assert_eq!(schema["type"], "object");
         assert!(schema["properties"]["query"].is_object());
@@ -265,7 +338,7 @@ mod tests {
 
     #[test]
     fn test_parse_duckduckgo_results_empty() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let result = tool
             .parse_duckduckgo_results("<html>No results here</html>", "test")
             .unwrap();
@@ -274,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_parse_duckduckgo_results_with_data() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let html = r#"
             <a class="result__a" href="https://example.com">Example Title</a>
             <a class="result__snippet">This is a description</a>
@@ -286,7 +359,7 @@ mod tests {
 
     #[test]
     fn test_parse_duckduckgo_results_decodes_redirect_url() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let html = r#"
             <a class="result__a" href="https://duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fpath%3Fa%3D1&amp;rut=test">Example Title</a>
             <a class="result__snippet">This is a description</a>
@@ -298,7 +371,7 @@ mod tests {
 
     #[test]
     fn test_constructor_clamps_web_search_limits() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 0, 0);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 0, 0);
         let html = r#"
             <a class="result__a" href="https://example.com">Example Title</a>
             <a class="result__snippet">This is a description</a>
@@ -309,21 +382,78 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_missing_query() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let result = tool.execute(json!({})).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_execute_empty_query() {
-        let tool = WebSearchTool::new("duckduckgo".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("duckduckgo".to_string(), None, None, 5, 15);
         let result = tool.execute(json!({"query": ""})).await;
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_execute_brave_without_api_key() {
-        let tool = WebSearchTool::new("brave".to_string(), None, 5, 15);
+        let tool = WebSearchTool::new("brave".to_string(), None, None, 5, 15);
+        let result = tool.execute(json!({"query": "test"})).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("API key"));
+    }
+
+    #[test]
+    fn test_parse_perplexity_results_basic() {
+        let tool = WebSearchTool::new(
+            "perplexity".to_string(),
+            None,
+            Some("key".to_string()),
+            5,
+            15,
+        );
+        let json = serde_json::json!({
+            "id": "abc",
+            "results": [
+                { "title": "Rust lang", "url": "https://rust-lang.org", "snippet": "A systems language." }
+            ]
+        });
+        let result = tool.parse_perplexity_results(&json, "rust").unwrap();
+        assert!(result.contains("Rust lang"));
+        assert!(result.contains("https://rust-lang.org"));
+        assert!(result.contains("A systems language."));
+        assert!(result.contains("via Perplexity"));
+    }
+
+    #[test]
+    fn test_parse_perplexity_results_empty() {
+        let tool = WebSearchTool::new(
+            "perplexity".to_string(),
+            None,
+            Some("key".to_string()),
+            5,
+            15,
+        );
+        let json = serde_json::json!({ "id": "abc", "results": [] });
+        let result = tool.parse_perplexity_results(&json, "rust").unwrap();
+        assert!(result.contains("No results found"));
+    }
+
+    #[test]
+    fn test_parse_perplexity_results_invalid_response() {
+        let tool = WebSearchTool::new(
+            "perplexity".to_string(),
+            None,
+            Some("key".to_string()),
+            5,
+            15,
+        );
+        let json = serde_json::json!({ "error": "bad request" });
+        assert!(tool.parse_perplexity_results(&json, "rust").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_execute_perplexity_without_api_key() {
+        let tool = WebSearchTool::new("perplexity".to_string(), None, None, 5, 15);
         let result = tool.execute(json!({"query": "test"})).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("API key"));


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: `web_search_tool` had no Perplexity Search option despite Perplexity offering a dedicated Search API (`POST /search`) returning structured results identical in shape to Brave
- Why it matters: Perplexity Search provides real-time, continuously refreshed web results with a clean REST API — useful as a drop-in alternative to Brave without changing any agent config structure
- What changed: added `"perplexity"` as a third provider in `WebSearchTool` with config field, secret lifecycle, env var override, factory wiring, 4 unit tests, and docs
- What did **not** change: DuckDuckGo and Brave logic untouched; no new crate dependencies; no trait interface changes; no optional Perplexity filter params (YAGNI)

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `tool, config: core, docs`
- Module labels: `tool: web_search_tool`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: —

## Change Metadata

- Change type: `feature`
- Primary scope: `provider`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A — no superseded PRs.

## Validation Evidence (required)

```bash
# fmt
cargo fmt --all -- --check                              # pass

# correctness gate (pre-push hook)
cargo clippy --locked --all-targets -- -D clippy::correctness   # pass — warnings are all pre-existing

# tests (pre-push hook)
cargo test --locked                                     # pass
```

Targeted web search tests (17/17):
```
test tools::web_search_tool::tests::test_parse_perplexity_results_basic ... ok
test tools::web_search_tool::tests::test_parse_perplexity_results_empty ... ok
test tools::web_search_tool::tests::test_parse_perplexity_results_invalid_response ... ok
test tools::web_search_tool::tests::test_execute_perplexity_without_api_key ... ok
test tools::web_search_tool::tests::test_execute_brave_without_api_key ... ok
... (12 pre-existing tests also pass)
```

- Evidence provided: test output above + live API call verified locally (see Human Verification)
- If any command is intentionally skipped: `cargo clippy -- -D warnings` skipped; pre-existing warnings across unrelated files would cause false failure. The hook and CI gate on `clippy::correctness` only, which is clean.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? Yes — `POST https://api.perplexity.ai/search`
- Secrets/tokens handling changed? Yes — `perplexity_api_key` added to `WebSearchConfig`; follows the identical `decrypt_optional_secret` / `encrypt_optional_secret` path already used by `brave_api_key`. Key is never logged.
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: outbound call is to a fixed, known Perplexity endpoint; timeout is user-configurable (default 15 s); key is encrypted at rest by `SecretStore`; error on missing key is explicit (`bail!`)

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: no real keys or personal data in code, tests, or docs; test fixture uses literal `"key"` placeholder
- Neutral wording confirmation: pass

## Compatibility / Migration

- Backward compatible? Yes — `perplexity_api_key` is `Option<String>` with `#[serde(default)]`; existing config files load without error
- Config/env changes? Yes — new `perplexity_api_key` config key; new `ZEROCLAW_PERPLEXITY_API_KEY` / `PERPLEXITY_API_KEY` env var (latter is shared with the Perplexity LLM provider)
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? Yes
- Locale navigation parity updated in `README*`, `docs/README*`, `docs/SUMMARY.md`? N/A — no nav structure changed, only content within existing docs
- Localized runtime-contract docs updated? Yes — `docs/i18n/vi/langgraph-integration.md` and `docs/vi/langgraph-integration.md` updated in same commit
- Vietnamese canonical docs synced? Yes — `docs/i18n/vi/langgraph-integration.md` updated; `docs/config-reference.vi.md` has no `[web_search]` section to sync (not present in that locale file prior to this PR)
- If any `No`/`N.A.`: `docs/config-reference.vi.md` — no `[web_search]` section existed before this PR; EN section added here is the baseline; localized version can follow in a separate PR if needed

## Human Verification (required)

- Verified scenarios: live API call against real Perplexity Search endpoint confirmed — results returned with correct title/URL/snippet structure; missing API key returns explicit error; all pre-existing Brave/DuckDuckGo tests still pass; pre-push hook passes end-to-end
- Edge cases checked: empty snippet field (skipped in output); `max_results` clamp applied to results iteration
- What was not verified: —

## Side Effects / Blast Radius

- Affected subsystems/workflows: `web_search_tool` only; `WebSearchConfig` struct gains one new optional field
- Potential unintended effects: `PERPLEXITY_API_KEY` env var is now read by both the LLM provider and the web search tool; this is intentional (one key, two uses) but worth noting
- Guardrails/monitoring for early detection: explicit `bail!` on missing key; HTTP status checked before JSON parse; existing observability (`tracing::info!` on query) unchanged

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (analysis, implementation, tests, docs)
- Workflow/plan summary: analysed Brave Search implementation → fetched Perplexity Search API docs → wrote plan → implemented following identical provider pattern → ran quality gate and tests
- Verification focus: constructor signature update propagated to all test call sites; secret lifecycle mirrors Brave exactly
- Confirmation: naming and architecture boundaries followed per `CLAUDE.md` and `CONTRIBUTING.md`

## Rollback Plan (required)

- Fast rollback: `git revert HEAD` — reverts all 8 files, no migrations
- Feature flags or config toggles: `web_search.enabled = false` disables the tool entirely without touching provider config
- Observable failure symptoms: `"Perplexity API key not configured"` error in tool output if provider is set to `"perplexity"` without a key

## Risks and Mitigations

- Risk: `PERPLEXITY_API_KEY` env var is shared between the LLM provider and the web search tool — a key scoped only to one API may not have permissions for the other
  - Mitigation: Perplexity uses the same API key for both LLM and Search APIs on the same account; noted explicitly in `.env.example` and `config-reference.md`