### PR TITLE
fix(security): use raw string literals with # delimiters in leak_detector

### DIFF
--- a/src/security/leak_detector.rs
+++ b/src/security/leak_detector.rs
@@ -89,7 +89,7 @@ impl LeakDetector {
                 (Regex::new(r"gh[pousr]_[a-zA-Z0-9]{36,}").unwrap(), "GitHub token"),
                 (Regex::new(r"github_pat_[a-zA-Z0-9_]{22,}").unwrap(), "GitHub PAT"),
                 // Generic
-                (Regex::new(r"api[_-]?key[=:]\s*['\"]*[a-zA-Z0-9_-]{20,}").unwrap(), "Generic API key"),
+                (Regex::new(r#"api[_-]?key[=:]\s*['"]*[a-zA-Z0-9_-]{20,}"#).unwrap(), "Generic API key"),
             ]
         });
 
@@ -107,7 +107,7 @@ impl LeakDetector {
         let regexes = AWS_PATTERNS.get_or_init(|| {
             vec![
                 (Regex::new(r"AKIA[A-Z0-9]{16}").unwrap(), "AWS Access Key ID"),
-                (Regex::new(r"aws[_-]?secret[_-]?access[_-]?key[=:]\s*['\"]*[a-zA-Z0-9/+=]{40}").unwrap(), "AWS Secret Access Key"),
+                (Regex::new(r#"aws[_-]?secret[_-]?access[_-]?key[=:]\s*['"]*[a-zA-Z0-9/+=]{40}"#).unwrap(), "AWS Secret Access Key"),
             ]
         });
 
@@ -124,9 +124,9 @@ impl LeakDetector {
         static SECRET_PATTERNS: OnceLock<Vec<(Regex, &'static str)>> = OnceLock::new();
         let regexes = SECRET_PATTERNS.get_or_init(|| {
             vec![
-                (Regex::new(r"(?i)password[=:]\s*['\"]*[^\s'\"]{8,}").unwrap(), "Password in config"),
-                (Regex::new(r"(?i)secret[=:]\s*['\"]*[a-zA-Z0-9_-]{16,}").unwrap(), "Secret value"),
-                (Regex::new(r"(?i)token[=:]\s*['\"]*[a-zA-Z0-9_.-]{20,}").unwrap(), "Token value"),
+                (Regex::new(r#"(?i)password[=:]\s*['"]*[^\s'"]{8,}"#).unwrap(), "Password in config"),
+                (Regex::new(r#"(?i)secret[=:]\s*['"]*[a-zA-Z0-9_-]{16,}"#).unwrap(), "Secret value"),
+                (Regex::new(r#"(?i)token[=:]\s*['"]*[a-zA-Z0-9_.-]{20,}"#).unwrap(), "Token value"),
             ]
         });
 


### PR DESCRIPTION
## Summary

- **Problem:** Raw strings with backslash-quote patterns fail to compile on Rust 2021+.
- **Why it matters:** `cargo check --lib` fails with unterminated character literal errors.
- **What changed:** Use `r#"..."#` delimiter syntax for 5 affected regex patterns.

## Validation Evidence (required)

```bash
cargo check --lib  # Raw string errors resolved
```

## Security Impact (required)

- Regex patterns unchanged (only delimiter syntax)
- No behavioral changes

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass

## Rollback Plan (required)

- Fast rollback: `git revert <commit>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated code formatting in security detection patterns to improve maintainability and code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->