### PR TITLE
docs(readme): add ZeroClaw Views ecosystem entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1022,6 +1022,12 @@ You can also override at runtime with `ZEROCLAW_OPEN_SKILLS_ENABLED`, `ZEROCLAW_
 
 Skill installs are now gated by a built-in static security audit. `zeroclaw skills install <source>` blocks symlinks, script-like files, unsafe markdown link patterns, and high-risk shell payload snippets before accepting a skill. You can run `zeroclaw skills audit <source_or_name>` to validate a local directory or an installed skill manually.
 
+### Ecosystem Projects
+
+Community-built projects that extend ZeroClaw UX and operations:
+
+- **ZeroClaw Views**: Full-stack dashboard companion (Vue 3 frontend + Rust BFF) covering chat, agents, memory browsing, config editing, and workflow integrations. Repository: <https://github.com/liuguangzhong/zeroclaw-views>
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary

Addresses #1667 by adding a first-party ecosystem entry in the README for the community-built ZeroClaw Views dashboard project.

## Changes

- Add `Ecosystem Projects` subsection under the README collaboration/skills area
- Add a concise description + canonical repository link for ZeroClaw Views

## Scope

- documentation-only change
- no runtime behavior or CI policy changes

Refs #1667
