### PR TITLE
ci(release): pin setup-ndk action to sha for pub-release

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -229,7 +229,7 @@ jobs:
 
             - name: Setup Android NDK
               if: matrix.android_ndk
-              uses: nttld/setup-ndk@v1
+              uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1
               id: setup-ndk
               with:
                   ndk-version: r26d


### PR DESCRIPTION
## Summary
Pin `nttld/setup-ndk` to a full commit SHA in `.github/workflows/pub-release.yml`.

## Why
`Pub Release` runs for `v0.1.7` fail with `startup_failure` because workflow policy requires third-party actions to be pinned.

## Validation
- Workflow file updated to SHA pin only
- No runtime logic changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build pipeline configuration to use a pinned dependency version for improved build stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->