### PR TITLE
hardening(security): sanitize upstream error surfaces across channels

### DIFF
--- a/src/channels/dingtalk.rs
+++ b/src/channels/dingtalk.rs
@@ -97,7 +97,8 @@ impl DingTalkChannel {
         if !resp.status().is_success() {
             let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("DingTalk gateway registration failed ({status}): {err}");
+            let sanitized = crate::providers::sanitize_api_error(&err);
+            anyhow::bail!("DingTalk gateway registration failed ({status}): {sanitized}");
         }
 
         let gw: GatewayResponse = resp.json().await?;
@@ -140,7 +141,8 @@ impl Channel for DingTalkChannel {
         if !resp.status().is_success() {
             let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("DingTalk webhook reply failed ({status}): {err}");
+            let sanitized = crate::providers::sanitize_api_error(&err);
+            anyhow::bail!("DingTalk webhook reply failed ({status}): {sanitized}");
         }
 
         Ok(())
@@ -163,7 +165,8 @@ impl Channel for DingTalkChannel {
                 Ok(Message::Text(t)) => t,
                 Ok(Message::Close(_)) => break,
                 Err(e) => {
-                    tracing::warn!("DingTalk WebSocket error: {e}");
+                    let sanitized = crate::providers::sanitize_api_error(&e.to_string());
+                    tracing::warn!("DingTalk WebSocket error: {sanitized}");
                     break;
                 }
                 _ => continue,

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -291,7 +291,8 @@ async fn send_discord_message_json(
             .text()
             .await
             .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
-        anyhow::bail!("Discord send message failed ({status}): {err}");
+        let sanitized = crate::providers::sanitize_api_error(&err);
+        anyhow::bail!("Discord send message failed ({status}): {sanitized}");
     }
 
     Ok(())
@@ -339,7 +340,8 @@ async fn send_discord_message_with_files(
             .text()
             .await
             .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
-        anyhow::bail!("Discord send message with files failed ({status}): {err}");
+        let sanitized = crate::providers::sanitize_api_error(&err);
+        anyhow::bail!("Discord send message with files failed ({status}): {sanitized}");
     }
 
     Ok(())
@@ -909,7 +911,8 @@ impl Channel for DiscordChannel {
                 .text()
                 .await
                 .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
-            anyhow::bail!("Discord add reaction failed ({status}): {err}");
+            let sanitized = crate::providers::sanitize_api_error(&err);
+            anyhow::bail!("Discord add reaction failed ({status}): {sanitized}");
         }
 
         Ok(())
@@ -936,7 +939,8 @@ impl Channel for DiscordChannel {
                 .text()
                 .await
                 .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
-            anyhow::bail!("Discord remove reaction failed ({status}): {err}");
+            let sanitized = crate::providers::sanitize_api_error(&err);
+            anyhow::bail!("Discord remove reaction failed ({status}): {sanitized}");
         }
 
         Ok(())

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -405,7 +405,8 @@ impl MatrixChannel {
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Matrix whoami failed: {err}");
+            let sanitized = crate::providers::sanitize_api_error(&err);
+            anyhow::bail!("Matrix whoami failed: {sanitized}");
         }
 
         Ok(resp.json().await?)
@@ -536,7 +537,10 @@ impl MatrixChannel {
 
             if !resp.status().is_success() {
                 let err = resp.text().await.unwrap_or_default();
-                anyhow::bail!("Matrix room alias resolution failed for '{configured}': {err}");
+                let sanitized = crate::providers::sanitize_api_error(&err);
+                anyhow::bail!(
+                    "Matrix room alias resolution failed for '{configured}': {sanitized}"
+                );
             }
 
             let resolved: RoomAliasResponse = resp.json().await?;
@@ -564,7 +568,8 @@ impl MatrixChannel {
 
         if !resp.status().is_success() {
             let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Matrix room access check failed for '{room_id}': {err}");
+            let sanitized = crate::providers::sanitize_api_error(&err);
+            anyhow::bail!("Matrix room access check failed for '{room_id}': {sanitized}");
         }
 
         Ok(())
@@ -593,7 +598,8 @@ impl MatrixChannel {
         }
 
         let err = resp.text().await.unwrap_or_default();
-        anyhow::bail!("Matrix room encryption check failed for '{room_id}': {err}");
+        let sanitized = crate::providers::sanitize_api_error(&err);
+        anyhow::bail!("Matrix room encryption check failed for '{room_id}': {sanitized}");
     }
 
     async fn ensure_room_supported(&self, room_id: &str) -> anyhow::Result<()> {

--- a/src/channels/mattermost.rs
+++ b/src/channels/mattermost.rs
@@ -124,7 +124,8 @@ impl Channel for MattermostChannel {
                 .text()
                 .await
                 .unwrap_or_else(|e| format!("<failed to read response: {e}>"));
-            bail!("Mattermost post failed ({status}): {body}");
+            let sanitized = crate::providers::sanitize_api_error(&body);
+            bail!("Mattermost post failed ({status}): {sanitized}");
         }
 
         Ok(())

--- a/src/channels/nextcloud_talk.rs
+++ b/src/channels/nextcloud_talk.rs
@@ -196,7 +196,8 @@ impl NextcloudTalkChannel {
 
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
-        tracing::error!("Nextcloud Talk send failed: {status} — {body}");
+        let sanitized = crate::providers::sanitize_api_error(&body);
+        tracing::error!("Nextcloud Talk send failed: {status} — {sanitized}");
         anyhow::bail!("Nextcloud Talk API error: {status}");
     }
 }

--- a/src/channels/qq.rs
+++ b/src/channels/qq.rs
@@ -403,7 +403,8 @@ impl QQChannel {
         if !resp.status().is_success() {
             let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("QQ {op} failed ({status}): {err}");
+            let sanitized = crate::providers::sanitize_api_error(&err);
+            anyhow::bail!("QQ {op} failed ({status}): {sanitized}");
         }
 
         Ok(())
@@ -435,7 +436,8 @@ impl QQChannel {
         if !resp.status().is_success() {
             let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("QQ upload media failed ({status}): {err}");
+            let sanitized = crate::providers::sanitize_api_error(&err);
+            anyhow::bail!("QQ upload media failed ({status}): {sanitized}");
         }
 
         let payload: Value = resp.json().await?;
@@ -466,7 +468,8 @@ impl QQChannel {
         if !resp.status().is_success() {
             let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("QQ token request failed ({status}): {err}");
+            let sanitized = crate::providers::sanitize_api_error(&err);
+            anyhow::bail!("QQ token request failed ({status}): {sanitized}");
         }
 
         let data: serde_json::Value = resp.json().await?;
@@ -529,7 +532,8 @@ impl QQChannel {
         if !resp.status().is_success() {
             let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("QQ gateway request failed ({status}): {err}");
+            let sanitized = crate::providers::sanitize_api_error(&err);
+            anyhow::bail!("QQ gateway request failed ({status}): {sanitized}");
         }
 
         let data: serde_json::Value = resp.json().await?;

--- a/src/channels/signal.rs
+++ b/src/channels/signal.rs
@@ -316,7 +316,8 @@ impl Channel for SignalChannel {
                 Ok(r) => {
                     let status = r.status();
                     let body = r.text().await.unwrap_or_default();
-                    tracing::warn!("Signal SSE returned {status}: {body}");
+                    let sanitized = crate::providers::sanitize_api_error(&body);
+                    tracing::warn!("Signal SSE returned {status}: {sanitized}");
                     tokio::time::sleep(tokio::time::Duration::from_secs(retry_delay_secs)).await;
                     retry_delay_secs = (retry_delay_secs * 2).min(max_delay_secs);
                     continue;

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -127,7 +127,8 @@ impl SlackChannel {
                 .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
 
             if !status.is_success() {
-                anyhow::bail!("Slack conversations.list failed ({status}): {body}");
+                let sanitized = crate::providers::sanitize_api_error(&body);
+                anyhow::bail!("Slack conversations.list failed ({status}): {sanitized}");
             }
 
             let data: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
@@ -209,7 +210,8 @@ impl Channel for SlackChannel {
             .unwrap_or_else(|e| format!("<failed to read response body: {e}>"));
 
         if !status.is_success() {
-            anyhow::bail!("Slack chat.postMessage failed ({status}): {body}");
+            let sanitized = crate::providers::sanitize_api_error(&body);
+            anyhow::bail!("Slack chat.postMessage failed ({status}): {sanitized}");
         }
 
         // Slack returns 200 for most app-level errors; check JSON "ok" field

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -438,8 +438,9 @@ impl TelegramChannel {
             let response = match client.post(&url).json(&body).send().await {
                 Ok(resp) => resp,
                 Err(err) => {
+                    let sanitized = TelegramChannel::sanitize_telegram_error(&err.to_string());
                     tracing::warn!(
-                        "Telegram: failed to add ACK reaction to chat_id={chat_id}, message_id={message_id}: {err}"
+                        "Telegram: failed to add ACK reaction to chat_id={chat_id}, message_id={message_id}: {sanitized}"
                     );
                     return;
                 }
@@ -448,8 +449,9 @@ impl TelegramChannel {
             if !response.status().is_success() {
                 let status = response.status();
                 let err_body = response.text().await.unwrap_or_default();
+                let sanitized = TelegramChannel::sanitize_telegram_error(&err_body);
                 tracing::warn!(
-                    "Telegram: add ACK reaction failed for chat_id={chat_id}, message_id={message_id}: status={status}, body={err_body}"
+                    "Telegram: add ACK reaction failed for chat_id={chat_id}, message_id={message_id}: status={status}, body={sanitized}"
                 );
             }
         });
@@ -457,6 +459,10 @@ impl TelegramChannel {
 
     fn http_client(&self) -> reqwest::Client {
         crate::config::build_runtime_proxy_client("channel.telegram")
+    }
+
+    fn sanitize_telegram_error(input: &str) -> String {
+        crate::providers::sanitize_api_error(input)
     }
 
     fn normalize_identity(value: &str) -> String {
@@ -1754,12 +1760,14 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             if !plain_resp.status().is_success() {
                 let plain_status = plain_resp.status();
                 let plain_err = plain_resp.text().await.unwrap_or_default();
+                let sanitized_markdown_err = Self::sanitize_telegram_error(&markdown_err);
+                let sanitized_plain_err = Self::sanitize_telegram_error(&plain_err);
                 anyhow::bail!(
                     "Telegram sendMessage failed (markdown {}: {}; plain {}: {})",
                     markdown_status,
-                    markdown_err,
+                    sanitized_markdown_err,
                     plain_status,
-                    plain_err
+                    sanitized_plain_err
                 );
             }
 
@@ -1802,7 +1810,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram {method} by URL failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram {method} by URL failed: {sanitized}");
         }
 
         tracing::info!("Telegram {method} sent to {chat_id}: {url}");
@@ -1933,7 +1942,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendDocument failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendDocument failed: {sanitized}");
         }
 
         tracing::info!("Telegram document sent to {chat_id}: {file_name}");
@@ -1972,7 +1982,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendDocument failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendDocument failed: {sanitized}");
         }
 
         tracing::info!("Telegram document sent to {chat_id}: {file_name}");
@@ -2016,7 +2027,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendPhoto failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendPhoto failed: {sanitized}");
         }
 
         tracing::info!("Telegram photo sent to {chat_id}: {file_name}");
@@ -2055,7 +2067,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendPhoto failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendPhoto failed: {sanitized}");
         }
 
         tracing::info!("Telegram photo sent to {chat_id}: {file_name}");
@@ -2099,7 +2112,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendVideo failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendVideo failed: {sanitized}");
         }
 
         tracing::info!("Telegram video sent to {chat_id}: {file_name}");
@@ -2143,7 +2157,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendAudio failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendAudio failed: {sanitized}");
         }
 
         tracing::info!("Telegram audio sent to {chat_id}: {file_name}");
@@ -2187,7 +2202,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendVoice failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendVoice failed: {sanitized}");
         }
 
         tracing::info!("Telegram voice sent to {chat_id}: {file_name}");
@@ -2224,7 +2240,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendDocument by URL failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendDocument by URL failed: {sanitized}");
         }
 
         tracing::info!("Telegram document (URL) sent to {chat_id}: {url}");
@@ -2261,7 +2278,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendPhoto by URL failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendPhoto by URL failed: {sanitized}");
         }
 
         tracing::info!("Telegram photo (URL) sent to {chat_id}: {url}");
@@ -2344,7 +2362,8 @@ impl Channel for TelegramChannel {
 
         if !resp.status().is_success() {
             let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Telegram sendMessage (draft) failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendMessage (draft) failed: {sanitized}");
         }
 
         let resp_json: serde_json::Value = resp.json().await?;
@@ -2423,7 +2442,8 @@ impl Channel for TelegramChannel {
         } else {
             let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
-            tracing::debug!("Telegram editMessageText failed ({status}): {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            tracing::debug!("Telegram editMessageText failed ({status}): {sanitized}");
         }
 
         Ok(())
@@ -2578,7 +2598,8 @@ impl Channel for TelegramChannel {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            tracing::debug!("Telegram deleteMessage failed ({status}): {body}");
+            let sanitized = Self::sanitize_telegram_error(&body);
+            tracing::debug!("Telegram deleteMessage failed ({status}): {sanitized}");
         }
 
         Ok(())
@@ -2641,14 +2662,16 @@ impl Channel for TelegramChannel {
             });
             match self.http_client().post(&url).json(&probe).send().await {
                 Err(e) => {
-                    tracing::warn!("Telegram startup probe error: {e}; retrying in 5s");
+                    let sanitized = Self::sanitize_telegram_error(&e.to_string());
+                    tracing::warn!("Telegram startup probe error: {sanitized}; retrying in 5s");
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 }
                 Ok(resp) => {
                     match resp.json::<serde_json::Value>().await {
                         Err(e) => {
+                            let sanitized = Self::sanitize_telegram_error(&e.to_string());
                             tracing::warn!(
-                                "Telegram startup probe parse error: {e}; retrying in 5s"
+                                "Telegram startup probe parse error: {sanitized}; retrying in 5s"
                             );
                             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                         }
@@ -2716,7 +2739,8 @@ impl Channel for TelegramChannel {
             let resp = match self.http_client().post(&url).json(&body).send().await {
                 Ok(r) => r,
                 Err(e) => {
-                    tracing::warn!("Telegram poll error: {e}");
+                    let sanitized = Self::sanitize_telegram_error(&e.to_string());
+                    tracing::warn!("Telegram poll error: {sanitized}");
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     continue;
                 }
@@ -2725,7 +2749,8 @@ impl Channel for TelegramChannel {
             let data: serde_json::Value = match resp.json().await {
                 Ok(d) => d,
                 Err(e) => {
-                    tracing::warn!("Telegram parse error: {e}");
+                    let sanitized = Self::sanitize_telegram_error(&e.to_string());
+                    tracing::warn!("Telegram parse error: {sanitized}");
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     continue;
                 }
@@ -2822,7 +2847,8 @@ Ensure only one `zeroclaw` process is using this bot token."
         {
             Ok(Ok(resp)) => resp.status().is_success(),
             Ok(Err(e)) => {
-                tracing::debug!("Telegram health check failed: {e}");
+                let sanitized = Self::sanitize_telegram_error(&e.to_string());
+                tracing::debug!("Telegram health check failed: {sanitized}");
                 false
             }
             Err(_) => {

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -1458,9 +1458,10 @@ impl Provider for BedrockProvider {
                     .text()
                     .await
                     .unwrap_or_else(|_| "unknown error".to_string());
+                let sanitized = super::sanitize_api_error(&body);
                 let _ = tx
                     .send(Err(StreamError::Provider(format!(
-                        "Bedrock stream request failed ({status}): {body}"
+                        "Bedrock stream request failed ({status}): {sanitized}"
                     ))))
                     .await;
                 return;

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -327,7 +327,8 @@ fn refresh_gemini_cli_token(
         .unwrap_or_else(|_| "<failed to read response body>".to_string());
 
     if !status.is_success() {
-        anyhow::bail!("Gemini CLI OAuth refresh failed (HTTP {status}): {body}");
+        let sanitized = super::sanitize_api_error(&body);
+        anyhow::bail!("Gemini CLI OAuth refresh failed (HTTP {status}): {sanitized}");
     }
 
     #[derive(Deserialize)]
@@ -841,7 +842,8 @@ impl GeminiProvider {
                 );
                 return Ok(seed);
             }
-            anyhow::bail!("loadCodeAssist failed (HTTP {status}): {body}");
+            let sanitized = super::sanitize_api_error(&body);
+            anyhow::bail!("loadCodeAssist failed (HTTP {status}): {sanitized}");
         }
 
         #[derive(Deserialize)]


### PR DESCRIPTION
## Summary
- sanitize raw upstream response bodies before logging or bubbling errors across channel adapters (Telegram, Lark, Signal, Nextcloud Talk, Matrix, QQ, DingTalk, Discord, Mattermost, Slack)
- harden provider-side error paths in Gemini OAuth/loadCodeAssist and Bedrock streaming failures
- extend secret scrubbing rules to cover generic  fields ( and ) with new tests

## Why
- several channel/provider paths still emitted unsanitized upstream bodies in logs/errors
- upstream payloads can contain credentials or bearer material; this change ensures consistent redaction at the edge

## Validation
- 
- 
running 1 test
test providers::tests::sanitize_redacts_json_token_field ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s
- 
running 1 test
test providers::tests::sanitize_redacts_query_token_field ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s
- 
running 17 tests
test providers::tests::sanitize_handles_json_wrapped_key ... ok
test providers::tests::sanitize_preserves_short_bearer_phrase_without_secret ... ok
test providers::tests::sanitize_keeps_bare_prefix ... ok
test providers::tests::sanitize_handles_delimiter_boundaries ... ok
test providers::tests::sanitize_no_secret_no_change ... ok
test providers::tests::sanitize_redacts_bearer_token_sequence ... ok
test providers::tests::sanitize_redacts_json_access_token_field ... ok
test providers::tests::sanitize_redacts_json_token_field ... ok
test providers::tests::sanitize_preserves_unicode_boundaries ... ok
test providers::tests::sanitize_redacts_query_client_secret_field ... ok
test providers::tests::sanitize_redacts_query_token_field ... ok
test providers::tests::sanitize_scrubs_multiple_prefixes ... ok
test providers::tests::sanitize_scrubs_sk_prefix ... ok
test providers::tests::sanitize_short_prefix_then_real_key ... ok
test providers::tests::sanitize_sk_proj_comment_then_real_key ... ok
test providers::tests::sanitize_truncates_after_scrub ... ok
test providers::tests::sanitize_truncates_long_error ... ok

test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 3223 filtered out; finished in 0.00s
- ==> /Users/chum/.cargo/bin/cargo test --locked --lib run_tool_call_loop_denies_supervised_tools_on_non_cli_channels

running 1 test
test agent::loop_::tests::run_tool_call_loop_denies_supervised_tools_on_non_cli_channels ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.03s

==> /Users/chum/.cargo/bin/cargo test --locked --lib run_tool_call_loop_blocks_tools_excluded_for_channel

running 1 test
test agent::loop_::tests::run_tool_call_loop_blocks_tools_excluded_for_channel ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.03s

==> /Users/chum/.cargo/bin/cargo test --locked --lib webhook_rejects_public_traffic_without_auth_layers

running 1 test
test gateway::tests::webhook_rejects_public_traffic_without_auth_layers ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s

==> /Users/chum/.cargo/bin/cargo test --locked --lib metrics_endpoint_rejects_public_clients_when_pairing_is_disabled

running 1 test
test gateway::tests::metrics_endpoint_rejects_public_clients_when_pairing_is_disabled ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s

==> /Users/chum/.cargo/bin/cargo test --locked --lib metrics_endpoint_requires_bearer_token_when_pairing_is_enabled

running 1 test
test gateway::tests::metrics_endpoint_requires_bearer_token_when_pairing_is_enabled ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s

==> /Users/chum/.cargo/bin/cargo test --locked --lib extract_ws_bearer_token_rejects_empty_tokens

running 1 test
test gateway::ws::tests::extract_ws_bearer_token_rejects_empty_tokens ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s

==> /Users/chum/.cargo/bin/cargo test --locked --lib autonomy_config_serde_defaults_non_cli_excluded_tools

running 1 test
test config::schema::tests::autonomy_config_serde_defaults_non_cli_excluded_tools ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s

==> /Users/chum/.cargo/bin/cargo test --locked --lib config_validate_rejects_duplicate_non_cli_excluded_tools

running 1 test
test config::schema::tests::config_validate_rejects_duplicate_non_cli_excluded_tools ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s

==> /Users/chum/.cargo/bin/cargo test --locked --lib config_debug_redacts_sensitive_values

running 1 test
test config::schema::tests::config_debug_redacts_sensitive_values ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s

==> /Users/chum/.cargo/bin/cargo test --locked --lib config_save_encrypts_nested_credentials

running 1 test
test config::schema::tests::config_save_encrypts_nested_credentials ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.04s

==> /Users/chum/.cargo/bin/cargo test --locked --lib replayed_totp_code_is_rejected

running 1 test
test security::otp::tests::replayed_totp_code_is_rejected ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.02s

==> /Users/chum/.cargo/bin/cargo test --locked --lib validate_command_execution_rejects_forbidden_paths

running 1 test
test security::policy::tests::validate_command_execution_rejects_forbidden_paths ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s

==> /Users/chum/.cargo/bin/cargo test --locked --lib screenshot_path_validation_blocks_escaped_paths

running 1 test
test tools::browser::tests::screenshot_path_validation_blocks_escaped_paths ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s

==> /Users/chum/.cargo/bin/cargo test --locked --lib test_execute_blocked_in_read_only_mode

running 1 test
test tools::web_search_tool::tests::test_execute_blocked_in_read_only_mode ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s

==> /Users/chum/.cargo/bin/cargo test --locked --lib key_file_created_on_first_encrypt

running 1 test
test security::secrets::tests::key_file_created_on_first_encrypt ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.01s

==> /Users/chum/.cargo/bin/cargo test --locked --lib scrub_google_api_key_prefix

running 1 test
test providers::tests::scrub_google_api_key_prefix ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s

==> /Users/chum/.cargo/bin/cargo test --locked --lib scrub_aws_access_key_prefix

running 1 test
test providers::tests::scrub_aws_access_key_prefix ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3239 filtered out; finished in 0.00s
