### PR TITLE
feat(security): enable TOTP by default with quick setup opt-out

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4135,8 +4135,8 @@ pub enum OtpMethod {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct OtpConfig {
-    /// Enable OTP gating. Defaults to disabled for backward compatibility.
-    #[serde(default)]
+    /// Enable OTP gating. Defaults to enabled.
+    #[serde(default = "default_otp_enabled")]
     pub enabled: bool,
 
     /// OTP method.
@@ -4164,6 +4164,10 @@ pub struct OtpConfig {
     pub gated_domain_categories: Vec<String>,
 }
 
+fn default_otp_enabled() -> bool {
+    true
+}
+
 fn default_otp_token_ttl_secs() -> u64 {
     30
 }
@@ -4185,7 +4189,7 @@ fn default_otp_gated_actions() -> Vec<String> {
 impl Default for OtpConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: default_otp_enabled(),
             method: OtpMethod::Totp,
             token_ttl_secs: default_otp_token_ttl_secs(),
             cache_valid_secs: default_otp_cache_valid_secs(),
@@ -9895,7 +9899,7 @@ default_temperature = 0.7
         )
         .unwrap();
 
-        assert!(!parsed.security.otp.enabled);
+        assert!(parsed.security.otp.enabled);
         assert_eq!(parsed.security.otp.method, OtpMethod::Totp);
         assert!(!parsed.security.estop.enabled);
         assert!(parsed.security.estop.require_otp_to_resume);

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,10 @@ enum Commands {
         /// Memory backend (sqlite, lucid, markdown, none) - used in quick mode, default: sqlite
         #[arg(long)]
         memory: Option<String>,
+
+        /// Disable OTP in quick setup (not recommended)
+        #[arg(long)]
+        no_totp: bool,
     },
 
     /// Start the AI agent loop
@@ -735,6 +739,7 @@ async fn main() -> Result<()> {
         provider,
         model,
         memory,
+        no_totp,
     } = &cli.command
     {
         let interactive = *interactive;
@@ -744,14 +749,21 @@ async fn main() -> Result<()> {
         let provider = provider.clone();
         let model = model.clone();
         let memory = memory.clone();
+        let no_totp = *no_totp;
 
         if interactive && channels_only {
             bail!("Use either --interactive or --channels-only, not both");
         }
         if channels_only
-            && (api_key.is_some() || provider.is_some() || model.is_some() || memory.is_some())
+            && (api_key.is_some()
+                || provider.is_some()
+                || model.is_some()
+                || memory.is_some()
+                || no_totp)
         {
-            bail!("--channels-only does not accept --api-key, --provider, --model, or --memory");
+            bail!(
+                "--channels-only does not accept --api-key, --provider, --model, --memory, or --no-totp"
+            );
         }
         if channels_only && force {
             bail!("--channels-only does not accept --force");
@@ -767,6 +779,7 @@ async fn main() -> Result<()> {
                 model.as_deref(),
                 memory.as_deref(),
                 force,
+                no_totp,
             )
             .await
         }?;
@@ -1992,6 +2005,17 @@ mod tests {
 
         match cli.command {
             Commands::Onboard { force, .. } => assert!(force),
+            other => panic!("expected onboard command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn onboard_cli_accepts_no_totp_flag() {
+        let cli = Cli::try_parse_from(["zeroclaw", "onboard", "--no-totp"])
+            .expect("onboard --no-totp should parse");
+
+        match cli.command {
+            Commands::Onboard { no_totp, .. } => assert!(no_totp),
             other => panic!("expected onboard command, got {other:?}"),
         }
     }

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -411,6 +411,7 @@ pub async fn run_quick_setup(
     model_override: Option<&str>,
     memory_backend: Option<&str>,
     force: bool,
+    no_totp: bool,
 ) -> Result<Config> {
     let home = directories::UserDirs::new()
         .map(|u| u.home_dir().to_path_buf())
@@ -422,6 +423,7 @@ pub async fn run_quick_setup(
         model_override,
         memory_backend,
         force,
+        no_totp,
         &home,
     )
     .await
@@ -456,6 +458,7 @@ async fn run_quick_setup_with_home(
     model_override: Option<&str>,
     memory_backend: Option<&str>,
     force: bool,
+    no_totp: bool,
     home: &Path,
 ) -> Result<Config> {
     println!("{}", style(BANNER).cyan().bold());
@@ -486,7 +489,7 @@ async fn run_quick_setup_with_home(
     // Create memory config based on backend choice
     let memory_config = memory_config_defaults_for_backend(&memory_backend_name);
 
-    let config = Config {
+    let mut config = Config {
         workspace_dir: workspace_dir.clone(),
         config_path: config_path.clone(),
         api_key: credential_override.map(|c| {
@@ -540,6 +543,9 @@ async fn run_quick_setup_with_home(
         agents_ipc: crate::config::AgentsIpcConfig::default(),
         model_support_vision: None,
     };
+    if no_totp {
+        config.security.otp.enabled = false;
+    }
 
     config.save().await?;
     persist_workspace_selection(&config.config_path).await?;
@@ -582,7 +588,11 @@ async fn run_quick_setup_with_home(
     println!(
         "  {} Security:   {}",
         style("✓").green().bold(),
-        style("Supervised (workspace-scoped)").green()
+        if no_totp {
+            style("Supervised (workspace-scoped), TOTP disabled (--no-totp)").yellow()
+        } else {
+            style("Supervised (workspace-scoped), TOTP enabled").green()
+        }
     );
     println!(
         "  {} Memory:     {} (auto-save: {})",
@@ -620,6 +630,16 @@ async fn run_quick_setup_with_home(
         style("Config saved:").white().bold(),
         style(config_path.display()).green()
     );
+    if no_totp {
+        println!(
+            "  {} {}",
+            style("⚠").yellow().bold(),
+            style(
+                "TOTP is disabled by operator choice. This reduces protection for sensitive actions."
+            )
+            .yellow()
+        );
+    }
     println!();
     println!("  {}", style("Next steps:").white().bold());
     if credential_override.is_none() {
@@ -6009,6 +6029,7 @@ mod tests {
         model_override: Option<&str>,
         memory_backend: Option<&str>,
         force: bool,
+        no_totp: bool,
         home: &Path,
     ) -> Result<Config> {
         let _env_guard = env_lock().lock().await;
@@ -6021,6 +6042,7 @@ mod tests {
             model_override,
             memory_backend,
             force,
+            no_totp,
             home,
         )
         .await
@@ -6098,6 +6120,7 @@ mod tests {
             Some("custom-model-946"),
             Some("sqlite"),
             false,
+            false,
             tmp.path(),
         )
         .await
@@ -6122,6 +6145,7 @@ mod tests {
             None,
             Some("sqlite"),
             false,
+            false,
             tmp.path(),
         )
         .await
@@ -6130,6 +6154,44 @@ mod tests {
         let expected = default_model_for_provider("anthropic");
         assert_eq!(config.default_provider.as_deref(), Some("anthropic"));
         assert_eq!(config.default_model.as_deref(), Some(expected.as_str()));
+    }
+
+    #[tokio::test]
+    async fn quick_setup_enables_totp_by_default() {
+        let tmp = TempDir::new().unwrap();
+
+        let config = run_quick_setup_with_clean_env(
+            Some("sk-totp-default"),
+            Some("openrouter"),
+            None,
+            Some("sqlite"),
+            false,
+            false,
+            tmp.path(),
+        )
+        .await
+        .expect("quick setup should succeed");
+
+        assert!(config.security.otp.enabled);
+    }
+
+    #[tokio::test]
+    async fn quick_setup_no_totp_disables_totp() {
+        let tmp = TempDir::new().unwrap();
+
+        let config = run_quick_setup_with_clean_env(
+            Some("sk-no-totp"),
+            Some("openrouter"),
+            None,
+            Some("sqlite"),
+            false,
+            true,
+            tmp.path(),
+        )
+        .await
+        .expect("quick setup should succeed with --no-totp behavior");
+
+        assert!(!config.security.otp.enabled);
     }
 
     #[tokio::test]
@@ -6148,6 +6210,7 @@ mod tests {
             Some("openrouter"),
             Some("custom-model"),
             Some("sqlite"),
+            false,
             false,
             tmp.path(),
         )
@@ -6179,6 +6242,7 @@ mod tests {
             Some("custom-model-fresh"),
             Some("sqlite"),
             true,
+            false,
             tmp.path(),
         )
         .await
@@ -6212,6 +6276,7 @@ mod tests {
             Some("openrouter"),
             Some("model-env"),
             Some("sqlite"),
+            false,
             false,
             tmp.path(),
         )


### PR DESCRIPTION
## Summary
- switch `security.otp.enabled` default to `true` in schema/runtime defaults
- add `zeroclaw onboard --no-totp` for explicit quick-setup opt-out
- wire CLI parsing + quick-setup behavior + tests for default enabled vs explicit opt-out

## Validation
- `cargo fmt --all`
- `cargo test onboard_cli_accepts_no_totp_flag -- --nocapture`
- `cargo test quick_setup_enables_totp_by_default -- --nocapture`
- `cargo test quick_setup_no_totp_disables_totp -- --nocapture`
- `cargo test security_defaults_are_backward_compatible -- --nocapture`

Refs #1855