### PR TITLE
fix(security): repair leak detector regex literals and WATI query derive

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1334,7 +1334,7 @@ async fn handle_wati_verify(
     (StatusCode::BAD_REQUEST, "Missing hub.challenge".to_string())
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct WatiVerifyQuery {
     #[serde(rename = "hub.challenge")]
     pub challenge: Option<String>,

--- a/src/security/leak_detector.rs
+++ b/src/security/leak_detector.rs
@@ -7,7 +7,6 @@
 //! Contributed from RustyClaw (MIT licensed).
 
 use regex::Regex;
-use serde::{Deserialize, Serialize};
 use std::sync::OnceLock;
 
 /// Result of leak detection.
@@ -89,7 +88,7 @@ impl LeakDetector {
                 (Regex::new(r"gh[pousr]_[a-zA-Z0-9]{36,}").unwrap(), "GitHub token"),
                 (Regex::new(r"github_pat_[a-zA-Z0-9_]{22,}").unwrap(), "GitHub PAT"),
                 // Generic
-                (Regex::new(r"api[_-]?key[=:]\s*['\"]*[a-zA-Z0-9_-]{20,}").unwrap(), "Generic API key"),
+                (Regex::new(r#"api[_-]?key[=:]\s*['"]*[a-zA-Z0-9_-]{20,}"#).unwrap(), "Generic API key"),
             ]
         });
 
@@ -107,7 +106,7 @@ impl LeakDetector {
         let regexes = AWS_PATTERNS.get_or_init(|| {
             vec![
                 (Regex::new(r"AKIA[A-Z0-9]{16}").unwrap(), "AWS Access Key ID"),
-                (Regex::new(r"aws[_-]?secret[_-]?access[_-]?key[=:]\s*['\"]*[a-zA-Z0-9/+=]{40}").unwrap(), "AWS Secret Access Key"),
+                (Regex::new(r#"aws[_-]?secret[_-]?access[_-]?key[=:]\s*['"]*[a-zA-Z0-9/+=]{40}"#).unwrap(), "AWS Secret Access Key"),
             ]
         });
 
@@ -124,9 +123,9 @@ impl LeakDetector {
         static SECRET_PATTERNS: OnceLock<Vec<(Regex, &'static str)>> = OnceLock::new();
         let regexes = SECRET_PATTERNS.get_or_init(|| {
             vec![
-                (Regex::new(r"(?i)password[=:]\s*['\"]*[^\s'\"]{8,}").unwrap(), "Password in config"),
-                (Regex::new(r"(?i)secret[=:]\s*['\"]*[a-zA-Z0-9_-]{16,}").unwrap(), "Secret value"),
-                (Regex::new(r"(?i)token[=:]\s*['\"]*[a-zA-Z0-9_.-]{20,}").unwrap(), "Token value"),
+                (Regex::new(r#"(?i)password[=:]\s*['"]*[^\s'"]{8,}"#).unwrap(), "Password in config"),
+                (Regex::new(r#"(?i)secret[=:]\s*['"]*[a-zA-Z0-9_-]{16,}"#).unwrap(), "Secret value"),
+                (Regex::new(r#"(?i)token[=:]\s*['"]*[a-zA-Z0-9_.-]{20,}"#).unwrap(), "Token value"),
             ]
         });
 


### PR DESCRIPTION
## Problem
- `cargo build --release --locked` failed due to invalid raw string regex literals in `leak_detector` (`"` inside `r...`).
- `WatiVerifyQuery` used `Deserialize` derive without an in-scope import, which also caused the `/wati` GET handler type check to fail.

## Changes
- Converted affected regex literals in `src/security/leak_detector.rs` to `r#...#` form where embedded quotes are required.
- Updated `WatiVerifyQuery` derive to `#[derive(Debug, serde::Deserialize)]` in `src/gateway/mod.rs`.
- Removed unused serde imports from `leak_detector.rs`.

## Validation
- Ran: `cargo build --release --locked`
- Result: success

## Risk / Rollback
- Risk: low, scoped to parsing/compile correctness for existing patterns and WATI query extraction.
- Rollback: revert commit `89fbc70`.