### PR TITLE
fix(ci): restore codex e2e compilation after provider ctor change

### DIFF
--- a/tests/agent_e2e.rs
+++ b/tests/agent_e2e.rs
@@ -674,7 +674,8 @@ async fn e2e_live_openai_codex_multi_turn() {
     use zeroclaw::providers::openai_codex::OpenAiCodexProvider;
     use zeroclaw::providers::traits::Provider;
 
-    let provider = OpenAiCodexProvider::new(&ProviderRuntimeOptions::default());
+    let provider = OpenAiCodexProvider::new(&ProviderRuntimeOptions::default(), None)
+        .expect("provider should initialize");
     let model = "gpt-5.3-codex";
 
     // Turn 1: establish a fact

--- a/tests/openai_codex_vision_e2e.rs
+++ b/tests/openai_codex_vision_e2e.rs
@@ -12,7 +12,7 @@
 //! Run manually: `cargo test provider_vision -- --ignored --nocapture`
 
 use anyhow::Result;
-use zeroclaw::providers::{ChatMessage, ChatRequest, Provider, ProviderRuntimeOptions};
+use zeroclaw::providers::{ChatMessage, ChatRequest, ProviderRuntimeOptions};
 
 /// Tests that provider supports vision input.
 ///
@@ -150,6 +150,7 @@ async fn openai_codex_second_vision_support() -> Result<()> {
         zeroclaw_dir: None,
         secrets_encrypt: false,
         reasoning_enabled: None,
+        provider_api_url: None,
     };
 
     let provider = zeroclaw::providers::create_provider_with_options("openai-codex", None, &opts)?;


### PR DESCRIPTION
## Summary
- update `tests/agent_e2e.rs` to call `OpenAiCodexProvider::new(..., None)` and unwrap the `Result`
- update `tests/openai_codex_vision_e2e.rs` to include `provider_api_url: None` in `ProviderRuntimeOptions`
- remove now-unused `Provider` import in the vision E2E test

## Why
`dev` head `f4f6f5f` failed `CI Run` and `Test E2E` because these tests still used the old provider constructor signature.

## Validation
- `cargo fmt --all --check`
- `cargo test --test agent_e2e --no-run`
- `cargo test --test openai_codex_vision_e2e --no-run`
- `cargo clippy --locked --all-targets -- -D clippy::correctness`