### PR TITLE
[supersede #1354] feat(composio): fix v3 compatibility with parameter discovery, NLP text execution, and error enrichment

### DIFF
--- a/src/tools/composio.rs
+++ b/src/tools/composio.rs
@@ -1212,8 +1212,10 @@ fn format_schema_hint(schema: &serde_json::Value) -> Option<String> {
             String::new()
         } else {
             // Truncate long descriptions to keep the hint concise.
+            // Use char boundary to avoid panic on multi-byte UTF-8.
             let short = if desc.len() > 80 {
-                format!("{}...", &desc[..77])
+                let end = desc.floor_char_boundary(77);
+                format!("{}...", &desc[..end])
             } else {
                 desc.to_string()
             };


### PR DESCRIPTION
Supersedes #1354 to recover from merge conflicts against latest `dev`.

- Source PR: https://github.com/zeroclaw-labs/zeroclaw/pull/1354
- Recovery mode: automated replay on top of current `dev`
- Merge policy: all CI checks green (except non-blocking `Enforce Dev -> Main Promotion`)

Original PR description:

## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): `dev`
- Problem: The Composio v3 API returns full `input_parameters` JSON Schemas in its list response (`GET /api/v3/tools`), but `ComposioV3Tool` silently discarded this **required** field. The LLM agent saw only action names and descriptions -- never parameter schemas -- so it guessed `params` blindly on every `execute` call, looping on 400 errors. Additionally, the v3 execute endpoint's official `text` (NLP) mode was not surfaced, and execute errors were truncated to 240 characters with no remediation guidance.
- Why it matters: Any user with Composio enabled hits a token-burning failure loop where the agent cannot discover or self-correct the correct parameters for v3 actions. Reported by community.
- What changed: Single file -- `src/tools/composio.rs` (+199 -14). Three layers: (1) Capture `input_parameters` from v3 list response and show compact `[params: key1*, key2]` hints in `list` output. (2) Add `text` parameter for NLP execution via Composio's v3 `text` field (mutually exclusive with `arguments`). (3) On `execute` failure, auto-fetch tool schema via `GET /api/v3/tools/{slug}` and append formatted parameter hints to the error message.
- What did **not** change (scope boundary): No changes to `connect`, `list_accounts`, or any other tool. No changes to v2 fallback logic for non-text execute. No changes to any other module or file.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `tool`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `tool: composio`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): N/A (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `runtime`

## Linked Issue

- Closes # N/A
- Related # Community report about Composio v3 compatibility (agent loops guessing parameters)
- Depends on # N/A
- Supersedes # N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A -- this PR does not supersede another PR.

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check   # Pass (Rust 1.92.0)
cargo clippy --all-targets -- -D warnings   # Pass (Rust 1.92.0)
cargo test   # Pass -- 46/46 composio tests pass (Rust 1.92.0)
```

- Evidence provided (test/log/trace/screenshot/perf): All 46 existing unit tests pass with Rust 1.92.0 (CI toolchain). Code reviewed against official Composio v3 API docs: [GET /api/v3/tools](https://docs.composio.dev/reference/api-reference/tools/getTools), [GET /api/v3/tools/{slug}](https://docs.composio.dev/reference/api-reference/tools/get-tools-by-tool-slug), [POST /api/v3/tools/execute/{slug}](https://docs.composio.dev/reference/api-reference/tools/post-tools-execute-by-tool-slug). No integration tests with live Composio API.
- If any command is intentionally skipped, explain why: None skipped.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): Yes
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: New `GET /api/v3/tools/{slug}` call to `backend.composio.dev` on execute failure only. Read-only metadata fetch using existing `x-api-key` header. HTTPS enforced via `ensure_https`. Same security patterns as existing `list_actions` and `execute_action` methods.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: No PII or sensitive data introduced. Tool schema responses from Composio are public metadata.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Uses ZeroClaw-native terminology throughout.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): No -- two breaking API changes: (1) `ComposioAction` struct gains `input_parameters: Option<serde_json::Value>` field (direct struct construction will fail to compile; JSON deserialization remains compatible via `serde(default)`). (2) `execute_action` gains `text: Option<&str>` parameter (all callers must be updated). Both are primarily internal types with minimal external usage.
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No -- only internal tool description for LLM consumption changed, no user-facing docs or UI strings.
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: Not triggered -- no docs or user-facing wording changes.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: All 46 existing unit tests pass. Root cause analysis traced full LLM execution path (tool definition -> list -> execute -> error -> retry loop). Each assumption verified against official Composio v3 API docs. `input_parameters` confirmed as **required** field in v3 list response. `text` confirmed as official v3 execute parameter. `floor_char_boundary` usage consistent with `shell.rs`, `screenshot.rs`, `memory/hygiene.rs`.
- Edge cases checked: v2 fallback still works when `text` is not provided. `text` mode skips v2 fallback appropriately (v2 has no NLP). Schema fetch failures degrade gracefully (no error enrichment, but execute error still surfaces). `format_input_params_hint` handles missing properties, empty properties, and missing required array. UTF-8 truncation uses `floor_char_boundary` to avoid panics on multi-byte characters.
- What was not verified: No integration testing with live Composio API. Response shape assumptions are based on official docs, not runtime validation. No testing of actual LLM agent behavior with the new parameter hints or text mode.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Composio tool integration, LLM agent tool-calling loop
- Potential unintended effects: (1) Each failed `execute` now triggers an additional `GET /api/v3/tools/{slug}` call -- adds latency on failure path, could hit rate limits. No caching implemented. (2) `execute_action` signature changed -- external callers (if any) will break. (3) `text` and `params` mutual exclusivity not enforced -- if both provided, `text` silently wins.
- Guardrails/monitoring for early detection: Composio API errors are already logged. Monitor for increased `get_tool_schema` call volume and any new "tool schema lookup failed" or "Composio v3 NLP execute failed" errors.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Devin (autonomous coding agent)
- Workflow/plan summary (if any): Root cause analysis traced full LLM execution path from tool definition -> list -> execute -> error. Verified all assumptions against official Composio v3 API docs. Implemented three-layer defense: (1) capture `input_parameters` from list response, (2) support `text` NLP mode, (3) enrich errors with schema on failure.
- Verification focus: Critical -- no integration testing with live Composio API. Reviewer should verify response shape assumptions and consider adding integration tests.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes -- follows existing `ComposioTool` method patterns, uses established error handling conventions, maintains v3/v2 API structure, adheres to KISS/YAGNI principles.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>` or redeploy previous version
- Feature flags or config toggles (if any): None -- changes are always active
- Observable failure symptoms: Agent reports "Composio v3 tool schema lookup failed" errors; Composio actions continue to fail with incorrect parameters if parameter hints don't work as expected; "Composio v3 NLP execute failed" errors if text mode is unreliable.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: No integration testing with live Composio API -- response shape assumptions based on docs only.
  - Mitigation: Reviewer should manually verify against live API. Consider adding `#[ignore]` integration test.

- Risk: `get_tool_schema` called on every execute failure adds latency and could hit rate limits.
  - Mitigation: Consider caching schemas in a `HashMap<String, Value>` on `ComposioTool` after first fetch.

- Risk: `text` and `params` mutual exclusivity not enforced -- if both provided, `text` silently wins.
  - Mitigation: Add validation in execute handler or document the precedence behavior.

- Risk: Breaking public API changes (`execute_action` signature, `ComposioAction` struct).
  - Mitigation: Impact likely minimal (primarily internal types). Document in release notes.

- Risk: Composio's NLP `text` mode reliability is unknown.
  - Mitigation: Monitor for "Composio v3 NLP execute failed" errors. Layer 2 is additive -- removing it doesn't affect Layers 1 and 3.

---

**Root Cause Analysis:** Traced full LLM execution path and verified against [official Composio v3 API docs](https://docs.composio.dev/reference/api-reference/tools/getTools):
1. **RC1 -- `input_parameters` silently dropped:** v3 list response returns `input_parameters` as a **required** field, but `ComposioV3Tool` didn't capture it. LLM had zero way to discover parameter schemas.
2. **RC2 -- NLP execution not supported:** v3 execute endpoint officially accepts `text` (natural language) as alternative to `arguments`, but this wasn't exposed.
3. **RC3 -- Error messages truncated:** `sanitize_error_message` truncates to 240 chars, cutting off Composio's `suggested_fix`. No schema guidance in errors.

---

**Devin session:** https://app.devin.ai/sessions/df203860e4a8464c8a10184ab931c2f5
**Requested by:** @pappacorleone
