### PR TITLE
chore(ci): lock workflow ownership and use blacksmith runners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owner for all files
-* @theonlyhennygod @chumyin
+* @theonlyhennygod
 
 # Important functional modules
 /src/agent/** @theonlyhennygod
@@ -8,25 +8,25 @@
 /src/tools/** @theonlyhennygod
 /src/gateway/** @theonlyhennygod
 /src/runtime/** @theonlyhennygod
-/src/memory/** @theonlyhennygod @chumyin
+/src/memory/** @theonlyhennygod
 /Cargo.toml @theonlyhennygod
 /Cargo.lock @theonlyhennygod
 
 # Security / tests / CI-CD ownership
-/src/security/** @chumyin
-/tests/** @chumyin
-/.github/** @chumyin
-/.github/workflows/** @chumyin
-/.github/codeql/** @chumyin
-/.github/dependabot.yml @chumyin
-/SECURITY.md @chumyin
-/docs/actions-source-policy.md @chumyin
-/docs/ci-map.md @chumyin
+/src/security/** @theonlyhennygod
+/tests/** @theonlyhennygod
+/.github/** @theonlyhennygod
+/.github/workflows/** @theonlyhennygod
+/.github/codeql/** @theonlyhennygod
+/.github/dependabot.yml @theonlyhennygod
+/SECURITY.md @theonlyhennygod
+/docs/actions-source-policy.md @theonlyhennygod
+/docs/ci-map.md @theonlyhennygod
 
 # Docs & governance
-/docs/** @chumyin
-/AGENTS.md @chumyin
-/CLAUDE.md @chumyin
-/CONTRIBUTING.md @chumyin
-/docs/pr-workflow.md @chumyin
-/docs/reviewer-playbook.md @chumyin
+/docs/** @theonlyhennygod
+/AGENTS.md @theonlyhennygod
+/CLAUDE.md @theonlyhennygod
+/CONTRIBUTING.md @theonlyhennygod
+/docs/pr-workflow.md @theonlyhennygod
+/docs/reviewer-playbook.md @theonlyhennygod

--- a/.github/workflows/pr-auto-response.yml
+++ b/.github/workflows/pr-auto-response.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'labeled' || github.event.action == 'unlabeled')) ||
       (github.event_name == 'pull_request_target' &&
       (github.event.action == 'labeled' || github.event.action == 'unlabeled'))
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       issues: write
@@ -38,7 +38,7 @@ jobs:
             await script({ github, context, core });
   first-interaction:
     if: github.event.action == 'opened'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       issues: write
       pull-requests: write
@@ -69,7 +69,7 @@ jobs:
 
   labeled-routes:
     if: github.event.action == 'labeled'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/pr-check-stale.yml
+++ b/.github/workflows/pr-check-stale.yml
@@ -12,7 +12,7 @@ jobs:
         permissions:
             issues: write
             pull-requests: write
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         steps:
             - name: Mark stale issues and pull requests
               uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0

--- a/.github/workflows/pr-check-status.yml
+++ b/.github/workflows/pr-check-status.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   nudge-stale-prs:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-intake-checks.yml
+++ b/.github/workflows/pr-intake-checks.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
     intake:
         name: Intake Checks
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         timeout-minutes: 10
         steps:
             - name: Checkout repository

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
     label:
-        runs-on: ubuntu-latest
+        runs-on: blacksmith-2vcpu-ubuntu-2404
         steps:
             - name: Checkout repository
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -147,28 +147,28 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - os: ubuntu-latest
+                    - os: blacksmith-2vcpu-ubuntu-2404
                       target: x86_64-unknown-linux-gnu
                       artifact: zeroclaw
                       archive_ext: tar.gz
                       cross_compiler: ""
                       linker_env: ""
                       linker: ""
-                    - os: ubuntu-latest
+                    - os: blacksmith-2vcpu-ubuntu-2404
                       target: aarch64-unknown-linux-gnu
                       artifact: zeroclaw
                       archive_ext: tar.gz
                       cross_compiler: gcc-aarch64-linux-gnu
                       linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
                       linker: aarch64-linux-gnu-gcc
-                    - os: ubuntu-latest
+                    - os: blacksmith-2vcpu-ubuntu-2404
                       target: armv7-unknown-linux-gnueabihf
                       artifact: zeroclaw
                       archive_ext: tar.gz
                       cross_compiler: gcc-arm-linux-gnueabihf
                       linker_env: CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER
                       linker: arm-linux-gnueabihf-gcc
-                    - os: ubuntu-latest
+                    - os: blacksmith-2vcpu-ubuntu-2404
                       target: armv7-linux-androideabi
                       artifact: zeroclaw
                       archive_ext: tar.gz
@@ -177,7 +177,7 @@ jobs:
                       linker: ""
                       android_ndk: true
                       android_api: 21
-                    - os: ubuntu-latest
+                    - os: blacksmith-2vcpu-ubuntu-2404
                       target: aarch64-linux-android
                       artifact: zeroclaw
                       archive_ext: tar.gz

--- a/.github/workflows/sync-contributors.yml
+++ b/.github/workflows/sync-contributors.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   update-notice:
     name: Update NOTICE with new contributors
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
Moves Linux runners to Blacksmith and makes @theonlyhennygod sole owner of CI workflows.