### PR TITLE
feat(unsafe-debt): deep integrate policy-driven audit coverage

### DIFF
--- a/scripts/ci/config/unsafe_debt_policy.toml
+++ b/scripts/ci/config/unsafe_debt_policy.toml
@@ -1,0 +1,17 @@
+[audit]
+# Paths that the audit must cover (repo-root relative prefixes).
+include_paths = ["src", "crates", "tests", "benches", "fuzz"]
+
+# Optional prefixes to exclude from the audit.
+ignore_paths = []
+
+# Optional pattern IDs to ignore.
+ignore_pattern_ids = []
+
+# When true, crate roots in scope must include `#![forbid(unsafe_code)]`
+# or `#![deny(unsafe_code)]`.
+enforce_crate_unsafe_guard = true
+
+# When true, the audit exits non-zero if any discovered crate roots are
+# outside the scoped include_paths/ignore_paths.
+fail_on_excluded_crate_roots = false


### PR DESCRIPTION
## Summary
- add policy-driven configuration to `scripts/ci/unsafe_debt_audit.py`
  - `--policy-file`, `--ignore-path`, `--ignore-pattern-id`
  - support `[audit]` config for include scope, ignore scope, pattern suppression, guard toggles
- add coverage visibility in audit output
  - `crate_roots_total`, `crate_roots_scanned`, `crate_roots_excluded`, `excluded_crate_roots`
- add optional strict gate
  - `--fail-on-excluded-crate-roots` and policy equivalent
- add default policy template
  - `scripts/ci/config/unsafe_debt_policy.toml`
- extend unit tests for policy/excluded-root behaviors

## Why
This deep integration turns unsafe audit from a hardcoded scan into a governed system that can evolve with repo topology while preserving deterministic outputs and explicit coverage accountability.

## Validation
- `python3 -m unittest scripts.ci.tests.test_ci_scripts` ✅
- `python3 scripts/ci/unsafe_debt_audit.py --repo-root . --output-json /tmp/unsafe-audit-deep-integrated.json --fail-on-findings` ✅
- `cargo check -q` ✅

Linear: RMN-53
