### PR TITLE
feat(site): rebuild design language and docs readability

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -6,13 +6,7 @@
     <title>ZeroClaw</title>
     <meta
       name="description"
-      content="A high-tech, cold, smooth-motion gateway interface for ZeroClaw documentation."
-    />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Orbitron:wght@500;700;900&family=Space+Grotesk:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
+      content="Fast, small, and fully autonomous AI assistant infrastructure. Deploy anywhere. Swap anything."
     />
   </head>
   <body>

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@types/react": "^19.0.7",
@@ -1195,18 +1197,58 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1221,6 +1263,18 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1241,6 +1295,16 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1311,6 +1375,66 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1322,14 +1446,12 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1341,6 +1463,41 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1402,6 +1559,34 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1445,6 +1630,118 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1478,6 +1775,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1488,11 +1795,853 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -1519,6 +2668,31 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -1570,6 +2744,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -1591,6 +2775,33 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -1599,6 +2810,72 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rollup": {
@@ -1672,6 +2949,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -1689,6 +3008,26 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
@@ -1701,6 +3040,93 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -1732,6 +3158,34 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -1815,6 +3269,16 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/site/package.json
+++ b/site/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@types/react": "^19.0.7",

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -1,1876 +1,951 @@
 import {
+  isValidElement,
   useEffect,
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
   type ReactNode,
 } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 type Locale = "en" | "zh";
 type ThemeMode = "system" | "dark" | "light";
 type ResolvedTheme = "dark" | "light";
-type LocalizedText = Record<Locale, string>;
+type Category =
+  | "Core"
+  | "Setup"
+  | "Operations"
+  | "Security"
+  | "Reference"
+  | "International";
 
-const categories = [
-  "Getting Started",
-  "Configuration",
-  "Channels",
-  "Operations",
-  "Security",
-  "Reference",
-] as const;
-
-const levelFilterOptions = ["All", "Core", "Advanced"] as const;
-
-type DocCategory = (typeof categories)[number];
-type CategoryFilter = "All" | DocCategory;
-type DocLevel = "Core" | "Advanced";
-type LevelFilter = (typeof levelFilterOptions)[number];
+type Localized = Record<Locale, string>;
 
 type DocEntry = {
-  title: LocalizedText;
-  path: string;
-  category: DocCategory;
-  summary: LocalizedText;
-  level: DocLevel;
-  featured?: boolean;
-  keywords?: string[];
-};
-
-type QuickPath = {
-  title: LocalizedText;
-  summary: LocalizedText;
-  docs: string[];
-};
-
-type Capability = {
-  title: LocalizedText;
-  text: LocalizedText;
-};
-
-type ExecutionPhase = {
-  phase: LocalizedText;
-  detail: LocalizedText;
-};
-
-type PaletteAction = {
   id: string;
-  label: string;
-  hint: string;
-  keywords: string[];
-  run: () => void;
+  category: Category;
+  path: string;
+  zhPath?: string;
+  title: Localized;
+  summary: Localized;
+  keywords?: string[];
 };
 
 type PaletteEntry = {
   id: string;
-  kind: "action" | "doc";
   label: string;
   hint: string;
-  meta?: string;
   run: () => void;
 };
 
-function bi(en: string, zh: string): LocalizedText {
-  return { en, zh };
-}
+const repoBase = "https://github.com/zeroclaw-labs/zeroclaw/blob/main";
+const rawBase = "https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main";
 
-const categoryLabels: Record<Locale, Record<DocCategory, string>> = {
-  en: {
-    "Getting Started": "Getting Started",
-    Configuration: "Configuration",
-    Channels: "Channels",
-    Operations: "Operations",
-    Security: "Security",
-    Reference: "Reference",
+const docs: DocEntry[] = [
+  {
+    id: "repo-readme",
+    category: "Core",
+    path: "README.md",
+    zhPath: "README.zh-CN.md",
+    title: { en: "Repository README", zh: "仓库 README" },
+    summary: {
+      en: "Project overview, architecture, benchmarks, setup, and operations.",
+      zh: "项目总览、架构、基准、安装与运维入口。",
+    },
+    keywords: ["overview", "architecture", "benchmark", "quick start"],
   },
-  zh: {
-    "Getting Started": "快速开始",
-    Configuration: "配置",
-    Channels: "渠道集成",
-    Operations: "运维",
-    Security: "安全",
-    Reference: "参考资料",
+  {
+    id: "docs-home",
+    category: "Core",
+    path: "docs/README.md",
+    zhPath: "docs/i18n/zh-CN/README.md",
+    title: { en: "Docs Hub", zh: "文档总览" },
+    summary: {
+      en: "Primary documentation hub for all ZeroClaw capabilities.",
+      zh: "ZeroClaw 全量文档的总入口。",
+    },
+    keywords: ["docs", "hub", "summary"],
   },
-};
+  {
+    id: "docs-summary",
+    category: "Core",
+    path: "docs/SUMMARY.md",
+    zhPath: "docs/i18n/zh-CN/SUMMARY.md",
+    title: { en: "Docs Table of Contents", zh: "文档目录" },
+    summary: {
+      en: "Structured index for all docs sections and files.",
+      zh: "结构化文档目录与索引。",
+    },
+    keywords: ["toc", "summary", "index"],
+  },
+  {
+    id: "one-click-bootstrap",
+    category: "Setup",
+    path: "docs/one-click-bootstrap.md",
+    zhPath: "docs/i18n/zh-CN/one-click-bootstrap.md",
+    title: { en: "One-Click Bootstrap", zh: "一键安装" },
+    summary: {
+      en: "Fast installer path for dependencies and ZeroClaw runtime.",
+      zh: "快速完成依赖与 ZeroClaw 运行时安装。",
+    },
+  },
+  {
+    id: "getting-started",
+    category: "Setup",
+    path: "docs/getting-started/README.md",
+    title: { en: "Getting Started", zh: "快速开始" },
+    summary: {
+      en: "Boot sequence, first commands, and onboarding flow.",
+      zh: "启动流程、首批命令与引导步骤。",
+    },
+  },
+  {
+    id: "network-deployment",
+    category: "Setup",
+    path: "docs/network-deployment.md",
+    zhPath: "docs/i18n/zh-CN/network-deployment.md",
+    title: { en: "Network Deployment", zh: "网络部署" },
+    summary: {
+      en: "Service setup, daemon/gateway, and network run modes.",
+      zh: "服务配置、daemon/gateway 与网络运行模式。",
+    },
+  },
+  {
+    id: "hardware",
+    category: "Setup",
+    path: "docs/hardware/README.md",
+    title: { en: "Hardware Guide", zh: "硬件指南" },
+    summary: {
+      en: "Board and hardware references for edge deployment.",
+      zh: "边缘部署相关板卡与硬件参考。",
+    },
+  },
+  {
+    id: "operations-runbook",
+    category: "Operations",
+    path: "docs/operations-runbook.md",
+    zhPath: "docs/i18n/zh-CN/operations-runbook.md",
+    title: { en: "Operations Runbook", zh: "运维手册" },
+    summary: {
+      en: "Operational procedures, incident handling, and checks.",
+      zh: "运维流程、故障处理与巡检实践。",
+    },
+  },
+  {
+    id: "ops-overview",
+    category: "Operations",
+    path: "docs/operations/README.md",
+    title: { en: "Operations Overview", zh: "运维概览" },
+    summary: {
+      en: "Operations section hub with runbooks and safeguards.",
+      zh: "运维章节入口，包含 runbook 与保障策略。",
+    },
+  },
+  {
+    id: "connectivity-probes",
+    category: "Operations",
+    path: "docs/operations/connectivity-probes-runbook.md",
+    title: { en: "Connectivity Probes", zh: "连通性探针" },
+    summary: {
+      en: "Probe workflow and diagnosis guidelines.",
+      zh: "探针流程与诊断指南。",
+    },
+  },
+  {
+    id: "troubleshooting",
+    category: "Operations",
+    path: "docs/troubleshooting.md",
+    zhPath: "docs/i18n/zh-CN/troubleshooting.md",
+    title: { en: "Troubleshooting", zh: "问题排查" },
+    summary: {
+      en: "Systematic recovery checklist for common failures.",
+      zh: "常见故障的系统化排查与恢复清单。",
+    },
+  },
+  {
+    id: "security-overview",
+    category: "Security",
+    path: "docs/security/README.md",
+    title: { en: "Security Overview", zh: "安全概览" },
+    summary: {
+      en: "Security architecture, controls, and policy model.",
+      zh: "安全架构、控制项与策略模型。",
+    },
+  },
+  {
+    id: "sandboxing",
+    category: "Security",
+    path: "docs/sandboxing.md",
+    zhPath: "docs/i18n/zh-CN/sandboxing.md",
+    title: { en: "Sandboxing", zh: "沙箱机制" },
+    summary: {
+      en: "Runtime sandbox boundaries and risk containment.",
+      zh: "运行时沙箱边界与风险隔离。",
+    },
+  },
+  {
+    id: "agnostic-security",
+    category: "Security",
+    path: "docs/agnostic-security.md",
+    zhPath: "docs/i18n/zh-CN/agnostic-security.md",
+    title: { en: "Agnostic Security", zh: "模型无关安全" },
+    summary: {
+      en: "Provider-agnostic security stance and operating model.",
+      zh: "面向多模型的统一安全基线与运行方式。",
+    },
+  },
+  {
+    id: "config-reference",
+    category: "Reference",
+    path: "docs/config-reference.md",
+    zhPath: "docs/i18n/zh-CN/config-reference.md",
+    title: { en: "Config Reference", zh: "配置参考" },
+    summary: {
+      en: "All runtime configuration fields and defaults.",
+      zh: "运行时配置字段与默认值。",
+    },
+  },
+  {
+    id: "commands-reference",
+    category: "Reference",
+    path: "docs/commands-reference.md",
+    zhPath: "docs/i18n/zh-CN/commands-reference.md",
+    title: { en: "Commands Reference", zh: "命令参考" },
+    summary: {
+      en: "CLI command map for onboarding, runtime, and tooling.",
+      zh: "覆盖引导、运行时与工具的 CLI 命令总览。",
+    },
+  },
+  {
+    id: "custom-providers",
+    category: "Reference",
+    path: "docs/custom-providers.md",
+    zhPath: "docs/i18n/zh-CN/custom-providers.md",
+    title: { en: "Custom Providers", zh: "自定义模型提供方" },
+    summary: {
+      en: "OpenAI-compatible and custom endpoint integration.",
+      zh: "OpenAI 兼容与自定义端点集成指南。",
+    },
+  },
+  {
+    id: "channels-reference",
+    category: "Reference",
+    path: "docs/channels-reference.md",
+    zhPath: "docs/i18n/zh-CN/channels-reference.md",
+    title: { en: "Channels Reference", zh: "渠道参考" },
+    summary: {
+      en: "Slack/Telegram/Discord/WhatsApp and channel wiring.",
+      zh: "Slack/Telegram/Discord/WhatsApp 等渠道配置。",
+    },
+  },
+  {
+    id: "reference-overview",
+    category: "Reference",
+    path: "docs/reference/README.md",
+    title: { en: "Reference Overview", zh: "参考总览" },
+    summary: {
+      en: "Reference section index across runtime internals.",
+      zh: "运行时内部参考索引。",
+    },
+  },
+  {
+    id: "resource-limits",
+    category: "Reference",
+    path: "docs/resource-limits.md",
+    zhPath: "docs/i18n/zh-CN/resource-limits.md",
+    title: { en: "Resource Limits", zh: "资源限制" },
+    summary: {
+      en: "CPU, memory, and execution constraints guide.",
+      zh: "CPU、内存与执行约束说明。",
+    },
+  },
+  {
+    id: "i18n-guide",
+    category: "International",
+    path: "docs/i18n-guide.md",
+    zhPath: "docs/i18n/zh-CN/i18n-guide.md",
+    title: { en: "i18n Guide", zh: "国际化指南" },
+    summary: {
+      en: "Localization strategy and docs translation workflow.",
+      zh: "本地化策略与文档翻译流程。",
+    },
+  },
+  {
+    id: "zh-docs-home",
+    category: "International",
+    path: "docs/i18n/zh-CN/README.md",
+    title: { en: "Chinese Docs Hub", zh: "中文文档总览" },
+    summary: {
+      en: "Chinese documentation index and translated content set.",
+      zh: "中文文档入口与翻译内容索引。",
+    },
+  },
+];
 
-const levelLabels: Record<Locale, Record<LevelFilter, string>> = {
+const categories: Array<Category | "All"> = [
+  "All",
+  "Core",
+  "Setup",
+  "Operations",
+  "Security",
+  "Reference",
+  "International",
+];
+
+const categoryLabel: Record<Locale, Record<Category | "All", string>> = {
   en: {
     All: "All",
     Core: "Core",
-    Advanced: "Advanced",
+    Setup: "Setup",
+    Operations: "Operations",
+    Security: "Security",
+    Reference: "Reference",
+    International: "International",
   },
   zh: {
     All: "全部",
     Core: "核心",
-    Advanced: "进阶",
+    Setup: "部署",
+    Operations: "运维",
+    Security: "安全",
+    Reference: "参考",
+    International: "多语言",
   },
 };
 
-const languageLabels: Record<Locale, Record<Locale, string>> = {
+const copy = {
   en: {
-    en: "EN",
-    zh: "ZH",
-  },
-  zh: {
-    en: "英文",
-    zh: "中文",
-  },
-};
-
-const themeLabels: Record<Locale, Record<ThemeMode, string>> = {
-  en: {
-    system: "Auto",
-    dark: "Dark",
-    light: "Light",
-  },
-  zh: {
-    system: "自动",
-    dark: "深色",
-    light: "浅色",
-  },
-};
-
-const capabilities: Capability[] = [
-  {
-    title: bi("Velocity Routing", "极速路由"),
-    text: bi(
-      "High-speed command and message lanes tuned for low latency and stable fan-out under sustained load.",
-      "高吞吐命令与消息通道，针对低延迟和高压下稳定分发进行调优。"
-    ),
-  },
-  {
-    title: bi("Cold-State Control", "冷态控制"),
-    text: bi(
-      "Deterministic runtime boundaries keep long-running workflows crisp, predictable, and resilient.",
-      "确定性的运行时边界让长流程保持清晰、可预测且具备韧性。"
-    ),
-  },
-  {
-    title: bi("Policy Surface", "策略面"),
-    text: bi(
-      "Security defaults stay explicit and auditable from ingress validation to tool invocation.",
-      "从入口校验到工具调用，安全默认项保持显式、可审计。"
-    ),
-  },
-  {
-    title: bi("Signal Telemetry", "信号遥测"),
-    text: bi(
-      "Operator feedback loops expose execution rhythm in real time without sacrificing flow.",
-      "在不破坏流畅性的前提下，实时暴露执行节奏与反馈回路。"
-    ),
-  },
-];
-
-const executionPhases: ExecutionPhase[] = [
-  {
-    phase: bi("Ingress", "接入"),
-    detail: bi(
-      "Webhook and channel payload normalization",
-      "Webhook 与渠道负载标准化"
-    ),
-  },
-  {
-    phase: bi("Policy", "策略"),
-    detail: bi(
-      "Authentication and runtime guard checks",
-      "认证与运行时防护校验"
-    ),
-  },
-  {
-    phase: bi("Inference", "推理"),
-    detail: bi(
-      "Provider dispatch with fallback controls",
-      "带回退控制的模型路由分发"
-    ),
-  },
-  {
-    phase: bi("Delivery", "投递"),
-    detail: bi(
-      "Response routing with trace visibility",
-      "带可追踪可见性的响应投递"
-    ),
-  },
-];
-
-const signalFeed: LocalizedText[] = [
-  bi("gateway.pulse/ops-eu-1 :: RTT 17ms", "gateway.pulse/ops-eu-1 :: 往返 17ms"),
-  bi("policy.guard/strict-mode :: pass", "policy.guard/strict-mode :: 通过"),
-  bi("provider.dispatch/openai :: stable", "provider.dispatch/openai :: 稳定"),
-  bi("channel.delivery/slack :: stream", "channel.delivery/slack :: 流式"),
-];
-
-const traitChips: LocalizedText[] = [
-  bi("Rust-native Core", "Rust 原生核心"),
-  bi("Low-latency Runtime", "低延迟运行时"),
-  bi("Policy-first Execution", "策略优先执行"),
-  bi("Traceable Operations", "可追踪运维"),
-];
-
-const sectionNav = [
-  { id: "hero-core", label: bi("Overview", "总览") },
-  { id: "core-shortcuts", label: bi("Shortcuts", "捷径") },
-  { id: "quick-paths", label: bi("Pathways", "路径") },
-  { id: "capability-stack", label: bi("Capabilities", "能力") },
-  { id: "execution-lattice", label: bi("Execution", "执行") },
-  { id: "docs-navigator", label: bi("Docs", "文档") },
-] as const;
-
-const quickPaths: QuickPath[] = [
-  {
-    title: bi("Launch a Fresh Node", "快速启动节点"),
-    summary: bi(
-      "From zero to a running instance with deployment boundaries defined early.",
-      "从零到可运行实例，并提前明确部署边界。"
-    ),
-    docs: [
-      "docs/getting-started/README.md",
-      "docs/one-click-bootstrap.md",
-      "docs/network-deployment.md",
-    ],
-  },
-  {
-    title: bi("Wire Channels Fast", "快速接入渠道"),
-    summary: bi(
-      "Connect external chat surfaces and validate routing behavior quickly.",
-      "快速接入外部聊天渠道并验证路由行为。"
-    ),
-    docs: [
-      "docs/channels-reference.md",
-      "docs/mattermost-setup.md",
-      "docs/nextcloud-talk-setup.md",
-    ],
-  },
-  {
-    title: bi("Harden Runtime Policy", "强化运行策略"),
-    summary: bi(
-      "Lock down sandbox, security posture, and operational guardrails.",
-      "完善沙箱、安全姿态和运维防护策略。"
-    ),
-    docs: [
-      "docs/security/README.md",
-      "docs/sandboxing.md",
-      "docs/operations/README.md",
-    ],
-  },
-];
-
-const docsCatalog: DocEntry[] = [
-  {
-    title: bi("Docs Home", "文档首页"),
-    path: "docs/README.md",
-    category: "Getting Started",
-    summary: bi(
-      "Main documentation hub with starting points and structure.",
-      "文档总入口，包含起步路径与结构索引。"
-    ),
-    level: "Core",
-    featured: true,
-    keywords: ["docs", "home", "文档", "入口"],
-  },
-  {
-    title: bi("Getting Started", "快速开始"),
-    path: "docs/getting-started/README.md",
-    category: "Getting Started",
-    summary: bi(
-      "Installation and first-run onboarding references.",
-      "安装与首次运行的引导说明。"
-    ),
-    level: "Core",
-    featured: true,
-    keywords: ["install", "onboarding", "安装", "起步"],
-  },
-  {
-    title: bi("One-click Bootstrap", "一键初始化"),
-    path: "docs/one-click-bootstrap.md",
-    category: "Getting Started",
-    summary: bi(
-      "Fast bootstrap flow for new environments.",
-      "面向新环境的快速初始化流程。"
-    ),
-    level: "Core",
-    keywords: ["bootstrap", "new env", "初始化"],
-  },
-  {
-    title: bi("Network Deployment", "网络部署"),
-    path: "docs/network-deployment.md",
-    category: "Getting Started",
-    summary: bi(
-      "Gateway and callback deployment topology guidance.",
-      "网关与回调部署拓扑指南。"
-    ),
-    level: "Advanced",
-    keywords: ["network", "deployment", "网关", "部署"],
-  },
-  {
-    title: bi("Config Reference", "配置参考"),
-    path: "docs/config-reference.md",
-    category: "Configuration",
-    summary: bi(
-      "Canonical runtime and provider configuration schema.",
-      "标准运行时与模型提供方配置结构。"
-    ),
-    level: "Core",
-    featured: true,
-    keywords: ["config", "schema", "配置"],
-  },
-  {
-    title: bi("Commands Reference", "命令参考"),
-    path: "docs/commands-reference.md",
-    category: "Configuration",
-    summary: bi(
-      "CLI command map and behavior details.",
-      "CLI 命令清单与行为细节。"
-    ),
-    level: "Core",
-    keywords: ["commands", "cli", "命令"],
-  },
-  {
-    title: bi("Custom Providers", "自定义提供方"),
-    path: "docs/custom-providers.md",
-    category: "Configuration",
-    summary: bi(
-      "How to wire custom inference provider integrations.",
-      "如何接入自定义模型提供方。"
-    ),
-    level: "Advanced",
-    keywords: ["provider", "integration", "提供方", "集成"],
-  },
-  {
-    title: bi("Channels Reference", "渠道参考"),
-    path: "docs/channels-reference.md",
-    category: "Channels",
-    summary: bi(
-      "Unified channel setup, routing, and troubleshooting.",
-      "统一渠道配置、路由与排障指南。"
-    ),
-    level: "Core",
-    featured: true,
-    keywords: ["channels", "routing", "渠道", "路由"],
-  },
-  {
-    title: bi("Mattermost Setup", "Mattermost 配置"),
-    path: "docs/mattermost-setup.md",
-    category: "Channels",
-    summary: bi(
-      "Mattermost integration runbook and expected behavior.",
-      "Mattermost 集成操作手册与预期行为。"
-    ),
-    level: "Advanced",
-    keywords: ["mattermost", "integration", "集成"],
-  },
-  {
-    title: bi("Nextcloud Talk Setup", "Nextcloud Talk 配置"),
-    path: "docs/nextcloud-talk-setup.md",
-    category: "Channels",
-    summary: bi(
-      "Native Nextcloud Talk webhook and bot setup.",
-      "原生 Nextcloud Talk webhook 与机器人配置。"
-    ),
-    level: "Advanced",
-    keywords: ["nextcloud", "talk", "webhook"],
-  },
-  {
-    title: bi("Operations Hub", "运维中心"),
-    path: "docs/operations/README.md",
-    category: "Operations",
-    summary: bi(
-      "Operational runbooks and recovery procedures.",
-      "运维手册与故障恢复流程。"
-    ),
-    level: "Core",
-    keywords: ["operations", "runbook", "运维", "恢复"],
-  },
-  {
-    title: bi("Connectivity Probes Runbook", "连通性探针手册"),
-    path: "docs/operations/connectivity-probes-runbook.md",
-    category: "Operations",
-    summary: bi(
-      "Probe strategy, diagnostics, and alerting actions.",
-      "探针策略、诊断流程与告警动作。"
-    ),
-    level: "Advanced",
-    keywords: ["probe", "diagnostics", "告警", "探针"],
-  },
-  {
-    title: bi("Security Overview", "安全总览"),
-    path: "docs/security/README.md",
-    category: "Security",
-    summary: bi(
-      "Security policy, process, and advisory handling.",
-      "安全策略、流程与公告处理规范。"
-    ),
-    level: "Core",
-    keywords: ["security", "policy", "安全"],
-  },
-  {
-    title: bi("Sandboxing", "沙箱机制"),
-    path: "docs/sandboxing.md",
-    category: "Security",
-    summary: bi(
-      "Isolation modes, boundaries, and tradeoffs.",
-      "隔离模式、边界与权衡。"
-    ),
-    level: "Advanced",
-    keywords: ["sandbox", "isolation", "沙箱", "隔离"],
-  },
-  {
-    title: bi("Agnostic Security", "跨提供方安全"),
-    path: "docs/agnostic-security.md",
-    category: "Security",
-    summary: bi(
-      "Cross-provider security posture and design rationale.",
-      "跨模型提供方的安全姿态与设计依据。"
-    ),
-    level: "Advanced",
-    keywords: ["agnostic", "cross-provider", "跨提供方"],
-  },
-  {
-    title: bi("Reference Index", "参考索引"),
-    path: "docs/reference/README.md",
-    category: "Reference",
-    summary: bi(
-      "Reference material index for deeper lookup.",
-      "用于深入查阅的参考资料索引。"
-    ),
-    level: "Core",
-    keywords: ["reference", "index", "索引"],
-  },
-  {
-    title: bi("Docs Inventory", "文档清单"),
-    path: "docs/docs-inventory.md",
-    category: "Reference",
-    summary: bi(
-      "Inventory and ownership view of documentation assets.",
-      "文档资产与归属的清单视图。"
-    ),
-    level: "Advanced",
-    keywords: ["inventory", "ownership", "文档清单"],
-  },
-  {
-    title: bi("Resource Limits", "资源限制"),
-    path: "docs/resource-limits.md",
-    category: "Reference",
-    summary: bi(
-      "Runtime and deployment resource limit guidance.",
-      "运行时与部署资源限制建议。"
-    ),
-    level: "Advanced",
-    keywords: ["resource", "limits", "资源"],
-  },
-  {
-    title: bi("Repository README", "仓库 README"),
-    path: "README.md",
-    category: "Reference",
-    summary: bi(
-      "Project overview, features, and quick commands.",
-      "项目概览、能力说明与快速命令。"
-    ),
-    level: "Core",
-    featured: true,
-    keywords: ["readme", "project", "仓库", "项目"],
-  },
-];
-
-const monitorStats = [
-  {
-    label: bi("Queue Depth", "队列深度"),
-    value: bi("Stable", "稳定"),
-  },
-  {
-    label: bi("Retry Rate", "重试率"),
-    value: bi("0.4%", "0.4%"),
-  },
-  {
-    label: bi("Dispatch RTT", "分发延迟"),
-    value: bi("17ms", "17ms"),
-  },
-  {
-    label: bi("Guard State", "防护状态"),
-    value: bi("Strict", "严格"),
-  },
-];
-
-const textBundle = {
-  en: {
-    navDocs: "Docs Navigator",
-    navRepo: "Repository",
-    openPalette: "Command Palette",
-    languageLabel: "Language",
-    themeLabel: "Theme",
-    statusPill: "Cold Core Online",
-    heroKicker: "Private Gateway Control Plane",
-    heroTitle: ["Lightning Fast.", "Ice Cold.", "Precise by Design."],
-    heroLead:
-      "Inspired by modern product surfaces, this interface blends high contrast, restrained glow, and rapid yet smooth motion while keeping documentation access immediate and obvious.",
-    browseDocsNow: "Browse Docs Now",
-    openDocsHome: "Open Docs Home",
+    navDocs: "Docs",
+    navGitHub: "GitHub",
+    navWebsite: "zeroclawlabs.ai",
+    badge: "PRIVATE AGENT INTELLIGENCE.",
+    title: "Zero overhead. Zero compromise. 100% Rust. 100% Agnostic.",
+    summary:
+      "Fast, small, and fully autonomous AI assistant infrastructure.",
+    summary2: "Deploy anywhere. Swap anything.",
+    notice:
+      "Official source channels: use this repository as the source of truth and zeroclawlabs.ai as the official website.",
+    ctaDocs: "Read docs now",
+    ctaBootstrap: "One-click bootstrap",
     metrics: [
-      { label: "Execution Profile", value: "Rapid / Deterministic" },
-      { label: "Build Material", value: "100% Rust Engine" },
-      { label: "Visual Mode", value: "Black · Blue · Silver" },
-      { label: "Docs Indexed", value: `${docsCatalog.length} Files` },
+      { label: "Runtime Memory", value: "< 5MB" },
+      { label: "Cold Start", value: "< 10ms" },
+      { label: "Edge Hardware", value: "$10-class" },
+      { label: "Language", value: "100% Rust" },
     ],
-    runtimeLabel: "runtime://zeroclaw/gateway",
-    live: "Live",
-    coreDocsShortcuts: "Core Docs Shortcuts",
-    openFullNavigator: "Open Full Navigator",
-    quickStartPaths: "Quick Start Paths",
-    taskFirstRouting: "Task-first Routing",
-    capabilityStack: "Capability Stack",
-    executionLattice: "Execution Lattice",
-    operatorSignal: "Operator Signal",
-    operatorSignalIntro:
-      "Fast transitions, clear hierarchy, and controlled glow ensure the interface reads quickly while staying calm in long sessions.",
-    docsNavigator: "Docs Navigator",
-    docsIntro:
-      "Search by topic, file name, or category. Filter quickly, then open rendered docs directly on GitHub.",
-    searchDocs: "Search docs",
-    searchPlaceholder: "Try: config, channels, security, operations...",
-    quickKeys: "Quick keys:",
-    quickKeySearchHint: "focus search",
-    quickKeyResetHint: "reset filters",
-    resetFilters: "Reset Filters",
-    docsCount: (count: number, filtered: boolean) =>
-      `${count} doc${count === 1 ? "" : "s"} matched${
-        filtered ? " in filtered mode" : " across all sections"
-      }`,
-    topMatches: "Top Matches",
-    noMatchPrefix: "No docs matched your filter. Try broader keywords like",
-    noMatchA: "config",
-    noMatchConnector: "or",
-    noMatchB: "security",
-    panelFooter:
-      "Documentation remains the primary navigation target. Every major section is indexed for direct reading access.",
-    paletteTitle: "Command Palette",
-    palettePlaceholder: "Type a command or search docs...",
-    paletteClose: "Close",
-    paletteActionsGroup: "Quick Actions",
-    paletteDocsGroup: "Documentation",
-    paletteNoResults: "No matching command or doc entry.",
-    palettePreviewTitle: "Live Preview",
-    palettePreviewNoSelection: "Select an entry to inspect details and run.",
-    palettePreviewKindAction: "Action",
-    palettePreviewKindDoc: "Doc Entry",
-    palettePreviewOpenHint: "Opens in a new tab",
-    paletteHintNavigate: "Arrow/Tab to navigate",
-    paletteHintRun: "Enter to run",
-    paletteHintClose: "Esc to close",
-    actionJumpDocs: "Jump to Docs Navigator",
-    actionJumpDocsHint: "Scroll to the main docs section",
-    actionOpenDocsHome: "Open Docs Home",
-    actionOpenDocsHomeHint: "Open docs hub in a new tab",
-    actionOpenRepo: "Open Repository",
-    actionOpenRepoHint: "Open GitHub repository",
-    actionToggleLang: "Switch Language",
-    actionToggleLangHint: "Toggle between English and Chinese",
-    actionThemeDark: "Set Theme: Dark",
-    actionThemeLight: "Set Theme: Light",
-    actionThemeSystem: "Set Theme: Auto",
-    actionThemeHint: "Update visual theme mode",
-    sectionRailLabel: "Section navigation",
-    mobileDockDocs: "Docs",
-    mobileDockPalette: "Palette",
+    docsWorkspace: "Documentation Workspace",
+    docsLead:
+      "Browse, filter, and read project docs directly in-page. Open any item in GitHub when needed.",
+    search: "Search docs by topic, path, or keyword",
+    commandPalette: "Command palette",
+    sourceLabel: "Source",
+    openOnGithub: "Open on GitHub",
+    openRaw: "Open raw",
+    loading: "Loading document...",
+    fallback:
+      "Document preview is unavailable right now. You can still open the source directly:",
+    empty: "No docs matched your current filter.",
+    paletteHint: "Type a command or document name",
+    actionFocus: "Focus docs search",
+    actionTop: "Back to top",
+    actionTheme: "Cycle theme",
+    actionLocale: "Toggle language",
+    status: "Current Theme",
   },
   zh: {
-    navDocs: "文档导航",
-    navRepo: "仓库",
-    openPalette: "命令面板",
-    languageLabel: "语言",
-    themeLabel: "主题",
-    statusPill: "冷核在线",
-    heroKicker: "私有网关控制平面",
-    heroTitle: ["闪电级速度。", "冰冷而克制。", "精准而生。"],
-    heroLead:
-      "参考现代产品界面的节奏，这个页面将高对比、克制发光与迅捷流畅动效结合，同时把文档可达性放在第一优先级。",
-    browseDocsNow: "立即浏览文档",
-    openDocsHome: "打开文档首页",
+    navDocs: "文档",
+    navGitHub: "GitHub",
+    navWebsite: "zeroclawlabs.ai",
+    badge: "PRIVATE AGENT INTELLIGENCE.",
+    title: "Zero overhead. Zero compromise. 100% Rust. 100% Agnostic.",
+    summary: "Fast, small, and fully autonomous AI assistant infrastructure.",
+    summary2: "Deploy anywhere. Swap anything.",
+    notice:
+      "官方信息渠道：请以本仓库为事实来源，以 zeroclawlabs.ai 为官方网站。",
+    ctaDocs: "立即阅读文档",
+    ctaBootstrap: "一键安装",
     metrics: [
-      { label: "执行画像", value: "快速 / 确定性" },
-      { label: "构建材质", value: "100% Rust 引擎" },
-      { label: "视觉模式", value: "黑 · 蓝 · 银" },
-      { label: "已索引文档", value: `${docsCatalog.length} 个文件` },
+      { label: "运行内存", value: "< 5MB" },
+      { label: "冷启动", value: "< 10ms" },
+      { label: "边缘硬件", value: "$10 级别" },
+      { label: "语言", value: "100% Rust" },
     ],
-    runtimeLabel: "runtime://zeroclaw/gateway",
-    live: "实时",
-    coreDocsShortcuts: "核心文档捷径",
-    openFullNavigator: "打开完整导航",
-    quickStartPaths: "任务快速路径",
-    taskFirstRouting: "任务优先路由",
-    capabilityStack: "能力栈",
-    executionLattice: "执行晶格",
-    operatorSignal: "操作信号",
-    operatorSignalIntro:
-      "快速过渡、清晰层级与克制发光，让界面在长时间使用时依然高效且不疲劳。",
-    docsNavigator: "文档导航器",
-    docsIntro:
-      "按主题、文件名或分类搜索，快速过滤后可直接打开 GitHub 渲染文档。",
-    searchDocs: "搜索文档",
-    searchPlaceholder: "例如：config、channels、security、operations...",
-    quickKeys: "快捷键：",
-    quickKeySearchHint: "聚焦搜索",
-    quickKeyResetHint: "重置筛选",
-    resetFilters: "重置筛选",
-    docsCount: (count: number, filtered: boolean) =>
-      `匹配到 ${count} 个文档${filtered ? "（已筛选）" : "（全量范围）"}`,
-    topMatches: "最佳匹配",
-    noMatchPrefix: "没有匹配结果，建议尝试更宽泛关键词，例如",
-    noMatchA: "config",
-    noMatchConnector: "或",
-    noMatchB: "security",
-    panelFooter: "文档是第一导航目标，所有核心部分均已索引并可直达阅读。",
-    paletteTitle: "命令面板",
-    palettePlaceholder: "输入命令或搜索文档...",
-    paletteClose: "关闭",
-    paletteActionsGroup: "快捷动作",
-    paletteDocsGroup: "文档",
-    paletteNoResults: "没有匹配的命令或文档。",
-    palettePreviewTitle: "实时预览",
-    palettePreviewNoSelection: "选择一条结果查看细节并执行。",
-    palettePreviewKindAction: "动作",
-    palettePreviewKindDoc: "文档项",
-    palettePreviewOpenHint: "将使用新标签页打开",
-    paletteHintNavigate: "方向键/Tab 切换",
-    paletteHintRun: "Enter 执行",
-    paletteHintClose: "Esc 关闭",
-    actionJumpDocs: "跳转到文档导航",
-    actionJumpDocsHint: "滚动到主文档区域",
-    actionOpenDocsHome: "打开文档首页",
-    actionOpenDocsHomeHint: "新标签页打开文档总入口",
-    actionOpenRepo: "打开仓库",
-    actionOpenRepoHint: "打开 GitHub 仓库",
-    actionToggleLang: "切换语言",
-    actionToggleLangHint: "中英文切换",
-    actionThemeDark: "设置主题：深色",
-    actionThemeLight: "设置主题：浅色",
-    actionThemeSystem: "设置主题：自动",
-    actionThemeHint: "更新视觉主题模式",
-    sectionRailLabel: "分区导航",
-    mobileDockDocs: "文档",
-    mobileDockPalette: "面板",
+    docsWorkspace: "文档工作区",
+    docsLead: "在页面内直接浏览、过滤并阅读文档；需要时可一键跳转 GitHub 原文。",
+    search: "按主题、路径或关键字搜索",
+    commandPalette: "命令面板",
+    sourceLabel: "来源",
+    openOnGithub: "在 GitHub 打开",
+    openRaw: "打开原文",
+    loading: "文档加载中...",
+    fallback: "当前无法预览文档，你仍可直接打开源文件：",
+    empty: "当前筛选下没有匹配文档。",
+    paletteHint: "输入命令或文档名称",
+    actionFocus: "聚焦文档搜索",
+    actionTop: "回到顶部",
+    actionTheme: "切换主题",
+    actionLocale: "切换语言",
+    status: "当前主题",
   },
 } as const;
 
-const docsBase = "https://github.com/zeroclaw-labs/zeroclaw/blob/main";
-
-function getDocUrl(path: string): string {
-  return `${docsBase}/${path}`;
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\u4e00-\u9fa5\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-");
 }
 
-function localize(value: LocalizedText, locale: Locale): string {
-  return value[locale];
-}
-
-function escapeRegExp(text: string): string {
-  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function tokenizeQuery(query: string): string[] {
-  return Array.from(
-    new Set(
-      query
-        .trim()
-        .toLowerCase()
-        .split(/\s+/)
-        .map((token) => token.trim())
-        .filter((token) => token.length > 0)
-        .filter((token) => !/^[a-z0-9]$/i.test(token))
-    )
-  );
-}
-
-function scoreDoc(doc: DocEntry, tokens: string[], locale: Locale): number {
-  if (tokens.length === 0) {
-    return 0;
+function nodeText(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
   }
-
-  const altLocale: Locale = locale === "en" ? "zh" : "en";
-  const primaryTitle = localize(doc.title, locale).toLowerCase();
-  const primarySummary = localize(doc.summary, locale).toLowerCase();
-  const altTitle = localize(doc.title, altLocale).toLowerCase();
-  const altSummary = localize(doc.summary, altLocale).toLowerCase();
-  const primaryCategory = categoryLabels[locale][doc.category].toLowerCase();
-  const altCategory = categoryLabels[altLocale][doc.category].toLowerCase();
-  const path = doc.path.toLowerCase();
-  const keywords = (doc.keywords ?? []).join(" ").toLowerCase();
-
-  return tokens.reduce((score, token) => {
-    let current = score;
-
-    if (primaryTitle.includes(token)) {
-      current += 7;
-    }
-    if (primaryCategory.includes(token)) {
-      current += 5;
-    }
-    if (primarySummary.includes(token)) {
-      current += 4;
-    }
-    if (keywords.includes(token)) {
-      current += 3;
-    }
-    if (path.includes(token)) {
-      current += 2;
-    }
-    if (altTitle.includes(token) || altSummary.includes(token) || altCategory.includes(token)) {
-      current += 2;
-    }
-
-    return current;
-  }, 0);
+  if (Array.isArray(node)) {
+    return node.map((part) => nodeText(part)).join("");
+  }
+  if (isValidElement(node)) {
+    return nodeText(node.props.children as ReactNode);
+  }
+  return "";
 }
 
-function highlightMatches(text: string, tokens: string[]): ReactNode {
-  if (tokens.length === 0) {
-    return text;
+function withRepo(path: string): string {
+  return `${repoBase}/${path}`;
+}
+
+function withRaw(path: string): string {
+  return `${rawBase}/${path}`;
+}
+
+function resolvePath(doc: DocEntry, locale: Locale): string {
+  if (locale === "zh" && doc.zhPath) {
+    return doc.zhPath;
   }
+  return doc.path;
+}
 
-  const matcher = new RegExp(`(${tokens.map(escapeRegExp).join("|")})`, "ig");
-  const parts = text.split(matcher);
-
-  if (parts.length === 1) {
-    return text;
-  }
-
-  return parts.map((part, index) => {
-    const isMatch = tokens.some((token) => token === part.toLowerCase());
-    if (isMatch) {
-      return <mark key={`${part}-${index}`}>{part}</mark>;
+export default function App(): JSX.Element {
+  const [locale, setLocale] = useState<Locale>(() => {
+    if (typeof window === "undefined") {
+      return "en";
     }
-    return <span key={`${part}-${index}`}>{part}</span>;
+    return window.localStorage.getItem("zc-locale") === "zh" ? "zh" : "en";
   });
-}
 
-export default function App() {
+  const [themeMode, setThemeMode] = useState<ThemeMode>(() => {
+    if (typeof window === "undefined") {
+      return "system";
+    }
+    const stored = window.localStorage.getItem("zc-theme");
+    if (stored === "light" || stored === "dark" || stored === "system") {
+      return stored;
+    }
+    return "system";
+  });
+
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("dark");
+  const [category, setCategory] = useState<Category | "All">("All");
   const [query, setQuery] = useState("");
-  const [category, setCategory] = useState<CategoryFilter>("All");
-  const [level, setLevel] = useState<LevelFilter>("All");
-  const [locale, setLocale] = useState<Locale>("en");
-  const [themeMode, setThemeMode] = useState<ThemeMode>("system");
-  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>("dark");
-  const [isPaletteOpen, setPaletteOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string>("docs-home");
+
+  const [markdownCache, setMarkdownCache] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const [paletteOpen, setPaletteOpen] = useState(false);
   const [paletteQuery, setPaletteQuery] = useState("");
-  const [paletteIndex, setPaletteIndex] = useState(0);
-  const [activeSection, setActiveSection] = useState<(typeof sectionNav)[number]["id"]>(
-    sectionNav[0].id
-  );
-  const [scrollProgress, setScrollProgress] = useState(0);
 
-  const searchInputRef = useRef<HTMLInputElement>(null);
-  const paletteInputRef = useRef<HTMLInputElement>(null);
+  const docsSearchRef = useRef<HTMLInputElement | null>(null);
+  const paletteInputRef = useRef<HTMLInputElement | null>(null);
 
-  const copy = textBundle[locale];
-  const resolvedTheme: ResolvedTheme =
-    themeMode === "system" ? systemTheme : themeMode;
-
-  const featuredDocs = useMemo(
-    () => docsCatalog.filter((doc) => doc.featured).slice(0, 4),
-    []
-  );
-
-  const queryTokens = useMemo(() => tokenizeQuery(query), [query]);
-  const paletteTokens = useMemo(() => tokenizeQuery(paletteQuery), [paletteQuery]);
-
-  const docsLookup = useMemo(() => {
-    return new Map(docsCatalog.map((doc) => [doc.path, doc] as const));
-  }, []);
-
-  const filteredDocs = useMemo(() => {
-    const ranked = docsCatalog.map((doc) => ({
-      doc,
-      score: scoreDoc(doc, queryTokens, locale),
-    }));
-
-    return ranked
-      .filter(({ doc, score }) => {
-        const categoryMatch = category === "All" || doc.category === category;
-        if (!categoryMatch) {
-          return false;
-        }
-
-        const levelMatch = level === "All" || doc.level === level;
-        if (!levelMatch) {
-          return false;
-        }
-
-        if (queryTokens.length === 0) {
-          return true;
-        }
-
-        return score > 0;
-      })
-      .sort((left, right) => {
-        if (right.score !== left.score) {
-          return right.score - left.score;
-        }
-        if (left.doc.featured !== right.doc.featured) {
-          return left.doc.featured ? -1 : 1;
-        }
-        if (left.doc.level !== right.doc.level) {
-          return left.doc.level === "Core" ? -1 : 1;
-        }
-        return localize(left.doc.title, locale).localeCompare(
-          localize(right.doc.title, locale),
-          locale === "zh" ? "zh-Hans" : "en"
-        );
-      })
-      .map(({ doc }) => doc);
-  }, [category, level, locale, queryTokens]);
-
-  const categoryCounts = useMemo(() => {
-    return categories.reduce((acc, currentCategory) => {
-      const matched = docsCatalog.filter((doc) => {
-        if (doc.category !== currentCategory) {
-          return false;
-        }
-        if (level !== "All" && doc.level !== level) {
-          return false;
-        }
-        if (queryTokens.length === 0) {
-          return true;
-        }
-        return scoreDoc(doc, queryTokens, locale) > 0;
-      });
-
-      acc[currentCategory] = matched.length;
-      return acc;
-    }, {} as Record<DocCategory, number>);
-  }, [level, locale, queryTokens]);
-
-  const totalCategoryCount = useMemo(
-    () => Object.values(categoryCounts).reduce((sum, current) => sum + current, 0),
-    [categoryCounts]
-  );
-
-  const hasActiveFilters =
-    queryTokens.length > 0 || category !== "All" || level !== "All";
-
-  const topMatches = useMemo(() => {
-    if (!hasActiveFilters) {
-      return [];
-    }
-    return filteredDocs.slice(0, 4);
-  }, [filteredDocs, hasActiveFilters]);
-
-  const docsByCategory = useMemo(() => {
-    return categories.reduce((acc, currentCategory) => {
-      acc[currentCategory] = filteredDocs.filter(
-        (doc) => doc.category === currentCategory
-      );
-      return acc;
-    }, {} as Record<DocCategory, DocEntry[]>);
-  }, [filteredDocs]);
-
-  const paletteActions = useMemo<PaletteAction[]>(() => {
-    const openExternal = (path: string) => {
-      window.open(getDocUrl(path), "_blank", "noopener,noreferrer");
-    };
-
-    return [
-      {
-        id: "jump-docs",
-        label: copy.actionJumpDocs,
-        hint: copy.actionJumpDocsHint,
-        keywords: ["docs", "navigator", "文档", "导航"],
-        run: () => {
-          document
-            .getElementById("docs-navigator")
-            ?.scrollIntoView({ behavior: "smooth", block: "start" });
-        },
-      },
-      {
-        id: "open-docs-home",
-        label: copy.actionOpenDocsHome,
-        hint: copy.actionOpenDocsHomeHint,
-        keywords: ["docs", "home", "文档", "首页"],
-        run: () => {
-          openExternal("docs/README.md");
-        },
-      },
-      {
-        id: "open-repo",
-        label: copy.actionOpenRepo,
-        hint: copy.actionOpenRepoHint,
-        keywords: ["repo", "github", "仓库"],
-        run: () => {
-          openExternal("README.md");
-        },
-      },
-      {
-        id: "switch-language",
-        label: copy.actionToggleLang,
-        hint: copy.actionToggleLangHint,
-        keywords: ["language", "locale", "语言", "中英"],
-        run: () => {
-          setLocale((current) => (current === "en" ? "zh" : "en"));
-        },
-      },
-      {
-        id: "theme-dark",
-        label: copy.actionThemeDark,
-        hint: copy.actionThemeHint,
-        keywords: ["theme", "dark", "深色", "主题"],
-        run: () => {
-          setThemeMode("dark");
-        },
-      },
-      {
-        id: "theme-light",
-        label: copy.actionThemeLight,
-        hint: copy.actionThemeHint,
-        keywords: ["theme", "light", "浅色", "主题"],
-        run: () => {
-          setThemeMode("light");
-        },
-      },
-      {
-        id: "theme-system",
-        label: copy.actionThemeSystem,
-        hint: copy.actionThemeHint,
-        keywords: ["theme", "auto", "system", "自动"],
-        run: () => {
-          setThemeMode("system");
-        },
-      },
-    ];
-  }, [copy]);
-
-  const filteredPaletteActions = useMemo(() => {
-    if (paletteTokens.length === 0) {
-      return paletteActions;
-    }
-
-    return paletteActions.filter((action) => {
-      const haystack = `${action.label} ${action.hint} ${action.keywords.join(" ")}`.toLowerCase();
-      return paletteTokens.every((token) => haystack.includes(token));
-    });
-  }, [paletteActions, paletteTokens]);
-
-  const paletteDocResults = useMemo(() => {
-    const ranked = docsCatalog.map((doc) => ({
-      doc,
-      score: scoreDoc(doc, paletteTokens, locale),
-    }));
-
-    return ranked
-      .filter(({ doc, score }) => {
-        if (paletteTokens.length === 0) {
-          return doc.featured || doc.level === "Core";
-        }
-        return score > 0;
-      })
-      .sort((left, right) => {
-        if (right.score !== left.score) {
-          return right.score - left.score;
-        }
-        if (left.doc.featured !== right.doc.featured) {
-          return left.doc.featured ? -1 : 1;
-        }
-        return localize(left.doc.title, locale).localeCompare(
-          localize(right.doc.title, locale),
-          locale === "zh" ? "zh-Hans" : "en"
-        );
-      })
-      .slice(0, 8)
-      .map(({ doc }) => doc);
-  }, [locale, paletteTokens]);
-
-  const actionEntries = useMemo<PaletteEntry[]>(() => {
-    return filteredPaletteActions.map((action) => ({
-      id: `action-${action.id}`,
-      kind: "action",
-      label: action.label,
-      hint: action.hint,
-      run: action.run,
-    }));
-  }, [filteredPaletteActions]);
-
-  const docEntries = useMemo<PaletteEntry[]>(() => {
-    return paletteDocResults.map((doc) => ({
-      id: `doc-${doc.path}`,
-      kind: "doc",
-      label: localize(doc.title, locale),
-      hint: localize(doc.summary, locale),
-      meta: doc.path,
-      run: () => {
-        window.open(getDocUrl(doc.path), "_blank", "noopener,noreferrer");
-      },
-    }));
-  }, [locale, paletteDocResults]);
-
-  const paletteEntries = useMemo(
-    () => [...actionEntries, ...docEntries],
-    [actionEntries, docEntries]
-  );
-
-  const activePaletteEntry = paletteEntries[paletteIndex] ?? null;
+  const text = copy[locale];
 
   useEffect(() => {
-    const media = window.matchMedia("(prefers-color-scheme: dark)");
-    const updateSystemTheme = () => {
-      setSystemTheme(media.matches ? "dark" : "light");
-    };
-
-    updateSystemTheme();
-    media.addEventListener("change", updateSystemTheme);
-
-    return () => {
-      media.removeEventListener("change", updateSystemTheme);
-    };
-  }, []);
-
-  useEffect(() => {
-    const searchLang = new URL(window.location.href).searchParams.get("lang");
-    const storedLocale = window.localStorage.getItem("zeroclaw.locale");
-
-    if (searchLang === "en" || searchLang === "zh") {
-      setLocale(searchLang);
-    } else if (storedLocale === "en" || storedLocale === "zh") {
-      setLocale(storedLocale);
-    } else if (navigator.language.toLowerCase().startsWith("zh")) {
-      setLocale("zh");
-    }
-
-    const storedTheme = window.localStorage.getItem("zeroclaw.theme");
-    if (storedTheme === "system" || storedTheme === "dark" || storedTheme === "light") {
-      setThemeMode(storedTheme);
-    }
-  }, []);
-
-  useEffect(() => {
-    document.documentElement.dataset.theme = resolvedTheme;
-    document.documentElement.style.colorScheme = resolvedTheme;
-    window.localStorage.setItem("zeroclaw.theme", themeMode);
-  }, [resolvedTheme, themeMode]);
-
-  useEffect(() => {
-    document.documentElement.lang = locale === "zh" ? "zh-CN" : "en";
-    window.localStorage.setItem("zeroclaw.locale", locale);
-
-    const url = new URL(window.location.href);
-    if (url.searchParams.get("lang") !== locale) {
-      url.searchParams.set("lang", locale);
-      window.history.replaceState({}, "", `${url.pathname}${url.search}${url.hash}`);
-    }
+    window.localStorage.setItem("zc-locale", locale);
   }, [locale]);
 
   useEffect(() => {
-    const updateProgress = () => {
-      const scrollHeight =
-        document.documentElement.scrollHeight - window.innerHeight;
-      if (scrollHeight <= 0) {
-        setScrollProgress(0);
-        return;
+    window.localStorage.setItem("zc-theme", themeMode);
+
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+
+    const applyTheme = (): void => {
+      const nextTheme: ResolvedTheme =
+        themeMode === "system" ? (media.matches ? "dark" : "light") : themeMode;
+      document.documentElement.setAttribute("data-theme", nextTheme);
+      setResolvedTheme(nextTheme);
+    };
+
+    applyTheme();
+
+    if (themeMode === "system") {
+      media.addEventListener("change", applyTheme);
+      return () => media.removeEventListener("change", applyTheme);
+    }
+
+    return undefined;
+  }, [themeMode]);
+
+  const filteredDocs = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+
+    return docs.filter((doc) => {
+      if (category !== "All" && doc.category !== category) {
+        return false;
       }
 
-      setScrollProgress(Math.min(1, Math.max(0, window.scrollY / scrollHeight)));
-    };
+      if (!normalized) {
+        return true;
+      }
 
-    updateProgress();
-    window.addEventListener("scroll", updateProgress, { passive: true });
-    window.addEventListener("resize", updateProgress);
+      const bag = [
+        doc.title[locale],
+        doc.title.en,
+        doc.title.zh,
+        doc.summary[locale],
+        doc.path,
+        ...(doc.keywords ?? []),
+      ]
+        .join(" ")
+        .toLowerCase();
 
-    return () => {
-      window.removeEventListener("scroll", updateProgress);
-      window.removeEventListener("resize", updateProgress);
-    };
-  }, []);
+      return bag.includes(normalized);
+    });
+  }, [category, locale, query]);
 
   useEffect(() => {
-    const nodes = sectionNav
-      .map((section) => document.getElementById(section.id))
-      .filter((node): node is HTMLElement => Boolean(node));
-
-    if (nodes.length === 0 || !("IntersectionObserver" in window)) {
+    if (filteredDocs.length === 0) {
       return;
     }
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const inView = entries
-          .filter((entry) => entry.isIntersecting)
-          .sort((left, right) => right.intersectionRatio - left.intersectionRatio);
+    const stillVisible = filteredDocs.some((doc) => doc.id === selectedId);
+    if (!stillVisible) {
+      setSelectedId(filteredDocs[0].id);
+    }
+  }, [filteredDocs, selectedId]);
 
-        if (inView.length > 0) {
-          setActiveSection(inView[0].target.id as (typeof sectionNav)[number]["id"]);
+  const selectedDoc =
+    docs.find((doc) => doc.id === selectedId) ?? docs.find((doc) => doc.id === "docs-home") ?? docs[0];
+
+  const activePath = resolvePath(selectedDoc, locale);
+  const markdown = markdownCache[activePath] ?? "";
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
+    if (markdownCache[activePath]) {
+      return () => {
+        cancelled = true;
+        controller.abort();
+      };
+    }
+
+    async function load(): Promise<void> {
+      setLoading(true);
+      setError("");
+
+      try {
+        const response = await fetch(withRaw(activePath), {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
         }
+
+        const textBody = await response.text();
+
+        if (cancelled) {
+          return;
+        }
+
+        setMarkdownCache((prev) => ({
+          ...prev,
+          [activePath]: textBody,
+        }));
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+
+        const message = err instanceof Error ? err.message : "Failed to fetch";
+        setError(message);
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void load();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [activePath, markdownCache]);
+
+  const cycleTheme = (): void => {
+    setThemeMode((prev) => {
+      if (prev === "system") return "dark";
+      if (prev === "dark") return "light";
+      return "system";
+    });
+  };
+
+  const jumpToTop = (): void => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const focusSearch = (): void => {
+    docsSearchRef.current?.focus();
+  };
+
+  const paletteEntries = useMemo(() => {
+    const staticEntries: PaletteEntry[] = [
+      {
+        id: "focus-search",
+        label: text.actionFocus,
+        hint: text.docsWorkspace,
+        run: () => {
+          document.getElementById("docs-workspace")?.scrollIntoView({ behavior: "smooth", block: "start" });
+          setTimeout(() => docsSearchRef.current?.focus(), 300);
+        },
       },
       {
-        threshold: [0.12, 0.3, 0.55, 0.85],
-        rootMargin: "-28% 0px -58% 0px",
-      }
-    );
+        id: "top",
+        label: text.actionTop,
+        hint: "Home",
+        run: jumpToTop,
+      },
+      {
+        id: "theme",
+        label: text.actionTheme,
+        hint: `${text.status}: ${resolvedTheme}`,
+        run: cycleTheme,
+      },
+      {
+        id: "locale",
+        label: text.actionLocale,
+        hint: locale === "en" ? "EN -> 中文" : "中文 -> EN",
+        run: () => setLocale((prev) => (prev === "en" ? "zh" : "en")),
+      },
+    ];
 
-    nodes.forEach((node) => observer.observe(node));
-    return () => observer.disconnect();
-  }, []);
+    const dynamicEntries: PaletteEntry[] = filteredDocs.slice(0, 10).map((doc) => ({
+      id: `doc-${doc.id}`,
+      label: doc.title[locale],
+      hint: doc.path,
+      run: () => {
+        setSelectedId(doc.id);
+        document.getElementById("docs-workspace")?.scrollIntoView({ behavior: "smooth", block: "start" });
+      },
+    }));
+
+    return [...staticEntries, ...dynamicEntries];
+  }, [filteredDocs, locale, resolvedTheme, text.actionFocus, text.actionLocale, text.actionTheme, text.actionTop, text.docsWorkspace, text.status]);
+
+  const paletteResults = useMemo(() => {
+    const normalized = paletteQuery.trim().toLowerCase();
+    if (!normalized) {
+      return paletteEntries;
+    }
+
+    return paletteEntries.filter((entry) => {
+      return `${entry.label} ${entry.hint}`.toLowerCase().includes(normalized);
+    });
+  }, [paletteEntries, paletteQuery]);
 
   useEffect(() => {
-    const prefersReducedMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)"
-    ).matches;
-    const revealNodes = document.querySelectorAll<HTMLElement>(".reveal");
-    let observer: IntersectionObserver | null = null;
-
-    if (prefersReducedMotion || !("IntersectionObserver" in window)) {
-      revealNodes.forEach((node) => node.classList.add("in"));
-    } else {
-      observer = new IntersectionObserver(
-        (entries) => {
-          entries.forEach((entry) => {
-            if (entry.isIntersecting) {
-              entry.target.classList.add("in");
-              observer?.unobserve(entry.target);
-            }
-          });
-        },
-        { threshold: 0.12 }
-      );
-      revealNodes.forEach((node) => observer?.observe(node));
-    }
-
-    const root = document.documentElement;
-    const handlePointerMove = (event: PointerEvent) => {
-      root.style.setProperty("--pointer-x", `${event.clientX}px`);
-      root.style.setProperty("--pointer-y", `${event.clientY}px`);
-    };
-
-    if (!prefersReducedMotion) {
-      window.addEventListener("pointermove", handlePointerMove, {
-        passive: true,
-      });
-    }
-
-    return () => {
-      observer?.disconnect();
-      if (!prefersReducedMotion) {
-        window.removeEventListener("pointermove", handlePointerMove);
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!isPaletteOpen) {
-      return;
-    }
-
-    const timer = window.setTimeout(() => {
-      paletteInputRef.current?.focus();
-      paletteInputRef.current?.select();
-    }, 20);
-
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-
-    return () => {
-      window.clearTimeout(timer);
-      document.body.style.overflow = previousOverflow;
-    };
-  }, [isPaletteOpen]);
-
-  useEffect(() => {
-    if (!isPaletteOpen) {
-      return;
-    }
-    setPaletteIndex(0);
-  }, [actionEntries.length, docEntries.length, isPaletteOpen, paletteQuery]);
-
-  useEffect(() => {
-    if (paletteEntries.length === 0 && paletteIndex !== 0) {
-      setPaletteIndex(0);
-      return;
-    }
-
-    if (paletteIndex > paletteEntries.length - 1) {
-      setPaletteIndex(Math.max(0, paletteEntries.length - 1));
-    }
-  }, [paletteEntries.length, paletteIndex]);
-
-  useEffect(() => {
-    if (!isPaletteOpen) {
-      return;
-    }
-
-    const activeNode = document.querySelector<HTMLElement>(
-      `[data-palette-index="${paletteIndex}"]`
-    );
-    activeNode?.scrollIntoView({ block: "nearest" });
-  }, [isPaletteOpen, paletteIndex]);
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const key = event.key.toLowerCase();
-      const target = event.target as HTMLElement | null;
-      const isEditable =
-        target instanceof HTMLInputElement ||
-        target instanceof HTMLTextAreaElement ||
-        Boolean(target?.isContentEditable);
-
-      if ((event.metaKey || event.ctrlKey) && key === "k") {
+    function onKeyDown(event: KeyboardEvent): void {
+      const withCommand = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k";
+      if (withCommand) {
         event.preventDefault();
-        setPaletteOpen((open) => {
-          const next = !open;
-          if (!open) {
-            setPaletteIndex(0);
-          }
-          return next;
-        });
+        setPaletteOpen((prev) => !prev);
         return;
       }
 
       if (event.key === "Escape") {
-        if (isPaletteOpen) {
-          event.preventDefault();
-          setPaletteOpen(false);
-          setPaletteQuery("");
-          setPaletteIndex(0);
-          return;
-        }
-
-        if (target === searchInputRef.current) {
-          if (query || category !== "All" || level !== "All") {
-            setQuery("");
-            setCategory("All");
-            setLevel("All");
-          }
-          searchInputRef.current?.blur();
-        }
-      }
-
-      if (isPaletteOpen && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
-        if (paletteEntries.length === 0) {
-          return;
-        }
-        event.preventDefault();
-        setPaletteIndex((currentIndex) => {
-          if (event.key === "ArrowDown") {
-            return (currentIndex + 1) % paletteEntries.length;
-          }
-          return (currentIndex - 1 + paletteEntries.length) % paletteEntries.length;
-        });
-        return;
-      }
-
-      if (isPaletteOpen && event.key === "Tab") {
-        if (paletteEntries.length === 0) {
-          return;
-        }
-        event.preventDefault();
-        setPaletteIndex((currentIndex) => {
-          if (event.shiftKey) {
-            return (currentIndex - 1 + paletteEntries.length) % paletteEntries.length;
-          }
-          return (currentIndex + 1) % paletteEntries.length;
-        });
-        return;
-      }
-
-      if (isPaletteOpen && event.key === "Enter" && paletteEntries.length > 0) {
-        event.preventDefault();
-        const selected = paletteEntries[paletteIndex] ?? paletteEntries[0];
-        selected?.run();
         setPaletteOpen(false);
-        setPaletteQuery("");
-        setPaletteIndex(0);
-        return;
       }
+    }
 
-      if (event.key === "/" && !isEditable && !isPaletteOpen) {
-        event.preventDefault();
-        searchInputRef.current?.focus();
-        searchInputRef.current?.select();
-      }
-    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
 
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [category, isPaletteOpen, level, paletteEntries, paletteIndex, query]);
-
-  const closePalette = () => {
-    setPaletteOpen(false);
-    setPaletteQuery("");
-    setPaletteIndex(0);
-  };
-
-  const resetFilters = () => {
-    setQuery("");
-    setCategory("All");
-    setLevel("All");
-    searchInputRef.current?.focus();
-  };
+  useEffect(() => {
+    if (paletteOpen) {
+      setTimeout(() => paletteInputRef.current?.focus(), 0);
+    } else {
+      setPaletteQuery("");
+    }
+  }, [paletteOpen]);
 
   return (
-    <div className="app-shell">
-      <div className="ambient-grid" aria-hidden="true" />
-      <div className="ambient-glow" aria-hidden="true" />
-      <div className="cursor-glow" aria-hidden="true" />
-      <div className="scroll-progress" aria-hidden="true">
-        <i style={{ transform: `scaleX(${scrollProgress})` }} />
-      </div>
-
-      <nav className="section-rail" aria-label={copy.sectionRailLabel}>
-        {sectionNav.map((section) => (
-          <a
-            key={section.id}
-            href={`#${section.id}`}
-            className={`rail-link ${activeSection === section.id ? "active" : ""}`}
-            onClick={() => setActiveSection(section.id)}
-          >
-            <span className="rail-dot" aria-hidden="true" />
-            <span>{localize(section.label, locale)}</span>
-          </a>
-        ))}
-      </nav>
-
+    <div className="zc-app">
       <header className="topbar">
-        <div className="container topbar-inner">
-          <a className="wordmark" href="#">
+        <div className="topbar-inner">
+          <a className="brand" href="#top">
             ZeroClaw
           </a>
 
-          <div className="top-actions">
-            <a className="top-link" href="#docs-navigator">
-              {copy.navDocs}
+          <nav className="top-nav" aria-label="Primary">
+            <a href="#docs-workspace">{text.navDocs}</a>
+            <a href="https://github.com/zeroclaw-labs/zeroclaw" target="_blank" rel="noreferrer">
+              {text.navGitHub}
             </a>
-            <a className="top-link" href={getDocUrl("README.md")} target="_blank" rel="noreferrer">
-              {copy.navRepo}
+            <a href="https://zeroclawlabs.ai" target="_blank" rel="noreferrer">
+              {text.navWebsite}
             </a>
-            <button
-              type="button"
-              className="top-link top-link-btn"
-              onClick={() => {
-                setPaletteOpen(true);
-                setPaletteIndex(0);
-              }}
-            >
-              {copy.openPalette}
-              <span className="top-shortcut">Ctrl/Cmd+K</span>
-            </button>
+          </nav>
 
-            <div className="toggle-cluster" role="group" aria-label={copy.languageLabel}>
-              {(["en", "zh"] as const).map((item) => (
-                <button
-                  key={item}
-                  type="button"
-                  className={`toggle-chip ${locale === item ? "active" : ""}`}
-                  onClick={() => setLocale(item)}
-                  aria-pressed={locale === item}
-                >
-                  {languageLabels[locale][item]}
-                </button>
-              ))}
+          <div className="controls">
+            <div className="segmented" role="group" aria-label="Language">
+              <button
+                type="button"
+                className={locale === "en" ? "active" : ""}
+                onClick={() => setLocale("en")}
+              >
+                EN
+              </button>
+              <button
+                type="button"
+                className={locale === "zh" ? "active" : ""}
+                onClick={() => setLocale("zh")}
+              >
+                中文
+              </button>
             </div>
 
-            <div className="toggle-cluster" role="group" aria-label={copy.themeLabel}>
-              {(["system", "dark", "light"] as const).map((mode) => (
+            <div className="segmented" role="group" aria-label="Theme">
+              {(["system", "dark", "light"] as ThemeMode[]).map((mode) => (
                 <button
                   key={mode}
                   type="button"
-                  className={`toggle-chip ${themeMode === mode ? "active" : ""}`}
+                  className={themeMode === mode ? "active" : ""}
                   onClick={() => setThemeMode(mode)}
-                  aria-pressed={themeMode === mode}
                 >
-                  {themeLabels[locale][mode]}
+                  {mode}
                 </button>
               ))}
             </div>
 
-            <span className="status-pill" title={`theme:${resolvedTheme}`}>
-              {copy.statusPill}
-            </span>
+            <button type="button" className="palette-trigger" onClick={() => setPaletteOpen(true)}>
+              ⌘K
+            </button>
           </div>
         </div>
       </header>
 
-      <main className="container main-layout">
-        <section id="hero-core" className="hero hero-grid">
-          <div className="hero-copy">
-            <p className="hero-kicker reveal">{copy.heroKicker}</p>
-            <h1 className="hero-title reveal delay-1">
-              {copy.heroTitle[0]}
-              <br />
-              {copy.heroTitle[1]}
-              <br />
-              {copy.heroTitle[2]}
-            </h1>
-            <p className="hero-lead reveal delay-2">{copy.heroLead}</p>
+      <main id="top">
+        <section className="hero">
+          <div className="hero-inner">
+            <p className="eyebrow">{text.badge}</p>
+            <h1>{text.title}</h1>
+            <p className="lead">{text.summary}</p>
+            <p className="lead muted">{text.summary2}</p>
 
-            <div className="hero-actions reveal delay-3">
-              <a className="btn btn-primary" href="#docs-navigator">
-                {copy.browseDocsNow}
+            <div className="hero-cta">
+              <a className="btn primary" href="#docs-workspace">
+                {text.ctaDocs}
               </a>
               <a
-                className="btn"
-                href={getDocUrl("docs/README.md")}
+                className="btn ghost"
+                href={withRepo("docs/one-click-bootstrap.md")}
                 target="_blank"
                 rel="noreferrer"
               >
-                {copy.openDocsHome}
+                {text.ctaBootstrap}
               </a>
             </div>
 
-            <dl className="metrics reveal delay-4">
-              {copy.metrics.map((metric) => (
-                <div className="metric" key={metric.label}>
-                  <dt>{metric.label}</dt>
-                  <dd>{metric.value}</dd>
-                </div>
-              ))}
-            </dl>
-          </div>
+            <p className="notice">{text.notice}</p>
 
-          <aside className="command-deck reveal delay-2">
-            <header className="deck-head">
-              <span>{copy.runtimeLabel}</span>
-              <span className="live-pill">{copy.live}</span>
-            </header>
-
-            <div className="deck-body">
-              {signalFeed.map((line, index) => (
-                <p
-                  key={line.en}
-                  className="feed-row"
-                  style={{ animationDelay: `${index * 120}ms` } as CSSProperties}
-                >
-                  <span className="feed-index">0{index + 1}</span>
-                  <span>{localize(line, locale)}</span>
-                </p>
+            <div className="metrics" aria-label="Project metrics">
+              {text.metrics.map((metric) => (
+                <article key={metric.label} className="metric-card">
+                  <p className="metric-label">{metric.label}</p>
+                  <p className="metric-value">{metric.value}</p>
+                </article>
               ))}
             </div>
-
-            <div className="deck-bars">
-              {executionPhases.map((phase, index) => (
-                <div key={phase.phase.en} className="deck-bar-row">
-                  <span>{localize(phase.phase, locale)}</span>
-                  <span className="bar-track">
-                    <i
-                      style={
-                        {
-                          width: `${Math.min(95, 58 + index * 11)}%`,
-                          animationDelay: `${index * 160}ms`,
-                        } as CSSProperties
-                      }
-                    />
-                  </span>
-                </div>
-              ))}
-            </div>
-          </aside>
-        </section>
-
-        <section className="trait-band reveal">
-          {traitChips.map((chip, index) => (
-            <span key={chip.en} className={`trait-chip delay-${Math.min(index + 1, 4)}`}>
-              {localize(chip, locale)}
-            </span>
-          ))}
-        </section>
-
-        <section id="core-shortcuts" className="glass-panel">
-          <div className="section-head">
-            <h2 className="section-title reveal">{copy.coreDocsShortcuts}</h2>
-            <a className="section-head-link reveal delay-1" href="#docs-navigator">
-              {copy.openFullNavigator}
-            </a>
-          </div>
-          <div className="links-grid">
-            {featuredDocs.map((doc, index) => (
-              <a
-                key={doc.path}
-                href={getDocUrl(doc.path)}
-                className={`doc-link reveal delay-${Math.min(index + 1, 4)}`}
-                target="_blank"
-                rel="noreferrer"
-              >
-                <span>{localize(doc.title, locale)}</span>
-                <svg viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M7 17L17 7M17 7H8M17 7V16" />
-                </svg>
-              </a>
-            ))}
           </div>
         </section>
 
-        <section id="quick-paths" className="glass-panel">
-          <div className="section-head">
-            <h2 className="section-title reveal">{copy.quickStartPaths}</h2>
-            <span className="section-tag reveal delay-1">{copy.taskFirstRouting}</span>
+        <section id="docs-workspace" className="docs-shell">
+          <div className="docs-head">
+            <h2>{text.docsWorkspace}</h2>
+            <p>{text.docsLead}</p>
           </div>
-          <div className="path-grid">
-            {quickPaths.map((path, index) => (
-              <article
-                key={path.title.en}
-                className={`path-card reveal delay-${Math.min(index + 1, 4)}`}
-              >
-                <h3>{localize(path.title, locale)}</h3>
-                <p>{localize(path.summary, locale)}</p>
-                <div className="path-docs">
-                  {path.docs.map((docPath) => {
-                    const doc = docsLookup.get(docPath);
-                    if (!doc) {
-                      return null;
-                    }
-                    return (
-                      <a
-                        key={doc.path}
-                        href={getDocUrl(doc.path)}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="path-doc-link"
-                      >
-                        <span>{localize(doc.title, locale)}</span>
-                        <code>{doc.path}</code>
-                      </a>
-                    );
-                  })}
-                </div>
-              </article>
-            ))}
+
+          <div className="docs-toolbar">
+            <input
+              ref={docsSearchRef}
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={text.search}
+              aria-label={text.search}
+            />
+            <button type="button" className="btn ghost" onClick={() => setPaletteOpen(true)}>
+              {text.commandPalette}
+            </button>
           </div>
-        </section>
 
-        <section id="capability-stack" className="glass-panel">
-          <h2 className="section-title reveal">{copy.capabilityStack}</h2>
-          <div className="cap-grid">
-            {capabilities.map((cap, index) => (
-              <article
-                key={cap.title.en}
-                className={`cap-card reveal delay-${Math.min(index + 1, 4)}`}
-              >
-                <h3>{localize(cap.title, locale)}</h3>
-                <p>{localize(cap.text, locale)}</p>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section id="execution-lattice" className="workflow-grid">
-          <article className="glass-panel">
-            <h2 className="section-title reveal">{copy.executionLattice}</h2>
-            <ol className="phase-list">
-              {executionPhases.map((phase, index) => (
-                <li
-                  key={phase.phase.en}
-                  className={`phase-item reveal delay-${Math.min(index + 1, 4)}`}
-                >
-                  <span className="phase-num">{index + 1}</span>
-                  <div className="phase-text">
-                    <h3>{localize(phase.phase, locale)}</h3>
-                    <p>{localize(phase.detail, locale)}</p>
-                  </div>
-                </li>
-              ))}
-            </ol>
-          </article>
-
-          <aside className="glass-panel monitor-panel reveal delay-2">
-            <h2 className="section-title">{copy.operatorSignal}</h2>
-            <p className="monitor-intro">{copy.operatorSignalIntro}</p>
-            <div className="monitor-grid">
-              {monitorStats.map((stat) => (
-                <div key={stat.label.en}>
-                  <span>{localize(stat.label, locale)}</span>
-                  <strong>{localize(stat.value, locale)}</strong>
-                </div>
-              ))}
-            </div>
-          </aside>
-        </section>
-
-        <section id="docs-navigator" className="glass-panel docs-panel">
-          <h2 className="section-title reveal">{copy.docsNavigator}</h2>
-          <p className="docs-intro reveal delay-1">{copy.docsIntro}</p>
-
-          <div className="docs-tools reveal delay-1">
-            <label className="docs-search-wrap" htmlFor="docs-search-input">
-              <span className="docs-search-label">{copy.searchDocs}</span>
-              <input
-                id="docs-search-input"
-                ref={searchInputRef}
-                value={query}
-                onChange={(event) => setQuery(event.target.value)}
-                placeholder={copy.searchPlaceholder}
-                autoComplete="off"
-              />
-            </label>
-
-            <div className="docs-filter-stack">
-              <div className="category-row" role="tablist" aria-label="Doc category filters">
-                {(["All", ...categories] as const).map((item) => (
-                  <button
-                    key={item}
-                    type="button"
-                    className={`category-pill ${category === item ? "active" : ""}`}
-                    onClick={() => setCategory(item)}
-                    aria-pressed={category === item}
-                  >
-                    <span>
-                      {item === "All" ? levelLabels[locale].All : categoryLabels[locale][item]}
-                    </span>
-                    <small className="pill-count">
-                      {item === "All" ? totalCategoryCount : categoryCounts[item]}
-                    </small>
-                  </button>
-                ))}
-              </div>
-
-              <div className="category-row level-row" role="tablist" aria-label="Doc level filters">
-                {levelFilterOptions.map((item) => (
-                  <button
-                    key={item}
-                    type="button"
-                    className={`category-pill level-pill ${level === item ? "active" : ""}`}
-                    onClick={() => setLevel(item)}
-                    aria-pressed={level === item}
-                  >
-                    {levelLabels[locale][item]}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div className="docs-utility-row">
-              <p className="docs-hint">
-                {copy.quickKeys} <kbd>/</kbd> {copy.quickKeySearchHint}, <kbd>Esc</kbd>{" "}
-                {copy.quickKeyResetHint}.
-              </p>
+          <div className="category-row" role="tablist" aria-label="Doc categories">
+            {categories.map((item) => (
               <button
+                key={item}
                 type="button"
-                className="reset-filters-btn"
-                onClick={resetFilters}
-                disabled={!hasActiveFilters}
+                role="tab"
+                aria-selected={category === item}
+                className={category === item ? "active" : ""}
+                onClick={() => setCategory(item)}
               >
-                {copy.resetFilters}
+                {categoryLabel[locale][item]}
               </button>
-            </div>
+            ))}
           </div>
 
-          <p className="docs-count reveal delay-2">
-            {copy.docsCount(filteredDocs.length, hasActiveFilters)}
-          </p>
+          <div className="workspace-grid">
+            <aside className="doc-list" aria-label="Document list">
+              {filteredDocs.length === 0 ? (
+                <p className="empty-hint">{text.empty}</p>
+              ) : (
+                filteredDocs.map((doc) => {
+                  const isActive = doc.id === selectedId;
+                  return (
+                    <button
+                      key={doc.id}
+                      type="button"
+                      className={`doc-item ${isActive ? "active" : ""}`}
+                      onClick={() => setSelectedId(doc.id)}
+                    >
+                      <span className="doc-meta">{categoryLabel[locale][doc.category]}</span>
+                      <span className="doc-title">{doc.title[locale]}</span>
+                      <span className="doc-summary">{doc.summary[locale]}</span>
+                      <span className="doc-path">{resolvePath(doc, locale)}</span>
+                    </button>
+                  );
+                })
+              )}
+            </aside>
 
-          {topMatches.length > 0 && (
-            <section className="docs-top-matches reveal in delay-2">
-              <h3 className="docs-group-title">{copy.topMatches}</h3>
-              <div className="docs-grid">
-                {topMatches.map((doc) => (
-                  <a
-                    key={`top-${doc.path}`}
-                    href={getDocUrl(doc.path)}
-                    className="doc-nav-card doc-nav-card-priority"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    <div className="doc-nav-head">
-                      <strong>{highlightMatches(localize(doc.title, locale), queryTokens)}</strong>
-                      <span>{levelLabels[locale][doc.level]}</span>
-                    </div>
-                    <p>{highlightMatches(localize(doc.summary, locale), queryTokens)}</p>
-                    <code>{highlightMatches(doc.path, queryTokens)}</code>
+            <section className="doc-reader" aria-live="polite">
+              <header className="reader-head">
+                <div>
+                  <p>{text.sourceLabel}</p>
+                  <h3>{selectedDoc.title[locale]}</h3>
+                  <code>{activePath}</code>
+                </div>
+                <div className="reader-actions">
+                  <a href={withRepo(activePath)} target="_blank" rel="noreferrer">
+                    {text.openOnGithub}
                   </a>
-                ))}
-              </div>
+                  <a href={withRaw(activePath)} target="_blank" rel="noreferrer">
+                    {text.openRaw}
+                  </a>
+                </div>
+              </header>
+
+              {loading ? <p className="reader-status">{text.loading}</p> : null}
+
+              {!loading && error ? (
+                <p className="reader-status">
+                  {text.fallback} <a href={withRepo(activePath)}>{withRepo(activePath)}</a>
+                </p>
+              ) : null}
+
+              {!loading && !error && markdown ? (
+                <article className="markdown-body">
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={{
+                      h1: ({ children }) => {
+                        const id = slugify(nodeText(children));
+                        return <h1 id={id}>{children}</h1>;
+                      },
+                      h2: ({ children }) => {
+                        const id = slugify(nodeText(children));
+                        return <h2 id={id}>{children}</h2>;
+                      },
+                      h3: ({ children }) => {
+                        const id = slugify(nodeText(children));
+                        return <h3 id={id}>{children}</h3>;
+                      },
+                      a: ({ href, children }) => {
+                        const url = href ?? "#";
+                        const external = /^https?:\/\//i.test(url);
+                        return (
+                          <a href={url} target={external ? "_blank" : undefined} rel={external ? "noreferrer" : undefined}>
+                            {children}
+                          </a>
+                        );
+                      },
+                    }}
+                  >
+                    {markdown}
+                  </ReactMarkdown>
+                </article>
+              ) : null}
             </section>
-          )}
-
-          <div className="docs-groups">
-            {categories.map((cat, catIndex) => {
-              const docs = docsByCategory[cat];
-              if (docs.length === 0) {
-                return null;
-              }
-              return (
-                <section
-                  key={cat}
-                  className={`docs-group reveal delay-${Math.min(catIndex + 1, 4)}`}
-                >
-                  <h3 className="docs-group-title">{categoryLabels[locale][cat]}</h3>
-                  <div className="docs-grid">
-                    {docs.map((doc) => (
-                      <a
-                        key={doc.path}
-                        href={getDocUrl(doc.path)}
-                        className="doc-nav-card"
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        <div className="doc-nav-head">
-                          <strong>{highlightMatches(localize(doc.title, locale), queryTokens)}</strong>
-                          <span>{levelLabels[locale][doc.level]}</span>
-                        </div>
-                        <p>{highlightMatches(localize(doc.summary, locale), queryTokens)}</p>
-                        <code>{highlightMatches(doc.path, queryTokens)}</code>
-                      </a>
-                    ))}
-                  </div>
-                </section>
-              );
-            })}
-
-            {filteredDocs.length === 0 && (
-              <div className="doc-empty reveal in" role="status" aria-live="polite">
-                {copy.noMatchPrefix}
-                <code> {copy.noMatchA} </code>
-                {copy.noMatchConnector}
-                <code> {copy.noMatchB} </code>.
-              </div>
-            )}
           </div>
-
-          <footer className="panel-footer reveal delay-4">{copy.panelFooter}</footer>
         </section>
       </main>
 
-      <div className="mobile-dock">
-        <a className="dock-btn" href="#docs-navigator">
-          {copy.mobileDockDocs}
-        </a>
-        <button
-          type="button"
-          className="dock-btn"
-          onClick={() => {
-            setPaletteOpen(true);
-            setPaletteIndex(0);
-          }}
-        >
-          {copy.mobileDockPalette}
-        </button>
-      </div>
+      <footer className="footer">
+        <p>ZeroClaw · Trait-driven architecture · secure-by-default runtime · pluggable everything</p>
+      </footer>
 
-      {isPaletteOpen && (
-        <div className="palette-overlay" role="presentation" onClick={closePalette}>
-          <section
-            className="palette-panel"
-            role="dialog"
-            aria-modal="true"
-            aria-label={copy.paletteTitle}
-            onClick={(event) => event.stopPropagation()}
-          >
-            <header className="palette-head">
-              <input
-                ref={paletteInputRef}
-                value={paletteQuery}
-                onChange={(event) => setPaletteQuery(event.target.value)}
-                placeholder={copy.palettePlaceholder}
-                aria-label={copy.palettePlaceholder}
-              />
-              <button type="button" className="palette-close" onClick={closePalette}>
-                {copy.paletteClose}
-              </button>
-            </header>
-
-            <div className="palette-grid">
-              <div
-                className="palette-results"
-                role="listbox"
-                aria-activedescendant={
-                  activePaletteEntry ? `palette-option-${activePaletteEntry.id}` : undefined
+      {paletteOpen ? (
+        <div className="palette-backdrop" onClick={() => setPaletteOpen(false)}>
+          <div className="palette" role="dialog" aria-modal="true" onClick={(event) => event.stopPropagation()}>
+            <input
+              ref={paletteInputRef}
+              type="search"
+              value={paletteQuery}
+              onChange={(event) => setPaletteQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && paletteResults[0]) {
+                  paletteResults[0].run();
+                  setPaletteOpen(false);
                 }
-              >
-                <section>
-                  <p className="palette-section-title">
-                    {copy.paletteActionsGroup}
-                    <small>{actionEntries.length}</small>
-                  </p>
-                  <div className="palette-list">
-                    {actionEntries.map((entry, index) => (
-                      <button
-                        type="button"
-                        id={`palette-option-${entry.id}`}
-                        key={entry.id}
-                        data-palette-index={index}
-                        className={`palette-item ${paletteIndex === index ? "active" : ""}`}
-                        role="option"
-                        aria-selected={paletteIndex === index}
-                        onMouseEnter={() => setPaletteIndex(index)}
-                        onClick={() => {
-                          entry.run();
-                          closePalette();
-                        }}
-                      >
-                        <span className="palette-item-main">
-                          {highlightMatches(entry.label, paletteTokens)}
-                        </span>
-                        <small>{highlightMatches(entry.hint, paletteTokens)}</small>
-                      </button>
-                    ))}
-                  </div>
-                </section>
-
-                <section>
-                  <p className="palette-section-title">
-                    {copy.paletteDocsGroup}
-                    <small>{docEntries.length}</small>
-                  </p>
-                  <div className="palette-list">
-                    {docEntries.map((entry, index) => {
-                      const globalIndex = actionEntries.length + index;
-                      return (
-                        <button
-                          type="button"
-                          id={`palette-option-${entry.id}`}
-                          key={entry.id}
-                          data-palette-index={globalIndex}
-                          className={`palette-item palette-doc-item ${paletteIndex === globalIndex ? "active" : ""}`}
-                          role="option"
-                          aria-selected={paletteIndex === globalIndex}
-                          onMouseEnter={() => setPaletteIndex(globalIndex)}
-                          onClick={() => {
-                            entry.run();
-                            closePalette();
-                          }}
-                        >
-                          <span className="palette-item-main">
-                            {highlightMatches(entry.label, paletteTokens)}
-                          </span>
-                          <small>{highlightMatches(entry.hint, paletteTokens)}</small>
-                          <code>{highlightMatches(entry.meta ?? "", paletteTokens)}</code>
-                        </button>
-                      );
-                    })}
-                  </div>
-                </section>
-
-                {paletteEntries.length === 0 && (
-                  <p className="palette-empty">{copy.paletteNoResults}</p>
-                )}
-              </div>
-
-              <aside className="palette-preview" aria-live="polite">
-                <p className="palette-preview-title">{copy.palettePreviewTitle}</p>
-
-                {activePaletteEntry ? (
-                  <div className="preview-card">
-                    <p className="preview-kind">
-                      {activePaletteEntry.kind === "action"
-                        ? copy.palettePreviewKindAction
-                        : copy.palettePreviewKindDoc}
-                    </p>
-                    <h3>{highlightMatches(activePaletteEntry.label, paletteTokens)}</h3>
-                    <p>{highlightMatches(activePaletteEntry.hint, paletteTokens)}</p>
-                    {activePaletteEntry.meta && (
-                      <code>{highlightMatches(activePaletteEntry.meta, paletteTokens)}</code>
-                    )}
-                    {activePaletteEntry.kind === "doc" && (
-                      <span className="preview-open-hint">{copy.palettePreviewOpenHint}</span>
-                    )}
-                  </div>
-                ) : (
-                  <p className="palette-preview-empty">{copy.palettePreviewNoSelection}</p>
-                )}
-
-                <div className="palette-kbd-hints">
-                  <span>{copy.paletteHintNavigate}</span>
-                  <span>{copy.paletteHintRun}</span>
-                  <span>{copy.paletteHintClose}</span>
-                </div>
-              </aside>
+              }}
+              placeholder={text.paletteHint}
+              aria-label={text.paletteHint}
+            />
+            <div className="palette-list">
+              {paletteResults.slice(0, 12).map((entry) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  onClick={() => {
+                    entry.run();
+                    setPaletteOpen(false);
+                  }}
+                >
+                  <span>{entry.label}</span>
+                  <small>{entry.hint}</small>
+                </button>
+              ))}
             </div>
-          </section>
+          </div>
         </div>
-      )}
+      ) : null}
+
+      <button
+        type="button"
+        className="floating"
+        onClick={focusSearch}
+        aria-label={text.actionFocus}
+        title={text.actionFocus}
+      >
+        {text.navDocs}
+      </button>
     </div>
   );
 }

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -1,101 +1,56 @@
-@import url("https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&family=Orbitron:wght@500;700;900&family=Space+Grotesk:wght@400;500;700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&family=Sora:wght@500;600;700&display=swap");
 
 :root {
   color-scheme: dark;
 
-  --bg-void: #030712;
-  --bg-ice: #050810;
-  --bg-panel: #0a0f1a;
+  --bg: #05070d;
+  --bg-elevated: #0a101b;
+  --bg-panel: #0f1727;
+  --bg-soft: rgba(14, 22, 38, 0.75);
 
-  --ambient-a: rgba(56, 189, 248, 0.08);
-  --ambient-b: rgba(34, 211, 238, 0.09);
-  --ambient-grid-line: rgba(148, 163, 184, 0.08);
-  --ambient-cursor: rgba(56, 189, 248, 0.18);
+  --line: rgba(166, 185, 217, 0.2);
+  --line-strong: rgba(96, 165, 250, 0.45);
+  --text: #e8edf9;
+  --text-soft: #adbad3;
+  --text-muted: #8797b5;
 
-  --ink-bright: #ffffff;
-  --ink-soft: #e2e8f0;
-  --ink-silver: #94a3b8;
-  --ink-metal: #c8d2df;
+  --accent: #5fa7ff;
+  --accent-strong: #3b82f6;
+  --accent-soft: rgba(95, 167, 255, 0.18);
 
-  --arc-primary: #38bdf8;
-  --arc-secondary: #22d3ee;
-  --arc-glow: #67e8f9;
+  --shadow-panel: 0 20px 60px rgba(2, 6, 18, 0.55);
+  --shadow-soft: 0 10px 28px rgba(2, 6, 18, 0.4);
 
-  --line-subtle: rgba(148, 163, 184, 0.2);
-  --line-strong: rgba(56, 189, 248, 0.46);
+  --radius-xl: 22px;
+  --radius-l: 16px;
+  --radius-m: 12px;
 
-  --surface-topbar-a: rgba(3, 7, 18, 0.88);
-  --surface-topbar-b: rgba(3, 7, 18, 0.44);
-  --surface-glass-a: rgba(10, 15, 26, 0.82);
-  --surface-glass-b: rgba(5, 8, 16, 0.92);
-  --surface-card: rgba(8, 13, 24, 0.74);
-  --surface-card-strong: rgba(3, 7, 18, 0.7);
-  --surface-chip: rgba(10, 15, 26, 0.66);
-  --surface-input: rgba(7, 12, 24, 0.72);
-  --surface-control: rgba(10, 15, 26, 0.7);
-
-  --panel-shadow: 0 18px 50px rgba(1, 5, 18, 0.5);
-  --card-shadow: 0 10px 20px rgba(2, 7, 22, 0.4);
-
-  --mark-bg: rgba(103, 232, 249, 0.24);
-
-  --motion-fast: 150ms;
-  --motion-base: 320ms;
-  --motion-slow: 620ms;
-  --motion-sweep: 2400ms;
-  --ease-snap: cubic-bezier(0.2, 0.8, 0.2, 1);
-  --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
-
-  --pointer-x: 50vw;
-  --pointer-y: 35vh;
+  --container: min(1220px, calc(100% - 2.2rem));
 }
 
 :root[data-theme="light"] {
   color-scheme: light;
 
-  --bg-void: #eef4fb;
-  --bg-ice: #e7f0fa;
-  --bg-panel: #dbe7f4;
+  --bg: #f4f7fc;
+  --bg-elevated: #ffffff;
+  --bg-panel: #f8fbff;
+  --bg-soft: rgba(255, 255, 255, 0.78);
 
-  --ambient-a: rgba(2, 132, 199, 0.16);
-  --ambient-b: rgba(14, 165, 233, 0.15);
-  --ambient-grid-line: rgba(51, 65, 85, 0.12);
-  --ambient-cursor: rgba(2, 132, 199, 0.2);
+  --line: rgba(30, 58, 95, 0.18);
+  --line-strong: rgba(59, 130, 246, 0.42);
+  --text: #0f1b2d;
+  --text-soft: #22324d;
+  --text-muted: #5d6e8f;
 
-  --ink-bright: #0f172a;
-  --ink-soft: #1e293b;
-  --ink-silver: #475569;
-  --ink-metal: #334155;
+  --accent: #2563eb;
+  --accent-strong: #1d4ed8;
+  --accent-soft: rgba(37, 99, 235, 0.12);
 
-  --arc-primary: #0284c7;
-  --arc-secondary: #0369a1;
-  --arc-glow: #0ea5e9;
-
-  --line-subtle: rgba(51, 65, 85, 0.24);
-  --line-strong: rgba(2, 132, 199, 0.5);
-
-  --surface-topbar-a: rgba(238, 244, 251, 0.94);
-  --surface-topbar-b: rgba(238, 244, 251, 0.78);
-  --surface-glass-a: rgba(255, 255, 255, 0.9);
-  --surface-glass-b: rgba(239, 247, 255, 0.92);
-  --surface-card: rgba(255, 255, 255, 0.9);
-  --surface-card-strong: rgba(248, 252, 255, 0.95);
-  --surface-chip: rgba(255, 255, 255, 0.86);
-  --surface-input: rgba(255, 255, 255, 0.95);
-  --surface-control: rgba(255, 255, 255, 0.9);
-
-  --panel-shadow: 0 14px 32px rgba(15, 23, 42, 0.14);
-  --card-shadow: 0 8px 18px rgba(15, 23, 42, 0.14);
-
-  --mark-bg: rgba(14, 165, 233, 0.22);
+  --shadow-panel: 0 18px 40px rgba(14, 37, 66, 0.15);
+  --shadow-soft: 0 10px 24px rgba(14, 37, 66, 0.12);
 }
 
 * {
-  box-sizing: border-box;
-}
-
-*::before,
-*::after {
   box-sizing: border-box;
 }
 
@@ -107,1811 +62,730 @@ body,
 }
 
 body {
-  font-family: "Space Grotesk", "Noto Sans SC", "Segoe UI", sans-serif;
+  font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+  color: var(--text-soft);
   background:
-    radial-gradient(120% 90% at 10% 0%, var(--ambient-a), transparent 60%),
-    radial-gradient(120% 90% at 90% 10%, var(--ambient-b), transparent 65%),
-    linear-gradient(160deg, var(--bg-void), var(--bg-ice) 45%, var(--bg-panel));
-  color: var(--ink-soft);
-  letter-spacing: 0.01em;
-  line-height: 1.45;
-  overflow-x: hidden;
+    radial-gradient(circle at 8% 0%, rgba(56, 138, 255, 0.2), transparent 38%),
+    radial-gradient(circle at 88% 12%, rgba(140, 168, 215, 0.18), transparent 36%),
+    linear-gradient(170deg, var(--bg), #050b16 55%, var(--bg-elevated));
+  background-attachment: fixed;
+  line-height: 1.62;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-mark {
-  color: var(--ink-bright);
-  background: var(--mark-bg);
-  border-radius: 0.24rem;
-  padding: 0.02rem 0.18rem;
+:root[data-theme="light"] body {
+  background:
+    radial-gradient(circle at 8% 0%, rgba(37, 99, 235, 0.12), transparent 42%),
+    radial-gradient(circle at 88% 12%, rgba(125, 163, 255, 0.18), transparent 40%),
+    linear-gradient(170deg, #eef4ff, #f8fbff 62%, #eef4ff);
 }
 
-a,
-button {
-  -webkit-tap-highlight-color: transparent;
+a {
+  color: inherit;
+  text-decoration: none;
 }
 
-button {
+button,
+input {
   font: inherit;
 }
 
-a:focus-visible,
+button {
+  cursor: pointer;
+}
+
 button:focus-visible,
+a:focus-visible,
 input:focus-visible {
-  outline: 2px solid rgba(103, 232, 249, 0.72);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 
-.app-shell {
-  position: relative;
-  isolation: isolate;
-}
-
-.ambient-grid,
-.ambient-glow,
-.cursor-glow {
-  pointer-events: none;
-  position: fixed;
-  inset: 0;
-}
-
-.ambient-grid {
-  z-index: -3;
-  background-image:
-    linear-gradient(var(--ambient-grid-line) 1px, transparent 1px),
-    linear-gradient(90deg, var(--ambient-grid-line) 1px, transparent 1px);
-  background-size: 44px 44px;
-  mask-image: radial-gradient(circle at center, black 35%, transparent 90%);
-  opacity: 0.28;
-}
-
-.ambient-glow {
-  z-index: -3;
-  background-image:
-    linear-gradient(108deg, transparent 46%, rgba(103, 232, 249, 0.2) 50%, transparent 54%),
-    linear-gradient(70deg, transparent 48%, rgba(56, 189, 248, 0.14) 50%, transparent 52%);
-  animation: ionShift 8s linear infinite;
-  opacity: 0.24;
-}
-
-.cursor-glow {
-  z-index: -2;
-  background: radial-gradient(
-    360px circle at var(--pointer-x) var(--pointer-y),
-    var(--ambient-cursor),
-    transparent 58%
-  );
-}
-
-.scroll-progress {
-  position: fixed;
-  inset: 0 0 auto 0;
-  height: 2px;
-  z-index: 35;
-  pointer-events: none;
-  background: rgba(56, 189, 248, 0.08);
-}
-
-.scroll-progress i {
-  display: block;
-  height: 100%;
-  transform-origin: 0 50%;
-  background: linear-gradient(
-    90deg,
-    rgba(34, 211, 238, 0.72),
-    rgba(103, 232, 249, 0.95),
-    rgba(56, 189, 248, 0.9)
-  );
-  box-shadow: 0 0 12px rgba(56, 189, 248, 0.55);
-}
-
-@keyframes ionShift {
-  from {
-    transform: translateX(-18%) translateY(-6%);
-  }
-  to {
-    transform: translateX(18%) translateY(6%);
-  }
-}
-
-.container {
-  width: min(1200px, 100% - clamp(1.1rem, 2.2vw, 2.6rem));
-  margin-inline: auto;
-}
-
-.section-rail {
-  position: fixed;
-  right: clamp(0.5rem, 1.6vw, 1.25rem);
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 18;
-  display: grid;
-  gap: 0.42rem;
-}
-
-.rail-link {
-  text-decoration: none;
-  color: var(--ink-silver);
-  border: 1px solid var(--line-subtle);
-  background: color-mix(in srgb, var(--surface-card) 88%, transparent 12%);
-  border-radius: 999px;
-  padding: 0.28rem 0.52rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.42rem;
-  letter-spacing: 0.06em;
-  font-size: 0.66rem;
-  text-transform: uppercase;
-  transition:
-    border-color var(--motion-base) var(--ease-smooth),
-    color var(--motion-base) var(--ease-smooth),
-    background-color var(--motion-base) var(--ease-smooth),
-    transform var(--motion-fast) var(--ease-snap);
-}
-
-.rail-dot {
-  width: 0.42rem;
-  height: 0.42rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--ink-silver) 70%, transparent 30%);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--line-subtle) 65%, transparent 35%);
-}
-
-.rail-link:hover {
-  color: var(--ink-bright);
-  border-color: rgba(56, 189, 248, 0.52);
-  transform: translateX(-2px);
-}
-
-.rail-link.active {
-  color: var(--ink-bright);
-  border-color: rgba(56, 189, 248, 0.58);
-  background: rgba(56, 189, 248, 0.16);
-}
-
-.rail-link.active .rail-dot {
-  background: var(--arc-glow);
-  box-shadow: 0 0 12px rgba(103, 232, 249, 0.7);
+.zc-app {
+  min-height: 100vh;
 }
 
 .topbar {
   position: sticky;
   top: 0;
-  z-index: 20;
-  backdrop-filter: blur(10px);
-  background: linear-gradient(180deg, var(--surface-topbar-a), var(--surface-topbar-b));
-  border-bottom: 1px solid var(--line-subtle);
+  z-index: 40;
+  backdrop-filter: blur(14px);
+  background: color-mix(in srgb, var(--bg) 78%, transparent);
+  border-bottom: 1px solid var(--line);
 }
 
 .topbar-inner {
-  min-height: 76px;
+  width: var(--container);
+  margin: 0 auto;
+  min-height: 72px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 1rem;
-  padding: 0.52rem 0;
 }
 
-.wordmark {
-  font-family: "Orbitron", "Space Grotesk", sans-serif;
-  font-weight: 900;
-  font-size: clamp(1rem, 2vw, 1.2rem);
-  letter-spacing: 0.18em;
-  color: var(--ink-bright);
-  text-transform: uppercase;
-  text-decoration: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.54rem;
-  white-space: nowrap;
+.brand {
+  font-family: "Sora", sans-serif;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  color: var(--text);
+  margin-right: 1.2rem;
 }
 
-.wordmark::before {
-  content: "";
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-  background: var(--arc-glow);
-  box-shadow: 0 0 12px var(--arc-glow), 0 0 24px rgba(103, 232, 249, 0.5);
-}
-
-.top-actions {
+.top-nav {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 1rem;
 }
 
-.top-link {
-  color: var(--ink-silver);
-  text-decoration: none;
-  padding: 0.42rem 0.7rem;
-  border-radius: 999px;
-  border: 1px solid transparent;
-  font-size: 0.78rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  transition:
-    color var(--motion-base) var(--ease-smooth),
-    border-color var(--motion-base) var(--ease-smooth),
-    background-color var(--motion-base) var(--ease-smooth);
+.top-nav a {
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  transition: color 180ms ease;
 }
 
-.top-link:hover {
-  color: var(--ink-bright);
-  border-color: var(--line-subtle);
-  background: rgba(56, 189, 248, 0.08);
+.top-nav a:hover {
+  color: var(--text);
 }
 
-.top-link-btn {
-  appearance: none;
-  background: transparent;
-  cursor: pointer;
+.controls {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.segmented {
   display: inline-flex;
   align-items: center;
-  gap: 0.42rem;
-}
-
-.top-shortcut {
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.34rem;
-  padding: 0.04rem 0.28rem;
-  font-size: 0.66rem;
-  letter-spacing: 0.04em;
-  color: var(--ink-metal);
-}
-
-.toggle-cluster {
-  display: inline-flex;
-  align-items: center;
-  border: 1px solid var(--line-subtle);
-  background: var(--surface-control);
+  border: 1px solid var(--line);
   border-radius: 999px;
-  padding: 0.16rem;
-  gap: 0.16rem;
+  padding: 2px;
+  background: var(--bg-soft);
 }
 
-.toggle-chip {
-  appearance: none;
-  border: 1px solid transparent;
-  border-radius: 999px;
+.segmented button {
+  border: 0;
   background: transparent;
-  color: var(--ink-silver);
-  padding: 0.24rem 0.58rem;
-  font-size: 0.7rem;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition:
-    color var(--motion-base) var(--ease-smooth),
-    border-color var(--motion-base) var(--ease-smooth),
-    background-color var(--motion-base) var(--ease-smooth);
-}
-
-.toggle-chip:hover {
-  color: var(--ink-bright);
-  border-color: rgba(56, 189, 248, 0.45);
-}
-
-.toggle-chip.active {
-  color: var(--ink-bright);
-  background: rgba(56, 189, 248, 0.14);
-  border-color: rgba(56, 189, 248, 0.56);
-}
-
-.status-pill {
-  color: var(--arc-secondary);
-  border: 1px solid rgba(34, 211, 238, 0.4);
-  background: rgba(34, 211, 238, 0.08);
-  padding: 0.28rem 0.75rem;
+  color: var(--text-muted);
   border-radius: 999px;
-  font-size: 0.74rem;
-  font-weight: 600;
+  padding: 0.28rem 0.62rem;
+  font-size: 0.76rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
 
-.main-layout {
-  padding: clamp(3rem, 6vw, 4.9rem) 0 4.2rem;
-  display: grid;
-  gap: 2.2rem;
+.segmented button.active {
+  color: var(--text);
+  background: var(--accent-soft);
+}
+
+.palette-trigger {
+  border: 1px solid var(--line);
+  background: var(--bg-soft);
+  color: var(--text-muted);
+  border-radius: 10px;
+  min-width: 54px;
+  padding: 0.35rem 0.65rem;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.78rem;
+}
+
+main {
+  width: var(--container);
+  margin: 0 auto;
+  padding: 2.4rem 0 3rem;
 }
 
 .hero {
-  display: grid;
-  gap: 1.3rem;
   position: relative;
+  border: 1px solid var(--line);
+  background: linear-gradient(145deg, var(--bg-panel), color-mix(in srgb, var(--bg-panel) 82%, #040912 18%));
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-panel);
+  overflow: hidden;
   isolation: isolate;
 }
 
-.hero-grid {
-  grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
-  gap: 1.1rem;
-}
-
-.hero-grid::after {
+.hero::before {
   content: "";
   position: absolute;
-  inset: auto 0 -1.15rem 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(103, 232, 249, 0.44), transparent);
-  animation: railSweep var(--motion-sweep) linear infinite;
+  inset: 0;
+  background:
+    linear-gradient(120deg, transparent 20%, rgba(95, 167, 255, 0.14) 50%, transparent 80%),
+    linear-gradient(0deg, transparent 55%, rgba(255, 255, 255, 0.02) 100%);
+  pointer-events: none;
 }
 
-@keyframes railSweep {
-  from {
-    transform: translateX(-34%);
-  }
-  to {
-    transform: translateX(34%);
-  }
+.hero-inner {
+  position: relative;
+  padding: clamp(2rem, 4vw, 3.3rem);
 }
 
-.hero-copy {
-  display: grid;
-  align-content: start;
-  gap: 1.2rem;
-}
-
-.hero-kicker {
+.eyebrow {
   margin: 0;
-  color: var(--ink-metal);
-  font-weight: 600;
-  font-size: 0.9rem;
-  letter-spacing: 0.13em;
+  font-size: 0.76rem;
   text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  font-family: "IBM Plex Mono", monospace;
 }
 
-.hero-title {
-  margin: 0;
-  font-family: "Orbitron", "Space Grotesk", sans-serif;
-  font-size: clamp(2rem, 7vw, 5.2rem);
-  line-height: 0.95;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  color: var(--ink-bright);
-  text-wrap: balance;
-  text-shadow: 0 0 28px rgba(56, 189, 248, 0.22);
-  max-width: 14ch;
+.hero h1 {
+  margin: 0.8rem 0 1rem;
+  font-family: "Sora", sans-serif;
+  line-height: 1.12;
+  font-size: clamp(1.9rem, 4vw, 3.2rem);
+  color: var(--text);
+  max-width: 19ch;
 }
 
-.hero-lead {
+.lead {
   margin: 0;
+  font-size: clamp(1rem, 1.4vw, 1.16rem);
+  color: var(--text-soft);
   max-width: 66ch;
-  font-size: clamp(1rem, 1.6vw, 1.16rem);
-  color: var(--ink-silver);
 }
 
-.hero-actions {
+.lead.muted {
+  margin-top: 0.25rem;
+  color: var(--text-muted);
+}
+
+.hero-cta {
   display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-top: 1.4rem;
   flex-wrap: wrap;
-  gap: 0.82rem;
 }
 
 .btn {
-  appearance: none;
-  border: 1px solid var(--line-subtle);
-  color: var(--ink-soft);
-  text-decoration: none;
-  padding: 0.72rem 1.05rem;
-  background: var(--surface-control);
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  border-radius: 0.74rem;
-  transition:
-    transform var(--motion-fast) var(--ease-snap),
-    border-color var(--motion-base) var(--ease-smooth),
-    color var(--motion-base) var(--ease-smooth),
-    box-shadow var(--motion-base) var(--ease-smooth);
-  position: relative;
-  overflow: hidden;
-}
-
-.btn::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    105deg,
-    transparent 40%,
-    rgba(103, 232, 249, 0.36),
-    transparent 60%
-  );
-  transform: translateX(-140%);
-  transition: transform var(--motion-slow) var(--ease-smooth);
-  pointer-events: none;
-}
-
-.btn:hover {
-  transform: translateY(-2px);
-  border-color: var(--line-strong);
-  color: var(--ink-bright);
-  box-shadow:
-    0 0 0 1px rgba(34, 211, 238, 0.24) inset,
-    0 10px 24px rgba(2, 7, 22, 0.45),
-    0 0 22px rgba(56, 189, 248, 0.16);
-}
-
-.btn:hover::after {
-  transform: translateX(140%);
-}
-
-.btn-primary {
-  border-color: rgba(56, 189, 248, 0.5);
-  color: var(--ink-bright);
-  background: linear-gradient(
-    180deg,
-    rgba(56, 189, 248, 0.24),
-    var(--surface-control)
-  );
-}
-
-.metrics {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.76rem;
-}
-
-.metric {
-  border: 1px solid var(--line-subtle);
-  background: var(--surface-card-strong);
-  border-radius: 0.9rem;
-  padding: 0.9rem 0.95rem;
-}
-
-.metric dt {
-  margin: 0;
-  color: var(--ink-silver);
-  font-size: 0.79rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.metric dd {
-  margin: 0.24rem 0 0;
-  color: var(--ink-bright);
-  font-family: "Orbitron", "Space Grotesk", sans-serif;
-  font-weight: 700;
-  font-size: 0.98rem;
-  letter-spacing: 0.04em;
-}
-
-.command-deck {
-  border: 1px solid var(--line-subtle);
-  border-radius: 1rem;
-  background: linear-gradient(
-    145deg,
-    var(--surface-glass-a),
-    var(--surface-glass-b)
-  );
-  box-shadow: var(--panel-shadow);
-  overflow: hidden;
-  position: relative;
-}
-
-.command-deck::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    118deg,
-    transparent 40%,
-    rgba(103, 232, 249, 0.16) 50%,
-    transparent 60%
-  );
-  transform: translateX(-140%);
-  animation: deckSweep 3.8s linear infinite;
-  pointer-events: none;
-}
-
-@keyframes deckSweep {
-  from {
-    transform: translateX(-130%);
-  }
-  to {
-    transform: translateX(130%);
-  }
-}
-
-.deck-head {
-  padding: 0.78rem 0.92rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.7rem;
-  border-bottom: 1px solid var(--line-subtle);
-  background: var(--surface-card-strong);
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.74rem;
-  color: var(--ink-metal);
-}
-
-.live-pill {
-  padding: 0.16rem 0.48rem;
-  border-radius: 999px;
-  border: 1px solid rgba(34, 211, 238, 0.45);
-  color: var(--arc-secondary);
-  background: rgba(34, 211, 238, 0.08);
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  font-weight: 600;
-}
-
-.deck-body {
-  padding: 0.82rem 0.92rem;
-  display: grid;
-  gap: 0.46rem;
-}
-
-.feed-row {
-  margin: 0;
-  padding: 0.52rem 0.56rem;
-  border-radius: 0.64rem;
-  border: 1px solid var(--line-subtle);
-  background: var(--surface-card);
-  color: var(--ink-soft);
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.75rem;
-  display: flex;
-  align-items: center;
-  gap: 0.58rem;
-  animation: feedPulse 2.4s var(--ease-smooth) infinite;
-}
-
-@keyframes feedPulse {
-  0%,
-  100% {
-    border-color: var(--line-subtle);
-  }
-  50% {
-    border-color: rgba(56, 189, 248, 0.45);
-  }
-}
-
-.feed-index {
-  color: var(--arc-secondary);
-  min-width: 1.7rem;
-}
-
-.deck-bars {
-  padding: 0 0.92rem 0.98rem;
-  display: grid;
-  gap: 0.5rem;
-}
-
-.deck-bar-row {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: 0.65rem;
-  font-size: 0.74rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--ink-silver);
-}
-
-.bar-track {
-  height: 8px;
-  border-radius: 999px;
-  background: var(--surface-card-strong);
-  border: 1px solid var(--line-subtle);
-  overflow: hidden;
-}
-
-.bar-track i {
-  display: block;
-  height: 100%;
-  border-radius: inherit;
-  background: linear-gradient(
-    90deg,
-    rgba(56, 189, 248, 0.65),
-    rgba(103, 232, 249, 0.88)
-  );
-  box-shadow: 0 0 12px rgba(103, 232, 249, 0.45);
-  animation: barGlow 2.2s var(--ease-smooth) infinite;
-}
-
-@keyframes barGlow {
-  0%,
-  100% {
-    filter: brightness(0.9);
-  }
-  50% {
-    filter: brightness(1.1);
-  }
-}
-
-.trait-band {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.62rem;
-}
-
-.trait-chip {
-  border: 1px solid var(--line-subtle);
-  border-radius: 999px;
-  padding: 0.42rem 0.76rem;
-  color: var(--ink-metal);
-  font-size: 0.78rem;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  background: var(--surface-chip);
-  transition:
-    border-color var(--motion-base) var(--ease-smooth),
-    color var(--motion-base) var(--ease-smooth),
-    transform var(--motion-fast) var(--ease-snap);
-}
-
-.trait-chip:hover {
-  border-color: rgba(56, 189, 248, 0.42);
-  color: var(--ink-bright);
-  transform: translateY(-1px);
-}
-
-.glass-panel {
-  border-radius: 1rem;
-  border: 1px solid var(--line-subtle);
-  background: linear-gradient(145deg, var(--surface-glass-a), var(--surface-glass-b));
-  backdrop-filter: blur(9px);
-  box-shadow: var(--panel-shadow);
-  padding: 1.35rem;
-}
-
-.section-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-bottom: 1rem;
-}
-
-.section-title {
-  margin: 0;
-  font-family: "Orbitron", "Space Grotesk", sans-serif;
-  font-size: clamp(1.1rem, 2.4vw, 1.5rem);
-  color: var(--ink-bright);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.section-head-link {
-  color: var(--arc-secondary);
-  text-decoration: none;
-  font-size: 0.76rem;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  border: 1px solid rgba(34, 211, 238, 0.35);
-  border-radius: 999px;
-  padding: 0.3rem 0.65rem;
-  transition:
-    border-color var(--motion-base) var(--ease-smooth),
-    color var(--motion-base) var(--ease-smooth),
-    background-color var(--motion-base) var(--ease-smooth);
-}
-
-.section-head-link:hover {
-  color: var(--ink-bright);
-  border-color: rgba(56, 189, 248, 0.55);
-  background: rgba(56, 189, 248, 0.12);
-}
-
-.section-tag {
-  color: var(--ink-metal);
-  border: 1px solid var(--line-subtle);
-  border-radius: 999px;
-  padding: 0.28rem 0.62rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 0.7rem;
-}
-
-.cap-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.9rem;
-}
-
-.cap-card {
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.84rem;
-  background: var(--surface-card-strong);
-  padding: 1rem;
-  position: relative;
-  overflow: hidden;
-  transition:
-    transform var(--motion-fast) var(--ease-snap),
-    border-color var(--motion-base) var(--ease-smooth),
-    box-shadow var(--motion-base) var(--ease-smooth);
-}
-
-.cap-card::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(
-    circle at 15% 0%,
-    rgba(56, 189, 248, 0.16),
-    transparent 48%
-  );
-  opacity: 0;
-  transition: opacity var(--motion-base) var(--ease-smooth);
-  pointer-events: none;
-}
-
-.cap-card:hover {
-  transform: translateY(-3px);
-  border-color: rgba(56, 189, 248, 0.4);
-  box-shadow: var(--card-shadow);
-}
-
-.cap-card:hover::before {
-  opacity: 1;
-}
-
-.cap-card h3 {
-  margin: 0 0 0.52rem;
-  font-size: 1.03rem;
-  color: var(--ink-bright);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.cap-card p {
-  margin: 0;
-  color: var(--ink-silver);
-  font-size: 0.94rem;
-}
-
-.workflow-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
-  gap: 0.95rem;
-}
-
-.phase-list {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.72rem;
-}
-
-.phase-item {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: start;
-  gap: 0.72rem;
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.82rem;
-  background: var(--surface-card-strong);
-  padding: 0.78rem 0.86rem;
-}
-
-.phase-num {
-  width: 1.76rem;
-  height: 1.76rem;
-  border-radius: 999px;
-  border: 1px solid rgba(56, 189, 248, 0.52);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: var(--arc-secondary);
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.8rem;
-}
-
-.phase-text h3 {
-  margin: 0;
-  color: var(--ink-bright);
-  font-size: 0.95rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.phase-text p {
-  margin: 0.3rem 0 0;
-  color: var(--ink-silver);
-  font-size: 0.9rem;
-}
-
-.monitor-panel {
-  display: grid;
-  align-content: start;
-  gap: 0.9rem;
-}
-
-.monitor-intro {
-  margin: 0;
-  color: var(--ink-silver);
-  font-size: 0.94rem;
-}
-
-.monitor-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.64rem;
-}
-
-.monitor-grid div {
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.7rem;
-  padding: 0.62rem 0.7rem;
-  background: var(--surface-card);
-  display: grid;
-  gap: 0.22rem;
-}
-
-.monitor-grid span {
-  color: var(--ink-silver);
-  font-size: 0.76rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.monitor-grid strong {
-  color: var(--ink-bright);
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.91rem;
-}
-
-.links-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem;
-}
-
-.doc-link {
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.78rem;
-  background: var(--surface-card);
-  color: var(--ink-soft);
-  text-decoration: none;
-  padding: 0.9rem 1rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.8rem;
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.82rem;
-  letter-spacing: 0.02em;
+  border-radius: 12px;
+  min-height: 42px;
+  padding: 0 1rem;
+  border: 1px solid var(--line);
   transition:
-    border-color var(--motion-base) var(--ease-smooth),
-    color var(--motion-base) var(--ease-smooth),
-    transform var(--motion-fast) var(--ease-snap),
-    box-shadow var(--motion-base) var(--ease-smooth);
+    transform 180ms ease,
+    background-color 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
 }
 
-.doc-link:hover {
-  transform: translateY(-2px);
-  color: var(--ink-bright);
-  border-color: rgba(56, 189, 248, 0.46);
-  box-shadow:
-    inset 3px 0 0 rgba(56, 189, 248, 0.76),
-    0 8px 22px rgba(2, 7, 22, 0.45);
-}
-
-.doc-link svg {
-  width: 15px;
-  height: 15px;
-  stroke: currentColor;
-  fill: none;
-  opacity: 0.72;
-  transition: transform var(--motion-fast) var(--ease-snap);
-}
-
-.doc-link:hover svg {
-  transform: translate(2px, -2px);
-  opacity: 1;
-}
-
-.path-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.85rem;
-}
-
-.path-card {
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.82rem;
-  background: var(--surface-card);
-  padding: 0.92rem;
-  display: grid;
-  align-content: start;
-  gap: 0.7rem;
-  transition:
-    transform var(--motion-fast) var(--ease-snap),
-    border-color var(--motion-base) var(--ease-smooth),
-    box-shadow var(--motion-base) var(--ease-smooth);
-}
-
-.path-card:hover {
-  transform: translateY(-2px);
-  border-color: rgba(56, 189, 248, 0.52);
-  box-shadow: 0 12px 24px rgba(2, 7, 22, 0.46);
-}
-
-.path-card h3 {
-  margin: 0;
-  color: var(--ink-bright);
-  font-size: 0.9rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-
-.path-card p {
-  margin: 0;
-  color: var(--ink-silver);
-  font-size: 0.85rem;
-}
-
-.path-docs {
-  display: grid;
-  gap: 0.44rem;
-}
-
-.path-doc-link {
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.58rem;
-  text-decoration: none;
-  background: var(--surface-card-strong);
-  padding: 0.42rem 0.5rem;
-  display: grid;
-  gap: 0.2rem;
-  transition:
-    border-color var(--motion-base) var(--ease-smooth),
-    background-color var(--motion-base) var(--ease-smooth);
-}
-
-.path-doc-link:hover {
-  border-color: rgba(56, 189, 248, 0.52);
-  background: var(--surface-card);
-}
-
-.path-doc-link span {
-  color: var(--ink-soft);
-  font-size: 0.8rem;
-}
-
-.path-doc-link code {
-  color: var(--ink-silver);
-  font-size: 0.68rem;
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-}
-
-#hero-core,
-#core-shortcuts,
-#quick-paths,
-#capability-stack,
-#execution-lattice,
-#docs-navigator {
-  scroll-margin-top: 92px;
-}
-
-.docs-panel {
-  scroll-margin-top: 92px;
-}
-
-.docs-intro {
-  margin: 0;
-  color: var(--ink-silver);
-  max-width: 70ch;
-}
-
-.docs-tools {
-  margin-top: 1rem;
-  display: grid;
-  gap: 0.9rem;
-}
-
-.docs-filter-stack {
-  display: grid;
-  gap: 0.62rem;
-}
-
-.docs-search-wrap {
-  display: grid;
-  gap: 0.35rem;
-}
-
-.docs-search-label {
-  font-size: 0;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  position: absolute;
-}
-
-.docs-search-wrap input {
-  width: 100%;
-  border: 1px solid var(--line-subtle);
-  background: var(--surface-input);
-  color: var(--ink-bright);
-  border-radius: 0.74rem;
-  padding: 0.72rem 0.85rem;
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.82rem;
-  transition:
-    border-color var(--motion-base) var(--ease-smooth),
-    box-shadow var(--motion-base) var(--ease-smooth);
-}
-
-.docs-search-wrap input::placeholder {
-  color: rgba(148, 163, 184, 0.8);
-}
-
-.docs-search-wrap input:focus {
-  border-color: rgba(56, 189, 248, 0.56);
-  box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.16);
-}
-
-.category-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.48rem;
-}
-
-.level-row {
-  opacity: 0.96;
-}
-
-.category-pill {
-  border: 1px solid var(--line-subtle);
-  background: var(--surface-chip);
-  color: var(--ink-silver);
-  border-radius: 999px;
-  padding: 0.34rem 0.7rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.38rem;
-  font-size: 0.76rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition:
-    border-color var(--motion-base) var(--ease-smooth),
-    color var(--motion-base) var(--ease-smooth),
-    background-color var(--motion-base) var(--ease-smooth),
-    transform var(--motion-fast) var(--ease-snap);
-}
-
-.category-pill:hover {
+.btn:hover {
   transform: translateY(-1px);
-  color: var(--ink-bright);
-  border-color: rgba(56, 189, 248, 0.48);
 }
 
-.category-pill.active {
-  color: var(--ink-bright);
-  background: rgba(56, 189, 248, 0.14);
-  border-color: rgba(56, 189, 248, 0.56);
+.btn.primary {
+  border-color: var(--accent-strong);
+  color: #ffffff;
+  background: linear-gradient(120deg, var(--accent-strong), #1e40af);
 }
 
-.pill-count {
-  border: 1px solid var(--line-subtle);
-  border-radius: 999px;
-  padding: 0.02rem 0.28rem;
-  font-size: 0.62rem;
-  color: var(--ink-metal);
-  letter-spacing: 0.04em;
-  line-height: 1.2;
+.btn.ghost {
+  background: var(--bg-soft);
+  color: var(--text-soft);
 }
 
-.category-pill.active .pill-count {
-  color: var(--ink-bright);
-  border-color: rgba(56, 189, 248, 0.55);
-  background: rgba(56, 189, 248, 0.2);
-}
-
-.level-pill {
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
-}
-
-.docs-utility-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.7rem;
-}
-
-.docs-hint {
-  margin: 0;
-  color: var(--ink-silver);
-  font-size: 0.79rem;
-  letter-spacing: 0.04em;
-}
-
-.docs-hint kbd {
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  color: var(--ink-soft);
-  border: 1px solid var(--line-subtle);
-  border-bottom-width: 2px;
-  border-radius: 0.35rem;
-  padding: 0.08rem 0.3rem;
-  margin-inline: 0.18rem;
-  background: var(--surface-control);
-}
-
-.reset-filters-btn {
-  border: 1px solid var(--line-subtle);
-  border-radius: 999px;
-  background: var(--surface-control);
-  color: var(--ink-soft);
-  font-size: 0.74rem;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  padding: 0.34rem 0.72rem;
-  cursor: pointer;
-  transition:
-    border-color var(--motion-base) var(--ease-smooth),
-    color var(--motion-base) var(--ease-smooth),
-    background-color var(--motion-base) var(--ease-smooth);
-}
-
-.reset-filters-btn:hover:not(:disabled) {
-  border-color: rgba(56, 189, 248, 0.58);
-  color: var(--ink-bright);
-  background: rgba(56, 189, 248, 0.12);
-}
-
-.reset-filters-btn:disabled {
-  cursor: not-allowed;
-  opacity: 0.52;
-}
-
-.docs-count {
-  margin: 0.8rem 0 0;
-  color: var(--ink-metal);
-  font-size: 0.84rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.docs-groups {
-  margin-top: 1rem;
-  display: grid;
-  gap: 1rem;
-}
-
-.docs-top-matches {
-  margin-top: 1rem;
-  display: grid;
-  gap: 0.6rem;
-}
-
-.docs-group {
-  display: grid;
-  gap: 0.6rem;
-  container-type: inline-size;
-}
-
-.docs-group-title {
-  margin: 0;
-  font-family: "Orbitron", "Space Grotesk", sans-serif;
+.notice {
+  margin: 1.2rem 0 0;
+  max-width: 74ch;
+  color: var(--text-muted);
   font-size: 0.92rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--ink-bright);
 }
 
-.docs-grid {
+.metrics {
+  margin-top: 1.5rem;
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.7rem;
 }
 
-.doc-nav-card {
-  text-decoration: none;
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.78rem;
-  padding: 0.78rem 0.86rem;
-  background: var(--surface-card);
-  display: grid;
-  gap: 0.48rem;
-  transition:
-    transform var(--motion-fast) var(--ease-snap),
-    border-color var(--motion-base) var(--ease-smooth),
-    box-shadow var(--motion-base) var(--ease-smooth);
-}
-
-.doc-nav-card:hover {
-  transform: translateY(-2px);
-  border-color: rgba(56, 189, 248, 0.5);
-  box-shadow:
-    var(--card-shadow),
-    0 0 0 1px rgba(56, 189, 248, 0.2) inset;
-}
-
-.doc-nav-card-priority {
-  border-color: rgba(56, 189, 248, 0.42);
-  background:
-    linear-gradient(170deg, color-mix(in srgb, var(--surface-card) 88%, var(--arc-primary) 12%), var(--surface-card)),
-    var(--surface-card);
-  box-shadow: inset 2px 0 0 rgba(56, 189, 248, 0.52);
-}
-
-.doc-nav-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-}
-
-.doc-nav-head strong {
-  color: var(--ink-bright);
-  font-size: 0.9rem;
-  letter-spacing: 0.02em;
-}
-
-.doc-nav-head span {
-  color: var(--arc-secondary);
-  border: 1px solid rgba(34, 211, 238, 0.38);
-  border-radius: 999px;
-  padding: 0.12rem 0.38rem;
-  font-size: 0.66rem;
-  text-transform: uppercase;
-  letter-spacing: 0.07em;
-  white-space: nowrap;
-}
-
-.doc-nav-card p {
-  margin: 0;
-  color: var(--ink-silver);
-  font-size: 0.86rem;
-}
-
-.doc-nav-card code {
-  color: color-mix(in srgb, var(--ink-soft) 92%, white 8%);
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.73rem;
-  background: var(--surface-card-strong);
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.5rem;
-  padding: 0.22rem 0.42rem;
-  overflow-wrap: anywhere;
-}
-
-.doc-empty {
-  border: 1px dashed color-mix(in srgb, var(--line-subtle) 80%, var(--ink-silver) 20%);
-  border-radius: 0.76rem;
-  padding: 0.78rem 0.9rem;
-  color: var(--ink-silver);
-  background: var(--surface-card);
-  font-size: 0.9rem;
-}
-
-.doc-empty code {
-  margin-inline: 0.2rem;
-  color: var(--ink-bright);
-}
-
-.panel-footer {
-  border-top: 1px solid var(--line-subtle);
-  margin-top: 1.1rem;
-  color: var(--ink-silver);
-  font-size: 0.84rem;
-  padding-top: 0.8rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.palette-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 40;
-  background: rgba(2, 7, 20, 0.58);
-  backdrop-filter: blur(5px);
-  display: grid;
-  place-items: center;
+.metric-card {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--bg-soft) 85%, transparent);
   padding: 0.9rem;
 }
 
-.palette-panel {
-  width: min(840px, 100%);
-  max-height: min(82vh, 780px);
-  border: 1px solid var(--line-subtle);
-  border-radius: 1rem;
-  background: linear-gradient(145deg, var(--surface-glass-a), var(--surface-glass-b));
-  box-shadow: 0 22px 48px rgba(2, 7, 22, 0.48);
+.metric-label {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+.metric-value {
+  margin: 0.2rem 0 0;
+  color: var(--text);
+  font-family: "Sora", sans-serif;
+  font-size: 1.22rem;
+}
+
+.docs-shell {
+  margin-top: 1.4rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-xl);
+  background: color-mix(in srgb, var(--bg-panel) 88%, transparent 12%);
+  box-shadow: var(--shadow-panel);
+  padding: 1.3rem;
+}
+
+.docs-head h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: clamp(1.25rem, 1.8vw, 1.6rem);
+  font-family: "Sora", sans-serif;
+}
+
+.docs-head p {
+  margin: 0.38rem 0 0;
+  color: var(--text-muted);
+}
+
+.docs-toolbar {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.docs-toolbar input {
+  flex: 1;
+  min-width: 0;
+  min-height: 44px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: color-mix(in srgb, var(--bg) 70%, transparent 30%);
+  color: var(--text);
+  padding: 0 0.95rem;
+}
+
+.docs-toolbar input::placeholder {
+  color: var(--text-muted);
+}
+
+.category-row {
+  margin-top: 0.9rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.category-row button {
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 999px;
+  padding: 0.36rem 0.76rem;
+  font-size: 0.82rem;
+}
+
+.category-row button.active {
+  color: var(--text);
+  border-color: var(--line-strong);
+  background: var(--accent-soft);
+}
+
+.workspace-grid {
+  margin-top: 1rem;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  gap: 1rem;
+  grid-template-columns: minmax(260px, 360px) minmax(0, 1fr);
+  align-items: start;
+}
+
+.doc-list {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-l);
+  background: color-mix(in srgb, var(--bg) 72%, transparent 28%);
+  padding: 0.6rem;
+  max-height: min(72vh, 860px);
+  overflow: auto;
+}
+
+.doc-item {
+  width: 100%;
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  color: var(--text-soft);
+  padding: 0.72rem;
+  display: grid;
+  gap: 0.24rem;
+  transition: border-color 160ms ease, background-color 160ms ease;
+}
+
+.doc-item + .doc-item {
+  margin-top: 0.44rem;
+}
+
+.doc-item:hover {
+  border-color: var(--line);
+  background: color-mix(in srgb, var(--accent-soft) 34%, transparent);
+}
+
+.doc-item.active {
+  border-color: var(--line-strong);
+  background: color-mix(in srgb, var(--accent-soft) 64%, transparent);
+}
+
+.doc-meta {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.72rem;
+  color: var(--accent);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.doc-title {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.doc-summary {
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+.doc-path {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-family: "IBM Plex Mono", monospace;
+  overflow-wrap: anywhere;
+}
+
+.empty-hint {
+  margin: 0;
+  color: var(--text-muted);
+  padding: 0.8rem;
+}
+
+.doc-reader {
+  border: 1px solid var(--line);
+  border-radius: var(--radius-l);
+  background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
+  min-height: 520px;
+}
+
+.reader-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: start;
+  padding: 1rem 1.1rem;
+  border-bottom: 1px solid var(--line);
+  background: color-mix(in srgb, var(--bg-soft) 82%, transparent);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+
+.reader-head p {
+  margin: 0;
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--text-muted);
+}
+
+.reader-head h3 {
+  margin: 0.34rem 0;
+  color: var(--text);
+  font-family: "Sora", sans-serif;
+  font-size: 1.06rem;
+}
+
+.reader-head code {
+  color: var(--text-muted);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.76rem;
+  overflow-wrap: anywhere;
+}
+
+.reader-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.reader-actions a {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  font-size: 0.82rem;
+  color: var(--text-soft);
+  padding: 0.36rem 0.64rem;
+  background: transparent;
+}
+
+.reader-actions a:hover {
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+
+.reader-status {
+  margin: 1rem 1.1rem;
+  color: var(--text-muted);
+}
+
+.markdown-body {
+  padding: 1.1rem;
+  color: var(--text-soft);
+}
+
+.markdown-body > *:first-child {
+  margin-top: 0;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4 {
+  font-family: "Sora", sans-serif;
+  color: var(--text);
+  line-height: 1.28;
+}
+
+.markdown-body h1 {
+  font-size: clamp(1.5rem, 2.3vw, 2rem);
+  margin-top: 0.2rem;
+}
+
+.markdown-body h2 {
+  margin-top: 1.8rem;
+  font-size: clamp(1.2rem, 1.5vw, 1.46rem);
+  padding-top: 0.2rem;
+}
+
+.markdown-body h3 {
+  margin-top: 1.28rem;
+  font-size: 1.04rem;
+}
+
+.markdown-body p,
+.markdown-body li,
+.markdown-body blockquote {
+  color: var(--text-soft);
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  padding-left: 1.35rem;
+}
+
+.markdown-body a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.markdown-body hr {
+  border: 0;
+  border-top: 1px solid var(--line);
+  margin: 1.6rem 0;
+}
+
+.markdown-body pre,
+.markdown-body code {
+  font-family: "IBM Plex Mono", monospace;
+}
+
+.markdown-body pre {
+  margin: 0.9rem 0;
+  background: color-mix(in srgb, var(--bg) 86%, transparent);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  overflow: auto;
+  padding: 0.85rem;
+}
+
+.markdown-body :not(pre) > code {
+  background: color-mix(in srgb, var(--accent-soft) 45%, transparent);
+  border-radius: 6px;
+  padding: 0.1rem 0.34rem;
+  color: var(--text);
+}
+
+.markdown-body table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+  font-size: 0.9rem;
+}
+
+.markdown-body th,
+.markdown-body td {
+  border: 1px solid var(--line);
+  padding: 0.5rem;
+  text-align: left;
+  vertical-align: top;
+}
+
+.markdown-body th {
+  color: var(--text);
+  background: color-mix(in srgb, var(--bg-soft) 92%, transparent);
+}
+
+.markdown-body img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+}
+
+.footer {
+  width: var(--container);
+  margin: 1.4rem auto 2rem;
+  color: var(--text-muted);
+  text-align: center;
+  font-size: 0.84rem;
+}
+
+.palette-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(6px);
+  display: grid;
+  place-items: start center;
+  padding-top: min(16vh, 120px);
+}
+
+.palette {
+  width: min(760px, calc(100% - 1.2rem));
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--bg-elevated) 92%, transparent);
+  box-shadow: var(--shadow-panel);
   overflow: hidden;
 }
 
-.palette-head {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 0.55rem;
-  padding: 0.72rem;
-  border-bottom: 1px solid var(--line-subtle);
-  background: var(--surface-card-strong);
-}
-
-.palette-head input {
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.62rem;
-  background: var(--surface-input);
-  color: var(--ink-bright);
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.82rem;
-  padding: 0.7rem 0.8rem;
-}
-
-.palette-head input::placeholder {
-  color: var(--ink-silver);
-}
-
-.palette-close {
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.62rem;
-  background: var(--surface-control);
-  color: var(--ink-soft);
-  padding: 0.58rem 0.82rem;
-  font-size: 0.74rem;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  cursor: pointer;
-}
-
-.palette-close:hover {
-  border-color: rgba(56, 189, 248, 0.56);
-  color: var(--ink-bright);
-}
-
-.palette-grid {
-  min-height: 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
-}
-
-.palette-results {
-  overflow: auto;
-  display: grid;
-  gap: 0.95rem;
-  padding: 0.84rem;
-  border-right: 1px solid var(--line-subtle);
-}
-
-.palette-section-title {
-  margin: 0 0 0.5rem;
-  position: sticky;
-  top: -0.1rem;
-  z-index: 1;
-  background: color-mix(in srgb, var(--surface-card-strong) 80%, transparent 20%);
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.52rem;
-  padding: 0.24rem 0.5rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.42rem;
-  color: var(--ink-metal);
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.72rem;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-}
-
-.palette-section-title small {
-  border: 1px solid var(--line-subtle);
-  border-radius: 999px;
-  padding: 0.02rem 0.36rem;
-  font-size: 0.62rem;
-  color: var(--ink-soft);
+.palette input {
+  width: 100%;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  background: transparent;
+  color: var(--text);
+  padding: 0.95rem 1rem;
 }
 
 .palette-list {
-  display: grid;
-  gap: 0.48rem;
+  max-height: min(50vh, 460px);
+  overflow: auto;
+  padding: 0.45rem;
 }
 
-.palette-item {
+.palette-list button {
   width: 100%;
   text-align: left;
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.72rem;
-  background: var(--surface-card);
-  padding: 0.62rem 0.72rem;
-  color: var(--ink-soft);
-  display: grid;
-  gap: 0.22rem;
-  cursor: pointer;
-  transition:
-    transform var(--motion-fast) var(--ease-snap),
-    border-color var(--motion-base) var(--ease-smooth),
-    box-shadow var(--motion-base) var(--ease-smooth);
-}
-
-.palette-item:hover {
-  transform: translateY(-1px);
-  border-color: rgba(56, 189, 248, 0.52);
-  box-shadow:
-    var(--card-shadow),
-    0 0 0 1px rgba(56, 189, 248, 0.2) inset;
-}
-
-.palette-item.active {
-  border-color: rgba(103, 232, 249, 0.72);
-  box-shadow:
-    var(--card-shadow),
-    0 0 0 1px rgba(56, 189, 248, 0.34) inset,
-    0 0 20px rgba(56, 189, 248, 0.2);
-  background: linear-gradient(
-    160deg,
-    color-mix(in srgb, var(--surface-card) 84%, var(--arc-primary) 16%),
-    var(--surface-card)
-  );
-}
-
-.palette-item-main {
-  color: var(--ink-bright);
-  font-size: 0.86rem;
-  letter-spacing: 0.02em;
-}
-
-.palette-item small {
-  color: var(--ink-silver);
-  font-size: 0.78rem;
-}
-
-.palette-doc-item code {
-  width: fit-content;
-  color: var(--ink-metal);
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.42rem;
-  padding: 0.12rem 0.34rem;
-  background: var(--surface-card-strong);
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.7rem;
-}
-
-.palette-empty {
-  margin: 0;
-  border: 1px dashed var(--line-subtle);
-  border-radius: 0.72rem;
-  padding: 0.68rem 0.72rem;
-  color: var(--ink-silver);
-  background: var(--surface-card);
-  font-size: 0.86rem;
-}
-
-.palette-preview {
-  min-height: 0;
-  display: grid;
-  align-content: start;
-  gap: 0.7rem;
-  padding: 0.84rem;
-  background: color-mix(in srgb, var(--surface-card-strong) 82%, transparent 18%);
-}
-
-.palette-preview-title {
-  margin: 0;
-  color: var(--ink-metal);
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.72rem;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-}
-
-.preview-card {
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.84rem;
-  background: var(--surface-card);
-  padding: 0.7rem;
-  display: grid;
-  gap: 0.45rem;
-}
-
-.preview-kind {
-  margin: 0;
-  width: fit-content;
-  border: 1px solid rgba(34, 211, 238, 0.44);
-  border-radius: 999px;
-  color: var(--arc-secondary);
-  background: rgba(34, 211, 238, 0.1);
-  padding: 0.14rem 0.42rem;
-  font-size: 0.62rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.preview-card h3 {
-  margin: 0;
-  color: var(--ink-bright);
-  font-size: 0.93rem;
-  letter-spacing: 0.02em;
-}
-
-.preview-card p {
-  margin: 0;
-  color: var(--ink-silver);
-  font-size: 0.82rem;
-  line-height: 1.5;
-}
-
-.preview-card code {
-  width: fit-content;
-  color: var(--ink-metal);
-  font-family: "JetBrains Mono", ui-monospace, monospace;
-  font-size: 0.7rem;
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.45rem;
-  padding: 0.12rem 0.34rem;
-  background: var(--surface-card-strong);
-}
-
-.preview-open-hint {
-  color: var(--ink-silver);
-  font-size: 0.72rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-
-.palette-preview-empty {
-  margin: 0;
-  border: 1px dashed var(--line-subtle);
-  border-radius: 0.72rem;
-  padding: 0.64rem 0.7rem;
-  color: var(--ink-silver);
-  font-size: 0.82rem;
-  background: var(--surface-card);
-}
-
-.palette-kbd-hints {
-  display: grid;
-  gap: 0.34rem;
-}
-
-.palette-kbd-hints span {
-  border: 1px solid var(--line-subtle);
-  border-radius: 0.5rem;
-  padding: 0.26rem 0.44rem;
-  color: var(--ink-soft);
-  background: var(--surface-card);
-  font-size: 0.72rem;
-  letter-spacing: 0.04em;
-}
-
-.mobile-dock {
-  position: fixed;
-  left: 50%;
-  bottom: 0.9rem;
-  transform: translateX(-50%);
-  z-index: 26;
-  display: none;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--text-soft);
+  padding: 0.62rem 0.68rem;
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
-  border: 1px solid var(--line-subtle);
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.palette-list button:hover {
+  border-color: var(--line);
+  background: color-mix(in srgb, var(--accent-soft) 50%, transparent);
+}
+
+.palette-list small {
+  font-family: "IBM Plex Mono", monospace;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  overflow-wrap: anywhere;
+  text-align: right;
+}
+
+.floating {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 35;
+  border: 1px solid var(--line-strong);
+  background: color-mix(in srgb, var(--accent-soft) 72%, var(--bg));
+  color: var(--text);
   border-radius: 999px;
-  padding: 0.32rem;
-  background: color-mix(in srgb, var(--surface-control) 86%, transparent 14%);
-  backdrop-filter: blur(12px);
-  box-shadow: 0 12px 28px rgba(2, 7, 20, 0.42);
+  min-height: 42px;
+  padding: 0 0.92rem;
+  font-size: 0.82rem;
+  box-shadow: var(--shadow-soft);
 }
 
-.dock-btn {
-  appearance: none;
-  border: 1px solid var(--line-subtle);
-  border-radius: 999px;
-  padding: 0.4rem 0.75rem;
-  background: var(--surface-card);
-  color: var(--ink-soft);
-  text-decoration: none;
-  font-size: 0.74rem;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition:
-    border-color var(--motion-base) var(--ease-smooth),
-    color var(--motion-base) var(--ease-smooth),
-    background-color var(--motion-base) var(--ease-smooth);
-}
+@media (max-width: 1120px) {
+  .workspace-grid {
+    grid-template-columns: 1fr;
+  }
 
-.dock-btn:hover {
-  color: var(--ink-bright);
-  border-color: rgba(56, 189, 248, 0.58);
-  background: rgba(56, 189, 248, 0.14);
-}
-
-.reveal {
-  opacity: 0;
-  transform: translateY(16px);
-  transition:
-    opacity var(--motion-slow) var(--ease-smooth),
-    transform var(--motion-slow) var(--ease-smooth);
-}
-
-.reveal.in {
-  opacity: 1;
-  transform: translateY(0);
-}
-
-.delay-1 {
-  transition-delay: 90ms;
-}
-
-.delay-2 {
-  transition-delay: 180ms;
-}
-
-.delay-3 {
-  transition-delay: 270ms;
-}
-
-.delay-4 {
-  transition-delay: 360ms;
-}
-
-@container (max-width: 600px) {
-  .doc-nav-head {
-    flex-direction: column;
-    align-items: flex-start;
+  .doc-list {
+    max-height: 340px;
   }
 }
 
-@media (max-width: 1360px) {
-  .section-rail {
-    display: none;
-  }
-}
-
-@media (max-width: 1280px) {
-  .container {
-    width: min(1140px, 100% - 1.8rem);
+@media (max-width: 900px) {
+  .topbar-inner {
+    min-height: 64px;
+    flex-wrap: wrap;
+    padding: 0.55rem 0;
   }
 
-  .path-grid {
+  .top-nav {
+    order: 3;
+    width: 100%;
+    padding-bottom: 0.4rem;
+  }
+
+  .metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 1120px) {
-  .hero-grid,
-  .workflow-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .command-deck {
-    max-width: 680px;
-  }
-
-  .topbar-inner {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .top-actions {
-    width: 100%;
-    justify-content: flex-start;
-  }
-}
-
-@media (max-width: 920px) {
-  .metrics,
-  .cap-grid,
-  .links-grid,
-  .monitor-grid,
-  .docs-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .hero-title {
-    max-width: 18ch;
-  }
-
-  .status-pill {
-    display: none;
-  }
-
-  .top-shortcut {
-    display: none;
-  }
-
-  .palette-panel {
-    width: min(760px, 100%);
-  }
-
-  .palette-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .palette-results {
-    border-right: none;
-    border-bottom: 1px solid var(--line-subtle);
-    max-height: 52vh;
-  }
-
-  .palette-preview {
-    max-height: 30vh;
-    overflow: auto;
-  }
-}
-
-@media (max-width: 820px) {
-  .mobile-dock {
-    display: inline-flex;
-  }
-
-  .main-layout {
-    padding-bottom: 5.2rem;
-  }
-}
-
-@media (max-width: 760px) {
-  .main-layout {
-    gap: 1.5rem;
-  }
-
-  .hero-actions .btn {
-    flex: 1 1 100%;
-    text-align: center;
-  }
-
-  .section-head {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .docs-utility-row {
-    align-items: flex-start;
-    justify-content: flex-start;
-  }
-
-  .palette-head {
-    grid-template-columns: 1fr;
-  }
-
-  .palette-close {
-    width: fit-content;
-  }
-
-  .palette-preview {
-    display: none;
-  }
-
-  .palette-results {
-    max-height: 64vh;
-  }
-}
-
 @media (max-width: 640px) {
-  .top-actions a.top-link {
-    display: none;
+  :root {
+    --container: min(1220px, calc(100% - 1rem));
   }
 
-  .top-actions .top-link-btn {
-    display: inline-flex;
+  main {
+    padding-top: 1.1rem;
   }
 
-  .toggle-cluster {
+  .controls {
     width: 100%;
     justify-content: space-between;
   }
 
-  .toggle-chip {
-    flex: 1 1 auto;
-    text-align: center;
-    padding-inline: 0.4rem;
+  .segmented {
+    max-width: calc(100vw - 7.5rem);
+    overflow: auto;
   }
 
-  .path-grid {
-    grid-template-columns: 1fr;
+  .hero-inner {
+    padding: 1.2rem;
   }
 
-  .glass-panel {
-    padding: 1rem;
+  .docs-shell {
+    padding: 0.86rem;
   }
 
-  .docs-count,
-  .panel-footer {
-    text-transform: none;
-    letter-spacing: 0.02em;
+  .docs-toolbar {
+    flex-direction: column;
+  }
+
+  .reader-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .floating {
+    right: 0.6rem;
+    bottom: 0.6rem;
   }
 }
 
@@ -1919,22 +793,8 @@ input:focus-visible {
   *,
   *::before,
   *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
+    animation: none !important;
+    transition: none !important;
     scroll-behavior: auto !important;
-  }
-
-  .ambient-glow,
-  .cursor-glow,
-  .hero-grid::after,
-  .btn::after,
-  .command-deck::after {
-    display: none !important;
-  }
-
-  .reveal {
-    opacity: 1 !important;
-    transform: none !important;
   }
 }


### PR DESCRIPTION
## Summary\n- redesign site visual language with cleaner black/blue/silver system and typography refresh\n- replace decorative landing focus with direct docs workspace and in-page markdown reading\n- keep responsive layout, dark/light/system theme, bilingual UI, and command palette\n- source hero/tagline copy from README and zeroclawlabs.ai official wording\n\n## Validation\n- npm install --include=dev\n- npm run build\n