### PR TITLE
fix(release): restore GNU Linux GLIBC compatibility baseline

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -165,7 +165,9 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - os: blacksmith-2vcpu-ubuntu-2404
+                    # Keep GNU Linux release artifacts on Ubuntu 22.04 to preserve
+                    # a broadly compatible GLIBC baseline for user distributions.
+                    - os: ubuntu-22.04
                       target: x86_64-unknown-linux-gnu
                       artifact: zeroclaw
                       archive_ext: tar.gz
@@ -180,7 +182,7 @@ jobs:
                       linker_env: ""
                       linker: ""
                       use_cross: true
-                    - os: blacksmith-2vcpu-ubuntu-2404
+                    - os: ubuntu-22.04
                       target: aarch64-unknown-linux-gnu
                       artifact: zeroclaw
                       archive_ext: tar.gz
@@ -195,7 +197,7 @@ jobs:
                       linker_env: ""
                       linker: ""
                       use_cross: true
-                    - os: blacksmith-2vcpu-ubuntu-2404
+                    - os: ubuntu-22.04
                       target: armv7-unknown-linux-gnueabihf
                       artifact: zeroclaw
                       archive_ext: tar.gz


### PR DESCRIPTION
## Summary
- pin GNU Linux release targets to `ubuntu-22.04` to keep a broadly compatible GLIBC baseline
- preserve newer `dev` matrix additions (including `*-musl` targets on Blacksmith runners)
- avoid runtime breakage like `GLIBC_2.39 not found` on Ubuntu 22.04 / Debian 12

## Changes
- `.github/workflows/pub-release.yml`
  - `x86_64-unknown-linux-gnu` -> `ubuntu-22.04`
  - `aarch64-unknown-linux-gnu` -> `ubuntu-22.04`
  - `armv7-unknown-linux-gnueabihf` -> `ubuntu-22.04`

## Validation
- YAML parses successfully
- matrix mapping validated locally to ensure only GNU Linux targets moved to 22.04

Closes #1854


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use Ubuntu 22.04 for release builds across multiple Linux targets. Added clarifying comments to the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->