### PR TITLE
chore(codeowners): rebalance review ownership and remove @willsarg

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owner for all files
-* @chumyin
+* @theonlyhennygod @chumyin
 
 # Important functional modules
 /src/agent/** @theonlyhennygod


### PR DESCRIPTION
## Summary
- set default CODEOWNERS reviewer to `@theonlyhennygod` and `@chumyin` for all files
- route `CI/CD`, `.github` policy files, and security/test-related areas to `@chumyin`
- assign important functional modules to `@theonlyhennygod` for targeted review
- remove all `@willsarg` ownership entries

## Details
- default: `* @theonlyhennygod` and `* @chumyin`
- important functional modules:
  - `/src/agent/**`
  - `/src/providers/**`
  - `/src/channels/**`
  - `/src/tools/**`
  - `/src/gateway/**`
  - `/src/runtime/**`
  - `/src/memory/**`
  - `/Cargo.toml`, `/Cargo.lock`
- CI/CD + security/tests:
  - `/.github/**`, `/.github/workflows/**`, `/.github/codeql/**`, `/.github/dependabot.yml`
  - `/src/security/**`, `/tests/**`, `/SECURITY.md`
  - `/docs/actions-source-policy.md`, `/docs/ci-map.md`

## Validation
- ownership rules inspected in `.github/CODEOWNERS`
- confirmed `@willsarg` no longer appears in CODEOWNERS
