### PR TITLE
fix: correct string literal escaping in leak_detector.rs

### DIFF
--- a/src/security/leak_detector.rs
+++ b/src/security/leak_detector.rs
@@ -89,7 +89,7 @@ impl LeakDetector {
                 (Regex::new(r"gh[pousr]_[a-zA-Z0-9]{36,}").unwrap(), "GitHub token"),
                 (Regex::new(r"github_pat_[a-zA-Z0-9_]{22,}").unwrap(), "GitHub PAT"),
                 // Generic
-                (Regex::new(r"api[_-]?key[=:]\s*['\"]*[a-zA-Z0-9_-]{20,}").unwrap(), "Generic API key"),
+                (Regex::new(r#"api[_-]?key[=:]\s*['"]*[a-zA-Z0-9_-]{20,}"#).unwrap(), "Generic API key"),
             ]
         });
 
@@ -107,7 +107,7 @@ impl LeakDetector {
         let regexes = AWS_PATTERNS.get_or_init(|| {
             vec![
                 (Regex::new(r"AKIA[A-Z0-9]{16}").unwrap(), "AWS Access Key ID"),
-                (Regex::new(r"aws[_-]?secret[_-]?access[_-]?key[=:]\s*['\"]*[a-zA-Z0-9/+=]{40}").unwrap(), "AWS Secret Access Key"),
+                (Regex::new(r#"aws[_-]?secret[_-]?access[_-]?key[=:]\s*['"]*[a-zA-Z0-9/+=]{40}"#).unwrap(), "AWS Secret Access Key"),
             ]
         });
 
@@ -124,9 +124,9 @@ impl LeakDetector {
         static SECRET_PATTERNS: OnceLock<Vec<(Regex, &'static str)>> = OnceLock::new();
         let regexes = SECRET_PATTERNS.get_or_init(|| {
             vec![
-                (Regex::new(r"(?i)password[=:]\s*['\"]*[^\s'\"]{8,}").unwrap(), "Password in config"),
-                (Regex::new(r"(?i)secret[=:]\s*['\"]*[a-zA-Z0-9_-]{16,}").unwrap(), "Secret value"),
-                (Regex::new(r"(?i)token[=:]\s*['\"]*[a-zA-Z0-9_.-]{20,}").unwrap(), "Token value"),
+                (Regex::new(r#"(?i)password[=:]\s*['"]*[^\s'"]{8,}"#).unwrap(), "Password in config"),
+                (Regex::new(r#"(?i)secret[=:]\s*['"]*[a-zA-Z0-9_-]{16,}"#).unwrap(), "Secret value"),
+                (Regex::new(r#"(?i)token[=:]\s*['"]*[a-zA-Z0-9_.-]{20,}"#).unwrap(), "Token value"),
             ]
         });
 


### PR DESCRIPTION
## Summary

Fixes #1527 — bootstrap script fails to compile due to invalid raw string literals in `src/security/leak_detector.rs`.

## Root Cause

Several regex patterns use `r"..."` raw string literals that contain `\"` sequences. In Rust raw strings, backslash has no special meaning, so `\"` doesn't escape the quote — it terminates the string early. This produces the compilation errors reported in the issue:

- `prefix \`key\` is unknown`
- `prefix \`ID\` is unknown`
- `unknown start of token: \\`
- `unterminated character literal`

## Fix

Switch the affected raw string literals from `r"..."` to `r#"..."#` delimiters, which allow quote characters inside the string without termination. Five patterns were fixed across three functions:

- `check_api_keys` — Generic API key pattern (line 92)
- `check_aws_credentials` — AWS Secret Access Key pattern (line 110)
- `check_generic_secrets` — Password, Secret, and Token patterns (lines 127-129)

No behavioral change to the regex matching logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal representation of security detection patterns for better code maintainability. Functional behavior of leak detection remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->