### PR TITLE
feat(telegram): register bot commands with setMyCommands on startup

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -574,7 +574,20 @@ impl TelegramChannel {
         if !resp.status().is_success() {
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
-            tracing::warn!("setMyCommands failed: status={status}, body={text}");
+            // Only log Telegram's error_code and description, not the full body
+            let detail = serde_json::from_str::<serde_json::Value>(&text)
+                .ok()
+                .and_then(|v| {
+                    let code = v.get("error_code");
+                    let desc = v.get("description").and_then(|d| d.as_str());
+                    match (code, desc) {
+                        (Some(c), Some(d)) => Some(format!("error_code={c}, description={d}")),
+                        (_, Some(d)) => Some(format!("description={d}")),
+                        _ => None,
+                    }
+                })
+                .unwrap_or_else(|| "no parseable error detail".to_string());
+            tracing::warn!("setMyCommands failed: status={status}, {detail}");
         } else {
             tracing::info!("Telegram bot commands registered successfully");
         }


### PR DESCRIPTION
## Summary

- Base branch target: `dev`
- Problem: Telegram bot commands are not registered with the Bot API, so users don't see available commands in the chat's command menu
- Why it matters: Users have to know commands exist to use them; discoverability is poor for new users
- What changed: Added `register_commands()` method that POSTs to Telegram's `setMyCommands` API on startup; called non-fatally before polling loop
- What did **not** change: No changes to command handling/dispatch logic; no config schema changes

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: telegram`

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Related: Telegram UX improvement for command discoverability

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo check                   # pass (2 pre-existing unrelated warnings)
```

- Evidence provided: compilation check
- No commands intentionally skipped

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? Yes — one POST to Telegram's `setMyCommands` API on startup
- Secrets/tokens handling changed? No (uses existing bot token)
- File system access scope changed? No
- Risk/mitigation: The API call uses the existing authenticated Telegram client. Error responses are parsed for safe fields only (error_code, description) — raw response bodies are NOT logged per security policy.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: Raw Telegram API response bodies redacted in error logs; only error_code and description fields extracted
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through

- i18n follow-through triggered? No (code-only change)

## Human Verification (required)

- Verified scenarios: Bot commands appear in Telegram's command menu after restart
- Edge cases checked: Bot still starts normally if setMyCommands fails
- What was not verified: Behavior when Telegram API is unreachable at startup

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Telegram channel startup only
- Potential unintended effects: None — registration is non-fatal
- Guardrails/monitoring: Warning log emitted on registration failure

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: Non-fatal startup behavior, log redaction
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None
- Observable failure symptoms: Commands not appearing in Telegram menu (silent degradation)

## Risks and Mitigations

- Risk: None significant — feature is purely additive and non-fatal on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)