### PR TITLE
hardening(logging): sanitize channel API error bodies

### DIFF
--- a/src/channels/linq.rs
+++ b/src/channels/linq.rs
@@ -280,7 +280,8 @@ impl Channel for LinqChannel {
             if !create_resp.status().is_success() {
                 let status = create_resp.status();
                 let error_body = create_resp.text().await.unwrap_or_default();
-                tracing::error!("Linq create chat failed: {status} — {error_body}");
+                let sanitized = crate::providers::sanitize_api_error(&error_body);
+                tracing::error!("Linq create chat failed: {status} — {sanitized}");
                 anyhow::bail!("Linq API error: {status}");
             }
 
@@ -289,7 +290,8 @@ impl Channel for LinqChannel {
 
         let status = resp.status();
         let error_body = resp.text().await.unwrap_or_default();
-        tracing::error!("Linq send failed: {status} — {error_body}");
+        let sanitized = crate::providers::sanitize_api_error(&error_body);
+        tracing::error!("Linq send failed: {status} — {sanitized}");
         anyhow::bail!("Linq API error: {status}");
     }
 

--- a/src/channels/wati.rs
+++ b/src/channels/wati.rs
@@ -197,7 +197,8 @@ impl Channel for WatiChannel {
         if !resp.status().is_success() {
             let status = resp.status();
             let error_body = resp.text().await.unwrap_or_default();
-            tracing::error!("WATI send failed: {status} — {error_body}");
+            let sanitized = crate::providers::sanitize_api_error(&error_body);
+            tracing::error!("WATI send failed: {status} — {sanitized}");
             anyhow::bail!("WATI API error: {status}");
         }
 

--- a/src/channels/whatsapp.rs
+++ b/src/channels/whatsapp.rs
@@ -195,7 +195,8 @@ impl Channel for WhatsAppChannel {
         if !resp.status().is_success() {
             let status = resp.status();
             let error_body = resp.text().await.unwrap_or_default();
-            tracing::error!("WhatsApp send failed: {status} — {error_body}");
+            let sanitized = crate::providers::sanitize_api_error(&error_body);
+            tracing::error!("WhatsApp send failed: {status} — {sanitized}");
             anyhow::bail!("WhatsApp API error: {status}");
         }
 


### PR DESCRIPTION
## Summary
- harden channel failure logging by sanitizing upstream API error bodies before they are written to logs
- apply this to high-surface webhook channels where provider responses may include sensitive material:
  - `WATI`
  - `Linq`
  - `WhatsApp`
- strengthen shared provider sanitizer coverage for additional secret-bearing formats (`access_token`, `api_key`, `client_secret`, bearer token sequences), with minimum-length guards to avoid over-redacting benign phrases

## Why
Several channel send paths were logging raw upstream response bodies on failure. Those payloads may include credential-like fields or secret-bearing tokens depending on provider behavior and proxy layers.

This PR ensures error bodies are filtered through `sanitize_api_error` before logging, reducing accidental secret exposure risk while preserving actionable diagnostics.

## Changes
- `src/channels/wati.rs`
  - sanitize `error_body` before `tracing::error!`
- `src/channels/linq.rs`
  - sanitize `error_body` for both create-chat and send failure logs
- `src/channels/whatsapp.rs`
  - sanitize `error_body` before `tracing::error!`
- `src/providers/mod.rs`
  - expand `scrub_secret_patterns` for common structured and bearer formats
  - add targeted unit tests for new sanitizer behavior

## Validation
- `cargo fmt --all`
- `cargo test --locked --lib providers::tests::sanitize_`
- `cargo test --locked --lib providers::tests::scrub_`
- `cargo test --locked --lib sanitize_redacts_json_access_token_field`
- `cargo test --locked --lib sanitize_redacts_query_client_secret_field`
- `cargo test --locked --lib sanitize_redacts_bearer_token_sequence`
- `cargo test --locked --lib sanitize_preserves_short_bearer_phrase_without_secret`
- `./scripts/ci/security_regression_tests.sh`
