### PR TITLE
fix(ci): repair CodeRabbit config and align auto-review base branch

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -21,15 +21,14 @@ reviews:
     # Only review PRs targeting these branches
     base_branches:
       - main
-      - develop
+      - dev
     # Skip reviews for draft PRs or WIP
     drafts: false
     # Enable base branch analysis
     base_branch_analysis: true
   
-  # Poem configuration
-  poem:
-    enabled: false
+  # Poem feature toggle (must be a boolean, not an object)
+  poem: false
   
   # Reviewer suggestions
   reviewer:


### PR DESCRIPTION
## Summary
- Fix CodeRabbit config schema violation by changing `reviews.poem` from an object to a boolean.
- Align CodeRabbit auto-review base branch list with repository policy (`dev` instead of non-existent `develop`).
- Keep scope minimal to unblock PR review automation and prevent fallback-to-default behavior.

## Root-Cause Analysis
- The reported CodeRabbit error (`Expected boolean, received object at reviews.poem`) is caused by `.coderabbit.yaml` using:
  - `reviews.poem.enabled: false`
- CodeRabbit expects:
  - `reviews.poem: false`
- Repository branch policy is `dev`/`main`; `develop` does not exist in `zeroclaw-labs/zeroclaw`, so previous config was misaligned.

## Validation
- Parsed YAML locally after change:
  - `reviews.poem == false`
  - `reviews.auto_review.base_branches == ["main", "dev"]`

## Links
Closes #1752
Resolves RMN-113
