### PR TITLE
fix(security): allow configured shell env expansions

### DIFF
--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -64,6 +64,16 @@ pub use leak_detector::{LeakDetector, LeakResult};
 #[allow(unused_imports)]
 pub use prompt_guard::{GuardAction, GuardResult, PromptGuard};
 
+/// Validate shell environment variable names (`[A-Za-z_][A-Za-z0-9_]*`).
+pub fn is_valid_env_var_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii_alphabetic() || first == '_' => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+}
+
 /// Redact sensitive values for safe logging. Shows first 4 chars + "***" suffix.
 /// This function intentionally breaks the data-flow taint chain for static analysis.
 pub fn redact(value: &str) -> String {

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -1,3 +1,4 @@
+use super::is_valid_env_var_name;
 use parking_lot::Mutex;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -419,15 +420,6 @@ fn contains_unquoted_char(command: &str, target: char) -> bool {
     false
 }
 
-fn is_valid_shell_env_var_name(name: &str) -> bool {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(first) if first.is_ascii_alphabetic() || first == '_' => {}
-        _ => return false,
-    }
-    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
-}
-
 /// Detect unquoted shell variable expansions that are not explicitly allowlisted.
 ///
 /// Allowed forms:
@@ -519,7 +511,7 @@ fn contains_disallowed_unquoted_shell_variable_expansion(
                 }
 
                 let inner: String = chars[i + 2..j].iter().collect();
-                if !is_valid_shell_env_var_name(&inner)
+                if !is_valid_env_var_name(&inner)
                     || !allowed_vars.iter().any(|allowed| allowed == &inner)
                 {
                     return true;
@@ -1805,22 +1797,24 @@ mod tests {
     #[test]
     fn command_allows_explicit_shell_env_passthrough_variables() {
         let p = SecurityPolicy {
-            shell_env_passthrough: vec!["TOKEN_VAR".into()],
+            shell_env_passthrough: vec!["ZEROCLAW_TEST_TOKEN".into()],
             ..SecurityPolicy::default()
         };
-        assert!(p.is_command_allowed("echo $TOKEN_VAR"));
-        assert!(p.is_command_allowed("echo ${TOKEN_VAR}"));
-        assert!(p.is_command_allowed("echo \"Authorization: Bearer $TOKEN_VAR\""));
+        assert!(p.is_command_allowed("echo $ZEROCLAW_TEST_TOKEN"));
+        assert!(p.is_command_allowed("echo ${ZEROCLAW_TEST_TOKEN}"));
+        assert!(p.is_command_allowed("echo \"Authorization: Bearer $ZEROCLAW_TEST_TOKEN\""));
+        assert!(p.is_command_allowed("echo \"Authorization: Bearer ${ZEROCLAW_TEST_TOKEN}\""));
     }
 
     #[test]
     fn command_rejects_non_passthrough_or_complex_variable_expansions() {
         let p = SecurityPolicy {
-            shell_env_passthrough: vec!["TOKEN_VAR".into()],
+            shell_env_passthrough: vec!["ZEROCLAW_TEST_TOKEN".into()],
             ..SecurityPolicy::default()
         };
         assert!(!p.is_command_allowed("echo $HOME"));
-        assert!(!p.is_command_allowed("echo ${TOKEN_VAR:-fallback}"));
+        assert!(!p.is_command_allowed("echo \"Authorization: Bearer ${HOME}\""));
+        assert!(!p.is_command_allowed("echo ${ZEROCLAW_TEST_TOKEN:-fallback}"));
         assert!(!p.is_command_allowed("echo $1"));
     }
 

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -1,5 +1,6 @@
 use super::traits::{Tool, ToolResult};
 use crate::runtime::RuntimeAdapter;
+use crate::security::is_valid_env_var_name;
 use crate::security::SecurityPolicy;
 use crate::security::SyscallAnomalyDetector;
 use async_trait::async_trait;
@@ -41,15 +42,6 @@ impl ShellTool {
             syscall_detector,
         }
     }
-}
-
-fn is_valid_env_var_name(name: &str) -> bool {
-    let mut chars = name.chars();
-    match chars.next() {
-        Some(first) if first.is_ascii_alphabetic() || first == '_' => {}
-        _ => return false,
-    }
-    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
 }
 
 pub(super) fn collect_allowed_shell_env_vars(security: &SecurityPolicy) -> Vec<String> {


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): `dev`
- Problem: `shell_env_passthrough` was ineffective because policy blocked all unquoted `$...` expansions before allowlist evaluation.
- Why it matters: agents could not use allowlisted runtime secrets/tokens in shell workflows, causing legitimate automation failures.
- What changed: replaced blanket `$...` rejection with allowlist-aware parsing for `$NAME` and `${NAME}`; kept blocking command substitution/special params/complex brace expressions; added targeted policy + shell tests; extracted shared env-var-name validation utility.
- What did **not** change (scope boundary): no change to default-deny posture for non-allowlisted vars, no change to `http_request` variable interpolation semantics, no broad relaxation of shell risk checks.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto-managed
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `security,tool,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `tool: shell`, `security: policy`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `security`

## Linked Issue

- Closes #1857
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)
- Linear issue key(s) (required, e.g. `RMN-123`): `RMN-146`
- Linear issue URL(s): https://linear.app/zeroclawlabs/issue/RMN-146/bug-allow-configured-env-var-access-in-shell-commands

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo test command_allows_explicit_shell_env_passthrough_variables -- --nocapture
cargo test command_rejects_non_passthrough_or_complex_variable_expansions -- --nocapture
cargo test shell_allows_passthrough_variable_expansion -- --nocapture
cargo test shell_blocks_plain_variable_expansion -- --nocapture
cargo fmt --all -- --check
```

- Evidence provided (test/log/trace/screenshot/perf): test logs from policy + shell unit coverage, plus formatting gate output.
- If any command is intentionally skipped, explain why: full `cargo clippy --all-targets -- -D warnings` and full `cargo test` were not re-run in this update because this PR delta is scoped to existing targeted coverage paths and CI gates.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `Yes` (scoped)
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `Yes`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation:
  - Risk: operator could over-broaden `shell_env_passthrough` (for example `PATH` or similarly sensitive ambient variables), increasing command-surface flexibility.
  - Mitigation: parser remains strict and only allows literal `$NAME`/`${NAME}` where `NAME` is explicitly allowlisted and syntactically valid; it still rejects `$(` command substitution, special/positional params (`$1`, `$?`, etc.), malformed/complex brace expressions (for example `${VAR:-fallback}`), and read-only autonomy still blocks all shell commands.
  - Risk: scanner edge cases in quoted contexts could accidentally over-allow.
  - Mitigation: regression tests now cover plain `$VAR`, `${VAR}`, and double-quoted `${VAR}` allow/deny boundaries.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: test values use synthetic placeholders (`ZEROCLAW_TEST_TOKEN`) and no real secrets.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No` (uses existing `autonomy.shell_env_passthrough`)
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: allowlisted token expansion works in policy and shell execution paths.
- Edge cases checked: double-quoted `${VAR}` path, non-allowlisted `${HOME}`, complex `${VAR:-fallback}`, special parameter `$1`.
- What was not verified: end-to-end `http_request` interpolation behavior is out of scope for this issue.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `src/security/policy.rs` shell command validation path; `src/tools/shell.rs` env passthrough filtering.
- Potential unintended effects: misconfigured passthrough list could permit more variable expansion than intended.
- Guardrails/monitoring for early detection: strict parser + policy tests + CI required gates + CodeQL/security workflows.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local codex CLI + targeted cargo tests.
- Workflow/plan summary (if any): reproduced policy behavior, applied minimal review-driven deltas, validated with focused regressions.
- Verification focus: parser allow/deny boundaries and shell execution behavior.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `fc9de000` on branch `issue-1857-env-var-access`.
- Feature flags or config toggles (if any): immediate operational rollback is to set `autonomy.shell_env_passthrough = []` (or remove key) to restore blanket effective blocking of variable expansions.
- Observable failure symptoms: if regression occurs, commands using allowlisted `$VAR`/`${VAR}` fail again with policy rejection; or unexpected allowance would appear in policy tests/CI.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: allowlist misconfiguration widens variable expansion surface.
  - Mitigation: explicit allowlist requirement, strict variable-name validation, blocked complex/special expansion forms.
- Risk: parser logic drift between shell and policy modules.
  - Mitigation: shared `is_valid_env_var_name` utility and targeted coverage across both modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened shell command security: only explicitly allowlisted, valid environment variables ($NAME or ${NAME}) are expanded; complex or disallowed forms are rejected.
  * Improved handling of quoting and escaping to prevent accidental/unexpected expansions.

* **Tests**
  * Added tests verifying allowed passthrough expansions and rejection of non-passthrough/complex expansions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->