### PR TITLE
docs(channels): improve Lark config placeholder values

### DIFF
--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -306,8 +306,8 @@ verify_tls = true
 
 ```toml
 [channels_config.lark]
-app_id = "cli_xxx"
-app_secret = "xxx"
+app_id = "your_lark_app_id"
+app_secret = "your_lark_app_secret"
 encrypt_key = ""                    # optional
 verification_token = ""             # optional
 allowed_users = ["*"]
@@ -319,8 +319,8 @@ port = 8081                          # required for webhook mode
 
 ```toml
 [channels_config.feishu]
-app_id = "cli_xxx"
-app_secret = "xxx"
+app_id = "your_lark_app_id"
+app_secret = "your_lark_app_secret"
 encrypt_key = ""                    # optional
 verification_token = ""             # optional
 allowed_users = ["*"]

--- a/docs/i18n/vi/channels-reference.md
+++ b/docs/i18n/vi/channels-reference.md
@@ -289,8 +289,8 @@ verify_tls = true
 
 ```toml
 [channels_config.lark]
-app_id = "cli_xxx"
-app_secret = "xxx"
+app_id = "your_lark_app_id"
+app_secret = "your_lark_app_secret"
 encrypt_key = ""                    # tùy chọn
 verification_token = ""             # tùy chọn
 allowed_users = ["*"]


### PR DESCRIPTION
## Summary

- **Problem:** Lark channel config examples use vague `cli_xxx` and `xxx` placeholders.
- **Why it matters:** New users may not understand what values to substitute.
- **What changed:** Replaced with descriptive `your_lark_app_id` and `your_lark_app_secret`.

## Validation Evidence (required)

- Verified TOML syntax still valid

## Security Impact (required)

- Documentation only

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass

## Rollback Plan (required)

- Fast rollback: `git revert <commit>`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity in Lark and Feishu channel configuration examples by updating credential placeholder values to be more descriptive. Updated in both English and Vietnamese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->