### PR TITLE
fix(tests): align Groq test fixtures with /openai/v1 base URL

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -4798,7 +4798,7 @@ mod tests {
 
         let groq = OpenAiCompatibleProvider::new(
             "Groq",
-            "https://api.groq.com/openai",
+            "https://api.groq.com/openai/v1",
             Some("fake_key"),
             AuthStyle::Bearer,
         );

--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -2425,7 +2425,7 @@ mod tests {
             make_provider("Moonshot", "https://api.moonshot.cn", None),
             make_provider("GLM", "https://open.bigmodel.cn", None),
             make_provider("MiniMax", "https://api.minimaxi.com/v1", None),
-            make_provider("Groq", "https://api.groq.com/openai", None),
+            make_provider("Groq", "https://api.groq.com/openai/v1", None),
             make_provider("Mistral", "https://api.mistral.ai", None),
             make_provider("xAI", "https://api.x.ai", None),
             make_provider("Astrai", "https://as-trai.com/v1", None),


### PR DESCRIPTION
## Summary
- Aligns Groq test fixtures with the correct `/openai/v1` base URL
- The main provider registration was already fixed in a previous commit

## Issue
The Groq provider registration in `src/providers/mod.rs` correctly uses:
```
https://api.groq.com/openai/v1
```

But test fixtures still had the old URL without `/v1`:
```
https://api.groq.com/openai
```

## Files Changed
- `src/providers/compatible.rs` - Updated Groq test fixture URL
- `src/channels/telegram.rs` - Updated Groq test fixture URL

## Test Plan
- [x] All provider compatible tests pass (84 tests)
- [x] All telegram tests pass (140 tests)

Closes #1439

🦀 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Groq API endpoint references in test fixtures to use the versioned `/v1` path for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Validation Evidence
- GitHub Actions required checks are green on current head `b609538ce61d21f18a0654cf01a8675a5260236c` (CI Required Gate, Security Required Gate, Lint, Build, Test, CodeQL all passed).
- Change set is test-fixture alignment only (`/openai` -> `/openai/v1`) and has no runtime production logic expansion.

## Security Impact
- No production security control changed; this PR updates fixture URLs used in tests.
- No new secrets, auth scopes, or network permissions are introduced.

## Privacy and Data Hygiene
- No PII schema/path changes and no additional logging/storage behavior introduced.
- Test-only URL normalization has no end-user data handling impact.

## Rollback Plan
- Revert this PR commit from `fix/issue-1439-groq-test-fixture` if needed.
- Rollback impact is limited to test fixture endpoint strings.