### PR TITLE
fix(tests): restore Channel::update_draft trait compatibility

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4021,9 +4021,9 @@ mod tests {
             _recipient: &str,
             _message_id: &str,
             text: &str,
-        ) -> anyhow::Result<()> {
+        ) -> anyhow::Result<Option<String>> {
             self.draft_updates.lock().await.push(text.to_string());
-            Ok(())
+            Ok(None)
         }
 
         async fn finalize_draft(


### PR DESCRIPTION
## Summary
- fix `DraftStreamingRecordingChannel::update_draft` mock signature to match `Channel` trait
- return `Ok(None)` to preserve existing draft-id behavior in tests

## Why
`dev` head commit `21696e1` is red in `Security Regression Tests` due to trait signature mismatch (E0053). This patch restores compile/test compatibility for the regression gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated draft update handling to provide additional information during the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->