### PR TITLE
fix(agent): improve iteration-limit recovery and continuity

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -90,14 +90,14 @@ Operational note for container users:
 | Key | Default | Purpose |
 |---|---|---|
 | `compact_context` | `false` | When true: bootstrap_max_chars=6000, rag_chunk_limit=2. Use for 13B or smaller models |
-| `max_tool_iterations` | `10` | Maximum tool-call loop turns per user message across CLI, gateway, and channels |
+| `max_tool_iterations` | `20` | Maximum tool-call loop turns per user message across CLI, gateway, and channels |
 | `max_history_messages` | `50` | Maximum conversation history messages retained per session |
 | `parallel_tools` | `false` | Enable parallel tool execution within a single iteration |
 | `tool_dispatcher` | `auto` | Tool dispatch strategy |
 
 Notes:
 
-- Setting `max_tool_iterations = 0` falls back to safe default `10`.
+- Setting `max_tool_iterations = 0` falls back to safe default `20`.
 - If a channel message exceeds this value, the runtime returns: `Agent exceeded maximum tool iterations (<value>)`.
 - In CLI, gateway, and channel tool loops, multiple independent tool calls are executed concurrently by default when the pending calls do not require approval gating; result order remains stable.
 - `parallel_tools` applies to the `Agent::turn()` API surface. It does not gate the runtime loop used by CLI, gateway, or channel handlers.

--- a/docs/i18n/fr/config-reference.md
+++ b/docs/i18n/fr/config-reference.md
@@ -20,3 +20,4 @@ Source anglaise:
 ## Notes de mise à jour
 
 - Ajout de `provider.reasoning_level` (OpenAI Codex `/responses`). Voir la source anglaise pour les détails.
+- Valeur par défaut de `agent.max_tool_iterations` augmentée à `20` (fallback sûr si `0`).

--- a/docs/i18n/vi/config-reference.md
+++ b/docs/i18n/vi/config-reference.md
@@ -74,14 +74,14 @@ Lưu ý cho người dùng container:
 | Khóa | Mặc định | Mục đích |
 |---|---|---|
 | `compact_context` | `false` | Khi bật: bootstrap_max_chars=6000, rag_chunk_limit=2. Dùng cho model 13B trở xuống |
-| `max_tool_iterations` | `10` | Số vòng lặp tool-call tối đa mỗi tin nhắn trên CLI, gateway và channels |
+| `max_tool_iterations` | `20` | Số vòng lặp tool-call tối đa mỗi tin nhắn trên CLI, gateway và channels |
 | `max_history_messages` | `50` | Số tin nhắn lịch sử tối đa giữ lại mỗi phiên |
 | `parallel_tools` | `false` | Bật thực thi tool song song trong một lượt |
 | `tool_dispatcher` | `auto` | Chiến lược dispatch tool |
 
 Lưu ý:
 
-- Đặt `max_tool_iterations = 0` sẽ dùng giá trị mặc định an toàn `10`.
+- Đặt `max_tool_iterations = 0` sẽ dùng giá trị mặc định an toàn `20`.
 - Nếu tin nhắn kênh vượt giá trị này, runtime trả về: `Agent exceeded maximum tool iterations (<value>)`.
 - Trong vòng lặp tool của CLI, gateway và channel, các lời gọi tool độc lập được thực thi đồng thời mặc định khi không cần phê duyệt; thứ tự kết quả giữ ổn định.
 - `parallel_tools` áp dụng cho API `Agent::turn()`. Không ảnh hưởng đến vòng lặp runtime của CLI, gateway hay channel.

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -628,8 +628,8 @@ pub struct AgentConfig {
     /// When true: bootstrap_max_chars=6000, rag_chunk_limit=2. Use for 13B or smaller models.
     #[serde(default)]
     pub compact_context: bool,
-    /// Maximum tool-call loop turns per user message. Default: `10`.
-    /// Setting to `0` falls back to the safe default of `10`.
+    /// Maximum tool-call loop turns per user message. Default: `20`.
+    /// Setting to `0` falls back to the safe default of `20`.
     #[serde(default = "default_agent_max_tool_iterations")]
     pub max_tool_iterations: usize,
     /// Maximum conversation history messages retained per session. Default: `50`.
@@ -644,7 +644,7 @@ pub struct AgentConfig {
 }
 
 fn default_agent_max_tool_iterations() -> usize {
-    10
+    20
 }
 
 fn default_agent_max_history_messages() -> usize {
@@ -7169,7 +7169,7 @@ reasoning_level = "high"
     async fn agent_config_defaults() {
         let cfg = AgentConfig::default();
         assert!(!cfg.compact_context);
-        assert_eq!(cfg.max_tool_iterations, 10);
+        assert_eq!(cfg.max_tool_iterations, 20);
         assert_eq!(cfg.max_history_messages, 50);
         assert!(!cfg.parallel_tools);
         assert_eq!(cfg.tool_dispatcher, "auto");

--- a/tests/agent_loop_robustness.rs
+++ b/tests/agent_loop_robustness.rs
@@ -315,14 +315,14 @@ async fn agent_handles_mixed_tool_success_and_failure() {
 // TG4.3: Iteration limit enforcement (#777)
 // ═════════════════════════════════════════════════════════════════════════════
 
-/// Agent should not exceed max_tool_iterations (default=10) even with
+/// Agent should not exceed max_tool_iterations (default=20) even with
 /// a provider that keeps returning tool calls
 #[tokio::test]
 async fn agent_respects_max_tool_iterations() {
     let (counting_tool, count) = CountingTool::new();
 
-    // Create 20 tool call responses - more than the default limit of 10
-    let mut responses: Vec<ChatResponse> = (0..20)
+    // Create 30 tool call responses - more than the default limit of 20
+    let mut responses: Vec<ChatResponse> = (0..30)
         .map(|i| {
             tool_response(vec![ToolCall {
                 id: format!("tc_{i}"),
@@ -344,8 +344,8 @@ async fn agent_respects_max_tool_iterations() {
 
     let invocations = *count.lock().unwrap();
     assert!(
-        invocations <= 10,
-        "tool invocations ({invocations}) should not exceed default max_tool_iterations (10)"
+        invocations <= 20,
+        "tool invocations ({invocations}) should not exceed default max_tool_iterations (20)"
     );
 }
 

--- a/tests/config_persistence.rs
+++ b/tests/config_persistence.rs
@@ -49,8 +49,8 @@ fn config_default_temperature_positive() {
 fn agent_config_default_max_tool_iterations() {
     let agent = AgentConfig::default();
     assert_eq!(
-        agent.max_tool_iterations, 10,
-        "default max_tool_iterations should be 10"
+        agent.max_tool_iterations, 20,
+        "default max_tool_iterations should be 20"
     );
 }
 
@@ -199,7 +199,7 @@ default_temperature = 0.7
     let parsed: Config = toml::from_str(minimal_toml).expect("minimal TOML should parse");
 
     // Agent config should use defaults
-    assert_eq!(parsed.agent.max_tool_iterations, 10);
+    assert_eq!(parsed.agent.max_tool_iterations, 20);
     assert_eq!(parsed.agent.max_history_messages, 50);
     assert!(!parsed.agent.compact_context);
 }

--- a/tests/config_schema.rs
+++ b/tests/config_schema.rs
@@ -231,7 +231,7 @@ fn config_empty_toml_requires_temperature() {
 fn config_minimal_toml_with_temperature_uses_defaults() {
     let toml_str = "default_temperature = 0.7\n";
     let parsed: Config = toml::from_str(toml_str).expect("minimal TOML should parse");
-    assert_eq!(parsed.agent.max_tool_iterations, 10);
+    assert_eq!(parsed.agent.max_tool_iterations, 20);
     assert_eq!(parsed.gateway.port, 42617);
 }
 
@@ -240,7 +240,7 @@ fn config_only_temperature_parses() {
     let toml_str = "default_temperature = 1.2\n";
     let parsed: Config = toml::from_str(toml_str).expect("temperature-only TOML should parse");
     assert!((parsed.default_temperature - 1.2).abs() < f64::EPSILON);
-    assert_eq!(parsed.agent.max_tool_iterations, 10);
+    assert_eq!(parsed.agent.max_tool_iterations, 20);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- improve continuity when a turn hits tool-iteration limits
- increase safe default `agent.max_tool_iterations` from `10` to `20`
- return actionable pause/resume guidance instead of only generic hard-fail messaging

## Changes
- `src/agent/loop_.rs`
  - default max tool iterations: `20`
  - add limit-error detection helper
  - CLI interactive flow now records a pause notice that explicitly says context/progress are preserved and user can reply `continue`
- `src/channels/mod.rs`
  - detect tool-iteration-limit errors separately from generic runtime failures
  - send a dedicated pause message with resume guidance
  - append a preserved-context assistant marker so follow-up can continue coherently
- `src/config/schema.rs`
  - default docs/schema comments updated to `20`
- docs/tests updates
  - `docs/config-reference.md`
  - `docs/i18n/vi/config-reference.md`
  - `docs/i18n/fr/config-reference.md`
  - updated config/robustness/channel tests for the new default + messaging path

## Validation
- `cargo test max_tool_iterations -- --nocapture`
- `cargo fmt --all -- --check`

Closes #1836


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased default tool-iteration limit from 10 to 20 per user message.
  * Enhanced error handling when reaching tool-iteration limits with a pause notification that preserves context and allows resuming.

* **Documentation**
  * Updated configuration reference documentation across all supported languages to reflect new default limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->