### PR TITLE
fix(telegram): populate thread_ts for per-topic session isolation

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -260,11 +260,19 @@ impl InFlightTaskCompletion {
 }
 
 fn conversation_memory_key(msg: &traits::ChannelMessage) -> String {
-    format!("{}_{}_{}", msg.channel, msg.sender, msg.id)
+    // Include thread_ts for per-topic memory isolation in forum groups
+    match &msg.thread_ts {
+        Some(tid) => format!("{}_{}_{}_{}", msg.channel, tid, msg.sender, msg.id),
+        None => format!("{}_{}_{}", msg.channel, msg.sender, msg.id),
+    }
 }
 
 fn conversation_history_key(msg: &traits::ChannelMessage) -> String {
-    format!("{}_{}", msg.channel, msg.sender)
+    // Include thread_ts for per-topic session isolation in forum groups
+    match &msg.thread_ts {
+        Some(tid) => format!("{}_{}_{}", msg.channel, tid, msg.sender),
+        None => format!("{}_{}", msg.channel, msg.sender),
+    }
 }
 
 fn interruption_scope_key(msg: &traits::ChannelMessage) -> String {

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -953,7 +953,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             .and_then(serde_json::Value::as_i64)
             .map(|id| id.to_string());
 
-        let reply_target = if let Some(tid) = thread_id {
+        let reply_target = if let Some(ref tid) = thread_id {
             format!("{}:{}", chat_id, tid)
         } else {
             chat_id.clone()
@@ -1031,7 +1031,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs(),
-            thread_ts: None,
+            thread_ts: thread_id,
         })
     }
 
@@ -1080,7 +1080,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             .and_then(serde_json::Value::as_i64)
             .map(|id| id.to_string());
 
-        let reply_target = if let Some(tid) = thread_id {
+        let reply_target = if let Some(ref tid) = thread_id {
             format!("{}:{}", chat_id, tid)
         } else {
             chat_id.clone()
@@ -1148,7 +1148,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs(),
-            thread_ts: None,
+            thread_ts: thread_id,
         })
     }
 
@@ -1274,7 +1274,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             .map(|id| id.to_string());
 
         // reply_target: chat_id or chat_id:thread_id format
-        let reply_target = if let Some(tid) = thread_id {
+        let reply_target = if let Some(ref tid) = thread_id {
             format!("{}:{}", chat_id, tid)
         } else {
             chat_id.clone()
@@ -1304,7 +1304,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs(),
-            thread_ts: None,
+            thread_ts: thread_id,
         })
     }
 


### PR DESCRIPTION
## Summary

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): `dev`
- Problem: Messages from the same sender in different Telegram forum topics shared conversation context because `thread_ts` was never populated from the extracted `message_thread_id`.
- Why it matters: Conversation context from Topic A bleeds into Topic B for the same user, breaking conversational isolation between topics.
- What changed:
  - Set `thread_ts` to `thread_id` in all Telegram message parsing functions
  - Updated `conversation_history_key()` to include `thread_ts` when present
  - Updated `conversation_memory_key()` to also include `thread_ts` for memory isolation
- What did **not** change (scope boundary): Reply routing behavior is unchanged. Non-forum groups and DMs continue to work as before.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `channel`
- Module labels: `channel: telegram`

## Change Metadata

- Change type: `bugfix`
- Primary scope: `channel`

## Linked Issue

- Closes #1532

## Validation Evidence (required)

```bash
cargo check --lib  # ✓ compiles cleanly
```

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Code review confirms thread_id is now preserved through the full message parsing pipeline
- Edge cases checked: Non-forum groups and DMs continue to use `thread_ts: None`, preserving existing behavior

## Side Effects / Blast Radius (required)

- Affected subsystems: `conversation_history_key`, `conversation_memory_key`, Telegram message parsing
- Potential unintended effects: None — existing histories for forum users will reset (new key format), which is acceptable since the old shared behavior was incorrect

## Rollback Plan (required)

- Fast rollback: `git revert <merge-commit>`