### PR TITLE
ci: remove blacksmith dependencies from workflows

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,5 @@
 self-hosted-runner:
     labels:
-        - blacksmith-2vcpu-ubuntu-2404
+        - Linux
+        - X64
+        - racknerd

--- a/.github/workflows/ci-build-fast.yml
+++ b/.github/workflows/ci-build-fast.yml
@@ -22,7 +22,7 @@ env:
 jobs:
     changes:
         name: Detect Change Scope
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         outputs:
             rust_changed: ${{ steps.scope.outputs.rust_changed }}
             docs_only: ${{ steps.scope.outputs.docs_only }}
@@ -43,7 +43,7 @@ jobs:
         name: Build (Fast)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true' || needs.changes.outputs.workflow_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 25
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -52,7 +52,7 @@ jobs:
               with:
                   toolchain: 1.92.0
 
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
               with:
                   prefix-key: fast-build
                   cache-targets: true

--- a/.github/workflows/ci-canary-gate.yml
+++ b/.github/workflows/ci-canary-gate.yml
@@ -83,7 +83,7 @@ permissions:
 jobs:
     canary-plan:
         name: Canary Plan
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         outputs:
             mode: ${{ steps.inputs.outputs.mode }}
@@ -231,7 +231,7 @@ jobs:
         name: Canary Execute
         needs: [canary-plan]
         if: github.event_name == 'workflow_dispatch' && needs.canary-plan.outputs.mode == 'execute' && needs.canary-plan.outputs.ready_to_execute == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 10
         permissions:
             contents: write

--- a/.github/workflows/ci-change-audit.yml
+++ b/.github/workflows/ci-change-audit.yml
@@ -44,7 +44,7 @@ permissions:
 jobs:
     audit:
         name: CI Change Audit
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 15
         steps:
             - name: Checkout

--- a/.github/workflows/ci-connectivity-probes.yml
+++ b/.github/workflows/ci-connectivity-probes.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
     probes:
         name: Provider Connectivity Probes
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/ci-provider-connectivity.yml
+++ b/.github/workflows/ci-provider-connectivity.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
     probe:
         name: Provider Connectivity Probe
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - name: Checkout

--- a/.github/workflows/ci-reproducible-build.yml
+++ b/.github/workflows/ci-reproducible-build.yml
@@ -47,7 +47,7 @@ env:
 jobs:
     reproducibility:
         name: Reproducible Build Probe
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 45
         steps:
             - name: Checkout

--- a/.github/workflows/ci-rollback.yml
+++ b/.github/workflows/ci-rollback.yml
@@ -58,7 +58,7 @@ permissions:
 jobs:
     rollback-plan:
         name: Rollback Guard Plan
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         outputs:
             branch: ${{ steps.plan.outputs.branch }}
@@ -182,7 +182,7 @@ jobs:
         name: Rollback Execute Actions
         needs: [rollback-plan]
         if: github.event_name == 'workflow_dispatch' && needs.rollback-plan.outputs.mode == 'execute' && needs.rollback-plan.outputs.ready_to_execute == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 15
         permissions:
             contents: write

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -21,7 +21,7 @@ env:
 jobs:
     changes:
         name: Detect Change Scope
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         outputs:
             docs_only: ${{ steps.scope.outputs.docs_only }}
             docs_changed: ${{ steps.scope.outputs.docs_changed }}
@@ -46,7 +46,7 @@ jobs:
         name: Lint Gate (Format + Clippy + Strict Delta)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 25
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -56,7 +56,7 @@ jobs:
               with:
                   toolchain: 1.92.0
                   components: rustfmt, clippy
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
               with:
                   prefix-key: ci-run-lint
             - name: Run rust quality gate
@@ -70,14 +70,14 @@ jobs:
         name: Test
         needs: [changes, lint]
         if: needs.changes.outputs.rust_changed == 'true' && needs.lint.result == 'success'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
               with:
                   toolchain: 1.92.0
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
               with:
                   prefix-key: ci-run-test
             - name: Run tests
@@ -87,7 +87,7 @@ jobs:
         name: Build (Smoke)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
 
         steps:
@@ -95,7 +95,7 @@ jobs:
             - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
               with:
                   toolchain: 1.92.0
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
               with:
                   prefix-key: ci-run-build
                   cache-targets: true
@@ -108,14 +108,14 @@ jobs:
         name: Test Flake Retry Probe
         needs: [changes, lint, test]
         if: always() && needs.changes.outputs.rust_changed == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:full'))
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 25
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
               with:
                   toolchain: 1.92.0
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
               with:
                   prefix-key: ci-run-flake-probe
             - name: Probe flaky failure via single retry
@@ -155,7 +155,7 @@ jobs:
         name: Docs-Only Fast Path
         needs: [changes]
         if: needs.changes.outputs.docs_only == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - name: Skip heavy jobs for docs-only change
               run: echo "Docs-only change detected. Rust lint/test/build skipped."
@@ -164,7 +164,7 @@ jobs:
         name: Non-Rust Fast Path
         needs: [changes]
         if: needs.changes.outputs.docs_only != 'true' && needs.changes.outputs.rust_changed != 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - name: Skip Rust jobs for non-Rust change scope
               run: echo "No Rust-impacting files changed. Rust lint/test/build skipped."
@@ -173,7 +173,7 @@ jobs:
         name: Docs Quality
         needs: [changes]
         if: needs.changes.outputs.docs_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -228,7 +228,7 @@ jobs:
         name: Lint Feedback
         if: github.event_name == 'pull_request'
         needs: [changes, lint, docs-quality]
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         permissions:
             contents: read
             pull-requests: write
@@ -254,7 +254,7 @@ jobs:
         name: Workflow Owner Approval
         needs: [changes]
         if: github.event_name == 'pull_request' && needs.changes.outputs.workflow_changed == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         permissions:
             contents: read
             pull-requests: read
@@ -275,7 +275,7 @@ jobs:
         name: License File Owner Guard
         needs: [changes]
         if: github.event_name == 'pull_request'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         permissions:
             contents: read
             pull-requests: read
@@ -293,7 +293,7 @@ jobs:
         name: CI Required Gate
         if: always()
         needs: [changes, lint, test, build, flake-probe, docs-only, non-rust, docs-quality, lint-feedback, workflow-owner-approval, license-file-owner-guard]
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - name: Enforce required status
               shell: bash

--- a/.github/workflows/ci-supply-chain-provenance.yml
+++ b/.github/workflows/ci-supply-chain-provenance.yml
@@ -28,7 +28,7 @@ env:
 jobs:
     provenance:
         name: Build + Provenance Bundle
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 35
         steps:
             - name: Checkout

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -50,7 +50,7 @@ permissions:
 jobs:
     docs-quality:
         name: Docs Quality Gate
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         outputs:
             docs_files: ${{ steps.scope.outputs.docs_files }}
@@ -197,7 +197,7 @@ jobs:
         name: Docs Preview Artifact
         needs: [docs-quality]
         if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'preview')
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -296,7 +296,7 @@ jobs:
         name: Deploy Docs to GitHub Pages
         needs: [docs-quality]
         if: needs.docs-quality.outputs.deploy_target == 'production' && needs.docs-quality.outputs.ready_to_deploy == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         permissions:
             contents: read

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -57,7 +57,7 @@ env:
 jobs:
     resolve-profile:
         name: Resolve Matrix Profile
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         outputs:
             profile: ${{ steps.resolve.outputs.profile }}
             lane_job_prefix: ${{ steps.resolve.outputs.lane_job_prefix }}
@@ -129,7 +129,7 @@ jobs:
     feature-check:
         name: ${{ needs.resolve-profile.outputs.lane_job_prefix }} (${{ matrix.name }})
         needs: [resolve-profile]
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: ${{ fromJSON(needs.resolve-profile.outputs.lane_timeout_minutes) }}
         strategy:
             fail-fast: false
@@ -160,7 +160,7 @@ jobs:
               with:
                   toolchain: 1.92.0
 
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
               with:
                   prefix-key: feature-matrix-${{ matrix.name }}
 
@@ -262,7 +262,7 @@ jobs:
         name: ${{ needs.resolve-profile.outputs.summary_job_name }}
         needs: [resolve-profile, feature-check]
         if: always()
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/main-promotion-gate.yml
+++ b/.github/workflows/main-promotion-gate.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
     enforce-dev-promotion:
         name: Enforce Dev -> Main Promotion
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - name: Validate PR source branch
               shell: bash

--- a/.github/workflows/nightly-all-features.yml
+++ b/.github/workflows/nightly-all-features.yml
@@ -24,7 +24,7 @@ env:
 jobs:
     nightly-lanes:
         name: Nightly Lane (${{ matrix.name }})
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 70
         strategy:
             fail-fast: false
@@ -51,7 +51,7 @@ jobs:
               with:
                   toolchain: 1.92.0
 
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
               with:
                   prefix-key: nightly-all-features-${{ matrix.name }}
 
@@ -114,7 +114,7 @@ jobs:
         name: Nightly Summary & Routing
         needs: [nightly-lanes]
         if: always()
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/pr-auto-response.yml
+++ b/.github/workflows/pr-auto-response.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'labeled' || github.event.action == 'unlabeled')) ||
       (github.event_name == 'pull_request_target' &&
       (github.event.action == 'labeled' || github.event.action == 'unlabeled'))
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       contents: read
       issues: write
@@ -38,7 +38,7 @@ jobs:
             await script({ github, context, core });
   first-interaction:
     if: github.event.action == 'opened'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       issues: write
       pull-requests: write
@@ -69,7 +69,7 @@ jobs:
 
   labeled-routes:
     if: github.event.action == 'labeled'
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/pr-check-stale.yml
+++ b/.github/workflows/pr-check-stale.yml
@@ -12,7 +12,7 @@ jobs:
         permissions:
             issues: write
             pull-requests: write
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - name: Mark stale issues and pull requests
               uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0

--- a/.github/workflows/pr-check-status.yml
+++ b/.github/workflows/pr-check-status.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   nudge-stale-prs:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: [self-hosted, Linux, X64]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-intake-checks.yml
+++ b/.github/workflows/pr-intake-checks.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
     intake:
         name: Intake Checks
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 10
         steps:
             - name: Checkout repository

--- a/.github/workflows/pr-label-policy-check.yml
+++ b/.github/workflows/pr-label-policy-check.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
     contributor-tier-consistency:
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 10
         steps:
             - name: Checkout

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
     label:
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - name: Checkout repository
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/pub-docker-img.yml
+++ b/.github/workflows/pub-docker-img.yml
@@ -30,7 +30,7 @@ jobs:
     pr-smoke:
         name: PR Docker Smoke
         if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 25
         permissions:
             contents: read
@@ -38,8 +38,8 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-            - name: Setup Blacksmith Builder
-              uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
+            - name: Setup Buildx Builder
+              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v1
 
             - name: Extract metadata (tags, labels)
               if: github.event_name == 'pull_request'
@@ -51,7 +51,7 @@ jobs:
                       type=ref,event=pr
 
             - name: Build smoke image
-              uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v2
               with:
                   context: .
                   push: false
@@ -70,7 +70,7 @@ jobs:
     publish:
         name: Build and Push Docker Image
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'zeroclaw-labs/zeroclaw'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 45
         environment:
             name: release
@@ -82,8 +82,8 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-            - name: Setup Blacksmith Builder
-              uses: useblacksmith/setup-docker-builder@ef12d5b165b596e3aa44ea8198d8fde563eab402 # v1
+            - name: Setup Buildx Builder
+              uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v1
 
             - name: Log in to Container Registry
               uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -119,7 +119,7 @@ jobs:
                   } >> "$GITHUB_OUTPUT"
 
             - name: Build and push Docker image
-              uses: useblacksmith/build-push-action@30c71162f16ea2c27c3e21523255d209b8b538c1 # v2
+              uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v2
               with:
                   context: .
                   push: true

--- a/.github/workflows/pub-prerelease.yml
+++ b/.github/workflows/pub-prerelease.yml
@@ -40,7 +40,7 @@ env:
 jobs:
     prerelease-guard:
         name: Pre-release Guard
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         outputs:
             release_tag: ${{ steps.vars.outputs.release_tag }}
@@ -172,7 +172,7 @@ jobs:
     build-prerelease:
         name: Build Pre-release Artifact
         needs: [prerelease-guard]
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 45
         steps:
             - name: Checkout tag
@@ -184,7 +184,7 @@ jobs:
               with:
                   toolchain: 1.92.0
 
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
               with:
                   prefix-key: prerelease-${{ needs.prerelease-guard.outputs.release_tag }}
                   cache-targets: true
@@ -234,7 +234,7 @@ jobs:
         name: Publish GitHub Pre-release
         needs: [prerelease-guard, build-prerelease]
         if: needs.prerelease-guard.outputs.ready_to_publish == 'true'
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 15
         steps:
             - name: Download prerelease artifacts

--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -44,7 +44,7 @@ env:
 jobs:
     prepare:
         name: Prepare Release Context
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         outputs:
             release_ref: ${{ steps.vars.outputs.release_ref }}
             release_tag: ${{ steps.vars.outputs.release_tag }}
@@ -174,7 +174,7 @@ jobs:
                       cross_compiler: ""
                       linker_env: ""
                       linker: ""
-                    - os: blacksmith-2vcpu-ubuntu-2404
+                    - os: racknerd
                       target: x86_64-unknown-linux-musl
                       artifact: zeroclaw
                       archive_ext: tar.gz
@@ -189,7 +189,7 @@ jobs:
                       cross_compiler: gcc-aarch64-linux-gnu
                       linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
                       linker: aarch64-linux-gnu-gcc
-                    - os: blacksmith-2vcpu-ubuntu-2404
+                    - os: racknerd
                       target: aarch64-unknown-linux-musl
                       artifact: zeroclaw
                       archive_ext: tar.gz
@@ -204,7 +204,7 @@ jobs:
                       cross_compiler: gcc-arm-linux-gnueabihf
                       linker_env: CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER
                       linker: arm-linux-gnueabihf-gcc
-                    - os: blacksmith-2vcpu-ubuntu-2404
+                    - os: racknerd
                       target: armv7-linux-androideabi
                       artifact: zeroclaw
                       archive_ext: tar.gz
@@ -213,7 +213,7 @@ jobs:
                       linker: ""
                       android_ndk: true
                       android_api: 21
-                    - os: blacksmith-2vcpu-ubuntu-2404
+                    - os: racknerd
                       target: aarch64-linux-android
                       artifact: zeroclaw
                       archive_ext: tar.gz
@@ -254,7 +254,7 @@ jobs:
                   toolchain: 1.92.0
                   targets: ${{ matrix.target }}
 
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
               if: runner.os != 'Windows'
 
             - name: Install cross for MUSL targets
@@ -375,7 +375,7 @@ jobs:
     verify-artifacts:
         name: Verify Artifact Set
         needs: [prepare, build-release]
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               with:
@@ -436,7 +436,7 @@ jobs:
         name: Publish Release
         if: needs.prepare.outputs.publish_release == 'true'
         needs: [prepare, verify-artifacts]
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 45
         environment:
             name: release

--- a/.github/workflows/sec-audit.yml
+++ b/.github/workflows/sec-audit.yml
@@ -83,7 +83,7 @@ env:
 jobs:
     audit:
         name: Security Audit
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -94,7 +94,7 @@ jobs:
 
     deny:
         name: License & Supply Chain
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -149,14 +149,14 @@ jobs:
 
     security-regressions:
         name: Security Regression Tests
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
               with:
                   toolchain: 1.92.0
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
               with:
                   prefix-key: sec-audit-security-regressions
             - name: Run security regression suite
@@ -165,7 +165,7 @@ jobs:
 
     secrets:
         name: Secrets Governance (Gitleaks)
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -360,7 +360,7 @@ jobs:
 
     sbom:
         name: SBOM Snapshot
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -425,7 +425,7 @@ jobs:
 
     unsafe-debt:
         name: Unsafe Debt Audit
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -564,7 +564,7 @@ jobs:
         name: Security Required Gate
         if: always() && (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
         needs: [audit, deny, security-regressions, secrets, sbom, unsafe-debt]
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - name: Enforce security gate
               shell: bash

--- a/.github/workflows/sec-codeql.yml
+++ b/.github/workflows/sec-codeql.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
     codeql:
         name: CodeQL Analysis
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 30
         steps:
             - name: Checkout repository

--- a/.github/workflows/sec-vorpal-reviewdog.yml
+++ b/.github/workflows/sec-vorpal-reviewdog.yml
@@ -85,7 +85,7 @@ permissions:
 jobs:
     vorpal:
         name: Vorpal Reviewdog Scan
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - name: Checkout

--- a/.github/workflows/sync-contributors.yml
+++ b/.github/workflows/sync-contributors.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   update-notice:
     name: Update NOTICE with new contributors
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/test-benchmarks.yml
+++ b/.github/workflows/test-benchmarks.yml
@@ -19,14 +19,14 @@ env:
 jobs:
     benchmarks:
         name: Criterion Benchmarks
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
               with:
                   toolchain: 1.92.0
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
 
             - name: Run benchmarks
               run: cargo bench --locked 2>&1 | tee benchmark_output.txt

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -18,13 +18,13 @@ env:
 jobs:
     integration-tests:
         name: Integration / E2E Tests
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
             - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
               with:
                   toolchain: 1.92.0
-            - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
             - name: Run integration / E2E tests
               run: cargo test --test agent_e2e --locked --verbose

--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -24,7 +24,7 @@ env:
 jobs:
     fuzz:
         name: Fuzz (${{ matrix.target }})
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 60
         strategy:
             fail-fast: false

--- a/.github/workflows/test-rust-build.yml
+++ b/.github/workflows/test-rust-build.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   run:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: [self-hosted, Linux, X64]
     timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - name: Checkout repository
@@ -53,7 +53,7 @@ jobs:
 
       - name: Restore Rust cache
         if: inputs.use_cache
-        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
 
       - name: Run command
         shell: bash

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
     no-tabs:
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 10
         steps:
             - name: Checkout
@@ -54,7 +54,7 @@ jobs:
                   PY
 
     actionlint:
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 10
         steps:
             - name: Checkout

--- a/TESTING_TELEGRAM.md
+++ b/TESTING_TELEGRAM.md
@@ -297,7 +297,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/docs/actions-source-policy.md
+++ b/docs/actions-source-policy.md
@@ -23,7 +23,7 @@ Selected allowlist patterns:
 - `softprops/action-gh-release@*`
 - `sigstore/cosign-installer@*`
 - `Checkmarx/vorpal-reviewdog-github-action@*`
-- `useblacksmith/*` (Blacksmith self-hosted runner infrastructure)
+- `Swatinem/rust-cache@*`
 
 ## Change Control Export
 
@@ -78,13 +78,11 @@ Latest sweep notes:
 - 2026-02-21: Added manual Vorpal reviewdog workflow for targeted secure-coding checks on supported file types
     - Added allowlist pattern: `Checkmarx/vorpal-reviewdog-github-action@*`
     - Workflow uses pinned source: `Checkmarx/vorpal-reviewdog-github-action@8cc292f337a2f1dea581b4f4bd73852e7becb50d` (v1.2.0)
-- 2026-02-17: Rust dependency cache migrated from `Swatinem/rust-cache` to `useblacksmith/rust-cache`
-    - No new allowlist pattern required (`useblacksmith/*` already allowlisted)
+- 2026-02-26: Standardized runner/action sources for cache and Docker build paths
+    - Added allowlist pattern: `Swatinem/rust-cache@*`
+    - Docker build jobs use `docker/setup-buildx-action` and `docker/build-push-action`
 - 2026-02-16: Hidden dependency discovered in `release.yml`: `sigstore/cosign-installer@...`
     - Added allowlist pattern: `sigstore/cosign-installer@*`
-- 2026-02-16: Blacksmith migration blocked workflow execution
-    - Added allowlist pattern: `useblacksmith/*` for self-hosted runner infrastructure
-    - Actions: `useblacksmith/setup-docker-builder@v1`, `useblacksmith/build-push-action@v2`
 - 2026-02-17: Security audit reproducibility/freshness balance update
     - Added allowlist pattern: `rustsec/audit-check@*`
     - Replaced inline `cargo install cargo-audit` execution with pinned `rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998` in `security.yml`

--- a/docs/i18n/el/actions-source-policy.md
+++ b/docs/i18n/el/actions-source-policy.md
@@ -25,7 +25,7 @@
 - `softprops/action-gh-release@*`
 - `sigstore/cosign-installer@*`
 - `Checkmarx/vorpal-reviewdog-github-action@*`
-- `useblacksmith/*` (Υποδομή Blacksmith)
+- `Swatinem/rust-cache@*`
 
 ## Διαδικασία Ελέγχου Αλλαγών
 
@@ -74,7 +74,7 @@ gh api repos/zeroclaw-labs/zeroclaw/actions/permissions/selected-actions
 ## Ιστορικό Αλλαγών
 
 - **2026-02-21**: Προσθήκη `Checkmarx/vorpal-reviewdog-github-action@*` για στοχευμένους ελέγχους ασφαλείας.
-- **2026-02-17**: Μετάβαση στο `useblacksmith/rust-cache` για τη διαχείριση προσωρινής μνήμης Rust.
+- **2026-02-26**: Τυποποίηση runner/action για Rust cache και Docker builds με `Swatinem/rust-cache`, `docker/setup-buildx-action`, `docker/build-push-action`.
 - **2026-02-16**: Προσθήκη `sigstore/cosign-installer@*` για την υπογραφή εκδόσεων.
 - **2026-02-17**: Αντικατάσταση του `cargo install cargo-audit` με την ενέργεια `rustsec/audit-check@*`.
 

--- a/docs/i18n/vi/actions-source-policy.md
+++ b/docs/i18n/vi/actions-source-policy.md
@@ -22,7 +22,7 @@ Các mẫu allowlist được chọn:
 - `rhysd/actionlint@*`
 - `softprops/action-gh-release@*`
 - `sigstore/cosign-installer@*`
-- `useblacksmith/*` (cơ sở hạ tầng self-hosted runner Blacksmith)
+- `Swatinem/rust-cache@*`
 
 ## Xuất kiểm soát thay đổi
 
@@ -74,13 +74,11 @@ Nếu gặp phải, chỉ thêm action tin cậy còn thiếu cụ thể đó, c
 
 Ghi chú quét gần đây nhất:
 
-- 2026-02-17: Cache phụ thuộc Rust được migrate từ `Swatinem/rust-cache` sang `useblacksmith/rust-cache`
-    - Không cần mẫu allowlist mới (`useblacksmith/*` đã có trong allowlist)
+- 2026-02-26: Chuẩn hóa runner/action cho cache Rust và Docker build
+    - Đã thêm mẫu allowlist: `Swatinem/rust-cache@*`
+    - Docker build dùng `docker/setup-buildx-action` và `docker/build-push-action`
 - 2026-02-16: Phụ thuộc ẩn được phát hiện trong `release.yml`: `sigstore/cosign-installer@...`
     - Đã thêm mẫu allowlist: `sigstore/cosign-installer@*`
-- 2026-02-16: Migration Blacksmith chặn thực thi workflow
-    - Đã thêm mẫu allowlist: `useblacksmith/*` cho cơ sở hạ tầng self-hosted runner
-    - Actions: `useblacksmith/setup-docker-builder@v1`, `useblacksmith/build-push-action@v2`
 - 2026-02-17: Cập nhật cân bằng tính tái tạo/độ tươi của security audit
     - Đã thêm mẫu allowlist: `rustsec/audit-check@*`
     - Thay thế thực thi nội tuyến `cargo install cargo-audit` bằng `rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998` được pin trong `security.yml`


### PR DESCRIPTION
## Summary
- remove Blacksmith runner label usage from all workflows
- migrate jobs to self-hosted labels (`[self-hosted, Linux, X64]`) and keep targeted matrix entries on `racknerd`
- replace `useblacksmith/*` actions with pinned `Swatinem/rust-cache`, `docker/setup-buildx-action`, and `docker/build-push-action`
- update actionlint runner label config and policy docs to match current sources

## Validation
- repo-wide search confirms no `blacksmith` / `useblacksmith` references remain
- workflow YAML parse check passed for all files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized continuous integration infrastructure by standardizing runner configurations and build tools across all GitHub Actions workflows
  * Transitioned runner assignment strategy from fixed host labels to flexible, scalable self-hosted runner pools
  * Updated CI workflow configurations and supporting documentation to reflect infrastructure standardization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->