### PR TITLE
ci: fix self-hosted codeql build toolchain

### DIFF
--- a/.github/workflows/sec-codeql.yml
+++ b/.github/workflows/sec-codeql.yml
@@ -57,6 +57,16 @@ jobs:
               with:
                   toolchain: 1.92.0
 
+            - name: Ensure native build tools
+              shell: bash
+              run: |
+                  SUDO=""
+                  if command -v sudo >/dev/null 2>&1; then
+                      SUDO="sudo"
+                  fi
+                  $SUDO apt-get update
+                  $SUDO apt-get install -y --no-install-recommends build-essential pkg-config
+
             - name: Build
               run: cargo build --workspace --all-targets --locked
 


### PR DESCRIPTION
## Summary
- add a native build tool bootstrap step for self-hosted Linux in CodeQL workflow
- install `build-essential` and `pkg-config` before `cargo build`

## Root cause
- CodeQL job failed with `linker cc not found` on self-hosted runner

## Validation
- failure log reviewed from main commit checks
- workflow updated at `.github/workflows/sec-codeql.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline reliability by ensuring native build tools are available during the CodeQL analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->