### PR TITLE
docs(macOS): add update and uninstall instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Localized hubs: [简体中文](README.zh-CN.md) · [日本語](README.ja.md) · 
 |---|---|
 | Install and run ZeroClaw quickly | [README.md (Quick Start)](../README.md#quick-start) |
 | Bootstrap in one command | [one-click-bootstrap.md](one-click-bootstrap.md) |
+| Update or uninstall on macOS | [getting-started/macos-update-uninstall.md](getting-started/macos-update-uninstall.md) |
 | Find commands by task | [commands-reference.md](commands-reference.md) |
 | Check config defaults and keys quickly | [config-reference.md](config-reference.md) |
 | Configure custom providers/endpoints | [custom-providers.md](custom-providers.md) |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -26,6 +26,7 @@ Last refreshed: **February 18, 2026**.
 ### 1) Getting Started
 
 - [getting-started/README.md](getting-started/README.md)
+- [getting-started/macos-update-uninstall.md](getting-started/macos-update-uninstall.md)
 - [one-click-bootstrap.md](one-click-bootstrap.md)
 
 ### 2) Command/Config References & Integrations

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -6,7 +6,8 @@ For first-time setup and quick orientation.
 
 1. Main overview and quick start: [../../README.md](../../README.md)
 2. One-click setup and dual bootstrap mode: [../one-click-bootstrap.md](../one-click-bootstrap.md)
-3. Find commands by tasks: [../commands-reference.md](../commands-reference.md)
+3. Update or uninstall on macOS: [macos-update-uninstall.md](macos-update-uninstall.md)
+4. Find commands by tasks: [../commands-reference.md](../commands-reference.md)
 
 ## Choose Your Path
 
@@ -30,3 +31,4 @@ For first-time setup and quick orientation.
 
 - Runtime operations: [../operations/README.md](../operations/README.md)
 - Reference catalogs: [../reference/README.md](../reference/README.md)
+- macOS lifecycle tasks: [macos-update-uninstall.md](macos-update-uninstall.md)

--- a/docs/getting-started/macos-update-uninstall.md
+++ b/docs/getting-started/macos-update-uninstall.md
@@ -1,0 +1,112 @@
+# macOS Update and Uninstall Guide
+
+This page documents supported update and uninstall procedures for ZeroClaw on macOS (OS X).
+
+Last verified: **February 22, 2026**.
+
+## 1) Check current install method
+
+```bash
+which zeroclaw
+zeroclaw --version
+```
+
+Typical locations:
+
+- Homebrew: `/opt/homebrew/bin/zeroclaw` (Apple Silicon) or `/usr/local/bin/zeroclaw` (Intel)
+- Cargo/bootstrap/manual: `~/.cargo/bin/zeroclaw`
+
+If both exist, your shell `PATH` order decides which one runs.
+
+## 2) Update on macOS
+
+### A) Homebrew install
+
+```bash
+brew update
+brew upgrade zeroclaw
+zeroclaw --version
+```
+
+### B) Clone + bootstrap install
+
+From your local repository checkout:
+
+```bash
+git pull --ff-only
+./bootstrap.sh --prefer-prebuilt
+zeroclaw --version
+```
+
+If you want source-only update:
+
+```bash
+git pull --ff-only
+cargo install --path . --force --locked
+zeroclaw --version
+```
+
+### C) Manual prebuilt binary install
+
+Re-run your download/install flow with the latest release asset, then verify:
+
+```bash
+zeroclaw --version
+```
+
+## 3) Uninstall on macOS
+
+### A) Stop and remove background service first
+
+This prevents the daemon from continuing to run after binary removal.
+
+```bash
+zeroclaw service stop || true
+zeroclaw service uninstall || true
+```
+
+Service artifacts removed by `service uninstall`:
+
+- `~/Library/LaunchAgents/com.zeroclaw.daemon.plist`
+
+### B) Remove the binary by install method
+
+Homebrew:
+
+```bash
+brew uninstall zeroclaw
+```
+
+Cargo/bootstrap/manual (`~/.cargo/bin/zeroclaw`):
+
+```bash
+cargo uninstall zeroclaw || true
+rm -f ~/.cargo/bin/zeroclaw
+```
+
+### C) Optional: remove local runtime data
+
+Only run this if you want a full cleanup of config, auth profiles, logs, and workspace state.
+
+```bash
+rm -rf ~/.zeroclaw
+```
+
+## 4) Verify uninstall completed
+
+```bash
+command -v zeroclaw || echo "zeroclaw binary not found"
+pgrep -fl zeroclaw || echo "No running zeroclaw process"
+```
+
+If `pgrep` still finds a process, stop it manually and re-check:
+
+```bash
+pkill -f zeroclaw
+```
+
+## Related docs
+
+- [One-Click Bootstrap](../one-click-bootstrap.md)
+- [Commands Reference](../commands-reference.md)
+- [Troubleshooting](../troubleshooting.md)


### PR DESCRIPTION
## Summary
- add a dedicated macOS update/uninstall guide under getting-started docs
- cover update paths for Homebrew, bootstrap/source, and manual binary installs
- document service cleanup on macOS (launchd) and optional full data cleanup
- link the new guide from docs hub, getting-started index, and SUMMARY

Fixes #1338