### PR TITLE
fix(ci): align codex tests with provider runtime API

### DIFF
--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -1013,11 +1013,11 @@ data: [DONE]
     #[test]
     fn capabilities_includes_vision() {
         let options = ProviderRuntimeOptions {
+            provider_api_url: None,
             zeroclaw_dir: None,
             secrets_encrypt: false,
             auth_profile_override: None,
             reasoning_enabled: None,
-            provider_api_url: None,
         };
         let provider =
             OpenAiCodexProvider::new(&options, None).expect("provider should initialize");

--- a/tests/agent_e2e.rs
+++ b/tests/agent_e2e.rs
@@ -674,7 +674,7 @@ async fn e2e_live_openai_codex_multi_turn() {
     use zeroclaw::providers::openai_codex::OpenAiCodexProvider;
     use zeroclaw::providers::traits::Provider;
 
-    let provider = OpenAiCodexProvider::new(&ProviderRuntimeOptions::default());
+    let provider = OpenAiCodexProvider::new(&ProviderRuntimeOptions::default(), None).unwrap();
     let model = "gpt-5.3-codex";
 
     // Turn 1: establish a fact

--- a/tests/openai_codex_vision_e2e.rs
+++ b/tests/openai_codex_vision_e2e.rs
@@ -147,6 +147,7 @@ async fn openai_codex_second_vision_support() -> Result<()> {
     // Create provider with profile override
     let opts = ProviderRuntimeOptions {
         auth_profile_override: Some("second".to_string()),
+        provider_api_url: None,
         zeroclaw_dir: None,
         secrets_encrypt: false,
         reasoning_enabled: None,


### PR DESCRIPTION
## Summary
Fixes post-merge dev CI breakage caused by provider API/signature drift in tests.

### Changes
- update `OpenAiCodexProvider::new` callsites in tests to pass new `gateway_api_key` arg and unwrap `Result`
- add missing `provider_api_url` in `ProviderRuntimeOptions` literal in vision e2e test
- sync openai_codex provider unit test constructor usage with new signature

## Context
This follows failures on dev for merge commit `005cd38d27e48b3cda10d9dd45d4c6d718bcefa0` in:
- CI Run: 22336564973
- Test E2E: 22336564963
