### PR TITLE
[supersede #1388] fix(provider): disable native tool calling for MiniMax

### DIFF
--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -33,8 +33,8 @@ pub struct OpenAiCompatibleProvider {
     /// to the first `user` message, then drop the system messages.
     /// Required for providers that reject `role: system` (e.g. MiniMax).
     merge_system_into_user: bool,
-    /// Whether this provider supports OpenAI-style native tool definitions
-    /// in API payloads.
+    /// Whether this provider supports OpenAI-style native tool calling.
+    /// When false, tools are injected into the system prompt as text.
     native_tool_calling: bool,
 }
 
@@ -2394,16 +2394,19 @@ mod tests {
     }
 
     #[test]
-    fn merge_system_constructor_disables_native_tool_calling() {
+    fn minimax_provider_disables_native_tool_calling() {
         let p = OpenAiCompatibleProvider::new_merge_system_into_user(
             "MiniMax",
-            "https://api.minimaxi.com/v1",
+            "https://api.minimax.chat/v1",
             Some("k"),
             AuthStyle::Bearer,
         );
         let caps = <OpenAiCompatibleProvider as Provider>::capabilities(&p);
-        assert!(!caps.native_tool_calling);
-        assert!(!p.supports_native_tools());
+        assert!(
+            !caps.native_tool_calling,
+            "MiniMax should use prompt-guided tool calling, not native"
+        );
+        assert!(!caps.vision);
     }
 
     #[test]


### PR DESCRIPTION
Supersedes #1388 to recover from merge conflicts against latest `dev`.

- Source PR: https://github.com/zeroclaw-labs/zeroclaw/pull/1388
- Recovery mode: automated replay on top of current `dev`
- Merge policy: all CI checks green (except non-blocking `Enforce Dev -> Main Promotion`)

Original PR description:

## Summary

- Base branch target: `main`
- Problem: MiniMax API does not support OpenAI-style native tool definitions (`tools` parameter). Sending them causes 500 Internal Server Error on every request, making MiniMax completely unusable when tools are configured.
- Why it matters: MiniMax provider is workflow-blocked for all users with tools enabled.
- What changed: Added `native_tool_calling` field to `OpenAiCompatibleProvider`; MiniMax (via `new_merge_system_into_user`) sets it to `false`, falling back to prompt-guided tool calling.
- What did **not** change: All other providers remain `native_tool_calling: true`. No behavioral change for non-MiniMax providers.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `provider`
- Module labels: `provider: minimax`
- Contributor tier label: N/A
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `provider`

## Linked Issue

- Closes #1387

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo test -p zeroclaw --lib providers::compatible
# test result: ok. 74 passed; 0 failed; 0 ignored
```

- Evidence provided: all 74 compatible provider tests pass, including new `minimax_provider_disables_native_tool_calling` test
- Full `cargo fmt`, `cargo clippy`, `cargo test` deferred to CI

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes — MiniMax previously always failed with 500 when tools were present; this fix makes it work.
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (code-only change)

## Human Verification (required)

- Verified scenarios: MiniMax provider reports `native_tool_calling: false`; all other providers report `true`
- Edge cases checked: `new_merge_system_into_user` is the only constructor setting `native_tool_calling: false`
- What was not verified: End-to-end MiniMax prompt-guided tool calling quality (model capability dependent)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: MiniMax provider tool calling path only
- Potential unintended effects: Prompt-guided tool calling may be less reliable than native (model capability limitation, not a code issue)
- Guardrails/monitoring: Agent loop already has fallback XML/markdown tool call parsing (`parse_tool_calls`)

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (code review, test execution)
- Workflow/plan summary: Traced full code path from error → provider capabilities → agent loop tool dispatch → API request body
- Verification focus: Confirmed MiniMax `chat()` override honors `native_tool_calling` via agent loop `use_native_tools` flag
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None needed; revert restores previous (broken) behavior
- Observable failure symptoms: MiniMax 500 errors return if reverted

## Risks and Mitigations

- Risk: MiniMax M2.5 may not reliably follow prompt-guided tool calling XML format
  - Mitigation: This is a model capability limitation, not a code bug. The alternative (native tools) causes 500 errors, so prompt-guided is strictly better.
