### PR TITLE
[supersede #1536] feat(channels): add /new and /clear commands to reset conversation context

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -35,7 +35,6 @@ pub mod slack;
 pub mod telegram;
 pub mod traits;
 pub mod transcription;
-pub mod wati;
 pub mod whatsapp;
 #[cfg(feature = "whatsapp-web")]
 pub mod whatsapp_storage;
@@ -62,7 +61,6 @@ pub use signal::SignalChannel;
 pub use slack::SlackChannel;
 pub use telegram::TelegramChannel;
 pub use traits::{Channel, SendMessage};
-pub use wati::WatiChannel;
 pub use whatsapp::WhatsAppChannel;
 #[cfg(feature = "whatsapp-web")]
 pub use whatsapp_web::WhatsAppWebChannel;
@@ -153,7 +151,7 @@ enum ChannelRuntimeCommand {
     SetProvider(String),
     ShowModel,
     SetModel(String),
-    NewSession,
+    NewConversation,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -226,6 +224,7 @@ struct ChannelRuntimeContext {
     multimodal: crate::config::MultimodalConfig,
     hooks: Option<Arc<crate::hooks::HookRunner>>,
     non_cli_excluded_tools: Arc<Vec<String>>,
+    audit_logger: Option<Arc<crate::security::AuditLogger>>,
 }
 
 #[derive(Clone)]
@@ -457,6 +456,60 @@ fn build_channel_system_prompt(
     prompt
 }
 
+/// Build a concise summary of active (in_progress / blocked) goals for injection
+/// into channel system prompts.  This lets the agent correlate user messages with
+/// ongoing goals and proactively update goal state when users provide corrections,
+/// new information, or feedback relevant to an existing goal.
+///
+/// The summary is intentionally compact (≤ ~1500 chars) to avoid crowding the
+/// context window.
+async fn build_active_goals_summary(workspace_dir: &Path) -> String {
+    let engine = crate::goals::engine::GoalEngine::new(workspace_dir);
+    let state = match engine.load_state().await {
+        Ok(s) => s,
+        Err(_) => return String::new(),
+    };
+
+    use crate::goals::engine::GoalStatus;
+
+    let active: Vec<_> = state
+        .goals
+        .iter()
+        .filter(|g| matches!(g.status, GoalStatus::InProgress | GoalStatus::Blocked))
+        .collect();
+
+    if active.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::from(
+        "== Active Goals (read from state/goals.json) ==\n\
+         IMPORTANT: First determine whether the user's message is an independent question/topic \
+         or directly related to one of these goals. Most user messages are independent questions — \
+         answer them directly without modifying any goal state.\n\
+         Only update a goal when the user's message EXPLICITLY and CLEARLY refers to that specific \
+         goal (e.g. by goal ID, exact task name, or unambiguous continuation of a prior conversation \
+         about that goal). Do NOT force-associate loosely related keywords with existing goals.\n\
+         When you do update a goal, use file_edit on state/goals.json (e.g. revise description, \
+         update working_memory, adjust steps, change status).\n\n",
+    );
+
+    for g in &active {
+        let status = match g.status {
+            GoalStatus::InProgress => "in_progress",
+            GoalStatus::Blocked => "blocked",
+            _ => unreachable!(),
+        };
+        let _ = writeln!(out, "- [{}] ({}) {}", g.id, status, g.description);
+        if let Some(ref wm) = g.working_memory {
+            let wm_preview = truncate_with_ellipsis(wm, 200);
+            let _ = writeln!(out, "  working_memory: {wm_preview}");
+        }
+    }
+
+    out
+}
+
 fn normalize_cached_channel_turns(turns: Vec<ChatMessage>) -> Vec<ChatMessage> {
     let mut normalized = Vec::with_capacity(turns.len());
     let mut expecting_user = true;
@@ -495,10 +548,6 @@ fn supports_runtime_model_switch(channel_name: &str) -> bool {
 }
 
 fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRuntimeCommand> {
-    if !supports_runtime_model_switch(channel_name) {
-        return None;
-    }
-
     let trimmed = content.trim();
     if !trimmed.starts_with('/') {
         return None;
@@ -513,7 +562,10 @@ fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRun
         .to_ascii_lowercase();
 
     match base_command.as_str() {
-        "/models" => {
+        // /new and /clear work on all channels.
+        "/new" | "/clear" => Some(ChannelRuntimeCommand::NewConversation),
+        // Model switching is only available on channels that support it.
+        "/models" if supports_runtime_model_switch(channel_name) => {
             if let Some(provider) = parts.next() {
                 Some(ChannelRuntimeCommand::SetProvider(
                     provider.trim().to_string(),
@@ -522,7 +574,7 @@ fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRun
                 Some(ChannelRuntimeCommand::ShowProviders)
             }
         }
-        "/model" => {
+        "/model" if supports_runtime_model_switch(channel_name) => {
             let model = parts.collect::<Vec<_>>().join(" ").trim().to_string();
             if model.is_empty() {
                 Some(ChannelRuntimeCommand::ShowModel)
@@ -530,7 +582,6 @@ fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRun
                 Some(ChannelRuntimeCommand::SetModel(model))
             }
         }
-        "/new" => Some(ChannelRuntimeCommand::NewSession),
         _ => None,
     }
 }
@@ -1022,6 +1073,10 @@ async fn handle_runtime_command_if_needed(
     let mut current = get_route_selection(ctx, &sender_key);
 
     let response = match command {
+        ChannelRuntimeCommand::NewConversation => {
+            clear_sender_history(ctx, &sender_key);
+            "🔄 Conversation context cleared. Starting fresh.".to_string()
+        }
         ChannelRuntimeCommand::ShowProviders => build_providers_help_response(&current),
         ChannelRuntimeCommand::SetProvider(raw_provider) => {
             match resolve_provider_alias(&raw_provider) {
@@ -1067,10 +1122,6 @@ async fn handle_runtime_command_if_needed(
                     current.provider
                 )
             }
-        }
-        ChannelRuntimeCommand::NewSession => {
-            clear_sender_history(ctx, &sender_key);
-            "Conversation history cleared. Starting fresh.".to_string()
         }
     };
 
@@ -1527,6 +1578,9 @@ async fn process_channel_message(
         return;
     }
 
+    let health_component = format!("channel:{}", msg.channel);
+    crate::health::set_component_activity(&health_component, Some("processing"));
+
     println!(
         "  💬 [{}] from {}: {}",
         msg.channel,
@@ -1640,8 +1694,16 @@ async fn process_channel_message(
         }
     }
 
-    let system_prompt =
-        build_channel_system_prompt(ctx.system_prompt.as_str(), &msg.channel, &msg.reply_target);
+    let mut system_prompt = build_channel_system_prompt(ctx.system_prompt.as_str(), &msg.channel);
+
+    // Inject active goals summary so the agent can correlate user messages
+    // with in-progress goals and update them proactively.
+    let goals_summary = build_active_goals_summary(&ctx.workspace_dir).await;
+    if !goals_summary.is_empty() {
+        system_prompt.push_str("\n\n");
+        system_prompt.push_str(&goals_summary);
+    }
+
     let mut history = vec![ChatMessage::system(system_prompt)];
     history.extend(prior_turns);
     let use_streaming = target_channel
@@ -1663,7 +1725,7 @@ async fn process_channel_message(
         (None, None)
     };
 
-    let draft_message_id = if use_streaming {
+    let draft_message_id: Option<Arc<tokio::sync::Mutex<String>>> = if use_streaming {
         if let Some(channel) = target_channel.as_ref() {
             match channel
                 .send_draft(
@@ -1671,7 +1733,8 @@ async fn process_channel_message(
                 )
                 .await
             {
-                Ok(id) => id,
+                Ok(Some(id)) => Some(Arc::new(tokio::sync::Mutex::new(id))),
+                Ok(None) => None,
                 Err(e) => {
                     tracing::debug!("Failed to send draft on {}: {e}", channel.name());
                     None
@@ -1684,14 +1747,11 @@ async fn process_channel_message(
         None
     };
 
-    let draft_updater = if let (Some(mut rx), Some(draft_id_ref), Some(channel_ref)) = (
-        delta_rx,
-        draft_message_id.as_deref(),
-        target_channel.as_ref(),
-    ) {
+    let draft_updater = if let (Some(mut rx), Some(draft_id_arc), Some(channel_ref)) =
+        (delta_rx, draft_message_id.clone(), target_channel.as_ref())
+    {
         let channel = Arc::clone(channel_ref);
         let reply_target = msg.reply_target.clone();
-        let draft_id = draft_id_ref.to_string();
         Some(tokio::spawn(async move {
             let mut accumulated = String::new();
             while let Some(delta) = rx.recv().await {
@@ -1700,11 +1760,18 @@ async fn process_channel_message(
                     continue;
                 }
                 accumulated.push_str(&delta);
-                if let Err(e) = channel
+                let draft_id = draft_id_arc.lock().await.clone();
+                match channel
                     .update_draft(&reply_target, &draft_id, &accumulated)
                     .await
                 {
-                    tracing::debug!("Draft update failed: {e}");
+                    Ok(Some(new_id)) => {
+                        *draft_id_arc.lock().await = new_id;
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        tracing::debug!("Draft update failed: {e}");
+                    }
                 }
             }
         }))
@@ -1767,6 +1834,8 @@ async fn process_channel_message(
                 } else {
                     ctx.non_cli_excluded_tools.as_ref()
                 },
+                Some(ctx.workspace_dir.as_path()),
+                ctx.audit_logger.as_deref(),
             ),
         ) => LlmExecutionResult::Completed(result),
     };
@@ -1807,11 +1876,12 @@ async fn process_channel_message(
                     "elapsed_ms": started_at.elapsed().as_millis(),
                 }),
             );
-            if let (Some(channel), Some(draft_id)) =
-                (target_channel.as_ref(), draft_message_id.as_deref())
-            {
-                if let Err(err) = channel.cancel_draft(&msg.reply_target, draft_id).await {
-                    tracing::debug!("Failed to cancel draft on {}: {err}", channel.name());
+            if let Some(channel) = target_channel.as_ref() {
+                if let Some(ref draft_id_arc) = draft_message_id {
+                    let draft_id = draft_id_arc.lock().await.clone();
+                    if let Err(err) = channel.cancel_draft(&msg.reply_target, &draft_id).await {
+                        tracing::debug!("Failed to cancel draft on {}: {err}", channel.name());
+                    }
                 }
             }
         }
@@ -1919,9 +1989,18 @@ async fn process_channel_message(
                 truncate_with_ellipsis(&delivered_response, 80)
             );
             if let Some(channel) = target_channel.as_ref() {
-                if let Some(ref draft_id) = draft_message_id {
-                    if let Err(e) = channel
-                        .finalize_draft(&msg.reply_target, draft_id, &delivered_response)
+                if let Some(ref draft_id_arc) = draft_message_id {
+                    let draft_id = draft_id_arc.lock().await.clone();
+                    if delivered_response.trim().is_empty() {
+                        // Nothing to show — remove the placeholder draft
+                        if let Err(err) = channel.cancel_draft(&msg.reply_target, &draft_id).await {
+                            tracing::debug!(
+                                "Failed to cancel empty draft on {}: {err}",
+                                channel.name()
+                            );
+                        }
+                    } else if let Err(e) = channel
+                        .finalize_draft(&msg.reply_target, &draft_id, &delivered_response)
                         .await
                     {
                         tracing::warn!("Failed to finalize draft: {e}; sending as new message");
@@ -1964,11 +2043,12 @@ async fn process_channel_message(
                         "elapsed_ms": started_at.elapsed().as_millis(),
                     }),
                 );
-                if let (Some(channel), Some(draft_id)) =
-                    (target_channel.as_ref(), draft_message_id.as_deref())
-                {
-                    if let Err(err) = channel.cancel_draft(&msg.reply_target, draft_id).await {
-                        tracing::debug!("Failed to cancel draft on {}: {err}", channel.name());
+                if let Some(channel) = target_channel.as_ref() {
+                    if let Some(ref draft_id_arc) = draft_message_id {
+                        let draft_id = draft_id_arc.lock().await.clone();
+                        if let Err(err) = channel.cancel_draft(&msg.reply_target, &draft_id).await {
+                            tracing::debug!("Failed to cancel draft on {}: {err}", channel.name());
+                        }
                     }
                 }
             } else if is_context_window_overflow_error(&e) {
@@ -1998,9 +2078,10 @@ async fn process_channel_message(
                     }),
                 );
                 if let Some(channel) = target_channel.as_ref() {
-                    if let Some(ref draft_id) = draft_message_id {
+                    if let Some(ref draft_id_arc) = draft_message_id {
+                        let draft_id = draft_id_arc.lock().await.clone();
                         let _ = channel
-                            .finalize_draft(&msg.reply_target, draft_id, error_text)
+                            .finalize_draft(&msg.reply_target, &draft_id, error_text)
                             .await;
                     } else {
                         let _ = channel
@@ -2046,9 +2127,10 @@ async fn process_channel_message(
                     );
                 }
                 if let Some(channel) = target_channel.as_ref() {
-                    if let Some(ref draft_id) = draft_message_id {
+                    if let Some(ref draft_id_arc) = draft_message_id {
+                        let draft_id = draft_id_arc.lock().await.clone();
                         let _ = channel
-                            .finalize_draft(&msg.reply_target, draft_id, &format!("⚠️ Error: {e}"))
+                            .finalize_draft(&msg.reply_target, &draft_id, &format!("⚠️ Error: {e}"))
                             .await;
                     } else {
                         let _ = channel
@@ -2094,9 +2176,10 @@ async fn process_channel_message(
             if let Some(channel) = target_channel.as_ref() {
                 let error_text =
                     "⚠️ Request timed out while waiting for the model. Please try again.";
-                if let Some(ref draft_id) = draft_message_id {
+                if let Some(ref draft_id_arc) = draft_message_id {
+                    let draft_id = draft_id_arc.lock().await.clone();
                     let _ = channel
-                        .finalize_draft(&msg.reply_target, draft_id, error_text)
+                        .finalize_draft(&msg.reply_target, &draft_id, error_text)
                         .await;
                 } else {
                     let _ = channel
@@ -2109,6 +2192,8 @@ async fn process_channel_message(
             }
         }
     }
+
+    crate::health::set_component_activity(&health_component, None);
 
     // Swap 👀 → ✅ (or ⚠️ on error) to signal processing is complete
     if let Some(channel) = target_channel.as_ref() {
@@ -2176,7 +2261,12 @@ async fn run_message_dispatch_loop(
                 }
             }
 
-            process_channel_message(worker_ctx, msg, cancellation_token).await;
+            crate::providers::reliable::run_in_channel_scope(process_channel_message(
+                worker_ctx,
+                msg,
+                cancellation_token,
+            ))
+            .await;
 
             if interrupt_enabled {
                 let mut active = in_flight.lock().await;
@@ -2863,18 +2953,6 @@ fn collect_configured_channels(
         });
     }
 
-    if let Some(ref wati_cfg) = config.channels_config.wati {
-        channels.push(ConfiguredChannel {
-            display_name: "WATI",
-            channel: Arc::new(WatiChannel::new(
-                wati_cfg.api_token.clone(),
-                wati_cfg.api_url.clone(),
-                wati_cfg.tenant_id.clone(),
-                wati_cfg.allowed_numbers.clone(),
-            )),
-        });
-    }
-
     if let Some(ref nc) = config.channels_config.nextcloud_talk {
         channels.push(ConfiguredChannel {
             display_name: "Nextcloud Talk",
@@ -3126,7 +3204,6 @@ pub async fn start_channels(config: Config) -> Result<()> {
         composio_entity_id,
         &config.browser,
         &config.http_request,
-        &config.web_fetch,
         &workspace,
         &config.agents,
         config.api_key.as_deref(),
@@ -3166,7 +3243,7 @@ pub async fn start_channels(config: Config) -> Result<()> {
     if config.browser.enabled {
         tool_descs.push((
             "browser_open",
-            "Open approved HTTPS URLs in system browser (allowlist-only, no scraping)",
+            "Open approved HTTPS URLs in Brave Browser (allowlist-only, no scraping)",
         ));
     }
     if config.composio.enabled {
@@ -3349,6 +3426,22 @@ pub async fn start_channels(config: Config) -> Result<()> {
             None
         },
         non_cli_excluded_tools: Arc::new(config.autonomy.non_cli_excluded_tools.clone()),
+        audit_logger: if config.security.audit.enabled {
+            let zeroclaw_dir = config
+                .config_path
+                .parent()
+                .map(std::path::PathBuf::from)
+                .unwrap_or_else(|| config.workspace_dir.clone());
+            match crate::security::AuditLogger::new(config.security.audit.clone(), zeroclaw_dir) {
+                Ok(logger) => Some(Arc::new(logger)),
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to create audit logger for channels; tool call audit disabled");
+                    None
+                }
+            }
+        } else {
+            None
+        },
     });
 
     run_message_dispatch_loop(rx, runtime_ctx, max_in_flight_messages).await;
@@ -3562,6 +3655,7 @@ mod tests {
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         };
 
         assert!(compact_sender_history(&ctx, &sender));
@@ -3611,6 +3705,7 @@ mod tests {
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         };
 
         append_sender_turn(&ctx, &sender, ChatMessage::user("hello"));
@@ -3663,6 +3758,7 @@ mod tests {
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         };
 
         assert!(rollback_orphan_user_turn(&ctx, &sender, "pending"));
@@ -4093,6 +4189,7 @@ BTC is currently around $65,000 based on latest tool output."#
                     success: false,
                     output: String::new(),
                     error: Some("unexpected symbol".to_string()),
+                    error_kind: None,
                 });
             }
 
@@ -4100,6 +4197,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 success: true,
                 output: r#"{"symbol":"BTC","price_usd":65000}"#.to_string(),
                 error: None,
+                error_kind: None,
             })
         }
     }
@@ -4138,6 +4236,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -4197,6 +4296,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -4270,6 +4370,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -4329,6 +4430,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -4397,6 +4499,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -4486,6 +4589,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -4557,6 +4661,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -4643,6 +4748,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -4714,6 +4820,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -4774,6 +4881,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -4945,6 +5053,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(4);
@@ -5025,6 +5134,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);
@@ -5117,6 +5227,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);
@@ -5191,6 +5302,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -5250,6 +5362,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -5766,6 +5879,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -5851,6 +5965,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -5936,6 +6051,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(
@@ -6485,6 +6601,7 @@ This is an example JSON object for profile settings."#;
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         // Simulate a photo attachment message with [IMAGE:] marker.
@@ -6551,6 +6668,7 @@ This is an example JSON object for profile settings."#;
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             non_cli_excluded_tools: Arc::new(Vec::new()),
+            audit_logger: None,
         });
 
         process_channel_message(


### PR DESCRIPTION
Supersedes #1536 to recover from merge conflicts against latest `dev`.

- Source PR: https://github.com/zeroclaw-labs/zeroclaw/pull/1536
- Recovery mode: automated replay on top of current `dev`
- Merge policy: all CI checks green (except non-blocking `Enforce Dev -> Main Promotion`)

Original PR description:

## Summary

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): `dev`
- Problem: Users on Lark/Feishu and other non-Telegram/Discord channels cannot reset conversation context. Runtime commands were gated behind `supports_runtime_model_switch`, blocking `/new` and `/clear` on channels that don't support model switching.
- Why it matters: Conversation reset is a basic UX need for all channels, not just those supporting model switching.
- What changed: Moved the `supports_runtime_model_switch` gate from the top of `parse_runtime_command` to per-command matching. Added `NewConversation` variant and `/new`/`/clear` handler that calls `clear_sender_history`.
- What did **not** change (scope boundary): No model switching behavior changed. `/models` and `/model` remain channel-restricted.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `channel`
- Module labels: `channel: mod`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Closes #
- Related #

## Validation Evidence (required)

Commands and result summary:

```bash
cargo check  # upstream leak_detector.rs has pre-existing errors; channels/mod.rs compiles cleanly
```

- Evidence provided: Patch applies cleanly to upstream/dev, only src/channels/mod.rs changed
- If any command is intentionally skipped, explain why: Full cargo check blocked by pre-existing upstream error in leak_detector.rs (unrelated)

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Tested /new command on Lark channel — conversation history cleared, fresh response
- Edge cases checked: /models and /model still rejected on non-supported channels
- What was not verified: Other channel types beyond Lark

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Channel runtime command parsing
- Potential unintended effects: None — additive change, existing commands unchanged
- Guardrails/monitoring for early detection: Existing tests cover command parsing

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>`
- Feature flags or config toggles: None
- Observable failure symptoms: /new or /clear not responding

## Risks and Mitigations

- Risk: None — minimal, additive change
  - Mitigation: N/A
