### PR TITLE
fix(bootstrap): honor configured channel features from config

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -39,6 +39,7 @@ Options:
   --prefer-prebuilt          Try latest release binary first; fallback to source build on miss
   --prebuilt-only            Install only from latest release binary (no source build fallback)
   --force-source-build       Disable prebuilt flow and always build from source
+  --cargo-features <list>    Extra Cargo features for local source build/install (comma-separated)
   --onboard                  Run onboarding after install
   --interactive-onboard      Run interactive onboarding (implies --onboard)
   --api-key <key>            API key for non-interactive onboarding
@@ -78,6 +79,8 @@ Environment:
   ZEROCLAW_DOCKER_NETWORK    Docker network for ZeroClaw + sidecars (default: zeroclaw-bootstrap-net)
   ZEROCLAW_DOCKER_CARGO_FEATURES
                             Extra Cargo features for Docker builds (comma-separated)
+  ZEROCLAW_CARGO_FEATURES    Extra Cargo features for local source builds (comma-separated)
+  ZEROCLAW_CONFIG_PATH       Config path used for channel feature auto-detection (default: ~/.zeroclaw/config.toml)
   ZEROCLAW_DOCKER_DAEMON_NAME
                             Daemon container name for --docker-daemon (default: zeroclaw-daemon)
   ZEROCLAW_DOCKER_DAEMON_BIND_HOST
@@ -188,6 +191,71 @@ should_attempt_prebuilt_for_resources() {
   fi
 
   return 1
+}
+
+append_csv_feature() {
+  local csv="${1:-}"
+  local feature="${2:-}"
+  local normalized
+  local -a entries=()
+  local existing_feature
+
+  normalized="$(printf '%s' "$feature" | tr -d '[:space:]')"
+  if [[ -z "$normalized" ]]; then
+    echo "$csv"
+    return 0
+  fi
+
+  if [[ -n "$csv" ]]; then
+    IFS=',' read -r -a entries <<< "$csv"
+  fi
+  for existing_feature in "${entries[@]:-}"; do
+    if [[ "$(printf '%s' "$existing_feature" | tr -d '[:space:]')" == "$normalized" ]]; then
+      echo "$csv"
+      return 0
+    fi
+  done
+
+  if [[ -n "$csv" ]]; then
+    echo "$csv,$normalized"
+  else
+    echo "$normalized"
+  fi
+}
+
+merge_csv_features() {
+  local base="${1:-}"
+  local incoming="${2:-}"
+  local merged="$base"
+  local -a incoming_features=()
+  local feature
+
+  if [[ -n "$incoming" ]]; then
+    IFS=',' read -r -a incoming_features <<< "$incoming"
+  fi
+  for feature in "${incoming_features[@]:-}"; do
+    merged="$(append_csv_feature "$merged" "$feature")"
+  done
+  echo "$merged"
+}
+
+detect_config_channel_features() {
+  local config_path="${1:-}"
+  local features=""
+
+  if [[ -z "$config_path" || ! -f "$config_path" ]]; then
+    echo ""
+    return 0
+  fi
+
+  if grep -Eq '^[[:space:]]*\[channels_config\.(lark|feishu)\][[:space:]]*$' "$config_path"; then
+    features="$(append_csv_feature "$features" "channel-lark")"
+  fi
+  if grep -Eq '^[[:space:]]*\[channels_config\.matrix\][[:space:]]*$' "$config_path"; then
+    features="$(append_csv_feature "$features" "channel-matrix")"
+  fi
+
+  echo "$features"
 }
 
 install_prebuilt_binary() {
@@ -1241,6 +1309,9 @@ CONTAINER_CLI="${ZEROCLAW_CONTAINER_CLI:-docker}"
 API_KEY="${ZEROCLAW_API_KEY:-}"
 PROVIDER="${ZEROCLAW_PROVIDER:-openrouter}"
 MODEL="${ZEROCLAW_MODEL:-}"
+LOCAL_CARGO_FEATURES="${ZEROCLAW_CARGO_FEATURES:-}"
+LOCAL_CONFIG_PATH="${ZEROCLAW_CONFIG_PATH:-$HOME/.zeroclaw/config.toml}"
+AUTO_CONFIG_FEATURES=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -1299,6 +1370,14 @@ while [[ $# -gt 0 ]]; do
     --force-source-build)
       FORCE_SOURCE_BUILD=true
       shift
+      ;;
+    --cargo-features)
+      LOCAL_CARGO_FEATURES="${2:-}"
+      [[ -n "$LOCAL_CARGO_FEATURES" ]] || {
+        error "--cargo-features requires a comma-separated value"
+        exit 1
+      }
+      shift 2
       ;;
     --onboard)
       RUN_ONBOARD=true
@@ -1482,6 +1561,9 @@ if [[ "$PREBUILT_ONLY" == true ]]; then
 fi
 
 if [[ "$DOCKER_MODE" == true ]]; then
+  if [[ -n "$LOCAL_CARGO_FEATURES" ]]; then
+    warn "--cargo-features / ZEROCLAW_CARGO_FEATURES are ignored with --docker (use ZEROCLAW_DOCKER_CARGO_FEATURES)."
+  fi
   ensure_docker_ready
   if [[ "$RUN_ONBOARD" == false ]]; then
     if [[ -n "$DOCKER_CONFIG_FILE" || "$DOCKER_DAEMON_MODE" == true ]]; then
@@ -1527,6 +1609,19 @@ DONE
   exit 0
 fi
 
+AUTO_CONFIG_FEATURES="$(detect_config_channel_features "$LOCAL_CONFIG_PATH")"
+if [[ -n "$AUTO_CONFIG_FEATURES" ]]; then
+  info "Detected channel features in config ($LOCAL_CONFIG_PATH): $AUTO_CONFIG_FEATURES"
+  LOCAL_CARGO_FEATURES="$(merge_csv_features "$LOCAL_CARGO_FEATURES" "$AUTO_CONFIG_FEATURES")"
+  if [[ "$PREBUILT_ONLY" == true ]]; then
+    warn "prebuilt-only mode may omit configured channel features: $AUTO_CONFIG_FEATURES"
+  elif [[ "$FORCE_SOURCE_BUILD" == false ]]; then
+    info "Using source build to satisfy configured channel feature requirements."
+    FORCE_SOURCE_BUILD=true
+    PREFER_PREBUILT=false
+  fi
+fi
+
 if [[ "$FORCE_SOURCE_BUILD" == false ]]; then
   if [[ "$PREFER_PREBUILT" == false && "$PREBUILT_ONLY" == false ]]; then
     if should_attempt_prebuilt_for_resources "$WORK_DIR"; then
@@ -1562,14 +1657,24 @@ fi
 
 if [[ "$SKIP_BUILD" == false ]]; then
   info "Building release binary"
-  cargo build --release --locked
+  BUILD_CMD=(cargo build --release --locked)
+  if [[ -n "$LOCAL_CARGO_FEATURES" ]]; then
+    info "Applying local Cargo features for build: $LOCAL_CARGO_FEATURES"
+    BUILD_CMD+=(--features "$LOCAL_CARGO_FEATURES")
+  fi
+  "${BUILD_CMD[@]}"
 else
   info "Skipping build"
 fi
 
 if [[ "$SKIP_INSTALL" == false ]]; then
   info "Installing zeroclaw to cargo bin"
-  cargo install --path "$WORK_DIR" --force --locked
+  INSTALL_CMD=(cargo install --path "$WORK_DIR" --force --locked)
+  if [[ -n "$LOCAL_CARGO_FEATURES" ]]; then
+    info "Applying local Cargo features for install: $LOCAL_CARGO_FEATURES"
+    INSTALL_CMD+=(--features "$LOCAL_CARGO_FEATURES")
+  fi
+  "${INSTALL_CMD[@]}"
 else
   info "Skipping install"
 fi


### PR DESCRIPTION
## Summary

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): `dev`
- Problem: bootstrap installs can leave channel-enabled configs running binaries missing required channel features, with no automatic feature-aware source-build path.
- Why it matters: operators configuring Lark/Feishu or Matrix can hit runtime warnings and missing channel startup after a successful bootstrap.
- What changed: added local cargo feature controls, auto-detected channel features from config, and forced source-build fallback when configured channel features are required.
- What did **not** change (scope boundary): no runtime channel logic changes in Rust channel modules; Docker build feature handling remains unchanged.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S` (expected)
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `scripts,config`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `scripts: bootstrap`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: n/a

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #1764
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)
- Linear issue key(s) (required, e.g. `RMN-123`): `RMN-165`
- Linear issue URL(s): https://linear.app/zeroclawlabs/issue/RMN-165/bug-bootstrap-respects-configured-channel-build-features

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): n/a
- Integrated scope by source PR (what was materially carried forward): n/a
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): no superseded PR
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
bash -n scripts/bootstrap.sh
ZEROCLAW_CONFIG_PATH=/tmp/zc1764-config.toml bash scripts/bootstrap.sh --prefer-prebuilt --skip-build --skip-install
```

- Evidence provided (test/log/trace/screenshot/perf): shell validation output confirms parsing success and auto-detected channel features (`channel-lark,channel-matrix`) forcing source-build path.
- If any command is intentionally skipped, explain why: full `cargo` test/clippy suite intentionally skipped because this PR only changes installer shell logic, not Rust compilation units.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: n/a

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no user data persisted; only bootstrap option handling changed.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `Yes`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: optional new env/flag support only (`ZEROCLAW_CARGO_FEATURES`, `ZEROCLAW_CONFIG_PATH`, `--cargo-features`).

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `No`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N.A.`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N.A.`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: no docs/i18n content changed.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: config with `[channels_config.lark]` and `[channels_config.matrix]` causes automatic feature detection and source-build enforcement.
- Edge cases checked: empty feature CSV handling under `set -u`; Docker mode warns that local feature flags are ignored.
- What was not verified: full end-to-end install on live constrained host.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: bootstrap CLI argument parsing and local build/install command composition.
- Potential unintended effects: user-supplied malformed `--cargo-features` values could still produce cargo-level errors (expected behavior).
- Guardrails/monitoring for early detection: bootstrap logs now print chosen feature set and source-build override decision.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): CLI triage + patching + shell validation.
- Workflow/plan summary (if any): issue context triage, isolated worktree patch, syntax/dry-run validation, tracker sync.
- Verification focus: `set -euo pipefail` safety, feature merge correctness, prebuilt/source decision behavior.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert commit on `issue-1764-bootstrap-channel-features` branch or `git revert` after merge.
- Feature flags or config toggles (if any): unset `ZEROCLAW_CARGO_FEATURES` / `ZEROCLAW_CONFIG_PATH`; avoid `--cargo-features`.
- Observable failure symptoms: bootstrap may not auto-force source build for configured channels.

## Risks and Mitigations

- Risk: auto-detection scans only one config path and may miss nonstandard configs.
  - Mitigation: added `ZEROCLAW_CONFIG_PATH` override.
- Risk: feature CSV merge logic could break under empty inputs.
  - Mitigation: explicit empty-array handling validated with `set -u` dry-run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automatic configuration detection during the build process
  * Enhanced feature flag management to seamlessly merge user-defined and auto-detected settings
  * Better handling of build configuration based on configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->