### PR TITLE
fix(qq): passive reply msg_id/msg_seq + image media send support

### DIFF
--- a/src/channels/qq.rs
+++ b/src/channels/qq.rs
@@ -204,7 +204,13 @@ impl QQChannel {
         self.allowed_users.iter().any(|u| u == "*" || u == user_id)
     }
 
-    async fn post_json(&self, token: &str, url: &str, body: &Value, op: &str) -> anyhow::Result<()> {
+    async fn post_json(
+        &self,
+        token: &str,
+        url: &str,
+        body: &Value,
+        op: &str,
+    ) -> anyhow::Result<()> {
         ensure_https(url)?;
 
         let resp = self


### PR DESCRIPTION
Closes #1549
Closes #1578
Refs RMN-10
Resolves RMN-27

## Summary

This PR fixes the QQ reply/send path in two coupled areas:

1. Passive-reply compliance for QQ (`msg_id` / `msg_seq`)
2. Image marker sending via QQ media flow (`msg_type=7` with `media.file_info`)

## Root cause

- QQ channel always sent `msg_type=0` text payloads and never attached passive-reply identity fields (`msg_id`, `msg_seq`), causing `40034102` (`主动消息失败, 无权限`) for reply flows.
- Outgoing `[IMAGE:<url>]` markers had no QQ implementation; images could not be sent through QQ media APIs.

## Changes

- Added outgoing marker parsing for QQ:
  - extracts remote `[IMAGE:http(s)://...]` markers
  - keeps non-remote markers as plain text
- Added QQ media upload step:
  - `POST /v2/users/{openid}/files` or `POST /v2/groups/{group_openid}/files`
  - uses `file_type=1`, `srv_send_msg=false`, then sends message with `msg_type=7` and `media.file_info`
- Added passive-reply fields on send when inbound `msg_id` is available:
  - `msg_id` and monotonic `msg_seq` per message segment
- Propagated inbound QQ event `id` into `ChannelMessage.thread_ts` so reply sends can reuse it as passive `msg_id`
- Added/updated unit tests for:
  - outgoing image marker parsing
  - text/media payload construction with passive fields

## Validation

- `cargo test --lib qq::tests`
- `cargo build --release --locked -q`
