### PR TITLE
feat(agent): inject allowed_commands policy into system prompt

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -67,7 +67,9 @@ pub use whatsapp::WhatsAppChannel;
 #[cfg(feature = "whatsapp-web")]
 pub use whatsapp_web::WhatsAppWebChannel;
 
-use crate::agent::loop_::{build_tool_instructions, run_tool_call_loop, scrub_credentials};
+use crate::agent::loop_::{
+    build_shell_policy_instructions, build_tool_instructions, run_tool_call_loop, scrub_credentials,
+};
 use crate::config::Config;
 use crate::identity;
 use crate::memory::{self, Memory};
@@ -3199,6 +3201,7 @@ pub async fn start_channels(config: Config) -> Result<()> {
     if !native_tools {
         system_prompt.push_str(&build_tool_instructions(tools_registry.as_ref()));
     }
+    system_prompt.push_str(&build_shell_policy_instructions(&config.autonomy));
 
     if !skills.is_empty() {
         println!(


### PR DESCRIPTION
## Summary
- add `build_shell_policy_instructions` to render runtime shell constraints from `[autonomy]`
- inject shell policy context into system prompts for:
  - CLI/daemon `agent::run`
  - channel entrypoint `agent::process_message`
  - channel runtime startup prompt wiring
- include policy guidance for `read_only`, wildcard allowlists, explicit allowlists, and supervised/high-risk behavior
- add unit tests for shell policy prompt generation variants

## Validation
- `cargo test build_shell_policy_instructions_ -- --test-threads=1`
- `cargo test build_tool_instructions_includes_all_tools -- --test-threads=1`

Closes #1618
Resolves RMN-61
Refs RMN-57
