### PR TITLE
fix(cron): support qq/email announcement delivery

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -1,5 +1,6 @@
 use crate::channels::{
-    Channel, DiscordChannel, MattermostChannel, SendMessage, SlackChannel, TelegramChannel,
+    Channel, DiscordChannel, EmailChannel, MattermostChannel, QQChannel, SendMessage, SlackChannel,
+    TelegramChannel,
 };
 use crate::config::Config;
 use crate::cron::{
@@ -363,6 +364,28 @@ pub(crate) async fn deliver_announcement(
                 mm.thread_replies.unwrap_or(true),
                 mm.mention_only.unwrap_or(false),
             );
+            channel.send(&SendMessage::new(output, target)).await?;
+        }
+        "qq" => {
+            let qq = config
+                .channels_config
+                .qq
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("qq channel not configured"))?;
+            let channel = QQChannel::new(
+                qq.app_id.clone(),
+                qq.app_secret.clone(),
+                qq.allowed_users.clone(),
+            );
+            channel.send(&SendMessage::new(output, target)).await?;
+        }
+        "email" => {
+            let email = config
+                .channels_config
+                .email
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("email channel not configured"))?;
+            let channel = EmailChannel::new(email.clone());
             channel.send(&SendMessage::new(output, target)).await?;
         }
         other => anyhow::bail!("unsupported delivery channel: {other}"),

--- a/src/tools/cron_add.rs
+++ b/src/tools/cron_add.rs
@@ -56,7 +56,7 @@ impl Tool for CronAddTool {
     fn description(&self) -> &str {
         "Create a scheduled cron job (shell or agent) with cron/at/every schedules. \
          Use job_type='agent' with a prompt to run the AI agent on schedule. \
-         To deliver output to a channel (Discord, Telegram, Slack, Mattermost), set \
+         To deliver output to a channel (Discord, Telegram, Slack, Mattermost, QQ, Email), set \
          delivery={\"mode\":\"announce\",\"channel\":\"discord\",\"to\":\"<channel_id_or_chat_id>\"}. \
          This is the preferred tool for sending scheduled/delayed messages to users via channels."
     }
@@ -80,7 +80,7 @@ impl Tool for CronAddTool {
                     "description": "Delivery config to send job output to a channel. Example: {\"mode\":\"announce\",\"channel\":\"discord\",\"to\":\"<channel_id>\"}",
                     "properties": {
                         "mode": { "type": "string", "enum": ["none", "announce"], "description": "Set to 'announce' to deliver output to a channel" },
-                        "channel": { "type": "string", "enum": ["telegram", "discord", "slack", "mattermost"], "description": "Channel type to deliver to" },
+                        "channel": { "type": "string", "enum": ["telegram", "discord", "slack", "mattermost", "qq", "email"], "description": "Channel type to deliver to" },
                         "to": { "type": "string", "description": "Target: Discord channel ID, Telegram chat ID, Slack channel, etc." },
                         "best_effort": { "type": "boolean", "description": "If true, delivery failure does not fail the job" }
                     }


### PR DESCRIPTION
## Summary
- add qq and email delivery handling to cron announcement dispatch
- wire QQ and email constructors with existing config fields
- extend cron_add delivery schema/options to accept qq/email channels

## Validation
- cargo test -p zeroclaw cron::scheduler::tests::deliver_if_configured_handles_none_and_invalid_channel -- --nocapture
- cargo fmt --all -- --check

Closes #1868