### PR TITLE
ci(release): pin setup-ndk action to sha for pub-release

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -229,7 +229,7 @@ jobs:
 
             - name: Setup Android NDK
               if: matrix.android_ndk
-              uses: nttld/setup-ndk@v1
+              uses: nttld/setup-ndk@ed92fe6cadad69be94a966a7ee3271275e62f779 # v1
               id: setup-ndk
               with:
                   ndk-version: r26d


### PR DESCRIPTION
Hotfix release workflow startup failure: pin  to commit SHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure pinning for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->