### PR TITLE
feat(models): add list, set, and status subcommands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -579,6 +579,19 @@ enum ModelCommands {
         #[arg(long)]
         force: bool,
     },
+    /// List cached models for a provider
+    List {
+        /// Provider name (defaults to configured default provider)
+        #[arg(long)]
+        provider: Option<String>,
+    },
+    /// Set the default model in config
+    Set {
+        /// Model name to set as default
+        model: String,
+    },
+    /// Show current model configuration and cache status
+    Status,
 }
 
 #[derive(Subcommand, Debug)]
@@ -899,6 +912,11 @@ async fn main() -> Result<()> {
             ModelCommands::Refresh { provider, force } => {
                 onboard::run_models_refresh(&config, provider.as_deref(), force).await
             }
+            ModelCommands::List { provider } => {
+                onboard::run_models_list(&config, provider.as_deref()).await
+            }
+            ModelCommands::Set { model } => onboard::run_models_set(&config, &model).await,
+            ModelCommands::Status => onboard::run_models_status(&config).await,
         },
 
         Commands::Providers => {

--- a/src/onboard/mod.rs
+++ b/src/onboard/mod.rs
@@ -2,7 +2,10 @@ pub mod wizard;
 
 // Re-exported for CLI and external use
 #[allow(unused_imports)]
-pub use wizard::{run_channels_repair_wizard, run_models_refresh, run_quick_setup, run_wizard};
+pub use wizard::{
+    run_channels_repair_wizard, run_models_list, run_models_refresh, run_models_set,
+    run_models_status, run_quick_setup, run_wizard,
+};
 
 #[cfg(test)]
 mod tests {
@@ -16,5 +19,8 @@ mod tests {
         assert_reexport_exists(run_channels_repair_wizard);
         assert_reexport_exists(run_quick_setup);
         assert_reexport_exists(run_models_refresh);
+        assert_reexport_exists(run_models_list);
+        assert_reexport_exists(run_models_set);
+        assert_reexport_exists(run_models_status);
     }
 }

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -1742,6 +1742,93 @@ pub async fn run_models_refresh(
     }
 }
 
+pub async fn run_models_list(config: &Config, provider_override: Option<&str>) -> Result<()> {
+    let provider_name = provider_override
+        .or(config.default_provider.as_deref())
+        .unwrap_or("openrouter");
+
+    let cached = load_any_cached_models_for_provider(&config.workspace_dir, provider_name).await?;
+
+    let Some(cached) = cached else {
+        println!();
+        println!(
+            "  No cached models for '{provider_name}'. Run: zeroclaw models refresh --provider {provider_name}"
+        );
+        println!();
+        return Ok(());
+    };
+
+    println!();
+    println!(
+        "  {} models for '{}' (cached {} ago):",
+        cached.models.len(),
+        provider_name,
+        humanize_age(cached.age_secs)
+    );
+    println!();
+    for model in &cached.models {
+        let marker = if config.default_model.as_deref() == Some(model.as_str()) {
+            "* "
+        } else {
+            "  "
+        };
+        println!("  {marker}{model}");
+    }
+    println!();
+    Ok(())
+}
+
+pub async fn run_models_set(config: &Config, model: &str) -> Result<()> {
+    let model = model.trim();
+    if model.is_empty() {
+        anyhow::bail!("Model name cannot be empty");
+    }
+
+    let mut updated = config.clone();
+    updated.default_model = Some(model.to_string());
+    updated.save().await?;
+
+    println!();
+    println!("  Default model set to '{}'.", style(model).green().bold());
+    println!();
+    Ok(())
+}
+
+pub async fn run_models_status(config: &Config) -> Result<()> {
+    let provider = config.default_provider.as_deref().unwrap_or("openrouter");
+    let model = config.default_model.as_deref().unwrap_or("(not set)");
+
+    println!();
+    println!("  Provider:  {}", style(provider).cyan());
+    println!("  Model:     {}", style(model).cyan());
+    println!(
+        "  Temp:      {}",
+        style(format!("{:.1}", config.default_temperature)).cyan()
+    );
+
+    match load_any_cached_models_for_provider(&config.workspace_dir, provider).await? {
+        Some(cached) => {
+            println!(
+                "  Cache:     {} models (updated {} ago)",
+                cached.models.len(),
+                humanize_age(cached.age_secs)
+            );
+            let fresh = cached.age_secs < MODEL_CACHE_TTL_SECS;
+            if fresh {
+                println!("  Freshness: {}", style("fresh").green());
+            } else {
+                println!("  Freshness: {}", style("stale").yellow());
+            }
+        }
+        None => {
+            println!("  Cache:     {}", style("none").yellow());
+        }
+    }
+
+    println!();
+    Ok(())
+}
+
 // ── Step helpers ─────────────────────────────────────────────────
 
 fn print_step(current: u8, total: u8, title: &str) {


### PR DESCRIPTION
 Summary

  - Base branch target: dev
  - Problem: zeroclaw models only has refresh; users cannot list cached models, switch default model, or check status
  from CLI
  - Why it matters: Model selection is the most common configuration task; forcing manual config.toml editing is poor
  UX
  - What changed: Added List, Set, Status variants to ModelCommands + three handler functions + re-exports + re-export
  test
  - What did not change: refresh behavior, cache format, config schema, no new dependencies

Closes: #1450

  Label Snapshot (required)

  - Risk label: risk: low
  - Size label: size: S
  - Scope labels: onboard, config
  - Module labels: onboard: wizard
  - Contributor tier label: (auto-managed)
  - If any auto-label is incorrect: N/A

  Change Metadata

  - Change type: feature
  - Primary scope: config

  Linked Issue

  - Closes #(the issue above)
  - Related: N/A
  - Depends on: N/A
  - Supersedes: N/A

  Supersede Attribution

  N/A — not superseding any PR.

  Validation Evidence (required)

  cargo fmt --all -- --check     # exit 0
  cargo clippy --all-targets     # 0 errors in changed files (pre-existing errors in telegram.rs/wizard.rs unrelated)
  cargo test --lib               # 2889 passed, 0 failed, 2 ignored
  cargo test --lib onboard::tests  # 1 passed (re-export coverage)

  - Evidence provided: All three validation commands pass. Changed files have zero new clippy warnings.
  - If any command is intentionally skipped: cargo clippy -- -D warnings fails globally due to 39+ pre-existing errors
  in unrelated files. Our three changed files produce zero clippy diagnostics.

  Security Impact (required)

  - New permissions/capabilities? No
  - New external network calls? No
  - Secrets/tokens handling changed? No (set delegates to existing Config::save() which handles encryption)
  - File system access scope changed? No (writes to existing config.toml path only)

  Privacy and Data Hygiene (required)

  - Data-hygiene status: pass
  - Redaction/anonymization notes: No personal data in code, output, or tests
  - Neutral wording confirmation: All identifiers use project-native naming (zeroclaw models, provider names)

  Compatibility / Migration

  - Backward compatible? Yes (additive CLI subcommands only)
  - Config/env changes? No
  - Migration needed? No

  i18n Follow-Through

  - i18n follow-through triggered? No (no docs or user-facing wording changes in docs/)

  Human Verification (required)

  - Verified scenarios: models list with cache, models list without cache, models set with valid name, models status
  with/without cache
  - Edge cases checked: empty model name → bail, missing cache → guidance message, stale cache display
  - What was not verified: end-to-end with live provider (requires API key); Config::save() encryption path
  (pre-existing, tested elsewhere)

  Side Effects / Blast Radius (required)

  - Affected subsystems/workflows: CLI command routing (main.rs), model management (onboard/wizard.rs)
  - Potential unintended effects: None — list and status are read-only; set uses the same Config::save() as onboarding
  wizard
  - Guardrails/monitoring: Empty model name rejected at entry; Config::save() creates .bak before overwrite

  Agent Collaboration Notes

  - Agent tools used: Claude Code (Read, Edit, Bash, Grep, Task/Explore)
  - Workflow: Explored existing ModelCommands, cache infrastructure, and Config::save() → implemented minimal handlers
  → validated
  - Verification focus: Zero regression (2889 tests), zero new clippy warnings, fmt clean
  - Confirmation: naming + architecture boundaries followed (CLAUDE.md)

  Rollback Plan (required)

  - Fast rollback command/path: git revert <commit-sha>
  - Feature flags or config toggles: None needed (additive CLI only)
  - Observable failure symptoms: zeroclaw models list/set/status subcommands would disappear from CLI help

  Risks and Mitigations

  - Risk: models set accepts any string without validating against cached models — user could set a non-existent model
  name.
    - Mitigation: This matches existing behavior (config.toml allows any default_model value). Runtime provider will
  return a clear error if the model doesn't exist. Adding validation would require a fresh network call, violating the
  "no network in set" design.