### PR TITLE
feat(agent): add CLI parameters to agent for runtime config overrides

### DIFF
--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -17,6 +17,21 @@ pub enum AutonomyLevel {
     Full,
 }
 
+impl std::str::FromStr for AutonomyLevel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "read_only" | "readonly" => Ok(Self::ReadOnly),
+            "supervised" => Ok(Self::Supervised),
+            "full" => Ok(Self::Full),
+            _ => Err(format!(
+                "invalid autonomy level '{s}': expected read_only, supervised, or full"
+            )),
+        }
+    }
+}
+
 /// Risk score for shell command execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandRiskLevel {


### PR DESCRIPTION
Base branch: dev

  Summary

  - Base branch target: dev
  - Problem: zeroclaw agent lacks CLI flags for commonly adjusted config fields (autonomy, rate limits, context mode,
  memory backend), forcing users to edit config.toml and restart for every temporary tweak.
  - Why it matters: 80% of "temporary adjustment" scenarios (one-shot full-autonomy tasks, lightweight model testing,
  batch throughput tuning) require config file round-trips that break flow and add friction.
  - What changed: Added 6 CLI parameters to zeroclaw agent that override config fields at launch, plus FromStr on
  AutonomyLevel for clap parsing.
  - What did not change (scope boundary): agent::run() signature, Config schema, loop_.rs, docs, i18n, any downstream
  module.

Closes: #1605

  Label Snapshot (required)

  - Risk label: risk: low
  - Size label: size: S (2 files, +79/-12 lines)
  - Scope labels: agent, security, config
  - Module labels: security: policy
  - Contributor tier label: (auto-managed)
  - If any auto-label is incorrect: N/A

  Change Metadata

  - Change type: feature
  - Primary scope: agent

  Linked Issue

  - Closes #(the issue number created above)
  - Related: N/A
  - Depends on: N/A
  - Supersedes: N/A

  Supersede Attribution (required when Supersedes # is used)

  N/A — not superseding any PR.

  Validation Evidence (required)

  cargo fmt --all -- --check   # pass
  cargo clippy --all-targets -- -D warnings   # no new warnings (all pre-existing in unrelated files)
  cargo test   # 3045 passed, 0 failed, 2 ignored
  cargo run -- agent --help   # all 6 new flags visible
  cargo run -- agent -m "quick task" --memory-backend none --compact-context   # confirmed backend="none"

  - Evidence provided: CLI output confirmed backend="none" and agent responded correctly
  - If any command is intentionally skipped: N/A

  Security Impact (required)

  - New permissions/capabilities? No — CLI merely overrides existing config fields that users can already set in
  config.toml
  - New external network calls? No
  - Secrets/tokens handling changed? No
  - File system access scope changed? No

  Privacy and Data Hygiene (required)

  - Data-hygiene status: pass
  - Redaction/anonymization notes: No personal data in code, tests, or examples
  - Neutral wording confirmation: All examples use generic placeholder messages ("quick task", "hello")

  Compatibility / Migration

  - Backward compatible? Yes — all new fields are Option<T> (default None) or bool (default false); omitting them
  preserves exact existing behavior
  - Config/env changes? No
  - Migration needed? No

  i18n Follow-Through (required when docs or user-facing wording changes)

  - i18n follow-through triggered? No — changes are CLI flags only, no docs navigation or user-facing wording in docs
  files changed

  Human Verification (required)

  - Verified scenarios:
    - zeroclaw agent --help displays all 6 new flags with correct descriptions
    - zeroclaw agent -m "quick task" --memory-backend none --compact-context — logs confirm backend="none", agent
  responds normally
    - zeroclaw agent -m "hello" --autonomy-level full --max-actions-per-hour 100 — parses without error
  - Edge cases checked:
    - Invalid autonomy level (--autonomy-level bogus) produces clear clap error
    - Omitting all new flags preserves default behavior exactly
  - What was not verified: --max-tool-iterations and --max-history-messages runtime effect (requires multi-turn
  tool-calling session with real provider)

  Side Effects / Blast Radius (required)

  - Affected subsystems/workflows: src/main.rs CLI parsing, src/security/policy.rs type definition
  - Potential unintended effects: None — override logic runs before agent::run() and only mutates the Config struct
  in-place
  - Guardrails/monitoring: Existing clap validation ensures type safety; AutonomyLevel::FromStr rejects invalid values
  with descriptive error

  Agent Collaboration Notes (recommended)

  - Agent tools used: Claude Code (research, implementation, validation)
  - Workflow/plan summary: Plan mode -> read existing code -> implement FromStr + CLI fields + override logic ->
  validate with fmt/clippy/test/help/runtime
  - Verification focus: CLI parsing correctness, no regression, config override propagation
  - Confirmation: naming + architecture boundaries followed (CLAUDE.md + CONTRIBUTING.md): Yes — FromStr added to
  existing type, no cross-module coupling, factory/trait architecture untouched

  Rollback Plan (required)

  - Fast rollback command/path: git revert <commit-sha>
  - Feature flags or config toggles: N/A — omitting CLI flags restores default behavior
  - Observable failure symptoms: CLI parse errors on invalid values (handled by clap)

  Risks and Mitigations

  - Risk: User passes --autonomy-level full --max-actions-per-hour 99999 bypassing intended safety defaults
    - Mitigation: This is intentional — users can already set these values in config.toml. CLI flags are explicitly
  opt-in and equivalent to config file edits. SecurityPolicy enforcement (rate limiter, command allowlist, path policy)
   still applies regardless of autonomy level.