### PR TITLE
chore(fmt): fix loop_ formatting drift after #1505

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -5502,7 +5502,10 @@ Let me check the result."#;
         assert_eq!(map_tool_name_alias("memorystore"), "memory_store");
         assert_eq!(map_tool_name_alias("memoryforget"), "memory_forget");
         assert_eq!(map_tool_name_alias("http"), "http_request");
-        assert_eq!(map_tool_name_alias("totally_unknown_tool"), "totally_unknown_tool");
+        assert_eq!(
+            map_tool_name_alias("totally_unknown_tool"),
+            "totally_unknown_tool"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- fix rustfmt drift in src/agent/loop_.rs introduced after #1505 merge
- no behavior change; formatting-only

## Why
- dev push CI failed in CI Run (Lint Gate) on commit 8ab75fd

## Validation
- ./scripts/ci/rust_quality_gate.sh (failure reproduced before fix)
- cargo fmt --all -- --check

## Scope
- formatting only in src/agent/loop_.rs
