### PR TITLE
ci(review): require non-bot approval on pull requests

### DIFF
--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -274,6 +274,29 @@ jobs:
                     const script = require('./.github/workflows/scripts/ci_workflow_owner_approval.js');
                     await script({ github, context, core });
 
+    human-review-approval:
+        name: Human Review Approval
+        needs: [changes]
+        if: github.event_name == 'pull_request'
+        runs-on: [self-hosted, aws-india]
+        permissions:
+            contents: read
+            pull-requests: read
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              with:
+                  ref: ${{ github.event.pull_request.base.sha }}
+
+            - name: Require at least one human approving review
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  HUMAN_REVIEW_BOT_LOGINS: ${{ vars.HUMAN_REVIEW_BOT_LOGINS }}
+              with:
+                  script: |
+                    const script = require('./.github/workflows/scripts/ci_human_review_guard.js');
+                    await script({ github, context, core });
+
     license-file-owner-guard:
         name: License File Owner Guard
         needs: [changes]
@@ -295,7 +318,7 @@ jobs:
     ci-required:
         name: CI Required Gate
         if: always()
-        needs: [changes, lint, test, build, flake-probe, docs-only, non-rust, docs-quality, lint-feedback, workflow-owner-approval, license-file-owner-guard]
+        needs: [changes, lint, test, build, flake-probe, docs-only, non-rust, docs-quality, lint-feedback, workflow-owner-approval, human-review-approval, license-file-owner-guard]
         runs-on: [self-hosted, aws-india]
         steps:
             - name: Enforce required status
@@ -309,13 +332,19 @@ jobs:
                   workflow_changed="${{ needs.changes.outputs.workflow_changed }}"
                   docs_result="${{ needs.docs-quality.result }}"
                   workflow_owner_result="${{ needs.workflow-owner-approval.result }}"
+                  human_review_result="${{ needs.human-review-approval.result }}"
                   license_owner_result="${{ needs.license-file-owner-guard.result }}"
 
                   if [ "${{ needs.changes.outputs.docs_only }}" = "true" ]; then
                     echo "workflow_owner_approval=${workflow_owner_result}"
+                    echo "human_review_approval=${human_review_result}"
                     echo "license_file_owner_guard=${license_owner_result}"
                     if [ "$event_name" = "pull_request" ] && [ "$workflow_changed" = "true" ] && [ "$workflow_owner_result" != "success" ]; then
                       echo "Workflow files changed but workflow owner approval gate did not pass."
+                      exit 1
+                    fi
+                    if [ "$event_name" = "pull_request" ] && [ "$human_review_result" != "success" ]; then
+                      echo "Human review approval guard did not pass."
                       exit 1
                     fi
                     if [ "$event_name" = "pull_request" ] && [ "$license_owner_result" != "success" ]; then
@@ -333,9 +362,14 @@ jobs:
                   if [ "$rust_changed" != "true" ]; then
                     echo "rust_changed=false (non-rust fast path)"
                     echo "workflow_owner_approval=${workflow_owner_result}"
+                    echo "human_review_approval=${human_review_result}"
                     echo "license_file_owner_guard=${license_owner_result}"
                     if [ "$event_name" = "pull_request" ] && [ "$workflow_changed" = "true" ] && [ "$workflow_owner_result" != "success" ]; then
                       echo "Workflow files changed but workflow owner approval gate did not pass."
+                      exit 1
+                    fi
+                    if [ "$event_name" = "pull_request" ] && [ "$human_review_result" != "success" ]; then
+                      echo "Human review approval guard did not pass."
                       exit 1
                     fi
                     if [ "$event_name" = "pull_request" ] && [ "$license_owner_result" != "success" ]; then
@@ -363,10 +397,16 @@ jobs:
                   echo "flake_probe=${flake_result}"
                   echo "docs=${docs_result}"
                   echo "workflow_owner_approval=${workflow_owner_result}"
+                  echo "human_review_approval=${human_review_result}"
                   echo "license_file_owner_guard=${license_owner_result}"
 
                   if [ "$event_name" = "pull_request" ] && [ "$workflow_changed" = "true" ] && [ "$workflow_owner_result" != "success" ]; then
                     echo "Workflow files changed but workflow owner approval gate did not pass."
+                    exit 1
+                  fi
+
+                  if [ "$event_name" = "pull_request" ] && [ "$human_review_result" != "success" ]; then
+                    echo "Human review approval guard did not pass."
                     exit 1
                   fi
 

--- a/.github/workflows/scripts/ci_human_review_guard.js
+++ b/.github/workflows/scripts/ci_human_review_guard.js
@@ -1,0 +1,61 @@
+// Enforce at least one human approval on pull requests.
+// Used by .github/workflows/ci-run.yml via actions/github-script.
+
+module.exports = async ({ github, context, core }) => {
+  const owner = context.repo.owner;
+  const repo = context.repo.repo;
+  const prNumber = context.payload.pull_request?.number;
+  if (!prNumber) {
+    core.setFailed("Missing pull_request context.");
+    return;
+  }
+
+  const botAllowlist = new Set(
+    (process.env.HUMAN_REVIEW_BOT_LOGINS || "github-actions[bot],dependabot[bot],coderabbitai[bot]")
+      .split(",")
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+  const isBotAccount = (login, accountType) => {
+    if (!login) return false;
+    if ((accountType || "").toLowerCase() === "bot") return true;
+    if (login.endsWith("[bot]")) return true;
+    return botAllowlist.has(login);
+  };
+
+  const reviews = await github.paginate(github.rest.pulls.listReviews, {
+    owner,
+    repo,
+    pull_number: prNumber,
+    per_page: 100,
+  });
+
+  const latestReviewByUser = new Map();
+  const decisiveStates = new Set(["APPROVED", "CHANGES_REQUESTED", "DISMISSED"]);
+  for (const review of reviews) {
+    const login = review.user?.login?.toLowerCase();
+    if (!login) continue;
+    if (!decisiveStates.has(review.state)) continue;
+    latestReviewByUser.set(login, {
+      state: review.state,
+      type: review.user?.type || "",
+    });
+  }
+
+  const humanApprovers = [];
+  for (const [login, review] of latestReviewByUser.entries()) {
+    if (review.state !== "APPROVED") continue;
+    if (isBotAccount(login, review.type)) continue;
+    humanApprovers.push(login);
+  }
+
+  if (humanApprovers.length === 0) {
+    core.setFailed(
+      "No human approving review found. At least one non-bot approval is required before merge.",
+    );
+    return;
+  }
+
+  core.info(`Human approval check passed. Approver(s): ${humanApprovers.join(", ")}`);
+};


### PR DESCRIPTION
## Summary

- Problem: `#1792` requires merge-gating on at least one non-bot human approval.
- Change: add a dedicated `human-review-approval` job in `CI Run` and wire it into `CI Required Gate`.
- Hardening: checkout `github.event.pull_request.base.sha` before loading guard logic, so policy code is evaluated from base branch content.
- Guard logic: ignore non-decisive review states (`COMMENTED`/`PENDING`) when computing latest reviewer decision.

## Change Scope

- `.github/workflows/ci-run.yml`
- `.github/workflows/scripts/ci_human_review_guard.js`

## Linked Issue

- Closes #1792
- Linear: RMN-148

## Validation

```bash
node -e "require('./.github/workflows/scripts/ci_human_review_guard.js'); console.log('ok')"
git diff --check
```

## Security / Compatibility

- New permissions/capabilities: No
- New external network calls: No
- Secrets/tokens handling changed: No
- Backward compatibility: Yes
- Migration needed: No

## Rollback Plan

- Revert the merge commit that introduces this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added mandatory human approval requirement to pull request workflow. The CI/CD process now enforces that at least one human reviewer must approve changes before merge checks complete. Bot and automated accounts are excluded from satisfying this requirement to ensure genuine human oversight.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->