### PR TITLE
hardening(deps): govern matrix indexeddb derivative advisory

### DIFF
--- a/.github/security/deny-ignore-governance.json
+++ b/.github/security/deny-ignore-governance.json
@@ -14,6 +14,13 @@
       "reason": "Upstream rust-nostr advisory mitigation is still in progress; monitor until released fix lands.",
       "ticket": "RMN-21",
       "expires_on": "2026-12-31"
+    },
+    {
+      "id": "RUSTSEC-2024-0388",
+      "owner": "repo-maintainers",
+      "reason": "Transitive via matrix-sdk indexeddb dependency chain in current matrix release line; track removal when upstream drops derivative.",
+      "ticket": "RMN-21",
+      "expires_on": "2026-12-31"
     }
   ]
 }

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,9 @@ ignore = [
     # bincode v2.0.1 via probe-rs — upstream project ceased; accepted transitive risk for current hardware stack.
     { id = "RUSTSEC-2025-0141", reason = "Transitive via probe-rs in current release path; tracked for replacement when probe-rs updates." },
     { id = "RUSTSEC-2024-0384", reason = "Reported to `rust-nostr/nostr` and it's WIP" },
+    # derivative v2.2.0 via wasm_evt_listener -> matrix_indexed_db_futures -> matrix-sdk-indexeddb.
+    # This chain is transitive under matrix-sdk's IndexedDB integration path; matrix-sdk remains pinned to 0.16 in current release line.
+    { id = "RUSTSEC-2024-0388", reason = "Transitive via matrix-sdk indexeddb dependency chain; tracked until matrix-sdk ecosystem removes derivative." },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary
- performed a fresh dependency security sweep in clean worktree context (`cargo audit`, dependency path tracing, feature-path inspection)
- confirmed `RUSTSEC-2024-0388` (`derivative`) is still present transitively via `matrix-sdk-indexeddb` chain in current `matrix-sdk 0.16` ecosystem
- added explicit governance coverage for `RUSTSEC-2024-0388` in both deny policy and governance metadata to keep supply-chain exceptions auditable

## Why this change
Current upstream versions used by this release line do not provide patched alternatives for these three `unmaintained` advisories yet:
- `RUSTSEC-2025-0141` (`bincode`) via `probe-rs`
- `RUSTSEC-2024-0384` (`instant`) via `nostr-sdk`
- `RUSTSEC-2024-0388` (`derivative`) via matrix indexeddb transitive path

This PR closes the policy gap where one active advisory was not yet represented in deny governance metadata.

## Files changed
- `deny.toml`: add `RUSTSEC-2024-0388` ignore with transitive-risk rationale
- `.github/security/deny-ignore-governance.json`: add owner/reason/ticket/expiry entry for `RUSTSEC-2024-0388`

## Validation
- `python3 scripts/ci/deny_policy_guard.py --deny-file deny.toml --governance-file .github/security/deny-ignore-governance.json --output-json /tmp/deny-guard.json --output-md /tmp/deny-guard.md --fail-on-violation`
- `cargo audit -q`
- `./scripts/ci/security_regression_tests.sh`
- `python3 -m unittest scripts.ci.tests.test_ci_scripts.CiScriptsBehaviorTest.test_deny_policy_guard_passes_with_valid_governance scripts.ci.tests.test_ci_scripts.CiScriptsBehaviorTest.test_deny_policy_guard_detects_unmanaged_or_expired_governance -v`
