### PR TITLE
feat(channels): add query classification routing with logging for channels

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -746,7 +746,8 @@ fn classify_message_route(
     ctx: &ChannelRuntimeContext,
     message: &str,
 ) -> Option<ChannelRouteSelection> {
-    let decision = crate::agent::classifier::classify_with_decision(&ctx.query_classification, message)?;
+    let decision =
+        crate::agent::classifier::classify_with_decision(&ctx.query_classification, message)?;
 
     // Find the matching model route
     let route = ctx.model_routes.iter().find(|r| r.hint == decision.hint)?;
@@ -3594,8 +3595,8 @@ mod tests {
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             non_cli_excluded_tools: Arc::new(Vec::new()),
-        query_classification: crate::config::QueryClassificationConfig::default(),
-        model_routes: Vec::new(),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
         };
 
         assert!(compact_sender_history(&ctx, &sender));
@@ -3645,8 +3646,8 @@ mod tests {
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             non_cli_excluded_tools: Arc::new(Vec::new()),
-        query_classification: crate::config::QueryClassificationConfig::default(),
-        model_routes: Vec::new(),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
         };
 
         append_sender_turn(&ctx, &sender, ChatMessage::user("hello"));
@@ -3699,8 +3700,8 @@ mod tests {
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             non_cli_excluded_tools: Arc::new(Vec::new()),
-        query_classification: crate::config::QueryClassificationConfig::default(),
-        model_routes: Vec::new(),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
         };
 
         assert!(rollback_orphan_user_turn(&ctx, &sender, "pending"));


### PR DESCRIPTION
## Summary
Add query classification support to channel message processing (Telegram, Discord, Slack, etc.). When `query_classification` is enabled with `model_routes`, each incoming message is now classified and routed to the appropriate model with an INFO-level log line.

## Changes
- Add `query_classification` and `model_routes` fields to `ChannelRuntimeContext`
- Add `classify_message_route` function that logs classification decisions
- Update `process_channel_message` to try classification before default routing
- Initialize new fields in channel runtime context
- Update all test contexts with new fields

## Log Format
```
INFO query_classification: Classified message route hint="fast" model="anthropic/claude-haiku-4-5" rule_priority=10 message_length=12
```

## Tests
- All 8 classifier tests pass
- All 76 channel tests pass

## Acceptance Criteria (from issue)
- [x] When query_classification is enabled, each classified message produces a log line with hint, model, and matched rule
- [x] Log level is INFO
- [x] No log line when classification is disabled or no rules match (falls through to default)

Closes #1367

## Validation Evidence
- GitHub Actions required checks are green on current head `bb8772f4061c74c136ef79aeed1af9ea8cc2fa53` (CI Required Gate, Security Required Gate, Lint, Build, Test, CodeQL all passed).
- Scope is limited to channel query-classification routing + logging path; no CI failures remain.

## Security Impact
- No new auth boundary, secret handling path, or outbound integration was introduced.
- Logging output is structured to routing metadata (`hint`, `model`, `rule_priority`, `message_length`) rather than raw user payload content.

## Privacy and Data Hygiene
- This change does not add new data collection sinks or persistence.
- Log output avoids full message body capture; only classification metadata is emitted at INFO level.

## Rollback Plan
- Revert this PR commit from `feat/issue-1367-query-classification-logging` if behavior is not desired.
- System falls back to existing default model routing path without classification logging.