### PR TITLE
fix(slack): honor Retry-After for conversations.history rate limits

### DIFF
--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -298,7 +298,7 @@ impl SlackChannel {
         }
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.subsec_nanos() as u64)
+            .map(|d| u64::from(d.subsec_nanos()))
             .unwrap_or(0);
         nanos % (max_jitter_ms + 1)
     }


### PR DESCRIPTION
## Summary
- add `conversations.history` retry handling for Slack 429 and `ratelimited` responses
- parse `Retry-After`, apply exponential backoff (capped) plus bounded jitter, and emit structured retry/exhaustion logs
- add focused unit tests for retry-after parsing and delay computation

## Validation
- `cargo fmt --all`
- `cargo test channels::slack::tests:: -- --nocapture`

Refs #1839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented robust retry mechanism for Slack message history requests, automatically handling rate limit responses with exponential backoff strategy to ensure more reliable message synchronization during peak usage periods.
  * Enhanced error handling and logging for improved visibility and debugging of Slack API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->