### PR TITLE
feat(site): launch responsive docs hub with pages deploy

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,64 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - site/**
+      - docs/**
+      - README.md
+      - .github/workflows/pages-deploy.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+
+      - name: Install Dependencies
+        working-directory: site
+        run: npm ci
+
+      - name: Build Site
+        working-directory: site
+        run: npm run build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: gh-pages
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ firmware/*/target
 __pycache__/
 *.pyc
 docker-compose.override.yml
+site/node_modules/
+site/.vite/
+gh-pages/
 
 # Environment files (may contain secrets)
 .env

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,67 @@
+# ZeroClaw GitHub Pages Frontend (Vite)
+
+This is the standalone frontend for GitHub Pages.
+
+## Commands
+
+```bash
+cd site
+npm install
+npm run dev
+```
+
+Build for GitHub Pages:
+
+```bash
+cd site
+npm run build
+```
+
+Build output is generated at:
+
+```text
+/home/ubuntu/zeroclaw/gh-pages
+```
+
+Notes:
+
+- Output directory is intentionally `gh-pages/` (not `out/`).
+- Vite base is configured to `/zeroclaw/` for `https://zeroclaw-labs.github.io/zeroclaw/`.
+- Docs links in UI point to rendered GitHub docs pages for direct reading.
+- Docs Navigator supports:
+  - keyword search with weighted ranking
+  - category and level filters (`Core` / `Advanced`)
+  - quick keyboard shortcuts: `/` to focus search, `Esc` to reset filters
+- "Quick Start Paths" provides task-first doc flows for onboarding, channels, and hardening.
+- Command palette is enabled:
+  - open via `Ctrl/Cmd + K`
+  - includes quick actions (jump docs, repo, theme/language switching)
+  - includes direct docs fuzzy search entries
+  - supports keyboard navigation (`↑` / `↓` / `Enter`) with active-item highlighting
+  - supports `Tab` / `Shift+Tab` cycling and live preview panel (desktop)
+- Theme system is enabled:
+  - `Auto` / `Dark` / `Light`
+  - preference persisted in `localStorage`
+- i18n is enabled:
+  - UI supports `English` and `简体中文`
+  - language preference persisted in `localStorage`
+  - URL language parameter (`?lang=en` / `?lang=zh`) is synchronized for shareable links
+- Responsive system is deepened:
+  - improved breakpoints for desktop/tablet/mobile
+  - adaptive topbar controls and panel layouts
+  - container query used for doc-card compact mode
+  - desktop section rail + mobile quick dock for faster long-page navigation
+
+## Deployment
+
+The repository includes workflow:
+
+```text
+.github/workflows/pages-deploy.yml
+```
+
+Behavior:
+
+- Trigger on pushes to `main` when `site/**`, `docs/**`, or `README.md` changes.
+- Build runs in `site/` and publishes artifact from `gh-pages/`.
+- Deploys with GitHub Pages official actions.

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZeroClaw // Cold Velocity Interface</title>
+    <meta
+      name="description"
+      content="A high-tech, cold, smooth-motion gateway interface for ZeroClaw documentation."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Orbitron:wght@500;700;900&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,0 +1,1820 @@
+{
+  "name": "zeroclaw-pages-ui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zeroclaw-pages-ui",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      },
+      "devDependencies": {
+        "@types/react": "^19.0.7",
+        "@types/react-dom": "^19.0.3",
+        "@vitejs/plugin-react": "^4.3.4",
+        "typescript": "~5.7.2",
+        "vite": "^6.0.7"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001774",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
+      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.302",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "zeroclaw-pages-ui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --host"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.7",
+    "@types/react-dom": "^19.0.3",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "~5.7.2",
+    "vite": "^6.0.7"
+  }
+}

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -1,0 +1,1876 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+
+type Locale = "en" | "zh";
+type ThemeMode = "system" | "dark" | "light";
+type ResolvedTheme = "dark" | "light";
+type LocalizedText = Record<Locale, string>;
+
+const categories = [
+  "Getting Started",
+  "Configuration",
+  "Channels",
+  "Operations",
+  "Security",
+  "Reference",
+] as const;
+
+const levelFilterOptions = ["All", "Core", "Advanced"] as const;
+
+type DocCategory = (typeof categories)[number];
+type CategoryFilter = "All" | DocCategory;
+type DocLevel = "Core" | "Advanced";
+type LevelFilter = (typeof levelFilterOptions)[number];
+
+type DocEntry = {
+  title: LocalizedText;
+  path: string;
+  category: DocCategory;
+  summary: LocalizedText;
+  level: DocLevel;
+  featured?: boolean;
+  keywords?: string[];
+};
+
+type QuickPath = {
+  title: LocalizedText;
+  summary: LocalizedText;
+  docs: string[];
+};
+
+type Capability = {
+  title: LocalizedText;
+  text: LocalizedText;
+};
+
+type ExecutionPhase = {
+  phase: LocalizedText;
+  detail: LocalizedText;
+};
+
+type PaletteAction = {
+  id: string;
+  label: string;
+  hint: string;
+  keywords: string[];
+  run: () => void;
+};
+
+type PaletteEntry = {
+  id: string;
+  kind: "action" | "doc";
+  label: string;
+  hint: string;
+  meta?: string;
+  run: () => void;
+};
+
+function bi(en: string, zh: string): LocalizedText {
+  return { en, zh };
+}
+
+const categoryLabels: Record<Locale, Record<DocCategory, string>> = {
+  en: {
+    "Getting Started": "Getting Started",
+    Configuration: "Configuration",
+    Channels: "Channels",
+    Operations: "Operations",
+    Security: "Security",
+    Reference: "Reference",
+  },
+  zh: {
+    "Getting Started": "快速开始",
+    Configuration: "配置",
+    Channels: "渠道集成",
+    Operations: "运维",
+    Security: "安全",
+    Reference: "参考资料",
+  },
+};
+
+const levelLabels: Record<Locale, Record<LevelFilter, string>> = {
+  en: {
+    All: "All",
+    Core: "Core",
+    Advanced: "Advanced",
+  },
+  zh: {
+    All: "全部",
+    Core: "核心",
+    Advanced: "进阶",
+  },
+};
+
+const languageLabels: Record<Locale, Record<Locale, string>> = {
+  en: {
+    en: "EN",
+    zh: "ZH",
+  },
+  zh: {
+    en: "英文",
+    zh: "中文",
+  },
+};
+
+const themeLabels: Record<Locale, Record<ThemeMode, string>> = {
+  en: {
+    system: "Auto",
+    dark: "Dark",
+    light: "Light",
+  },
+  zh: {
+    system: "自动",
+    dark: "深色",
+    light: "浅色",
+  },
+};
+
+const capabilities: Capability[] = [
+  {
+    title: bi("Velocity Routing", "极速路由"),
+    text: bi(
+      "High-speed command and message lanes tuned for low latency and stable fan-out under sustained load.",
+      "高吞吐命令与消息通道，针对低延迟和高压下稳定分发进行调优。"
+    ),
+  },
+  {
+    title: bi("Cold-State Control", "冷态控制"),
+    text: bi(
+      "Deterministic runtime boundaries keep long-running workflows crisp, predictable, and resilient.",
+      "确定性的运行时边界让长流程保持清晰、可预测且具备韧性。"
+    ),
+  },
+  {
+    title: bi("Policy Surface", "策略面"),
+    text: bi(
+      "Security defaults stay explicit and auditable from ingress validation to tool invocation.",
+      "从入口校验到工具调用，安全默认项保持显式、可审计。"
+    ),
+  },
+  {
+    title: bi("Signal Telemetry", "信号遥测"),
+    text: bi(
+      "Operator feedback loops expose execution rhythm in real time without sacrificing flow.",
+      "在不破坏流畅性的前提下，实时暴露执行节奏与反馈回路。"
+    ),
+  },
+];
+
+const executionPhases: ExecutionPhase[] = [
+  {
+    phase: bi("Ingress", "接入"),
+    detail: bi(
+      "Webhook and channel payload normalization",
+      "Webhook 与渠道负载标准化"
+    ),
+  },
+  {
+    phase: bi("Policy", "策略"),
+    detail: bi(
+      "Authentication and runtime guard checks",
+      "认证与运行时防护校验"
+    ),
+  },
+  {
+    phase: bi("Inference", "推理"),
+    detail: bi(
+      "Provider dispatch with fallback controls",
+      "带回退控制的模型路由分发"
+    ),
+  },
+  {
+    phase: bi("Delivery", "投递"),
+    detail: bi(
+      "Response routing with trace visibility",
+      "带可追踪可见性的响应投递"
+    ),
+  },
+];
+
+const signalFeed: LocalizedText[] = [
+  bi("gateway.pulse/ops-eu-1 :: RTT 17ms", "gateway.pulse/ops-eu-1 :: 往返 17ms"),
+  bi("policy.guard/strict-mode :: pass", "policy.guard/strict-mode :: 通过"),
+  bi("provider.dispatch/openai :: stable", "provider.dispatch/openai :: 稳定"),
+  bi("channel.delivery/slack :: stream", "channel.delivery/slack :: 流式"),
+];
+
+const traitChips: LocalizedText[] = [
+  bi("Rust-native Core", "Rust 原生核心"),
+  bi("Low-latency Runtime", "低延迟运行时"),
+  bi("Policy-first Execution", "策略优先执行"),
+  bi("Traceable Operations", "可追踪运维"),
+];
+
+const sectionNav = [
+  { id: "hero-core", label: bi("Overview", "总览") },
+  { id: "core-shortcuts", label: bi("Shortcuts", "捷径") },
+  { id: "quick-paths", label: bi("Pathways", "路径") },
+  { id: "capability-stack", label: bi("Capabilities", "能力") },
+  { id: "execution-lattice", label: bi("Execution", "执行") },
+  { id: "docs-navigator", label: bi("Docs", "文档") },
+] as const;
+
+const quickPaths: QuickPath[] = [
+  {
+    title: bi("Launch a Fresh Node", "快速启动节点"),
+    summary: bi(
+      "From zero to a running instance with deployment boundaries defined early.",
+      "从零到可运行实例，并提前明确部署边界。"
+    ),
+    docs: [
+      "docs/getting-started/README.md",
+      "docs/one-click-bootstrap.md",
+      "docs/network-deployment.md",
+    ],
+  },
+  {
+    title: bi("Wire Channels Fast", "快速接入渠道"),
+    summary: bi(
+      "Connect external chat surfaces and validate routing behavior quickly.",
+      "快速接入外部聊天渠道并验证路由行为。"
+    ),
+    docs: [
+      "docs/channels-reference.md",
+      "docs/mattermost-setup.md",
+      "docs/nextcloud-talk-setup.md",
+    ],
+  },
+  {
+    title: bi("Harden Runtime Policy", "强化运行策略"),
+    summary: bi(
+      "Lock down sandbox, security posture, and operational guardrails.",
+      "完善沙箱、安全姿态和运维防护策略。"
+    ),
+    docs: [
+      "docs/security/README.md",
+      "docs/sandboxing.md",
+      "docs/operations/README.md",
+    ],
+  },
+];
+
+const docsCatalog: DocEntry[] = [
+  {
+    title: bi("Docs Home", "文档首页"),
+    path: "docs/README.md",
+    category: "Getting Started",
+    summary: bi(
+      "Main documentation hub with starting points and structure.",
+      "文档总入口，包含起步路径与结构索引。"
+    ),
+    level: "Core",
+    featured: true,
+    keywords: ["docs", "home", "文档", "入口"],
+  },
+  {
+    title: bi("Getting Started", "快速开始"),
+    path: "docs/getting-started/README.md",
+    category: "Getting Started",
+    summary: bi(
+      "Installation and first-run onboarding references.",
+      "安装与首次运行的引导说明。"
+    ),
+    level: "Core",
+    featured: true,
+    keywords: ["install", "onboarding", "安装", "起步"],
+  },
+  {
+    title: bi("One-click Bootstrap", "一键初始化"),
+    path: "docs/one-click-bootstrap.md",
+    category: "Getting Started",
+    summary: bi(
+      "Fast bootstrap flow for new environments.",
+      "面向新环境的快速初始化流程。"
+    ),
+    level: "Core",
+    keywords: ["bootstrap", "new env", "初始化"],
+  },
+  {
+    title: bi("Network Deployment", "网络部署"),
+    path: "docs/network-deployment.md",
+    category: "Getting Started",
+    summary: bi(
+      "Gateway and callback deployment topology guidance.",
+      "网关与回调部署拓扑指南。"
+    ),
+    level: "Advanced",
+    keywords: ["network", "deployment", "网关", "部署"],
+  },
+  {
+    title: bi("Config Reference", "配置参考"),
+    path: "docs/config-reference.md",
+    category: "Configuration",
+    summary: bi(
+      "Canonical runtime and provider configuration schema.",
+      "标准运行时与模型提供方配置结构。"
+    ),
+    level: "Core",
+    featured: true,
+    keywords: ["config", "schema", "配置"],
+  },
+  {
+    title: bi("Commands Reference", "命令参考"),
+    path: "docs/commands-reference.md",
+    category: "Configuration",
+    summary: bi(
+      "CLI command map and behavior details.",
+      "CLI 命令清单与行为细节。"
+    ),
+    level: "Core",
+    keywords: ["commands", "cli", "命令"],
+  },
+  {
+    title: bi("Custom Providers", "自定义提供方"),
+    path: "docs/custom-providers.md",
+    category: "Configuration",
+    summary: bi(
+      "How to wire custom inference provider integrations.",
+      "如何接入自定义模型提供方。"
+    ),
+    level: "Advanced",
+    keywords: ["provider", "integration", "提供方", "集成"],
+  },
+  {
+    title: bi("Channels Reference", "渠道参考"),
+    path: "docs/channels-reference.md",
+    category: "Channels",
+    summary: bi(
+      "Unified channel setup, routing, and troubleshooting.",
+      "统一渠道配置、路由与排障指南。"
+    ),
+    level: "Core",
+    featured: true,
+    keywords: ["channels", "routing", "渠道", "路由"],
+  },
+  {
+    title: bi("Mattermost Setup", "Mattermost 配置"),
+    path: "docs/mattermost-setup.md",
+    category: "Channels",
+    summary: bi(
+      "Mattermost integration runbook and expected behavior.",
+      "Mattermost 集成操作手册与预期行为。"
+    ),
+    level: "Advanced",
+    keywords: ["mattermost", "integration", "集成"],
+  },
+  {
+    title: bi("Nextcloud Talk Setup", "Nextcloud Talk 配置"),
+    path: "docs/nextcloud-talk-setup.md",
+    category: "Channels",
+    summary: bi(
+      "Native Nextcloud Talk webhook and bot setup.",
+      "原生 Nextcloud Talk webhook 与机器人配置。"
+    ),
+    level: "Advanced",
+    keywords: ["nextcloud", "talk", "webhook"],
+  },
+  {
+    title: bi("Operations Hub", "运维中心"),
+    path: "docs/operations/README.md",
+    category: "Operations",
+    summary: bi(
+      "Operational runbooks and recovery procedures.",
+      "运维手册与故障恢复流程。"
+    ),
+    level: "Core",
+    keywords: ["operations", "runbook", "运维", "恢复"],
+  },
+  {
+    title: bi("Connectivity Probes Runbook", "连通性探针手册"),
+    path: "docs/operations/connectivity-probes-runbook.md",
+    category: "Operations",
+    summary: bi(
+      "Probe strategy, diagnostics, and alerting actions.",
+      "探针策略、诊断流程与告警动作。"
+    ),
+    level: "Advanced",
+    keywords: ["probe", "diagnostics", "告警", "探针"],
+  },
+  {
+    title: bi("Security Overview", "安全总览"),
+    path: "docs/security/README.md",
+    category: "Security",
+    summary: bi(
+      "Security policy, process, and advisory handling.",
+      "安全策略、流程与公告处理规范。"
+    ),
+    level: "Core",
+    keywords: ["security", "policy", "安全"],
+  },
+  {
+    title: bi("Sandboxing", "沙箱机制"),
+    path: "docs/sandboxing.md",
+    category: "Security",
+    summary: bi(
+      "Isolation modes, boundaries, and tradeoffs.",
+      "隔离模式、边界与权衡。"
+    ),
+    level: "Advanced",
+    keywords: ["sandbox", "isolation", "沙箱", "隔离"],
+  },
+  {
+    title: bi("Agnostic Security", "跨提供方安全"),
+    path: "docs/agnostic-security.md",
+    category: "Security",
+    summary: bi(
+      "Cross-provider security posture and design rationale.",
+      "跨模型提供方的安全姿态与设计依据。"
+    ),
+    level: "Advanced",
+    keywords: ["agnostic", "cross-provider", "跨提供方"],
+  },
+  {
+    title: bi("Reference Index", "参考索引"),
+    path: "docs/reference/README.md",
+    category: "Reference",
+    summary: bi(
+      "Reference material index for deeper lookup.",
+      "用于深入查阅的参考资料索引。"
+    ),
+    level: "Core",
+    keywords: ["reference", "index", "索引"],
+  },
+  {
+    title: bi("Docs Inventory", "文档清单"),
+    path: "docs/docs-inventory.md",
+    category: "Reference",
+    summary: bi(
+      "Inventory and ownership view of documentation assets.",
+      "文档资产与归属的清单视图。"
+    ),
+    level: "Advanced",
+    keywords: ["inventory", "ownership", "文档清单"],
+  },
+  {
+    title: bi("Resource Limits", "资源限制"),
+    path: "docs/resource-limits.md",
+    category: "Reference",
+    summary: bi(
+      "Runtime and deployment resource limit guidance.",
+      "运行时与部署资源限制建议。"
+    ),
+    level: "Advanced",
+    keywords: ["resource", "limits", "资源"],
+  },
+  {
+    title: bi("Repository README", "仓库 README"),
+    path: "README.md",
+    category: "Reference",
+    summary: bi(
+      "Project overview, features, and quick commands.",
+      "项目概览、能力说明与快速命令。"
+    ),
+    level: "Core",
+    featured: true,
+    keywords: ["readme", "project", "仓库", "项目"],
+  },
+];
+
+const monitorStats = [
+  {
+    label: bi("Queue Depth", "队列深度"),
+    value: bi("Stable", "稳定"),
+  },
+  {
+    label: bi("Retry Rate", "重试率"),
+    value: bi("0.4%", "0.4%"),
+  },
+  {
+    label: bi("Dispatch RTT", "分发延迟"),
+    value: bi("17ms", "17ms"),
+  },
+  {
+    label: bi("Guard State", "防护状态"),
+    value: bi("Strict", "严格"),
+  },
+];
+
+const textBundle = {
+  en: {
+    navDocs: "Docs Navigator",
+    navRepo: "Repository",
+    openPalette: "Command Palette",
+    languageLabel: "Language",
+    themeLabel: "Theme",
+    statusPill: "Cold Core Online",
+    heroKicker: "Private Gateway Control Plane",
+    heroTitle: ["Lightning Fast.", "Ice Cold.", "Precise by Design."],
+    heroLead:
+      "Inspired by modern product surfaces, this interface blends high contrast, restrained glow, and rapid yet smooth motion while keeping documentation access immediate and obvious.",
+    browseDocsNow: "Browse Docs Now",
+    openDocsHome: "Open Docs Home",
+    metrics: [
+      { label: "Execution Profile", value: "Rapid / Deterministic" },
+      { label: "Build Material", value: "100% Rust Engine" },
+      { label: "Visual Mode", value: "Black · Blue · Silver" },
+      { label: "Docs Indexed", value: `${docsCatalog.length} Files` },
+    ],
+    runtimeLabel: "runtime://zeroclaw/gateway",
+    live: "Live",
+    coreDocsShortcuts: "Core Docs Shortcuts",
+    openFullNavigator: "Open Full Navigator",
+    quickStartPaths: "Quick Start Paths",
+    taskFirstRouting: "Task-first Routing",
+    capabilityStack: "Capability Stack",
+    executionLattice: "Execution Lattice",
+    operatorSignal: "Operator Signal",
+    operatorSignalIntro:
+      "Fast transitions, clear hierarchy, and controlled glow ensure the interface reads quickly while staying calm in long sessions.",
+    docsNavigator: "Docs Navigator",
+    docsIntro:
+      "Search by topic, file name, or category. Filter quickly, then open rendered docs directly on GitHub.",
+    searchDocs: "Search docs",
+    searchPlaceholder: "Try: config, channels, security, operations...",
+    quickKeys: "Quick keys:",
+    quickKeySearchHint: "focus search",
+    quickKeyResetHint: "reset filters",
+    resetFilters: "Reset Filters",
+    docsCount: (count: number, filtered: boolean) =>
+      `${count} doc${count === 1 ? "" : "s"} matched${
+        filtered ? " in filtered mode" : " across all sections"
+      }`,
+    topMatches: "Top Matches",
+    noMatchPrefix: "No docs matched your filter. Try broader keywords like",
+    noMatchA: "config",
+    noMatchConnector: "or",
+    noMatchB: "security",
+    panelFooter:
+      "Documentation remains the primary navigation target. Every major section is indexed for direct reading access.",
+    paletteTitle: "Command Palette",
+    palettePlaceholder: "Type a command or search docs...",
+    paletteClose: "Close",
+    paletteActionsGroup: "Quick Actions",
+    paletteDocsGroup: "Documentation",
+    paletteNoResults: "No matching command or doc entry.",
+    palettePreviewTitle: "Live Preview",
+    palettePreviewNoSelection: "Select an entry to inspect details and run.",
+    palettePreviewKindAction: "Action",
+    palettePreviewKindDoc: "Doc Entry",
+    palettePreviewOpenHint: "Opens in a new tab",
+    paletteHintNavigate: "Arrow/Tab to navigate",
+    paletteHintRun: "Enter to run",
+    paletteHintClose: "Esc to close",
+    actionJumpDocs: "Jump to Docs Navigator",
+    actionJumpDocsHint: "Scroll to the main docs section",
+    actionOpenDocsHome: "Open Docs Home",
+    actionOpenDocsHomeHint: "Open docs hub in a new tab",
+    actionOpenRepo: "Open Repository",
+    actionOpenRepoHint: "Open GitHub repository",
+    actionToggleLang: "Switch Language",
+    actionToggleLangHint: "Toggle between English and Chinese",
+    actionThemeDark: "Set Theme: Dark",
+    actionThemeLight: "Set Theme: Light",
+    actionThemeSystem: "Set Theme: Auto",
+    actionThemeHint: "Update visual theme mode",
+    sectionRailLabel: "Section navigation",
+    mobileDockDocs: "Docs",
+    mobileDockPalette: "Palette",
+  },
+  zh: {
+    navDocs: "文档导航",
+    navRepo: "仓库",
+    openPalette: "命令面板",
+    languageLabel: "语言",
+    themeLabel: "主题",
+    statusPill: "冷核在线",
+    heroKicker: "私有网关控制平面",
+    heroTitle: ["闪电级速度。", "冰冷而克制。", "精准而生。"],
+    heroLead:
+      "参考现代产品界面的节奏，这个页面将高对比、克制发光与迅捷流畅动效结合，同时把文档可达性放在第一优先级。",
+    browseDocsNow: "立即浏览文档",
+    openDocsHome: "打开文档首页",
+    metrics: [
+      { label: "执行画像", value: "快速 / 确定性" },
+      { label: "构建材质", value: "100% Rust 引擎" },
+      { label: "视觉模式", value: "黑 · 蓝 · 银" },
+      { label: "已索引文档", value: `${docsCatalog.length} 个文件` },
+    ],
+    runtimeLabel: "runtime://zeroclaw/gateway",
+    live: "实时",
+    coreDocsShortcuts: "核心文档捷径",
+    openFullNavigator: "打开完整导航",
+    quickStartPaths: "任务快速路径",
+    taskFirstRouting: "任务优先路由",
+    capabilityStack: "能力栈",
+    executionLattice: "执行晶格",
+    operatorSignal: "操作信号",
+    operatorSignalIntro:
+      "快速过渡、清晰层级与克制发光，让界面在长时间使用时依然高效且不疲劳。",
+    docsNavigator: "文档导航器",
+    docsIntro:
+      "按主题、文件名或分类搜索，快速过滤后可直接打开 GitHub 渲染文档。",
+    searchDocs: "搜索文档",
+    searchPlaceholder: "例如：config、channels、security、operations...",
+    quickKeys: "快捷键：",
+    quickKeySearchHint: "聚焦搜索",
+    quickKeyResetHint: "重置筛选",
+    resetFilters: "重置筛选",
+    docsCount: (count: number, filtered: boolean) =>
+      `匹配到 ${count} 个文档${filtered ? "（已筛选）" : "（全量范围）"}`,
+    topMatches: "最佳匹配",
+    noMatchPrefix: "没有匹配结果，建议尝试更宽泛关键词，例如",
+    noMatchA: "config",
+    noMatchConnector: "或",
+    noMatchB: "security",
+    panelFooter: "文档是第一导航目标，所有核心部分均已索引并可直达阅读。",
+    paletteTitle: "命令面板",
+    palettePlaceholder: "输入命令或搜索文档...",
+    paletteClose: "关闭",
+    paletteActionsGroup: "快捷动作",
+    paletteDocsGroup: "文档",
+    paletteNoResults: "没有匹配的命令或文档。",
+    palettePreviewTitle: "实时预览",
+    palettePreviewNoSelection: "选择一条结果查看细节并执行。",
+    palettePreviewKindAction: "动作",
+    palettePreviewKindDoc: "文档项",
+    palettePreviewOpenHint: "将使用新标签页打开",
+    paletteHintNavigate: "方向键/Tab 切换",
+    paletteHintRun: "Enter 执行",
+    paletteHintClose: "Esc 关闭",
+    actionJumpDocs: "跳转到文档导航",
+    actionJumpDocsHint: "滚动到主文档区域",
+    actionOpenDocsHome: "打开文档首页",
+    actionOpenDocsHomeHint: "新标签页打开文档总入口",
+    actionOpenRepo: "打开仓库",
+    actionOpenRepoHint: "打开 GitHub 仓库",
+    actionToggleLang: "切换语言",
+    actionToggleLangHint: "中英文切换",
+    actionThemeDark: "设置主题：深色",
+    actionThemeLight: "设置主题：浅色",
+    actionThemeSystem: "设置主题：自动",
+    actionThemeHint: "更新视觉主题模式",
+    sectionRailLabel: "分区导航",
+    mobileDockDocs: "文档",
+    mobileDockPalette: "面板",
+  },
+} as const;
+
+const docsBase = "https://github.com/zeroclaw-labs/zeroclaw/blob/main";
+
+function getDocUrl(path: string): string {
+  return `${docsBase}/${path}`;
+}
+
+function localize(value: LocalizedText, locale: Locale): string {
+  return value[locale];
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function tokenizeQuery(query: string): string[] {
+  return Array.from(
+    new Set(
+      query
+        .trim()
+        .toLowerCase()
+        .split(/\s+/)
+        .map((token) => token.trim())
+        .filter((token) => token.length > 0)
+        .filter((token) => !/^[a-z0-9]$/i.test(token))
+    )
+  );
+}
+
+function scoreDoc(doc: DocEntry, tokens: string[], locale: Locale): number {
+  if (tokens.length === 0) {
+    return 0;
+  }
+
+  const altLocale: Locale = locale === "en" ? "zh" : "en";
+  const primaryTitle = localize(doc.title, locale).toLowerCase();
+  const primarySummary = localize(doc.summary, locale).toLowerCase();
+  const altTitle = localize(doc.title, altLocale).toLowerCase();
+  const altSummary = localize(doc.summary, altLocale).toLowerCase();
+  const primaryCategory = categoryLabels[locale][doc.category].toLowerCase();
+  const altCategory = categoryLabels[altLocale][doc.category].toLowerCase();
+  const path = doc.path.toLowerCase();
+  const keywords = (doc.keywords ?? []).join(" ").toLowerCase();
+
+  return tokens.reduce((score, token) => {
+    let current = score;
+
+    if (primaryTitle.includes(token)) {
+      current += 7;
+    }
+    if (primaryCategory.includes(token)) {
+      current += 5;
+    }
+    if (primarySummary.includes(token)) {
+      current += 4;
+    }
+    if (keywords.includes(token)) {
+      current += 3;
+    }
+    if (path.includes(token)) {
+      current += 2;
+    }
+    if (altTitle.includes(token) || altSummary.includes(token) || altCategory.includes(token)) {
+      current += 2;
+    }
+
+    return current;
+  }, 0);
+}
+
+function highlightMatches(text: string, tokens: string[]): ReactNode {
+  if (tokens.length === 0) {
+    return text;
+  }
+
+  const matcher = new RegExp(`(${tokens.map(escapeRegExp).join("|")})`, "ig");
+  const parts = text.split(matcher);
+
+  if (parts.length === 1) {
+    return text;
+  }
+
+  return parts.map((part, index) => {
+    const isMatch = tokens.some((token) => token === part.toLowerCase());
+    if (isMatch) {
+      return <mark key={`${part}-${index}`}>{part}</mark>;
+    }
+    return <span key={`${part}-${index}`}>{part}</span>;
+  });
+}
+
+export default function App() {
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState<CategoryFilter>("All");
+  const [level, setLevel] = useState<LevelFilter>("All");
+  const [locale, setLocale] = useState<Locale>("en");
+  const [themeMode, setThemeMode] = useState<ThemeMode>("system");
+  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>("dark");
+  const [isPaletteOpen, setPaletteOpen] = useState(false);
+  const [paletteQuery, setPaletteQuery] = useState("");
+  const [paletteIndex, setPaletteIndex] = useState(0);
+  const [activeSection, setActiveSection] = useState<(typeof sectionNav)[number]["id"]>(
+    sectionNav[0].id
+  );
+  const [scrollProgress, setScrollProgress] = useState(0);
+
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const paletteInputRef = useRef<HTMLInputElement>(null);
+
+  const copy = textBundle[locale];
+  const resolvedTheme: ResolvedTheme =
+    themeMode === "system" ? systemTheme : themeMode;
+
+  const featuredDocs = useMemo(
+    () => docsCatalog.filter((doc) => doc.featured).slice(0, 4),
+    []
+  );
+
+  const queryTokens = useMemo(() => tokenizeQuery(query), [query]);
+  const paletteTokens = useMemo(() => tokenizeQuery(paletteQuery), [paletteQuery]);
+
+  const docsLookup = useMemo(() => {
+    return new Map(docsCatalog.map((doc) => [doc.path, doc] as const));
+  }, []);
+
+  const filteredDocs = useMemo(() => {
+    const ranked = docsCatalog.map((doc) => ({
+      doc,
+      score: scoreDoc(doc, queryTokens, locale),
+    }));
+
+    return ranked
+      .filter(({ doc, score }) => {
+        const categoryMatch = category === "All" || doc.category === category;
+        if (!categoryMatch) {
+          return false;
+        }
+
+        const levelMatch = level === "All" || doc.level === level;
+        if (!levelMatch) {
+          return false;
+        }
+
+        if (queryTokens.length === 0) {
+          return true;
+        }
+
+        return score > 0;
+      })
+      .sort((left, right) => {
+        if (right.score !== left.score) {
+          return right.score - left.score;
+        }
+        if (left.doc.featured !== right.doc.featured) {
+          return left.doc.featured ? -1 : 1;
+        }
+        if (left.doc.level !== right.doc.level) {
+          return left.doc.level === "Core" ? -1 : 1;
+        }
+        return localize(left.doc.title, locale).localeCompare(
+          localize(right.doc.title, locale),
+          locale === "zh" ? "zh-Hans" : "en"
+        );
+      })
+      .map(({ doc }) => doc);
+  }, [category, level, locale, queryTokens]);
+
+  const categoryCounts = useMemo(() => {
+    return categories.reduce((acc, currentCategory) => {
+      const matched = docsCatalog.filter((doc) => {
+        if (doc.category !== currentCategory) {
+          return false;
+        }
+        if (level !== "All" && doc.level !== level) {
+          return false;
+        }
+        if (queryTokens.length === 0) {
+          return true;
+        }
+        return scoreDoc(doc, queryTokens, locale) > 0;
+      });
+
+      acc[currentCategory] = matched.length;
+      return acc;
+    }, {} as Record<DocCategory, number>);
+  }, [level, locale, queryTokens]);
+
+  const totalCategoryCount = useMemo(
+    () => Object.values(categoryCounts).reduce((sum, current) => sum + current, 0),
+    [categoryCounts]
+  );
+
+  const hasActiveFilters =
+    queryTokens.length > 0 || category !== "All" || level !== "All";
+
+  const topMatches = useMemo(() => {
+    if (!hasActiveFilters) {
+      return [];
+    }
+    return filteredDocs.slice(0, 4);
+  }, [filteredDocs, hasActiveFilters]);
+
+  const docsByCategory = useMemo(() => {
+    return categories.reduce((acc, currentCategory) => {
+      acc[currentCategory] = filteredDocs.filter(
+        (doc) => doc.category === currentCategory
+      );
+      return acc;
+    }, {} as Record<DocCategory, DocEntry[]>);
+  }, [filteredDocs]);
+
+  const paletteActions = useMemo<PaletteAction[]>(() => {
+    const openExternal = (path: string) => {
+      window.open(getDocUrl(path), "_blank", "noopener,noreferrer");
+    };
+
+    return [
+      {
+        id: "jump-docs",
+        label: copy.actionJumpDocs,
+        hint: copy.actionJumpDocsHint,
+        keywords: ["docs", "navigator", "文档", "导航"],
+        run: () => {
+          document
+            .getElementById("docs-navigator")
+            ?.scrollIntoView({ behavior: "smooth", block: "start" });
+        },
+      },
+      {
+        id: "open-docs-home",
+        label: copy.actionOpenDocsHome,
+        hint: copy.actionOpenDocsHomeHint,
+        keywords: ["docs", "home", "文档", "首页"],
+        run: () => {
+          openExternal("docs/README.md");
+        },
+      },
+      {
+        id: "open-repo",
+        label: copy.actionOpenRepo,
+        hint: copy.actionOpenRepoHint,
+        keywords: ["repo", "github", "仓库"],
+        run: () => {
+          openExternal("README.md");
+        },
+      },
+      {
+        id: "switch-language",
+        label: copy.actionToggleLang,
+        hint: copy.actionToggleLangHint,
+        keywords: ["language", "locale", "语言", "中英"],
+        run: () => {
+          setLocale((current) => (current === "en" ? "zh" : "en"));
+        },
+      },
+      {
+        id: "theme-dark",
+        label: copy.actionThemeDark,
+        hint: copy.actionThemeHint,
+        keywords: ["theme", "dark", "深色", "主题"],
+        run: () => {
+          setThemeMode("dark");
+        },
+      },
+      {
+        id: "theme-light",
+        label: copy.actionThemeLight,
+        hint: copy.actionThemeHint,
+        keywords: ["theme", "light", "浅色", "主题"],
+        run: () => {
+          setThemeMode("light");
+        },
+      },
+      {
+        id: "theme-system",
+        label: copy.actionThemeSystem,
+        hint: copy.actionThemeHint,
+        keywords: ["theme", "auto", "system", "自动"],
+        run: () => {
+          setThemeMode("system");
+        },
+      },
+    ];
+  }, [copy]);
+
+  const filteredPaletteActions = useMemo(() => {
+    if (paletteTokens.length === 0) {
+      return paletteActions;
+    }
+
+    return paletteActions.filter((action) => {
+      const haystack = `${action.label} ${action.hint} ${action.keywords.join(" ")}`.toLowerCase();
+      return paletteTokens.every((token) => haystack.includes(token));
+    });
+  }, [paletteActions, paletteTokens]);
+
+  const paletteDocResults = useMemo(() => {
+    const ranked = docsCatalog.map((doc) => ({
+      doc,
+      score: scoreDoc(doc, paletteTokens, locale),
+    }));
+
+    return ranked
+      .filter(({ doc, score }) => {
+        if (paletteTokens.length === 0) {
+          return doc.featured || doc.level === "Core";
+        }
+        return score > 0;
+      })
+      .sort((left, right) => {
+        if (right.score !== left.score) {
+          return right.score - left.score;
+        }
+        if (left.doc.featured !== right.doc.featured) {
+          return left.doc.featured ? -1 : 1;
+        }
+        return localize(left.doc.title, locale).localeCompare(
+          localize(right.doc.title, locale),
+          locale === "zh" ? "zh-Hans" : "en"
+        );
+      })
+      .slice(0, 8)
+      .map(({ doc }) => doc);
+  }, [locale, paletteTokens]);
+
+  const actionEntries = useMemo<PaletteEntry[]>(() => {
+    return filteredPaletteActions.map((action) => ({
+      id: `action-${action.id}`,
+      kind: "action",
+      label: action.label,
+      hint: action.hint,
+      run: action.run,
+    }));
+  }, [filteredPaletteActions]);
+
+  const docEntries = useMemo<PaletteEntry[]>(() => {
+    return paletteDocResults.map((doc) => ({
+      id: `doc-${doc.path}`,
+      kind: "doc",
+      label: localize(doc.title, locale),
+      hint: localize(doc.summary, locale),
+      meta: doc.path,
+      run: () => {
+        window.open(getDocUrl(doc.path), "_blank", "noopener,noreferrer");
+      },
+    }));
+  }, [locale, paletteDocResults]);
+
+  const paletteEntries = useMemo(
+    () => [...actionEntries, ...docEntries],
+    [actionEntries, docEntries]
+  );
+
+  const activePaletteEntry = paletteEntries[paletteIndex] ?? null;
+
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const updateSystemTheme = () => {
+      setSystemTheme(media.matches ? "dark" : "light");
+    };
+
+    updateSystemTheme();
+    media.addEventListener("change", updateSystemTheme);
+
+    return () => {
+      media.removeEventListener("change", updateSystemTheme);
+    };
+  }, []);
+
+  useEffect(() => {
+    const searchLang = new URL(window.location.href).searchParams.get("lang");
+    const storedLocale = window.localStorage.getItem("zeroclaw.locale");
+
+    if (searchLang === "en" || searchLang === "zh") {
+      setLocale(searchLang);
+    } else if (storedLocale === "en" || storedLocale === "zh") {
+      setLocale(storedLocale);
+    } else if (navigator.language.toLowerCase().startsWith("zh")) {
+      setLocale("zh");
+    }
+
+    const storedTheme = window.localStorage.getItem("zeroclaw.theme");
+    if (storedTheme === "system" || storedTheme === "dark" || storedTheme === "light") {
+      setThemeMode(storedTheme);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = resolvedTheme;
+    document.documentElement.style.colorScheme = resolvedTheme;
+    window.localStorage.setItem("zeroclaw.theme", themeMode);
+  }, [resolvedTheme, themeMode]);
+
+  useEffect(() => {
+    document.documentElement.lang = locale === "zh" ? "zh-CN" : "en";
+    window.localStorage.setItem("zeroclaw.locale", locale);
+
+    const url = new URL(window.location.href);
+    if (url.searchParams.get("lang") !== locale) {
+      url.searchParams.set("lang", locale);
+      window.history.replaceState({}, "", `${url.pathname}${url.search}${url.hash}`);
+    }
+  }, [locale]);
+
+  useEffect(() => {
+    const updateProgress = () => {
+      const scrollHeight =
+        document.documentElement.scrollHeight - window.innerHeight;
+      if (scrollHeight <= 0) {
+        setScrollProgress(0);
+        return;
+      }
+
+      setScrollProgress(Math.min(1, Math.max(0, window.scrollY / scrollHeight)));
+    };
+
+    updateProgress();
+    window.addEventListener("scroll", updateProgress, { passive: true });
+    window.addEventListener("resize", updateProgress);
+
+    return () => {
+      window.removeEventListener("scroll", updateProgress);
+      window.removeEventListener("resize", updateProgress);
+    };
+  }, []);
+
+  useEffect(() => {
+    const nodes = sectionNav
+      .map((section) => document.getElementById(section.id))
+      .filter((node): node is HTMLElement => Boolean(node));
+
+    if (nodes.length === 0 || !("IntersectionObserver" in window)) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const inView = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((left, right) => right.intersectionRatio - left.intersectionRatio);
+
+        if (inView.length > 0) {
+          setActiveSection(inView[0].target.id as (typeof sectionNav)[number]["id"]);
+        }
+      },
+      {
+        threshold: [0.12, 0.3, 0.55, 0.85],
+        rootMargin: "-28% 0px -58% 0px",
+      }
+    );
+
+    nodes.forEach((node) => observer.observe(node));
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+    const revealNodes = document.querySelectorAll<HTMLElement>(".reveal");
+    let observer: IntersectionObserver | null = null;
+
+    if (prefersReducedMotion || !("IntersectionObserver" in window)) {
+      revealNodes.forEach((node) => node.classList.add("in"));
+    } else {
+      observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add("in");
+              observer?.unobserve(entry.target);
+            }
+          });
+        },
+        { threshold: 0.12 }
+      );
+      revealNodes.forEach((node) => observer?.observe(node));
+    }
+
+    const root = document.documentElement;
+    const handlePointerMove = (event: PointerEvent) => {
+      root.style.setProperty("--pointer-x", `${event.clientX}px`);
+      root.style.setProperty("--pointer-y", `${event.clientY}px`);
+    };
+
+    if (!prefersReducedMotion) {
+      window.addEventListener("pointermove", handlePointerMove, {
+        passive: true,
+      });
+    }
+
+    return () => {
+      observer?.disconnect();
+      if (!prefersReducedMotion) {
+        window.removeEventListener("pointermove", handlePointerMove);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isPaletteOpen) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      paletteInputRef.current?.focus();
+      paletteInputRef.current?.select();
+    }, 20);
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      window.clearTimeout(timer);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isPaletteOpen]);
+
+  useEffect(() => {
+    if (!isPaletteOpen) {
+      return;
+    }
+    setPaletteIndex(0);
+  }, [actionEntries.length, docEntries.length, isPaletteOpen, paletteQuery]);
+
+  useEffect(() => {
+    if (paletteEntries.length === 0 && paletteIndex !== 0) {
+      setPaletteIndex(0);
+      return;
+    }
+
+    if (paletteIndex > paletteEntries.length - 1) {
+      setPaletteIndex(Math.max(0, paletteEntries.length - 1));
+    }
+  }, [paletteEntries.length, paletteIndex]);
+
+  useEffect(() => {
+    if (!isPaletteOpen) {
+      return;
+    }
+
+    const activeNode = document.querySelector<HTMLElement>(
+      `[data-palette-index="${paletteIndex}"]`
+    );
+    activeNode?.scrollIntoView({ block: "nearest" });
+  }, [isPaletteOpen, paletteIndex]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const key = event.key.toLowerCase();
+      const target = event.target as HTMLElement | null;
+      const isEditable =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        Boolean(target?.isContentEditable);
+
+      if ((event.metaKey || event.ctrlKey) && key === "k") {
+        event.preventDefault();
+        setPaletteOpen((open) => {
+          const next = !open;
+          if (!open) {
+            setPaletteIndex(0);
+          }
+          return next;
+        });
+        return;
+      }
+
+      if (event.key === "Escape") {
+        if (isPaletteOpen) {
+          event.preventDefault();
+          setPaletteOpen(false);
+          setPaletteQuery("");
+          setPaletteIndex(0);
+          return;
+        }
+
+        if (target === searchInputRef.current) {
+          if (query || category !== "All" || level !== "All") {
+            setQuery("");
+            setCategory("All");
+            setLevel("All");
+          }
+          searchInputRef.current?.blur();
+        }
+      }
+
+      if (isPaletteOpen && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
+        if (paletteEntries.length === 0) {
+          return;
+        }
+        event.preventDefault();
+        setPaletteIndex((currentIndex) => {
+          if (event.key === "ArrowDown") {
+            return (currentIndex + 1) % paletteEntries.length;
+          }
+          return (currentIndex - 1 + paletteEntries.length) % paletteEntries.length;
+        });
+        return;
+      }
+
+      if (isPaletteOpen && event.key === "Tab") {
+        if (paletteEntries.length === 0) {
+          return;
+        }
+        event.preventDefault();
+        setPaletteIndex((currentIndex) => {
+          if (event.shiftKey) {
+            return (currentIndex - 1 + paletteEntries.length) % paletteEntries.length;
+          }
+          return (currentIndex + 1) % paletteEntries.length;
+        });
+        return;
+      }
+
+      if (isPaletteOpen && event.key === "Enter" && paletteEntries.length > 0) {
+        event.preventDefault();
+        const selected = paletteEntries[paletteIndex] ?? paletteEntries[0];
+        selected?.run();
+        setPaletteOpen(false);
+        setPaletteQuery("");
+        setPaletteIndex(0);
+        return;
+      }
+
+      if (event.key === "/" && !isEditable && !isPaletteOpen) {
+        event.preventDefault();
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [category, isPaletteOpen, level, paletteEntries, paletteIndex, query]);
+
+  const closePalette = () => {
+    setPaletteOpen(false);
+    setPaletteQuery("");
+    setPaletteIndex(0);
+  };
+
+  const resetFilters = () => {
+    setQuery("");
+    setCategory("All");
+    setLevel("All");
+    searchInputRef.current?.focus();
+  };
+
+  return (
+    <div className="app-shell">
+      <div className="ambient-grid" aria-hidden="true" />
+      <div className="ambient-glow" aria-hidden="true" />
+      <div className="cursor-glow" aria-hidden="true" />
+      <div className="scroll-progress" aria-hidden="true">
+        <i style={{ transform: `scaleX(${scrollProgress})` }} />
+      </div>
+
+      <nav className="section-rail" aria-label={copy.sectionRailLabel}>
+        {sectionNav.map((section) => (
+          <a
+            key={section.id}
+            href={`#${section.id}`}
+            className={`rail-link ${activeSection === section.id ? "active" : ""}`}
+            onClick={() => setActiveSection(section.id)}
+          >
+            <span className="rail-dot" aria-hidden="true" />
+            <span>{localize(section.label, locale)}</span>
+          </a>
+        ))}
+      </nav>
+
+      <header className="topbar">
+        <div className="container topbar-inner">
+          <a className="wordmark" href="#">
+            ZeroClaw
+          </a>
+
+          <div className="top-actions">
+            <a className="top-link" href="#docs-navigator">
+              {copy.navDocs}
+            </a>
+            <a className="top-link" href={getDocUrl("README.md")} target="_blank" rel="noreferrer">
+              {copy.navRepo}
+            </a>
+            <button
+              type="button"
+              className="top-link top-link-btn"
+              onClick={() => {
+                setPaletteOpen(true);
+                setPaletteIndex(0);
+              }}
+            >
+              {copy.openPalette}
+              <span className="top-shortcut">Ctrl/Cmd+K</span>
+            </button>
+
+            <div className="toggle-cluster" role="group" aria-label={copy.languageLabel}>
+              {(["en", "zh"] as const).map((item) => (
+                <button
+                  key={item}
+                  type="button"
+                  className={`toggle-chip ${locale === item ? "active" : ""}`}
+                  onClick={() => setLocale(item)}
+                  aria-pressed={locale === item}
+                >
+                  {languageLabels[locale][item]}
+                </button>
+              ))}
+            </div>
+
+            <div className="toggle-cluster" role="group" aria-label={copy.themeLabel}>
+              {(["system", "dark", "light"] as const).map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  className={`toggle-chip ${themeMode === mode ? "active" : ""}`}
+                  onClick={() => setThemeMode(mode)}
+                  aria-pressed={themeMode === mode}
+                >
+                  {themeLabels[locale][mode]}
+                </button>
+              ))}
+            </div>
+
+            <span className="status-pill" title={`theme:${resolvedTheme}`}>
+              {copy.statusPill}
+            </span>
+          </div>
+        </div>
+      </header>
+
+      <main className="container main-layout">
+        <section id="hero-core" className="hero hero-grid">
+          <div className="hero-copy">
+            <p className="hero-kicker reveal">{copy.heroKicker}</p>
+            <h1 className="hero-title reveal delay-1">
+              {copy.heroTitle[0]}
+              <br />
+              {copy.heroTitle[1]}
+              <br />
+              {copy.heroTitle[2]}
+            </h1>
+            <p className="hero-lead reveal delay-2">{copy.heroLead}</p>
+
+            <div className="hero-actions reveal delay-3">
+              <a className="btn btn-primary" href="#docs-navigator">
+                {copy.browseDocsNow}
+              </a>
+              <a
+                className="btn"
+                href={getDocUrl("docs/README.md")}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {copy.openDocsHome}
+              </a>
+            </div>
+
+            <dl className="metrics reveal delay-4">
+              {copy.metrics.map((metric) => (
+                <div className="metric" key={metric.label}>
+                  <dt>{metric.label}</dt>
+                  <dd>{metric.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+
+          <aside className="command-deck reveal delay-2">
+            <header className="deck-head">
+              <span>{copy.runtimeLabel}</span>
+              <span className="live-pill">{copy.live}</span>
+            </header>
+
+            <div className="deck-body">
+              {signalFeed.map((line, index) => (
+                <p
+                  key={line.en}
+                  className="feed-row"
+                  style={{ animationDelay: `${index * 120}ms` } as CSSProperties}
+                >
+                  <span className="feed-index">0{index + 1}</span>
+                  <span>{localize(line, locale)}</span>
+                </p>
+              ))}
+            </div>
+
+            <div className="deck-bars">
+              {executionPhases.map((phase, index) => (
+                <div key={phase.phase.en} className="deck-bar-row">
+                  <span>{localize(phase.phase, locale)}</span>
+                  <span className="bar-track">
+                    <i
+                      style={
+                        {
+                          width: `${Math.min(95, 58 + index * 11)}%`,
+                          animationDelay: `${index * 160}ms`,
+                        } as CSSProperties
+                      }
+                    />
+                  </span>
+                </div>
+              ))}
+            </div>
+          </aside>
+        </section>
+
+        <section className="trait-band reveal">
+          {traitChips.map((chip, index) => (
+            <span key={chip.en} className={`trait-chip delay-${Math.min(index + 1, 4)}`}>
+              {localize(chip, locale)}
+            </span>
+          ))}
+        </section>
+
+        <section id="core-shortcuts" className="glass-panel">
+          <div className="section-head">
+            <h2 className="section-title reveal">{copy.coreDocsShortcuts}</h2>
+            <a className="section-head-link reveal delay-1" href="#docs-navigator">
+              {copy.openFullNavigator}
+            </a>
+          </div>
+          <div className="links-grid">
+            {featuredDocs.map((doc, index) => (
+              <a
+                key={doc.path}
+                href={getDocUrl(doc.path)}
+                className={`doc-link reveal delay-${Math.min(index + 1, 4)}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                <span>{localize(doc.title, locale)}</span>
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M7 17L17 7M17 7H8M17 7V16" />
+                </svg>
+              </a>
+            ))}
+          </div>
+        </section>
+
+        <section id="quick-paths" className="glass-panel">
+          <div className="section-head">
+            <h2 className="section-title reveal">{copy.quickStartPaths}</h2>
+            <span className="section-tag reveal delay-1">{copy.taskFirstRouting}</span>
+          </div>
+          <div className="path-grid">
+            {quickPaths.map((path, index) => (
+              <article
+                key={path.title.en}
+                className={`path-card reveal delay-${Math.min(index + 1, 4)}`}
+              >
+                <h3>{localize(path.title, locale)}</h3>
+                <p>{localize(path.summary, locale)}</p>
+                <div className="path-docs">
+                  {path.docs.map((docPath) => {
+                    const doc = docsLookup.get(docPath);
+                    if (!doc) {
+                      return null;
+                    }
+                    return (
+                      <a
+                        key={doc.path}
+                        href={getDocUrl(doc.path)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="path-doc-link"
+                      >
+                        <span>{localize(doc.title, locale)}</span>
+                        <code>{doc.path}</code>
+                      </a>
+                    );
+                  })}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section id="capability-stack" className="glass-panel">
+          <h2 className="section-title reveal">{copy.capabilityStack}</h2>
+          <div className="cap-grid">
+            {capabilities.map((cap, index) => (
+              <article
+                key={cap.title.en}
+                className={`cap-card reveal delay-${Math.min(index + 1, 4)}`}
+              >
+                <h3>{localize(cap.title, locale)}</h3>
+                <p>{localize(cap.text, locale)}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section id="execution-lattice" className="workflow-grid">
+          <article className="glass-panel">
+            <h2 className="section-title reveal">{copy.executionLattice}</h2>
+            <ol className="phase-list">
+              {executionPhases.map((phase, index) => (
+                <li
+                  key={phase.phase.en}
+                  className={`phase-item reveal delay-${Math.min(index + 1, 4)}`}
+                >
+                  <span className="phase-num">{index + 1}</span>
+                  <div className="phase-text">
+                    <h3>{localize(phase.phase, locale)}</h3>
+                    <p>{localize(phase.detail, locale)}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </article>
+
+          <aside className="glass-panel monitor-panel reveal delay-2">
+            <h2 className="section-title">{copy.operatorSignal}</h2>
+            <p className="monitor-intro">{copy.operatorSignalIntro}</p>
+            <div className="monitor-grid">
+              {monitorStats.map((stat) => (
+                <div key={stat.label.en}>
+                  <span>{localize(stat.label, locale)}</span>
+                  <strong>{localize(stat.value, locale)}</strong>
+                </div>
+              ))}
+            </div>
+          </aside>
+        </section>
+
+        <section id="docs-navigator" className="glass-panel docs-panel">
+          <h2 className="section-title reveal">{copy.docsNavigator}</h2>
+          <p className="docs-intro reveal delay-1">{copy.docsIntro}</p>
+
+          <div className="docs-tools reveal delay-1">
+            <label className="docs-search-wrap" htmlFor="docs-search-input">
+              <span className="docs-search-label">{copy.searchDocs}</span>
+              <input
+                id="docs-search-input"
+                ref={searchInputRef}
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={copy.searchPlaceholder}
+                autoComplete="off"
+              />
+            </label>
+
+            <div className="docs-filter-stack">
+              <div className="category-row" role="tablist" aria-label="Doc category filters">
+                {(["All", ...categories] as const).map((item) => (
+                  <button
+                    key={item}
+                    type="button"
+                    className={`category-pill ${category === item ? "active" : ""}`}
+                    onClick={() => setCategory(item)}
+                    aria-pressed={category === item}
+                  >
+                    <span>
+                      {item === "All" ? levelLabels[locale].All : categoryLabels[locale][item]}
+                    </span>
+                    <small className="pill-count">
+                      {item === "All" ? totalCategoryCount : categoryCounts[item]}
+                    </small>
+                  </button>
+                ))}
+              </div>
+
+              <div className="category-row level-row" role="tablist" aria-label="Doc level filters">
+                {levelFilterOptions.map((item) => (
+                  <button
+                    key={item}
+                    type="button"
+                    className={`category-pill level-pill ${level === item ? "active" : ""}`}
+                    onClick={() => setLevel(item)}
+                    aria-pressed={level === item}
+                  >
+                    {levelLabels[locale][item]}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="docs-utility-row">
+              <p className="docs-hint">
+                {copy.quickKeys} <kbd>/</kbd> {copy.quickKeySearchHint}, <kbd>Esc</kbd>{" "}
+                {copy.quickKeyResetHint}.
+              </p>
+              <button
+                type="button"
+                className="reset-filters-btn"
+                onClick={resetFilters}
+                disabled={!hasActiveFilters}
+              >
+                {copy.resetFilters}
+              </button>
+            </div>
+          </div>
+
+          <p className="docs-count reveal delay-2">
+            {copy.docsCount(filteredDocs.length, hasActiveFilters)}
+          </p>
+
+          {topMatches.length > 0 && (
+            <section className="docs-top-matches reveal in delay-2">
+              <h3 className="docs-group-title">{copy.topMatches}</h3>
+              <div className="docs-grid">
+                {topMatches.map((doc) => (
+                  <a
+                    key={`top-${doc.path}`}
+                    href={getDocUrl(doc.path)}
+                    className="doc-nav-card doc-nav-card-priority"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <div className="doc-nav-head">
+                      <strong>{highlightMatches(localize(doc.title, locale), queryTokens)}</strong>
+                      <span>{levelLabels[locale][doc.level]}</span>
+                    </div>
+                    <p>{highlightMatches(localize(doc.summary, locale), queryTokens)}</p>
+                    <code>{highlightMatches(doc.path, queryTokens)}</code>
+                  </a>
+                ))}
+              </div>
+            </section>
+          )}
+
+          <div className="docs-groups">
+            {categories.map((cat, catIndex) => {
+              const docs = docsByCategory[cat];
+              if (docs.length === 0) {
+                return null;
+              }
+              return (
+                <section
+                  key={cat}
+                  className={`docs-group reveal delay-${Math.min(catIndex + 1, 4)}`}
+                >
+                  <h3 className="docs-group-title">{categoryLabels[locale][cat]}</h3>
+                  <div className="docs-grid">
+                    {docs.map((doc) => (
+                      <a
+                        key={doc.path}
+                        href={getDocUrl(doc.path)}
+                        className="doc-nav-card"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        <div className="doc-nav-head">
+                          <strong>{highlightMatches(localize(doc.title, locale), queryTokens)}</strong>
+                          <span>{levelLabels[locale][doc.level]}</span>
+                        </div>
+                        <p>{highlightMatches(localize(doc.summary, locale), queryTokens)}</p>
+                        <code>{highlightMatches(doc.path, queryTokens)}</code>
+                      </a>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+
+            {filteredDocs.length === 0 && (
+              <div className="doc-empty reveal in" role="status" aria-live="polite">
+                {copy.noMatchPrefix}
+                <code> {copy.noMatchA} </code>
+                {copy.noMatchConnector}
+                <code> {copy.noMatchB} </code>.
+              </div>
+            )}
+          </div>
+
+          <footer className="panel-footer reveal delay-4">{copy.panelFooter}</footer>
+        </section>
+      </main>
+
+      <div className="mobile-dock">
+        <a className="dock-btn" href="#docs-navigator">
+          {copy.mobileDockDocs}
+        </a>
+        <button
+          type="button"
+          className="dock-btn"
+          onClick={() => {
+            setPaletteOpen(true);
+            setPaletteIndex(0);
+          }}
+        >
+          {copy.mobileDockPalette}
+        </button>
+      </div>
+
+      {isPaletteOpen && (
+        <div className="palette-overlay" role="presentation" onClick={closePalette}>
+          <section
+            className="palette-panel"
+            role="dialog"
+            aria-modal="true"
+            aria-label={copy.paletteTitle}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <header className="palette-head">
+              <input
+                ref={paletteInputRef}
+                value={paletteQuery}
+                onChange={(event) => setPaletteQuery(event.target.value)}
+                placeholder={copy.palettePlaceholder}
+                aria-label={copy.palettePlaceholder}
+              />
+              <button type="button" className="palette-close" onClick={closePalette}>
+                {copy.paletteClose}
+              </button>
+            </header>
+
+            <div className="palette-grid">
+              <div
+                className="palette-results"
+                role="listbox"
+                aria-activedescendant={
+                  activePaletteEntry ? `palette-option-${activePaletteEntry.id}` : undefined
+                }
+              >
+                <section>
+                  <p className="palette-section-title">
+                    {copy.paletteActionsGroup}
+                    <small>{actionEntries.length}</small>
+                  </p>
+                  <div className="palette-list">
+                    {actionEntries.map((entry, index) => (
+                      <button
+                        type="button"
+                        id={`palette-option-${entry.id}`}
+                        key={entry.id}
+                        data-palette-index={index}
+                        className={`palette-item ${paletteIndex === index ? "active" : ""}`}
+                        role="option"
+                        aria-selected={paletteIndex === index}
+                        onMouseEnter={() => setPaletteIndex(index)}
+                        onClick={() => {
+                          entry.run();
+                          closePalette();
+                        }}
+                      >
+                        <span className="palette-item-main">
+                          {highlightMatches(entry.label, paletteTokens)}
+                        </span>
+                        <small>{highlightMatches(entry.hint, paletteTokens)}</small>
+                      </button>
+                    ))}
+                  </div>
+                </section>
+
+                <section>
+                  <p className="palette-section-title">
+                    {copy.paletteDocsGroup}
+                    <small>{docEntries.length}</small>
+                  </p>
+                  <div className="palette-list">
+                    {docEntries.map((entry, index) => {
+                      const globalIndex = actionEntries.length + index;
+                      return (
+                        <button
+                          type="button"
+                          id={`palette-option-${entry.id}`}
+                          key={entry.id}
+                          data-palette-index={globalIndex}
+                          className={`palette-item palette-doc-item ${paletteIndex === globalIndex ? "active" : ""}`}
+                          role="option"
+                          aria-selected={paletteIndex === globalIndex}
+                          onMouseEnter={() => setPaletteIndex(globalIndex)}
+                          onClick={() => {
+                            entry.run();
+                            closePalette();
+                          }}
+                        >
+                          <span className="palette-item-main">
+                            {highlightMatches(entry.label, paletteTokens)}
+                          </span>
+                          <small>{highlightMatches(entry.hint, paletteTokens)}</small>
+                          <code>{highlightMatches(entry.meta ?? "", paletteTokens)}</code>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </section>
+
+                {paletteEntries.length === 0 && (
+                  <p className="palette-empty">{copy.paletteNoResults}</p>
+                )}
+              </div>
+
+              <aside className="palette-preview" aria-live="polite">
+                <p className="palette-preview-title">{copy.palettePreviewTitle}</p>
+
+                {activePaletteEntry ? (
+                  <div className="preview-card">
+                    <p className="preview-kind">
+                      {activePaletteEntry.kind === "action"
+                        ? copy.palettePreviewKindAction
+                        : copy.palettePreviewKindDoc}
+                    </p>
+                    <h3>{highlightMatches(activePaletteEntry.label, paletteTokens)}</h3>
+                    <p>{highlightMatches(activePaletteEntry.hint, paletteTokens)}</p>
+                    {activePaletteEntry.meta && (
+                      <code>{highlightMatches(activePaletteEntry.meta, paletteTokens)}</code>
+                    )}
+                    {activePaletteEntry.kind === "doc" && (
+                      <span className="preview-open-hint">{copy.palettePreviewOpenHint}</span>
+                    )}
+                  </div>
+                ) : (
+                  <p className="palette-preview-empty">{copy.palettePreviewNoSelection}</p>
+                )}
+
+                <div className="palette-kbd-hints">
+                  <span>{copy.paletteHintNavigate}</span>
+                  <span>{copy.paletteHintRun}</span>
+                  <span>{copy.paletteHintClose}</span>
+                </div>
+              </aside>
+            </div>
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/site/src/main.tsx
+++ b/site/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1,0 +1,1940 @@
+@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Orbitron:wght@500;700;900&family=Space+Grotesk:wght@400;500;700&display=swap");
+
+:root {
+  color-scheme: dark;
+
+  --bg-void: #030712;
+  --bg-ice: #050810;
+  --bg-panel: #0a0f1a;
+
+  --ambient-a: rgba(56, 189, 248, 0.08);
+  --ambient-b: rgba(34, 211, 238, 0.09);
+  --ambient-grid-line: rgba(148, 163, 184, 0.08);
+  --ambient-cursor: rgba(56, 189, 248, 0.18);
+
+  --ink-bright: #ffffff;
+  --ink-soft: #e2e8f0;
+  --ink-silver: #94a3b8;
+  --ink-metal: #c8d2df;
+
+  --arc-primary: #38bdf8;
+  --arc-secondary: #22d3ee;
+  --arc-glow: #67e8f9;
+
+  --line-subtle: rgba(148, 163, 184, 0.2);
+  --line-strong: rgba(56, 189, 248, 0.46);
+
+  --surface-topbar-a: rgba(3, 7, 18, 0.88);
+  --surface-topbar-b: rgba(3, 7, 18, 0.44);
+  --surface-glass-a: rgba(10, 15, 26, 0.82);
+  --surface-glass-b: rgba(5, 8, 16, 0.92);
+  --surface-card: rgba(8, 13, 24, 0.74);
+  --surface-card-strong: rgba(3, 7, 18, 0.7);
+  --surface-chip: rgba(10, 15, 26, 0.66);
+  --surface-input: rgba(7, 12, 24, 0.72);
+  --surface-control: rgba(10, 15, 26, 0.7);
+
+  --panel-shadow: 0 18px 50px rgba(1, 5, 18, 0.5);
+  --card-shadow: 0 10px 20px rgba(2, 7, 22, 0.4);
+
+  --mark-bg: rgba(103, 232, 249, 0.24);
+
+  --motion-fast: 150ms;
+  --motion-base: 320ms;
+  --motion-slow: 620ms;
+  --motion-sweep: 2400ms;
+  --ease-snap: cubic-bezier(0.2, 0.8, 0.2, 1);
+  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
+
+  --pointer-x: 50vw;
+  --pointer-y: 35vh;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+
+  --bg-void: #eef4fb;
+  --bg-ice: #e7f0fa;
+  --bg-panel: #dbe7f4;
+
+  --ambient-a: rgba(2, 132, 199, 0.16);
+  --ambient-b: rgba(14, 165, 233, 0.15);
+  --ambient-grid-line: rgba(51, 65, 85, 0.12);
+  --ambient-cursor: rgba(2, 132, 199, 0.2);
+
+  --ink-bright: #0f172a;
+  --ink-soft: #1e293b;
+  --ink-silver: #475569;
+  --ink-metal: #334155;
+
+  --arc-primary: #0284c7;
+  --arc-secondary: #0369a1;
+  --arc-glow: #0ea5e9;
+
+  --line-subtle: rgba(51, 65, 85, 0.24);
+  --line-strong: rgba(2, 132, 199, 0.5);
+
+  --surface-topbar-a: rgba(238, 244, 251, 0.94);
+  --surface-topbar-b: rgba(238, 244, 251, 0.78);
+  --surface-glass-a: rgba(255, 255, 255, 0.9);
+  --surface-glass-b: rgba(239, 247, 255, 0.92);
+  --surface-card: rgba(255, 255, 255, 0.9);
+  --surface-card-strong: rgba(248, 252, 255, 0.95);
+  --surface-chip: rgba(255, 255, 255, 0.86);
+  --surface-input: rgba(255, 255, 255, 0.95);
+  --surface-control: rgba(255, 255, 255, 0.9);
+
+  --panel-shadow: 0 14px 32px rgba(15, 23, 42, 0.14);
+  --card-shadow: 0 8px 18px rgba(15, 23, 42, 0.14);
+
+  --mark-bg: rgba(14, 165, 233, 0.22);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: "Space Grotesk", "Noto Sans SC", "Segoe UI", sans-serif;
+  background:
+    radial-gradient(120% 90% at 10% 0%, var(--ambient-a), transparent 60%),
+    radial-gradient(120% 90% at 90% 10%, var(--ambient-b), transparent 65%),
+    linear-gradient(160deg, var(--bg-void), var(--bg-ice) 45%, var(--bg-panel));
+  color: var(--ink-soft);
+  letter-spacing: 0.01em;
+  line-height: 1.45;
+  overflow-x: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+mark {
+  color: var(--ink-bright);
+  background: var(--mark-bg);
+  border-radius: 0.24rem;
+  padding: 0.02rem 0.18rem;
+}
+
+a,
+button {
+  -webkit-tap-highlight-color: transparent;
+}
+
+button {
+  font: inherit;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible {
+  outline: 2px solid rgba(103, 232, 249, 0.72);
+  outline-offset: 2px;
+}
+
+.app-shell {
+  position: relative;
+  isolation: isolate;
+}
+
+.ambient-grid,
+.ambient-glow,
+.cursor-glow {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+}
+
+.ambient-grid {
+  z-index: -3;
+  background-image:
+    linear-gradient(var(--ambient-grid-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--ambient-grid-line) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: radial-gradient(circle at center, black 35%, transparent 90%);
+  opacity: 0.28;
+}
+
+.ambient-glow {
+  z-index: -3;
+  background-image:
+    linear-gradient(108deg, transparent 46%, rgba(103, 232, 249, 0.2) 50%, transparent 54%),
+    linear-gradient(70deg, transparent 48%, rgba(56, 189, 248, 0.14) 50%, transparent 52%);
+  animation: ionShift 8s linear infinite;
+  opacity: 0.24;
+}
+
+.cursor-glow {
+  z-index: -2;
+  background: radial-gradient(
+    360px circle at var(--pointer-x) var(--pointer-y),
+    var(--ambient-cursor),
+    transparent 58%
+  );
+}
+
+.scroll-progress {
+  position: fixed;
+  inset: 0 0 auto 0;
+  height: 2px;
+  z-index: 35;
+  pointer-events: none;
+  background: rgba(56, 189, 248, 0.08);
+}
+
+.scroll-progress i {
+  display: block;
+  height: 100%;
+  transform-origin: 0 50%;
+  background: linear-gradient(
+    90deg,
+    rgba(34, 211, 238, 0.72),
+    rgba(103, 232, 249, 0.95),
+    rgba(56, 189, 248, 0.9)
+  );
+  box-shadow: 0 0 12px rgba(56, 189, 248, 0.55);
+}
+
+@keyframes ionShift {
+  from {
+    transform: translateX(-18%) translateY(-6%);
+  }
+  to {
+    transform: translateX(18%) translateY(6%);
+  }
+}
+
+.container {
+  width: min(1200px, 100% - clamp(1.1rem, 2.2vw, 2.6rem));
+  margin-inline: auto;
+}
+
+.section-rail {
+  position: fixed;
+  right: clamp(0.5rem, 1.6vw, 1.25rem);
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 18;
+  display: grid;
+  gap: 0.42rem;
+}
+
+.rail-link {
+  text-decoration: none;
+  color: var(--ink-silver);
+  border: 1px solid var(--line-subtle);
+  background: color-mix(in srgb, var(--surface-card) 88%, transparent 12%);
+  border-radius: 999px;
+  padding: 0.28rem 0.52rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  letter-spacing: 0.06em;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  transition:
+    border-color var(--motion-base) var(--ease-smooth),
+    color var(--motion-base) var(--ease-smooth),
+    background-color var(--motion-base) var(--ease-smooth),
+    transform var(--motion-fast) var(--ease-snap);
+}
+
+.rail-dot {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--ink-silver) 70%, transparent 30%);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--line-subtle) 65%, transparent 35%);
+}
+
+.rail-link:hover {
+  color: var(--ink-bright);
+  border-color: rgba(56, 189, 248, 0.52);
+  transform: translateX(-2px);
+}
+
+.rail-link.active {
+  color: var(--ink-bright);
+  border-color: rgba(56, 189, 248, 0.58);
+  background: rgba(56, 189, 248, 0.16);
+}
+
+.rail-link.active .rail-dot {
+  background: var(--arc-glow);
+  box-shadow: 0 0 12px rgba(103, 232, 249, 0.7);
+}
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(10px);
+  background: linear-gradient(180deg, var(--surface-topbar-a), var(--surface-topbar-b));
+  border-bottom: 1px solid var(--line-subtle);
+}
+
+.topbar-inner {
+  min-height: 76px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.52rem 0;
+}
+
+.wordmark {
+  font-family: "Orbitron", "Space Grotesk", sans-serif;
+  font-weight: 900;
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  letter-spacing: 0.18em;
+  color: var(--ink-bright);
+  text-transform: uppercase;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.54rem;
+  white-space: nowrap;
+}
+
+.wordmark::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--arc-glow);
+  box-shadow: 0 0 12px var(--arc-glow), 0 0 24px rgba(103, 232, 249, 0.5);
+}
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.top-link {
+  color: var(--ink-silver);
+  text-decoration: none;
+  padding: 0.42rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  transition:
+    color var(--motion-base) var(--ease-smooth),
+    border-color var(--motion-base) var(--ease-smooth),
+    background-color var(--motion-base) var(--ease-smooth);
+}
+
+.top-link:hover {
+  color: var(--ink-bright);
+  border-color: var(--line-subtle);
+  background: rgba(56, 189, 248, 0.08);
+}
+
+.top-link-btn {
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+}
+
+.top-shortcut {
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.34rem;
+  padding: 0.04rem 0.28rem;
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  color: var(--ink-metal);
+}
+
+.toggle-cluster {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--line-subtle);
+  background: var(--surface-control);
+  border-radius: 999px;
+  padding: 0.16rem;
+  gap: 0.16rem;
+}
+
+.toggle-chip {
+  appearance: none;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--ink-silver);
+  padding: 0.24rem 0.58rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    color var(--motion-base) var(--ease-smooth),
+    border-color var(--motion-base) var(--ease-smooth),
+    background-color var(--motion-base) var(--ease-smooth);
+}
+
+.toggle-chip:hover {
+  color: var(--ink-bright);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.toggle-chip.active {
+  color: var(--ink-bright);
+  background: rgba(56, 189, 248, 0.14);
+  border-color: rgba(56, 189, 248, 0.56);
+}
+
+.status-pill {
+  color: var(--arc-secondary);
+  border: 1px solid rgba(34, 211, 238, 0.4);
+  background: rgba(34, 211, 238, 0.08);
+  padding: 0.28rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.main-layout {
+  padding: clamp(3rem, 6vw, 4.9rem) 0 4.2rem;
+  display: grid;
+  gap: 2.2rem;
+}
+
+.hero {
+  display: grid;
+  gap: 1.3rem;
+  position: relative;
+  isolation: isolate;
+}
+
+.hero-grid {
+  grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
+  gap: 1.1rem;
+}
+
+.hero-grid::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -1.15rem 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(103, 232, 249, 0.44), transparent);
+  animation: railSweep var(--motion-sweep) linear infinite;
+}
+
+@keyframes railSweep {
+  from {
+    transform: translateX(-34%);
+  }
+  to {
+    transform: translateX(34%);
+  }
+}
+
+.hero-copy {
+  display: grid;
+  align-content: start;
+  gap: 1.2rem;
+}
+
+.hero-kicker {
+  margin: 0;
+  color: var(--ink-metal);
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.hero-title {
+  margin: 0;
+  font-family: "Orbitron", "Space Grotesk", sans-serif;
+  font-size: clamp(2rem, 7vw, 5.2rem);
+  line-height: 0.95;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--ink-bright);
+  text-wrap: balance;
+  text-shadow: 0 0 28px rgba(56, 189, 248, 0.22);
+  max-width: 14ch;
+}
+
+.hero-lead {
+  margin: 0;
+  max-width: 66ch;
+  font-size: clamp(1rem, 1.6vw, 1.16rem);
+  color: var(--ink-silver);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.82rem;
+}
+
+.btn {
+  appearance: none;
+  border: 1px solid var(--line-subtle);
+  color: var(--ink-soft);
+  text-decoration: none;
+  padding: 0.72rem 1.05rem;
+  background: var(--surface-control);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  border-radius: 0.74rem;
+  transition:
+    transform var(--motion-fast) var(--ease-snap),
+    border-color var(--motion-base) var(--ease-smooth),
+    color var(--motion-base) var(--ease-smooth),
+    box-shadow var(--motion-base) var(--ease-smooth);
+  position: relative;
+  overflow: hidden;
+}
+
+.btn::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    105deg,
+    transparent 40%,
+    rgba(103, 232, 249, 0.36),
+    transparent 60%
+  );
+  transform: translateX(-140%);
+  transition: transform var(--motion-slow) var(--ease-smooth);
+  pointer-events: none;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  border-color: var(--line-strong);
+  color: var(--ink-bright);
+  box-shadow:
+    0 0 0 1px rgba(34, 211, 238, 0.24) inset,
+    0 10px 24px rgba(2, 7, 22, 0.45),
+    0 0 22px rgba(56, 189, 248, 0.16);
+}
+
+.btn:hover::after {
+  transform: translateX(140%);
+}
+
+.btn-primary {
+  border-color: rgba(56, 189, 248, 0.5);
+  color: var(--ink-bright);
+  background: linear-gradient(
+    180deg,
+    rgba(56, 189, 248, 0.24),
+    var(--surface-control)
+  );
+}
+
+.metrics {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.76rem;
+}
+
+.metric {
+  border: 1px solid var(--line-subtle);
+  background: var(--surface-card-strong);
+  border-radius: 0.9rem;
+  padding: 0.9rem 0.95rem;
+}
+
+.metric dt {
+  margin: 0;
+  color: var(--ink-silver);
+  font-size: 0.79rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.metric dd {
+  margin: 0.24rem 0 0;
+  color: var(--ink-bright);
+  font-family: "Orbitron", "Space Grotesk", sans-serif;
+  font-weight: 700;
+  font-size: 0.98rem;
+  letter-spacing: 0.04em;
+}
+
+.command-deck {
+  border: 1px solid var(--line-subtle);
+  border-radius: 1rem;
+  background: linear-gradient(
+    145deg,
+    var(--surface-glass-a),
+    var(--surface-glass-b)
+  );
+  box-shadow: var(--panel-shadow);
+  overflow: hidden;
+  position: relative;
+}
+
+.command-deck::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    118deg,
+    transparent 40%,
+    rgba(103, 232, 249, 0.16) 50%,
+    transparent 60%
+  );
+  transform: translateX(-140%);
+  animation: deckSweep 3.8s linear infinite;
+  pointer-events: none;
+}
+
+@keyframes deckSweep {
+  from {
+    transform: translateX(-130%);
+  }
+  to {
+    transform: translateX(130%);
+  }
+}
+
+.deck-head {
+  padding: 0.78rem 0.92rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+  border-bottom: 1px solid var(--line-subtle);
+  background: var(--surface-card-strong);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.74rem;
+  color: var(--ink-metal);
+}
+
+.live-pill {
+  padding: 0.16rem 0.48rem;
+  border-radius: 999px;
+  border: 1px solid rgba(34, 211, 238, 0.45);
+  color: var(--arc-secondary);
+  background: rgba(34, 211, 238, 0.08);
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  font-weight: 600;
+}
+
+.deck-body {
+  padding: 0.82rem 0.92rem;
+  display: grid;
+  gap: 0.46rem;
+}
+
+.feed-row {
+  margin: 0;
+  padding: 0.52rem 0.56rem;
+  border-radius: 0.64rem;
+  border: 1px solid var(--line-subtle);
+  background: var(--surface-card);
+  color: var(--ink-soft);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.58rem;
+  animation: feedPulse 2.4s var(--ease-smooth) infinite;
+}
+
+@keyframes feedPulse {
+  0%,
+  100% {
+    border-color: var(--line-subtle);
+  }
+  50% {
+    border-color: rgba(56, 189, 248, 0.45);
+  }
+}
+
+.feed-index {
+  color: var(--arc-secondary);
+  min-width: 1.7rem;
+}
+
+.deck-bars {
+  padding: 0 0.92rem 0.98rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.deck-bar-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.74rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-silver);
+}
+
+.bar-track {
+  height: 8px;
+  border-radius: 999px;
+  background: var(--surface-card-strong);
+  border: 1px solid var(--line-subtle);
+  overflow: hidden;
+}
+
+.bar-track i {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(
+    90deg,
+    rgba(56, 189, 248, 0.65),
+    rgba(103, 232, 249, 0.88)
+  );
+  box-shadow: 0 0 12px rgba(103, 232, 249, 0.45);
+  animation: barGlow 2.2s var(--ease-smooth) infinite;
+}
+
+@keyframes barGlow {
+  0%,
+  100% {
+    filter: brightness(0.9);
+  }
+  50% {
+    filter: brightness(1.1);
+  }
+}
+
+.trait-band {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.62rem;
+}
+
+.trait-chip {
+  border: 1px solid var(--line-subtle);
+  border-radius: 999px;
+  padding: 0.42rem 0.76rem;
+  color: var(--ink-metal);
+  font-size: 0.78rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  background: var(--surface-chip);
+  transition:
+    border-color var(--motion-base) var(--ease-smooth),
+    color var(--motion-base) var(--ease-smooth),
+    transform var(--motion-fast) var(--ease-snap);
+}
+
+.trait-chip:hover {
+  border-color: rgba(56, 189, 248, 0.42);
+  color: var(--ink-bright);
+  transform: translateY(-1px);
+}
+
+.glass-panel {
+  border-radius: 1rem;
+  border: 1px solid var(--line-subtle);
+  background: linear-gradient(145deg, var(--surface-glass-a), var(--surface-glass-b));
+  backdrop-filter: blur(9px);
+  box-shadow: var(--panel-shadow);
+  padding: 1.35rem;
+}
+
+.section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.section-title {
+  margin: 0;
+  font-family: "Orbitron", "Space Grotesk", sans-serif;
+  font-size: clamp(1.1rem, 2.4vw, 1.5rem);
+  color: var(--ink-bright);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.section-head-link {
+  color: var(--arc-secondary);
+  text-decoration: none;
+  font-size: 0.76rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  border: 1px solid rgba(34, 211, 238, 0.35);
+  border-radius: 999px;
+  padding: 0.3rem 0.65rem;
+  transition:
+    border-color var(--motion-base) var(--ease-smooth),
+    color var(--motion-base) var(--ease-smooth),
+    background-color var(--motion-base) var(--ease-smooth);
+}
+
+.section-head-link:hover {
+  color: var(--ink-bright);
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.section-tag {
+  color: var(--ink-metal);
+  border: 1px solid var(--line-subtle);
+  border-radius: 999px;
+  padding: 0.28rem 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+}
+
+.cap-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.9rem;
+}
+
+.cap-card {
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.84rem;
+  background: var(--surface-card-strong);
+  padding: 1rem;
+  position: relative;
+  overflow: hidden;
+  transition:
+    transform var(--motion-fast) var(--ease-snap),
+    border-color var(--motion-base) var(--ease-smooth),
+    box-shadow var(--motion-base) var(--ease-smooth);
+}
+
+.cap-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    circle at 15% 0%,
+    rgba(56, 189, 248, 0.16),
+    transparent 48%
+  );
+  opacity: 0;
+  transition: opacity var(--motion-base) var(--ease-smooth);
+  pointer-events: none;
+}
+
+.cap-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(56, 189, 248, 0.4);
+  box-shadow: var(--card-shadow);
+}
+
+.cap-card:hover::before {
+  opacity: 1;
+}
+
+.cap-card h3 {
+  margin: 0 0 0.52rem;
+  font-size: 1.03rem;
+  color: var(--ink-bright);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.cap-card p {
+  margin: 0;
+  color: var(--ink-silver);
+  font-size: 0.94rem;
+}
+
+.workflow-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: 0.95rem;
+}
+
+.phase-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.72rem;
+}
+
+.phase-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: start;
+  gap: 0.72rem;
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.82rem;
+  background: var(--surface-card-strong);
+  padding: 0.78rem 0.86rem;
+}
+
+.phase-num {
+  width: 1.76rem;
+  height: 1.76rem;
+  border-radius: 999px;
+  border: 1px solid rgba(56, 189, 248, 0.52);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--arc-secondary);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.8rem;
+}
+
+.phase-text h3 {
+  margin: 0;
+  color: var(--ink-bright);
+  font-size: 0.95rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.phase-text p {
+  margin: 0.3rem 0 0;
+  color: var(--ink-silver);
+  font-size: 0.9rem;
+}
+
+.monitor-panel {
+  display: grid;
+  align-content: start;
+  gap: 0.9rem;
+}
+
+.monitor-intro {
+  margin: 0;
+  color: var(--ink-silver);
+  font-size: 0.94rem;
+}
+
+.monitor-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.64rem;
+}
+
+.monitor-grid div {
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.7rem;
+  padding: 0.62rem 0.7rem;
+  background: var(--surface-card);
+  display: grid;
+  gap: 0.22rem;
+}
+
+.monitor-grid span {
+  color: var(--ink-silver);
+  font-size: 0.76rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.monitor-grid strong {
+  color: var(--ink-bright);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.91rem;
+}
+
+.links-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.doc-link {
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.78rem;
+  background: var(--surface-card);
+  color: var(--ink-soft);
+  text-decoration: none;
+  padding: 0.9rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.82rem;
+  letter-spacing: 0.02em;
+  transition:
+    border-color var(--motion-base) var(--ease-smooth),
+    color var(--motion-base) var(--ease-smooth),
+    transform var(--motion-fast) var(--ease-snap),
+    box-shadow var(--motion-base) var(--ease-smooth);
+}
+
+.doc-link:hover {
+  transform: translateY(-2px);
+  color: var(--ink-bright);
+  border-color: rgba(56, 189, 248, 0.46);
+  box-shadow:
+    inset 3px 0 0 rgba(56, 189, 248, 0.76),
+    0 8px 22px rgba(2, 7, 22, 0.45);
+}
+
+.doc-link svg {
+  width: 15px;
+  height: 15px;
+  stroke: currentColor;
+  fill: none;
+  opacity: 0.72;
+  transition: transform var(--motion-fast) var(--ease-snap);
+}
+
+.doc-link:hover svg {
+  transform: translate(2px, -2px);
+  opacity: 1;
+}
+
+.path-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.path-card {
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.82rem;
+  background: var(--surface-card);
+  padding: 0.92rem;
+  display: grid;
+  align-content: start;
+  gap: 0.7rem;
+  transition:
+    transform var(--motion-fast) var(--ease-snap),
+    border-color var(--motion-base) var(--ease-smooth),
+    box-shadow var(--motion-base) var(--ease-smooth);
+}
+
+.path-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.52);
+  box-shadow: 0 12px 24px rgba(2, 7, 22, 0.46);
+}
+
+.path-card h3 {
+  margin: 0;
+  color: var(--ink-bright);
+  font-size: 0.9rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.path-card p {
+  margin: 0;
+  color: var(--ink-silver);
+  font-size: 0.85rem;
+}
+
+.path-docs {
+  display: grid;
+  gap: 0.44rem;
+}
+
+.path-doc-link {
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.58rem;
+  text-decoration: none;
+  background: var(--surface-card-strong);
+  padding: 0.42rem 0.5rem;
+  display: grid;
+  gap: 0.2rem;
+  transition:
+    border-color var(--motion-base) var(--ease-smooth),
+    background-color var(--motion-base) var(--ease-smooth);
+}
+
+.path-doc-link:hover {
+  border-color: rgba(56, 189, 248, 0.52);
+  background: var(--surface-card);
+}
+
+.path-doc-link span {
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+}
+
+.path-doc-link code {
+  color: var(--ink-silver);
+  font-size: 0.68rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+}
+
+#hero-core,
+#core-shortcuts,
+#quick-paths,
+#capability-stack,
+#execution-lattice,
+#docs-navigator {
+  scroll-margin-top: 92px;
+}
+
+.docs-panel {
+  scroll-margin-top: 92px;
+}
+
+.docs-intro {
+  margin: 0;
+  color: var(--ink-silver);
+  max-width: 70ch;
+}
+
+.docs-tools {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.9rem;
+}
+
+.docs-filter-stack {
+  display: grid;
+  gap: 0.62rem;
+}
+
+.docs-search-wrap {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.docs-search-label {
+  font-size: 0;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+}
+
+.docs-search-wrap input {
+  width: 100%;
+  border: 1px solid var(--line-subtle);
+  background: var(--surface-input);
+  color: var(--ink-bright);
+  border-radius: 0.74rem;
+  padding: 0.72rem 0.85rem;
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.82rem;
+  transition:
+    border-color var(--motion-base) var(--ease-smooth),
+    box-shadow var(--motion-base) var(--ease-smooth);
+}
+
+.docs-search-wrap input::placeholder {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.docs-search-wrap input:focus {
+  border-color: rgba(56, 189, 248, 0.56);
+  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.16);
+}
+
+.category-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.48rem;
+}
+
+.level-row {
+  opacity: 0.96;
+}
+
+.category-pill {
+  border: 1px solid var(--line-subtle);
+  background: var(--surface-chip);
+  color: var(--ink-silver);
+  border-radius: 999px;
+  padding: 0.34rem 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.38rem;
+  font-size: 0.76rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    border-color var(--motion-base) var(--ease-smooth),
+    color var(--motion-base) var(--ease-smooth),
+    background-color var(--motion-base) var(--ease-smooth),
+    transform var(--motion-fast) var(--ease-snap);
+}
+
+.category-pill:hover {
+  transform: translateY(-1px);
+  color: var(--ink-bright);
+  border-color: rgba(56, 189, 248, 0.48);
+}
+
+.category-pill.active {
+  color: var(--ink-bright);
+  background: rgba(56, 189, 248, 0.14);
+  border-color: rgba(56, 189, 248, 0.56);
+}
+
+.pill-count {
+  border: 1px solid var(--line-subtle);
+  border-radius: 999px;
+  padding: 0.02rem 0.28rem;
+  font-size: 0.62rem;
+  color: var(--ink-metal);
+  letter-spacing: 0.04em;
+  line-height: 1.2;
+}
+
+.category-pill.active .pill-count {
+  color: var(--ink-bright);
+  border-color: rgba(56, 189, 248, 0.55);
+  background: rgba(56, 189, 248, 0.2);
+}
+
+.level-pill {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+}
+
+.docs-utility-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.docs-hint {
+  margin: 0;
+  color: var(--ink-silver);
+  font-size: 0.79rem;
+  letter-spacing: 0.04em;
+}
+
+.docs-hint kbd {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  color: var(--ink-soft);
+  border: 1px solid var(--line-subtle);
+  border-bottom-width: 2px;
+  border-radius: 0.35rem;
+  padding: 0.08rem 0.3rem;
+  margin-inline: 0.18rem;
+  background: var(--surface-control);
+}
+
+.reset-filters-btn {
+  border: 1px solid var(--line-subtle);
+  border-radius: 999px;
+  background: var(--surface-control);
+  color: var(--ink-soft);
+  font-size: 0.74rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  padding: 0.34rem 0.72rem;
+  cursor: pointer;
+  transition:
+    border-color var(--motion-base) var(--ease-smooth),
+    color var(--motion-base) var(--ease-smooth),
+    background-color var(--motion-base) var(--ease-smooth);
+}
+
+.reset-filters-btn:hover:not(:disabled) {
+  border-color: rgba(56, 189, 248, 0.58);
+  color: var(--ink-bright);
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.reset-filters-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.docs-count {
+  margin: 0.8rem 0 0;
+  color: var(--ink-metal);
+  font-size: 0.84rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.docs-groups {
+  margin-top: 1rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.docs-top-matches {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.docs-group {
+  display: grid;
+  gap: 0.6rem;
+  container-type: inline-size;
+}
+
+.docs-group-title {
+  margin: 0;
+  font-family: "Orbitron", "Space Grotesk", sans-serif;
+  font-size: 0.92rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-bright);
+}
+
+.docs-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.doc-nav-card {
+  text-decoration: none;
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.78rem;
+  padding: 0.78rem 0.86rem;
+  background: var(--surface-card);
+  display: grid;
+  gap: 0.48rem;
+  transition:
+    transform var(--motion-fast) var(--ease-snap),
+    border-color var(--motion-base) var(--ease-smooth),
+    box-shadow var(--motion-base) var(--ease-smooth);
+}
+
+.doc-nav-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.5);
+  box-shadow:
+    var(--card-shadow),
+    0 0 0 1px rgba(56, 189, 248, 0.2) inset;
+}
+
+.doc-nav-card-priority {
+  border-color: rgba(56, 189, 248, 0.42);
+  background:
+    linear-gradient(170deg, color-mix(in srgb, var(--surface-card) 88%, var(--arc-primary) 12%), var(--surface-card)),
+    var(--surface-card);
+  box-shadow: inset 2px 0 0 rgba(56, 189, 248, 0.52);
+}
+
+.doc-nav-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.doc-nav-head strong {
+  color: var(--ink-bright);
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+}
+
+.doc-nav-head span {
+  color: var(--arc-secondary);
+  border: 1px solid rgba(34, 211, 238, 0.38);
+  border-radius: 999px;
+  padding: 0.12rem 0.38rem;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  white-space: nowrap;
+}
+
+.doc-nav-card p {
+  margin: 0;
+  color: var(--ink-silver);
+  font-size: 0.86rem;
+}
+
+.doc-nav-card code {
+  color: color-mix(in srgb, var(--ink-soft) 92%, white 8%);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.73rem;
+  background: var(--surface-card-strong);
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.5rem;
+  padding: 0.22rem 0.42rem;
+  overflow-wrap: anywhere;
+}
+
+.doc-empty {
+  border: 1px dashed color-mix(in srgb, var(--line-subtle) 80%, var(--ink-silver) 20%);
+  border-radius: 0.76rem;
+  padding: 0.78rem 0.9rem;
+  color: var(--ink-silver);
+  background: var(--surface-card);
+  font-size: 0.9rem;
+}
+
+.doc-empty code {
+  margin-inline: 0.2rem;
+  color: var(--ink-bright);
+}
+
+.panel-footer {
+  border-top: 1px solid var(--line-subtle);
+  margin-top: 1.1rem;
+  color: var(--ink-silver);
+  font-size: 0.84rem;
+  padding-top: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.palette-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  background: rgba(2, 7, 20, 0.58);
+  backdrop-filter: blur(5px);
+  display: grid;
+  place-items: center;
+  padding: 0.9rem;
+}
+
+.palette-panel {
+  width: min(840px, 100%);
+  max-height: min(82vh, 780px);
+  border: 1px solid var(--line-subtle);
+  border-radius: 1rem;
+  background: linear-gradient(145deg, var(--surface-glass-a), var(--surface-glass-b));
+  box-shadow: 0 22px 48px rgba(2, 7, 22, 0.48);
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  overflow: hidden;
+}
+
+.palette-head {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.55rem;
+  padding: 0.72rem;
+  border-bottom: 1px solid var(--line-subtle);
+  background: var(--surface-card-strong);
+}
+
+.palette-head input {
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.62rem;
+  background: var(--surface-input);
+  color: var(--ink-bright);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.82rem;
+  padding: 0.7rem 0.8rem;
+}
+
+.palette-head input::placeholder {
+  color: var(--ink-silver);
+}
+
+.palette-close {
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.62rem;
+  background: var(--surface-control);
+  color: var(--ink-soft);
+  padding: 0.58rem 0.82rem;
+  font-size: 0.74rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.palette-close:hover {
+  border-color: rgba(56, 189, 248, 0.56);
+  color: var(--ink-bright);
+}
+
+.palette-grid {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
+}
+
+.palette-results {
+  overflow: auto;
+  display: grid;
+  gap: 0.95rem;
+  padding: 0.84rem;
+  border-right: 1px solid var(--line-subtle);
+}
+
+.palette-section-title {
+  margin: 0 0 0.5rem;
+  position: sticky;
+  top: -0.1rem;
+  z-index: 1;
+  background: color-mix(in srgb, var(--surface-card-strong) 80%, transparent 20%);
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.52rem;
+  padding: 0.24rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  color: var(--ink-metal);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.palette-section-title small {
+  border: 1px solid var(--line-subtle);
+  border-radius: 999px;
+  padding: 0.02rem 0.36rem;
+  font-size: 0.62rem;
+  color: var(--ink-soft);
+}
+
+.palette-list {
+  display: grid;
+  gap: 0.48rem;
+}
+
+.palette-item {
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.72rem;
+  background: var(--surface-card);
+  padding: 0.62rem 0.72rem;
+  color: var(--ink-soft);
+  display: grid;
+  gap: 0.22rem;
+  cursor: pointer;
+  transition:
+    transform var(--motion-fast) var(--ease-snap),
+    border-color var(--motion-base) var(--ease-smooth),
+    box-shadow var(--motion-base) var(--ease-smooth);
+}
+
+.palette-item:hover {
+  transform: translateY(-1px);
+  border-color: rgba(56, 189, 248, 0.52);
+  box-shadow:
+    var(--card-shadow),
+    0 0 0 1px rgba(56, 189, 248, 0.2) inset;
+}
+
+.palette-item.active {
+  border-color: rgba(103, 232, 249, 0.72);
+  box-shadow:
+    var(--card-shadow),
+    0 0 0 1px rgba(56, 189, 248, 0.34) inset,
+    0 0 20px rgba(56, 189, 248, 0.2);
+  background: linear-gradient(
+    160deg,
+    color-mix(in srgb, var(--surface-card) 84%, var(--arc-primary) 16%),
+    var(--surface-card)
+  );
+}
+
+.palette-item-main {
+  color: var(--ink-bright);
+  font-size: 0.86rem;
+  letter-spacing: 0.02em;
+}
+
+.palette-item small {
+  color: var(--ink-silver);
+  font-size: 0.78rem;
+}
+
+.palette-doc-item code {
+  width: fit-content;
+  color: var(--ink-metal);
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.42rem;
+  padding: 0.12rem 0.34rem;
+  background: var(--surface-card-strong);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.7rem;
+}
+
+.palette-empty {
+  margin: 0;
+  border: 1px dashed var(--line-subtle);
+  border-radius: 0.72rem;
+  padding: 0.68rem 0.72rem;
+  color: var(--ink-silver);
+  background: var(--surface-card);
+  font-size: 0.86rem;
+}
+
+.palette-preview {
+  min-height: 0;
+  display: grid;
+  align-content: start;
+  gap: 0.7rem;
+  padding: 0.84rem;
+  background: color-mix(in srgb, var(--surface-card-strong) 82%, transparent 18%);
+}
+
+.palette-preview-title {
+  margin: 0;
+  color: var(--ink-metal);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.preview-card {
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.84rem;
+  background: var(--surface-card);
+  padding: 0.7rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.preview-kind {
+  margin: 0;
+  width: fit-content;
+  border: 1px solid rgba(34, 211, 238, 0.44);
+  border-radius: 999px;
+  color: var(--arc-secondary);
+  background: rgba(34, 211, 238, 0.1);
+  padding: 0.14rem 0.42rem;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.preview-card h3 {
+  margin: 0;
+  color: var(--ink-bright);
+  font-size: 0.93rem;
+  letter-spacing: 0.02em;
+}
+
+.preview-card p {
+  margin: 0;
+  color: var(--ink-silver);
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.preview-card code {
+  width: fit-content;
+  color: var(--ink-metal);
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.7rem;
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.45rem;
+  padding: 0.12rem 0.34rem;
+  background: var(--surface-card-strong);
+}
+
+.preview-open-hint {
+  color: var(--ink-silver);
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.palette-preview-empty {
+  margin: 0;
+  border: 1px dashed var(--line-subtle);
+  border-radius: 0.72rem;
+  padding: 0.64rem 0.7rem;
+  color: var(--ink-silver);
+  font-size: 0.82rem;
+  background: var(--surface-card);
+}
+
+.palette-kbd-hints {
+  display: grid;
+  gap: 0.34rem;
+}
+
+.palette-kbd-hints span {
+  border: 1px solid var(--line-subtle);
+  border-radius: 0.5rem;
+  padding: 0.26rem 0.44rem;
+  color: var(--ink-soft);
+  background: var(--surface-card);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+}
+
+.mobile-dock {
+  position: fixed;
+  left: 50%;
+  bottom: 0.9rem;
+  transform: translateX(-50%);
+  z-index: 26;
+  display: none;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--line-subtle);
+  border-radius: 999px;
+  padding: 0.32rem;
+  background: color-mix(in srgb, var(--surface-control) 86%, transparent 14%);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 12px 28px rgba(2, 7, 20, 0.42);
+}
+
+.dock-btn {
+  appearance: none;
+  border: 1px solid var(--line-subtle);
+  border-radius: 999px;
+  padding: 0.4rem 0.75rem;
+  background: var(--surface-card);
+  color: var(--ink-soft);
+  text-decoration: none;
+  font-size: 0.74rem;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    border-color var(--motion-base) var(--ease-smooth),
+    color var(--motion-base) var(--ease-smooth),
+    background-color var(--motion-base) var(--ease-smooth);
+}
+
+.dock-btn:hover {
+  color: var(--ink-bright);
+  border-color: rgba(56, 189, 248, 0.58);
+  background: rgba(56, 189, 248, 0.14);
+}
+
+.reveal {
+  opacity: 0;
+  transform: translateY(16px);
+  transition:
+    opacity var(--motion-slow) var(--ease-smooth),
+    transform var(--motion-slow) var(--ease-smooth);
+}
+
+.reveal.in {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.delay-1 {
+  transition-delay: 90ms;
+}
+
+.delay-2 {
+  transition-delay: 180ms;
+}
+
+.delay-3 {
+  transition-delay: 270ms;
+}
+
+.delay-4 {
+  transition-delay: 360ms;
+}
+
+@container (max-width: 600px) {
+  .doc-nav-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 1360px) {
+  .section-rail {
+    display: none;
+  }
+}
+
+@media (max-width: 1280px) {
+  .container {
+    width: min(1140px, 100% - 1.8rem);
+  }
+
+  .path-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 1120px) {
+  .hero-grid,
+  .workflow-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .command-deck {
+    max-width: 680px;
+  }
+
+  .topbar-inner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .top-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 920px) {
+  .metrics,
+  .cap-grid,
+  .links-grid,
+  .monitor-grid,
+  .docs-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-title {
+    max-width: 18ch;
+  }
+
+  .status-pill {
+    display: none;
+  }
+
+  .top-shortcut {
+    display: none;
+  }
+
+  .palette-panel {
+    width: min(760px, 100%);
+  }
+
+  .palette-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .palette-results {
+    border-right: none;
+    border-bottom: 1px solid var(--line-subtle);
+    max-height: 52vh;
+  }
+
+  .palette-preview {
+    max-height: 30vh;
+    overflow: auto;
+  }
+}
+
+@media (max-width: 820px) {
+  .mobile-dock {
+    display: inline-flex;
+  }
+
+  .main-layout {
+    padding-bottom: 5.2rem;
+  }
+}
+
+@media (max-width: 760px) {
+  .main-layout {
+    gap: 1.5rem;
+  }
+
+  .hero-actions .btn {
+    flex: 1 1 100%;
+    text-align: center;
+  }
+
+  .section-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .docs-utility-row {
+    align-items: flex-start;
+    justify-content: flex-start;
+  }
+
+  .palette-head {
+    grid-template-columns: 1fr;
+  }
+
+  .palette-close {
+    width: fit-content;
+  }
+
+  .palette-preview {
+    display: none;
+  }
+
+  .palette-results {
+    max-height: 64vh;
+  }
+}
+
+@media (max-width: 640px) {
+  .top-actions a.top-link {
+    display: none;
+  }
+
+  .top-actions .top-link-btn {
+    display: inline-flex;
+  }
+
+  .toggle-cluster {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .toggle-chip {
+    flex: 1 1 auto;
+    text-align: center;
+    padding-inline: 0.4rem;
+  }
+
+  .path-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .glass-panel {
+    padding: 1rem;
+  }
+
+  .docs-count,
+  .panel-footer {
+    text-transform: none;
+    letter-spacing: 0.02em;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .ambient-glow,
+  .cursor-glow,
+  .hero-grid::after,
+  .btn::after,
+  .command-deck::after {
+    display: none !important;
+  }
+
+  .reveal {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  base: "/zeroclaw/",
+  plugins: [react()],
+  build: {
+    outDir: "../gh-pages",
+    emptyOutDir: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add a Vite + React docs hub under `site/` with responsive layout, dark mode, and i18n-ready structure
- add GitHub Pages deploy workflow `.github/workflows/pages-deploy.yml`
- set Vite output dir to root-level `gh-pages/` and ignore build/dependency artifacts

## Validation
- npm ci
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched GitHub Pages documentation hub with live search, category/level filtering, and text highlighting
  * Added dark/light theme support with automatic system preference detection
  * Implemented bilingual interface (English and Chinese)
  * Built command palette for keyboard-driven navigation and actions
  * Responsive design with section navigation and scroll progress tracking

* **Documentation**
  * Added comprehensive setup and feature documentation

* **Chores**
  * Configured automated deployment workflow for GitHub Pages
  * Established Vite and React development environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->