### PR TITLE
fix(discord): recover text attachments when content type is missing

### DIFF
--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -132,18 +132,50 @@ fn normalize_group_reply_allowed_sender_ids(sender_ids: Vec<String>) -> Vec<Stri
 /// Process Discord message attachments and return a string to append to the
 /// agent message context.
 ///
-/// Only `text/*` MIME types are fetched and inlined. All other types are
-/// silently skipped. Fetch errors are logged as warnings.
+/// `text/*` MIME types are fetched and inlined. If Discord omits `content_type`
+/// or reports `application/octet-stream`, text-like filenames are inferred via
+/// extension (for example `message.txt` for auto-converted long messages).
+/// Unsupported attachments are skipped with warning-level logs.
+const DISCORD_TEXT_ATTACHMENT_EXTENSIONS: &[&str] = &[
+    "txt", "md", "json", "csv", "log", "py", "js", "ts", "rs", "toml", "yaml", "yml", "xml",
+    "html", "css", "sh",
+];
+
+fn is_text_like_discord_attachment(content_type: Option<&str>, filename: &str) -> bool {
+    let normalized_content_type = content_type
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_ascii_lowercase());
+
+    if let Some(content_type) = normalized_content_type.as_deref() {
+        if content_type.starts_with("text/") {
+            return true;
+        }
+        if content_type != "application/octet-stream" {
+            return false;
+        }
+    }
+
+    if filename.eq_ignore_ascii_case("message.txt") {
+        return true;
+    }
+
+    let Some(extension) = Path::new(filename).extension().and_then(|ext| ext.to_str()) else {
+        return false;
+    };
+
+    DISCORD_TEXT_ATTACHMENT_EXTENSIONS
+        .iter()
+        .any(|allowed| extension.eq_ignore_ascii_case(allowed))
+}
+
 async fn process_attachments(
     attachments: &[serde_json::Value],
     client: &reqwest::Client,
 ) -> String {
     let mut parts: Vec<String> = Vec::new();
     for att in attachments {
-        let ct = att
-            .get("content_type")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+        let ct = att.get("content_type").and_then(|v| v.as_str());
         let name = att
             .get("filename")
             .and_then(|v| v.as_str())
@@ -152,13 +184,16 @@ async fn process_attachments(
             tracing::warn!(name, "discord: attachment has no url, skipping");
             continue;
         };
-        if ct.starts_with("text/") {
+        if is_text_like_discord_attachment(ct, name) {
             match client.get(url).send().await {
-                Ok(resp) if resp.status().is_success() => {
-                    if let Ok(text) = resp.text().await {
+                Ok(resp) if resp.status().is_success() => match resp.text().await {
+                    Ok(text) => {
                         parts.push(format!("[{name}]\n{text}"));
                     }
-                }
+                    Err(error) => {
+                        tracing::warn!(name, error = %error, "discord attachment read error");
+                    }
+                },
                 Ok(resp) => {
                     tracing::warn!(name, status = %resp.status(), "discord attachment fetch failed");
                 }
@@ -167,9 +202,9 @@ async fn process_attachments(
                 }
             }
         } else {
-            tracing::debug!(
+            tracing::warn!(
                 name,
-                content_type = ct,
+                content_type = ct.unwrap_or(""),
                 "discord: skipping unsupported attachment type"
             );
         }
@@ -984,6 +1019,8 @@ impl Channel for DiscordChannel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn discord_channel_name() {
@@ -1556,6 +1593,65 @@ mod tests {
         })];
         let result = process_attachments(&attachments, &client).await;
         assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn process_attachments_infers_text_when_content_type_missing() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/message.txt"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("hello from discord"))
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let attachments = vec![serde_json::json!({
+            "url": format!("{}/message.txt", mock_server.uri()),
+            "filename": "message.txt"
+        })];
+
+        let result = process_attachments(&attachments, &client).await;
+        assert!(result.contains("[message.txt]"));
+        assert!(result.contains("hello from discord"));
+    }
+
+    #[tokio::test]
+    async fn process_attachments_infers_text_for_octet_stream_txt_extension() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/notes.TXT"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("line one\nline two"))
+            .mount(&mock_server)
+            .await;
+
+        let client = reqwest::Client::new();
+        let attachments = vec![serde_json::json!({
+            "url": format!("{}/notes.TXT", mock_server.uri()),
+            "filename": "notes.TXT",
+            "content_type": "application/octet-stream"
+        })];
+
+        let result = process_attachments(&attachments, &client).await;
+        assert!(result.contains("[notes.TXT]"));
+        assert!(result.contains("line one"));
+    }
+
+    #[test]
+    fn text_like_discord_attachment_detection_respects_mime_and_filename_fallback() {
+        assert!(is_text_like_discord_attachment(
+            Some("text/plain"),
+            "report.bin"
+        ));
+        assert!(is_text_like_discord_attachment(None, "message.txt"));
+        assert!(is_text_like_discord_attachment(
+            Some("application/octet-stream"),
+            "trace.log"
+        ));
+        assert!(!is_text_like_discord_attachment(
+            Some("application/pdf"),
+            "notes.txt"
+        ));
+        assert!(!is_text_like_discord_attachment(None, "image.png"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): `dev`
- Problem: Discord inbound `.txt` attachments were intermittently dropped when `content_type` was missing or `application/octet-stream`.
- Why it matters: long messages auto-converted by Discord (for example `message.txt`) were silently lost, breaking conversation continuity.
- What changed: added MIME+filename fallback classification for text-like attachments, special-cased `message.txt`, raised unsupported attachment skip logs to warn, and added focused regression tests.
- What did **not** change (scope boundary): no changes to outbound attachment upload flow or non-text attachment parsing behavior.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto-managed
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `channel: discord`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #1864
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)
- Linear issue key(s) (required, e.g. `RMN-123`): `RMN-149`
- Linear issue URL(s): https://linear.app/zeroclawlabs/issue/RMN-149/bug-fix-discord-txt-attachment-fallback-when-content-type-is-missing

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo test process_attachments_ -- --nocapture
cargo test text_like_discord_attachment_detection_respects_mime_and_filename_fallback -- --nocapture
cargo fmt --all -- --check
```

- Evidence provided (test/log/trace/screenshot/perf): targeted unit/integration-style attachment tests + formatting check.
- If any command is intentionally skipped, explain why: full `cargo clippy --all-targets -- -D warnings` and full `cargo test` are deferred to CI because the delta is scoped to Discord attachment handling.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No` (reuses existing attachment fetch path)
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: synthetic fixture content only.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: missing `content_type` + `message.txt` now inlines content; octet-stream with `.txt` extension inlines content.
- Edge cases checked: unsupported MIME stays skipped; filename extension matching is case-insensitive.
- What was not verified: live Discord end-to-end against production API (covered by parser/attachment tests only in this change).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Discord inbound attachment processing.
- Potential unintended effects: additional warning logs for unsupported attachments may increase log volume.
- Guardrails/monitoring for early detection: explicit warn context includes filename/content_type for quick triage.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local codex CLI + targeted cargo tests.
- Workflow/plan summary (if any): implemented fallback classifier, strengthened diagnostics, added focused tests.
- Verification focus: MIME fallback correctness + non-regression on unsupported file types.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `$(git -C /Users/argenisdelarosa/Developer/zeroclaw-issue-1864 rev-parse --short HEAD)` on branch `issue-1864-discord-txt-attachment-fallback`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: if rollback is needed, text attachments with missing/octet-stream MIME will resume being dropped.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: unsupported non-text files may now generate more warning logs.
  - Mitigation: warnings are intentionally scoped with attachment metadata and represent actionable operator diagnostics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord text attachments are now automatically recognized using filename extensions when content type information is unavailable or generic.

* **Bug Fixes**
  * Enhanced error handling for attachment processing with improved diagnostic logging for unsupported files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->