### PR TITLE
[supersede #1656] fix: resolve all clippy warnings across codebase

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -881,15 +881,13 @@ pub(crate) async fn run_tool_call_loop(
             ordered_results[*idx] = Some((call.name.clone(), call.tool_call_id.clone(), outcome));
         }
 
-        for entry in ordered_results {
-            if let Some((tool_name, tool_call_id, outcome)) = entry {
-                individual_results.push((tool_call_id, outcome.output.clone()));
-                let _ = writeln!(
-                    tool_results,
-                    "<tool_result name=\"{}\">\n{}\n</tool_result>",
-                    tool_name, outcome.output
-                );
-            }
+        for (tool_name, tool_call_id, outcome) in ordered_results.into_iter().flatten() {
+            individual_results.push((tool_call_id, outcome.output.clone()));
+            let _ = writeln!(
+                tool_results,
+                "<tool_result name=\"{}\">\n{}\n</tool_result>",
+                tool_name, outcome.output
+            );
         }
 
         // Add assistant message with tool calls + tool results to history.

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -362,6 +362,7 @@ fn split_message_for_discord(message: &str) -> Vec<String> {
     chunks
 }
 
+#[allow(clippy::cast_possible_truncation)]
 fn pick_uniform_index(len: usize) -> usize {
     debug_assert!(len > 0);
     let upper = len as u64;
@@ -389,9 +390,10 @@ fn encode_emoji_for_discord(emoji: &str) -> String {
         return emoji.to_string();
     }
 
+    use std::fmt::Write as _;
     let mut encoded = String::new();
     for byte in emoji.as_bytes() {
-        encoded.push_str(&format!("%{byte:02X}"));
+        write!(encoded, "%{byte:02X}").ok();
     }
     encoded
 }
@@ -1366,6 +1368,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::format_collect)]
     fn split_message_many_short_lines() {
         // Many short lines should be batched into chunks under the limit
         let msg: String = (0..500).map(|i| format!("line {i}\n")).collect();

--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -1503,6 +1503,7 @@ impl LarkChannel {
 // WS helper functions
 // ─────────────────────────────────────────────────────────────────────────────
 
+#[allow(clippy::cast_possible_truncation)]
 fn pick_uniform_index(len: usize) -> usize {
     debug_assert!(len > 0);
     let upper = len as u64;

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -42,7 +42,7 @@ pub mod whatsapp_storage;
 #[cfg(feature = "whatsapp-web")]
 pub mod whatsapp_web;
 
-pub use clawdtalk::{ClawdTalkChannel, ClawdTalkConfig};
+pub use clawdtalk::ClawdTalkChannel;
 pub use cli::CliChannel;
 pub use dingtalk::DingTalkChannel;
 pub use discord::DiscordChannel;
@@ -1308,9 +1308,7 @@ fn sanitize_tool_json_value(
         return None;
     }
 
-    let Some(object) = value.as_object() else {
-        return None;
-    };
+    let object = value.as_object()?;
 
     if let Some(tool_calls) = object.get("tool_calls").and_then(|value| value.as_array()) {
         if !tool_calls.is_empty()
@@ -1350,7 +1348,7 @@ fn strip_isolated_tool_json_artifacts(message: &str, known_tool_names: &HashSet<
     let mut saw_tool_call_payload = false;
 
     while cursor < message.len() {
-        let Some(rel_start) = message[cursor..].find(|ch: char| ch == '{' || ch == '[') else {
+        let Some(rel_start) = message[cursor..].find(['{', '[']) else {
             cleaned.push_str(&message[cursor..]);
             break;
         };
@@ -2693,9 +2691,10 @@ struct ConfiguredChannel {
     channel: Arc<dyn Channel>,
 }
 
+#[allow(unused_variables)]
 fn collect_configured_channels(
     config: &Config,
-    _matrix_skip_context: &str,
+    matrix_skip_context: &str,
 ) -> Vec<ConfiguredChannel> {
     let mut channels = Vec::new();
 
@@ -2783,7 +2782,7 @@ fn collect_configured_channels(
     if config.channels_config.matrix.is_some() {
         tracing::warn!(
             "Matrix channel is configured but this build was compiled without `channel-matrix`; skipping Matrix {}.",
-            _matrix_skip_context
+            matrix_skip_context
         );
     }
 

--- a/src/channels/nextcloud_talk.rs
+++ b/src/channels/nextcloud_talk.rs
@@ -429,7 +429,7 @@ mod tests {
             "message": {
                 "actorType": "users",
                 "actorId": "user_a",
-                "timestamp": 1735701200123u64,
+                "timestamp": 1_735_701_200_123_u64,
                 "message": "hello"
             }
         });

--- a/src/channels/wati.rs
+++ b/src/channels/wati.rs
@@ -335,7 +335,7 @@ mod tests {
             "text": "Hello from WATI!",
             "waId": "1234567890",
             "fromMe": false,
-            "timestamp": 1705320000u64
+            "timestamp": 1_705_320_000_u64
         });
 
         let msgs = ch.parse_webhook_payload(&payload);
@@ -344,7 +344,7 @@ mod tests {
         assert_eq!(msgs[0].content, "Hello from WATI!");
         assert_eq!(msgs[0].channel, "wati");
         assert_eq!(msgs[0].reply_target, "+1234567890");
-        assert_eq!(msgs[0].timestamp, 1705320000);
+        assert_eq!(msgs[0].timestamp, 1_705_320_000);
     }
 
     #[test]
@@ -381,7 +381,7 @@ mod tests {
             "message": { "body": "Alt field test" },
             "wa_id": "1234567890",
             "from_me": false,
-            "timestamp": 1705320000u64
+            "timestamp": 1_705_320_000_u64
         });
 
         let msgs = ch.parse_webhook_payload(&payload);
@@ -396,11 +396,11 @@ mod tests {
         let payload = serde_json::json!({
             "text": "Test",
             "waId": "1234567890",
-            "timestamp": 1705320000u64
+            "timestamp": 1_705_320_000_u64
         });
 
         let msgs = ch.parse_webhook_payload(&payload);
-        assert_eq!(msgs[0].timestamp, 1705320000);
+        assert_eq!(msgs[0].timestamp, 1_705_320_000);
     }
 
     #[test]
@@ -409,11 +409,11 @@ mod tests {
         let payload = serde_json::json!({
             "text": "Test",
             "waId": "1234567890",
-            "timestamp": 1705320000000u64
+            "timestamp": 1_705_320_000_000_u64
         });
 
         let msgs = ch.parse_webhook_payload(&payload);
-        assert_eq!(msgs[0].timestamp, 1705320000);
+        assert_eq!(msgs[0].timestamp, 1_705_320_000);
     }
 
     #[test]
@@ -426,7 +426,7 @@ mod tests {
         });
 
         let msgs = ch.parse_webhook_payload(&payload);
-        assert_eq!(msgs[0].timestamp, 1736942400);
+        assert_eq!(msgs[0].timestamp, 1_736_942_400);
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,7 +20,7 @@ pub use schema::{
     WebFetchConfig, WebSearchConfig, WebhookConfig,
 };
 
-pub fn name_and_presence<T: traits::ChannelConfig>(channel: &Option<T>) -> (&'static str, bool) {
+pub fn name_and_presence<T: traits::ChannelConfig>(channel: Option<&T>) -> (&'static str, bool) {
     (T::name(), channel.is_some())
 }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -537,7 +537,7 @@ fn parse_skills_prompt_injection_mode(raw: &str) -> Option<SkillsPromptInjection
 }
 
 /// Skills loading configuration (`[skills]` section).
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct SkillsConfig {
     /// Enable loading and syncing the community open-skills repository.
     /// Default: `false` (opt-in).
@@ -551,16 +551,6 @@ pub struct SkillsConfig {
     /// `full` preserves legacy behavior. `compact` keeps context small and loads skills on demand.
     #[serde(default)]
     pub prompt_injection_mode: SkillsPromptInjectionMode,
-}
-
-impl Default for SkillsConfig {
-    fn default() -> Self {
-        Self {
-            open_skills_enabled: false,
-            open_skills_dir: None,
-            prompt_injection_mode: SkillsPromptInjectionMode::default(),
-        }
-    }
 }
 
 /// Multimodal (image) handling configuration (`[multimodal]` section).
@@ -2076,18 +2066,10 @@ impl Default for HooksConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct BuiltinHooksConfig {
     /// Enable the command-logger hook (logs tool calls for auditing).
     pub command_logger: bool,
-}
-
-impl Default for BuiltinHooksConfig {
-    fn default() -> Self {
-        Self {
-            command_logger: false,
-        }
-    }
 }
 
 // ── Autonomy / Security ──────────────────────────────────────────
@@ -2774,7 +2756,7 @@ pub struct CustomTunnelConfig {
 struct ConfigWrapper<T: ChannelConfig>(std::marker::PhantomData<T>);
 
 impl<T: ChannelConfig> ConfigWrapper<T> {
-    fn new(_: &Option<T>) -> Self {
+    fn new(_: Option<&T>) -> Self {
         Self(std::marker::PhantomData)
     }
 }
@@ -2850,81 +2832,81 @@ impl ChannelsConfig {
     pub fn channels_except_webhook(&self) -> Vec<(Box<dyn super::traits::ConfigHandle>, bool)> {
         vec![
             (
-                Box::new(ConfigWrapper::new(&self.telegram)),
+                Box::new(ConfigWrapper::new(self.telegram.as_ref())),
                 self.telegram.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.discord)),
+                Box::new(ConfigWrapper::new(self.discord.as_ref())),
                 self.discord.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.slack)),
+                Box::new(ConfigWrapper::new(self.slack.as_ref())),
                 self.slack.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.mattermost)),
+                Box::new(ConfigWrapper::new(self.mattermost.as_ref())),
                 self.mattermost.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.imessage)),
+                Box::new(ConfigWrapper::new(self.imessage.as_ref())),
                 self.imessage.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.matrix)),
+                Box::new(ConfigWrapper::new(self.matrix.as_ref())),
                 self.matrix.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.signal)),
+                Box::new(ConfigWrapper::new(self.signal.as_ref())),
                 self.signal.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.whatsapp)),
+                Box::new(ConfigWrapper::new(self.whatsapp.as_ref())),
                 self.whatsapp.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.linq)),
+                Box::new(ConfigWrapper::new(self.linq.as_ref())),
                 self.linq.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.wati)),
+                Box::new(ConfigWrapper::new(self.wati.as_ref())),
                 self.wati.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.nextcloud_talk)),
+                Box::new(ConfigWrapper::new(self.nextcloud_talk.as_ref())),
                 self.nextcloud_talk.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.email)),
+                Box::new(ConfigWrapper::new(self.email.as_ref())),
                 self.email.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.irc)),
+                Box::new(ConfigWrapper::new(self.irc.as_ref())),
                 self.irc.is_some()
             ),
             (
-                Box::new(ConfigWrapper::new(&self.lark)),
+                Box::new(ConfigWrapper::new(self.lark.as_ref())),
                 self.lark.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.feishu)),
+                Box::new(ConfigWrapper::new(self.feishu.as_ref())),
                 self.feishu.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.dingtalk)),
+                Box::new(ConfigWrapper::new(self.dingtalk.as_ref())),
                 self.dingtalk.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.qq)),
+                Box::new(ConfigWrapper::new(self.qq.as_ref())),
                 self.qq
                     .as_ref()
                     .is_some_and(|qq| qq.receive_mode == QQReceiveMode::Websocket)
             ),
             (
-                Box::new(ConfigWrapper::new(&self.nostr)),
+                Box::new(ConfigWrapper::new(self.nostr.as_ref())),
                 self.nostr.is_some(),
             ),
             (
-                Box::new(ConfigWrapper::new(&self.clawdtalk)),
+                Box::new(ConfigWrapper::new(self.clawdtalk.as_ref())),
                 self.clawdtalk.is_some(),
             ),
         ]
@@ -2933,7 +2915,7 @@ impl ChannelsConfig {
     pub fn channels(&self) -> Vec<(Box<dyn super::traits::ConfigHandle>, bool)> {
         let mut ret = self.channels_except_webhook();
         ret.push((
-            Box::new(ConfigWrapper::new(&self.webhook)),
+            Box::new(ConfigWrapper::new(self.webhook.as_ref())),
             self.webhook.is_some(),
         ));
         ret
@@ -5116,7 +5098,7 @@ async fn sync_directory(path: &Path) -> Result<()> {
         dir.sync_all()
             .await
             .with_context(|| format!("Failed to fsync directory metadata: {}", path.display()))?;
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(not(unix))]

--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -575,6 +575,7 @@ fn mask_vec_secrets(values: &mut [String]) {
     }
 }
 
+#[allow(clippy::ref_option)]
 fn restore_optional_secret(value: &mut Option<String>, current: &Option<String>) {
     if value.as_deref().is_some_and(is_masked_secret) {
         *value = current.clone();
@@ -699,7 +700,7 @@ fn restore_masked_sensitive_fields(
         &current.storage.provider.config.db_url,
     );
 
-    for (name, agent) in incoming.agents.iter_mut() {
+    for (name, agent) in &mut incoming.agents {
         if let Some(current_agent) = current.agents.get(name) {
             restore_optional_secret(&mut agent.api_key, &current_agent.api_key);
         }

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -71,8 +71,7 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
     while let Some(msg) = socket.recv().await {
         let msg = match msg {
             Ok(Message::Text(text)) => text,
-            Ok(Message::Close(_)) => break,
-            Err(_) => break,
+            Ok(Message::Close(_)) | Err(_) => break,
             _ => continue,
         };
 

--- a/src/hardware/mod.rs
+++ b/src/hardware/mod.rs
@@ -109,7 +109,7 @@ pub fn handle_command(cmd: crate::HardwareCommands, _config: &Config) -> Result<
         let _ = &cmd;
         println!("Hardware discovery requires the 'hardware' feature.");
         println!("Build with: cargo build --features hardware");
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(all(

--- a/src/main.rs
+++ b/src/main.rs
@@ -794,8 +794,7 @@ async fn main() -> Result<()> {
     }
 
     match cli.command {
-        Commands::Onboard { .. } => unreachable!(),
-        Commands::Completions { .. } => unreachable!(),
+        Commands::Onboard { .. } | Commands::Completions { .. } => unreachable!(),
 
         Commands::Agent {
             message,

--- a/src/memory/hygiene.rs
+++ b/src/memory/hygiene.rs
@@ -324,6 +324,7 @@ fn memory_date_from_filename(filename: &str) -> Option<NaiveDate> {
     NaiveDate::parse_from_str(date_part, "%Y-%m-%d").ok()
 }
 
+#[allow(clippy::incompatible_msrv)]
 fn date_prefix(filename: &str) -> Option<NaiveDate> {
     if filename.len() < 10 {
         return None;

--- a/src/observability/runtime_trace.rs
+++ b/src/observability/runtime_trace.rs
@@ -22,7 +22,6 @@ pub enum RuntimeTraceStorageMode {
 impl RuntimeTraceStorageMode {
     fn from_raw(raw: &str) -> Self {
         match raw.trim().to_ascii_lowercase().as_str() {
-            "none" => Self::None,
             "rolling" => Self::Rolling,
             "full" => Self::Full,
             _ => Self::None,

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -2028,7 +2028,7 @@ fn resolve_interactive_onboarding_mode(
             "  Existing config found at {}. Select setup mode",
             config_path.display()
         ))
-        .items(&options)
+        .items(options)
         .default(1)
         .interact()?;
 
@@ -5863,7 +5863,7 @@ mod tests {
         apply_provider_update(
             &mut config,
             "anthropic".to_string(),
-            "".to_string(),
+            String::new(),
             "claude-sonnet-4-5-20250929".to_string(),
             None,
         );

--- a/src/peripherals/mod.rs
+++ b/src/peripherals/mod.rs
@@ -24,8 +24,6 @@ pub mod uno_q_setup;
 #[cfg(all(feature = "peripheral-rpi", target_os = "linux"))]
 pub mod rpi;
 
-pub use traits::Peripheral;
-
 use crate::config::{Config, PeripheralBoardConfig, PeripheralsConfig};
 #[cfg(feature = "hardware")]
 use crate::tools::HardwareMemoryMapTool;
@@ -228,6 +226,7 @@ pub async fn create_peripheral_tools(config: &PeripheralsConfig) -> Result<Vec<B
 }
 
 #[cfg(not(feature = "hardware"))]
+#[allow(clippy::unused_async)]
 pub async fn create_peripheral_tools(_config: &PeripheralsConfig) -> Result<Vec<Box<dyn Tool>>> {
     Ok(Vec::new())
 }

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -710,12 +710,12 @@ impl BedrockProvider {
                         let after_semi = &rest[semi + 1..];
                         if let Some(b64) = after_semi.strip_prefix("base64,") {
                             let format = match mime {
-                                "image/jpeg" | "image/jpg" => "jpeg",
                                 "image/png" => "png",
                                 "image/gif" => "gif",
                                 "image/webp" => "webp",
                                 _ => "jpeg",
                             };
+
                             blocks.push(ContentBlock::Image(ImageWrapper {
                                 image: ImageBlock {
                                     format: format.to_string(),

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -1375,8 +1375,8 @@ mod tests {
     fn oauth_refresh_form_omits_client_credentials_when_missing() {
         let form = build_oauth_refresh_form("refresh-token", None, None);
         let map: std::collections::HashMap<_, _> = form.into_iter().collect();
-        assert!(map.get("client_id").is_none());
-        assert!(map.get("client_secret").is_none());
+        assert!(!map.contains_key("client_id"));
+        assert!(!map.contains_key("client_secret"));
     }
 
     #[test]
@@ -1802,7 +1802,7 @@ mod tests {
         let creds: GeminiCliOAuthCreds = serde_json::from_str(json).unwrap();
         assert_eq!(creds.access_token.as_deref(), Some("ya29.test-token"));
         assert_eq!(creds.refresh_token.as_deref(), Some("1//test-refresh"));
-        assert_eq!(creds.expiry_date, Some(4102444800000));
+        assert_eq!(creds.expiry_date, Some(4_102_444_800_000));
         assert!(creds.expiry.is_none());
     }
 
@@ -1821,7 +1821,7 @@ mod tests {
         assert_eq!(creds.id_token.as_deref(), Some("header.payload.sig"));
         assert_eq!(creds.client_id.as_deref(), Some("test-client-id"));
         assert_eq!(creds.client_secret.as_deref(), Some("test-client-secret"));
-        assert_eq!(creds.expiry_date, Some(4102444800000));
+        assert_eq!(creds.expiry_date, Some(4_102_444_800_000));
     }
 
     #[test]

--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -281,7 +281,6 @@ fn clamp_reasoning_effort(model: &str, effort: &str) -> String {
         return match effort {
             "low" | "medium" | "high" => effort.to_string(),
             "minimal" => "low".to_string(),
-            "xhigh" => "high".to_string(),
             _ => "high".to_string(),
         };
     }

--- a/src/security/leak_detector.rs
+++ b/src/security/leak_detector.rs
@@ -311,7 +311,7 @@ mod tests {
                 assert!(patterns.iter().any(|p| p.contains("Stripe")));
                 assert!(redacted.contains("[REDACTED"));
             }
-            _ => panic!("Should detect Stripe key"),
+            LeakResult::Clean => panic!("Should detect Stripe key"),
         }
     }
 
@@ -324,7 +324,7 @@ mod tests {
             LeakResult::Detected { patterns, .. } => {
                 assert!(patterns.iter().any(|p| p.contains("AWS")));
             }
-            _ => panic!("Should detect AWS key"),
+            LeakResult::Clean => panic!("Should detect AWS key"),
         }
     }
 
@@ -342,7 +342,7 @@ MIIEowIBAAKCAQEA0ZPr5JeyVDonXsKhfq...
                 assert!(patterns.iter().any(|p| p.contains("private key")));
                 assert!(redacted.contains("[REDACTED_PRIVATE_KEY]"));
             }
-            _ => panic!("Should detect private key"),
+            LeakResult::Clean => panic!("Should detect private key"),
         }
     }
 
@@ -356,7 +356,7 @@ MIIEowIBAAKCAQEA0ZPr5JeyVDonXsKhfq...
                 assert!(patterns.iter().any(|p| p.contains("JWT")));
                 assert!(redacted.contains("[REDACTED_JWT]"));
             }
-            _ => panic!("Should detect JWT"),
+            LeakResult::Clean => panic!("Should detect JWT"),
         }
     }
 
@@ -369,7 +369,7 @@ MIIEowIBAAKCAQEA0ZPr5JeyVDonXsKhfq...
             LeakResult::Detected { patterns, .. } => {
                 assert!(patterns.iter().any(|p| p.contains("PostgreSQL")));
             }
-            _ => panic!("Should detect database URL"),
+            LeakResult::Clean => panic!("Should detect database URL"),
         }
     }
 

--- a/src/security/prompt_guard.rs
+++ b/src/security/prompt_guard.rs
@@ -114,7 +114,9 @@ impl PromptGuard {
         // Normalize score to 0.0-1.0 range (max possible is 6.0, one per category)
         let normalized_score = (total_score / 6.0).min(1.0);
 
-        if !detected_patterns.is_empty() {
+        if detected_patterns.is_empty() {
+            GuardResult::Safe
+        } else {
             match self.action {
                 GuardAction::Block if max_score > self.sensitivity => {
                     GuardResult::Blocked(format!(
@@ -125,8 +127,6 @@ impl PromptGuard {
                 }
                 _ => GuardResult::Suspicious(detected_patterns, normalized_score),
             }
-        } else {
-            GuardResult::Safe
         }
     }
 

--- a/src/skills/audit.rs
+++ b/src/skills/audit.rs
@@ -200,12 +200,12 @@ fn audit_manifest_file(root: &Path, path: &Path, report: &mut SkillAuditReport) 
                     .push(format!("{rel}: tools[{idx}] is missing a command field."));
             }
 
-            if kind.eq_ignore_ascii_case("script") || kind.eq_ignore_ascii_case("shell") {
-                if command.is_some_and(|value| value.trim().is_empty()) {
-                    report
-                        .findings
-                        .push(format!("{rel}: tools[{idx}] has an empty {kind} command."));
-                }
+            if (kind.eq_ignore_ascii_case("script") || kind.eq_ignore_ascii_case("shell"))
+                && command.is_some_and(|value| value.trim().is_empty())
+            {
+                report
+                    .findings
+                    .push(format!("{rel}: tools[{idx}] has an empty {kind} command."));
             }
         }
     }

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -238,7 +238,7 @@ fn open_skills_enabled_from_sources(
     env_override: Option<&str>,
 ) -> bool {
     if let Some(raw) = env_override {
-        if let Some(enabled) = parse_open_skills_enabled(&raw) {
+        if let Some(enabled) = parse_open_skills_enabled(raw) {
             return enabled;
         }
         if !raw.trim().is_empty() {

--- a/src/tools/screenshot.rs
+++ b/src/tools/screenshot.rs
@@ -150,6 +150,7 @@ impl ScreenshotTool {
     }
 
     /// Read the screenshot file and return base64-encoded result.
+    #[allow(clippy::incompatible_msrv)]
     async fn read_and_encode(output_path: &std::path::Path) -> anyhow::Result<ToolResult> {
         // Check file size before reading to prevent OOM on large screenshots
         const MAX_RAW_BYTES: u64 = 1_572_864; // ~1.5 MB (base64 expands ~33%)

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -120,6 +120,7 @@ impl Tool for ShellTool {
         })
     }
 
+    #[allow(clippy::incompatible_msrv)]
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
         let command = extract_command_argument(&args)
             .ok_or_else(|| anyhow::anyhow!("Missing 'command' parameter"))?;

--- a/tests/config_persistence.rs
+++ b/tests/config_persistence.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::field_reassign_with_default)]
 //! TG2: Config Load/Save Round-Trip Tests
 //!
 //! Prevents: Pattern 2 — Config persistence & workspace discovery bugs (13% of user bugs).

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::field_reassign_with_default)]
 //! Config Schema Boundary Tests
 //!
 //! Validates: config defaults, backward compatibility, invalid input rejection,

--- a/tests/gemini_fallback_oauth_refresh.rs
+++ b/tests/gemini_fallback_oauth_refresh.rs
@@ -4,7 +4,9 @@
 //! 1. Primary provider (OpenAI Codex) fails
 //! 2. Fallback to Gemini is triggered
 //! 3. Gemini OAuth tokens are expired (we manually expire them)
+//!
 //! Then:
+//!
 //! - Gemini provider's warmup() automatically refreshes the tokens
 //! - The fallback request succeeds
 //!

--- a/tests/openai_codex_vision_e2e.rs
+++ b/tests/openai_codex_vision_e2e.rs
@@ -12,7 +12,7 @@
 //! Run manually: `cargo test provider_vision -- --ignored --nocapture`
 
 use anyhow::Result;
-use zeroclaw::providers::{ChatMessage, ChatRequest, Provider, ProviderRuntimeOptions};
+use zeroclaw::providers::{ChatMessage, ChatRequest, ProviderRuntimeOptions};
 
 /// Tests that provider supports vision input.
 ///

--- a/tests/provider_schema.rs
+++ b/tests/provider_schema.rs
@@ -292,7 +292,7 @@ fn provider_construction_with_different_auth_styles() {
 
 #[test]
 fn chat_messages_maintain_role_sequence() {
-    let history = vec![
+    let history = [
         ChatMessage::system("You are helpful"),
         ChatMessage::user("What is Rust?"),
         ChatMessage::assistant("Rust is a systems programming language"),
@@ -309,7 +309,7 @@ fn chat_messages_maintain_role_sequence() {
 
 #[test]
 fn chat_messages_with_tool_calls_maintain_sequence() {
-    let history = vec![
+    let history = [
         ChatMessage::system("You are helpful"),
         ChatMessage::user("Search for Rust"),
         ChatMessage::assistant("I'll search for that"),


### PR DESCRIPTION
Supersedes #1656 to recover from merge conflicts against latest `dev`.

- Source PR: https://github.com/zeroclaw-labs/zeroclaw/pull/1656
- Recovery mode: automated replay on top of current `dev`
- Merge policy: all CI checks green (except non-blocking `Enforce Dev -> Main Promotion`)

Original PR description:

## Summary

- Fix all clippy errors reported by `cargo clippy --all-targets -- -D warnings` on Rust 1.93
- Pure lint/style fixes — no logic or behavior changes
- 31 files changed, 124 insertions, 140 deletions (net -16 lines)

## Changes by category

| Category | Files | Fix |
|----------|-------|-----|
| `format!` appended to String | telegram, discord | `write!`/`writeln!` |
| Redundant field names | agent/loop_ | `field: field` → `field` |
| Long numeric literals | wati, nextcloud_talk, telegram, gemini | Added `_` separators |
| Wildcard match on single variant | security/leak_detector | `_` → explicit `LeakResult::Clean` |
| Derivable Default impls | config/schema | `#[derive(Default)]` |
| `&Option<T>` → idiomatic | config/schema, config/mod, gateway/api | `Option<&T>` or `#[allow]` |
| Identical match arms | gateway/ws, observability, providers, main, onboard | Merged with `\|` |
| Unnecessary bool not | agent/loop_, security/prompt_guard | Restructured conditions |
| Cast truncation | discord, lark | `#[allow(clippy::cast_possible_truncation)]` with rationale |
| Unnecessary return/borrow | config/schema, hardware, telegram, skills, onboard | Removed |
| Unused imports | channels/mod, peripherals/mod | Removed |
| MSRV-gated APIs | memory/hygiene, tools/shell, tools/screenshot | `#[allow(clippy::incompatible_msrv)]` |
| `.get().is_none()` | gemini | `!contains_key()` |
| Explicit iteration | gateway/api | `&mut map` loop |
| Test-only | 5 test files | `vec!` → array, allow lints, doc indent |

## Validation

```
cargo fmt --all -- --check               ✅
cargo clippy --all-targets -- -D warnings ✅ (0 errors, 0 warnings)
cargo test                                ✅ (all passed)
```

## Risk and Rollback

- **Risk**: Low — lint-only changes, no logic modifications
- **Rollback**: `git revert <commit>`

## Non-goals

- Does not bump MSRV (uses local `#[allow]` for `floor_char_boundary` call sites)
- Does not address `cargo clippy --all-features` (only default feature set)


Made with [Cursor](https://cursor.com)
