### PR TITLE
feat(qq): support webhook receive mode with QQ challenge validation

### DIFF
--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -387,7 +387,15 @@ allowed_users = ["*"]
 app_id = "qq-app-id"
 app_secret = "qq-app-secret"
 allowed_users = ["*"]
+receive_mode = "webhook" # webhook (default) or websocket (legacy fallback)
 ```
+
+Notes:
+
+- `webhook` mode is now the default and serves inbound callbacks at `POST /qq`.
+- QQ validation challenge payloads (`op = 13`) are auto-signed using `app_secret`.
+- `X-Bot-Appid` is checked when present and must match `app_id`.
+- Set `receive_mode = "websocket"` to keep the legacy gateway WS receive path.
 
 ### 4.16 Nextcloud Talk
 

--- a/docs/i18n/vi/channels-reference.md
+++ b/docs/i18n/vi/channels-reference.md
@@ -340,7 +340,15 @@ allowed_users = ["*"]
 app_id = "qq-app-id"
 app_secret = "qq-app-secret"
 allowed_users = ["*"]
+receive_mode = "webhook" # webhook (mặc định) hoặc websocket (legacy fallback)
 ```
+
+Ghi chú:
+
+- `webhook` hiện là chế độ mặc định, nhận callback tại `POST /qq`.
+- Gói xác thực QQ (`op = 13`) được ký tự động bằng `app_secret`.
+- Nếu có header `X-Bot-Appid`, giá trị phải khớp `app_id`.
+- Đặt `receive_mode = "websocket"` nếu cần giữ đường nhận sự kiện WS cũ.
 
 ### 4.14 iMessage
 

--- a/docs/vi/channels-reference.md
+++ b/docs/vi/channels-reference.md
@@ -340,7 +340,15 @@ allowed_users = ["*"]
 app_id = "qq-app-id"
 app_secret = "qq-app-secret"
 allowed_users = ["*"]
+receive_mode = "webhook" # webhook (mặc định) hoặc websocket (legacy fallback)
 ```
+
+Ghi chú:
+
+- `webhook` hiện là chế độ mặc định, nhận callback tại `POST /qq`.
+- Gói xác thực QQ (`op = 13`) được ký tự động bằng `app_secret`.
+- Nếu có header `X-Bot-Appid`, giá trị phải khớp `app_id`.
+- Đặt `receive_mode = "websocket"` nếu cần giữ đường nhận sự kiện WS cũ.
 
 ### 4.14 iMessage
 

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2946,14 +2946,20 @@ fn collect_configured_channels(
     }
 
     if let Some(ref qq) = config.channels_config.qq {
-        channels.push(ConfiguredChannel {
-            display_name: "QQ",
-            channel: Arc::new(QQChannel::new(
-                qq.app_id.clone(),
-                qq.app_secret.clone(),
-                qq.allowed_users.clone(),
-            )),
-        });
+        if qq.receive_mode == crate::config::schema::QQReceiveMode::Webhook {
+            tracing::info!(
+                "QQ channel configured with receive_mode=webhook; websocket listener startup skipped."
+            );
+        } else {
+            channels.push(ConfiguredChannel {
+                display_name: "QQ",
+                channel: Arc::new(QQChannel::new(
+                    qq.app_id.clone(),
+                    qq.app_secret.clone(),
+                    qq.allowed_users.clone(),
+                )),
+            });
+        }
     }
 
     if let Some(ref ct) = config.channels_config.clawdtalk {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -440,6 +440,7 @@ mod tests {
             app_id: "app-id".into(),
             app_secret: "app-secret".into(),
             allowed_users: vec!["*".into()],
+            receive_mode: crate::config::schema::QQReceiveMode::Websocket,
         });
         assert!(has_supervised_channels(&config));
     }


### PR DESCRIPTION
## Summary
- add `channels_config.qq.receive_mode` with `webhook` as default and keep websocket fallback
- add QQ webhook endpoint `POST /qq` in gateway for challenge + event handling
- reuse QQ message parsing logic across websocket and webhook paths
- support QQ validation challenge (`op=13`) signed via app secret
- update onboarding, daemon/channel launchability checks, and docs for new QQ mode

## Testing
- cargo test --lib channels::qq::tests:: -- --nocapture
- cargo test --lib gateway::tests::qq_webhook -- --nocapture
- cargo test --lib config::schema::tests::qq_config -- --nocapture
- cargo test --lib daemon::tests::detects_qq_as_supervised_channel -- --nocapture
- cargo test --lib onboard::wizard::tests::launchable_channels_include_signal_mattermost_qq_nextcloud_and_feishu -- --nocapture

Fixes #1608