### PR TITLE
fix(web): improve web access diagnostics and operator guidance

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -455,12 +455,52 @@ Notes:
 | `allowed_domains` | `[]` | Allowed domains for HTTP requests (exact/subdomain match, or `"*"` for all public domains) |
 | `max_response_size` | `1000000` | Maximum response size in bytes (default: 1 MB) |
 | `timeout_secs` | `30` | Request timeout in seconds |
+| `user_agent` | `ZeroClaw/1.0` | User-Agent header for outbound HTTP requests |
 
 Notes:
 
 - Deny-by-default: if `allowed_domains` is empty, all HTTP requests are rejected.
 - Use exact domain or subdomain matching (e.g. `"api.example.com"`, `"example.com"`), or `"*"` to allow any public domain.
 - Local/private targets are still blocked even when `"*"` is configured.
+- Shell `curl`/`wget` are classified as high-risk and may be blocked by autonomy policy. Prefer `http_request` for direct HTTP calls.
+
+## `[web_fetch]`
+
+| Key | Default | Purpose |
+|---|---|---|
+| `enabled` | `false` | Enable `web_fetch` for page-to-text extraction |
+| `provider` | `fast_html2md` | Fetch/render backend: `fast_html2md`, `nanohtml2text`, `firecrawl` |
+| `api_key` | unset | API key for provider backends that require it (e.g. `firecrawl`) |
+| `api_url` | unset | Optional API URL override (self-hosted/alternate endpoint) |
+| `allowed_domains` | `["*"]` | Domain allowlist (`"*"` allows all public domains) |
+| `blocked_domains` | `[]` | Denylist applied before allowlist |
+| `max_response_size` | `500000` | Maximum returned payload size in bytes |
+| `timeout_secs` | `30` | Request timeout in seconds |
+| `user_agent` | `ZeroClaw/1.0` | User-Agent header for fetch requests |
+
+Notes:
+
+- `web_fetch` is optimized for summarization/data extraction from web pages.
+- Redirect targets are revalidated against allow/deny domain policy.
+- Local/private network targets remain blocked even when `allowed_domains = ["*"]`.
+
+## `[web_search]`
+
+| Key | Default | Purpose |
+|---|---|---|
+| `enabled` | `false` | Enable `web_search_tool` |
+| `provider` | `duckduckgo` | Search backend: `duckduckgo`, `brave`, `firecrawl` |
+| `api_key` | unset | Generic provider key (used by `firecrawl`, fallback for `brave`) |
+| `api_url` | unset | Optional API URL override |
+| `brave_api_key` | unset | Dedicated Brave key (required for `provider = "brave"` unless `api_key` is set) |
+| `max_results` | `5` | Maximum search results returned (clamped to 1-10) |
+| `timeout_secs` | `15` | Request timeout in seconds |
+| `user_agent` | `ZeroClaw/1.0` | User-Agent header for search requests |
+
+Notes:
+
+- If DuckDuckGo returns `403`/`429` in your network, switch provider to `brave` or `firecrawl`.
+- `web_search` finds candidate URLs; pair it with `web_fetch` for page content extraction.
 
 ## `[gateway]`
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -192,6 +192,97 @@ zeroclaw channel doctor
 
 Then verify channel-specific credentials + allowlist fields in config.
 
+## Web Access Issues
+
+### `curl`/`wget` blocked in shell tool
+
+Symptom:
+
+- tool output includes `Command blocked: high-risk command is disallowed by policy`
+- model says `curl`/`wget` is blocked
+
+Why this happens:
+
+- `curl`/`wget` are high-risk shell commands and may be blocked by autonomy policy.
+
+Preferred fix:
+
+- use purpose-built tools instead of shell fetch:
+  - `http_request` for direct API/HTTP calls
+  - `web_fetch` for page content extraction/summarization
+
+Minimal config:
+
+```toml
+[http_request]
+enabled = true
+allowed_domains = ["*"]
+
+[web_fetch]
+enabled = true
+provider = "fast_html2md"
+allowed_domains = ["*"]
+```
+
+### `web_search_tool` fails with `403`/`429`
+
+Symptom:
+
+- tool output includes `DuckDuckGo search failed with status: 403` (or `429`)
+
+Why this happens:
+
+- some networks/proxies/rate limits block DuckDuckGo HTML search endpoint traffic.
+
+Fix options:
+
+1. Switch provider to Brave (recommended when you have an API key):
+
+```toml
+[web_search]
+enabled = true
+provider = "brave"
+brave_api_key = "<SECRET>"
+```
+
+2. Switch provider to Firecrawl (if enabled in your build):
+
+```toml
+[web_search]
+enabled = true
+provider = "firecrawl"
+api_key = "<SECRET>"
+```
+
+3. Keep DuckDuckGo for search, but use `web_fetch` to read pages once you have URLs.
+
+### `web_fetch`/`http_request` says host is not allowed
+
+Symptom:
+
+- errors like `Host '<domain>' is not in http_request.allowed_domains`
+- or `web_fetch tool is enabled but no allowed_domains are configured`
+
+Fix:
+
+- include exact domains or `"*"` for public internet access:
+
+```toml
+[http_request]
+enabled = true
+allowed_domains = ["*"]
+
+[web_fetch]
+enabled = true
+allowed_domains = ["*"]
+blocked_domains = []
+```
+
+Security notes:
+
+- local/private network targets are blocked even with `"*"`
+- keep explicit domain allowlists in production environments when possible
+
 ## Service Mode
 
 ### Service installed but not running

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -700,6 +700,13 @@ impl SecurityPolicy {
 
         if risk == CommandRiskLevel::High {
             if self.block_high_risk_commands {
+                let lower = command.to_ascii_lowercase();
+                if lower.contains("curl") || lower.contains("wget") {
+                    return Err(
+                        "Command blocked: high-risk command is disallowed by policy. Shell curl/wget are blocked; use `http_request` or `web_fetch` with configured allowed_domains."
+                            .into(),
+                    );
+                }
                 return Err("Command blocked: high-risk command is disallowed by policy".into());
             }
             if self.autonomy == AutonomyLevel::Supervised && !approved {


### PR DESCRIPTION
Closes #1769
Refs RMN-149

## Summary
- Problem: operators cannot reliably diagnose why web access/search is blocked, and failures look like opaque transport errors.
- Why it matters: users may assume the model fetched live data when it actually cannot access required domains/providers.
- What changed: improved web access diagnostics, added provider-specific guidance, and documented `[web_fetch]` / `[web_search]` configuration plus troubleshooting.

## Validation Evidence (required)
Commands and result summary:
```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

## Security Impact (required)
- New permissions/capabilities? (`Yes/No`): No
- Risk introduced: low (error messaging + docs only)
- Mitigation/control: existing policy gates and command restrictions unchanged

## Privacy and Data Hygiene (required)
- Data-hygiene status (`pass|needs-follow-up`): pass
- New data collection/storage: none
- Secret handling impact: none

## Rollback Plan (required)
- Fast rollback command/path: revert PR #1862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added web_fetch and web_search configuration blocks with customizable settings and domain controls.

* **Documentation**
  * Added Web Access Issues troubleshooting section with guidance on blocked commands and search failures.
  * Expanded configuration reference documentation.

* **Bug Fixes**
  * Enhanced error messages for blocked shell commands directing users to recommended alternatives.
  * Improved search tool error handling with provider-specific guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->