### PR TITLE
fix(channel): replace invalid Telegram ACK reaction emojis

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -16,7 +16,7 @@ const TELEGRAM_MAX_MESSAGE_LENGTH: usize = 4096;
 /// Reserve space for continuation markers added by send_text_chunks:
 /// worst case is "(continued)\n\n" + chunk + "\n\n(continues...)" = 30 extra chars
 const TELEGRAM_CONTINUATION_OVERHEAD: usize = 30;
-const TELEGRAM_ACK_REACTIONS: &[&str] = &["⚡️", "🙌", "💪", "👌", "👀"];
+const TELEGRAM_ACK_REACTIONS: &[&str] = &["⚡️", "👌", "👀", "🔥", "👍"];
 
 /// Metadata for an incoming document or photo attachment.
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
## Summary

- Base branch target: `dev`
- Problem: 2 of 5 emojis in `TELEGRAM_ACK_REACTIONS` (🙌, 💪) are not in Telegram's allowed reaction set, causing `REACTION_INVALID` (400) on ~40% of incoming messages
- Why it matters: ACK reactions silently fail, producing WARN log noise on every affected message
- What changed: replaced 🙌 and 💪 with 🔥 and 👍 (both verified valid via the Bot API)
- What did **not** change: pool size (5), selection logic, reaction request shape, tests

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: telegram`
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #1475

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo test --lib channels::telegram -- telegram_ack_reaction
# result: ok. 137 passed; 0 failed; 1 ignored; 0 measured; 2772 filtered out
```

Additionally, each emoji was validated directly against the Telegram Bot API `setMessageReaction` endpoint in a live private chat:

| Emoji | Result |
|-------|--------|
| ⚡️ | ✅ valid (kept) |
| 🙌 | ❌ `REACTION_INVALID` (removed) |
| 💪 | ❌ `REACTION_INVALID` (removed) |
| 👌 | ✅ valid (kept) |
| 👀 | ✅ valid (kept) |
| 🔥 | ✅ valid (added) |
| 👍 | ✅ valid (added) |

- Evidence provided: local test run + live API test results
- If any command is intentionally skipped, explain why: `cargo fmt` and `cargo clippy` skipped locally; CI will cover these.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any Yes, describe risk and mitigation: N/A — all No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: chat IDs redacted in issue #1475 logs
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: each emoji in old and new pool tested against live Telegram Bot API
- Edge cases checked: confirmed all 5 new pool emojis return `ok: true`
- What was not verified: `cargo fmt`, `cargo clippy` (CI will cover)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Telegram channel ACK reactions only
- Potential unintended effects: none — cosmetic feature, no functional impact
- Guardrails/monitoring for early detection: existing WARN log will disappear if fix is correct

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: live API validation of emoji compatibility + local `cargo test`
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: none
- Observable failure symptoms: WARN logs return for `REACTION_INVALID`

## Risks and Mitigations

- Risk: Telegram could change their allowed reaction set in the future
  - Mitigation: the WARN log already catches this; a more robust fix would query the API at startup, but that's out of scope for this patch