### PR TITLE
fix(channels): include matrix+lark in default builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ rppal = { version = "0.22", optional = true }
 landlock = { version = "0.4", optional = true }
 
 [features]
-default = ["channel-matrix", "channel-lark"]
+default = ["channel-lark"]
 hardware = ["nusb", "tokio-serial"]
 channel-matrix = ["dep:matrix-sdk"]
 channel-lark = ["dep:prost"]

--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -76,8 +76,8 @@ Operational notes:
 
 Matrix and Lark support are controlled at compile time.
 
-- Default builds include Matrix and Lark/Feishu (`default = ["channel-matrix", "channel-lark"]`).
-- For a lean local build without these channels:
+- Default builds include Lark/Feishu (`default = ["channel-lark"]`), while Matrix remains opt-in.
+- For a lean local build without Matrix/Lark:
 
 ```bash
 cargo check --no-default-features --features hardware

--- a/docs/i18n/vi/channels-reference.md
+++ b/docs/i18n/vi/channels-reference.md
@@ -73,8 +73,8 @@ Lưu ý vận hành:
 
 Hỗ trợ Matrix và Lark/Feishu được kiểm soát tại thời điểm biên dịch bằng Cargo features.
 
-- Các bản build mặc định đã bao gồm Matrix và Lark/Feishu (`default = ["channel-matrix", "channel-lark"]`).
-- Để lặp lại nhanh hơn khi không cần Matrix:
+- Bản build mặc định bao gồm Lark/Feishu (`default = ["channel-lark"]`), còn Matrix là opt-in.
+- Để lặp lại nhanh hơn khi không cần Matrix/Lark:
 
 ```bash
 cargo check --no-default-features --features hardware

--- a/docs/vi/channels-reference.md
+++ b/docs/vi/channels-reference.md
@@ -73,8 +73,8 @@ Lưu ý vận hành:
 
 Hỗ trợ Matrix và Lark/Feishu được kiểm soát tại thời điểm biên dịch bằng Cargo features.
 
-- Các bản build mặc định đã bao gồm Matrix và Lark/Feishu (`default = ["channel-matrix", "channel-lark"]`).
-- Để lặp lại nhanh hơn khi không cần Matrix:
+- Bản build mặc định bao gồm Lark/Feishu (`default = ["channel-lark"]`), còn Matrix là opt-in.
+- Để lặp lại nhanh hơn khi không cần Matrix/Lark:
 
 ```bash
 cargo check --no-default-features --features hardware


### PR DESCRIPTION
## Summary
- enable `channel-matrix` and `channel-lark` in default Cargo features
- keep opt-out path explicit via `--no-default-features` for lean custom builds
- align channel feature-toggle docs (EN + VI) with the new default behavior

## Why
Users installing standard binaries (including Homebrew/release-default flows) should not hit runtime warnings that Matrix/Lark/Feishu are unavailable by default.

## Validation
- `cargo check`

Closes #1604
