### PR TITLE
feat(providers): add Novita AI as OpenAI-compatible provider

### DIFF
--- a/.github/workflows/scripts/pr_labeler.js
+++ b/.github/workflows/scripts/pr_labeler.js
@@ -267,6 +267,7 @@ const providerKeywordHints = [
   "groq",
   "together",
   "fireworks",
+  "novita",
   "cohere",
   "openai",
   "openrouter",

--- a/docs/providers-reference.md
+++ b/docs/providers-reference.md
@@ -51,6 +51,7 @@ credential is not reused for fallback providers.
 | `deepseek` | — | No | `DEEPSEEK_API_KEY` |
 | `together` | `together-ai` | No | `TOGETHER_API_KEY` |
 | `fireworks` | `fireworks-ai` | No | `FIREWORKS_API_KEY` |
+| `novita` | — | No | `NOVITA_API_KEY` |
 | `perplexity` | — | No | `PERPLEXITY_API_KEY` |
 | `cohere` | — | No | `COHERE_API_KEY` |
 | `copilot` | `github-copilot` | No | (use config/`API_KEY` fallback with GitHub token) |

--- a/src/integrations/registry.rs
+++ b/src/integrations/registry.rs
@@ -473,6 +473,18 @@ pub fn all_integrations() -> Vec<IntegrationEntry> {
             },
         },
         IntegrationEntry {
+            name: "Novita AI",
+            description: "Affordable open-source inference",
+            category: IntegrationCategory::AiModel,
+            status_fn: |c| {
+                if c.default_provider.as_deref() == Some("novita") {
+                    IntegrationStatus::Active
+                } else {
+                    IntegrationStatus::Available
+                }
+            },
+        },
+        IntegrationEntry {
             name: "Cohere",
             description: "Command R+ & embeddings",
             category: IntegrationCategory::AiModel,

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -671,6 +671,7 @@ fn default_model_for_provider(provider: &str) -> String {
         "xai" => "grok-4-1-fast-reasoning".into(),
         "perplexity" => "sonar-pro".into(),
         "fireworks" => "accounts/fireworks/models/llama-v3p3-70b-instruct".into(),
+        "novita" => "minimax/minimax-m2.5".into(),
         "together-ai" => "meta-llama/Llama-3.3-70B-Instruct-Turbo".into(),
         "cohere" => "command-a-03-2025".into(),
         "moonshot" => "kimi-k2.5".into(),
@@ -862,6 +863,12 @@ fn curated_models_for_provider(provider_name: &str) -> Vec<(String, String)> {
             (
                 "accounts/fireworks/models/mixtral-8x22b-instruct".to_string(),
                 "Mixtral 8x22B".to_string(),
+            ),
+        ],
+        "novita" => vec![
+            (
+                "minimax/minimax-m2.5".to_string(),
+                "MiniMax M2.5".to_string(),
             ),
         ],
         "together-ai" => vec![
@@ -1116,6 +1123,7 @@ fn supports_live_model_fetch(provider_name: &str) -> bool {
             | "astrai"
             | "venice"
             | "fireworks"
+            | "novita"
             | "cohere"
             | "moonshot"
             | "glm"
@@ -1141,6 +1149,7 @@ fn models_endpoint_for_provider(provider_name: &str) -> Option<&'static str> {
             "xai" => Some("https://api.x.ai/v1/models"),
             "together-ai" => Some("https://api.together.xyz/v1/models"),
             "fireworks" => Some("https://api.fireworks.ai/inference/v1/models"),
+            "novita" => Some("https://api.novita.ai/openai/v1/models"),
             "cohere" => Some("https://api.cohere.com/compatibility/v1/models"),
             "moonshot" => Some("https://api.moonshot.ai/v1/models"),
             "glm" => Some("https://api.z.ai/api/paas/v4/models"),
@@ -1940,6 +1949,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
         1 => vec![
             ("groq", "Groq — ultra-fast LPU inference"),
             ("fireworks", "Fireworks AI — fast open-source inference"),
+            ("novita", "Novita AI — affordable open-source inference"),
             ("together-ai", "Together AI — open-source model hosting"),
             ("nvidia", "NVIDIA NIM — DeepSeek, Llama, & more"),
         ],
@@ -2363,6 +2373,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
                 "deepseek" => "https://platform.deepseek.com/api_keys",
                 "together-ai" => "https://api.together.xyz/settings/api-keys",
                 "fireworks" => "https://fireworks.ai/account/api-keys",
+                "novita" => "https://novita.ai/settings/key-management",
                 "perplexity" => "https://www.perplexity.ai/settings/api",
                 "xai" => "https://console.x.ai",
                 "cohere" => "https://dashboard.cohere.com/api-keys",
@@ -2652,6 +2663,7 @@ fn provider_env_var(name: &str) -> &'static str {
         "xai" => "XAI_API_KEY",
         "together-ai" => "TOGETHER_API_KEY",
         "fireworks" | "fireworks-ai" => "FIREWORKS_API_KEY",
+        "novita" => "NOVITA_API_KEY",
         "perplexity" => "PERPLEXITY_API_KEY",
         "cohere" => "COHERE_API_KEY",
         "kimi-code" => "KIMI_CODE_API_KEY",

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -818,6 +818,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "xai" | "grok" => vec!["XAI_API_KEY"],
         "together" | "together-ai" => vec!["TOGETHER_API_KEY"],
         "fireworks" | "fireworks-ai" => vec!["FIREWORKS_API_KEY"],
+        "novita" => vec!["NOVITA_API_KEY"],
         "perplexity" => vec!["PERPLEXITY_API_KEY"],
         "cohere" => vec!["COHERE_API_KEY"],
         name if is_moonshot_alias(name) => vec!["MOONSHOT_API_KEY"],
@@ -1094,6 +1095,9 @@ fn create_provider_with_url_and_options(
         ))),
         "fireworks" | "fireworks-ai" => Ok(Box::new(OpenAiCompatibleProvider::new(
             "Fireworks AI", "https://api.fireworks.ai/inference/v1", key, AuthStyle::Bearer,
+        ))),
+        "novita" => Ok(Box::new(OpenAiCompatibleProvider::new(
+            "Novita AI", "https://api.novita.ai/openai", key, AuthStyle::Bearer,
         ))),
         "perplexity" => Ok(Box::new(OpenAiCompatibleProvider::new(
             "Perplexity", "https://api.perplexity.ai", key, AuthStyle::Bearer,
@@ -1618,6 +1622,12 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             name: "fireworks",
             display_name: "Fireworks AI",
             aliases: &["fireworks-ai"],
+            local: false,
+        },
+        ProviderInfo {
+            name: "novita",
+            display_name: "Novita AI",
+            aliases: &[],
             local: false,
         },
         ProviderInfo {
@@ -2240,6 +2250,11 @@ mod tests {
     }
 
     #[test]
+    fn factory_novita() {
+        assert!(create_provider("novita", Some("key")).is_ok());
+    }
+
+    #[test]
     fn factory_perplexity() {
         assert!(create_provider("perplexity", Some("key")).is_ok());
     }
@@ -2583,6 +2598,7 @@ mod tests {
             "deepseek",
             "together",
             "fireworks",
+            "novita",
             "perplexity",
             "cohere",
             "copilot",


### PR DESCRIPTION
## Summary

Add Novita AI as a new OpenAI-compatible LLM provider to the ZeroClaw ecosystem.

## Changes

- **Provider factory** (`src/providers/mod.rs`):
  - Register Novita AI with canonical ID `novita`
  - Configure OpenAI-compatible endpoint: `https://api.novita.ai/openai`
  - Map environment variable `NOVITA_API_KEY` for authentication
  - Add factory test `factory_novita()`

- **Integrations registry** (`src/integrations/registry.rs`):
  - Add "Novita AI" entry with description "Affordable open-source inference"
  - Implement active/available status detection based on `default_provider` config

- **Onboarding wizard** (`src/onboard/wizard.rs`):
  - Set default model to `minimax/minimax-m2.5`
  - Configure model discovery endpoint: `https://api.novita.ai/openai/v1/models`
  - Add to provider selection menu (Fast Inference category)
  - Link API key management URL: `https://novita.ai/settings/key-management`

- **Documentation** (`docs/providers-reference.md`):
  - Add Novita AI to provider catalog table

- **CI/Automation** (`.github/workflows/scripts/pr_labeler.js`):
  - Add "novita" to provider keyword hints for automatic PR labeling

## Testing

```bash
# Provider factory test
cargo test providers::tests::factory_novita

# Manual validation
zeroclaw init  # Select Novita AI in wizard
export NOVITA_API_KEY="your-key"
zeroclaw chat "Hello"
```

## Non-goals

- Does not add custom Novita-specific features (uses standard OpenAI-compatible interface)
- Does not include advanced model routing or vision support (can be added later if needed)

## Risk and Rollback

- **Risk**: Low - isolated provider addition with no changes to existing providers
- **Rollback**: Revert this PR; Novita AI will no longer be listed as a selectable option

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)