### PR TITLE
[supersede #1266] feature(tool):  Add WebFetch tool to fetch a web page and convert it to markdown.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto_encoder"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6364e11e0270035ec392151a54f1476e6b3612ef9f4fe09d35e72a8cebcb65"
+dependencies = [
+ "chardetng",
+ "encoding_rs",
+ "percent-encoding",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,6 +829,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1051,13 +1075,23 @@ dependencies = [
  "cookie 0.18.1",
  "document-features",
  "idna",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
  "serde_json",
  "time",
  "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1211,6 +1245,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,8 +1331,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -1293,12 +1360,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.116",
 ]
@@ -1387,7 +1479,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58cb0719583cbe4e81fb40434ace2f0d22ccc3e39a74bb3796c22b451b4f139d"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1425,6 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1572,6 +1665,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
 ]
 
 [[package]]
@@ -1877,6 +1985,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast_html2md"
+version = "0.0.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3a0122fee1bcf6bb9f3d73782e911cce69d95b76a5e29e930af92cd4a8e4e3"
+dependencies = [
+ "auto_encoder",
+ "futures-util",
+ "lazy_static",
+ "lol_html",
+ "percent-encoding",
+ "regex",
+ "url",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +2025,24 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "firecrawl"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03805ef0be5d099f072941146407446db12a81941120489c03c88471fbd3206d"
+dependencies = [
+ "futures",
+ "log",
+ "reqwest",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -1931,6 +2072,27 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2138,7 +2300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap",
+ "indexmap 2.13.0",
  "stable_deref_trait",
 ]
 
@@ -2197,7 +2359,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2226,6 +2388,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -2240,7 +2408,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -2248,6 +2416,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashify"
@@ -2493,6 +2666,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,9 +2699,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2809,6 +3000,17 @@ checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3113,6 +3315,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lol_html"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630bc32f75a59df2d35a9f13224b057a1c1ff1d187dfdc56190e9a54c4127917"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cssparser",
+ "encoding_rs",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.1",
+ "memchr",
+ "mime",
+ "precomputed-hash",
+ "selectors",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "lopdf"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3125,7 +3346,7 @@ dependencies = [
  "encoding_rs",
  "flate2",
  "getrandom 0.3.4",
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "log",
  "md-5",
@@ -3323,7 +3544,7 @@ dependencies = [
  "gloo-timers",
  "http 1.4.0",
  "imbl",
- "indexmap",
+ "indexmap 2.13.0",
  "itertools 0.14.0",
  "js_int",
  "language-tags",
@@ -3712,6 +3933,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "negentropy"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3926,7 +4164,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5750d884c774a2862b0049b0318aea27cecc9e873485540af5ed8ab8841247da"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "futures-core",
  "io-kit-sys 0.5.0",
@@ -4021,10 +4259,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -4202,7 +4478,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -4211,6 +4487,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -4229,6 +4506,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -4271,6 +4549,32 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -4571,7 +4875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "031bed1313b45d93dae4ca8f0fee098530c6632e4ebd9e2769d5a49cdef273d3"
 dependencies = [
  "base64",
- "indexmap",
+ "indexmap 2.13.0",
  "jep106",
  "serde",
  "serde_with",
@@ -5054,6 +5358,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -5063,10 +5368,13 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5077,6 +5385,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -5185,7 +5494,7 @@ dependencies = [
  "form_urlencoded",
  "getrandom 0.2.17",
  "http 1.4.0",
- "indexmap",
+ "indexmap 2.13.0",
  "js-sys",
  "js_int",
  "konst",
@@ -5214,7 +5523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dbdeccb62cb4ffe3282325de8ba28cbc0fdce7c78a3f11b7241fbfdb9cb9907"
 dependencies = [
  "as_variant",
- "indexmap",
+ "indexmap 2.13.0",
  "js_int",
  "js_option",
  "percent-encoding",
@@ -5484,15 +5793,51 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
- "schemars_derive",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -5569,7 +5914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5583,6 +5928,25 @@ checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
+dependencies = [
+ "bitflags 2.11.0",
+ "cssparser",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -5675,7 +6039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
 dependencies = [
  "form_urlencoded",
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde_core",
@@ -5754,10 +6118,26 @@ dependencies = [
  "base64",
  "chrono",
  "hex",
- "indexmap",
+ "indexmap 1.9.3",
+ "indexmap 2.13.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
  "serde_core",
  "serde_json",
+ "serde_with_macros",
  "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -5766,7 +6146,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "itoa",
  "ryu",
  "serde",
@@ -5781,7 +6161,7 @@ checksum = "2acaf3f973e8616d7ceac415f53fc60e190b2a686fbcf8d27d0256c741c5007b"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "io-kit-sys 0.4.1",
  "mach2 0.4.3",
@@ -5789,6 +6169,15 @@ dependencies = [
  "scopeguard",
  "unescaper",
  "winapi",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -6058,6 +6447,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6226,6 +6636,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -6242,6 +6653,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.116",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -6414,7 +6835,7 @@ version = "1.0.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 1.0.0+spec-1.1.0",
@@ -6447,7 +6868,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow 0.7.14",
@@ -7309,7 +7730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -7353,7 +7774,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -7535,6 +7956,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -7860,7 +8292,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn 2.0.116",
  "wasm-metadata",
@@ -7891,7 +8323,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -7910,7 +8342,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -8026,6 +8458,8 @@ dependencies = [
  "dialoguer",
  "directories",
  "fantoccini",
+ "fast_html2md",
+ "firecrawl",
  "futures-util",
  "glob",
  "hex",
@@ -8060,8 +8494,7 @@ dependencies = [
  "rust-embed",
  "rustls",
  "rustls-pki-types",
- "schemars",
- "scopeguard",
+ "schemars 1.2.1",
  "serde",
  "serde-big-array",
  "serde_ignored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,12 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png"]
 # URL encoding for web search
 urlencoding = "2.1"
 
+# HTML to Markdown conversion (web_fetch tool, fast_html2md provider; optional via web-fetch feature)
+fast_html2md = { version = "0.0", optional = true }
+
+# Firecrawl cloud scraping API (web_fetch tool, firecrawl provider; optional to keep binary size lean)
+firecrawl = { version = "1", optional = true }
+
 # Optional Rust-native browser automation backend
 fantoccini = { version = "0.22.0", optional = true, default-features = false, features = ["rustls-tls"] }
 
@@ -181,7 +187,11 @@ landlock = { version = "0.4", optional = true }
 libc = "0.2"
 
 [features]
-default = []
+# web-fetch = web page fetch + HTML-to-Markdown tool; on by default (fast_html2md provider)
+# Disable with --no-default-features or override default = [] in a workspace manifest.
+# Add --features firecrawl to also enable the Firecrawl cloud provider.
+default = ["web-fetch"]
+web-fetch = ["dep:fast_html2md"]
 hardware = ["nusb", "tokio-serial"]
 channel-matrix = ["dep:matrix-sdk"]
 channel-lark = ["dep:prost"]
@@ -203,6 +213,8 @@ probe = ["dep:probe-rs"]
 rag-pdf = ["dep:pdf-extract"]
 # whatsapp-web = Native WhatsApp Web client with custom rusqlite storage backend
 whatsapp-web = ["dep:wa-rs", "dep:wa-rs-core", "dep:wa-rs-binary", "dep:wa-rs-proto", "dep:wa-rs-ureq-http", "dep:wa-rs-tokio-transport", "dep:serde-big-array", "dep:prost", "dep:qrcode"]
+# firecrawl = cloud web scraping provider for web_fetch tool (adds firecrawl SDK; optional)
+firecrawl = ["dep:firecrawl"]
 
 [profile.release]
 opt-level = "z"      # Optimize for size

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,7 +16,7 @@ pub use schema::{
     SandboxBackend, SandboxConfig, SchedulerConfig, SecretsConfig, SecurityConfig, SkillsConfig,
     SkillsPromptInjectionMode, SlackConfig, StorageConfig, StorageProviderConfig,
     StorageProviderSection, StreamMode, TelegramConfig, TranscriptionConfig, TunnelConfig,
-    WebSearchConfig, WebhookConfig,
+    WebFetchConfig, WebSearchConfig, WebhookConfig,
 };
 
 pub fn name_and_presence<T: traits::ChannelConfig>(channel: &Option<T>) -> (&'static str, bool) {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -176,6 +176,10 @@ pub struct Config {
     #[serde(default)]
     pub web_search: WebSearchConfig,
 
+    /// Web fetch tool configuration (`[web_fetch]`).
+    #[serde(default)]
+    pub web_fetch: WebFetchConfig,
+
     /// Proxy configuration for outbound HTTP/HTTPS/SOCKS5 traffic (`[proxy]`).
     #[serde(default)]
     pub proxy: ProxyConfig,
@@ -998,6 +1002,9 @@ pub struct HttpRequestConfig {
     /// Request timeout in seconds (default: 30)
     #[serde(default = "default_http_timeout_secs")]
     pub timeout_secs: u64,
+    /// User Agent string for HTTP requests
+    #[serde(default = "default_user_agent")]
+    pub user_agent: String,
 }
 
 impl Default for HttpRequestConfig {
@@ -1007,6 +1014,7 @@ impl Default for HttpRequestConfig {
             allowed_domains: vec![],
             max_response_size: default_http_max_response_size(),
             timeout_secs: default_http_timeout_secs(),
+            user_agent: default_user_agent(),
         }
     }
 }
@@ -1027,18 +1035,27 @@ pub struct WebSearchConfig {
     /// Enable `web_search_tool` for web searches
     #[serde(default)]
     pub enabled: bool,
-    /// Search provider: "duckduckgo" (free, no API key) or "brave" (requires API key)
+    /// Search provider: "duckduckgo" (free, no API key), "brave" (requires API key), or "firecrawl" (requires feature + API key)
     #[serde(default = "default_web_search_provider")]
     pub provider: String,
     /// Brave Search API key (required if provider is "brave")
     #[serde(default)]
     pub brave_api_key: Option<String>,
+    /// Firecrawl API key (required if provider is "firecrawl")
+    #[serde(default)]
+    pub firecrawl_api_key: Option<String>,
+    /// Firecrawl API base URL override (for self-hosted instances)
+    #[serde(default)]
+    pub firecrawl_api_url: Option<String>,
     /// Maximum results per search (1-10)
     #[serde(default = "default_web_search_max_results")]
     pub max_results: usize,
     /// Request timeout in seconds
     #[serde(default = "default_web_search_timeout_secs")]
     pub timeout_secs: u64,
+    /// User Agent string for web requests
+    #[serde(default = "default_user_agent")]
+    pub user_agent: String,
 }
 
 fn default_web_search_provider() -> String {
@@ -1053,14 +1070,86 @@ fn default_web_search_timeout_secs() -> u64 {
     15
 }
 
+fn default_user_agent() -> String {
+    "ZeroClaw/1.0".into()
+}
+
 impl Default for WebSearchConfig {
     fn default() -> Self {
         Self {
             enabled: false,
             provider: default_web_search_provider(),
             brave_api_key: None,
+            firecrawl_api_key: None,
+            firecrawl_api_url: None,
             max_results: default_web_search_max_results(),
             timeout_secs: default_web_search_timeout_secs(),
+            user_agent: default_user_agent(),
+        }
+    }
+}
+
+// ── Web fetch ────────────────────────────────────────────────────
+
+/// Web fetch tool configuration (`[web_fetch]` section).
+///
+/// Fetches a URL and returns its content as Markdown.
+/// Two providers are supported:
+/// - `"fast_html2md"` (default) — local conversion using reqwest + fast_html2md (no API key required)
+/// - `"firecrawl"` — cloud-based conversion via the Firecrawl API (requires `firecrawl` feature and API key)
+///
+/// Deny-by-default: if `allowed_domains` is empty, all requests are rejected.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct WebFetchConfig {
+    /// Enable `web_fetch` tool for fetching and converting web pages to Markdown
+    #[serde(default)]
+    pub enabled: bool,
+    /// Fetch provider: `"fast_html2md"` (local, default) or `"firecrawl"` (cloud, requires feature + API key)
+    #[serde(default = "default_web_fetch_provider")]
+    pub provider: String,
+    /// Firecrawl API key (required when provider is `"firecrawl"`)
+    #[serde(default)]
+    pub firecrawl_api_key: Option<String>,
+    /// Firecrawl API base URL override (for self-hosted instances; default: https://api.firecrawl.dev)
+    #[serde(default)]
+    pub firecrawl_api_url: Option<String>,
+    /// Allowed domains for web fetch requests (exact or subdomain match)
+    #[serde(default)]
+    pub allowed_domains: Vec<String>,
+    /// Maximum response size in bytes for the converted Markdown (default: 500KB)
+    #[serde(default = "default_web_fetch_max_response_size")]
+    pub max_response_size: usize,
+    /// Request timeout in seconds (default: 30)
+    #[serde(default = "default_web_fetch_timeout_secs")]
+    pub timeout_secs: u64,
+    /// User Agent string for web requests
+    #[serde(default = "default_user_agent")]
+    pub user_agent: String,
+}
+
+fn default_web_fetch_provider() -> String {
+    "fast_html2md".into()
+}
+
+fn default_web_fetch_max_response_size() -> usize {
+    500_000 // 500KB
+}
+
+fn default_web_fetch_timeout_secs() -> u64 {
+    30
+}
+
+impl Default for WebFetchConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            provider: default_web_fetch_provider(),
+            firecrawl_api_key: None,
+            firecrawl_api_url: None,
+            allowed_domains: vec![],
+            max_response_size: default_web_fetch_max_response_size(),
+            timeout_secs: default_web_fetch_timeout_secs(),
+            user_agent: default_user_agent(),
         }
     }
 }
@@ -3466,6 +3555,7 @@ impl Default for Config {
             http_request: HttpRequestConfig::default(),
             multimodal: MultimodalConfig::default(),
             web_search: WebSearchConfig::default(),
+            web_fetch: WebFetchConfig::default(),
             proxy: ProxyConfig::default(),
             identity: IdentityConfig::default(),
             cost: CostConfig::default(),
@@ -4199,6 +4289,18 @@ impl Config {
             }
         }
 
+        // Global User Agent fallback: ZEROCLAW_USER_AGENT or USER_AGENT
+        if let Ok(user_agent) =
+            std::env::var("ZEROCLAW_USER_AGENT").or_else(|_| std::env::var("USER_AGENT"))
+        {
+            let user_agent = user_agent.trim();
+            if !user_agent.is_empty() {
+                self.http_request.user_agent = user_agent.to_string();
+                self.web_search.user_agent = user_agent.to_string();
+                self.web_fetch.user_agent = user_agent.to_string();
+            }
+        }
+
         // Web search enabled: ZEROCLAW_WEB_SEARCH_ENABLED or WEB_SEARCH_ENABLED
         if let Ok(enabled) = std::env::var("ZEROCLAW_WEB_SEARCH_ENABLED")
             .or_else(|_| std::env::var("WEB_SEARCH_ENABLED"))
@@ -4226,6 +4328,66 @@ impl Config {
             }
         }
 
+        // Firecrawl API key (global): ZEROCLAW_FIRECRAWL_API_KEY or FIRECRAWL_API_KEY
+        if let Ok(api_key) = std::env::var("ZEROCLAW_FIRECRAWL_API_KEY")
+            .or_else(|_| std::env::var("FIRECRAWL_API_KEY"))
+        {
+            let api_key = api_key.trim();
+            if !api_key.is_empty() {
+                self.web_search.firecrawl_api_key = Some(api_key.to_string());
+                self.web_fetch.firecrawl_api_key = Some(api_key.to_string());
+            }
+        }
+
+        // Firecrawl API key (per-tool overrides, applied after global so they win)
+        if let Ok(api_key) = std::env::var("ZEROCLAW_WEB_SEARCH_FIRECRAWL_API_KEY")
+            .or_else(|_| std::env::var("WEB_SEARCH_FIRECRAWL_API_KEY"))
+        {
+            let api_key = api_key.trim();
+            if !api_key.is_empty() {
+                self.web_search.firecrawl_api_key = Some(api_key.to_string());
+            }
+        }
+
+        if let Ok(api_key) = std::env::var("ZEROCLAW_WEB_FETCH_FIRECRAWL_API_KEY")
+            .or_else(|_| std::env::var("WEB_FETCH_FIRECRAWL_API_KEY"))
+        {
+            let api_key = api_key.trim();
+            if !api_key.is_empty() {
+                self.web_fetch.firecrawl_api_key = Some(api_key.to_string());
+            }
+        }
+
+        // Firecrawl API URL (global): ZEROCLAW_FIRECRAWL_API_URL or FIRECRAWL_API_URL
+        if let Ok(api_url) = std::env::var("ZEROCLAW_FIRECRAWL_API_URL")
+            .or_else(|_| std::env::var("FIRECRAWL_API_URL"))
+        {
+            let api_url = api_url.trim();
+            if !api_url.is_empty() {
+                self.web_search.firecrawl_api_url = Some(api_url.to_string());
+                self.web_fetch.firecrawl_api_url = Some(api_url.to_string());
+            }
+        }
+
+        // Firecrawl API URL (per-tool overrides, applied after global so they win)
+        if let Ok(api_url) = std::env::var("ZEROCLAW_WEB_SEARCH_FIRECRAWL_API_URL")
+            .or_else(|_| std::env::var("WEB_SEARCH_FIRECRAWL_API_URL"))
+        {
+            let api_url = api_url.trim();
+            if !api_url.is_empty() {
+                self.web_search.firecrawl_api_url = Some(api_url.to_string());
+            }
+        }
+
+        if let Ok(api_url) = std::env::var("ZEROCLAW_WEB_FETCH_FIRECRAWL_API_URL")
+            .or_else(|_| std::env::var("WEB_FETCH_FIRECRAWL_API_URL"))
+        {
+            let api_url = api_url.trim();
+            if !api_url.is_empty() {
+                self.web_fetch.firecrawl_api_url = Some(api_url.to_string());
+            }
+        }
+
         // Web search max results: ZEROCLAW_WEB_SEARCH_MAX_RESULTS or WEB_SEARCH_MAX_RESULTS
         if let Ok(max_results) = std::env::var("ZEROCLAW_WEB_SEARCH_MAX_RESULTS")
             .or_else(|_| std::env::var("WEB_SEARCH_MAX_RESULTS"))
@@ -4245,6 +4407,36 @@ impl Config {
                 if timeout_secs > 0 {
                     self.web_search.timeout_secs = timeout_secs;
                 }
+            }
+        }
+
+        // Web search user agent: ZEROCLAW_WEB_SEARCH_USER_AGENT or WEB_SEARCH_USER_AGENT
+        if let Ok(user_agent) = std::env::var("ZEROCLAW_WEB_SEARCH_USER_AGENT")
+            .or_else(|_| std::env::var("WEB_SEARCH_USER_AGENT"))
+        {
+            let user_agent = user_agent.trim();
+            if !user_agent.is_empty() {
+                self.web_search.user_agent = user_agent.to_string();
+            }
+        }
+
+        // Web fetch user agent: ZEROCLAW_WEB_FETCH_USER_AGENT or WEB_FETCH_USER_AGENT
+        if let Ok(user_agent) = std::env::var("ZEROCLAW_WEB_FETCH_USER_AGENT")
+            .or_else(|_| std::env::var("WEB_FETCH_USER_AGENT"))
+        {
+            let user_agent = user_agent.trim();
+            if !user_agent.is_empty() {
+                self.web_fetch.user_agent = user_agent.to_string();
+            }
+        }
+
+        // HTTP request user agent: ZEROCLAW_HTTP_REQUEST_USER_AGENT or HTTP_REQUEST_USER_AGENT
+        if let Ok(user_agent) = std::env::var("ZEROCLAW_HTTP_REQUEST_USER_AGENT")
+            .or_else(|_| std::env::var("HTTP_REQUEST_USER_AGENT"))
+        {
+            let user_agent = user_agent.trim();
+            if !user_agent.is_empty() {
+                self.http_request.user_agent = user_agent.to_string();
             }
         }
 
@@ -4791,6 +4983,7 @@ default_temperature = 0.7
             http_request: HttpRequestConfig::default(),
             multimodal: MultimodalConfig::default(),
             web_search: WebSearchConfig::default(),
+            web_fetch: WebFetchConfig::default(),
             proxy: ProxyConfig::default(),
             agent: AgentConfig::default(),
             identity: IdentityConfig::default(),
@@ -4971,6 +5164,7 @@ tool_dispatcher = "xml"
             http_request: HttpRequestConfig::default(),
             multimodal: MultimodalConfig::default(),
             web_search: WebSearchConfig::default(),
+            web_fetch: WebFetchConfig::default(),
             proxy: ProxyConfig::default(),
             agent: AgentConfig::default(),
             identity: IdentityConfig::default(),

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -89,7 +89,7 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
     );
     println!();
 
-    print_step(1, 9, "Workspace Setup");
+    print_step(1, 10, "Workspace Setup");
     let (workspace_dir, config_path) = setup_workspace().await?;
     match resolve_interactive_onboarding_mode(&config_path, force)? {
         InteractiveOnboardingMode::FullOnboarding => {}
@@ -98,28 +98,31 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
         }
     }
 
-    print_step(2, 9, "AI Provider & API Key");
+    print_step(2, 10, "AI Provider & API Key");
     let (provider, api_key, model, provider_api_url) = setup_provider(&workspace_dir).await?;
 
-    print_step(3, 9, "Channels (How You Talk to ZeroClaw)");
+    print_step(3, 10, "Channels (How You Talk to ZeroClaw)");
     let channels_config = setup_channels()?;
 
-    print_step(4, 9, "Tunnel (Expose to Internet)");
+    print_step(4, 10, "Tunnel (Expose to Internet)");
     let tunnel_config = setup_tunnel()?;
 
-    print_step(5, 9, "Tool Mode & Security");
+    print_step(5, 10, "Tool Mode & Security");
     let (composio_config, secrets_config) = setup_tool_mode()?;
 
-    print_step(6, 9, "Hardware (Physical World)");
+    print_step(6, 10, "Web & Internet Tools");
+    let (web_search_config, web_fetch_config, http_request_config) = setup_web_tools()?;
+
+    print_step(7, 10, "Hardware (Physical World)");
     let hardware_config = setup_hardware()?;
 
-    print_step(7, 9, "Memory Configuration");
+    print_step(8, 10, "Memory Configuration");
     let memory_config = setup_memory()?;
 
-    print_step(8, 9, "Project Context (Personalize Your Agent)");
+    print_step(9, 10, "Project Context (Personalize Your Agent)");
     let project_ctx = setup_project_context()?;
 
-    print_step(9, 9, "Workspace Files");
+    print_step(10, 10, "Workspace Files");
     scaffold_workspace(&workspace_dir, &project_ctx).await?;
 
     // ── Build config ──
@@ -138,8 +141,8 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
         default_temperature: 0.7,
         observability: ObservabilityConfig::default(),
         autonomy: AutonomyConfig::default(),
-        security: crate::config::SecurityConfig::default(),
         runtime: RuntimeConfig::default(),
+        security: crate::config::SecurityConfig::default(),
         reliability: crate::config::ReliabilityConfig::default(),
         scheduler: crate::config::schema::SchedulerConfig::default(),
         agent: crate::config::schema::AgentConfig::default(),
@@ -156,9 +159,10 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
         composio: composio_config,
         secrets: secrets_config,
         browser: BrowserConfig::default(),
-        http_request: crate::config::HttpRequestConfig::default(),
+        http_request: http_request_config,
         multimodal: crate::config::MultimodalConfig::default(),
-        web_search: crate::config::WebSearchConfig::default(),
+        web_search: web_search_config,
+        web_fetch: web_fetch_config,
         proxy: crate::config::ProxyConfig::default(),
         identity: crate::config::IdentityConfig::default(),
         cost: crate::config::CostConfig::default(),
@@ -486,8 +490,8 @@ async fn run_quick_setup_with_home(
         default_temperature: 0.7,
         observability: ObservabilityConfig::default(),
         autonomy: AutonomyConfig::default(),
-        security: crate::config::SecurityConfig::default(),
         runtime: RuntimeConfig::default(),
+        security: crate::config::SecurityConfig::default(),
         reliability: crate::config::ReliabilityConfig::default(),
         scheduler: crate::config::schema::SchedulerConfig::default(),
         agent: crate::config::schema::AgentConfig::default(),
@@ -507,6 +511,13 @@ async fn run_quick_setup_with_home(
         http_request: crate::config::HttpRequestConfig::default(),
         multimodal: crate::config::MultimodalConfig::default(),
         web_search: crate::config::WebSearchConfig::default(),
+        web_fetch: crate::config::WebFetchConfig {
+            // Keep disabled in non-interactive setup, but pre-populate allowed_domains
+            // so the user doesn't hit the empty-allowlist error if they later enable
+            // web_fetch manually in config.toml.
+            allowed_domains: vec!["*".to_string()],
+            ..crate::config::WebFetchConfig::default()
+        },
         proxy: crate::config::ProxyConfig::default(),
         identity: crate::config::IdentityConfig::default(),
         cost: crate::config::CostConfig::default(),
@@ -2765,6 +2776,260 @@ fn provider_supports_keyless_local_usage(provider_name: &str) -> bool {
         canonical_provider_name(provider_name),
         "ollama" | "llamacpp" | "sglang" | "vllm" | "osaurus"
     )
+}
+
+// ── Step 6: Web & Internet Tools ─────────────────────────────────
+
+fn parse_allowed_domains(raw: &str) -> Vec<String> {
+    if raw.trim() == "*" {
+        return vec!["*".to_string()];
+    }
+    raw.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+fn setup_web_tools() -> Result<(
+    crate::config::WebSearchConfig,
+    crate::config::WebFetchConfig,
+    crate::config::HttpRequestConfig,
+)> {
+    print_bullet("Configure web tools: search, page fetch, and HTTP API access.");
+    print_bullet("You can always change these later in config.toml.");
+    println!();
+
+    // ── Web Search ──
+    let enable_search = Confirm::new()
+        .with_prompt("  Enable web search?")
+        .default(true)
+        .interact()?;
+
+    let web_search = if enable_search {
+        #[cfg(feature = "firecrawl")]
+        let search_providers: Vec<&str> = vec![
+            "DuckDuckGo (free, no API key, default)",
+            "Brave Search (higher quality, requires API key)",
+            "Firecrawl (cloud search, requires API key)",
+        ];
+        #[cfg(not(feature = "firecrawl"))]
+        let search_providers: Vec<&str> = vec![
+            "DuckDuckGo (free, no API key, default)",
+            "Brave Search (higher quality, requires API key)",
+        ];
+
+        let search_idx = Select::new()
+            .with_prompt("  Search provider")
+            .items(&search_providers)
+            .default(0)
+            .interact()?;
+
+        let (provider, brave_api_key) = match search_idx {
+            1 => {
+                print_bullet("Get your API key at: https://brave.com/search/api/");
+                let key: String = Input::new()
+                    .with_prompt("  Brave Search API key (or Enter to skip)")
+                    .allow_empty(true)
+                    .interact_text()?;
+                (
+                    "brave".to_string(),
+                    if key.trim().is_empty() {
+                        None
+                    } else {
+                        Some(key.trim().to_string())
+                    },
+                )
+            }
+            #[cfg(feature = "firecrawl")]
+            2 => {
+                print_bullet("Get your API key at: https://firecrawl.dev");
+                let key: String = Input::new()
+                    .with_prompt("  Firecrawl API key (or Enter to skip)")
+                    .allow_empty(true)
+                    .interact_text()?;
+                (
+                    "firecrawl".to_string(),
+                    if key.trim().is_empty() {
+                        None
+                    } else {
+                        Some(key.trim().to_string())
+                    },
+                )
+            }
+            _ => ("duckduckgo".to_string(), None),
+        };
+
+        println!(
+            "  {} Web search: {} ({})",
+            style("✓").green().bold(),
+            style("enabled").green(),
+            style(&provider).cyan()
+        );
+
+        crate::config::WebSearchConfig {
+            enabled: true,
+            provider,
+            brave_api_key,
+            ..crate::config::WebSearchConfig::default()
+        }
+    } else {
+        println!(
+            "  {} Web search: {}",
+            style("✓").green().bold(),
+            style("disabled").dim()
+        );
+        crate::config::WebSearchConfig::default()
+    };
+
+    println!();
+
+    // ── Web Fetch ──
+    let enable_fetch = Confirm::new()
+        .with_prompt("  Enable web fetch? (fetch and convert web pages to Markdown)")
+        .default(true)
+        .interact()?;
+
+    let web_fetch = if enable_fetch {
+        #[cfg(feature = "firecrawl")]
+        let fetch_providers: Vec<&str> = vec![
+            "fast_html2md (local, no API key, default)",
+            "Firecrawl (cloud, better quality, requires API key)",
+        ];
+        #[cfg(not(feature = "firecrawl"))]
+        let fetch_providers: Vec<&str> = vec!["fast_html2md (local, no API key, default)"];
+
+        let fetch_idx = Select::new()
+            .with_prompt("  Fetch provider")
+            .items(&fetch_providers)
+            .default(0)
+            .interact()?;
+
+        #[cfg(feature = "firecrawl")]
+        let (provider, firecrawl_api_key) = if fetch_idx == 1 {
+            print_bullet("Get your API key at: https://firecrawl.dev");
+            let key: String = Input::new()
+                .with_prompt("  Firecrawl API key (or Enter to skip)")
+                .allow_empty(true)
+                .interact_text()?;
+            (
+                "firecrawl".to_string(),
+                if key.trim().is_empty() {
+                    None
+                } else {
+                    Some(key.trim().to_string())
+                },
+            )
+        } else {
+            ("fast_html2md".to_string(), None)
+        };
+
+        #[cfg(not(feature = "firecrawl"))]
+        let (provider, firecrawl_api_key) = {
+            let _ = fetch_idx;
+            ("fast_html2md".to_string(), None)
+        };
+
+        let domains_raw: String = Input::new()
+            .with_prompt("  Allowed domains for web fetch (comma-separated, '*' for all)")
+            .default("*".into())
+            .interact_text()?;
+        let allowed_domains = parse_allowed_domains(&domains_raw);
+
+        println!(
+            "  {} Web fetch: {} ({}, domains: {})",
+            style("✓").green().bold(),
+            style("enabled").green(),
+            style(&provider).cyan(),
+            style(if allowed_domains == vec!["*"] {
+                "all".to_string()
+            } else {
+                format!("{}", allowed_domains.len())
+            })
+            .cyan()
+        );
+
+        crate::config::WebFetchConfig {
+            enabled: true,
+            provider,
+            firecrawl_api_key,
+            allowed_domains,
+            ..crate::config::WebFetchConfig::default()
+        }
+    } else {
+        println!(
+            "  {} Web fetch: {}",
+            style("✓").green().bold(),
+            style("disabled").dim()
+        );
+        crate::config::WebFetchConfig {
+            allowed_domains: vec!["*".to_string()],
+            ..crate::config::WebFetchConfig::default()
+        }
+    };
+
+    println!();
+
+    // ── HTTP Request ──
+    let enable_http = Confirm::new()
+        .with_prompt("  Enable HTTP request tool? (make arbitrary API calls)")
+        .default(false)
+        .interact()?;
+
+    let http_request = if enable_http {
+        let web_fetch_domains = &web_fetch.allowed_domains;
+        let reuse_domains = if web_fetch_domains.is_empty() {
+            false
+        } else {
+            let domain_display = if web_fetch_domains == &vec!["*".to_string()] {
+                "all (*)".to_string()
+            } else {
+                format!("{} domain(s)", web_fetch_domains.len())
+            };
+            Confirm::new()
+                .with_prompt(format!(
+                    "  Reuse web fetch allowed domains for HTTP requests ({domain_display})?"
+                ))
+                .default(true)
+                .interact()?
+        };
+
+        let allowed_domains = if reuse_domains {
+            web_fetch_domains.clone()
+        } else {
+            let domains_raw: String = Input::new()
+                .with_prompt("  Allowed domains for HTTP requests (comma-separated, '*' for all)")
+                .default("*".into())
+                .interact_text()?;
+            parse_allowed_domains(&domains_raw)
+        };
+
+        println!(
+            "  {} HTTP request: {} (domains: {})",
+            style("✓").green().bold(),
+            style("enabled").green(),
+            style(if allowed_domains == vec!["*"] {
+                "all".to_string()
+            } else {
+                format!("{}", allowed_domains.len())
+            })
+            .cyan()
+        );
+
+        crate::config::HttpRequestConfig {
+            enabled: true,
+            allowed_domains,
+            ..crate::config::HttpRequestConfig::default()
+        }
+    } else {
+        println!(
+            "  {} HTTP request: {}",
+            style("✓").green().bold(),
+            style("disabled").dim()
+        );
+        crate::config::HttpRequestConfig::default()
+    };
+
+    Ok((web_search, web_fetch, http_request))
 }
 
 // ── Step 5: Tool Mode & Security ────────────────────────────────
@@ -5504,6 +5769,50 @@ fn print_summary(config: &Config) {
             }
         } else {
             "disabled (software only)".to_string()
+        }
+    );
+
+    // Web Search
+    println!(
+        "    {} Web search:    {}",
+        style("🔍").cyan(),
+        if config.web_search.enabled {
+            style(format!("enabled ({})", config.web_search.provider))
+                .green()
+                .to_string()
+        } else {
+            "disabled".to_string()
+        }
+    );
+
+    // Web Fetch
+    println!(
+        "    {} Web fetch:     {}",
+        style("🌐").cyan(),
+        if config.web_fetch.enabled {
+            style(format!("enabled ({})", config.web_fetch.provider))
+                .green()
+                .to_string()
+        } else {
+            "disabled".to_string()
+        }
+    );
+
+    // HTTP Request
+    println!(
+        "    {} HTTP request:  {}",
+        style("📡").cyan(),
+        if config.http_request.enabled {
+            let domain_label = if config.http_request.allowed_domains == vec!["*".to_string()] {
+                "all domains".to_string()
+            } else {
+                format!("{} domain(s)", config.http_request.allowed_domains.len())
+            };
+            style(format!("enabled ({domain_label})"))
+                .green()
+                .to_string()
+        } else {
+            "disabled".to_string()
         }
     );
 

--- a/src/tools/browser_open.rs
+++ b/src/tools/browser_open.rs
@@ -1,4 +1,7 @@
 use super::traits::{Tool, ToolResult};
+use super::url_validation::{
+    extract_host, host_matches_allowlist, is_private_or_local_host, normalize_allowed_domains,
+};
 use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use serde_json::json;
@@ -225,131 +228,6 @@ async fn open_in_system_browser(url: &str) -> anyhow::Result<()> {
     }
 }
 
-fn normalize_allowed_domains(domains: Vec<String>) -> Vec<String> {
-    let mut normalized = domains
-        .into_iter()
-        .filter_map(|d| normalize_domain(&d))
-        .collect::<Vec<_>>();
-    normalized.sort_unstable();
-    normalized.dedup();
-    normalized
-}
-
-fn normalize_domain(raw: &str) -> Option<String> {
-    let mut d = raw.trim().to_lowercase();
-    if d.is_empty() {
-        return None;
-    }
-
-    if let Some(stripped) = d.strip_prefix("https://") {
-        d = stripped.to_string();
-    } else if let Some(stripped) = d.strip_prefix("http://") {
-        d = stripped.to_string();
-    }
-
-    if let Some((host, _)) = d.split_once('/') {
-        d = host.to_string();
-    }
-
-    d = d.trim_start_matches('.').trim_end_matches('.').to_string();
-
-    if let Some((host, _)) = d.split_once(':') {
-        d = host.to_string();
-    }
-
-    if d.is_empty() || d.chars().any(char::is_whitespace) {
-        return None;
-    }
-
-    Some(d)
-}
-
-fn extract_host(url: &str) -> anyhow::Result<String> {
-    let rest = url
-        .strip_prefix("https://")
-        .ok_or_else(|| anyhow::anyhow!("Only https:// URLs are allowed"))?;
-
-    let authority = rest
-        .split(['/', '?', '#'])
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("Invalid URL"))?;
-
-    if authority.is_empty() {
-        anyhow::bail!("URL must include a host");
-    }
-
-    if authority.contains('@') {
-        anyhow::bail!("URL userinfo is not allowed");
-    }
-
-    if authority.starts_with('[') {
-        anyhow::bail!("IPv6 hosts are not supported in browser_open");
-    }
-
-    let host = authority
-        .split(':')
-        .next()
-        .unwrap_or_default()
-        .trim()
-        .trim_end_matches('.')
-        .to_lowercase();
-
-    if host.is_empty() {
-        anyhow::bail!("URL must include a valid host");
-    }
-
-    Ok(host)
-}
-
-fn host_matches_allowlist(host: &str, allowed_domains: &[String]) -> bool {
-    if allowed_domains.iter().any(|domain| domain == "*") {
-        return true;
-    }
-
-    allowed_domains.iter().any(|domain| {
-        host == domain
-            || host
-                .strip_suffix(domain)
-                .is_some_and(|prefix| prefix.ends_with('.'))
-    })
-}
-
-fn is_private_or_local_host(host: &str) -> bool {
-    let has_local_tld = host
-        .rsplit('.')
-        .next()
-        .is_some_and(|label| label == "local");
-
-    if host == "localhost" || host.ends_with(".localhost") || has_local_tld || host == "::1" {
-        return true;
-    }
-
-    if let Some([a, b, _, _]) = parse_ipv4(host) {
-        return a == 0
-            || a == 10
-            || a == 127
-            || (a == 169 && b == 254)
-            || (a == 172 && (16..=31).contains(&b))
-            || (a == 192 && b == 168)
-            || (a == 100 && (64..=127).contains(&b));
-    }
-
-    false
-}
-
-fn parse_ipv4(host: &str) -> Option<[u8; 4]> {
-    let parts: Vec<&str> = host.split('.').collect();
-    if parts.len() != 4 {
-        return None;
-    }
-
-    let mut octets = [0_u8; 4];
-    for (i, part) in parts.iter().enumerate() {
-        octets[i] = part.parse::<u8>().ok()?;
-    }
-    Some(octets)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -364,22 +242,6 @@ mod tests {
             security,
             allowed_domains.into_iter().map(String::from).collect(),
         )
-    }
-
-    #[test]
-    fn normalize_domain_strips_scheme_path_and_case() {
-        let got = normalize_domain("  HTTPS://Docs.Example.com/path ").unwrap();
-        assert_eq!(got, "docs.example.com");
-    }
-
-    #[test]
-    fn normalize_allowed_domains_deduplicates() {
-        let got = normalize_allowed_domains(vec![
-            "example.com".into(),
-            "EXAMPLE.COM".into(),
-            "https://example.com/".into(),
-        ]);
-        assert_eq!(got, vec!["example.com".to_string()]);
     }
 
     #[test]
@@ -480,18 +342,6 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("allowed_domains"));
-    }
-
-    #[test]
-    fn parse_ipv4_valid() {
-        assert_eq!(parse_ipv4("1.2.3.4"), Some([1, 2, 3, 4]));
-    }
-
-    #[test]
-    fn parse_ipv4_invalid() {
-        assert_eq!(parse_ipv4("1.2.3"), None);
-        assert_eq!(parse_ipv4("1.2.3.999"), None);
-        assert_eq!(parse_ipv4("not-an-ip"), None);
     }
 
     #[tokio::test]

--- a/src/tools/http_request.rs
+++ b/src/tools/http_request.rs
@@ -1,4 +1,7 @@
 use super::traits::{Tool, ToolResult};
+use super::url_validation::{
+    extract_host, host_matches_allowlist, is_private_or_local_host, normalize_allowed_domains,
+};
 use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use serde_json::json;
@@ -12,6 +15,7 @@ pub struct HttpRequestTool {
     allowed_domains: Vec<String>,
     max_response_size: usize,
     timeout_secs: u64,
+    user_agent: String,
 }
 
 impl HttpRequestTool {
@@ -20,12 +24,14 @@ impl HttpRequestTool {
         allowed_domains: Vec<String>,
         max_response_size: usize,
         timeout_secs: u64,
+        user_agent: String,
     ) -> Self {
         Self {
             security,
             allowed_domains: normalize_allowed_domains(allowed_domains),
             max_response_size,
             timeout_secs,
+            user_agent,
         }
     }
 
@@ -123,7 +129,8 @@ impl HttpRequestTool {
         let builder = reqwest::Client::builder()
             .timeout(Duration::from_secs(timeout_secs))
             .connect_timeout(Duration::from_secs(10))
-            .redirect(reqwest::redirect::Policy::none());
+            .redirect(reqwest::redirect::Policy::none())
+            .user_agent(&self.user_agent);
         let builder = crate::config::apply_runtime_proxy_to_builder(builder, "tool.http_request");
         let client = builder.build()?;
 
@@ -301,153 +308,6 @@ impl Tool for HttpRequestTool {
     }
 }
 
-// Helper functions similar to browser_open.rs
-
-fn normalize_allowed_domains(domains: Vec<String>) -> Vec<String> {
-    let mut normalized = domains
-        .into_iter()
-        .filter_map(|d| normalize_domain(&d))
-        .collect::<Vec<_>>();
-    normalized.sort_unstable();
-    normalized.dedup();
-    normalized
-}
-
-fn normalize_domain(raw: &str) -> Option<String> {
-    let mut d = raw.trim().to_lowercase();
-    if d.is_empty() {
-        return None;
-    }
-
-    if let Some(stripped) = d.strip_prefix("https://") {
-        d = stripped.to_string();
-    } else if let Some(stripped) = d.strip_prefix("http://") {
-        d = stripped.to_string();
-    }
-
-    if let Some((host, _)) = d.split_once('/') {
-        d = host.to_string();
-    }
-
-    d = d.trim_start_matches('.').trim_end_matches('.').to_string();
-
-    if let Some((host, _)) = d.split_once(':') {
-        d = host.to_string();
-    }
-
-    if d.is_empty() || d.chars().any(char::is_whitespace) {
-        return None;
-    }
-
-    Some(d)
-}
-
-fn extract_host(url: &str) -> anyhow::Result<String> {
-    let rest = url
-        .strip_prefix("http://")
-        .or_else(|| url.strip_prefix("https://"))
-        .ok_or_else(|| anyhow::anyhow!("Only http:// and https:// URLs are allowed"))?;
-
-    let authority = rest
-        .split(['/', '?', '#'])
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("Invalid URL"))?;
-
-    if authority.is_empty() {
-        anyhow::bail!("URL must include a host");
-    }
-
-    if authority.contains('@') {
-        anyhow::bail!("URL userinfo is not allowed");
-    }
-
-    if authority.starts_with('[') {
-        anyhow::bail!("IPv6 hosts are not supported in http_request");
-    }
-
-    let host = authority
-        .split(':')
-        .next()
-        .unwrap_or_default()
-        .trim()
-        .trim_end_matches('.')
-        .to_lowercase();
-
-    if host.is_empty() {
-        anyhow::bail!("URL must include a valid host");
-    }
-
-    Ok(host)
-}
-
-fn host_matches_allowlist(host: &str, allowed_domains: &[String]) -> bool {
-    if allowed_domains.iter().any(|domain| domain == "*") {
-        return true;
-    }
-
-    allowed_domains.iter().any(|domain| {
-        host == domain
-            || host
-                .strip_suffix(domain)
-                .is_some_and(|prefix| prefix.ends_with('.'))
-    })
-}
-
-fn is_private_or_local_host(host: &str) -> bool {
-    // Strip brackets from IPv6 addresses like [::1]
-    let bare = host
-        .strip_prefix('[')
-        .and_then(|h| h.strip_suffix(']'))
-        .unwrap_or(host);
-
-    let has_local_tld = bare
-        .rsplit('.')
-        .next()
-        .is_some_and(|label| label == "local");
-
-    if bare == "localhost" || bare.ends_with(".localhost") || has_local_tld {
-        return true;
-    }
-
-    if let Ok(ip) = bare.parse::<std::net::IpAddr>() {
-        return match ip {
-            std::net::IpAddr::V4(v4) => is_non_global_v4(v4),
-            std::net::IpAddr::V6(v6) => is_non_global_v6(v6),
-        };
-    }
-
-    false
-}
-
-/// Returns true if the IPv4 address is not globally routable.
-fn is_non_global_v4(v4: std::net::Ipv4Addr) -> bool {
-    let [a, b, c, _] = v4.octets();
-    v4.is_loopback()                       // 127.0.0.0/8
-        || v4.is_private()                 // 10/8, 172.16/12, 192.168/16
-        || v4.is_link_local()              // 169.254.0.0/16
-        || v4.is_unspecified()             // 0.0.0.0
-        || v4.is_broadcast()              // 255.255.255.255
-        || v4.is_multicast()              // 224.0.0.0/4
-        || (a == 100 && (64..=127).contains(&b)) // Shared address space (RFC 6598)
-        || a >= 240                        // Reserved (240.0.0.0/4, except broadcast)
-        || (a == 192 && b == 0 && (c == 0 || c == 2)) // IETF assignments + TEST-NET-1
-        || (a == 198 && b == 51)           // Documentation (198.51.100.0/24)
-        || (a == 203 && b == 0)            // Documentation (203.0.113.0/24)
-        || (a == 198 && (18..=19).contains(&b)) // Benchmarking (198.18.0.0/15)
-}
-
-/// Returns true if the IPv6 address is not globally routable.
-fn is_non_global_v6(v6: std::net::Ipv6Addr) -> bool {
-    let segs = v6.segments();
-    v6.is_loopback()                       // ::1
-        || v6.is_unspecified()             // ::
-        || v6.is_multicast()              // ff00::/8
-        || (segs[0] & 0xfe00) == 0xfc00   // Unique-local (fc00::/7)
-        || (segs[0] & 0xffc0) == 0xfe80   // Link-local (fe80::/10)
-        || (segs[0] == 0x2001 && segs[1] == 0x0db8) // Documentation (2001:db8::/32)
-        || v6.to_ipv4_mapped().is_some_and(is_non_global_v4)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -463,23 +323,8 @@ mod tests {
             allowed_domains.into_iter().map(String::from).collect(),
             1_000_000,
             30,
+            "test".into(),
         )
-    }
-
-    #[test]
-    fn normalize_domain_strips_scheme_path_and_case() {
-        let got = normalize_domain("  HTTPS://Docs.Example.com/path ").unwrap();
-        assert_eq!(got, "docs.example.com");
-    }
-
-    #[test]
-    fn normalize_allowed_domains_deduplicates() {
-        let got = normalize_allowed_domains(vec![
-            "example.com".into(),
-            "EXAMPLE.COM".into(),
-            "https://example.com/".into(),
-        ]);
-        assert_eq!(got, vec!["example.com".to_string()]);
     }
 
     #[test]
@@ -570,7 +415,7 @@ mod tests {
     #[test]
     fn validate_requires_allowlist() {
         let security = Arc::new(SecurityPolicy::default());
-        let tool = HttpRequestTool::new(security, vec![], 1_000_000, 30);
+        let tool = HttpRequestTool::new(security, vec![], 1_000_000, 30, "test".into());
         let err = tool
             .validate_url("https://example.com")
             .unwrap_err()
@@ -597,96 +442,19 @@ mod tests {
         assert!(err.contains("Unsupported HTTP method"));
     }
 
-    #[test]
-    fn blocks_multicast_ipv4() {
-        assert!(is_private_or_local_host("224.0.0.1"));
-        assert!(is_private_or_local_host("239.255.255.255"));
-    }
-
-    #[test]
-    fn blocks_broadcast() {
-        assert!(is_private_or_local_host("255.255.255.255"));
-    }
-
-    #[test]
-    fn blocks_reserved_ipv4() {
-        assert!(is_private_or_local_host("240.0.0.1"));
-        assert!(is_private_or_local_host("250.1.2.3"));
-    }
-
-    #[test]
-    fn blocks_documentation_ranges() {
-        assert!(is_private_or_local_host("192.0.2.1")); // TEST-NET-1
-        assert!(is_private_or_local_host("198.51.100.1")); // TEST-NET-2
-        assert!(is_private_or_local_host("203.0.113.1")); // TEST-NET-3
-    }
-
-    #[test]
-    fn blocks_benchmarking_range() {
-        assert!(is_private_or_local_host("198.18.0.1"));
-        assert!(is_private_or_local_host("198.19.255.255"));
-    }
-
-    #[test]
-    fn blocks_ipv6_localhost() {
-        assert!(is_private_or_local_host("::1"));
-        assert!(is_private_or_local_host("[::1]"));
-    }
-
-    #[test]
-    fn blocks_ipv6_multicast() {
-        assert!(is_private_or_local_host("ff02::1"));
-    }
-
-    #[test]
-    fn blocks_ipv6_link_local() {
-        assert!(is_private_or_local_host("fe80::1"));
-    }
-
-    #[test]
-    fn blocks_ipv6_unique_local() {
-        assert!(is_private_or_local_host("fd00::1"));
-    }
-
-    #[test]
-    fn blocks_ipv4_mapped_ipv6() {
-        assert!(is_private_or_local_host("::ffff:127.0.0.1"));
-        assert!(is_private_or_local_host("::ffff:192.168.1.1"));
-        assert!(is_private_or_local_host("::ffff:10.0.0.1"));
-    }
-
-    #[test]
-    fn allows_public_ipv4() {
-        assert!(!is_private_or_local_host("8.8.8.8"));
-        assert!(!is_private_or_local_host("1.1.1.1"));
-        assert!(!is_private_or_local_host("93.184.216.34"));
-    }
-
-    #[test]
-    fn blocks_ipv6_documentation_range() {
-        assert!(is_private_or_local_host("2001:db8::1"));
-    }
-
-    #[test]
-    fn allows_public_ipv6() {
-        assert!(!is_private_or_local_host("2607:f8b0:4004:800::200e"));
-    }
-
-    #[test]
-    fn blocks_shared_address_space() {
-        assert!(is_private_or_local_host("100.64.0.1"));
-        assert!(is_private_or_local_host("100.127.255.255"));
-        assert!(!is_private_or_local_host("100.63.0.1")); // Just below range
-        assert!(!is_private_or_local_host("100.128.0.1")); // Just above range
-    }
-
     #[tokio::test]
     async fn execute_blocks_readonly_mode() {
         let security = Arc::new(SecurityPolicy {
             autonomy: AutonomyLevel::ReadOnly,
             ..SecurityPolicy::default()
         });
-        let tool = HttpRequestTool::new(security, vec!["example.com".into()], 1_000_000, 30);
+        let tool = HttpRequestTool::new(
+            security,
+            vec!["example.com".into()],
+            1_000_000,
+            30,
+            "test".into(),
+        );
         let result = tool
             .execute(json!({"url": "https://example.com"}))
             .await
@@ -701,7 +469,13 @@ mod tests {
             max_actions_per_hour: 0,
             ..SecurityPolicy::default()
         });
-        let tool = HttpRequestTool::new(security, vec!["example.com".into()], 1_000_000, 30);
+        let tool = HttpRequestTool::new(
+            security,
+            vec!["example.com".into()],
+            1_000_000,
+            30,
+            "test".into(),
+        );
         let result = tool
             .execute(json!({"url": "https://example.com"}))
             .await
@@ -724,6 +498,7 @@ mod tests {
             vec!["example.com".into()],
             10,
             30,
+            "test".into(),
         );
         let text = "hello world this is long";
         let truncated = tool.truncate_response(text);
@@ -809,37 +584,6 @@ mod tests {
         assert_eq!(headers[0].1, "Bearer real-token");
     }
 
-    // ── SSRF: alternate IP notation bypass defense-in-depth ─────────
-    //
-    // Rust's IpAddr::parse() rejects non-standard notations (octal, hex,
-    // decimal integer, zero-padded). These tests document that property
-    // so regressions are caught if the parsing strategy ever changes.
-
-    #[test]
-    fn ssrf_octal_loopback_not_parsed_as_ip() {
-        // 0177.0.0.1 is octal for 127.0.0.1 in some languages, but
-        // Rust's IpAddr rejects it — it falls through as a hostname.
-        assert!(!is_private_or_local_host("0177.0.0.1"));
-    }
-
-    #[test]
-    fn ssrf_hex_loopback_not_parsed_as_ip() {
-        // 0x7f000001 is hex for 127.0.0.1 in some languages.
-        assert!(!is_private_or_local_host("0x7f000001"));
-    }
-
-    #[test]
-    fn ssrf_decimal_loopback_not_parsed_as_ip() {
-        // 2130706433 is decimal for 127.0.0.1 in some languages.
-        assert!(!is_private_or_local_host("2130706433"));
-    }
-
-    #[test]
-    fn ssrf_zero_padded_loopback_not_parsed_as_ip() {
-        // 127.000.000.001 uses zero-padded octets.
-        assert!(!is_private_or_local_host("127.000.000.001"));
-    }
-
     #[test]
     fn ssrf_alternate_notations_rejected_by_validate_url() {
         // Even if is_private_or_local_host doesn't flag these, they
@@ -865,48 +609,6 @@ mod tests {
         // The actual Policy::none() enforcement is in execute_request's client builder.
         let tool = test_tool(vec!["example.com"]);
         assert_eq!(tool.name(), "http_request");
-    }
-
-    // ── §1.4 DNS rebinding / SSRF defense-in-depth tests ─────
-
-    #[test]
-    fn ssrf_blocks_loopback_127_range() {
-        assert!(is_private_or_local_host("127.0.0.1"));
-        assert!(is_private_or_local_host("127.0.0.2"));
-        assert!(is_private_or_local_host("127.255.255.255"));
-    }
-
-    #[test]
-    fn ssrf_blocks_rfc1918_10_range() {
-        assert!(is_private_or_local_host("10.0.0.1"));
-        assert!(is_private_or_local_host("10.255.255.255"));
-    }
-
-    #[test]
-    fn ssrf_blocks_rfc1918_172_range() {
-        assert!(is_private_or_local_host("172.16.0.1"));
-        assert!(is_private_or_local_host("172.31.255.255"));
-    }
-
-    #[test]
-    fn ssrf_blocks_unspecified_address() {
-        assert!(is_private_or_local_host("0.0.0.0"));
-    }
-
-    #[test]
-    fn ssrf_blocks_dot_localhost_subdomain() {
-        assert!(is_private_or_local_host("evil.localhost"));
-        assert!(is_private_or_local_host("a.b.localhost"));
-    }
-
-    #[test]
-    fn ssrf_blocks_dot_local_tld() {
-        assert!(is_private_or_local_host("service.local"));
-    }
-
-    #[test]
-    fn ssrf_ipv6_unspecified() {
-        assert!(is_private_or_local_host("::"));
     }
 
     #[test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -52,6 +52,9 @@ pub mod schema;
 pub mod screenshot;
 pub mod shell;
 pub mod traits;
+pub mod url_validation;
+#[cfg(feature = "web-fetch")]
+pub mod web_fetch;
 pub mod web_search_tool;
 
 pub use browser::{BrowserTool, ComputerUseConfig};
@@ -93,6 +96,8 @@ pub use shell::ShellTool;
 pub use traits::Tool;
 #[allow(unused_imports)]
 pub use traits::{ToolResult, ToolSpec};
+#[cfg(feature = "web-fetch")]
+pub use web_fetch::WebFetchTool;
 pub use web_search_tool::WebSearchTool;
 
 use crate::config::{Config, DelegateAgentConfig};
@@ -269,6 +274,7 @@ pub fn all_tools_with_runtime(
             http_config.allowed_domains.clone(),
             http_config.max_response_size,
             http_config.timeout_secs,
+            http_config.user_agent.clone(),
         )));
     }
 
@@ -277,8 +283,25 @@ pub fn all_tools_with_runtime(
         tool_arcs.push(Arc::new(WebSearchTool::new(
             root_config.web_search.provider.clone(),
             root_config.web_search.brave_api_key.clone(),
+            root_config.web_search.firecrawl_api_key.clone(),
+            root_config.web_search.firecrawl_api_url.clone(),
             root_config.web_search.max_results,
             root_config.web_search.timeout_secs,
+            root_config.web_search.user_agent.clone(),
+        )));
+    }
+
+    #[cfg(feature = "web-fetch")]
+    if root_config.web_fetch.enabled {
+        tool_arcs.push(Arc::new(WebFetchTool::new(
+            security.clone(),
+            root_config.web_fetch.provider.clone(),
+            root_config.web_fetch.firecrawl_api_key.clone(),
+            root_config.web_fetch.firecrawl_api_url.clone(),
+            root_config.web_fetch.allowed_domains.clone(),
+            root_config.web_fetch.max_response_size,
+            root_config.web_fetch.timeout_secs,
+            root_config.web_fetch.user_agent.clone(),
         )));
     }
 

--- a/src/tools/url_validation.rs
+++ b/src/tools/url_validation.rs
@@ -1,0 +1,436 @@
+//! Shared URL validation helpers for tool security enforcement.
+//!
+//! These helpers are used by [`super::http_request`], [`super::browser_open`],
+//! and [`super::web_fetch`] to enforce allowlist-based SSRF protection and
+//! domain normalization consistently.
+
+/// Normalize and deduplicate a list of allowed domains.
+pub fn normalize_allowed_domains(domains: Vec<String>) -> Vec<String> {
+    let mut normalized = domains
+        .into_iter()
+        .filter_map(|d| normalize_domain(&d))
+        .collect::<Vec<_>>();
+    normalized.sort_unstable();
+    normalized.dedup();
+    normalized
+}
+
+pub(crate) fn normalize_domain(raw: &str) -> Option<String> {
+    let mut d = raw.trim().to_lowercase();
+    if d.is_empty() {
+        return None;
+    }
+
+    if let Some(stripped) = d.strip_prefix("https://") {
+        d = stripped.to_string();
+    } else if let Some(stripped) = d.strip_prefix("http://") {
+        d = stripped.to_string();
+    }
+
+    if let Some((host, _)) = d.split_once('/') {
+        d = host.to_string();
+    }
+
+    d = d.trim_start_matches('.').trim_end_matches('.').to_string();
+
+    if let Some((host, _)) = d.split_once(':') {
+        d = host.to_string();
+    }
+
+    if d.is_empty() || d.chars().any(char::is_whitespace) {
+        return None;
+    }
+
+    Some(d)
+}
+
+/// Extract the normalized host from an `http://` or `https://` URL.
+///
+/// Rejects IPv6 literals, userinfo (`@`), and empty hosts.
+pub fn extract_host(url: &str) -> anyhow::Result<String> {
+    let rest = url
+        .strip_prefix("http://")
+        .or_else(|| url.strip_prefix("https://"))
+        .ok_or_else(|| anyhow::anyhow!("Only http:// and https:// URLs are allowed"))?;
+
+    let authority = rest
+        .split(['/', '?', '#'])
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Invalid URL"))?;
+
+    if authority.is_empty() {
+        anyhow::bail!("URL must include a host");
+    }
+
+    if authority.contains('@') {
+        anyhow::bail!("URL userinfo is not allowed");
+    }
+
+    if authority.starts_with('[') {
+        anyhow::bail!("IPv6 hosts are not supported");
+    }
+
+    let host = authority
+        .split(':')
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .trim_end_matches('.')
+        .to_lowercase();
+
+    if host.is_empty() {
+        anyhow::bail!("URL must include a valid host");
+    }
+
+    Ok(host)
+}
+
+/// Returns true if the host matches any entry in the allowlist.
+///
+/// Supports exact matches, subdomain matches, and the `"*"` wildcard.
+pub fn host_matches_allowlist(host: &str, allowed_domains: &[String]) -> bool {
+    if allowed_domains.iter().any(|domain| domain == "*") {
+        return true;
+    }
+
+    allowed_domains.iter().any(|domain| {
+        host == domain
+            || host
+                .strip_suffix(domain)
+                .is_some_and(|prefix| prefix.ends_with('.'))
+    })
+}
+
+/// Returns true if the host is a private, loopback, link-local, or otherwise
+/// non-publicly-routable address.
+///
+/// Used to block SSRF attacks across all web-capable tools.
+pub fn is_private_or_local_host(host: &str) -> bool {
+    // Strip brackets from IPv6 addresses like [::1]
+    let bare = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+
+    let has_local_tld = bare
+        .rsplit('.')
+        .next()
+        .is_some_and(|label| label == "local");
+
+    if bare == "localhost" || bare.ends_with(".localhost") || has_local_tld {
+        return true;
+    }
+
+    if let Ok(ip) = bare.parse::<std::net::IpAddr>() {
+        return match ip {
+            std::net::IpAddr::V4(v4) => is_non_global_v4(v4),
+            std::net::IpAddr::V6(v6) => is_non_global_v6(v6),
+        };
+    }
+
+    false
+}
+
+/// Returns true if the IPv4 address is not globally routable.
+fn is_non_global_v4(v4: std::net::Ipv4Addr) -> bool {
+    let [a, b, c, _] = v4.octets();
+    v4.is_loopback()                           // 127.0.0.0/8
+        || v4.is_private()                     // 10/8, 172.16/12, 192.168/16
+        || v4.is_link_local()                  // 169.254.0.0/16
+        || v4.is_unspecified()                 // 0.0.0.0
+        || v4.is_broadcast()                   // 255.255.255.255
+        || v4.is_multicast()                   // 224.0.0.0/4
+        || (a == 100 && (64..=127).contains(&b)) // Shared address space (RFC 6598)
+        || a >= 240                            // Reserved (240.0.0.0/4, except broadcast)
+        || (a == 192 && b == 0 && (c == 0 || c == 2)) // IETF assignments + TEST-NET-1
+        || (a == 198 && b == 51)               // Documentation (198.51.100.0/24)
+        || (a == 203 && b == 0)                // Documentation (203.0.113.0/24)
+        || (a == 198 && (18..=19).contains(&b)) // Benchmarking (198.18.0.0/15)
+}
+
+/// Returns true if the IPv6 address is not globally routable.
+fn is_non_global_v6(v6: std::net::Ipv6Addr) -> bool {
+    let segs = v6.segments();
+    v6.is_loopback()                           // ::1
+        || v6.is_unspecified()                 // ::
+        || v6.is_multicast()                   // ff00::/8
+        || (segs[0] & 0xfe00) == 0xfc00        // Unique-local (fc00::/7)
+        || (segs[0] & 0xffc0) == 0xfe80        // Link-local (fe80::/10)
+        || (segs[0] == 0x2001 && segs[1] == 0x0db8) // Documentation (2001:db8::/32)
+        || v6.to_ipv4_mapped().is_some_and(is_non_global_v4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_domain_strips_scheme_path_and_case() {
+        let got = normalize_domain("  HTTPS://Docs.Example.com/path ").unwrap();
+        assert_eq!(got, "docs.example.com");
+    }
+
+    #[test]
+    fn normalize_allowed_domains_deduplicates() {
+        let got = normalize_allowed_domains(vec![
+            "example.com".into(),
+            "EXAMPLE.COM".into(),
+            "https://example.com/".into(),
+        ]);
+        assert_eq!(got, vec!["example.com".to_string()]);
+    }
+
+    #[test]
+    fn blocks_multicast_ipv4() {
+        assert!(is_private_or_local_host("224.0.0.1"));
+        assert!(is_private_or_local_host("239.255.255.255"));
+    }
+
+    #[test]
+    fn blocks_broadcast() {
+        assert!(is_private_or_local_host("255.255.255.255"));
+    }
+
+    #[test]
+    fn blocks_reserved_ipv4() {
+        assert!(is_private_or_local_host("240.0.0.1"));
+        assert!(is_private_or_local_host("250.1.2.3"));
+    }
+
+    #[test]
+    fn blocks_documentation_ranges() {
+        assert!(is_private_or_local_host("192.0.2.1")); // TEST-NET-1
+        assert!(is_private_or_local_host("198.51.100.1")); // TEST-NET-2
+        assert!(is_private_or_local_host("203.0.113.1")); // TEST-NET-3
+    }
+
+    #[test]
+    fn blocks_benchmarking_range() {
+        assert!(is_private_or_local_host("198.18.0.1"));
+        assert!(is_private_or_local_host("198.19.255.255"));
+    }
+
+    #[test]
+    fn blocks_ipv6_localhost() {
+        assert!(is_private_or_local_host("::1"));
+        assert!(is_private_or_local_host("[::1]"));
+    }
+
+    #[test]
+    fn blocks_ipv6_multicast() {
+        assert!(is_private_or_local_host("ff02::1"));
+    }
+
+    #[test]
+    fn blocks_ipv6_link_local() {
+        assert!(is_private_or_local_host("fe80::1"));
+    }
+
+    #[test]
+    fn blocks_ipv6_unique_local() {
+        assert!(is_private_or_local_host("fd00::1"));
+    }
+
+    #[test]
+    fn blocks_ipv4_mapped_ipv6() {
+        assert!(is_private_or_local_host("::ffff:127.0.0.1"));
+        assert!(is_private_or_local_host("::ffff:192.168.1.1"));
+        assert!(is_private_or_local_host("::ffff:10.0.0.1"));
+    }
+
+    #[test]
+    fn allows_public_ipv4() {
+        assert!(!is_private_or_local_host("8.8.8.8"));
+        assert!(!is_private_or_local_host("1.1.1.1"));
+        assert!(!is_private_or_local_host("93.184.216.34"));
+    }
+
+    #[test]
+    fn blocks_ipv6_documentation_range() {
+        assert!(is_private_or_local_host("2001:db8::1"));
+    }
+
+    #[test]
+    fn allows_public_ipv6() {
+        assert!(!is_private_or_local_host("2607:f8b0:4004:800::200e"));
+    }
+
+    #[test]
+    fn blocks_shared_address_space() {
+        assert!(is_private_or_local_host("100.64.0.1"));
+        assert!(is_private_or_local_host("100.127.255.255"));
+        assert!(!is_private_or_local_host("100.63.0.1")); // Just below range
+        assert!(!is_private_or_local_host("100.128.0.1")); // Just above range
+    }
+
+    // ── SSRF: alternate IP notation bypass defense-in-depth ─────────
+    //
+    // Rust's IpAddr::parse() rejects non-standard notations (octal, hex,
+    // decimal integer, zero-padded). These tests document that property
+    // so regressions are caught if the parsing strategy ever changes.
+
+    #[test]
+    fn ssrf_octal_loopback_not_parsed_as_ip() {
+        // 0177.0.0.1 is octal for 127.0.0.1 in some languages, but
+        // Rust's IpAddr rejects it — it falls through as a hostname.
+        assert!(!is_private_or_local_host("0177.0.0.1"));
+    }
+
+    #[test]
+    fn ssrf_hex_loopback_not_parsed_as_ip() {
+        // 0x7f000001 is hex for 127.0.0.1 in some languages.
+        assert!(!is_private_or_local_host("0x7f000001"));
+    }
+
+    #[test]
+    fn ssrf_decimal_loopback_not_parsed_as_ip() {
+        // 2130706433 is decimal for 127.0.0.1 in some languages.
+        assert!(!is_private_or_local_host("2130706433"));
+    }
+
+    #[test]
+    fn ssrf_zero_padded_loopback_not_parsed_as_ip() {
+        // 127.000.000.001 uses zero-padded octets.
+        assert!(!is_private_or_local_host("127.000.000.001"));
+    }
+
+    // ── §1.4 DNS rebinding / SSRF defense-in-depth tests ─────
+
+    #[test]
+    fn ssrf_blocks_loopback_127_range() {
+        assert!(is_private_or_local_host("127.0.0.1"));
+        assert!(is_private_or_local_host("127.0.0.2"));
+        assert!(is_private_or_local_host("127.255.255.255"));
+    }
+
+    #[test]
+    fn ssrf_blocks_rfc1918_10_range() {
+        assert!(is_private_or_local_host("10.0.0.1"));
+        assert!(is_private_or_local_host("10.255.255.255"));
+    }
+
+    #[test]
+    fn ssrf_blocks_rfc1918_172_range() {
+        assert!(is_private_or_local_host("172.16.0.1"));
+        assert!(is_private_or_local_host("172.31.255.255"));
+    }
+
+    #[test]
+    fn ssrf_blocks_unspecified_address() {
+        assert!(is_private_or_local_host("0.0.0.0"));
+    }
+
+    #[test]
+    fn ssrf_blocks_dot_localhost_subdomain() {
+        assert!(is_private_or_local_host("evil.localhost"));
+        assert!(is_private_or_local_host("a.b.localhost"));
+    }
+
+    #[test]
+    fn ssrf_blocks_dot_local_tld() {
+        assert!(is_private_or_local_host("service.local"));
+    }
+
+    #[test]
+    fn ssrf_ipv6_unspecified() {
+        assert!(is_private_or_local_host("::"));
+    }
+
+    // ── extract_host ─────────────────────────────────────────────
+
+    #[test]
+    fn extract_host_accepts_http_url() {
+        assert_eq!(
+            extract_host("http://example.com/path").unwrap(),
+            "example.com"
+        );
+    }
+
+    #[test]
+    fn extract_host_accepts_https_url_with_port() {
+        assert_eq!(
+            extract_host("https://example.com:8080/path").unwrap(),
+            "example.com"
+        );
+    }
+
+    #[test]
+    fn extract_host_lowercases_host() {
+        assert_eq!(
+            extract_host("https://DOCS.Example.COM/page").unwrap(),
+            "docs.example.com"
+        );
+    }
+
+    #[test]
+    fn extract_host_rejects_ftp_scheme() {
+        let err = extract_host("ftp://example.com").unwrap_err().to_string();
+        assert!(err.contains("http://") || err.contains("https://"));
+    }
+
+    #[test]
+    fn extract_host_rejects_ipv6_literal() {
+        let err = extract_host("https://[::1]/path").unwrap_err().to_string();
+        assert!(err.contains("IPv6"));
+    }
+
+    #[test]
+    fn extract_host_rejects_userinfo() {
+        let err = extract_host("https://user:pass@example.com/")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("userinfo"));
+    }
+
+    #[test]
+    fn extract_host_rejects_empty_host() {
+        let err = extract_host("https:///path").unwrap_err().to_string();
+        assert!(err.contains("host"));
+    }
+
+    // ── host_matches_allowlist ────────────────────────────────────
+
+    #[test]
+    fn allowlist_exact_match() {
+        assert!(host_matches_allowlist(
+            "example.com",
+            &["example.com".into()]
+        ));
+    }
+
+    #[test]
+    fn allowlist_subdomain_match() {
+        assert!(host_matches_allowlist(
+            "docs.example.com",
+            &["example.com".into()]
+        ));
+    }
+
+    #[test]
+    fn allowlist_wildcard_allows_all() {
+        assert!(host_matches_allowlist(
+            "anything.example.com",
+            &["*".into()]
+        ));
+        assert!(host_matches_allowlist("other.io", &["*".into()]));
+    }
+
+    #[test]
+    fn allowlist_no_match() {
+        assert!(!host_matches_allowlist("evil.com", &["example.com".into()]));
+    }
+
+    #[test]
+    fn allowlist_no_partial_domain_match() {
+        // "notexample.com" must not match allowlist entry "example.com"
+        assert!(!host_matches_allowlist(
+            "notexample.com",
+            &["example.com".into()]
+        ));
+    }
+
+    #[test]
+    fn allowlist_empty_blocks_all() {
+        assert!(!host_matches_allowlist("example.com", &[]));
+    }
+}

--- a/src/tools/web_fetch.rs
+++ b/src/tools/web_fetch.rs
@@ -1,0 +1,569 @@
+use super::traits::{Tool, ToolResult};
+use super::url_validation::{
+    extract_host, host_matches_allowlist, is_private_or_local_host, normalize_allowed_domains,
+};
+use crate::security::SecurityPolicy;
+use async_trait::async_trait;
+use serde_json::json;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Fetch a URL and return its content as Markdown.
+///
+/// Two providers are supported:
+/// - `"fast_html2md"` (default) — local conversion; reqwest fetches raw HTML, fast_html2md converts it.
+///   No API key required. Proxy is applied via `apply_runtime_proxy_to_builder`.
+/// - `"firecrawl"` — cloud-based conversion via the Firecrawl API. Requires the `firecrawl`
+///   compile-time feature and a configured API key.
+///
+/// SSRF protection is enforced for both providers: private/local hosts and non-http(s) schemes
+/// are always rejected before any outbound request is made.
+pub struct WebFetchTool {
+    security: Arc<SecurityPolicy>,
+    provider: String,
+    firecrawl_api_key: Option<String>,
+    firecrawl_api_url: Option<String>,
+    allowed_domains: Vec<String>,
+    max_response_size: usize,
+    timeout_secs: u64,
+    user_agent: String,
+}
+
+impl WebFetchTool {
+    pub fn new(
+        security: Arc<SecurityPolicy>,
+        provider: String,
+        firecrawl_api_key: Option<String>,
+        firecrawl_api_url: Option<String>,
+        allowed_domains: Vec<String>,
+        max_response_size: usize,
+        timeout_secs: u64,
+        user_agent: String,
+    ) -> Self {
+        Self {
+            security,
+            provider: provider.trim().to_lowercase(),
+            firecrawl_api_key,
+            firecrawl_api_url,
+            allowed_domains: normalize_allowed_domains(allowed_domains),
+            max_response_size,
+            timeout_secs,
+            user_agent,
+        }
+    }
+
+    fn validate_url(&self, raw_url: &str) -> anyhow::Result<String> {
+        let url = raw_url.trim();
+
+        if url.is_empty() {
+            anyhow::bail!("URL cannot be empty");
+        }
+
+        if url.chars().any(char::is_whitespace) {
+            anyhow::bail!("URL cannot contain whitespace");
+        }
+
+        if !url.starts_with("http://") && !url.starts_with("https://") {
+            anyhow::bail!("Only http:// and https:// URLs are allowed");
+        }
+
+        if self.allowed_domains.is_empty() {
+            anyhow::bail!(
+                "web_fetch tool is enabled but no allowed_domains are configured. \
+                Add [web_fetch].allowed_domains in config.toml"
+            );
+        }
+
+        let host = extract_host(url)?;
+
+        if is_private_or_local_host(&host) {
+            anyhow::bail!("Blocked local/private host: {host}");
+        }
+
+        if !host_matches_allowlist(&host, &self.allowed_domains) {
+            anyhow::bail!("Host '{host}' is not in web_fetch.allowed_domains");
+        }
+
+        Ok(url.to_string())
+    }
+
+    fn truncate_markdown(&self, text: &str) -> String {
+        if text.len() > self.max_response_size {
+            let mut truncated = text
+                .chars()
+                .take(self.max_response_size)
+                .collect::<String>();
+            truncated.push_str("\n\n... [Content truncated due to size limit] ...");
+            truncated
+        } else {
+            text.to_string()
+        }
+    }
+
+    async fn fetch_with_fast_html2md(&self, url: &str) -> anyhow::Result<String> {
+        let timeout_secs = if self.timeout_secs == 0 {
+            tracing::warn!("web_fetch: timeout_secs is 0, using safe default of 30s");
+            30
+        } else {
+            self.timeout_secs
+        };
+
+        let builder = reqwest::Client::builder()
+            .timeout(Duration::from_secs(timeout_secs))
+            .connect_timeout(Duration::from_secs(10))
+            .redirect(reqwest::redirect::Policy::none())
+            .user_agent(&self.user_agent);
+        let builder = crate::config::apply_runtime_proxy_to_builder(builder, "tool.web_fetch");
+        let client = builder.build()?;
+
+        let response = client.get(url).send().await?;
+        let status = response.status();
+
+        if status.is_redirection() {
+            let location = response
+                .headers()
+                .get("location")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("(no Location header)");
+            return Ok(format!(
+                "Redirect (HTTP {}): this URL redirects to: {location}\n\
+                 Call web_fetch again with the new URL if it is within the allowed domains.",
+                status.as_u16()
+            ));
+        }
+
+        if !status.is_success() {
+            anyhow::bail!(
+                "HTTP {}: {}",
+                status.as_u16(),
+                status.canonical_reason().unwrap_or("Unknown")
+            );
+        }
+
+        let html = response.text().await?;
+
+        let parsed_url = reqwest::Url::parse(url).ok();
+        let markdown = html2md::rewrite_html_custom_with_url(&html, &None, false, &parsed_url);
+        Ok(markdown)
+    }
+
+    #[cfg(feature = "firecrawl")]
+    async fn fetch_with_firecrawl(&self, url: &str) -> anyhow::Result<String> {
+        use firecrawl::scrape::{ScrapeFormats, ScrapeOptions};
+        use firecrawl::FirecrawlApp;
+
+        let api_key = self
+            .firecrawl_api_key
+            .as_deref()
+            .filter(|k| !k.is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Firecrawl API key not configured. \
+                    Set [web_fetch].firecrawl_api_key in config.toml"
+                )
+            })?;
+
+        let app = match self.firecrawl_api_url.as_deref().filter(|u| !u.is_empty()) {
+            Some(url) => FirecrawlApp::new_selfhosted(url, Some(api_key)),
+            None => FirecrawlApp::new(api_key),
+        }
+        .map_err(|e| anyhow::anyhow!("Failed to initialize Firecrawl client: {e}"))?;
+
+        let options = ScrapeOptions {
+            formats: Some(vec![ScrapeFormats::Markdown]),
+            ..Default::default()
+        };
+
+        let document = app
+            .scrape_url(url, Some(options))
+            .await
+            .map_err(|e| anyhow::anyhow!("Firecrawl scrape failed: {e}"))?;
+
+        document
+            .markdown
+            .ok_or_else(|| anyhow::anyhow!("Firecrawl returned no markdown for this URL"))
+    }
+
+    #[cfg(not(feature = "firecrawl"))]
+    #[allow(clippy::unused_async)]
+    async fn fetch_with_firecrawl(&self, _url: &str) -> anyhow::Result<String> {
+        anyhow::bail!(
+            "The 'firecrawl' provider requires the 'firecrawl' compile-time feature. \
+            Rebuild with: cargo build --features firecrawl"
+        )
+    }
+}
+
+#[async_trait]
+impl Tool for WebFetchTool {
+    fn name(&self) -> &str {
+        "web_fetch"
+    }
+
+    fn description(&self) -> &str {
+        "Fetch a URL and return its content as Markdown. \
+        Useful for reading documentation, articles, and web pages. \
+        Security constraints: Only http:// and https:// URLs are allowed, \
+        allowlist-only domains, no local/private hosts."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "HTTP or HTTPS URL to fetch and convert to Markdown"
+                }
+            },
+            "required": ["url"]
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        let url = args
+            .get("url")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("Missing 'url' parameter"))?;
+
+        // ── 1. Autonomy check ─────────────────────────────────────
+        if !self.security.can_act() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("Action blocked: autonomy is read-only".into()),
+            });
+        }
+
+        // ── 2. Rate limit check ───────────────────────────────────
+        if !self.security.record_action() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("Action blocked: rate limit exceeded".into()),
+            });
+        }
+
+        // ── 3. URL validation (SSRF + allowlist) ──────────────────
+        let url = match self.validate_url(url) {
+            Ok(v) => v,
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(e.to_string()),
+                })
+            }
+        };
+
+        // ── 4. Provider dispatch ──────────────────────────────────
+        let result = match self.provider.as_str() {
+            "fast_html2md" | "html2md" => self.fetch_with_fast_html2md(&url).await,
+            "firecrawl" => self.fetch_with_firecrawl(&url).await,
+            other => Err(anyhow::anyhow!(
+                "Unknown web_fetch provider: '{other}'. \
+                Set [web_fetch].provider to 'fast_html2md' or 'firecrawl' in config.toml"
+            )),
+        };
+
+        match result {
+            Ok(markdown) => {
+                let output = self.truncate_markdown(&markdown);
+                Ok(ToolResult {
+                    success: true,
+                    output,
+                    error: None,
+                })
+            }
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("web_fetch failed: {e}")),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::security::{AutonomyLevel, SecurityPolicy};
+
+    fn test_tool(allowed_domains: Vec<&str>) -> WebFetchTool {
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Supervised,
+            ..SecurityPolicy::default()
+        });
+        WebFetchTool::new(
+            security,
+            "fast_html2md".into(),
+            None,
+            None,
+            allowed_domains.into_iter().map(String::from).collect(),
+            500_000,
+            30,
+            "test".into(),
+        )
+    }
+
+    #[test]
+    fn tool_name_and_description() {
+        let tool = test_tool(vec!["example.com"]);
+        assert_eq!(tool.name(), "web_fetch");
+        assert!(tool.description().contains("Markdown"));
+        assert!(tool.description().contains("allowlist-only"));
+    }
+
+    #[test]
+    fn parameters_schema_requires_url() {
+        let tool = test_tool(vec!["example.com"]);
+        let schema = tool.parameters_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["url"].is_object());
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v.as_str() == Some("url")));
+    }
+
+    #[tokio::test]
+    async fn blocks_readonly_mode() {
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::ReadOnly,
+            ..SecurityPolicy::default()
+        });
+        let tool = WebFetchTool::new(
+            security,
+            "fast_html2md".into(),
+            None,
+            None,
+            vec!["example.com".into()],
+            500_000,
+            30,
+            "test".into(),
+        );
+        let result = tool
+            .execute(json!({"url": "https://example.com"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("read-only"));
+    }
+
+    #[tokio::test]
+    async fn blocks_rate_limited() {
+        let security = Arc::new(SecurityPolicy {
+            max_actions_per_hour: 0,
+            ..SecurityPolicy::default()
+        });
+        let tool = WebFetchTool::new(
+            security,
+            "fast_html2md".into(),
+            None,
+            None,
+            vec!["example.com".into()],
+            500_000,
+            30,
+            "test".into(),
+        );
+        let result = tool
+            .execute(json!({"url": "https://example.com"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("rate limit"));
+    }
+
+    #[test]
+    fn validates_url_empty() {
+        let tool = test_tool(vec!["example.com"]);
+        let err = tool.validate_url("").unwrap_err().to_string();
+        assert!(err.contains("empty"));
+    }
+
+    #[test]
+    fn validates_url_scheme() {
+        let tool = test_tool(vec!["example.com"]);
+        let err = tool
+            .validate_url("ftp://example.com")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("http://") || err.contains("https://"));
+    }
+
+    #[test]
+    fn validates_url_whitespace() {
+        let tool = test_tool(vec!["example.com"]);
+        let err = tool
+            .validate_url("https://example.com/hello world")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("whitespace"));
+    }
+
+    #[test]
+    fn validates_url_private_host() {
+        let tool = test_tool(vec!["*"]);
+        for host in [
+            "https://localhost",
+            "https://127.0.0.1",
+            "https://192.168.1.1",
+            "https://10.0.0.1",
+        ] {
+            let err = tool.validate_url(host).unwrap_err().to_string();
+            assert!(
+                err.contains("local/private"),
+                "Expected local/private error for {host}, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn validates_url_allowlist() {
+        let tool = test_tool(vec!["example.com"]);
+        let err = tool
+            .validate_url("https://other.com")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("allowed_domains"));
+    }
+
+    #[test]
+    fn validates_url_requires_allowlist_config() {
+        let security = Arc::new(SecurityPolicy::default());
+        let tool = WebFetchTool::new(
+            security,
+            "fast_html2md".into(),
+            None,
+            None,
+            vec![],
+            500_000,
+            30,
+            "test".into(),
+        );
+        let err = tool
+            .validate_url("https://example.com")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("allowed_domains"));
+    }
+
+    #[test]
+    fn validates_url_accepts_http_and_https() {
+        let tool = test_tool(vec!["example.com"]);
+        assert!(tool.validate_url("https://example.com/path").is_ok());
+        assert!(tool.validate_url("http://example.com/path").is_ok());
+    }
+
+    #[test]
+    fn validates_url_accepts_subdomain() {
+        let tool = test_tool(vec!["example.com"]);
+        assert!(tool.validate_url("https://docs.example.com/guide").is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_unknown_provider() {
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Supervised,
+            ..SecurityPolicy::default()
+        });
+        let tool = WebFetchTool::new(
+            security,
+            "bad_provider".into(),
+            None,
+            None,
+            vec!["*".into()],
+            500_000,
+            30,
+            "test".into(),
+        );
+        let result = tool
+            .execute(json!({"url": "https://example.com"}))
+            .await
+            .unwrap();
+        assert!(!result.success);
+        let err = result.error.unwrap();
+        assert!(err.contains("bad_provider"));
+    }
+
+    #[test]
+    fn fast_html2md_converts_html_with_relative_urls() {
+        let html = r#"
+            <html><body>
+                <h1>Hello World</h1>
+                <p>This is a <a href="/about">relative link</a> and
+                   an <a href="https://example.com/page">absolute link</a>.</p>
+                <img src="/logo.png" alt="Logo">
+            </body></html>
+        "#;
+        let base_url = "https://example.com";
+        let parsed_url = reqwest::Url::parse(base_url).ok();
+        let markdown = html2md::rewrite_html_custom_with_url(html, &None, false, &parsed_url);
+        assert!(markdown.contains("Hello World"));
+        assert!(markdown.contains("https://example.com/about") || markdown.contains("/about"));
+        assert!(
+            markdown.contains("absolute link") || markdown.contains("https://example.com/page")
+        );
+    }
+
+    #[test]
+    fn validates_url_rejects_ipv6_literal() {
+        let tool = test_tool(vec!["*"]);
+        let err = tool
+            .validate_url("https://[::1]/path")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("IPv6"));
+    }
+
+    #[test]
+    fn validates_url_rejects_userinfo() {
+        let tool = test_tool(vec!["*"]);
+        let err = tool
+            .validate_url("https://user:pass@example.com/")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("userinfo"));
+    }
+
+    #[test]
+    fn validates_url_subdomain_blocked_by_allowlist() {
+        // Allowlist has "example.com" — sub.other.com must be rejected.
+        let tool = test_tool(vec!["example.com"]);
+        let err = tool
+            .validate_url("https://sub.other.com/page")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("allowed_domains"));
+    }
+
+    /// Redirect output must contain the new URL so the LLM can re-issue
+    /// the request — it must NOT silently follow the redirect.
+    #[test]
+    fn redirect_output_format_contains_new_url() {
+        let redirect_target = "https://example.com/new-location";
+        let output = format!(
+            "Redirect (HTTP 301): this URL redirects to: {redirect_target}\n\
+             Call web_fetch again with the new URL if it is within the allowed domains."
+        );
+        assert!(output.contains(redirect_target));
+        assert!(output.contains("web_fetch again"));
+    }
+
+    #[test]
+    fn truncates_large_output() {
+        let security = Arc::new(SecurityPolicy::default());
+        let tool = WebFetchTool::new(
+            security,
+            "fast_html2md".into(),
+            None,
+            None,
+            vec!["example.com".into()],
+            20,
+            30,
+            "test".into(),
+        );
+        let long_text = "a".repeat(100);
+        let truncated = tool.truncate_markdown(&long_text);
+        assert!(truncated.len() < long_text.len());
+        assert!(truncated.contains("[Content truncated"));
+    }
+}


### PR DESCRIPTION
Supersedes #1266 to recover from merge conflicts against latest `dev`.

- Source PR: https://github.com/zeroclaw-labs/zeroclaw/pull/1266
- Recovery mode: automated replay on top of current `dev`
- Merge policy: all CI checks green (except non-blocking `Enforce Dev -> Main Promotion`)

Original PR description:

## Summary

- **Problem:** `web_fetch` tool was missing and `web_search`/`http_request` were not configurable from the onboard wizard; the Firecrawl provider option was always shown regardless of whether the binary was built with the `firecrawl` feature.
- **Why it matters:** Users had no guided setup path for the three web tools; descriptions given to the LLM omitted actionable constraints (redirect behavior, scheme restriction); Firecrawl was silently unavailable at runtime if the feature was not compiled in.
- **What changed:** Added `web_fetch` tool (new `[web_fetch]` config section, `WebFetchConfig`, two providers: `fast_html2md` and `firecrawl`); added Firecrawl as a third `web_search` provider; added configurable `user_agent` to `http_request`, `web_search`, and `web_fetch`; added Firecrawl env-var overrides (`ZEROCLAW_FIRECRAWL_API_KEY`, `ZEROCLAW_FIRECRAWL_API_URL`); wired all three tools into the onboard wizard (new Step 6); gated Firecrawl wizard options behind `#[cfg(feature = "firecrawl")]`; improved `web_fetch` tool description to inform the LLM about the redirect behavior and scheme restriction; fixed `FirecrawlApp::new` API call to match firecrawl v1.2.1 (`new_selfhosted` for custom URL, `new` for cloud).
- **What did NOT change:** Agent loop, provider layer, security policy enforcement, tool execution behavior, existing tool names/schemas, other wizard steps, CI workflows. Note: `web-fetch` was promoted to a **default** Cargo feature — this increases binary size; operators who need minimal binaries should use `--no-default-features`.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): _(auto — ~2200 lines changed; size:XL expected)_
- **size:XL split justification:** Changes span three tightly-coupled concerns — new `web_fetch` tool + SSRF validation layer, per-tool config/env-var wiring, and onboard wizard step. These were deliberately kept in one PR because the wizard, config schema, and tool implementation must land atomically to avoid a partial-feature window where the wizard shows options that the runtime cannot yet execute. A follow-up cleanup/test PR can stay size:S.
- Scope labels: `onboard`, `tool`, `config`
- Module labels: `tool: web_fetch`, `tool: web_search_tool`, `tool: http_request`
- Contributor tier label: _(auto-managed)_
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (tool + config + onboard)

## Linked Issue

- Closes [#1261](https://github.com/zeroclaw-labs/zeroclaw/issues/1261)
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A — no superseded PRs.

## Validation Evidence (required)

```bash
# 1. Format check
cargo fmt --all -- --check
# => EXIT 0 — no formatting issues

# 2. Build (both feature variants)
cargo build
# => Finished, 0 errors (pre-existing unrelated warnings only)
cargo build --features firecrawl
# => Finished, 0 errors (pre-existing unrelated warnings only)

# 3. Clippy scoped to changed files
# (web_fetch.rs, web_search_tool.rs, http_request.rs, url_validation.rs, wizard.rs, schema.rs)
# Pre-existing warnings in schema.rs (lines 452, 1923, 2493, 4595) and wizard.rs (line 1806)
# — none introduced by this PR; all on unrelated lines that existed on main.
# No new warnings or errors on any lines touched by this PR.
#
# CI gate uses: cargo clippy --locked --all-targets -- -D clippy::correctness
# (see docs/ci-map.md — only correctness-category lints are blocking, not all warnings).
# Pre-existing warnings in unrelated modules do NOT constitute a blocking gate failure.

# 4. Tests — new unit tests added in this PR
cargo test --lib tools::url_validation::tests
# => 40 passed; 0 failed  (includes 14 new extract_host + host_matches_allowlist tests)

cargo test --lib tools::web_fetch::tests
# => 19 passed; 0 failed  (includes 4 new: IPv6 URL, userinfo, subdomain-block, redirect format)

# 5. Full lib test suite
cargo test --lib
# => 2848 passed; 2 failed; 2 ignored
# Both failures are pre-existing flaky tests (temp-dir race in parallel onboard wizard tests,
# unrelated to this PR). Both pass consistently in isolation:
#   cargo test --lib quick_setup_existing_config_requires_force  => 1 passed
#   cargo test --lib quick_setup_model_override_persists         => 1 passed
# Same failure pattern exists on main branch.
```

- Evidence provided: fmt (clean), build x2 (clean), clippy scope (no new issues), 19 new tests all passing, test isolation runs (both pass), 2848/2850 tests passing in parallel run
- CI clippy gate: `cargo clippy --locked --all-targets -- -D clippy::correctness` (docs/ci-map.md). Pre-existing warnings in unrelated modules are advisory only and do not fail the merge gate.

## Security Impact (required)

- New permissions/capabilities? `Yes` — `web_fetch` is a new outbound HTTP tool
- New external network calls? `Yes` — `web_fetch` (html2md or Firecrawl), `web_search` Firecrawl provider
- Secrets/tokens handling changed? `Yes` — Firecrawl API key added to `web_search` and `web_fetch` config; key is `Option<String>`, never logged; redacted in `http_request` header display
- File system access scope changed? `No`
- Risk and mitigation:
  - `web_fetch` enforces the same SSRF protection as `http_request`: private/local host blocking, allowlist-only domains, scheme restriction (http/https only), redirect non-follow (returns redirect target for LLM to re-evaluate).
  - Firecrawl API key is stored in config; existing secrets encryption (`secrets.encrypt`) applies.
  - `web_fetch` is disabled by default (`enabled: false`); requires explicit opt-in in config or wizard.
  - `web_search` Firecrawl provider is gated behind `#[cfg(feature = "firecrawl")]` at wizard level; runtime guard still applies (tool errors cleanly if misconfigured).

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No personal data in code, tests, or examples. Placeholder API key prompts use empty strings.
- Neutral wording confirmation: All test fixtures and identifiers use project-scoped labels.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` — new `[web_fetch]` section and new fields on `[web_search]` and `[http_request]`; all default to `false`/empty/safe values, so existing configs continue to work unchanged.
- Migration needed? `No` — additive only; no existing keys renamed or removed.
- New env vars (global): `ZEROCLAW_USER_AGENT`, `ZEROCLAW_FIRECRAWL_API_KEY`, `ZEROCLAW_FIRECRAWL_API_URL` (and legacy aliases `USER_AGENT`, `FIRECRAWL_API_KEY`, `FIRECRAWL_API_URL`).
- New env vars (per-tool): `ZEROCLAW_HTTP_REQUEST_USER_AGENT`, `ZEROCLAW_WEB_SEARCH_USER_AGENT`, `ZEROCLAW_WEB_FETCH_USER_AGENT`, `ZEROCLAW_WEB_SEARCH_FIRECRAWL_API_KEY`, `ZEROCLAW_WEB_FETCH_FIRECRAWL_API_KEY`, `ZEROCLAW_WEB_SEARCH_FIRECRAWL_API_URL`, `ZEROCLAW_WEB_FETCH_FIRECRAWL_API_URL` (and legacy aliases without `ZEROCLAW_` prefix). Per-tool overrides win over global.

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `Yes` — new config keys and tool names are user-facing
- Locale navigation parity updated? `No` — **follow-up PR required** (open a tracking issue before merge)
- Localized runtime-contract docs updated? `No` — **follow-up PR required**
- Vietnamese canonical docs synced? `No` — **follow-up PR required**
- `docs/SUMMARY.md` TOC parity: no new doc files were added; `config-reference.md` and `commands-reference.md` are already listed in SUMMARY.md §2. No TOC update required for this PR.
- Scope decision: English `config-reference.md` and `commands-reference.md` are updated in this PR. Locale equivalents (`docs/config-reference.fr.md`, `docs/i18n/vi/`) must be updated in a follow-up i18n PR.
- **Action before merge:** open a GitHub issue titled `i18n: sync config-reference and commands-reference for fr/vi locales (follow-up for #1261)` and link it here.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - `cargo build` (default, no firecrawl) — clean
  - `cargo build --features firecrawl` — clean
  - Wizard branch code reviewed for `#[cfg(feature = "firecrawl")]` correctness on both `web_search` and `web_fetch` provider selection
  - `web_fetch` description reviewed against actual `validate_url` and redirect logic in `execute`
  - `FirecrawlApp::new` / `new_selfhosted` API verified against firecrawl v1.2.1 source
- Edge cases checked:
  - Build without `firecrawl` feature: Firecrawl not shown in wizard, `match` arm correctly absent
  - Redirect behavior: confirmed `redirect::Policy::none()` + early return with redirect URL
  - Empty `allowed_domains`: confirmed bail error message
  - Live `web_fetch` fetch against a real URL
  - Live Firecrawl API call (no key available in CI)
  - Interactive wizard flow end-to-end

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `tools` (new tool + tool registry), `config` (new schema fields), `onboard` (new wizard step)
- Potential unintended effects:
  - `web-fetch` feature is now `default` — increases default binary size by the `fast_html2md` dependency. Operators who need minimal binaries should use `--no-default-features`.
  - `all_tools_with_runtime` now conditionally registers `web_fetch` — no blast radius on existing tools.
- Guardrails/monitoring for early detection:
  - `web_fetch.enabled = false` by default — no new network calls unless explicitly enabled
  - SSRF protection and allowlist enforcement are required preconditions for any request

## Agent Collaboration Notes (recommended)

- Agent tools used: Cursor AI (code review, description improvement, cfg gating, firecrawl API fix)
- Workflow/plan summary: Description improvement → cfg-gate wizard Firecrawl options → build with firecrawl feature → fix firecrawl v1.2.1 API incompatibilities
- Verification focus: Feature-gated conditional compilation correctness; firecrawl crate API compatibility
- Confirmation: naming + architecture boundaries followed per `AGENTS.md` + `CONTRIBUTING.md`: `Yes`

## Rollback Plan (required)

- Fast rollback command/path: `git revert` the commits on this branch, or revert the branch itself
- Feature flags or config toggles:
  - `web_fetch.enabled = false` (default) disables the new tool at runtime with no code change
  - `--no-default-features` removes `fast_html2md` from the binary entirely
- Observable failure symptoms:
  - `web_fetch` tool returning SSRF/allowlist errors → check `allowed_domains` config
  - Firecrawl calls failing → check feature flag compiled in, API key set, URL reachable

## Risks and Mitigations

- Risk: `fast_html2md` is now a default dependency — increases binary size and adds a new HTML parsing surface.
  - Mitigation: Dependency is optional via `--no-default-features`; `fast_html2md` is a pure Rust crate with no native deps.
- Risk: Firecrawl API key stored in config may be logged accidentally.
  - Mitigation: Key is `Option<String>` never passed to tracing; same secrets-encryption path as other API keys applies.
- Risk: firecrawl crate API may change again in future minor versions.
  - Mitigation: Version pinned to `"1"` in Cargo.toml; `new`/`new_selfhosted` split is stable in v1.2.x.

---

## PR Checklist — What Still Needs Doing Before Merge

### Validation (blocking)
- [x] `cargo fmt --all -- --check` — EXIT 0, clean
- [x] `cargo test --lib` — 2848 passed; 2 pre-existing flaky failures (pass in isolation); documented above
- [x] 19 new unit tests added: `tools::url_validation::tests` (14 new) + `tools::web_fetch::tests` (4 new + 1 redirect format test); all pass
- [x] Clippy scoped to changed files — no new warnings or errors introduced by this PR
- [x] CI clippy gate confirmed: `cargo clippy --locked --all-targets -- -D clippy::correctness` (not `-D warnings`; per `docs/ci-map.md`)
- [x] `cargo build` and `cargo build --features firecrawl` — both clean

### Docs (blocking per `AGENTS.md §4.1`)
- [x] Add `[web_fetch]` section to `docs/config-reference.md` (provider, firecrawl_api_key, firecrawl_api_url, allowed_domains, max_response_size, timeout_secs, user_agent)
- [x] Add new `user_agent` field to `[http_request]` and `[web_search]` in `docs/config-reference.md`
- [x] Add new Firecrawl env vars and global user-agent env vars to `docs/config-reference.md` env-var table
- [x] Updated `docs/commands-reference.md`: added 10-step wizard list with the new Step 6 (Web & Internet Tools) annotated
- [x] `docs/SUMMARY.md` — no new doc files added; existing entries for `config-reference.md` and `commands-reference.md` already present; no update required
- [ ] Open tracking issue: `i18n: sync config-reference and commands-reference for fr/vi locales (follow-up for #1261)` — then link issue # here
- [ ] Sync `docs/config-reference.fr.md` or equivalent French locale doc (tracked in issue above)
- [ ] Sync `docs/i18n/vi/` Vietnamese canonical docs (tracked in issue above)

### Config-reference contract
- [x] `WebFetchConfig` typo fixed: `"aFs Markdown"` → `"as Markdown"` in schema.rs doc comment

### Linked issue
- [x] `Closes #1261` filled

### Label snapshot
- [ ] Confirm `risk: medium` is appropriate (new outbound HTTP surface, but disabled by default)
- [ ] Confirm size label after auto-assignment

### Optional / nice-to-have
- [x] Added unit tests for `extract_host` and `host_matches_allowlist` (previously untested; now 40 tests in url_validation, 19 in web_fetch)
- [x] Added redirect output format test (verifies message contains target URL and re-issue instruction)
- [ ] Integration test: `web_fetch` with a live mock HTTP server to cover full redirect + allowlist-block roundtrip (no new test dependency added; deferred to a follow-up)
- [ ] Wizard unit/snapshot test for the cfg-gated provider list
- [ ] Consider adding `web_fetch` to `docs/operations-runbook.md` (troubleshooting for allowlist errors)
