### PR TITLE
[supersede #1691] feat(channel): add base_url option to Telegram config for Bale/compatible APIs

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2905,19 +2905,23 @@ fn collect_configured_channels(
     let mut channels = Vec::new();
 
     if let Some(ref tg) = config.channels_config.telegram {
+        let mut telegram = TelegramChannel::new(
+            tg.bot_token.clone(),
+            tg.allowed_users.clone(),
+            tg.effective_group_reply_mode().requires_mention(),
+        )
+        .with_group_reply_allowed_senders(tg.group_reply_allowed_sender_ids())
+        .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
+        .with_transcription(config.transcription.clone())
+        .with_workspace_dir(config.workspace_dir.clone());
+
+        if let Some(ref base_url) = tg.base_url {
+            telegram = telegram.with_api_base(base_url.clone());
+        }
+
         channels.push(ConfiguredChannel {
             display_name: "Telegram",
-            channel: Arc::new(
-                TelegramChannel::new(
-                    tg.bot_token.clone(),
-                    tg.allowed_users.clone(),
-                    tg.effective_group_reply_mode().requires_mention(),
-                )
-                .with_group_reply_allowed_senders(tg.group_reply_allowed_sender_ids())
-                .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
-                .with_transcription(config.transcription.clone())
-                .with_workspace_dir(config.workspace_dir.clone()),
-            ),
+            channel: Arc::new(telegram),
         });
     }
 

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -892,10 +892,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
     /// Download a file from the Telegram CDN.
     async fn download_file(&self, file_path: &str) -> anyhow::Result<Vec<u8>> {
-        let url = format!(
-            "https://api.telegram.org/file/bot{}/{file_path}",
-            self.bot_token
-        );
+        let url = format!("{}/file/bot{}/{file_path}", self.api_base, self.bot_token);
         let resp = self
             .http_client()
             .get(&url)
@@ -1537,10 +1534,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             .to_string();
 
         // Step 2: download the actual file
-        let download_url = format!(
-            "https://api.telegram.org/file/bot{}/{}",
-            self.bot_token, file_path
-        );
+        let download_url = format!("{}/file/bot{}/{}", self.api_base, self.bot_token, file_path);
         let img_resp = self.http_client().get(&download_url).send().await?;
         let bytes = img_resp.bytes().await?;
 
@@ -3078,6 +3072,17 @@ mod tests {
         assert_eq!(
             ch.api_url("getMe"),
             "https://api.telegram.org/bot123:ABC/getMe"
+        );
+    }
+
+    #[test]
+    fn telegram_custom_base_url() {
+        let ch = TelegramChannel::new("123:ABC".into(), vec![], false)
+            .with_api_base("https://tapi.bale.ai".to_string());
+        assert_eq!(ch.api_url("getMe"), "https://tapi.bale.ai/bot123:ABC/getMe");
+        assert_eq!(
+            ch.api_url("sendMessage"),
+            "https://tapi.bale.ai/bot123:ABC/sendMessage"
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -49,6 +49,7 @@ mod tests {
             interrupt_on_new_message: false,
             mention_only: false,
             group_reply: None,
+            base_url: None,
         };
 
         let discord = DiscordConfig {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -3393,6 +3393,11 @@ pub struct TelegramConfig {
     /// Group-chat trigger controls.
     #[serde(default)]
     pub group_reply: Option<GroupReplyConfig>,
+    /// Optional custom base URL for Telegram-compatible APIs.
+    /// Defaults to "https://api.telegram.org" when omitted.
+    /// Example for Bale messenger: "https://tapi.bale.ai"
+    #[serde(default)]
+    pub base_url: Option<String>,
 }
 
 impl ChannelConfig for TelegramConfig {
@@ -6353,6 +6358,7 @@ mod tests {
             interrupt_on_new_message: false,
             mention_only: false,
             group_reply: None,
+            base_url: None,
         });
         config.agents.insert(
             "worker".into(),
@@ -6701,6 +6707,7 @@ default_temperature = 0.7
                     interrupt_on_new_message: false,
                     mention_only: false,
                     group_reply: None,
+                    base_url: None,
                 }),
                 discord: None,
                 slack: None,
@@ -7158,6 +7165,7 @@ tool_dispatcher = "xml"
             interrupt_on_new_message: false,
             mention_only: false,
             group_reply: None,
+            base_url: None,
         });
 
         config.agents.insert(
@@ -7292,6 +7300,7 @@ tool_dispatcher = "xml"
             interrupt_on_new_message: true,
             mention_only: false,
             group_reply: None,
+            base_url: None,
         };
         let json = serde_json::to_string(&tc).unwrap();
         let parsed: TelegramConfig = serde_json::from_str(&json).unwrap();
@@ -7309,11 +7318,19 @@ tool_dispatcher = "xml"
         assert_eq!(parsed.stream_mode, StreamMode::Off);
         assert_eq!(parsed.draft_update_interval_ms, 1000);
         assert!(!parsed.interrupt_on_new_message);
+        assert!(parsed.base_url.is_none());
         assert_eq!(
             parsed.effective_group_reply_mode(),
             GroupReplyMode::AllMessages
         );
         assert!(parsed.group_reply_allowed_sender_ids().is_empty());
+    }
+
+    #[test]
+    async fn telegram_config_custom_base_url() {
+        let json = r#"{"bot_token":"tok","allowed_users":[],"base_url":"https://tapi.bale.ai"}"#;
+        let parsed: TelegramConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.base_url, Some("https://tapi.bale.ai".to_string()));
     }
 
     #[test]

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -405,6 +405,7 @@ mod tests {
             interrupt_on_new_message: false,
             mention_only: false,
             group_reply: None,
+            base_url: None,
         });
         assert!(has_supervised_channels(&config));
     }
@@ -540,6 +541,7 @@ mod tests {
             interrupt_on_new_message: false,
             mention_only: false,
             group_reply: None,
+            base_url: None,
         });
 
         let target = heartbeat_delivery_target(&config).unwrap();

--- a/src/integrations/registry.rs
+++ b/src/integrations/registry.rs
@@ -805,6 +805,7 @@ mod tests {
             interrupt_on_new_message: false,
             mention_only: false,
             group_reply: None,
+            base_url: None,
         });
         let entries = all_integrations();
         let tg = entries.iter().find(|e| e.name == "Telegram").unwrap();

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -3836,6 +3836,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     interrupt_on_new_message: false,
                     mention_only: false,
                     group_reply: None,
+                    base_url: None,
                 });
             }
             ChannelMenuChoice::Discord => {


### PR DESCRIPTION
Supersedes #1691 to recover from merge conflicts against latest `dev`.

- Source PR: https://github.com/zeroclaw-labs/zeroclaw/pull/1691
- Recovery mode: automated replay on top of current `dev`
- Merge policy: all CI checks green (except non-blocking `Enforce Dev -> Main Promotion`)

Original PR description:

## Summary
- Adds optional `base_url` parameter to Telegram channel configuration
- Enables use with Telegram-compatible APIs like Bale messenger
- Zero breaking changes - defaults to official Telegram API

## Configuration

```toml
[channel.telegram]
bot_token = "YOUR_BOT_TOKEN"
allowed_users = ["user1"]
base_url = "https://tapi.bale.ai"  # Optional, for Bale messenger
```

## Use Cases
- **Bale messenger** - 34M+ users in Iran, 100% Telegram API compatible
- **Local Bot API servers** - Self-hosted Telegram Bot API instances
- **Testing** - Custom endpoints for development/testing

## Changes
- Added `base_url: Option<String>` to `TelegramConfig` in config schema
- Updated `TelegramChannel::download_file()` to use `api_base` instead of hardcoded URL
- Updated channel creation to pass `base_url` if configured
- Added tests for custom base_url functionality

## Test Plan
- [x] All 3022 unit tests pass
- [x] Added `telegram_custom_base_url` test
- [x] Added `telegram_config_custom_base_url` config test
- [x] Verified backward compatibility (defaults work)

## Files Changed
- `src/config/schema.rs` - Added `base_url` field to `TelegramConfig`
- `src/channels/telegram.rs` - Use `api_base` for file downloads, added test
- `src/channels/mod.rs` - Pass `base_url` when creating Telegram channel
- Test fixtures updated in `wizard.rs`, `daemon/mod.rs`, `integrations/registry.rs`, `config/mod.rs`

Closes #1464

🦀 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional base URL configuration for Telegram channels, enabling customization of API endpoints while maintaining backward compatibility.

* **Tests**
  * Added validation tests for custom Telegram API base URL integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
