### PR TITLE
Android

### DIFF
--- a/.github/workflows/build-android-whatsapp.yml
+++ b/.github/workflows/build-android-whatsapp.yml
@@ -1,11 +1,10 @@
 name: Build Android Binary (with WhatsApp)
 
 on:
-  # Permite ejecutar el workflow manualmente desde la interfaz de GitHub
   workflow_dispatch:
     inputs:
       target:
-        description: 'Arquitectura de Android (aarch64-linux-android / armv7-linux-androideabi)'
+        description: 'Android architecture (aarch64-linux-android / armv7-linux-androideabi)'
         required: true
         default: 'aarch64-linux-android'
         type: choice
@@ -27,20 +26,67 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92.0 # O la versión que uses
+          toolchain: 1.92.0
           targets: ${{ github.event.inputs.target || 'aarch64-linux-android' }}
 
       - name: Cache dependencies
         uses: Swatinem/rust-cache@v2
 
-      - name: Install Android NDK
+      - name: Setup Android NDK
+        shell: bash
         run: |
-          # Descargar e instalar el NDK (ejemplo con la versión 26)
-          wget -q https://dl.google.com/android/repository/android-ndk-r26d-linux.zip
-          unzip -q android-ndk-r26d-linux.zip
-          echo "ANDROID_NDK_HOME=${PWD}/android-ndk-r26d" >> $GITHUB_ENV
-          # Añadir el linker al PATH
-          echo "${PWD}/android-ndk-r26d/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+          set -euo pipefail
+          NDK_VERSION="r26d"
+          NDK_ZIP="android-ndk-${NDK_VERSION}-linux.zip"
+          NDK_URL="https://dl.google.com/android/repository/${NDK_ZIP}"
+          NDK_ROOT="${RUNNER_TEMP}/android-ndk"
+          NDK_HOME="${NDK_ROOT}/android-ndk-${NDK_VERSION}"
+
+          sudo apt-get update -qq
+          sudo apt-get install -y unzip
+
+          mkdir -p "${NDK_ROOT}"
+          curl -fsSL "${NDK_URL}" -o "${RUNNER_TEMP}/${NDK_ZIP}"
+          unzip -q "${RUNNER_TEMP}/${NDK_ZIP}" -d "${NDK_ROOT}"
+
+          echo "ANDROID_NDK_HOME=${NDK_HOME}" >> "$GITHUB_ENV"
+          echo "${NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin" >> "$GITHUB_PATH"
+
+      - name: Configure Android toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGET="${{ github.event.inputs.target || 'aarch64-linux-android' }}"
+          NDK_HOME="${ANDROID_NDK_HOME}"
+          TOOLCHAIN="${NDK_HOME}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+          ANDROID_API=21
+
+          if [[ "$TARGET" == "armv7-linux-androideabi" ]]; then
+            CC="${TOOLCHAIN}/armv7a-linux-androideabi${ANDROID_API}-clang"
+            CXX="${TOOLCHAIN}/armv7a-linux-androideabi${ANDROID_API}-clang++"
+
+            # Some crates probe legacy compiler names (arm-linux-androideabi-clang)
+            ln -sf "$CC"  "${TOOLCHAIN}/arm-linux-androideabi-clang"
+            ln -sf "$CXX" "${TOOLCHAIN}/arm-linux-androideabi-clang++"
+
+            {
+              echo "CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=${CC}"
+              echo "CC_armv7_linux_androideabi=${CC}"
+              echo "CXX_armv7_linux_androideabi=${CXX}"
+              echo "AR_armv7_linux_androideabi=${TOOLCHAIN}/llvm-ar"
+            } >> "$GITHUB_ENV"
+
+          elif [[ "$TARGET" == "aarch64-linux-android" ]]; then
+            CC="${TOOLCHAIN}/aarch64-linux-android${ANDROID_API}-clang"
+            CXX="${TOOLCHAIN}/aarch64-linux-android${ANDROID_API}-clang++"
+
+            {
+              echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=${CC}"
+              echo "CC_aarch64_linux_android=${CC}"
+              echo "CXX_aarch64_linux_android=${CXX}"
+              echo "AR_aarch64_linux_android=${TOOLCHAIN}/llvm-ar"
+            } >> "$GITHUB_ENV"
+          fi
 
       - name: Build binary (with WhatsApp feature)
         run: |

--- a/src/channels/whatsapp_storage.rs
+++ b/src/channels/whatsapp_storage.rs
@@ -56,6 +56,7 @@ pub struct RusqliteStore {
 
 /// Helper macro to convert rusqlite errors to StoreError
 /// For execute statements that return usize, maps to ()
+#[cfg(feature = "whatsapp-web")]
 macro_rules! to_store_err {
     // For expressions returning Result<usize, E>
     (execute: $expr:expr) => {


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion):
- Problem:
- Why it matters:
- What changed:
- What did **not** change (scope boundary):

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`):
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`):
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`):
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- File system access scope changed? (`Yes/No`)
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`)
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any):
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
  - Mitigation:
