### PR TITLE
fix(gateway): skip pairing dialog in web UI when require_pairing is f…

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -689,6 +689,7 @@ async fn handle_health(State(state): State<AppState>) -> impl IntoResponse {
     let body = serde_json::json!({
         "status": "ok",
         "paired": state.pairing.is_paired(),
+        "require_pairing": state.pairing.require_pairing(),
         "runtime": crate::health::snapshot_json(),
     });
     Json(body)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -80,7 +80,7 @@ function PairingDialog({ onPair }: { onPair: (code: string) => Promise<void> }) 
 }
 
 function AppContent() {
-  const { isAuthenticated, pair, logout } = useAuth();
+  const { isAuthenticated, loading, pair, logout } = useAuth();
   const [locale, setLocaleState] = useState('tr');
 
   const setAppLocale = (newLocale: string) => {
@@ -96,6 +96,14 @@ function AppContent() {
     window.addEventListener('zeroclaw-unauthorized', handler);
     return () => window.removeEventListener('zeroclaw-unauthorized', handler);
   }, [logout]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-950 flex items-center justify-center">
+        <p className="text-gray-400">Connecting...</p>
+      </div>
+    );
+  }
 
   if (!isAuthenticated) {
     return <PairingDialog onPair={pair} />;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -93,6 +93,18 @@ export async function pair(code: string): Promise<{ token: string }> {
 }
 
 // ---------------------------------------------------------------------------
+// Public health (no auth required)
+// ---------------------------------------------------------------------------
+
+export async function getPublicHealth(): Promise<{ require_pairing: boolean; paired: boolean }> {
+  const response = await fetch('/health');
+  if (!response.ok) {
+    throw new Error(`Health check failed (${response.status})`);
+  }
+  return response.json() as Promise<{ require_pairing: boolean; paired: boolean }>;
+}
+
+// ---------------------------------------------------------------------------
 // Status / Health
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
 Closes #1463

  ## Problem

  When `require_pairing = false` in `config.toml`, the backend correctly skips auth, but the Web UI still shows the
  pairing PIN dialog on first load. The frontend only checks `localStorage` for a token — it never asks the server
  whether pairing is actually required.

  ## Fix

  - Backend: add `require_pairing` field to the public `GET /health` response
  - Frontend: `AuthProvider` fetches `/health` on mount; if `require_pairing` is `false`, skip PairingDialog and go
  straight to Dashboard
  - If `/health` is unreachable, fall back to showing PairingDialog (safe default)