### PR TITLE
feat(unsafe-debt): enforce crate-root unsafe guard policy

### DIFF
--- a/crates/robot-kit/src/lib.rs
+++ b/crates/robot-kit/src/lib.rs
@@ -86,6 +86,7 @@
 // #![warn(missing_docs)]
 #![allow(missing_docs)]
 #![warn(clippy::all)]
+#![forbid(unsafe_code)]
 
 pub mod config;
 pub mod traits;

--- a/fuzz/fuzz_targets/fuzz_command_validation.rs
+++ b/fuzz/fuzz_targets/fuzz_command_validation.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![forbid(unsafe_code)]
 use libfuzzer_sys::fuzz_target;
 use zeroclaw::security::SecurityPolicy;
 

--- a/fuzz/fuzz_targets/fuzz_config_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_config_parse.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![forbid(unsafe_code)]
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/fuzz_provider_response.rs
+++ b/fuzz/fuzz_targets/fuzz_provider_response.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![forbid(unsafe_code)]
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/fuzz_tool_params.rs
+++ b/fuzz/fuzz_targets/fuzz_tool_params.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![forbid(unsafe_code)]
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {

--- a/fuzz/fuzz_targets/fuzz_webhook_payload.rs
+++ b/fuzz/fuzz_targets/fuzz_webhook_payload.rs
@@ -1,4 +1,5 @@
 #![no_main]
+#![forbid(unsafe_code)]
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {


### PR DESCRIPTION
## Summary
- deepens `unsafe_debt_audit.py` with crate-root unsafe guard detection (`#![forbid|deny(unsafe_code)]`)
- adds regression tests for missing/valid crate-root guards
- hardens repo crate roots by adding `#![forbid(unsafe_code)]` to:
  - `crates/robot-kit/src/lib.rs`
  - all fuzz targets under `fuzz/fuzz_targets/*.rs`

## Why
The previous audit was pattern-based only. It could miss policy drift where a crate root omits a compile-time guard against introducing unsafe code in the future.

## Validation
- `python3 -m unittest scripts.ci.tests.test_ci_scripts`
- `python3 scripts/ci/unsafe_debt_audit.py --repo-root . --output-json /tmp/unsafe-audit-deep2.json --fail-on-findings`
- `cargo check -q`

Linear: RMN-52
