### PR TITLE
fix: resolve RMN-25 and RMN-33; verify RMN-7 and RMN-32 on dev

### DIFF
--- a/src/memory/hygiene.rs
+++ b/src/memory/hygiene.rs
@@ -328,7 +328,8 @@ fn date_prefix(filename: &str) -> Option<NaiveDate> {
     if filename.len() < 10 {
         return None;
     }
-    NaiveDate::parse_from_str(&filename[..filename.floor_char_boundary(10)], "%Y-%m-%d").ok()
+    let prefix_len = crate::util::floor_utf8_char_boundary(filename, 10);
+    NaiveDate::parse_from_str(&filename[..prefix_len], "%Y-%m-%d").ok()
 }
 
 fn is_older_than(path: &Path, cutoff: SystemTime) -> bool {

--- a/src/tools/composio.rs
+++ b/src/tools/composio.rs
@@ -1197,7 +1197,7 @@ fn format_schema_hint(schema: &serde_json::Value) -> Option<String> {
             // Truncate long descriptions to keep the hint concise.
             // Use char boundary to avoid panic on multi-byte UTF-8.
             let short = if desc.len() > 80 {
-                let end = desc.floor_char_boundary(77);
+                let end = crate::util::floor_utf8_char_boundary(desc, 77);
                 format!("{}...", &desc[..end])
             } else {
                 desc.to_string()

--- a/src/tools/screenshot.rs
+++ b/src/tools/screenshot.rs
@@ -173,7 +173,10 @@ impl ScreenshotTool {
                 let size = bytes.len();
                 let mut encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
                 let truncated = if encoded.len() > MAX_BASE64_BYTES {
-                    encoded.truncate(encoded.floor_char_boundary(MAX_BASE64_BYTES));
+                    encoded.truncate(crate::util::floor_utf8_char_boundary(
+                        &encoded,
+                        MAX_BASE64_BYTES,
+                    ));
                     true
                 } else {
                     false

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -164,11 +164,17 @@ impl Tool for ShellTool {
 
                 // Truncate output to prevent OOM
                 if stdout.len() > MAX_OUTPUT_BYTES {
-                    stdout.truncate(stdout.floor_char_boundary(MAX_OUTPUT_BYTES));
+                    stdout.truncate(crate::util::floor_utf8_char_boundary(
+                        &stdout,
+                        MAX_OUTPUT_BYTES,
+                    ));
                     stdout.push_str("\n... [output truncated at 1MB]");
                 }
                 if stderr.len() > MAX_OUTPUT_BYTES {
-                    stderr.truncate(stderr.floor_char_boundary(MAX_OUTPUT_BYTES));
+                    stderr.truncate(crate::util::floor_utf8_char_boundary(
+                        &stderr,
+                        MAX_OUTPUT_BYTES,
+                    ));
                     stderr.push_str("\n... [stderr truncated at 1MB]");
                 }
 

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -10,6 +10,18 @@ interface ChatMessage {
   timestamp: Date;
 }
 
+let fallbackMessageIdCounter = 0;
+
+function makeMessageId(): string {
+  const uuid = globalThis.crypto?.randomUUID?.();
+  if (uuid) return uuid;
+
+  fallbackMessageIdCounter += 1;
+  return `msg_${Date.now().toString(36)}_${fallbackMessageIdCounter.toString(36)}_${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+}
+
 export default function AgentChat() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -52,7 +64,7 @@ export default function AgentChat() {
             setMessages((prev) => [
               ...prev,
               {
-                id: crypto.randomUUID(),
+                id: makeMessageId(),
                 role: 'agent',
                 content,
                 timestamp: new Date(),
@@ -68,7 +80,7 @@ export default function AgentChat() {
           setMessages((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: makeMessageId(),
               role: 'agent',
               content: `[Tool Call] ${msg.name ?? 'unknown'}(${JSON.stringify(msg.args ?? {})})`,
               timestamp: new Date(),
@@ -80,7 +92,7 @@ export default function AgentChat() {
           setMessages((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: makeMessageId(),
               role: 'agent',
               content: `[Tool Result] ${msg.output ?? ''}`,
               timestamp: new Date(),
@@ -92,7 +104,7 @@ export default function AgentChat() {
           setMessages((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: makeMessageId(),
               role: 'agent',
               content: `[Error] ${msg.message ?? 'Unknown error'}`,
               timestamp: new Date(),
@@ -123,7 +135,7 @@ export default function AgentChat() {
     setMessages((prev) => [
       ...prev,
       {
-        id: crypto.randomUUID(),
+        id: makeMessageId(),
         role: 'user',
         content: trimmed,
         timestamp: new Date(),


### PR DESCRIPTION
## Summary

This PR deeply closes the current RMN stability cluster:

- RMN-33: Replace nightly-only `str::floor_char_boundary` usage with a stable helper (`floor_utf8_char_boundary`) and migrate all affected callsites.
- RMN-25: Fix dashboard agent chat crash in environments without `crypto.randomUUID` by introducing a compatibility ID generator.
- RMN-7 / RMN-32: Confirmed on current `dev` that the historical parser/derive/initializer breakages are already present as fixed and no longer reproducible.

## Code changes

- Added `floor_utf8_char_boundary` helper + tests in `src/util.rs`.
- Replaced `floor_char_boundary` callsites in:
  - `src/tools/shell.rs`
  - `src/tools/screenshot.rs`
  - `src/memory/hygiene.rs`
  - `src/tools/composio.rs`
- Added frontend fallback ID generation in:
  - `web/src/pages/AgentChat.tsx`

## Validation

- `cargo +1.90.0 check -q` ✅
- `cargo check -q` ✅
- `cargo test -q floor_utf8_char_boundary --lib` ✅
- `cd web && npm ci && npm run build` ✅

## RMN-7 / RMN-32 verification evidence (already fixed on dev)

- `src/security/leak_detector.rs` now uses hash raw strings for quote-containing regexes (no Rust 2021 parser break).
- `src/gateway/mod.rs` has `#[derive(Debug, serde::Deserialize)]` for `WatiVerifyQuery`.
- `src/gateway/mod.rs` test/state initializers include `wati: None` entries.

## Tracking

- RMN-7
- RMN-25
- RMN-32
- RMN-33
