### PR TITLE
[supersede #1515] feat(tools): add sub-agent orchestration (spawn, list, manage)

### DIFF
--- a/src/tools/subagent_manage.rs
+++ b/src/tools/subagent_manage.rs
@@ -104,12 +104,9 @@ impl SubAgentManageTool {
         // Status is a read operation — no security enforcement needed
         match self.registry.get_status(session_id) {
             Some(snap) => {
-                let duration_ms = snap.completed_at.map(|end| {
-                    (end - snap.started_at)
-                        .num_milliseconds()
-                        .max(0)
-                        .cast_unsigned()
-                });
+                let duration_ms = snap
+                    .completed_at
+                    .map(|end| (end - snap.started_at).num_milliseconds().max(0) as u64);
 
                 let mut output = json!({
                     "session_id": session_id,
@@ -128,7 +125,7 @@ impl SubAgentManageTool {
                     output["result"] = json!({
                         "success": r.success,
                         "output": if r.output.len() > 500 {
-                            format!("{}... (truncated)", &r.output[..500])
+                            { let trunc_idx = r.output.char_indices().nth(500).map(|(i, _)| i).unwrap_or(r.output.len()); format!("{}... (truncated)", &r.output[..trunc_idx]) }
                         } else {
                             r.output.clone()
                         },


### PR DESCRIPTION
Supersedes #1515 to recover from merge conflicts against latest `dev`.

- Source PR: https://github.com/zeroclaw-labs/zeroclaw/pull/1515
- Recovery mode: automated replay on top of current `dev`
- Merge policy: all CI checks green (except non-blocking `Enforce Dev -> Main Promotion`)

Original PR description:

## Summary

**Problem:** The existing `delegate` tool only supports synchronous sub-agent execution — it blocks the primary agent until the sub-agent completes. This prevents parallel workflows, long-running background tasks, and multi-agent orchestration.

**Why it matters:** Real-world agent workflows need background execution. A primary agent should be able to spawn research, coding, or analysis tasks and continue working while sub-agents run.

**What changed:** Added 3 new tools (`subagent_spawn`, `subagent_list`, `subagent_manage`) and a shared `SubAgentRegistry` for background sub-agent orchestration with full lifecycle management.

## New Tools

### `subagent_spawn`
Spawn a delegate agent in the background via `tokio::spawn`. Returns a `session_id` immediately.
- Respects existing `SecurityPolicy` (autonomy levels, rate limits)
- Enforces `DelegateAgentConfig` depth limits
- Configurable max concurrent sessions (default: 10)
- Uses `CancellationToken` for graceful cancellation

### `subagent_list`
List running/completed/failed/killed sessions with optional status filtering. Read-only.

### `subagent_manage`
Kill running sessions or query status with partial output.

## Validation Evidence

```bash
cargo test --lib tools::subagent
# test result: ok. 56 passed; 0 failed; 0 ignored

cargo check
# Finished dev profile — only pre-existing warnings

cargo clippy 2>&1 | grep subagent
# (no output — clean)
```

## Security Impact

**Risk: Low**
- All write ops (`spawn`, `kill`) enforce `ToolOperation::Act` via `SecurityPolicy`
- Read ops (`list`, `status`) enforce `ToolOperation::Observe`
- `ReadOnly` mode blocks spawn/kill, allows list/status
- Rate limiting enforced per-action
- Concurrent session limit (default: 10) prevents resource exhaustion
- Sub-agents inherit parent security policy and depth limits
- No new network exposure, no credential handling

## Privacy and Data Hygiene

- No PII stored beyond task description
- Sessions auto-cleanup after 1 hour
- No external network calls from registry
- No logging of task content at INFO level

## Rollback Plan

- All changes additive — removing 4 new files + reverting mod.rs/channels/mod.rs restores previous behavior
- No database migrations, no config schema changes
- Existing `delegate` tool completely untouched

## Test Coverage

56 tests across 4 modules: happy paths, error handling, security enforcement, concurrency, parameter validation, edge cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved duration calculation reliability for sub-agent execution times by eliminating potential conversion failures.

* **Chores**
  * Removed TaskPlanTool from available tools.
  * Simplified sub-agent orchestration by removing coordination and inter-process communication features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->