### PR TITLE
fix(linq): support current v3 webhook payload format

### DIFF
--- a/src/channels/linq.rs
+++ b/src/channels/linq.rs
@@ -61,7 +61,11 @@ impl LinqChannel {
 
     /// Parse an incoming webhook payload from Linq and extract messages.
     ///
-    /// Linq webhook envelope:
+    /// Supports both legacy and current Linq v3 webhook payload variants:
+    /// - Legacy shape: `data.from`, `data.chat_id`, `data.message.parts`
+    /// - Current shape: `data.sender_handle.handle`, `data.chat.id`, `data.parts`
+    ///
+    /// Linq webhook envelope (legacy example):
     /// ```json
     /// {
     ///   "api_version": "v3",
@@ -99,18 +103,41 @@ impl LinqChannel {
             return messages;
         };
 
-        // Skip messages sent by the bot itself
-        if data
+        // Skip messages sent by the bot itself.
+        // Linq can express this as:
+        // - legacy: data.is_from_me
+        // - v3: data.sender_handle.is_me
+        // - v3 direction marker: data.direction == "outbound"
+        let is_from_me = data
             .get("is_from_me")
             .and_then(|v| v.as_bool())
             .unwrap_or(false)
-        {
+            || data
+                .get("sender_handle")
+                .and_then(|sender| sender.get("is_me"))
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            || matches!(
+                data.get("direction").and_then(|v| v.as_str()),
+                Some("outbound")
+            );
+        if is_from_me {
             tracing::debug!("Linq: skipping is_from_me message");
             return messages;
         }
 
-        // Get sender phone number
-        let Some(from) = data.get("from").and_then(|f| f.as_str()) else {
+        // Get sender phone number.
+        // Prefer legacy `from`, then fallback to v3 `sender_handle.handle`.
+        let Some(from) = data
+            .get("from")
+            .and_then(|f| f.as_str())
+            .or_else(|| data.get("sender").and_then(|f| f.as_str()))
+            .or_else(|| {
+                data.get("sender_handle")
+                    .and_then(|sender| sender.get("handle"))
+                    .and_then(|h| h.as_str())
+            })
+        else {
             return messages;
         };
 
@@ -131,19 +158,29 @@ impl LinqChannel {
             return messages;
         }
 
-        // Get chat_id for reply routing
+        // Get chat_id for reply routing.
+        // Legacy: data.chat_id
+        // v3: data.chat.id
         let chat_id = data
             .get("chat_id")
             .and_then(|c| c.as_str())
+            .or_else(|| {
+                data.get("chat")
+                    .and_then(|chat| chat.get("id"))
+                    .and_then(|id| id.as_str())
+            })
             .unwrap_or("")
             .to_string();
 
-        // Extract text from message parts
-        let Some(message) = data.get("message") else {
-            return messages;
-        };
-
-        let Some(parts) = message.get("parts").and_then(|p| p.as_array()) else {
+        // Extract text from message parts.
+        // Legacy: data.message.parts
+        // v3: data.parts
+        let Some(parts) = data
+            .get("message")
+            .and_then(|message| message.get("parts"))
+            .and_then(|p| p.as_array())
+            .or_else(|| data.get("parts").and_then(|p| p.as_array()))
+        else {
             return messages;
         };
 
@@ -466,6 +503,56 @@ mod tests {
         assert_eq!(msgs[0].content, "Hello ZeroClaw!");
         assert_eq!(msgs[0].channel, "linq");
         assert_eq!(msgs[0].reply_target, "chat-789");
+    }
+
+    #[test]
+    fn linq_parse_current_v3_payload_shape() {
+        let ch = LinqChannel::new("tok".into(), "+15551234567".into(), vec!["*".into()]);
+        let payload = serde_json::json!({
+            "api_version": "v3",
+            "event_type": "message.received",
+            "created_at": "2026-02-25T19:00:00Z",
+            "data": {
+                "chat": {
+                    "id": "chat-v3-123"
+                },
+                "sender_handle": {
+                    "handle": "+12197797846",
+                    "is_me": false
+                },
+                "direction": "inbound",
+                "parts": [{
+                    "type": "text",
+                    "value": "hi clawd ppp"
+                }]
+            }
+        });
+
+        let msgs = ch.parse_webhook_payload(&payload);
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].sender, "+12197797846");
+        assert_eq!(msgs[0].content, "hi clawd ppp");
+        assert_eq!(msgs[0].reply_target, "chat-v3-123");
+    }
+
+    #[test]
+    fn linq_parse_current_v3_outbound_is_skipped() {
+        let ch = LinqChannel::new("tok".into(), "+15551234567".into(), vec!["*".into()]);
+        let payload = serde_json::json!({
+            "event_type": "message.received",
+            "data": {
+                "chat": { "id": "chat-v3-123" },
+                "sender_handle": {
+                    "handle": "+12197797846",
+                    "is_me": true
+                },
+                "direction": "outbound",
+                "parts": [{ "type": "text", "value": "self echo" }]
+            }
+        });
+
+        let msgs = ch.parse_webhook_payload(&payload);
+        assert!(msgs.is_empty(), "outbound/self messages should be skipped");
     }
 
     #[test]

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1580,6 +1580,15 @@ async fn handle_linq_webhook(
     let messages = linq.parse_webhook_payload(&payload);
 
     if messages.is_empty() {
+        if payload
+            .get("event_type")
+            .and_then(|v| v.as_str())
+            .is_some_and(|event| event == "message.received")
+        {
+            tracing::warn!(
+                "Linq webhook message.received produced no actionable messages (possible unsupported payload shape)"
+            );
+        }
         // Acknowledge the webhook even if no messages (could be status/delivery events)
         return (StatusCode::OK, Json(serde_json::json!({"status": "ok"})));
     }


### PR DESCRIPTION
## Summary
- fix Linq webhook parsing for current v3 payload format (`2026-02-03`)
- keep backward compatibility with legacy payload shape
- add explicit gateway warning when `message.received` yields zero actionable messages

## Root Cause
The parser assumed legacy fields (`data.from`, `data.chat_id`, `data.message.parts`) while current payloads use nested/shifted fields (`data.sender_handle.handle`, `data.chat.id`, `data.parts`). This led to silent message drops.

## Changes
- `src/channels/linq.rs`
  - sender extraction: `from` OR `sender` OR `sender_handle.handle`
  - chat extraction: `chat_id` OR `chat.id`
  - parts extraction: `message.parts` OR `data.parts`
  - self-message detection supports legacy and v3 markers (`is_from_me`, `sender_handle.is_me`, outbound direction)
  - added unit tests for v3 inbound/outbound behavior
- `src/gateway/mod.rs`
  - warning log for `message.received` events that parse to zero messages

## Validation
- `cargo test linq_parse_ -- --nocapture`
- `cargo fmt --all -- --check`

Closes #1845


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linq webhook message handling to support multiple payload formats and versions simultaneously.
  * Enhanced sender identification and message content extraction for improved reliability and consistency.
  * Added protective filtering for unauthorized sender detection and logging.
  * Implemented diagnostic warning logs for unsupported webhook payload shapes to assist with troubleshooting and system monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->