### PR TITLE
feat(release): add Android target support (armv7 + aarch64)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,10 @@ rustflags = ["-C", "link-arg=-static"]
 
 [target.aarch64-unknown-linux-musl]
 rustflags = ["-C", "link-arg=-static"]
+
+# Android targets (NDK toolchain)
+[target.armv7-linux-androideabi]
+linker = "armv7a-linux-androideabi21-clang"
+
+[target.aarch64-linux-android]
+linker = "aarch64-linux-android21-clang"

--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -168,6 +168,24 @@ jobs:
                       cross_compiler: gcc-arm-linux-gnueabihf
                       linker_env: CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER
                       linker: arm-linux-gnueabihf-gcc
+                    - os: ubuntu-latest
+                      target: armv7-linux-androideabi
+                      artifact: zeroclaw
+                      archive_ext: tar.gz
+                      cross_compiler: ""
+                      linker_env: ""
+                      linker: ""
+                      android_ndk: true
+                      android_api: 21
+                    - os: ubuntu-latest
+                      target: aarch64-linux-android
+                      artifact: zeroclaw
+                      archive_ext: tar.gz
+                      cross_compiler: ""
+                      linker_env: ""
+                      linker: ""
+                      android_ndk: true
+                      android_api: 21
                     - os: macos-15-intel
                       target: x86_64-apple-darwin
                       artifact: zeroclaw
@@ -208,6 +226,31 @@ jobs:
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y ${{ matrix.cross_compiler }}
+
+            - name: Setup Android NDK
+              if: matrix.android_ndk
+              uses: nttld/setup-ndk@v1
+              id: setup-ndk
+              with:
+                  ndk-version: r26d
+                  add-to-path: true
+
+            - name: Configure Android toolchain
+              if: matrix.android_ndk
+              run: |
+                  echo "Setting up Android NDK toolchain for ${{ matrix.target }}"
+                  NDK_HOME="${{ steps.setup-ndk.outputs.ndk-path }}"
+                  TOOLCHAIN="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+                  
+                  # Add to path for linker resolution
+                  echo "$TOOLCHAIN" >> $GITHUB_PATH
+                  
+                  # Set linker environment variables
+                  if [[ "${{ matrix.target }}" == "armv7-linux-androideabi" ]]; then
+                    echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=${TOOLCHAIN}/armv7a-linux-androideabi${{ matrix.android_api }}-clang" >> $GITHUB_ENV
+                  elif [[ "${{ matrix.target }}" == "aarch64-linux-android" ]]; then
+                    echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${TOOLCHAIN}/aarch64-linux-android${{ matrix.android_api }}-clang" >> $GITHUB_ENV
+                  fi
 
             - name: Build release
               shell: bash
@@ -262,6 +305,8 @@ jobs:
                     "zeroclaw-x86_64-unknown-linux-gnu.tar.gz"
                     "zeroclaw-aarch64-unknown-linux-gnu.tar.gz"
                     "zeroclaw-armv7-unknown-linux-gnueabihf.tar.gz"
+                    "zeroclaw-armv7-linux-androideabi.tar.gz"
+                    "zeroclaw-aarch64-linux-android.tar.gz"
                     "zeroclaw-x86_64-apple-darwin.tar.gz"
                     "zeroclaw-aarch64-apple-darwin.tar.gz"
                     "zeroclaw-x86_64-pc-windows-msvc.zip"

--- a/docs/android-setup.md
+++ b/docs/android-setup.md
@@ -1,0 +1,100 @@
+# Android Setup
+
+ZeroClaw provides prebuilt binaries for Android devices.
+
+## Supported Architectures
+
+| Target | Android Version | Devices |
+|--------|-----------------|---------|
+| `armv7-linux-androideabi` | Android 4.1+ (API 16+) | Older 32-bit phones (Galaxy S3, etc.) |
+| `aarch64-linux-android` | Android 5.0+ (API 21+) | Modern 64-bit phones |
+
+## Installation via Termux
+
+The easiest way to run ZeroClaw on Android is via [Termux](https://termux.dev/).
+
+### 1. Install Termux
+
+Download from [F-Droid](https://f-droid.org/packages/com.termux/) (recommended) or GitHub releases.
+
+> ⚠️ **Note:** The Play Store version is outdated and unsupported.
+
+### 2. Download ZeroClaw
+
+```bash
+# Check your architecture
+uname -m
+# aarch64 = 64-bit, armv7l/armv8l = 32-bit
+
+# Download the appropriate binary
+# For 64-bit (aarch64):
+curl -LO https://github.com/zeroclaw-labs/zeroclaw/releases/latest/download/zeroclaw-aarch64-linux-android.tar.gz
+tar xzf zeroclaw-aarch64-linux-android.tar.gz
+
+# For 32-bit (armv7):
+curl -LO https://github.com/zeroclaw-labs/zeroclaw/releases/latest/download/zeroclaw-armv7-linux-androideabi.tar.gz
+tar xzf zeroclaw-armv7-linux-androideabi.tar.gz
+```
+
+### 3. Install and Run
+
+```bash
+chmod +x zeroclaw
+mv zeroclaw $PREFIX/bin/
+
+# Verify installation
+zeroclaw --version
+
+# Run setup
+zeroclaw onboard
+```
+
+## Direct Installation via ADB
+
+For advanced users who want to run ZeroClaw outside Termux:
+
+```bash
+# From your computer with ADB
+adb push zeroclaw /data/local/tmp/
+adb shell chmod +x /data/local/tmp/zeroclaw
+adb shell /data/local/tmp/zeroclaw --version
+```
+
+> ⚠️ Running outside Termux requires a rooted device or specific permissions for full functionality.
+
+## Limitations on Android
+
+- **No systemd:** Use Termux's `termux-services` for daemon mode
+- **Storage access:** Requires Termux storage permissions (`termux-setup-storage`)
+- **Network:** Some features may require Android VPN permission for local binding
+
+## Building from Source
+
+To build for Android yourself:
+
+```bash
+# Install Android NDK
+# Add targets
+rustup target add armv7-linux-androideabi aarch64-linux-android
+
+# Set NDK path
+export ANDROID_NDK_HOME=/path/to/ndk
+export PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH
+
+# Build
+cargo build --release --target armv7-linux-androideabi
+cargo build --release --target aarch64-linux-android
+```
+
+## Troubleshooting
+
+### "Permission denied"
+```bash
+chmod +x zeroclaw
+```
+
+### "not found" or linker errors
+Make sure you downloaded the correct architecture for your device.
+
+### Old Android (4.x)
+Use the `armv7-linux-androideabi` build with API level 16+.


### PR DESCRIPTION
  ## Summary                                                                                                                                       
   Adds prebuilt Android binaries to ZeroClaw releases.                                                                                             
                                                                                                                                                    
   ## Changes                                                                                                                                       
   - armv7-linux-androideabi target (32-bit, API 21+)                                                                                               
   - aarch64-linux-android target (64-bit, API 21+)                                                                                                 
   - Android NDK r26d setup in release workflow                                                                                                     
   - docs/android-setup.md installation guide                                                                                                       
                                                                                                                                                    
   ## Motivation                                                                                                                                    
   ZeroClaw's small footprint makes it perfect for Android devices via Termux.