### PR TITLE
fix(security): use r#"..."# raw strings in leak_detector regex patterns

### DIFF
--- a/src/security/leak_detector.rs
+++ b/src/security/leak_detector.rs
@@ -89,7 +89,7 @@ impl LeakDetector {
                 (Regex::new(r"gh[pousr]_[a-zA-Z0-9]{36,}").unwrap(), "GitHub token"),
                 (Regex::new(r"github_pat_[a-zA-Z0-9_]{22,}").unwrap(), "GitHub PAT"),
                 // Generic
-                (Regex::new(r"api[_-]?key[=:]\s*['\"]*[a-zA-Z0-9_-]{20,}").unwrap(), "Generic API key"),
+                (Regex::new(r#"api[_-]?key[=:]\s*['"]*[a-zA-Z0-9_-]{20,}"#).unwrap(), "Generic API key"),
             ]
         });
 
@@ -107,7 +107,7 @@ impl LeakDetector {
         let regexes = AWS_PATTERNS.get_or_init(|| {
             vec![
                 (Regex::new(r"AKIA[A-Z0-9]{16}").unwrap(), "AWS Access Key ID"),
-                (Regex::new(r"aws[_-]?secret[_-]?access[_-]?key[=:]\s*['\"]*[a-zA-Z0-9/+=]{40}").unwrap(), "AWS Secret Access Key"),
+                (Regex::new(r#"aws[_-]?secret[_-]?access[_-]?key[=:]\s*['"]*[a-zA-Z0-9/+=]{40}"#).unwrap(), "AWS Secret Access Key"),
             ]
         });
 
@@ -124,9 +124,9 @@ impl LeakDetector {
         static SECRET_PATTERNS: OnceLock<Vec<(Regex, &'static str)>> = OnceLock::new();
         let regexes = SECRET_PATTERNS.get_or_init(|| {
             vec![
-                (Regex::new(r"(?i)password[=:]\s*['\"]*[^\s'\"]{8,}").unwrap(), "Password in config"),
-                (Regex::new(r"(?i)secret[=:]\s*['\"]*[a-zA-Z0-9_-]{16,}").unwrap(), "Secret value"),
-                (Regex::new(r"(?i)token[=:]\s*['\"]*[a-zA-Z0-9_.-]{20,}").unwrap(), "Token value"),
+                (Regex::new(r#"(?i)password[=:]\s*['"]*[^\s'"]{8,}"#).unwrap(), "Password in config"),
+                (Regex::new(r#"(?i)secret[=:]\s*['"]*[a-zA-Z0-9_-]{16,}"#).unwrap(), "Secret value"),
+                (Regex::new(r#"(?i)token[=:]\s*['"]*[a-zA-Z0-9_.-]{20,}"#).unwrap(), "Token value"),
             ]
         });
 


### PR DESCRIPTION
Closes #1577.

## Problem

Five regex patterns in `src/security/leak_detector.rs` (introduced in #1433) used `r"..."` raw string literals containing a `"` inside the character class `['\"]*`. In Rust, raw strings treat the first `"` as the closing delimiter — `\"` does **not** escape it — so the string terminated early, producing four cascading parse errors and making the crate uncompilable.

## Change

Replace `r"..."` with `r#"..."#` for the five affected lines (92, 110, 127, 128, 129) and remove the redundant `\` before the inner `"`. Regex semantics are identical.

## Non-goals

Does not touch other pre-existing compile errors (WATI gateway issues from #1472, `floor_char_boundary` unstable API calls) — separate concerns.

## Risk and Rollback

**Low risk.** Single-file, purely syntactic correction, no behavior change.
Rollback: revert this commit.

## Validation

The four original `leak_detector.rs` compile errors are resolved after this change. Full `cargo build` is still blocked by unrelated pre-existing errors in other modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code quality in security detection patterns. No impact on detection behavior or security functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->