### PR TITLE
chore(unsafe-debt): strict full crate coverage by default

### DIFF
--- a/firmware/zeroclaw-esp32-ui/src/main.rs
+++ b/firmware/zeroclaw-esp32-ui/src/main.rs
@@ -3,6 +3,7 @@
 //! This binary initializes ESP-IDF, boots a minimal Slint UI, and keeps
 //! architecture boundaries explicit so hardware integrations can be added
 //! incrementally.
+#![forbid(unsafe_code)]
 
 use anyhow::Context;
 use log::info;

--- a/firmware/zeroclaw-esp32/src/main.rs
+++ b/firmware/zeroclaw-esp32/src/main.rs
@@ -4,6 +4,7 @@
 //! responds with JSON. Compatible with host ZeroClaw SerialPeripheral protocol.
 //!
 //! Protocol: same as STM32 — see docs/hardware-peripherals-design.md
+#![forbid(unsafe_code)]
 
 use esp_idf_svc::hal::gpio::PinDriver;
 use esp_idf_svc::hal::peripherals::Peripherals;

--- a/firmware/zeroclaw-nucleo/src/main.rs
+++ b/firmware/zeroclaw-nucleo/src/main.rs
@@ -7,6 +7,7 @@
 
 #![no_std]
 #![no_main]
+#![forbid(unsafe_code)]
 
 use core::fmt::Write;
 use core::str;

--- a/scripts/ci/config/unsafe_debt_policy.toml
+++ b/scripts/ci/config/unsafe_debt_policy.toml
@@ -1,6 +1,6 @@
 [audit]
 # Paths that the audit must cover (repo-root relative prefixes).
-include_paths = ["src", "crates", "tests", "benches", "fuzz"]
+include_paths = ["src", "crates", "tests", "benches", "fuzz", "firmware"]
 
 # Optional prefixes to exclude from the audit.
 ignore_paths = []
@@ -14,4 +14,4 @@ enforce_crate_unsafe_guard = true
 
 # When true, the audit exits non-zero if any discovered crate roots are
 # outside the scoped include_paths/ignore_paths.
-fail_on_excluded_crate_roots = false
+fail_on_excluded_crate_roots = true


### PR DESCRIPTION
## Summary
- add `#![forbid(unsafe_code)]` to all firmware crate roots:
  - `firmware/zeroclaw-esp32/src/main.rs`
  - `firmware/zeroclaw-esp32-ui/src/main.rs`
  - `firmware/zeroclaw-nucleo/src/main.rs`
- tighten default unsafe debt policy (`scripts/ci/config/unsafe_debt_policy.toml`):
  - include `firmware` in `include_paths`
  - set `fail_on_excluded_crate_roots = true`

## Why
This upgrades default governance from partial scope to strict full crate-root coverage. New crates outside policy scope now fail fast, and firmware no longer remains outside the default audit envelope.

## Validation
- `python3 scripts/ci/unsafe_debt_audit.py --repo-root . --output-json /tmp/unsafe-audit-strict-full.json --fail-on-findings` ✅
  - `crate_roots_total=11`
  - `crate_roots_scanned=11`
  - `crate_roots_excluded=0`
  - `total_findings=0`
- `python3 -m unittest scripts.ci.tests.test_ci_scripts` ✅
- `cargo check -q` ✅

Linear: RMN-54
