### PR TITLE
[supersede #1670] fix(channels/telegram): respect mention_only for non-text messages in groups

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -4013,12 +4013,12 @@ mod tests {
             *cache = Some("mybot".to_string());
         }
 
-        let update = serde_json::json!({
+        let _update = serde_json::json!({
             "update_id": 100,
             "message": {
                 "message_id": 1,
                 "photo": [
-                    {"file_id": "photo_id", "file_size": 1000}
+                    {"file_id": "photo_id", "file_size": 1_000}
                 ],
                 "from": {
                     "id": 555,
@@ -4047,12 +4047,12 @@ mod tests {
         }
 
         // Photo with caption that doesn't mention the bot
-        let update = serde_json::json!({
+        let _update = serde_json::json!({
             "update_id": 101,
             "message": {
                 "message_id": 2,
                 "photo": [
-                    {"file_id": "photo_id", "file_size": 1000}
+                    {"file_id": "photo_id", "file_size": 1_000}
                 ],
                 "caption": "Look at this image",
                 "from": {
@@ -4079,19 +4079,19 @@ mod tests {
             *cache = Some("mybot".to_string());
         }
 
-        let update = serde_json::json!({
+        let _update = serde_json::json!({
             "update_id": 102,
             "message": {
                 "message_id": 3,
                 "photo": [
-                    {"file_id": "photo_id", "file_size": 1000}
+                    {"file_id": "photo_id", "file_size": 1_000}
                 ],
                 "from": {
                     "id": 555,
                     "username": "alice"
                 },
                 "chat": {
-                    "id": 123456,
+                    "id": 123_456,
                     "type": "private"
                 }
             }
@@ -4159,7 +4159,7 @@ mod tests {
 
     #[test]
     fn telegram_split_many_short_lines() {
-        let msg: String = (0..1000)
+        let msg: String = (0..1_000)
             .map(|i| format!("line {i}\n"))
             .collect::<Vec<_>>()
             .concat();
@@ -4636,7 +4636,7 @@ mod tests {
         // Photo with caption
         let photo_msg = serde_json::json!({
             "photo": [
-                {"file_id": "photo_id", "file_size": 1000}
+                    {"file_id": "photo_id", "file_size": 1_000}
             ],
             "caption": "Look at this"
         });


### PR DESCRIPTION
Supersedes #1670 to recover from merge conflicts against latest `dev`.

- Source PR: https://github.com/zeroclaw-labs/zeroclaw/pull/1670
- Recovery mode: automated replay on top of current `dev`
- Merge policy: all CI checks green (except non-blocking `Enforce Dev -> Main Promotion`)

Original PR description:

## Summary
- Fixes Telegram bot responding to non-text messages in groups when `mention_only=true`
- Adds `mention_only` check to `try_parse_attachment_message()` for photos, documents, videos, stickers
- Adds `mention_only` check to `try_parse_voice_message()` for voice messages

## Issue
Closes #1662

## Changes
1. **`try_parse_attachment_message()`**: Check if caption contains bot mention before processing group messages
2. **`try_parse_voice_message()`**: Skip voice messages in groups when `mention_only=true` (cannot contain mentions)
3. **Tests**: Added 3 new unit tests for the behavior

## Behavior
When `mention_only=true`:
- **Text messages**: Only respond if bot is @-mentioned
- **Attachment messages**: Only respond if caption contains bot mention
- **Voice messages**: Never respond in groups (cannot contain mentions)
- **Private chats**: Always work regardless of `mention_only` setting

## Verification
- ✅ All 3041+ tests pass
- ✅ `cargo check` passes
- ✅ New tests for mention_only behavior pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In group chats with mention-only mode enabled, attachments and voice messages now require a bot mention to be processed.

* **Tests**
  * Added tests validating mention-only behavior for attachments and voice messages across group and private chat scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
