### PR TITLE
RMN-169: feat(site): ship full docs reader on Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 docker-compose.override.yml
 site/node_modules/
 site/.vite/
+site/public/docs-content/
 gh-pages/
 
 # Environment files (may contain secrets)

--- a/site/package.json
+++ b/site/package.json
@@ -4,6 +4,8 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
+    "predev": "node scripts/generate-docs-manifest.mjs",
+    "prebuild": "node scripts/generate-docs-manifest.mjs",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --host"

--- a/site/scripts/generate-docs-manifest.mjs
+++ b/site/scripts/generate-docs-manifest.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const siteDir = process.cwd();
+const repoRoot = path.resolve(siteDir, "..");
+const docsRoot = path.join(repoRoot, "docs");
+const outRoot = path.join(siteDir, "public", "docs-content");
+const generatedDir = path.join(siteDir, "src", "generated");
+const manifestFile = path.join(generatedDir, "docs-manifest.json");
+
+const ROOT_ASSET_PATTERN = /\.(png|jpe?g|gif|webp|svg|avif)$/i;
+const MARKDOWN_PATTERN = /\.(md|mdx)$/i;
+
+function toPosix(filePath) {
+  return filePath.replace(/\\/g, "/");
+}
+
+function normalizePath(filePath) {
+  return toPosix(filePath).replace(/^\/+/, "").replace(/\/+/g, "/");
+}
+
+function stripMarkdownSyntax(text) {
+  return text
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/<[^>]+>/g, "")
+    .replace(/[*_~>#]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function detectLanguage(relativePath) {
+  const rel = normalizePath(relativePath);
+
+  const i18nMatch = /^docs\/i18n\/([^/]+)\//.exec(rel);
+  if (i18nMatch) {
+    return i18nMatch[1];
+  }
+
+  const suffixMatch = /\.(zh-CN|ja|ru|fr|vi|el)\.(md|mdx)$/i.exec(rel);
+  if (suffixMatch) {
+    return suffixMatch[1];
+  }
+
+  return "en";
+}
+
+function detectSection(relativePath) {
+  const rel = normalizePath(relativePath);
+
+  if (!rel.startsWith("docs/")) {
+    return "root";
+  }
+
+  const parts = rel.split("/");
+
+  if (parts[1] === "i18n") {
+    return parts[2] ? `i18n/${parts[2]}` : "i18n";
+  }
+
+  return parts[1] || "docs";
+}
+
+function fallbackTitle(relativePath) {
+  const filename = path.basename(relativePath).replace(/\.(md|mdx)$/i, "");
+
+  if (filename.toLowerCase() === "readme") {
+    const parent = path.basename(path.dirname(relativePath));
+    if (parent && parent !== "." && parent !== "docs" && parent !== "i18n") {
+      return `${parent} README`;
+    }
+  }
+
+  return filename
+    .replace(/[._-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractTitle(markdown, relativePath) {
+  const lines = markdown.split(/\r?\n/);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const heading = /^#{1,2}\s+(.+)$/.exec(trimmed);
+    if (heading) {
+      const title = stripMarkdownSyntax(heading[1].replace(/\s+#*$/, ""));
+      if (title) return title;
+    }
+  }
+
+  const h1Tag = /<h1[^>]*>([\s\S]*?)<\/h1>/i.exec(markdown);
+  if (h1Tag) {
+    const title = stripMarkdownSyntax(h1Tag[1]);
+    if (title) return title;
+  }
+
+  return fallbackTitle(relativePath);
+}
+
+function extractSummary(markdown) {
+  const lines = markdown.split(/\r?\n/);
+  let inCode = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    if (line.startsWith("```")) {
+      inCode = !inCode;
+      continue;
+    }
+
+    if (inCode || !line) {
+      continue;
+    }
+
+    if (
+      line.startsWith("#") ||
+      line.startsWith("|") ||
+      line.startsWith("<") ||
+      line.startsWith(">") ||
+      line.startsWith("-") ||
+      line.startsWith("*")
+    ) {
+      continue;
+    }
+
+    const cleaned = stripMarkdownSyntax(line);
+    if (cleaned.length >= 24) {
+      return cleaned.slice(0, 220);
+    }
+  }
+
+  return "Project documentation.";
+}
+
+function toId(relativePath) {
+  return normalizePath(relativePath)
+    .toLowerCase()
+    .replace(/[^a-z0-9/.-]/g, "-")
+    .replace(/[/.]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+async function ensureDir(dirPath) {
+  await fs.mkdir(dirPath, { recursive: true });
+}
+
+async function walkFiles(rootDir) {
+  const result = [];
+  const stack = [rootDir];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) continue;
+
+    const entries = await fs.readdir(current, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const next = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(next);
+      } else if (entry.isFile()) {
+        result.push(next);
+      }
+    }
+  }
+
+  return result;
+}
+
+async function copyIntoPublic(filePath) {
+  const rel = normalizePath(path.relative(repoRoot, filePath));
+  const target = path.join(outRoot, rel);
+  await ensureDir(path.dirname(target));
+  await fs.copyFile(filePath, target);
+}
+
+async function main() {
+  await ensureDir(generatedDir);
+  await fs.rm(outRoot, { recursive: true, force: true });
+  await ensureDir(outRoot);
+
+  const rootEntries = await fs.readdir(repoRoot, { withFileTypes: true });
+  const rootMarkdownFiles = rootEntries
+    .filter((entry) => entry.isFile() && MARKDOWN_PATTERN.test(entry.name))
+    .map((entry) => path.join(repoRoot, entry.name));
+
+  const rootAssetFiles = rootEntries
+    .filter((entry) => entry.isFile() && ROOT_ASSET_PATTERN.test(entry.name))
+    .map((entry) => path.join(repoRoot, entry.name));
+
+  const docsAllFiles = await walkFiles(docsRoot);
+  const markdownDocs = docsAllFiles.filter((filePath) => MARKDOWN_PATTERN.test(filePath));
+
+  for (const filePath of docsAllFiles) {
+    await copyIntoPublic(filePath);
+  }
+
+  for (const filePath of rootMarkdownFiles) {
+    await copyIntoPublic(filePath);
+  }
+
+  for (const filePath of rootAssetFiles) {
+    await copyIntoPublic(filePath);
+  }
+
+  const manifestEntries = [];
+  const markdownFiles = [...rootMarkdownFiles, ...markdownDocs];
+
+  for (const filePath of markdownFiles) {
+    const relativePath = normalizePath(path.relative(repoRoot, filePath));
+    const content = await fs.readFile(filePath, "utf8");
+
+    manifestEntries.push({
+      id: toId(relativePath),
+      path: relativePath,
+      title: extractTitle(content, relativePath),
+      summary: extractSummary(content),
+      section: detectSection(relativePath),
+      language: detectLanguage(relativePath),
+      sourceUrl: `https://github.com/zeroclaw-labs/zeroclaw/blob/main/${relativePath}`,
+    });
+  }
+
+  manifestEntries.sort((a, b) => a.path.localeCompare(b.path));
+
+  await fs.writeFile(manifestFile, JSON.stringify(manifestEntries, null, 2) + "\n", "utf8");
+
+  process.stdout.write(
+    `[docs-manifest] generated ${manifestEntries.length} markdown entries and copied docs assets\n`
+  );
+}
+
+main().catch((error) => {
+  process.stderr.write(`[docs-manifest] generation failed: ${String(error)}\n`);
+  process.exit(1);
+});

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -8,29 +8,31 @@ import {
 } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import manifestRaw from "./generated/docs-manifest.json";
 
 type Locale = "en" | "zh";
 type ThemeMode = "system" | "dark" | "light";
 type ResolvedTheme = "dark" | "light";
-type Category =
-  | "Core"
-  | "Setup"
-  | "Operations"
-  | "Security"
-  | "Reference"
-  | "International";
+type ReaderScale = "compact" | "comfortable" | "relaxed";
+type ReaderWidth = "normal" | "wide";
+
+type ManifestDoc = {
+  id: string;
+  path: string;
+  title: string;
+  summary: string;
+  section: string;
+  language: string;
+  sourceUrl: string;
+};
+
+type HeadingItem = {
+  id: string;
+  level: number;
+  text: string;
+};
 
 type Localized = Record<Locale, string>;
-
-type DocEntry = {
-  id: string;
-  category: Category;
-  path: string;
-  zhPath?: string;
-  title: Localized;
-  summary: Localized;
-  keywords?: string[];
-};
 
 type PaletteEntry = {
   id: string;
@@ -39,338 +41,22 @@ type PaletteEntry = {
   run: () => void;
 };
 
+const docs = [...(manifestRaw as ManifestDoc[])].sort((a, b) =>
+  a.path.localeCompare(b.path)
+);
+
 const repoBase = "https://github.com/zeroclaw-labs/zeroclaw/blob/main";
 const rawBase = "https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main";
 
-const docs: DocEntry[] = [
-  {
-    id: "repo-readme",
-    category: "Core",
-    path: "README.md",
-    zhPath: "README.zh-CN.md",
-    title: { en: "Repository README", zh: "仓库 README" },
-    summary: {
-      en: "Project overview, architecture, benchmarks, setup, and operations.",
-      zh: "项目总览、架构、基准、安装与运维入口。",
-    },
-    keywords: ["overview", "architecture", "benchmark", "quick start"],
-  },
-  {
-    id: "docs-home",
-    category: "Core",
-    path: "docs/README.md",
-    zhPath: "docs/i18n/zh-CN/README.md",
-    title: { en: "Docs Hub", zh: "文档总览" },
-    summary: {
-      en: "Primary documentation hub for all ZeroClaw capabilities.",
-      zh: "ZeroClaw 全量文档的总入口。",
-    },
-    keywords: ["docs", "hub", "summary"],
-  },
-  {
-    id: "docs-summary",
-    category: "Core",
-    path: "docs/SUMMARY.md",
-    zhPath: "docs/i18n/zh-CN/SUMMARY.md",
-    title: { en: "Docs Table of Contents", zh: "文档目录" },
-    summary: {
-      en: "Structured index for all docs sections and files.",
-      zh: "结构化文档目录与索引。",
-    },
-    keywords: ["toc", "summary", "index"],
-  },
-  {
-    id: "one-click-bootstrap",
-    category: "Setup",
-    path: "docs/one-click-bootstrap.md",
-    zhPath: "docs/i18n/zh-CN/one-click-bootstrap.md",
-    title: { en: "One-Click Bootstrap", zh: "一键安装" },
-    summary: {
-      en: "Fast installer path for dependencies and ZeroClaw runtime.",
-      zh: "快速完成依赖与 ZeroClaw 运行时安装。",
-    },
-  },
-  {
-    id: "getting-started",
-    category: "Setup",
-    path: "docs/getting-started/README.md",
-    title: { en: "Getting Started", zh: "快速开始" },
-    summary: {
-      en: "Boot sequence, first commands, and onboarding flow.",
-      zh: "启动流程、首批命令与引导步骤。",
-    },
-  },
-  {
-    id: "network-deployment",
-    category: "Setup",
-    path: "docs/network-deployment.md",
-    zhPath: "docs/i18n/zh-CN/network-deployment.md",
-    title: { en: "Network Deployment", zh: "网络部署" },
-    summary: {
-      en: "Service setup, daemon/gateway, and network run modes.",
-      zh: "服务配置、daemon/gateway 与网络运行模式。",
-    },
-  },
-  {
-    id: "hardware",
-    category: "Setup",
-    path: "docs/hardware/README.md",
-    title: { en: "Hardware Guide", zh: "硬件指南" },
-    summary: {
-      en: "Board and hardware references for edge deployment.",
-      zh: "边缘部署相关板卡与硬件参考。",
-    },
-  },
-  {
-    id: "operations-runbook",
-    category: "Operations",
-    path: "docs/operations-runbook.md",
-    zhPath: "docs/i18n/zh-CN/operations-runbook.md",
-    title: { en: "Operations Runbook", zh: "运维手册" },
-    summary: {
-      en: "Operational procedures, incident handling, and checks.",
-      zh: "运维流程、故障处理与巡检实践。",
-    },
-  },
-  {
-    id: "ops-overview",
-    category: "Operations",
-    path: "docs/operations/README.md",
-    title: { en: "Operations Overview", zh: "运维概览" },
-    summary: {
-      en: "Operations section hub with runbooks and safeguards.",
-      zh: "运维章节入口，包含 runbook 与保障策略。",
-    },
-  },
-  {
-    id: "connectivity-probes",
-    category: "Operations",
-    path: "docs/operations/connectivity-probes-runbook.md",
-    title: { en: "Connectivity Probes", zh: "连通性探针" },
-    summary: {
-      en: "Probe workflow and diagnosis guidelines.",
-      zh: "探针流程与诊断指南。",
-    },
-  },
-  {
-    id: "troubleshooting",
-    category: "Operations",
-    path: "docs/troubleshooting.md",
-    zhPath: "docs/i18n/zh-CN/troubleshooting.md",
-    title: { en: "Troubleshooting", zh: "问题排查" },
-    summary: {
-      en: "Systematic recovery checklist for common failures.",
-      zh: "常见故障的系统化排查与恢复清单。",
-    },
-  },
-  {
-    id: "security-overview",
-    category: "Security",
-    path: "docs/security/README.md",
-    title: { en: "Security Overview", zh: "安全概览" },
-    summary: {
-      en: "Security architecture, controls, and policy model.",
-      zh: "安全架构、控制项与策略模型。",
-    },
-  },
-  {
-    id: "sandboxing",
-    category: "Security",
-    path: "docs/sandboxing.md",
-    zhPath: "docs/i18n/zh-CN/sandboxing.md",
-    title: { en: "Sandboxing", zh: "沙箱机制" },
-    summary: {
-      en: "Runtime sandbox boundaries and risk containment.",
-      zh: "运行时沙箱边界与风险隔离。",
-    },
-  },
-  {
-    id: "agnostic-security",
-    category: "Security",
-    path: "docs/agnostic-security.md",
-    zhPath: "docs/i18n/zh-CN/agnostic-security.md",
-    title: { en: "Agnostic Security", zh: "模型无关安全" },
-    summary: {
-      en: "Provider-agnostic security stance and operating model.",
-      zh: "面向多模型的统一安全基线与运行方式。",
-    },
-  },
-  {
-    id: "config-reference",
-    category: "Reference",
-    path: "docs/config-reference.md",
-    zhPath: "docs/i18n/zh-CN/config-reference.md",
-    title: { en: "Config Reference", zh: "配置参考" },
-    summary: {
-      en: "All runtime configuration fields and defaults.",
-      zh: "运行时配置字段与默认值。",
-    },
-  },
-  {
-    id: "commands-reference",
-    category: "Reference",
-    path: "docs/commands-reference.md",
-    zhPath: "docs/i18n/zh-CN/commands-reference.md",
-    title: { en: "Commands Reference", zh: "命令参考" },
-    summary: {
-      en: "CLI command map for onboarding, runtime, and tooling.",
-      zh: "覆盖引导、运行时与工具的 CLI 命令总览。",
-    },
-  },
-  {
-    id: "custom-providers",
-    category: "Reference",
-    path: "docs/custom-providers.md",
-    zhPath: "docs/i18n/zh-CN/custom-providers.md",
-    title: { en: "Custom Providers", zh: "自定义模型提供方" },
-    summary: {
-      en: "OpenAI-compatible and custom endpoint integration.",
-      zh: "OpenAI 兼容与自定义端点集成指南。",
-    },
-  },
-  {
-    id: "channels-reference",
-    category: "Reference",
-    path: "docs/channels-reference.md",
-    zhPath: "docs/i18n/zh-CN/channels-reference.md",
-    title: { en: "Channels Reference", zh: "渠道参考" },
-    summary: {
-      en: "Slack/Telegram/Discord/WhatsApp and channel wiring.",
-      zh: "Slack/Telegram/Discord/WhatsApp 等渠道配置。",
-    },
-  },
-  {
-    id: "reference-overview",
-    category: "Reference",
-    path: "docs/reference/README.md",
-    title: { en: "Reference Overview", zh: "参考总览" },
-    summary: {
-      en: "Reference section index across runtime internals.",
-      zh: "运行时内部参考索引。",
-    },
-  },
-  {
-    id: "resource-limits",
-    category: "Reference",
-    path: "docs/resource-limits.md",
-    zhPath: "docs/i18n/zh-CN/resource-limits.md",
-    title: { en: "Resource Limits", zh: "资源限制" },
-    summary: {
-      en: "CPU, memory, and execution constraints guide.",
-      zh: "CPU、内存与执行约束说明。",
-    },
-  },
-  {
-    id: "i18n-guide",
-    category: "International",
-    path: "docs/i18n-guide.md",
-    zhPath: "docs/i18n/zh-CN/i18n-guide.md",
-    title: { en: "i18n Guide", zh: "国际化指南" },
-    summary: {
-      en: "Localization strategy and docs translation workflow.",
-      zh: "本地化策略与文档翻译流程。",
-    },
-  },
-  {
-    id: "zh-docs-home",
-    category: "International",
-    path: "docs/i18n/zh-CN/README.md",
-    title: { en: "Chinese Docs Hub", zh: "中文文档总览" },
-    summary: {
-      en: "Chinese documentation index and translated content set.",
-      zh: "中文文档入口与翻译内容索引。",
-    },
-  },
-];
-
-const categories: Array<Category | "All"> = [
-  "All",
-  "Core",
-  "Setup",
-  "Operations",
-  "Security",
-  "Reference",
-  "International",
-];
-
-const categoryLabel: Record<Locale, Record<Category | "All", string>> = {
-  en: {
-    All: "All",
-    Core: "Core",
-    Setup: "Setup",
-    Operations: "Operations",
-    Security: "Security",
-    Reference: "Reference",
-    International: "International",
-  },
-  zh: {
-    All: "全部",
-    Core: "核心",
-    Setup: "部署",
-    Operations: "运维",
-    Security: "安全",
-    Reference: "参考",
-    International: "多语言",
-  },
+const languageNames: Record<string, Localized> = {
+  en: { en: "English", zh: "英文" },
+  "zh-CN": { en: "Chinese (Simplified)", zh: "简体中文" },
+  ja: { en: "Japanese", zh: "日文" },
+  ru: { en: "Russian", zh: "俄文" },
+  fr: { en: "French", zh: "法文" },
+  vi: { en: "Vietnamese", zh: "越南文" },
+  el: { en: "Greek", zh: "希腊文" },
 };
-
-const engineeringPillars: Array<{
-  title: Localized;
-  detail: Localized;
-}> = [
-  {
-    title: {
-      en: "Trait-driven architecture",
-      zh: "Trait 驱动架构",
-    },
-    detail: {
-      en: "Providers, channels, tools, memory, and tunnels remain swappable through interfaces.",
-      zh: "Provider、Channel、Tool、Memory、Tunnel 通过接口保持可插拔。",
-    },
-  },
-  {
-    title: {
-      en: "Secure by default runtime",
-      zh: "默认安全运行时",
-    },
-    detail: {
-      en: "Pairing, sandboxing, explicit allowlists, and workspace scoping are baseline controls.",
-      zh: "配对、沙箱、显式白名单与工作区作用域作为基线控制。",
-    },
-  },
-  {
-    title: {
-      en: "Build once, run anywhere",
-      zh: "一次构建，到处运行",
-    },
-    detail: {
-      en: "Single-binary Rust workflow across ARM, x86, and RISC-V from edge to cloud.",
-      zh: "单一 Rust 二进制工作流覆盖 ARM、x86、RISC-V，从边缘到云端。",
-    },
-  },
-];
-
-const commandLane: Array<{
-  command: string;
-  hint: Localized;
-}> = [
-  {
-    command: "zeroclaw onboard --interactive",
-    hint: { en: "Generate config and credentials", zh: "生成配置与凭据" },
-  },
-  {
-    command: "zeroclaw agent",
-    hint: { en: "Run interactive agent mode", zh: "运行交互式 Agent 模式" },
-  },
-  {
-    command: "zeroclaw gateway && zeroclaw daemon",
-    hint: { en: "Start runtime services", zh: "启动运行时服务" },
-  },
-  {
-    command: "zeroclaw doctor",
-    hint: { en: "Validate environment and runtime health", zh: "校验环境与运行时健康状态" },
-  },
-];
 
 const copy = {
   en: {
@@ -388,20 +74,16 @@ const copy = {
     ctaBootstrap: "One-click bootstrap",
     commandLaneTitle: "Runtime command lane",
     commandLaneHint: "From official setup and operations flow",
-    metrics: [
-      { label: "Runtime Memory", value: "< 5MB" },
-      { label: "Cold Start", value: "< 10ms" },
-      { label: "Edge Hardware", value: "$10-class" },
-      { label: "Language", value: "100% Rust" },
-    ],
     engineeringTitle: "Engineering foundations",
     docsWorkspace: "Documentation Workspace",
     docsLead:
-      "Browse, filter, and read project docs directly in-page. Open any item in GitHub when needed.",
+      "All repository docs are indexed and readable directly on this GitHub Pages site with engineering-first layout and typography.",
     docsIndexed: "Indexed",
     docsFiltered: "Filtered",
     docsActive: "Active",
-    search: "Search docs by topic, path, or keyword",
+    sectionFilter: "Section",
+    languageFilter: "Language",
+    search: "Search docs by title, path, summary, or keyword",
     commandPalette: "Command palette",
     sourceLabel: "Source",
     openOnGithub: "Open on GitHub",
@@ -409,7 +91,21 @@ const copy = {
     loading: "Loading document...",
     fallback:
       "Document preview is unavailable right now. You can still open the source directly:",
-    empty: "No docs matched your current filter.",
+    empty: "No docs matched your current filters.",
+    allSections: "All sections",
+    allLanguages: "All languages",
+    outline: "Outline",
+    noOutline: "No headings found in this document.",
+    reading: "Reading mode",
+    scaleLabel: "Scale",
+    widthLabel: "Width",
+    compact: "Compact",
+    comfortable: "Comfortable",
+    relaxed: "Relaxed",
+    normalWidth: "Normal",
+    wideWidth: "Wide",
+    previousDoc: "Previous",
+    nextDoc: "Next",
     paletteHint: "Type a command or document name",
     actionFocus: "Focus docs search",
     actionTop: "Back to top",
@@ -431,19 +127,16 @@ const copy = {
     ctaBootstrap: "一键安装",
     commandLaneTitle: "运行命令通道",
     commandLaneHint: "来自官方安装与运维流程",
-    metrics: [
-      { label: "运行内存", value: "< 5MB" },
-      { label: "冷启动", value: "< 10ms" },
-      { label: "边缘硬件", value: "$10 级别" },
-      { label: "语言", value: "100% Rust" },
-    ],
     engineeringTitle: "工程基础",
     docsWorkspace: "文档工作区",
-    docsLead: "在页面内直接浏览、过滤并阅读文档；需要时可一键跳转 GitHub 原文。",
+    docsLead:
+      "仓库全量文档已建立索引并支持在 GitHub Pages 页面内直接阅读，采用工程化排版与阅读体验。",
     docsIndexed: "总文档",
     docsFiltered: "筛选后",
     docsActive: "当前文档",
-    search: "按主题、路径或关键字搜索",
+    sectionFilter: "分组",
+    languageFilter: "语言",
+    search: "按标题、路径、摘要或关键字搜索",
     commandPalette: "命令面板",
     sourceLabel: "来源",
     openOnGithub: "在 GitHub 打开",
@@ -451,6 +144,20 @@ const copy = {
     loading: "文档加载中...",
     fallback: "当前无法预览文档，你仍可直接打开源文件：",
     empty: "当前筛选下没有匹配文档。",
+    allSections: "全部分组",
+    allLanguages: "全部语言",
+    outline: "目录",
+    noOutline: "当前文档没有可提取的标题。",
+    reading: "阅读模式",
+    scaleLabel: "字号",
+    widthLabel: "宽度",
+    compact: "紧凑",
+    comfortable: "舒适",
+    relaxed: "宽松",
+    normalWidth: "标准",
+    wideWidth: "加宽",
+    previousDoc: "上一篇",
+    nextDoc: "下一篇",
     paletteHint: "输入命令或文档名称",
     actionFocus: "聚焦文档搜索",
     actionTop: "回到顶部",
@@ -460,12 +167,69 @@ const copy = {
   },
 } as const;
 
+const commandLane: Array<{ command: string; hint: Localized }> = [
+  {
+    command: "zeroclaw onboard --interactive",
+    hint: { en: "Generate config and credentials", zh: "生成配置与凭据" },
+  },
+  {
+    command: "zeroclaw agent",
+    hint: { en: "Run interactive agent mode", zh: "运行交互式 Agent 模式" },
+  },
+  {
+    command: "zeroclaw gateway && zeroclaw daemon",
+    hint: { en: "Start runtime services", zh: "启动运行时服务" },
+  },
+  {
+    command: "zeroclaw doctor",
+    hint: {
+      en: "Validate environment and runtime health",
+      zh: "校验环境与运行时健康状态",
+    },
+  },
+];
+
+const engineeringPillars: Array<{ title: Localized; detail: Localized }> = [
+  {
+    title: { en: "Trait-driven architecture", zh: "Trait 驱动架构" },
+    detail: {
+      en: "Providers, channels, tools, memory, and tunnels remain swappable through interfaces.",
+      zh: "Provider、Channel、Tool、Memory、Tunnel 通过接口保持可插拔。",
+    },
+  },
+  {
+    title: { en: "Secure by default runtime", zh: "默认安全运行时" },
+    detail: {
+      en: "Pairing, sandboxing, explicit allowlists, and workspace scoping are baseline controls.",
+      zh: "配对、沙箱、显式白名单与工作区作用域作为基线控制。",
+    },
+  },
+  {
+    title: { en: "Build once, run anywhere", zh: "一次构建，到处运行" },
+    detail: {
+      en: "Single-binary Rust workflow across ARM, x86, and RISC-V from edge to cloud.",
+      zh: "单一 Rust 二进制工作流覆盖 ARM、x86、RISC-V，从边缘到云端。",
+    },
+  },
+];
+
+function normalizePath(input: string): string {
+  return input
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/\/+/g, "/")
+    .replace(/^\.\//, "");
+}
+
 function slugify(text: string): string {
   return text
     .toLowerCase()
+    .replace(/<[^>]+>/g, "")
+    .replace(/\[[^\]]+\]\([^)]*\)/g, "")
     .replace(/[^\w\u4e00-\u9fa5\s-]/g, "")
     .trim()
-    .replace(/\s+/g, "-");
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
 }
 
 function nodeText(node: ReactNode): string {
@@ -481,19 +245,154 @@ function nodeText(node: ReactNode): string {
   return "";
 }
 
-function withRepo(path: string): string {
-  return `${repoBase}/${path}`;
+function encodePathSegments(filePath: string): string {
+  return normalizePath(filePath)
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
 }
 
-function withRaw(path: string): string {
-  return `${rawBase}/${path}`;
+function docsContentUrl(filePath: string): string {
+  return `${import.meta.env.BASE_URL}docs-content/${encodePathSegments(filePath)}`;
 }
 
-function resolvePath(doc: DocEntry, locale: Locale): string {
-  if (locale === "zh" && doc.zhPath) {
-    return doc.zhPath;
+function withRepo(filePath: string): string {
+  return `${repoBase}/${normalizePath(filePath)}`;
+}
+
+function withRaw(filePath: string): string {
+  return `${rawBase}/${normalizePath(filePath)}`;
+}
+
+function cleanHeadingText(raw: string): string {
+  return raw
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .replace(/\s+#*$/, "")
+    .trim();
+}
+
+function extractHeadings(markdown: string): HeadingItem[] {
+  const lines = markdown.split(/\r?\n/);
+  const headings: HeadingItem[] = [];
+  const slugCounts = new Map<string, number>();
+  let inCode = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+
+    if (line.startsWith("```")) {
+      inCode = !inCode;
+      continue;
+    }
+
+    if (inCode) {
+      continue;
+    }
+
+    const match = /^(#{1,3})\s+(.+)$/.exec(line);
+    if (!match) {
+      continue;
+    }
+
+    const level = match[1].length;
+    const text = cleanHeadingText(match[2]);
+    const base = slugify(text) || `section-${headings.length + 1}`;
+    const seen = (slugCounts.get(base) ?? 0) + 1;
+    slugCounts.set(base, seen);
+    const id = seen === 1 ? base : `${base}-${seen}`;
+
+    headings.push({ id, level, text });
   }
-  return doc.path;
+
+  return headings;
+}
+
+function inferSectionLabel(section: string, locale: Locale): string {
+  if (section === "root") {
+    return locale === "zh" ? "仓库根目录" : "Repository Root";
+  }
+
+  if (section === "docs") {
+    return locale === "zh" ? "文档总览" : "Docs Core";
+  }
+
+  if (section.startsWith("i18n/")) {
+    const language = section.split("/")[1] ?? "i18n";
+    return locale === "zh"
+      ? `多语言 / ${formatLanguage(language, locale)}`
+      : `i18n / ${formatLanguage(language, locale)}`;
+  }
+
+  const pretty = section.replace(/[-_]/g, " ");
+  return pretty.charAt(0).toUpperCase() + pretty.slice(1);
+}
+
+function formatLanguage(language: string, locale: Locale): string {
+  if (languageNames[language]) {
+    return languageNames[language][locale];
+  }
+
+  if (language === "en") {
+    return locale === "zh" ? "英文" : "English";
+  }
+
+  return language;
+}
+
+function canonicalDocPath(candidate: string, docSet: Set<string>): string | null {
+  const normalized = normalizePath(candidate);
+  const attempts = new Set<string>([normalized]);
+
+  if (normalized.endsWith("/")) {
+    attempts.add(`${normalized}README.md`);
+    attempts.add(`${normalized}README.mdx`);
+  }
+
+  if (!/\.[a-zA-Z0-9]+$/.test(normalized)) {
+    attempts.add(`${normalized}.md`);
+    attempts.add(`${normalized}.mdx`);
+    attempts.add(`${normalized}/README.md`);
+    attempts.add(`${normalized}/README.mdx`);
+  }
+
+  for (const attempt of attempts) {
+    if (docSet.has(attempt)) {
+      return attempt;
+    }
+  }
+
+  return null;
+}
+
+function resolveRelativePath(fromPath: string, target: string): {
+  path: string;
+  hash: string;
+} {
+  const base = new URL(`https://repo.local/${normalizePath(fromPath)}`);
+  const resolved = new URL(target, base);
+
+  return {
+    path: normalizePath(decodeURIComponent(resolved.pathname)),
+    hash: decodeURIComponent(resolved.hash.replace(/^#/, "")),
+  };
+}
+
+function getInitialDocPath(docSet: Set<string>): string {
+  if (typeof window === "undefined") {
+    return docs[0]?.path ?? "";
+  }
+
+  const url = new URL(window.location.href);
+  const requested = url.searchParams.get("doc");
+  if (requested) {
+    const decoded = normalizePath(decodeURIComponent(requested));
+    if (docSet.has(decoded)) {
+      return decoded;
+    }
+  }
+
+  return docs[0]?.path ?? "";
 }
 
 export default function App(): JSX.Element {
@@ -515,10 +414,16 @@ export default function App(): JSX.Element {
     return "system";
   });
 
+  const docSet = useMemo(() => new Set(docs.map((doc) => doc.path)), []);
+
+  const [selectedPath, setSelectedPath] = useState<string>(() =>
+    getInitialDocPath(docSet)
+  );
+
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("dark");
-  const [category, setCategory] = useState<Category | "All">("All");
   const [query, setQuery] = useState("");
-  const [selectedId, setSelectedId] = useState<string>("docs-home");
+  const [sectionFilter, setSectionFilter] = useState("all");
+  const [languageFilter, setLanguageFilter] = useState("all");
 
   const [markdownCache, setMarkdownCache] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
@@ -526,6 +431,11 @@ export default function App(): JSX.Element {
 
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [paletteQuery, setPaletteQuery] = useState("");
+
+  const [readerScale, setReaderScale] = useState<ReaderScale>("comfortable");
+  const [readerWidth, setReaderWidth] = useState<ReaderWidth>("normal");
+
+  const [pendingAnchor, setPendingAnchor] = useState<string>("");
 
   const docsSearchRef = useRef<HTMLInputElement | null>(null);
   const paletteInputRef = useRef<HTMLInputElement | null>(null);
@@ -558,105 +468,203 @@ export default function App(): JSX.Element {
     return undefined;
   }, [themeMode]);
 
+  const sectionOptions = useMemo(
+    () => ["all", ...new Set(docs.map((doc) => doc.section))],
+    []
+  );
+
+  const languageOptions = useMemo(
+    () => ["all", ...new Set(docs.map((doc) => doc.language))],
+    []
+  );
+
   const filteredDocs = useMemo(() => {
-    const normalized = query.trim().toLowerCase();
+    const needle = query.trim().toLowerCase();
 
     return docs.filter((doc) => {
-      if (category !== "All" && doc.category !== category) {
+      if (sectionFilter !== "all" && doc.section !== sectionFilter) {
         return false;
       }
 
-      if (!normalized) {
+      if (languageFilter !== "all" && doc.language !== languageFilter) {
+        return false;
+      }
+
+      if (!needle) {
         return true;
       }
 
       const bag = [
-        doc.title[locale],
-        doc.title.en,
-        doc.title.zh,
-        doc.summary[locale],
+        doc.title,
+        doc.summary,
         doc.path,
-        ...(doc.keywords ?? []),
+        doc.section,
+        doc.language,
       ]
         .join(" ")
         .toLowerCase();
 
-      return bag.includes(normalized);
+      return bag.includes(needle);
     });
-  }, [category, locale, query]);
+  }, [languageFilter, query, sectionFilter]);
+
+  const docsByPath = useMemo(() => new Map(docs.map((doc) => [doc.path, doc])), []);
+
+  const selectedDoc =
+    docsByPath.get(selectedPath) ?? filteredDocs[0] ?? docs[0] ?? null;
 
   useEffect(() => {
-    if (filteredDocs.length === 0) {
+    if (!selectedDoc) {
       return;
     }
 
-    const stillVisible = filteredDocs.some((doc) => doc.id === selectedId);
-    if (!stillVisible) {
-      setSelectedId(filteredDocs[0].id);
+    if (selectedPath !== selectedDoc.path) {
+      setSelectedPath(selectedDoc.path);
     }
-  }, [filteredDocs, selectedId]);
-
-  const selectedDoc =
-    docs.find((doc) => doc.id === selectedId) ?? docs.find((doc) => doc.id === "docs-home") ?? docs[0];
-
-  const activePath = resolvePath(selectedDoc, locale);
-  const markdown = markdownCache[activePath] ?? "";
+  }, [selectedDoc, selectedPath]);
 
   useEffect(() => {
-    let cancelled = false;
-    const controller = new AbortController();
-
-    if (markdownCache[activePath]) {
-      return () => {
-        cancelled = true;
-        controller.abort();
-      };
+    if (!selectedDoc) {
+      return;
     }
 
-    async function load(): Promise<void> {
-      setLoading(true);
-      setError("");
+    const url = new URL(window.location.href);
+    const current = url.searchParams.get("doc");
 
-      try {
-        const response = await fetch(withRaw(activePath), {
-          signal: controller.signal,
-        });
+    if (current !== selectedDoc.path) {
+      url.searchParams.set("doc", selectedDoc.path);
+      window.history.replaceState({}, "", `${url.pathname}?${url.searchParams.toString()}`);
+    }
+  }, [selectedDoc]);
 
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
+  useEffect(() => {
+    function onPopState(): void {
+      const url = new URL(window.location.href);
+      const next = url.searchParams.get("doc");
+      if (!next) {
+        return;
+      }
 
-        const textBody = await response.text();
-
-        if (cancelled) {
-          return;
-        }
-
-        setMarkdownCache((prev) => ({
-          ...prev,
-          [activePath]: textBody,
-        }));
-      } catch (err) {
-        if (cancelled) {
-          return;
-        }
-
-        const message = err instanceof Error ? err.message : "Failed to fetch";
-        setError(message);
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
+      const normalized = normalizePath(decodeURIComponent(next));
+      if (docSet.has(normalized)) {
+        setSelectedPath(normalized);
       }
     }
 
-    void load();
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [docSet]);
+
+  const activePath = selectedDoc?.path ?? "";
+  const markdown = markdownCache[activePath] ?? "";
+
+  useEffect(() => {
+    if (!selectedDoc) {
+      return;
+    }
+
+    if (markdownCache[activePath]) {
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+
+    async function loadDoc(): Promise<void> {
+      setLoading(true);
+      setError("");
+
+      const localUrl = docsContentUrl(activePath);
+      const fallbackRawUrl = withRaw(activePath);
+
+      const tryFetch = async (url: string): Promise<string | null> => {
+        try {
+          const response = await fetch(url, { signal: controller.signal });
+          if (!response.ok) {
+            return null;
+          }
+          return await response.text();
+        } catch {
+          return null;
+        }
+      };
+
+      const localContent = await tryFetch(localUrl);
+      const content = localContent ?? (await tryFetch(fallbackRawUrl));
+
+      if (cancelled) {
+        return;
+      }
+
+      if (content === null) {
+        setError("fetch_failed");
+        setLoading(false);
+        return;
+      }
+
+      setMarkdownCache((prev) => ({
+        ...prev,
+        [activePath]: content,
+      }));
+      setLoading(false);
+    }
+
+    void loadDoc();
 
     return () => {
       cancelled = true;
       controller.abort();
     };
-  }, [activePath, markdownCache]);
+  }, [activePath, markdownCache, selectedDoc]);
+
+  const headings = useMemo(() => extractHeadings(markdown), [markdown]);
+
+  useEffect(() => {
+    if (!pendingAnchor) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      const target = document.getElementById(pendingAnchor);
+      if (target) {
+        target.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+      setPendingAnchor("");
+    }, 90);
+
+    return () => window.clearTimeout(timer);
+  }, [headings, pendingAnchor]);
+
+  const groupedDocs = useMemo(() => {
+    const grouped = new Map<string, ManifestDoc[]>();
+
+    for (const doc of filteredDocs) {
+      if (!grouped.has(doc.section)) {
+        grouped.set(doc.section, []);
+      }
+      grouped.get(doc.section)?.push(doc);
+    }
+
+    return [...grouped.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  }, [filteredDocs]);
+
+  const currentIndex = filteredDocs.findIndex((doc) => doc.path === activePath);
+  const previousDoc = currentIndex > 0 ? filteredDocs[currentIndex - 1] : null;
+  const nextDoc =
+    currentIndex >= 0 && currentIndex < filteredDocs.length - 1
+      ? filteredDocs[currentIndex + 1]
+      : null;
+
+  const openDoc = (docPath: string, anchor = ""): void => {
+    if (!docSet.has(docPath)) {
+      return;
+    }
+
+    setSelectedPath(docPath);
+    if (anchor) {
+      setPendingAnchor(anchor);
+    }
+  };
 
   const cycleTheme = (): void => {
     setThemeMode((prev) => {
@@ -674,60 +682,80 @@ export default function App(): JSX.Element {
     docsSearchRef.current?.focus();
   };
 
-  const paletteEntries = useMemo(() => {
-    const staticEntries: PaletteEntry[] = [
+  const paletteActions = useMemo(
+    () => [
       {
         id: "focus-search",
         label: text.actionFocus,
         hint: text.docsWorkspace,
         run: () => {
-          document.getElementById("docs-workspace")?.scrollIntoView({ behavior: "smooth", block: "start" });
-          setTimeout(() => docsSearchRef.current?.focus(), 300);
+          document
+            .getElementById("docs-workspace")
+            ?.scrollIntoView({ behavior: "smooth", block: "start" });
+          setTimeout(() => docsSearchRef.current?.focus(), 220);
         },
       },
       {
-        id: "top",
+        id: "back-top",
         label: text.actionTop,
         hint: "Home",
         run: jumpToTop,
       },
       {
-        id: "theme",
+        id: "toggle-theme",
         label: text.actionTheme,
         hint: `${text.status}: ${resolvedTheme}`,
         run: cycleTheme,
       },
       {
-        id: "locale",
+        id: "toggle-locale",
         label: text.actionLocale,
         hint: locale === "en" ? "EN -> 中文" : "中文 -> EN",
         run: () => setLocale((prev) => (prev === "en" ? "zh" : "en")),
       },
-    ];
-
-    const dynamicEntries: PaletteEntry[] = filteredDocs.slice(0, 10).map((doc) => ({
-      id: `doc-${doc.id}`,
-      label: doc.title[locale],
-      hint: doc.path,
-      run: () => {
-        setSelectedId(doc.id);
-        document.getElementById("docs-workspace")?.scrollIntoView({ behavior: "smooth", block: "start" });
-      },
-    }));
-
-    return [...staticEntries, ...dynamicEntries];
-  }, [filteredDocs, locale, resolvedTheme, text.actionFocus, text.actionLocale, text.actionTheme, text.actionTop, text.docsWorkspace, text.status]);
+    ],
+    [locale, resolvedTheme, text.actionFocus, text.actionLocale, text.actionTheme, text.actionTop, text.docsWorkspace, text.status]
+  );
 
   const paletteResults = useMemo(() => {
-    const normalized = paletteQuery.trim().toLowerCase();
-    if (!normalized) {
-      return paletteEntries;
+    const needle = paletteQuery.trim().toLowerCase();
+
+    const actionEntries: PaletteEntry[] = paletteActions;
+
+    const docEntries: PaletteEntry[] = docs
+      .filter((doc) => {
+        if (!needle) {
+          return true;
+        }
+
+        return [doc.title, doc.summary, doc.path, doc.section, doc.language]
+          .join(" ")
+          .toLowerCase()
+          .includes(needle);
+      })
+      .slice(0, 18)
+      .map((doc) => ({
+        id: `doc-${doc.id}`,
+        label: doc.title,
+        hint: doc.path,
+        run: () => {
+          openDoc(doc.path);
+          document
+            .getElementById("docs-workspace")
+            ?.scrollIntoView({ behavior: "smooth", block: "start" });
+        },
+      }));
+
+    if (!needle) {
+      return [...actionEntries, ...docEntries.slice(0, 10)];
     }
 
-    return paletteEntries.filter((entry) => {
-      return `${entry.label} ${entry.hint}`.toLowerCase().includes(normalized);
-    });
-  }, [paletteEntries, paletteQuery]);
+    const matchedActions = actionEntries.filter((entry) =>
+      `${entry.label} ${entry.hint}`.toLowerCase().includes(needle)
+    );
+
+    return [...matchedActions, ...docEntries];
+  }, [docs, paletteActions, paletteQuery]);
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent): void {
@@ -754,6 +782,12 @@ export default function App(): JSX.Element {
       setPaletteQuery("");
     }
   }, [paletteOpen]);
+
+  if (!selectedDoc) {
+    return <div className="zc-app" />;
+  }
+
+  let headingRenderIndex = 0;
 
   return (
     <div className="zc-app">
@@ -855,12 +889,22 @@ export default function App(): JSX.Element {
             </div>
 
             <div className="metrics" aria-label="Project metrics">
-              {text.metrics.map((metric) => (
-                <article key={metric.label} className="metric-card">
-                  <p className="metric-label">{metric.label}</p>
-                  <p className="metric-value">{metric.value}</p>
-                </article>
-              ))}
+              <article className="metric-card">
+                <p className="metric-label">Runtime Memory</p>
+                <p className="metric-value">&lt; 5MB</p>
+              </article>
+              <article className="metric-card">
+                <p className="metric-label">Cold Start</p>
+                <p className="metric-value">&lt; 10ms</p>
+              </article>
+              <article className="metric-card">
+                <p className="metric-label">Edge Hardware</p>
+                <p className="metric-value">$10-class</p>
+              </article>
+              <article className="metric-card">
+                <p className="metric-label">Docs Indexed</p>
+                <p className="metric-value">{docs.length}</p>
+              </article>
             </div>
 
             <section className="principles" aria-label={text.engineeringTitle}>
@@ -891,7 +935,7 @@ export default function App(): JSX.Element {
               {text.docsFiltered}: <strong>{filteredDocs.length}</strong>
             </span>
             <span>
-              {text.docsActive}: <strong>{selectedDoc.title[locale]}</strong>
+              {text.docsActive}: <strong>{selectedDoc.title}</strong>
             </span>
           </div>
 
@@ -904,24 +948,40 @@ export default function App(): JSX.Element {
               placeholder={text.search}
               aria-label={text.search}
             />
+
+            <select
+              value={sectionFilter}
+              onChange={(event) => setSectionFilter(event.target.value)}
+              aria-label={text.sectionFilter}
+            >
+              <option value="all">{text.allSections}</option>
+              {sectionOptions
+                .filter((section) => section !== "all")
+                .map((section) => (
+                  <option key={section} value={section}>
+                    {inferSectionLabel(section, locale)}
+                  </option>
+                ))}
+            </select>
+
+            <select
+              value={languageFilter}
+              onChange={(event) => setLanguageFilter(event.target.value)}
+              aria-label={text.languageFilter}
+            >
+              <option value="all">{text.allLanguages}</option>
+              {languageOptions
+                .filter((language) => language !== "all")
+                .map((language) => (
+                  <option key={language} value={language}>
+                    {formatLanguage(language, locale)}
+                  </option>
+                ))}
+            </select>
+
             <button type="button" className="btn ghost" onClick={() => setPaletteOpen(true)}>
               {text.commandPalette}
             </button>
-          </div>
-
-          <div className="category-row" role="tablist" aria-label="Doc categories">
-            {categories.map((item) => (
-              <button
-                key={item}
-                type="button"
-                role="tab"
-                aria-selected={category === item}
-                className={category === item ? "active" : ""}
-                onClick={() => setCategory(item)}
-              >
-                {categoryLabel[locale][item]}
-              </button>
-            ))}
           </div>
 
           <div className="workspace-grid">
@@ -929,22 +989,31 @@ export default function App(): JSX.Element {
               {filteredDocs.length === 0 ? (
                 <p className="empty-hint">{text.empty}</p>
               ) : (
-                filteredDocs.map((doc) => {
-                  const isActive = doc.id === selectedId;
-                  return (
-                    <button
-                      key={doc.id}
-                      type="button"
-                      className={`doc-item ${isActive ? "active" : ""}`}
-                      onClick={() => setSelectedId(doc.id)}
-                    >
-                      <span className="doc-meta">{categoryLabel[locale][doc.category]}</span>
-                      <span className="doc-title">{doc.title[locale]}</span>
-                      <span className="doc-summary">{doc.summary[locale]}</span>
-                      <span className="doc-path">{resolvePath(doc, locale)}</span>
-                    </button>
-                  );
-                })
+                groupedDocs.map(([section, sectionDocs]) => (
+                  <section key={section} className="doc-group">
+                    <h3>{inferSectionLabel(section, locale)}</h3>
+                    <div>
+                      {sectionDocs.map((doc) => {
+                        const isActive = doc.path === activePath;
+                        return (
+                          <button
+                            key={doc.id}
+                            type="button"
+                            className={`doc-item ${isActive ? "active" : ""}`}
+                            onClick={() => openDoc(doc.path)}
+                          >
+                            <span className="doc-meta">
+                              {formatLanguage(doc.language, locale)}
+                            </span>
+                            <span className="doc-title">{doc.title}</span>
+                            <span className="doc-summary">{doc.summary}</span>
+                            <span className="doc-path">{doc.path}</span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </section>
+                ))
               )}
             </aside>
 
@@ -952,7 +1021,7 @@ export default function App(): JSX.Element {
               <header className="reader-head">
                 <div>
                   <p>{text.sourceLabel}</p>
-                  <h3>{selectedDoc.title[locale]}</h3>
+                  <h3>{selectedDoc.title}</h3>
                   <code>{activePath}</code>
                 </div>
                 <div className="reader-actions">
@@ -974,29 +1043,122 @@ export default function App(): JSX.Element {
               ) : null}
 
               {!loading && !error && markdown ? (
-                <article className="markdown-body">
+                <article className={`markdown-body size-${readerScale} width-${readerWidth}`}>
                   <ReactMarkdown
                     remarkPlugins={[remarkGfm]}
                     components={{
                       h1: ({ children }) => {
-                        const id = slugify(nodeText(children));
+                        const id = headings[headingRenderIndex]?.id ?? slugify(nodeText(children));
+                        headingRenderIndex += 1;
                         return <h1 id={id}>{children}</h1>;
                       },
                       h2: ({ children }) => {
-                        const id = slugify(nodeText(children));
+                        const id = headings[headingRenderIndex]?.id ?? slugify(nodeText(children));
+                        headingRenderIndex += 1;
                         return <h2 id={id}>{children}</h2>;
                       },
                       h3: ({ children }) => {
-                        const id = slugify(nodeText(children));
+                        const id = headings[headingRenderIndex]?.id ?? slugify(nodeText(children));
+                        headingRenderIndex += 1;
                         return <h3 id={id}>{children}</h3>;
                       },
                       a: ({ href, children }) => {
-                        const url = href ?? "#";
-                        const external = /^https?:\/\//i.test(url);
+                        const target = href ?? "";
+
+                        if (!target) {
+                          return <span>{children}</span>;
+                        }
+
+                        if (target.startsWith("#")) {
+                          const anchor = decodeURIComponent(target.replace(/^#/, ""));
+                          return (
+                            <a
+                              href={target}
+                              onClick={(event) => {
+                                event.preventDefault();
+                                setPendingAnchor(anchor);
+                              }}
+                            >
+                              {children}
+                            </a>
+                          );
+                        }
+
+                        if (/^[a-z]+:/i.test(target)) {
+                          return (
+                            <a href={target} target="_blank" rel="noreferrer">
+                              {children}
+                            </a>
+                          );
+                        }
+
+                        const resolved = resolveRelativePath(activePath, target);
+                        const docPath = canonicalDocPath(resolved.path, docSet);
+
+                        if (docPath) {
+                          const hrefDoc = `?doc=${encodeURIComponent(docPath)}`;
+                          const hrefAnchor = resolved.hash ? `#${encodeURIComponent(resolved.hash)}` : "";
+                          return (
+                            <a
+                              href={`${hrefDoc}${hrefAnchor}`}
+                              onClick={(event) => {
+                                event.preventDefault();
+                                openDoc(docPath, resolved.hash);
+                              }}
+                            >
+                              {children}
+                            </a>
+                          );
+                        }
+
+                        const looksLikeAsset =
+                          resolved.path.startsWith("docs/") ||
+                          /\.(png|jpe?g|gif|webp|svg|avif|txt|toml|json|yaml|yml)$/i.test(
+                            resolved.path
+                          );
+
+                        if (looksLikeAsset) {
+                          return (
+                            <a
+                              href={docsContentUrl(resolved.path)}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              {children}
+                            </a>
+                          );
+                        }
+
                         return (
-                          <a href={url} target={external ? "_blank" : undefined} rel={external ? "noreferrer" : undefined}>
+                          <a href={withRepo(resolved.path)} target="_blank" rel="noreferrer">
                             {children}
                           </a>
+                        );
+                      },
+                      img: ({ src, alt }) => {
+                        const original = src ?? "";
+                        if (!original) {
+                          return null;
+                        }
+
+                        if (/^https?:\/\//i.test(original) || original.startsWith("data:")) {
+                          return <img src={original} alt={alt ?? ""} loading="lazy" />;
+                        }
+
+                        const resolved = resolveRelativePath(activePath, original);
+                        const localAsset = docsContentUrl(resolved.path);
+
+                        return (
+                          <img
+                            src={localAsset}
+                            alt={alt ?? ""}
+                            loading="lazy"
+                            onError={(event) => {
+                              (event.currentTarget as HTMLImageElement).src = withRaw(
+                                resolved.path
+                              );
+                            }}
+                          />
                         );
                       },
                     }}
@@ -1005,18 +1167,102 @@ export default function App(): JSX.Element {
                   </ReactMarkdown>
                 </article>
               ) : null}
+
+              <footer className="reader-nav">
+                <button
+                  type="button"
+                  disabled={!previousDoc}
+                  onClick={() => previousDoc && openDoc(previousDoc.path)}
+                >
+                  {text.previousDoc}
+                </button>
+                <button
+                  type="button"
+                  disabled={!nextDoc}
+                  onClick={() => nextDoc && openDoc(nextDoc.path)}
+                >
+                  {text.nextDoc}
+                </button>
+              </footer>
             </section>
+
+            <aside className="reader-side" aria-label="Reader controls">
+              <section className="side-card">
+                <h3>{text.outline}</h3>
+                {headings.length === 0 ? (
+                  <p>{text.noOutline}</p>
+                ) : (
+                  <ul className="toc-list">
+                    {headings.map((heading) => (
+                      <li key={heading.id} data-level={heading.level}>
+                        <button type="button" onClick={() => setPendingAnchor(heading.id)}>
+                          {heading.text}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+
+              <section className="side-card">
+                <h3>{text.reading}</h3>
+
+                <div className="side-control">
+                  <p>{text.scaleLabel}</p>
+                  <div className="pill-row">
+                    {(["compact", "comfortable", "relaxed"] as ReaderScale[]).map((scale) => (
+                      <button
+                        key={scale}
+                        type="button"
+                        className={readerScale === scale ? "active" : ""}
+                        onClick={() => setReaderScale(scale)}
+                      >
+                        {scale === "compact"
+                          ? text.compact
+                          : scale === "comfortable"
+                            ? text.comfortable
+                            : text.relaxed}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="side-control">
+                  <p>{text.widthLabel}</p>
+                  <div className="pill-row">
+                    {(["normal", "wide"] as ReaderWidth[]).map((width) => (
+                      <button
+                        key={width}
+                        type="button"
+                        className={readerWidth === width ? "active" : ""}
+                        onClick={() => setReaderWidth(width)}
+                      >
+                        {width === "normal" ? text.normalWidth : text.wideWidth}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </section>
+            </aside>
           </div>
         </section>
       </main>
 
       <footer className="footer">
-        <p>ZeroClaw · Trait-driven architecture · secure-by-default runtime · pluggable everything</p>
+        <p>
+          ZeroClaw · Trait-driven architecture · secure-by-default runtime ·
+          pluggable everything
+        </p>
       </footer>
 
       {paletteOpen ? (
         <div className="palette-backdrop" onClick={() => setPaletteOpen(false)}>
-          <div className="palette" role="dialog" aria-modal="true" onClick={(event) => event.stopPropagation()}>
+          <div
+            className="palette"
+            role="dialog"
+            aria-modal="true"
+            onClick={(event) => event.stopPropagation()}
+          >
             <input
               ref={paletteInputRef}
               type="search"
@@ -1032,7 +1278,7 @@ export default function App(): JSX.Element {
               aria-label={text.paletteHint}
             />
             <div className="palette-list">
-              {paletteResults.slice(0, 12).map((entry) => (
+              {paletteResults.slice(0, 16).map((entry) => (
                 <button
                   key={entry.id}
                   type="button"

--- a/site/src/generated/docs-manifest.json
+++ b/site/src/generated/docs-manifest.json
@@ -1,0 +1,3476 @@
+[
+  {
+    "id": "agents-md",
+    "path": "AGENTS.md",
+    "title": "AGENTS.md — ZeroClaw Agent Engineering Protocol",
+    "summary": "This file defines the default working protocol for coding agents in this repository.",
+    "section": "root",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/AGENTS.md"
+  },
+  {
+    "id": "changelog-md",
+    "path": "CHANGELOG.md",
+    "title": "Changelog",
+    "summary": "All notable changes to ZeroClaw will be documented in this file.",
+    "section": "root",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/CHANGELOG.md"
+  },
+  {
+    "id": "cla-md",
+    "path": "CLA.md",
+    "title": "ZeroClaw Contributor License Agreement (CLA)",
+    "summary": "This Contributor License Agreement (\"CLA\") clarifies the intellectual",
+    "section": "root",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/CLA.md"
+  },
+  {
+    "id": "claude-md",
+    "path": "CLAUDE.md",
+    "title": "CLAUDE.md — ZeroClaw Agent Engineering Protocol",
+    "summary": "This file defines the default working protocol for Claude agents in this repository.",
+    "section": "root",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/CLAUDE.md"
+  },
+  {
+    "id": "code-of-conduct-md",
+    "path": "CODE_OF_CONDUCT.md",
+    "title": "Contributor Covenant Code of Conduct",
+    "summary": "We as members, contributors, and leaders pledge to make participation in our",
+    "section": "root",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/CODE_OF_CONDUCT.md"
+  },
+  {
+    "id": "contributing-el-md",
+    "path": "CONTRIBUTING.el.md",
+    "title": "Συνεισφορά στο ZeroClaw",
+    "summary": "Σας ευχαριστούμε για το ενδιαφέρον σας να συνεισφέρετε στο ZeroClaw! Αυτός ο οδηγός θα σας βοηθήσει να ξεκινήσετε.",
+    "section": "root",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/CONTRIBUTING.el.md"
+  },
+  {
+    "id": "contributing-md",
+    "path": "CONTRIBUTING.md",
+    "title": "Contributing to ZeroClaw",
+    "summary": "Thanks for your interest in contributing to ZeroClaw! This guide will help you get started.",
+    "section": "root",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/CONTRIBUTING.md"
+  },
+  {
+    "id": "docs-actions-source-policy-md",
+    "path": "docs/actions-source-policy.md",
+    "title": "Actions Source Policy (Phase 1)",
+    "summary": "This document defines the current GitHub Actions source-control policy for this repository.",
+    "section": "actions-source-policy.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/actions-source-policy.md"
+  },
+  {
+    "id": "docs-adding-boards-and-tools-md",
+    "path": "docs/adding-boards-and-tools.md",
+    "title": "Adding Boards and Tools — ZeroClaw Hardware Guide",
+    "summary": "This guide explains how to add new hardware boards and custom tools to ZeroClaw.",
+    "section": "adding-boards-and-tools.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/adding-boards-and-tools.md"
+  },
+  {
+    "id": "docs-agnostic-security-md",
+    "path": "docs/agnostic-security.md",
+    "title": "Agnostic Security: Zero Impact on Portability",
+    "summary": "1. ❓ Fast cross-compilation builds?",
+    "section": "agnostic-security.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/agnostic-security.md"
+  },
+  {
+    "id": "docs-android-setup-md",
+    "path": "docs/android-setup.md",
+    "title": "Android Setup",
+    "summary": "ZeroClaw provides prebuilt binaries for Android devices.",
+    "section": "android-setup.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/android-setup.md"
+  },
+  {
+    "id": "docs-arduino-uno-q-setup-md",
+    "path": "docs/arduino-uno-q-setup.md",
+    "title": "ZeroClaw on Arduino Uno Q — Step-by-Step Guide",
+    "summary": "Run ZeroClaw on the Arduino Uno Q's Linux side. Telegram works over WiFi; GPIO control uses the Bridge (requires a minimal App Lab app).",
+    "section": "arduino-uno-q-setup.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/arduino-uno-q-setup.md"
+  },
+  {
+    "id": "docs-audit-event-schema-md",
+    "path": "docs/audit-event-schema.md",
+    "title": "CI/Security Audit Event Schema",
+    "summary": "This document defines the normalized audit event envelope used by CI/CD and security workflows.",
+    "section": "audit-event-schema.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/audit-event-schema.md"
+  },
+  {
+    "id": "docs-audit-logging-md",
+    "path": "docs/audit-logging.md",
+    "title": "Audit Logging for ZeroClaw",
+    "summary": "ZeroClaw logs actions but lacks tamper-evident audit trails for:",
+    "section": "audit-logging.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/audit-logging.md"
+  },
+  {
+    "id": "docs-cargo-slicer-speedup-md",
+    "path": "docs/cargo-slicer-speedup.md",
+    "title": "Faster Builds with cargo-slicer",
+    "summary": "cargo-slicer is a RUSTCWRAPPER that stubs unreachable library functions at the MIR level, skipping LLVM codegen for code the final binary never calls.",
+    "section": "cargo-slicer-speedup.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/cargo-slicer-speedup.md"
+  },
+  {
+    "id": "docs-channels-reference-md",
+    "path": "docs/channels-reference.md",
+    "title": "Channels Reference",
+    "summary": "This document is the canonical reference for channel configuration in ZeroClaw.",
+    "section": "channels-reference.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/channels-reference.md"
+  },
+  {
+    "id": "docs-ci-map-md",
+    "path": "docs/ci-map.md",
+    "title": "CI Workflow Map",
+    "summary": "This document explains what each GitHub workflow does, when it runs, and whether it should block merges.",
+    "section": "ci-map.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/ci-map.md"
+  },
+  {
+    "id": "docs-commands-reference-md",
+    "path": "docs/commands-reference.md",
+    "title": "ZeroClaw Commands Reference",
+    "summary": "This reference is derived from the current CLI surface (zeroclaw --help).",
+    "section": "commands-reference.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/commands-reference.md"
+  },
+  {
+    "id": "docs-commands-reference-vi-md",
+    "path": "docs/commands-reference.vi.md",
+    "title": "Vietnamese Commands Reference (Moved)",
+    "summary": "Compatibility shim only.",
+    "section": "commands-reference.vi.md",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/commands-reference.vi.md"
+  },
+  {
+    "id": "docs-config-reference-md",
+    "path": "docs/config-reference.md",
+    "title": "ZeroClaw Config Reference (Operator-Oriented)",
+    "summary": "This is a high-signal reference for common config sections and defaults.",
+    "section": "config-reference.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/config-reference.md"
+  },
+  {
+    "id": "docs-config-reference-vi-md",
+    "path": "docs/config-reference.vi.md",
+    "title": "Vietnamese Config Reference (Moved)",
+    "summary": "Compatibility shim only.",
+    "section": "config-reference.vi.md",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/config-reference.vi.md"
+  },
+  {
+    "id": "docs-contributing-readme-md",
+    "path": "docs/contributing/README.md",
+    "title": "Contributing, Review, and CI Docs",
+    "summary": "For contributors, reviewers, and maintainers.",
+    "section": "contributing",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/contributing/README.md"
+  },
+  {
+    "id": "docs-custom-providers-md",
+    "path": "docs/custom-providers.md",
+    "title": "Custom Provider Configuration",
+    "summary": "ZeroClaw supports custom API endpoints for both OpenAI-compatible and Anthropic-compatible providers.",
+    "section": "custom-providers.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/custom-providers.md"
+  },
+  {
+    "id": "docs-datasheets-arduino-uno-md",
+    "path": "docs/datasheets/arduino-uno.md",
+    "title": "Arduino Uno",
+    "summary": "Arduino Uno is a microcontroller board based on the ATmega328P. It has 14 digital I/O pins (0–13) and 6 analog inputs (A0–A5).",
+    "section": "datasheets",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/datasheets/arduino-uno.md"
+  },
+  {
+    "id": "docs-datasheets-esp32-md",
+    "path": "docs/datasheets/esp32.md",
+    "title": "ESP32 GPIO Reference",
+    "summary": "ZeroClaw host sends JSON over serial (115200 baud):",
+    "section": "datasheets",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/datasheets/esp32.md"
+  },
+  {
+    "id": "docs-datasheets-nucleo-f401re-md",
+    "path": "docs/datasheets/nucleo-f401re.md",
+    "title": "Nucleo-F401RE GPIO",
+    "summary": "Project documentation.",
+    "section": "datasheets",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/datasheets/nucleo-f401re.md"
+  },
+  {
+    "id": "docs-datasheets-readme-md",
+    "path": "docs/datasheets/README.md",
+    "title": "Hardware Datasheets Index",
+    "summary": "Board-level reference sheets for supported hardware.",
+    "section": "datasheets",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/datasheets/README.md"
+  },
+  {
+    "id": "docs-doc-template-md",
+    "path": "docs/doc-template.md",
+    "title": "Documentation Template (Operational)",
+    "summary": "Use this template when adding a new operational or engineering document under docs/.",
+    "section": "doc-template.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/doc-template.md"
+  },
+  {
+    "id": "docs-docker-setup-md",
+    "path": "docs/docker-setup.md",
+    "title": "Docker Setup Guide",
+    "summary": "This guide explains how to run ZeroClaw in Docker mode, including bootstrap, onboarding, and daily usage.",
+    "section": "docker-setup.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/docker-setup.md"
+  },
+  {
+    "id": "docs-docs-audit-2026-02-24-md",
+    "path": "docs/docs-audit-2026-02-24.md",
+    "title": "Documentation Audit Snapshot (2026-02-24)",
+    "summary": "This snapshot records a deep documentation audit focused on completeness, navigation clarity, and i18n structure.",
+    "section": "docs-audit-2026-02-24.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/docs-audit-2026-02-24.md"
+  },
+  {
+    "id": "docs-docs-inventory-md",
+    "path": "docs/docs-inventory.md",
+    "title": "ZeroClaw Documentation Inventory",
+    "summary": "This inventory classifies documentation by intent and canonical location.",
+    "section": "docs-inventory.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/docs-inventory.md"
+  },
+  {
+    "id": "docs-frictionless-security-md",
+    "path": "docs/frictionless-security.md",
+    "title": "Frictionless Security: Zero Impact on Wizard",
+    "summary": "Only when user changes something:",
+    "section": "frictionless-security.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/frictionless-security.md"
+  },
+  {
+    "id": "docs-getting-started-macos-update-uninstall-md",
+    "path": "docs/getting-started/macos-update-uninstall.md",
+    "title": "macOS Update and Uninstall Guide",
+    "summary": "This page documents supported update and uninstall procedures for ZeroClaw on macOS (OS X).",
+    "section": "getting-started",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/getting-started/macos-update-uninstall.md"
+  },
+  {
+    "id": "docs-getting-started-readme-md",
+    "path": "docs/getting-started/README.md",
+    "title": "Getting Started Docs",
+    "summary": "For first-time setup and quick orientation.",
+    "section": "getting-started",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/getting-started/README.md"
+  },
+  {
+    "id": "docs-hardware-peripherals-design-md",
+    "path": "docs/hardware-peripherals-design.md",
+    "title": "Hardware Peripherals Design — ZeroClaw",
+    "summary": "ZeroClaw enables microcontrollers (MCUs) and Single Board Computers (SBCs) to dynamically interpret natural language commands, generate hardware-specific code, and execute peripheral interactions in real-time.",
+    "section": "hardware-peripherals-design.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/hardware-peripherals-design.md"
+  },
+  {
+    "id": "docs-hardware-readme-md",
+    "path": "docs/hardware/README.md",
+    "title": "Hardware & Peripherals Docs",
+    "summary": "For board integration, firmware flow, and peripheral architecture.",
+    "section": "hardware",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/hardware/README.md"
+  },
+  {
+    "id": "docs-i18n-coverage-md",
+    "path": "docs/i18n-coverage.md",
+    "title": "ZeroClaw i18n Coverage and Structure",
+    "summary": "This document defines the localization structure for ZeroClaw docs and tracks current coverage.",
+    "section": "i18n-coverage.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n-coverage.md"
+  },
+  {
+    "id": "docs-i18n-gap-backlog-md",
+    "path": "docs/i18n-gap-backlog.md",
+    "title": "i18n Gap Backlog",
+    "summary": "This file tracks localization parity gaps and closure state.",
+    "section": "i18n-gap-backlog.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n-gap-backlog.md"
+  },
+  {
+    "id": "docs-i18n-guide-md",
+    "path": "docs/i18n-guide.md",
+    "title": "ZeroClaw i18n Completion Guide",
+    "summary": "This guide defines how to keep multilingual documentation complete and consistent when docs change.",
+    "section": "i18n-guide.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n-guide.md"
+  },
+  {
+    "id": "docs-i18n-el-actions-source-policy-md",
+    "path": "docs/i18n/el/actions-source-policy.md",
+    "title": "Πολιτική Προέλευσης Ενεργειών (Φάση 1)",
+    "summary": "Αυτό το έγγραφο ορίζει την πολιτική ελέγχου προέλευσης για τα GitHub Actions σε αυτό το αποθετήριο.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/actions-source-policy.md"
+  },
+  {
+    "id": "docs-i18n-el-adding-boards-and-tools-md",
+    "path": "docs/i18n/el/adding-boards-and-tools.md",
+    "title": "Προσθήκη Πλακετών και Εργαλείων — Οδηγός Υλικού ZeroClaw",
+    "summary": "Αυτός ο οδηγός εξηγεί πώς να προσθέσετε νέες πλακέτες υλικού και προσαρμοσμένα εργαλεία στο ZeroClaw.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/adding-boards-and-tools.md"
+  },
+  {
+    "id": "docs-i18n-el-agnostic-security-md",
+    "path": "docs/i18n/el/agnostic-security.md",
+    "title": "Αγνωστικιστική Ασφάλεια: Μηδενικός Αντίκτυπος στη Φορητότητα",
+    "summary": "Θα προκαλέσουν οι λειτουργίες ασφαλείας προβλήματα στην:",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/agnostic-security.md"
+  },
+  {
+    "id": "docs-i18n-el-android-setup-md",
+    "path": "docs/i18n/el/android-setup.md",
+    "title": "Εγκατάσταση σε Android",
+    "summary": "Το ZeroClaw παρέχει προκατασκευασμένα εκτελέσιμα αρχεία (binaries) για συσκευές Android.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/android-setup.md"
+  },
+  {
+    "id": "docs-i18n-el-arduino-uno-q-setup-md",
+    "path": "docs/i18n/el/arduino-uno-q-setup.md",
+    "title": "Οδηγός Εγκατάστασης ZeroClaw σε Arduino Uno Q",
+    "summary": "Αυτός ο οδηγός περιγράφει τη διαδικασία εγκατάστασης και ρύθμισης του ZeroClaw στην πλευρά Linux του Arduino Uno Q.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/arduino-uno-q-setup.md"
+  },
+  {
+    "id": "docs-i18n-el-audit-event-schema-md",
+    "path": "docs/i18n/el/audit-event-schema.md",
+    "title": "Σχήμα Audit Event CI/Security (Ελληνικά)",
+    "summary": "Αυτή η σελίδα είναι συνοπτική τοπικοποιημένη γέφυρα για το σχήμα συμβάντων audit.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/audit-event-schema.md"
+  },
+  {
+    "id": "docs-i18n-el-audit-logging-md",
+    "path": "docs/i18n/el/audit-logging.md",
+    "title": "Καταγραφή Ελέγχου (Audit Logging)",
+    "summary": "Το ZeroClaw απαιτεί έναν μηχανισμό καταγραφής ελέγχου (audit trails) με προστασία από παραποίηση, προκειμένου να τεκμηριώνονται:",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/audit-logging.md"
+  },
+  {
+    "id": "docs-i18n-el-cargo-slicer-speedup-md",
+    "path": "docs/i18n/el/cargo-slicer-speedup.md",
+    "title": "Επιτάχυνση Μεταγλώττισης με το cargo-slicer",
+    "summary": "Το cargo-slicer είναι ένα εργαλείο βελτιστοποίησης που μειώνει τους χρόνους κατασκευής (build times) του ZeroClaw. Λειτουργεί αντικαθιστώντας αχρησιμοποίητες συναρτήσεις βιβλιοθηκών με κενές υλοποιήσεις (stubs), μειώνοντ",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/cargo-slicer-speedup.md"
+  },
+  {
+    "id": "docs-i18n-el-channels-reference-md",
+    "path": "docs/i18n/el/channels-reference.md",
+    "title": "Οδηγός Καναλιών Επικοινωνίας (Channels)",
+    "summary": "Αυτός ο οδηγός περιγράφει τη διαδικασία διαμόρφωσης των καναλιών επικοινωνίας (Telegram, Discord, κ.λπ.) στο ZeroClaw.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/channels-reference.md"
+  },
+  {
+    "id": "docs-i18n-el-ci-map-md",
+    "path": "docs/i18n/el/ci-map.md",
+    "title": "Οδηγός Αυτόματων Ελέγχων (CI Map)",
+    "summary": "Το παρόν έγγραφο περιγράφει τη δομή και τις λειτουργίες των αυτοματοποιημένων ελέγχων (GitHub Actions) στο ZeroClaw.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/ci-map.md"
+  },
+  {
+    "id": "docs-i18n-el-commands-reference-md",
+    "path": "docs/i18n/el/commands-reference.md",
+    "title": "Αναφορά Εντολών ZeroClaw (CLI Reference)",
+    "summary": "Αυτός ο οδηγός περιλαμβάνει το πλήρες σύνολο των εντολών που είναι διαθέσιμες στη διεπαφή γραμμής εντολών (CLI) του ZeroClaw.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/commands-reference.md"
+  },
+  {
+    "id": "docs-i18n-el-config-reference-md",
+    "path": "docs/i18n/el/config-reference.md",
+    "title": "Οδηγός Ρυθμίσεων ZeroClaw (config.toml)",
+    "summary": "Αυτός ο οδηγός εξηγεί τις πιο σημαντικές ρυθμίσεις που μπορείτε να κάνετε στο αρχείο config.toml.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/config-reference.md"
+  },
+  {
+    "id": "docs-i18n-el-contributing-readme-md",
+    "path": "docs/i18n/el/contributing/README.md",
+    "title": "Οδηγοί Συνεισφοράς και CI (Contributing & CI)",
+    "summary": "Αυτός ο φάκελος περιέχει τεκμηρίωση για τους συνεισφέροντες (contributors), τους αναθεωρητές (reviewers) και τους συντηρητές (maintainers) του ZeroClaw.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/contributing/README.md"
+  },
+  {
+    "id": "docs-i18n-el-custom-providers-md",
+    "path": "docs/i18n/el/custom-providers.md",
+    "title": "Οδηγός Προσαρμοσμένων Παρόχων AI (Custom Providers)",
+    "summary": "Το ZeroClaw σας επιτρέπει να συνδεθείτε με δικές σας υπηρεσίες AI, όπως τοπικούς διακομιστές ή εταιρικά δίκτυα.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/custom-providers.md"
+  },
+  {
+    "id": "docs-i18n-el-datasheets-arduino-uno-md",
+    "path": "docs/i18n/el/datasheets/arduino-uno.md",
+    "title": "Φύλλο Δεδομένων Arduino Uno",
+    "summary": "Το Arduino Uno είναι μια πλακέτα μικροελεγκτή βασισμένη στον ATmega328P. Διαθέτει 14 ψηφιακούς ακροδέκτες εισόδου/εξόδου (I/O) και 6 αναλογικές εισόδους (A0–A5).",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/datasheets/arduino-uno.md"
+  },
+  {
+    "id": "docs-i18n-el-datasheets-esp32-md",
+    "path": "docs/i18n/el/datasheets/esp32.md",
+    "title": "Φύλλο Δεδομένων ESP32 GPIO",
+    "summary": "Ο κεντρικός υπολογιστής (Host) του ZeroClaw επικοινωνεί μέσω σειριακής διεπαφής (115200 baud) χρησιμοποιώντας JSON:",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/datasheets/esp32.md"
+  },
+  {
+    "id": "docs-i18n-el-datasheets-nucleo-f401re-md",
+    "path": "docs/i18n/el/datasheets/nucleo-f401re.md",
+    "title": "Φύλλο Δεδομένων Nucleo-F401RE GPIO",
+    "summary": "Project documentation.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/datasheets/nucleo-f401re.md"
+  },
+  {
+    "id": "docs-i18n-el-datasheets-readme-md",
+    "path": "docs/i18n/el/datasheets/README.md",
+    "title": "Ευρετήριο Datasheets Υλικού (Ελληνικά)",
+    "summary": "Συγκεντρωτικός κατάλογος φύλλων δεδομένων για τις υποστηριζόμενες πλακέτες.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/datasheets/README.md"
+  },
+  {
+    "id": "docs-i18n-el-doc-template-md",
+    "path": "docs/i18n/el/doc-template.md",
+    "title": "Πρότυπο για Νέα Έγγραφα (Template)",
+    "summary": "Χρησιμοποιήστε αυτό το πρότυπο όταν θέλετε να γράψετε ένα νέο αρχείο βοήθειας ή τεχνικής αναφοράς στον φάκελο docs/.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/doc-template.md"
+  },
+  {
+    "id": "docs-i18n-el-docs-audit-2026-02-24-md",
+    "path": "docs/i18n/el/docs-audit-2026-02-24.md",
+    "title": "Snapshot Ελέγχου Τεκμηρίωσης (2026-02-24, Ελληνικά)",
+    "summary": "Αυτή η σελίδα είναι συνοπτική τοπικοποιημένη γέφυρα για το audit snapshot της 2026-02-24.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/docs-audit-2026-02-24.md"
+  },
+  {
+    "id": "docs-i18n-el-docs-inventory-md",
+    "path": "docs/i18n/el/docs-inventory.md",
+    "title": "Κατάλογος Εγγράφων ZeroClaw",
+    "summary": "Αυτή η σελίδα σας βοηθάει να βρείτε γρήγορα το έγγραφο που χρειάζεστε, ανάλογα με το τι θέλετε να κάνετε.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/docs-inventory.md"
+  },
+  {
+    "id": "docs-i18n-el-frictionless-security-md",
+    "path": "docs/i18n/el/frictionless-security.md",
+    "title": "Απλή και Αθόρυβη Ασφάλεια (Frictionless Security)",
+    "summary": "Αυτό το έγγραφο περιγράφει μια ιδέα για το πώς η ασφάλεια στο ZeroClaw μπορεί να γίνει \"σαν τον αερόσακο\": να είναι πάντα εκεί για να σας προστατεύει, αλλά να μην την βλέπετε μέχρι να χρειαστεί.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/frictionless-security.md"
+  },
+  {
+    "id": "docs-i18n-el-getting-started-macos-update-uninstall-md",
+    "path": "docs/i18n/el/getting-started/macos-update-uninstall.md",
+    "title": "Οδηγός Ενημέρωσης και Απεγκατάστασης στο macOS",
+    "summary": "Αυτή η σελίδα τεκμηριώνει τις υποστηριζόμενες διαδικασίες ενημέρωσης και απεγκατάστασης του ZeroClaw στο macOS (OS X).",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/getting-started/macos-update-uninstall.md"
+  },
+  {
+    "id": "docs-i18n-el-getting-started-readme-md",
+    "path": "docs/i18n/el/getting-started/README.md",
+    "title": "Πρώτα Βήματα (Getting Started)",
+    "summary": "Οδηγίες για την αρχική εγκατάσταση και την εξοικείωση με το οικοσύστημα του ZeroClaw.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/getting-started/README.md"
+  },
+  {
+    "id": "docs-i18n-el-hardware-peripherals-design-md",
+    "path": "docs/i18n/el/hardware-peripherals-design.md",
+    "title": "Σχεδιασμός Σύνδεσης με Υλικό (Hardware)",
+    "summary": "Το ZeroClaw μπορεί να ελέγχει ηλεκτρονικές πλακέτες (όπως το Arduino, το ESP32 ή το Raspberry Pi) χρησιμοποιώντας απλά λόγια. Για παράδειγμα, μπορείτε να του πείτε \"Άναψε το λαμπάκι (LED)\" και αυτό θα βρει πώς να το κάνε",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/hardware-peripherals-design.md"
+  },
+  {
+    "id": "docs-i18n-el-hardware-readme-md",
+    "path": "docs/i18n/el/hardware/README.md",
+    "title": "Τεκμηρίωση Υλικού και Περιφερειακών (Hardware)",
+    "summary": "Οδηγίες για την ενσωμάτωση πλακετών, τη διαχείριση υλικολογισμικού (firmware) και την αρχιτεκτονική περιφερειακών του ZeroClaw.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/hardware/README.md"
+  },
+  {
+    "id": "docs-i18n-el-i18n-coverage-md",
+    "path": "docs/i18n/el/i18n-coverage.md",
+    "title": "Χάρτης Κάλυψης i18n (Ελληνικά)",
+    "summary": "Αυτή η σελίδα είναι συνοπτική τοπικοποιημένη γέφυρα για τον πίνακα κάλυψης i18n.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/i18n-coverage.md"
+  },
+  {
+    "id": "docs-i18n-el-i18n-gap-backlog-md",
+    "path": "docs/i18n/el/i18n-gap-backlog.md",
+    "title": "Backlog Κενών i18n (Ελληνικά)",
+    "summary": "Αυτή η σελίδα είναι συνοπτική τοπικοποιημένη γέφυρα για το backlog κενών i18n.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/i18n-gap-backlog.md"
+  },
+  {
+    "id": "docs-i18n-el-i18n-guide-md",
+    "path": "docs/i18n/el/i18n-guide.md",
+    "title": "Οδηγός Ολοκλήρωσης i18n (Ελληνικά)",
+    "summary": "Αυτή η σελίδα είναι συνοπτική τοπικοποιημένη γέφυρα για τον οδηγό i18n completion.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/i18n-guide.md"
+  },
+  {
+    "id": "docs-i18n-el-langgraph-integration-md",
+    "path": "docs/i18n/el/langgraph-integration.md",
+    "title": "Χρήση του ZeroClaw με Python (LangGraph)",
+    "summary": "Αυτός ο οδηγός εξηγεί πώς να χρησιμοποιήσετε το πακέτο zeroclaw-tools στην Python για να κάνετε την AI πιο σταθερή όταν χρησιμοποιεί εργαλεία.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/langgraph-integration.md"
+  },
+  {
+    "id": "docs-i18n-el-matrix-e2ee-guide-md",
+    "path": "docs/i18n/el/matrix-e2ee-guide.md",
+    "title": "Οδηγός Matrix και Κρυπτογράφησης (E2EE)",
+    "summary": "Αυτός ο οδηγός σας βοηθάει να συνδέσετε το ZeroClaw με το Matrix και να λύσετε προβλήματα, ειδικά σε δωμάτια με κρυπτογράφηση (E2EE).",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/matrix-e2ee-guide.md"
+  },
+  {
+    "id": "docs-i18n-el-mattermost-setup-md",
+    "path": "docs/i18n/el/mattermost-setup.md",
+    "title": "Οδηγός Ενσωμάτωσης Mattermost",
+    "summary": "Το ZeroClaw παρέχει εγγενή υποστήριξη για το Mattermost μέσω του REST API v4. Η ενσωμάτωση αυτή είναι ιδανική για περιβάλλοντα αυτοφιλοξενούμενα (self-hosted), ιδιωτικά ή απομονωμένα (air-gapped), όπου η προστασία των δε",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/mattermost-setup.md"
+  },
+  {
+    "id": "docs-i18n-el-network-deployment-md",
+    "path": "docs/i18n/el/network-deployment.md",
+    "title": "Ανάπτυξη Δικτύου — ZeroClaw σε Raspberry Pi και Τοπικό Δίκτυο",
+    "summary": "Αυτό το έγγραφο καλύπτει την ανάπτυξη του ZeroClaw σε ένα Raspberry Pi ή σε άλλον κεντρικό υπολογιστή στο τοπικό σας δίκτυο, με κανάλια Telegram και προαιρετικά κανάλια webhook.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/network-deployment.md"
+  },
+  {
+    "id": "docs-i18n-el-nextcloud-talk-setup-md",
+    "path": "docs/i18n/el/nextcloud-talk-setup.md",
+    "title": "Ρύθμιση Nextcloud Talk",
+    "summary": "Αυτός ο οδηγός περιγράφει τη διαδικασία ενσωμάτωσης του Nextcloud Talk με το ZeroClaw.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/nextcloud-talk-setup.md"
+  },
+  {
+    "id": "docs-i18n-el-nucleo-setup-md",
+    "path": "docs/i18n/el/nucleo-setup.md",
+    "title": "ZeroClaw σε Nucleo-F401RE — Οδηγός Βήμα προς Βήμα",
+    "summary": "Εκτελέστε το ZeroClaw στον κεντρικό υπολογιστή σας (Mac ή Linux). Συνδέστε ένα Nucleo-F401RE μέσω USB. Ελέγξτε τα GPIO (LED, ακίδες) μέσω Telegram ή CLI.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/nucleo-setup.md"
+  },
+  {
+    "id": "docs-i18n-el-one-click-bootstrap-md",
+    "path": "docs/i18n/el/one-click-bootstrap.md",
+    "title": "Προετοιμασία με Ένα Κλικ (One-Click Bootstrap)",
+    "summary": "Αυτός ο οδηγός περιγράφει την ταχύτερη μέθοδο για την εγκατάσταση και την αρχικοποίηση του ZeroClaw.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/one-click-bootstrap.md"
+  },
+  {
+    "id": "docs-i18n-el-operations-runbook-md",
+    "path": "docs/i18n/el/operations-runbook.md",
+    "title": "Εγχειρίδιο Λειτουργιών ZeroClaw (Operations Runbook)",
+    "summary": "Αυτό το εγχειρίδιο προορίζεται για τους διαχειριστές του συστήματος που είναι υπεύθυνοι για τη διαθεσιμότητα, την ασφάλεια και την απόκριση σε περιστατικά.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/operations-runbook.md"
+  },
+  {
+    "id": "docs-i18n-el-operations-connectivity-probes-runbook-md",
+    "path": "docs/i18n/el/operations/connectivity-probes-runbook.md",
+    "title": "Runbook Συνδεσιμότητας Probes (Ελληνικά)",
+    "summary": "Αυτή η σελίδα είναι συνοπτική τοπικοποιημένη γέφυρα για το runbook probes συνδεσιμότητας provider στο CI.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/operations/connectivity-probes-runbook.md"
+  },
+  {
+    "id": "docs-i18n-el-operations-readme-md",
+    "path": "docs/i18n/el/operations/README.md",
+    "title": "Λειτουργία και Υλοποίηση (Operations & Deployment)",
+    "summary": "Τεχνική τεκμηρίωση για τον χειρισμό, τη συντήρηση και την ανάπτυξη του ZeroClaw σε περιβάλλοντα παραγωγής.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/operations/README.md"
+  },
+  {
+    "id": "docs-i18n-el-pr-workflow-md",
+    "path": "docs/i18n/el/pr-workflow.md",
+    "title": "Ροή Εργασιών Pull Request (PR)",
+    "summary": "Αυτό το έγγραφο περιγράφει τη διαδικασία διαχείρισης των Pull Requests (PR) στο ZeroClaw, με στόχο τη διασφάλιση υψηλής απόδοσης, ασφάλειας και σταθερότητας του κώδικα.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/pr-workflow.md"
+  },
+  {
+    "id": "docs-i18n-el-project-triage-snapshot-2026-02-18-md",
+    "path": "docs/i18n/el/project-triage-snapshot-2026-02-18.md",
+    "title": "Αναφορά Διαλογής Έργου ZeroClaw (Project Triage Snapshot)",
+    "summary": "Το παρόν έγγραφο αποτελεί μια στατική καταγραφή των ανοιχτών αιτημάτων (PR) και ζητημάτων (Issues) με σκοπό την καθοδήγηση των εργασιών τεκμηρίωσης και της αρχιτεκτονικής πληροφοριών.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/project-triage-snapshot-2026-02-18.md"
+  },
+  {
+    "id": "docs-i18n-el-project-readme-md",
+    "path": "docs/i18n/el/project/README.md",
+    "title": "Στιγμιότυπα Έργου και Διαλογή (Project Snapshot & Triage)",
+    "summary": "Αυτή η ενότητα περιλαμβάνει χρονικά περιορισμένα στιγμιότυπα (snapshots) της κατάστασης του έργου για τον σχεδιασμό και τον συντονισμό των εργασιών.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/project/README.md"
+  },
+  {
+    "id": "docs-i18n-el-providers-reference-md",
+    "path": "docs/i18n/el/providers-reference.md",
+    "title": "Αναφορά Παρόχων ZeroClaw (Providers Reference)",
+    "summary": "Αυτό το έγγραφο περιγράφει τα ID των παρόχων, τα ψευδώνυμα (aliases) και τις μεταβλητές περιβάλλοντος για τη διαχείριση των διαπιστευτηρίων.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/providers-reference.md"
+  },
+  {
+    "id": "docs-i18n-el-proxy-agent-playbook-md",
+    "path": "docs/i18n/el/proxy-agent-playbook.md",
+    "title": "Εγχειρίδιο Διαχείρισης Proxy (Proxy Agent Playbook)",
+    "summary": "Αυτό το εγχειρίδιο περιέχει έτοιμες κλήσεις εργαλείων για τη διαμόρφωση της συμπεριφοράς διαμεσολάβησης (proxy) μέσω της ρύθμισης proxyconfig.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/proxy-agent-playbook.md"
+  },
+  {
+    "id": "docs-i18n-el-readme-md",
+    "path": "docs/i18n/el/README.md",
+    "title": "Κέντρο Τεκμηρίωσης ZeroClaw",
+    "summary": "Αυτή η σελίδα αποτελεί το κεντρικό σημείο πρόσβασης για το σύστημα τεκμηρίωσης του ZeroClaw.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/README.md"
+  },
+  {
+    "id": "docs-i18n-el-reference-readme-md",
+    "path": "docs/i18n/el/reference/README.md",
+    "title": "Κατάλογοι Αναφοράς (Reference)",
+    "summary": "Δομημένο ευρετήριο τεχνικών αναφορών για εντολές CLI, παρόχους AI (Providers), κανάλια επικοινωνίας και παραμέτρους συστήματος.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/reference/README.md"
+  },
+  {
+    "id": "docs-i18n-el-release-process-md",
+    "path": "docs/i18n/el/release-process.md",
+    "title": "Διαδικασία Έκδοσης (Release Process)",
+    "summary": "Αυτό το εγχειρίδιο περιγράφει την τυπική ροή εργασιών έκδοσης νέων εκδόσεων για τους συντηρητές του ZeroClaw.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/release-process.md"
+  },
+  {
+    "id": "docs-i18n-el-resource-limits-md",
+    "path": "docs/i18n/el/resource-limits.md",
+    "title": "Όρια Πόρων (Resource Limits)",
+    "summary": "Το ZeroClaw εφαρμόζει περιορισμό ρυθμού (Rate Limiting - 20 ενέργειες/ώρα), αλλά δεν διαθέτει ανώτατα όρια χρήσης πόρων συστήματος. Χωρίς αυτούς τους περιορισμούς, ένας πράκτορας ενδέχεται να:",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/resource-limits.md"
+  },
+  {
+    "id": "docs-i18n-el-reviewer-playbook-md",
+    "path": "docs/i18n/el/reviewer-playbook.md",
+    "title": "Εγχειρίδιο Ελεγκτή (Reviewer Playbook)",
+    "summary": "Αυτό το εγχειρίδιο αποτελεί το λειτουργικό συμπλήρωμα του οδηγού PR Workflow.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/reviewer-playbook.md"
+  },
+  {
+    "id": "docs-i18n-el-sandboxing-md",
+    "path": "docs/i18n/el/sandboxing.md",
+    "title": "Στρατηγικές Sandboxing για το ZeroClaw",
+    "summary": "Το ZeroClaw εφαρμόζει ασφάλεια σε επίπεδο εφαρμογής (allowlists, path validation, injection prevention), αλλά δεν διαθέτει απομόνωση σε επίπεδο λειτουργικού συστήματος. Χωρίς sandboxing, ένας εξουσιοδοτημένος χρήστης μπο",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/sandboxing.md"
+  },
+  {
+    "id": "docs-i18n-el-security-roadmap-md",
+    "path": "docs/i18n/el/security-roadmap.md",
+    "title": "Οδικός Χάρτης Ασφάλειας ZeroClaw (Security Roadmap)",
+    "summary": "Το ZeroClaw διαθέτει ήδη ισχυρά θεμέλια ασφάλειας στο επίπεδο της εφαρμογής:",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/security-roadmap.md"
+  },
+  {
+    "id": "docs-i18n-el-security-readme-md",
+    "path": "docs/i18n/el/security/README.md",
+    "title": "Τεκμηρίωση Ασφάλειας (Security)",
+    "summary": "Αυτή η ενότητα περιλαμβάνει οδηγούς θωράκισης (Hardening) για την τρέχουσα λειτουργία του συστήματος, καθώς και μελλοντικές προτάσεις ασφαλείας.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/security/README.md"
+  },
+  {
+    "id": "docs-i18n-el-sop-connectivity-md",
+    "path": "docs/i18n/el/sop/connectivity.md",
+    "title": "Συνδεσιμότητα SOP & Event Fan-In",
+    "summary": "Αυτό το έγγραφο περιγράφει πώς τα εξωτερικά συμβάντα ενεργοποιούν εκτελέσεις SOP.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/sop/connectivity.md"
+  },
+  {
+    "id": "docs-i18n-el-sop-cookbook-md",
+    "path": "docs/i18n/el/sop/cookbook.md",
+    "title": "SOP Cookbook",
+    "summary": "Πρακτικά πρότυπα SOP στη μορφή SOP.toml + SOP.md που υποστηρίζεται από το runtime.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/sop/cookbook.md"
+  },
+  {
+    "id": "docs-i18n-el-sop-observability-md",
+    "path": "docs/i18n/el/sop/observability.md",
+    "title": "Παρατηρησιμότητα & Έλεγχος SOP",
+    "summary": "Αυτή η σελίδα καλύπτει πού αποθηκεύονται τα αποδεικτικά στοιχεία εκτέλεσης SOP και πώς να τα επιθεωρείτε.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/sop/observability.md"
+  },
+  {
+    "id": "docs-i18n-el-sop-readme-md",
+    "path": "docs/i18n/el/sop/README.md",
+    "title": "Τυποποιημένες Διαδικασίες Λειτουργίας (SOP)",
+    "summary": "Οι SOPs είναι ντετερμινιστικές διαδικασίες που εκτελούνται από το SopEngine. Παρέχουν αντιστοίχιση ενεργοποιητών, πύλες έγκρισης και ελέγξιμη κατάσταση εκτέλεσης.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/sop/README.md"
+  },
+  {
+    "id": "docs-i18n-el-sop-syntax-md",
+    "path": "docs/i18n/el/sop/syntax.md",
+    "title": "Αναφορά Σύνταξης SOP",
+    "summary": "Οι ορισμοί SOP φορτώνονται από υποκαταλόγους κάτω από το sopsdir (προεπιλογή: /sops).",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/sop/syntax.md"
+  },
+  {
+    "id": "docs-i18n-el-structure-readme-md",
+    "path": "docs/i18n/el/structure/README.md",
+    "title": "Χάρτης Δομής Τεκμηρίωσης ZeroClaw",
+    "summary": "Αυτή η σελίδα ορίζει τη δομή της τεκμηρίωσης κατά τρεις άξονες:",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/structure/README.md"
+  },
+  {
+    "id": "docs-i18n-el-summary-md",
+    "path": "docs/i18n/el/SUMMARY.md",
+    "title": "Πίνακας Περιεχομένων Τεκμηρίωσης ZeroClaw",
+    "summary": "Αυτό το αρχείο αποτελεί τον κεντρικό οδηγό πλοήγησης για το σύστημα τεκμηρίωσης.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/SUMMARY.md"
+  },
+  {
+    "id": "docs-i18n-el-troubleshooting-md",
+    "path": "docs/i18n/el/troubleshooting.md",
+    "title": "Αντιμετώπιση Προβλημάτων (Troubleshooting)",
+    "summary": "Αυτός ο οδηγός περιγράφει λύσεις για κοινά ζητήματα εγκατάστασης και εκτέλεσης του ZeroClaw.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/troubleshooting.md"
+  },
+  {
+    "id": "docs-i18n-el-zai-glm-setup-md",
+    "path": "docs/i18n/el/zai-glm-setup.md",
+    "title": "Διαμόρφωση Z.AI GLM",
+    "summary": "Το ZeroClaw υποστηρίζει τα μοντέλα GLM της Z.AI μέσω διεπαφών συμβατών με το OpenAI API.",
+    "section": "i18n/el",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/zai-glm-setup.md"
+  },
+  {
+    "id": "docs-i18n-fr-actions-source-policy-md",
+    "path": "docs/i18n/fr/actions-source-policy.md",
+    "title": "Passerelle de localisation: Actions Source Policy",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/actions-source-policy.md"
+  },
+  {
+    "id": "docs-i18n-fr-adding-boards-and-tools-md",
+    "path": "docs/i18n/fr/adding-boards-and-tools.md",
+    "title": "Passerelle de localisation: Adding Boards And Tools",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/adding-boards-and-tools.md"
+  },
+  {
+    "id": "docs-i18n-fr-agnostic-security-md",
+    "path": "docs/i18n/fr/agnostic-security.md",
+    "title": "Passerelle de localisation: Agnostic Security",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/agnostic-security.md"
+  },
+  {
+    "id": "docs-i18n-fr-android-setup-md",
+    "path": "docs/i18n/fr/android-setup.md",
+    "title": "Passerelle de localisation: Android Setup",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/android-setup.md"
+  },
+  {
+    "id": "docs-i18n-fr-arduino-uno-q-setup-md",
+    "path": "docs/i18n/fr/arduino-uno-q-setup.md",
+    "title": "Passerelle de localisation: Arduino Uno Q Setup",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/arduino-uno-q-setup.md"
+  },
+  {
+    "id": "docs-i18n-fr-audit-event-schema-md",
+    "path": "docs/i18n/fr/audit-event-schema.md",
+    "title": "Passerelle de localisation: Audit Event Schema",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/audit-event-schema.md"
+  },
+  {
+    "id": "docs-i18n-fr-audit-logging-md",
+    "path": "docs/i18n/fr/audit-logging.md",
+    "title": "Passerelle de localisation: Audit Logging",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/audit-logging.md"
+  },
+  {
+    "id": "docs-i18n-fr-cargo-slicer-speedup-md",
+    "path": "docs/i18n/fr/cargo-slicer-speedup.md",
+    "title": "Passerelle de localisation: Cargo Slicer Speedup",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/cargo-slicer-speedup.md"
+  },
+  {
+    "id": "docs-i18n-fr-channels-reference-md",
+    "path": "docs/i18n/fr/channels-reference.md",
+    "title": "Référence des canaux (Français)",
+    "summary": "Cette page est une localisation initiale Wave 1 pour les capacités de canaux et les chemins de configuration.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/channels-reference.md"
+  },
+  {
+    "id": "docs-i18n-fr-ci-map-md",
+    "path": "docs/i18n/fr/ci-map.md",
+    "title": "Passerelle de localisation: Ci Map",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/ci-map.md"
+  },
+  {
+    "id": "docs-i18n-fr-commands-reference-md",
+    "path": "docs/i18n/fr/commands-reference.md",
+    "title": "Référence des commandes (Français)",
+    "summary": "Cette page est une localisation initiale Wave 1 pour retrouver rapidement les commandes CLI ZeroClaw.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/commands-reference.md"
+  },
+  {
+    "id": "docs-i18n-fr-config-reference-md",
+    "path": "docs/i18n/fr/config-reference.md",
+    "title": "Référence de configuration (Français)",
+    "summary": "Cette page est une localisation initiale Wave 1 pour les clés de configuration et les valeurs par défaut.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/config-reference.md"
+  },
+  {
+    "id": "docs-i18n-fr-custom-providers-md",
+    "path": "docs/i18n/fr/custom-providers.md",
+    "title": "Passerelle de localisation: Custom Providers",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/custom-providers.md"
+  },
+  {
+    "id": "docs-i18n-fr-doc-template-md",
+    "path": "docs/i18n/fr/doc-template.md",
+    "title": "Passerelle de localisation: Doc Template",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/doc-template.md"
+  },
+  {
+    "id": "docs-i18n-fr-docs-audit-2026-02-24-md",
+    "path": "docs/i18n/fr/docs-audit-2026-02-24.md",
+    "title": "Passerelle de localisation: Docs Audit 2026 02 24",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/docs-audit-2026-02-24.md"
+  },
+  {
+    "id": "docs-i18n-fr-docs-inventory-md",
+    "path": "docs/i18n/fr/docs-inventory.md",
+    "title": "Inventaire documentaire (Français)",
+    "summary": "Cette page sert d'index rapide des documents top-level dans docs/i18n/fr/.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/docs-inventory.md"
+  },
+  {
+    "id": "docs-i18n-fr-frictionless-security-md",
+    "path": "docs/i18n/fr/frictionless-security.md",
+    "title": "Passerelle de localisation: Frictionless Security",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/frictionless-security.md"
+  },
+  {
+    "id": "docs-i18n-fr-hardware-peripherals-design-md",
+    "path": "docs/i18n/fr/hardware-peripherals-design.md",
+    "title": "Passerelle de localisation: Hardware Peripherals Design",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/hardware-peripherals-design.md"
+  },
+  {
+    "id": "docs-i18n-fr-i18n-coverage-md",
+    "path": "docs/i18n/fr/i18n-coverage.md",
+    "title": "Passerelle de localisation: I18n Coverage",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/i18n-coverage.md"
+  },
+  {
+    "id": "docs-i18n-fr-i18n-gap-backlog-md",
+    "path": "docs/i18n/fr/i18n-gap-backlog.md",
+    "title": "Passerelle de localisation: I18n Gap Backlog",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/i18n-gap-backlog.md"
+  },
+  {
+    "id": "docs-i18n-fr-i18n-guide-md",
+    "path": "docs/i18n/fr/i18n-guide.md",
+    "title": "Passerelle de localisation: I18n Guide",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/i18n-guide.md"
+  },
+  {
+    "id": "docs-i18n-fr-langgraph-integration-md",
+    "path": "docs/i18n/fr/langgraph-integration.md",
+    "title": "Passerelle de localisation: Langgraph Integration",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/langgraph-integration.md"
+  },
+  {
+    "id": "docs-i18n-fr-matrix-e2ee-guide-md",
+    "path": "docs/i18n/fr/matrix-e2ee-guide.md",
+    "title": "Passerelle de localisation: Matrix E2ee Guide",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/matrix-e2ee-guide.md"
+  },
+  {
+    "id": "docs-i18n-fr-mattermost-setup-md",
+    "path": "docs/i18n/fr/mattermost-setup.md",
+    "title": "Passerelle de localisation: Mattermost Setup",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/mattermost-setup.md"
+  },
+  {
+    "id": "docs-i18n-fr-network-deployment-md",
+    "path": "docs/i18n/fr/network-deployment.md",
+    "title": "Passerelle de localisation: Network Deployment",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/network-deployment.md"
+  },
+  {
+    "id": "docs-i18n-fr-nextcloud-talk-setup-md",
+    "path": "docs/i18n/fr/nextcloud-talk-setup.md",
+    "title": "Passerelle de localisation: Nextcloud Talk Setup",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/nextcloud-talk-setup.md"
+  },
+  {
+    "id": "docs-i18n-fr-nucleo-setup-md",
+    "path": "docs/i18n/fr/nucleo-setup.md",
+    "title": "Passerelle de localisation: Nucleo Setup",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/nucleo-setup.md"
+  },
+  {
+    "id": "docs-i18n-fr-one-click-bootstrap-md",
+    "path": "docs/i18n/fr/one-click-bootstrap.md",
+    "title": "Passerelle de localisation: One Click Bootstrap",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/one-click-bootstrap.md"
+  },
+  {
+    "id": "docs-i18n-fr-operations-runbook-md",
+    "path": "docs/i18n/fr/operations-runbook.md",
+    "title": "Runbook d'exploitation (Français)",
+    "summary": "Cette page est une localisation initiale Wave 1 pour les procédures day-2.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/operations-runbook.md"
+  },
+  {
+    "id": "docs-i18n-fr-pr-workflow-md",
+    "path": "docs/i18n/fr/pr-workflow.md",
+    "title": "Passerelle de localisation: Pr Workflow",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/pr-workflow.md"
+  },
+  {
+    "id": "docs-i18n-fr-project-triage-snapshot-2026-02-18-md",
+    "path": "docs/i18n/fr/project-triage-snapshot-2026-02-18.md",
+    "title": "Passerelle de localisation: Project Triage Snapshot 2026 02 18",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/project-triage-snapshot-2026-02-18.md"
+  },
+  {
+    "id": "docs-i18n-fr-providers-reference-md",
+    "path": "docs/i18n/fr/providers-reference.md",
+    "title": "Référence des providers (Français)",
+    "summary": "Cette page est une localisation initiale Wave 1 pour vérifier les IDs provider, alias et variables d'authentification.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/providers-reference.md"
+  },
+  {
+    "id": "docs-i18n-fr-proxy-agent-playbook-md",
+    "path": "docs/i18n/fr/proxy-agent-playbook.md",
+    "title": "Passerelle de localisation: Proxy Agent Playbook",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/proxy-agent-playbook.md"
+  },
+  {
+    "id": "docs-i18n-fr-readme-md",
+    "path": "docs/i18n/fr/README.md",
+    "title": "Hub de Documentation ZeroClaw (Français)",
+    "summary": "Cette page est le hub français aligné sur la structure canonique docs/i18n//.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/README.md"
+  },
+  {
+    "id": "docs-i18n-fr-release-process-md",
+    "path": "docs/i18n/fr/release-process.md",
+    "title": "Passerelle de localisation: Release Process",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/release-process.md"
+  },
+  {
+    "id": "docs-i18n-fr-resource-limits-md",
+    "path": "docs/i18n/fr/resource-limits.md",
+    "title": "Passerelle de localisation: Resource Limits",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/resource-limits.md"
+  },
+  {
+    "id": "docs-i18n-fr-reviewer-playbook-md",
+    "path": "docs/i18n/fr/reviewer-playbook.md",
+    "title": "Passerelle de localisation: Reviewer Playbook",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/reviewer-playbook.md"
+  },
+  {
+    "id": "docs-i18n-fr-sandboxing-md",
+    "path": "docs/i18n/fr/sandboxing.md",
+    "title": "Passerelle de localisation: Sandboxing",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/sandboxing.md"
+  },
+  {
+    "id": "docs-i18n-fr-security-roadmap-md",
+    "path": "docs/i18n/fr/security-roadmap.md",
+    "title": "Passerelle de localisation: Security Roadmap",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/security-roadmap.md"
+  },
+  {
+    "id": "docs-i18n-fr-summary-md",
+    "path": "docs/i18n/fr/SUMMARY.md",
+    "title": "Sommaire de la documentation ZeroClaw (Français, i18n)",
+    "summary": "Ce fichier est l'index de navigation pour docs/i18n/fr/.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/SUMMARY.md"
+  },
+  {
+    "id": "docs-i18n-fr-troubleshooting-md",
+    "path": "docs/i18n/fr/troubleshooting.md",
+    "title": "Dépannage (Français)",
+    "summary": "Cette page est une localisation initiale Wave 1 pour diagnostiquer rapidement les pannes courantes.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/troubleshooting.md"
+  },
+  {
+    "id": "docs-i18n-fr-zai-glm-setup-md",
+    "path": "docs/i18n/fr/zai-glm-setup.md",
+    "title": "Passerelle de localisation: Zai Glm Setup",
+    "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
+    "section": "i18n/fr",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/zai-glm-setup.md"
+  },
+  {
+    "id": "docs-i18n-ja-actions-source-policy-md",
+    "path": "docs/i18n/ja/actions-source-policy.md",
+    "title": "ローカライズブリッジ: Actions Source Policy",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/actions-source-policy.md"
+  },
+  {
+    "id": "docs-i18n-ja-adding-boards-and-tools-md",
+    "path": "docs/i18n/ja/adding-boards-and-tools.md",
+    "title": "ローカライズブリッジ: Adding Boards And Tools",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/adding-boards-and-tools.md"
+  },
+  {
+    "id": "docs-i18n-ja-agnostic-security-md",
+    "path": "docs/i18n/ja/agnostic-security.md",
+    "title": "ローカライズブリッジ: Agnostic Security",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/agnostic-security.md"
+  },
+  {
+    "id": "docs-i18n-ja-android-setup-md",
+    "path": "docs/i18n/ja/android-setup.md",
+    "title": "ローカライズブリッジ: Android Setup",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/android-setup.md"
+  },
+  {
+    "id": "docs-i18n-ja-arduino-uno-q-setup-md",
+    "path": "docs/i18n/ja/arduino-uno-q-setup.md",
+    "title": "ローカライズブリッジ: Arduino Uno Q Setup",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/arduino-uno-q-setup.md"
+  },
+  {
+    "id": "docs-i18n-ja-audit-event-schema-md",
+    "path": "docs/i18n/ja/audit-event-schema.md",
+    "title": "ローカライズブリッジ: Audit Event Schema",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/audit-event-schema.md"
+  },
+  {
+    "id": "docs-i18n-ja-audit-logging-md",
+    "path": "docs/i18n/ja/audit-logging.md",
+    "title": "ローカライズブリッジ: Audit Logging",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/audit-logging.md"
+  },
+  {
+    "id": "docs-i18n-ja-cargo-slicer-speedup-md",
+    "path": "docs/i18n/ja/cargo-slicer-speedup.md",
+    "title": "ローカライズブリッジ: Cargo Slicer Speedup",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/cargo-slicer-speedup.md"
+  },
+  {
+    "id": "docs-i18n-ja-channels-reference-md",
+    "path": "docs/i18n/ja/channels-reference.md",
+    "title": "チャネルリファレンス（日本語）",
+    "summary": "このページは Wave 1 の初版ローカライズです。チャネル機能と設定経路の確認用です。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/channels-reference.md"
+  },
+  {
+    "id": "docs-i18n-ja-ci-map-md",
+    "path": "docs/i18n/ja/ci-map.md",
+    "title": "ローカライズブリッジ: Ci Map",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/ci-map.md"
+  },
+  {
+    "id": "docs-i18n-ja-commands-reference-md",
+    "path": "docs/i18n/ja/commands-reference.md",
+    "title": "コマンドリファレンス（日本語）",
+    "summary": "このページは Wave 1 の初版ローカライズです。ZeroClaw CLI コマンドを素早く参照するための入口です。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/commands-reference.md"
+  },
+  {
+    "id": "docs-i18n-ja-config-reference-md",
+    "path": "docs/i18n/ja/config-reference.md",
+    "title": "設定リファレンス（日本語）",
+    "summary": "このページは Wave 1 の初版ローカライズです。主要設定キー、既定値、リスク境界を確認します。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/config-reference.md"
+  },
+  {
+    "id": "docs-i18n-ja-custom-providers-md",
+    "path": "docs/i18n/ja/custom-providers.md",
+    "title": "ローカライズブリッジ: Custom Providers",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/custom-providers.md"
+  },
+  {
+    "id": "docs-i18n-ja-doc-template-md",
+    "path": "docs/i18n/ja/doc-template.md",
+    "title": "ローカライズブリッジ: Doc Template",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/doc-template.md"
+  },
+  {
+    "id": "docs-i18n-ja-docs-audit-2026-02-24-md",
+    "path": "docs/i18n/ja/docs-audit-2026-02-24.md",
+    "title": "ローカライズブリッジ: Docs Audit 2026 02 24",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/docs-audit-2026-02-24.md"
+  },
+  {
+    "id": "docs-i18n-ja-docs-inventory-md",
+    "path": "docs/i18n/ja/docs-inventory.md",
+    "title": "ドキュメントインベントリ（日本語）",
+    "summary": "このページは docs/i18n/ja/ の top-level 文書を素早く参照するための索引です。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/docs-inventory.md"
+  },
+  {
+    "id": "docs-i18n-ja-frictionless-security-md",
+    "path": "docs/i18n/ja/frictionless-security.md",
+    "title": "ローカライズブリッジ: Frictionless Security",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/frictionless-security.md"
+  },
+  {
+    "id": "docs-i18n-ja-hardware-peripherals-design-md",
+    "path": "docs/i18n/ja/hardware-peripherals-design.md",
+    "title": "ローカライズブリッジ: Hardware Peripherals Design",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/hardware-peripherals-design.md"
+  },
+  {
+    "id": "docs-i18n-ja-i18n-coverage-md",
+    "path": "docs/i18n/ja/i18n-coverage.md",
+    "title": "ローカライズブリッジ: I18n Coverage",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/i18n-coverage.md"
+  },
+  {
+    "id": "docs-i18n-ja-i18n-gap-backlog-md",
+    "path": "docs/i18n/ja/i18n-gap-backlog.md",
+    "title": "ローカライズブリッジ: I18n Gap Backlog",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/i18n-gap-backlog.md"
+  },
+  {
+    "id": "docs-i18n-ja-i18n-guide-md",
+    "path": "docs/i18n/ja/i18n-guide.md",
+    "title": "ローカライズブリッジ: I18n Guide",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/i18n-guide.md"
+  },
+  {
+    "id": "docs-i18n-ja-langgraph-integration-md",
+    "path": "docs/i18n/ja/langgraph-integration.md",
+    "title": "ローカライズブリッジ: Langgraph Integration",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/langgraph-integration.md"
+  },
+  {
+    "id": "docs-i18n-ja-matrix-e2ee-guide-md",
+    "path": "docs/i18n/ja/matrix-e2ee-guide.md",
+    "title": "ローカライズブリッジ: Matrix E2ee Guide",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/matrix-e2ee-guide.md"
+  },
+  {
+    "id": "docs-i18n-ja-mattermost-setup-md",
+    "path": "docs/i18n/ja/mattermost-setup.md",
+    "title": "ローカライズブリッジ: Mattermost Setup",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/mattermost-setup.md"
+  },
+  {
+    "id": "docs-i18n-ja-network-deployment-md",
+    "path": "docs/i18n/ja/network-deployment.md",
+    "title": "ローカライズブリッジ: Network Deployment",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/network-deployment.md"
+  },
+  {
+    "id": "docs-i18n-ja-nextcloud-talk-setup-md",
+    "path": "docs/i18n/ja/nextcloud-talk-setup.md",
+    "title": "ローカライズブリッジ: Nextcloud Talk Setup",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/nextcloud-talk-setup.md"
+  },
+  {
+    "id": "docs-i18n-ja-nucleo-setup-md",
+    "path": "docs/i18n/ja/nucleo-setup.md",
+    "title": "ローカライズブリッジ: Nucleo Setup",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/nucleo-setup.md"
+  },
+  {
+    "id": "docs-i18n-ja-one-click-bootstrap-md",
+    "path": "docs/i18n/ja/one-click-bootstrap.md",
+    "title": "ローカライズブリッジ: One Click Bootstrap",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/one-click-bootstrap.md"
+  },
+  {
+    "id": "docs-i18n-ja-operations-runbook-md",
+    "path": "docs/i18n/ja/operations-runbook.md",
+    "title": "運用ランブック（日本語）",
+    "summary": "このページは Wave 1 の初版ローカライズです。Day-2 運用の標準手順を参照する入口です。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/operations-runbook.md"
+  },
+  {
+    "id": "docs-i18n-ja-pr-workflow-md",
+    "path": "docs/i18n/ja/pr-workflow.md",
+    "title": "ローカライズブリッジ: Pr Workflow",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/pr-workflow.md"
+  },
+  {
+    "id": "docs-i18n-ja-project-triage-snapshot-2026-02-18-md",
+    "path": "docs/i18n/ja/project-triage-snapshot-2026-02-18.md",
+    "title": "ローカライズブリッジ: Project Triage Snapshot 2026 02 18",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/project-triage-snapshot-2026-02-18.md"
+  },
+  {
+    "id": "docs-i18n-ja-providers-reference-md",
+    "path": "docs/i18n/ja/providers-reference.md",
+    "title": "Provider リファレンス（日本語）",
+    "summary": "このページは Wave 1 の初版ローカライズです。provider ID、別名、認証環境変数の確認に使います。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/providers-reference.md"
+  },
+  {
+    "id": "docs-i18n-ja-proxy-agent-playbook-md",
+    "path": "docs/i18n/ja/proxy-agent-playbook.md",
+    "title": "ローカライズブリッジ: Proxy Agent Playbook",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/proxy-agent-playbook.md"
+  },
+  {
+    "id": "docs-i18n-ja-readme-md",
+    "path": "docs/i18n/ja/README.md",
+    "title": "ZeroClaw ドキュメントハブ（日本語）",
+    "summary": "このファイルは docs/i18n// 構造における日本語ハブです。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/README.md"
+  },
+  {
+    "id": "docs-i18n-ja-release-process-md",
+    "path": "docs/i18n/ja/release-process.md",
+    "title": "ローカライズブリッジ: Release Process",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/release-process.md"
+  },
+  {
+    "id": "docs-i18n-ja-resource-limits-md",
+    "path": "docs/i18n/ja/resource-limits.md",
+    "title": "ローカライズブリッジ: Resource Limits",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/resource-limits.md"
+  },
+  {
+    "id": "docs-i18n-ja-reviewer-playbook-md",
+    "path": "docs/i18n/ja/reviewer-playbook.md",
+    "title": "ローカライズブリッジ: Reviewer Playbook",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/reviewer-playbook.md"
+  },
+  {
+    "id": "docs-i18n-ja-sandboxing-md",
+    "path": "docs/i18n/ja/sandboxing.md",
+    "title": "ローカライズブリッジ: Sandboxing",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/sandboxing.md"
+  },
+  {
+    "id": "docs-i18n-ja-security-roadmap-md",
+    "path": "docs/i18n/ja/security-roadmap.md",
+    "title": "ローカライズブリッジ: Security Roadmap",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/security-roadmap.md"
+  },
+  {
+    "id": "docs-i18n-ja-summary-md",
+    "path": "docs/i18n/ja/SUMMARY.md",
+    "title": "ZeroClaw 日本語目次（i18n）",
+    "summary": "このファイルは docs/i18n/ja/ のナビゲーション目です。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/SUMMARY.md"
+  },
+  {
+    "id": "docs-i18n-ja-troubleshooting-md",
+    "path": "docs/i18n/ja/troubleshooting.md",
+    "title": "トラブルシューティング（日本語）",
+    "summary": "このページは Wave 1 の初版ローカライズです。よくある障害の切り分け入口です。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/troubleshooting.md"
+  },
+  {
+    "id": "docs-i18n-ja-zai-glm-setup-md",
+    "path": "docs/i18n/ja/zai-glm-setup.md",
+    "title": "ローカライズブリッジ: Zai Glm Setup",
+    "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
+    "section": "i18n/ja",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/zai-glm-setup.md"
+  },
+  {
+    "id": "docs-i18n-readme-md",
+    "path": "docs/i18n/README.md",
+    "title": "ZeroClaw i18n Docs Index",
+    "summary": "Canonical localized documentation trees live here.",
+    "section": "i18n/README.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/README.md"
+  },
+  {
+    "id": "docs-i18n-ru-actions-source-policy-md",
+    "path": "docs/i18n/ru/actions-source-policy.md",
+    "title": "Локализованный bridge: Actions Source Policy",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/actions-source-policy.md"
+  },
+  {
+    "id": "docs-i18n-ru-adding-boards-and-tools-md",
+    "path": "docs/i18n/ru/adding-boards-and-tools.md",
+    "title": "Локализованный bridge: Adding Boards And Tools",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/adding-boards-and-tools.md"
+  },
+  {
+    "id": "docs-i18n-ru-agnostic-security-md",
+    "path": "docs/i18n/ru/agnostic-security.md",
+    "title": "Локализованный bridge: Agnostic Security",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/agnostic-security.md"
+  },
+  {
+    "id": "docs-i18n-ru-android-setup-md",
+    "path": "docs/i18n/ru/android-setup.md",
+    "title": "Локализованный bridge: Android Setup",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/android-setup.md"
+  },
+  {
+    "id": "docs-i18n-ru-arduino-uno-q-setup-md",
+    "path": "docs/i18n/ru/arduino-uno-q-setup.md",
+    "title": "Локализованный bridge: Arduino Uno Q Setup",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/arduino-uno-q-setup.md"
+  },
+  {
+    "id": "docs-i18n-ru-audit-event-schema-md",
+    "path": "docs/i18n/ru/audit-event-schema.md",
+    "title": "Локализованный bridge: Audit Event Schema",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/audit-event-schema.md"
+  },
+  {
+    "id": "docs-i18n-ru-audit-logging-md",
+    "path": "docs/i18n/ru/audit-logging.md",
+    "title": "Локализованный bridge: Audit Logging",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/audit-logging.md"
+  },
+  {
+    "id": "docs-i18n-ru-cargo-slicer-speedup-md",
+    "path": "docs/i18n/ru/cargo-slicer-speedup.md",
+    "title": "Локализованный bridge: Cargo Slicer Speedup",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/cargo-slicer-speedup.md"
+  },
+  {
+    "id": "docs-i18n-ru-channels-reference-md",
+    "path": "docs/i18n/ru/channels-reference.md",
+    "title": "Справочник каналов (Русский)",
+    "summary": "Это первичная локализация Wave 1 для обзора возможностей каналов и путей настройки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/channels-reference.md"
+  },
+  {
+    "id": "docs-i18n-ru-ci-map-md",
+    "path": "docs/i18n/ru/ci-map.md",
+    "title": "Локализованный bridge: Ci Map",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/ci-map.md"
+  },
+  {
+    "id": "docs-i18n-ru-commands-reference-md",
+    "path": "docs/i18n/ru/commands-reference.md",
+    "title": "Справочник команд (Русский)",
+    "summary": "Это первичная локализация Wave 1 для быстрого поиска CLI-команд ZeroClaw.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/commands-reference.md"
+  },
+  {
+    "id": "docs-i18n-ru-config-reference-md",
+    "path": "docs/i18n/ru/config-reference.md",
+    "title": "Справочник конфигурации (Русский)",
+    "summary": "Это первичная локализация Wave 1 для работы с ключами конфигурации и безопасными дефолтами.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/config-reference.md"
+  },
+  {
+    "id": "docs-i18n-ru-custom-providers-md",
+    "path": "docs/i18n/ru/custom-providers.md",
+    "title": "Локализованный bridge: Custom Providers",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/custom-providers.md"
+  },
+  {
+    "id": "docs-i18n-ru-doc-template-md",
+    "path": "docs/i18n/ru/doc-template.md",
+    "title": "Локализованный bridge: Doc Template",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/doc-template.md"
+  },
+  {
+    "id": "docs-i18n-ru-docs-audit-2026-02-24-md",
+    "path": "docs/i18n/ru/docs-audit-2026-02-24.md",
+    "title": "Локализованный bridge: Docs Audit 2026 02 24",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/docs-audit-2026-02-24.md"
+  },
+  {
+    "id": "docs-i18n-ru-docs-inventory-md",
+    "path": "docs/i18n/ru/docs-inventory.md",
+    "title": "Каталог документации (Русский)",
+    "summary": "Эта страница — быстрый индекс top-level документов в docs/i18n/ru/.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/docs-inventory.md"
+  },
+  {
+    "id": "docs-i18n-ru-frictionless-security-md",
+    "path": "docs/i18n/ru/frictionless-security.md",
+    "title": "Локализованный bridge: Frictionless Security",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/frictionless-security.md"
+  },
+  {
+    "id": "docs-i18n-ru-hardware-peripherals-design-md",
+    "path": "docs/i18n/ru/hardware-peripherals-design.md",
+    "title": "Локализованный bridge: Hardware Peripherals Design",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/hardware-peripherals-design.md"
+  },
+  {
+    "id": "docs-i18n-ru-i18n-coverage-md",
+    "path": "docs/i18n/ru/i18n-coverage.md",
+    "title": "Локализованный bridge: I18n Coverage",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/i18n-coverage.md"
+  },
+  {
+    "id": "docs-i18n-ru-i18n-gap-backlog-md",
+    "path": "docs/i18n/ru/i18n-gap-backlog.md",
+    "title": "Локализованный bridge: I18n Gap Backlog",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/i18n-gap-backlog.md"
+  },
+  {
+    "id": "docs-i18n-ru-i18n-guide-md",
+    "path": "docs/i18n/ru/i18n-guide.md",
+    "title": "Локализованный bridge: I18n Guide",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/i18n-guide.md"
+  },
+  {
+    "id": "docs-i18n-ru-langgraph-integration-md",
+    "path": "docs/i18n/ru/langgraph-integration.md",
+    "title": "Локализованный bridge: Langgraph Integration",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/langgraph-integration.md"
+  },
+  {
+    "id": "docs-i18n-ru-matrix-e2ee-guide-md",
+    "path": "docs/i18n/ru/matrix-e2ee-guide.md",
+    "title": "Локализованный bridge: Matrix E2ee Guide",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/matrix-e2ee-guide.md"
+  },
+  {
+    "id": "docs-i18n-ru-mattermost-setup-md",
+    "path": "docs/i18n/ru/mattermost-setup.md",
+    "title": "Локализованный bridge: Mattermost Setup",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/mattermost-setup.md"
+  },
+  {
+    "id": "docs-i18n-ru-network-deployment-md",
+    "path": "docs/i18n/ru/network-deployment.md",
+    "title": "Локализованный bridge: Network Deployment",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/network-deployment.md"
+  },
+  {
+    "id": "docs-i18n-ru-nextcloud-talk-setup-md",
+    "path": "docs/i18n/ru/nextcloud-talk-setup.md",
+    "title": "Локализованный bridge: Nextcloud Talk Setup",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/nextcloud-talk-setup.md"
+  },
+  {
+    "id": "docs-i18n-ru-nucleo-setup-md",
+    "path": "docs/i18n/ru/nucleo-setup.md",
+    "title": "Локализованный bridge: Nucleo Setup",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/nucleo-setup.md"
+  },
+  {
+    "id": "docs-i18n-ru-one-click-bootstrap-md",
+    "path": "docs/i18n/ru/one-click-bootstrap.md",
+    "title": "Локализованный bridge: One Click Bootstrap",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/one-click-bootstrap.md"
+  },
+  {
+    "id": "docs-i18n-ru-operations-runbook-md",
+    "path": "docs/i18n/ru/operations-runbook.md",
+    "title": "Операционный runbook (Русский)",
+    "summary": "Это первичная локализация Wave 1 для day-2 эксплуатации и стандартных процедур.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/operations-runbook.md"
+  },
+  {
+    "id": "docs-i18n-ru-pr-workflow-md",
+    "path": "docs/i18n/ru/pr-workflow.md",
+    "title": "Локализованный bridge: Pr Workflow",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/pr-workflow.md"
+  },
+  {
+    "id": "docs-i18n-ru-project-triage-snapshot-2026-02-18-md",
+    "path": "docs/i18n/ru/project-triage-snapshot-2026-02-18.md",
+    "title": "Локализованный bridge: Project Triage Snapshot 2026 02 18",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/project-triage-snapshot-2026-02-18.md"
+  },
+  {
+    "id": "docs-i18n-ru-providers-reference-md",
+    "path": "docs/i18n/ru/providers-reference.md",
+    "title": "Справочник провайдеров (Русский)",
+    "summary": "Это первичная локализация Wave 1 для проверки provider ID, алиасов и переменных окружения.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/providers-reference.md"
+  },
+  {
+    "id": "docs-i18n-ru-proxy-agent-playbook-md",
+    "path": "docs/i18n/ru/proxy-agent-playbook.md",
+    "title": "Локализованный bridge: Proxy Agent Playbook",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/proxy-agent-playbook.md"
+  },
+  {
+    "id": "docs-i18n-ru-readme-md",
+    "path": "docs/i18n/ru/README.md",
+    "title": "Документация ZeroClaw (Русский)",
+    "summary": "Этот файл — русскоязычный хаб в канонической структуре docs/i18n//.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/README.md"
+  },
+  {
+    "id": "docs-i18n-ru-release-process-md",
+    "path": "docs/i18n/ru/release-process.md",
+    "title": "Локализованный bridge: Release Process",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/release-process.md"
+  },
+  {
+    "id": "docs-i18n-ru-resource-limits-md",
+    "path": "docs/i18n/ru/resource-limits.md",
+    "title": "Локализованный bridge: Resource Limits",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/resource-limits.md"
+  },
+  {
+    "id": "docs-i18n-ru-reviewer-playbook-md",
+    "path": "docs/i18n/ru/reviewer-playbook.md",
+    "title": "Локализованный bridge: Reviewer Playbook",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/reviewer-playbook.md"
+  },
+  {
+    "id": "docs-i18n-ru-sandboxing-md",
+    "path": "docs/i18n/ru/sandboxing.md",
+    "title": "Локализованный bridge: Sandboxing",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/sandboxing.md"
+  },
+  {
+    "id": "docs-i18n-ru-security-roadmap-md",
+    "path": "docs/i18n/ru/security-roadmap.md",
+    "title": "Локализованный bridge: Security Roadmap",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/security-roadmap.md"
+  },
+  {
+    "id": "docs-i18n-ru-summary-md",
+    "path": "docs/i18n/ru/SUMMARY.md",
+    "title": "Содержание документации ZeroClaw (Русский, i18n)",
+    "summary": "Этот файл — навигационный индекс для docs/i18n/ru/.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/SUMMARY.md"
+  },
+  {
+    "id": "docs-i18n-ru-troubleshooting-md",
+    "path": "docs/i18n/ru/troubleshooting.md",
+    "title": "Troubleshooting (Русский)",
+    "summary": "Это первичная локализация Wave 1 для быстрого поиска типовых неисправностей.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/troubleshooting.md"
+  },
+  {
+    "id": "docs-i18n-ru-zai-glm-setup-md",
+    "path": "docs/i18n/ru/zai-glm-setup.md",
+    "title": "Локализованный bridge: Zai Glm Setup",
+    "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
+    "section": "i18n/ru",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/zai-glm-setup.md"
+  },
+  {
+    "id": "docs-i18n-vi-actions-source-policy-md",
+    "path": "docs/i18n/vi/actions-source-policy.md",
+    "title": "Chính sách nguồn Actions (Giai đoạn 1)",
+    "summary": "Tài liệu này định nghĩa chính sách kiểm soát nguồn GitHub Actions hiện tại cho repository này.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/actions-source-policy.md"
+  },
+  {
+    "id": "docs-i18n-vi-adding-boards-and-tools-md",
+    "path": "docs/i18n/vi/adding-boards-and-tools.md",
+    "title": "Thêm Board và Tool — Hướng dẫn phần cứng ZeroClaw",
+    "summary": "Hướng dẫn này giải thích cách thêm board phần cứng mới và tool tùy chỉnh vào ZeroClaw.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/adding-boards-and-tools.md"
+  },
+  {
+    "id": "docs-i18n-vi-agnostic-security-md",
+    "path": "docs/i18n/vi/agnostic-security.md",
+    "title": "Bảo mật không phụ thuộc nền tảng",
+    "summary": "1. ❓ Quá trình cross-compilation nhanh?",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/agnostic-security.md"
+  },
+  {
+    "id": "docs-i18n-vi-android-setup-md",
+    "path": "docs/i18n/vi/android-setup.md",
+    "title": "Thiết lập Android (Tiếng Việt)",
+    "summary": "Trang này là bản địa hóa tối thiểu cho hướng dẫn Android.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/android-setup.md"
+  },
+  {
+    "id": "docs-i18n-vi-arduino-uno-q-setup-md",
+    "path": "docs/i18n/vi/arduino-uno-q-setup.md",
+    "title": "ZeroClaw trên Arduino Uno Q — Hướng dẫn từng bước",
+    "summary": "Chạy ZeroClaw trên phía Linux của Arduino Uno Q. Telegram hoạt động qua WiFi; điều khiển GPIO dùng Bridge (yêu cầu một ứng dụng App Lab tối giản).",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/arduino-uno-q-setup.md"
+  },
+  {
+    "id": "docs-i18n-vi-audit-event-schema-md",
+    "path": "docs/i18n/vi/audit-event-schema.md",
+    "title": "Lược đồ Audit Event CI/Security (Tiếng Việt)",
+    "summary": "Trang này là bản địa hóa tối thiểu cho tài liệu lược đồ sự kiện kiểm toán.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/audit-event-schema.md"
+  },
+  {
+    "id": "docs-i18n-vi-audit-logging-md",
+    "path": "docs/i18n/vi/audit-logging.md",
+    "title": "Audit logging",
+    "summary": "ZeroClaw ghi log các hành động nhưng thiếu audit trail chống giả mạo cho:",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/audit-logging.md"
+  },
+  {
+    "id": "docs-i18n-vi-cargo-slicer-speedup-md",
+    "path": "docs/i18n/vi/cargo-slicer-speedup.md",
+    "title": "Tăng tốc build với cargo-slicer (Tiếng Việt)",
+    "summary": "Trang này là bản địa hóa tối thiểu cho hướng dẫn tối ưu tốc độ build bằng cargo-slicer.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/cargo-slicer-speedup.md"
+  },
+  {
+    "id": "docs-i18n-vi-channels-reference-md",
+    "path": "docs/i18n/vi/channels-reference.md",
+    "title": "Tài liệu tham khảo Channels",
+    "summary": "Tài liệu này là nguồn tham khảo chính thức về cấu hình channel trong ZeroClaw.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/channels-reference.md"
+  },
+  {
+    "id": "docs-i18n-vi-ci-map-md",
+    "path": "docs/i18n/vi/ci-map.md",
+    "title": "Bản đồ CI Workflow",
+    "summary": "Tài liệu này giải thích từng GitHub workflow làm gì, khi nào chạy và liệu nó có nên chặn merge hay không.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/ci-map.md"
+  },
+  {
+    "id": "docs-i18n-vi-commands-reference-md",
+    "path": "docs/i18n/vi/commands-reference.md",
+    "title": "Tham khảo lệnh ZeroClaw",
+    "summary": "Dựa trên CLI hiện tại (zeroclaw --help).",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/commands-reference.md"
+  },
+  {
+    "id": "docs-i18n-vi-config-reference-md",
+    "path": "docs/i18n/vi/config-reference.md",
+    "title": "Tham khảo cấu hình ZeroClaw",
+    "summary": "Các mục cấu hình thường dùng và giá trị mặc định.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/config-reference.md"
+  },
+  {
+    "id": "docs-i18n-vi-contributing-readme-md",
+    "path": "docs/i18n/vi/contributing/README.md",
+    "title": "Tài liệu đóng góp, review và CI",
+    "summary": "Dành cho contributor, reviewer và maintainer.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/contributing/README.md"
+  },
+  {
+    "id": "docs-i18n-vi-custom-providers-md",
+    "path": "docs/i18n/vi/custom-providers.md",
+    "title": "Cấu hình Provider Tùy chỉnh",
+    "summary": "ZeroClaw hỗ trợ endpoint API tùy chỉnh cho cả provider tương thích OpenAI lẫn Anthropic.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/custom-providers.md"
+  },
+  {
+    "id": "docs-i18n-vi-datasheets-arduino-uno-md",
+    "path": "docs/i18n/vi/datasheets/arduino-uno.md",
+    "title": "Arduino Uno",
+    "summary": "Arduino Uno là board vi điều khiển dựa trên ATmega328P. Có 14 pin digital I/O (0–13) và 6 đầu vào analog (A0–A5).",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/datasheets/arduino-uno.md"
+  },
+  {
+    "id": "docs-i18n-vi-datasheets-esp32-md",
+    "path": "docs/i18n/vi/datasheets/esp32.md",
+    "title": "Tham chiếu GPIO ESP32",
+    "summary": "ZeroClaw host gửi JSON qua serial (115200 baud):",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/datasheets/esp32.md"
+  },
+  {
+    "id": "docs-i18n-vi-datasheets-nucleo-f401re-md",
+    "path": "docs/i18n/vi/datasheets/nucleo-f401re.md",
+    "title": "GPIO Nucleo-F401RE",
+    "summary": "Project documentation.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/datasheets/nucleo-f401re.md"
+  },
+  {
+    "id": "docs-i18n-vi-datasheets-readme-md",
+    "path": "docs/i18n/vi/datasheets/README.md",
+    "title": "Chỉ mục Datasheet Phần cứng (Tiếng Việt)",
+    "summary": "Tập hợp tài liệu tham chiếu datasheet cho các board được hỗ trợ.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/datasheets/README.md"
+  },
+  {
+    "id": "docs-i18n-vi-doc-template-md",
+    "path": "docs/i18n/vi/doc-template.md",
+    "title": "Mẫu tài liệu (Tiếng Việt)",
+    "summary": "Trang này là cầu nối bản địa hóa cho mẫu tài liệu chuẩn.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/doc-template.md"
+  },
+  {
+    "id": "docs-i18n-vi-docs-audit-2026-02-24-md",
+    "path": "docs/i18n/vi/docs-audit-2026-02-24.md",
+    "title": "Snapshot kiểm toán tài liệu (2026-02-24, Tiếng Việt)",
+    "summary": "Trang này là bản địa hóa tối thiểu cho kết quả audit tài liệu ngày 2026-02-24.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/docs-audit-2026-02-24.md"
+  },
+  {
+    "id": "docs-i18n-vi-docs-inventory-md",
+    "path": "docs/i18n/vi/docs-inventory.md",
+    "title": "Danh mục tài liệu ZeroClaw (Tiếng Việt)",
+    "summary": "Trang này là bản địa hóa tối thiểu cho inventory tài liệu.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/docs-inventory.md"
+  },
+  {
+    "id": "docs-i18n-vi-frictionless-security-md",
+    "path": "docs/i18n/vi/frictionless-security.md",
+    "title": "Bảo mật không gây cản trở",
+    "summary": "Chỉ khi người dùng thay đổi:",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/frictionless-security.md"
+  },
+  {
+    "id": "docs-i18n-vi-getting-started-readme-md",
+    "path": "docs/i18n/vi/getting-started/README.md",
+    "title": "Tài liệu Bắt đầu",
+    "summary": "Dành cho cài đặt lần đầu và làm quen nhanh.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/getting-started/README.md"
+  },
+  {
+    "id": "docs-i18n-vi-hardware-peripherals-design-md",
+    "path": "docs/i18n/vi/hardware-peripherals-design.md",
+    "title": "Thiết kế Hardware Peripherals — ZeroClaw",
+    "summary": "ZeroClaw cho phép các vi điều khiển (MCU) và máy tính nhúng (SBC) phân tích lệnh ngôn ngữ tự nhiên theo thời gian thực, tổng hợp code phù hợp với từng phần cứng, và thực thi tương tác với ngoại vi trực tiếp.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/hardware-peripherals-design.md"
+  },
+  {
+    "id": "docs-i18n-vi-hardware-readme-md",
+    "path": "docs/i18n/vi/hardware/README.md",
+    "title": "Tài liệu phần cứng và ngoại vi",
+    "summary": "Tích hợp board, firmware và ngoại vi.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/hardware/README.md"
+  },
+  {
+    "id": "docs-i18n-vi-i18n-coverage-md",
+    "path": "docs/i18n/vi/i18n-coverage.md",
+    "title": "Bản đồ độ phủ i18n (Tiếng Việt)",
+    "summary": "Trang này là bản địa hóa tối thiểu cho coverage matrix i18n.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/i18n-coverage.md"
+  },
+  {
+    "id": "docs-i18n-vi-i18n-gap-backlog-md",
+    "path": "docs/i18n/vi/i18n-gap-backlog.md",
+    "title": "Backlog Thiếu hụt i18n (Tiếng Việt)",
+    "summary": "Trang này là bản địa hóa tối thiểu cho backlog khoảng trống i18n.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/i18n-gap-backlog.md"
+  },
+  {
+    "id": "docs-i18n-vi-i18n-guide-md",
+    "path": "docs/i18n/vi/i18n-guide.md",
+    "title": "Hướng dẫn hoàn thiện i18n (Tiếng Việt)",
+    "summary": "Trang này là bản địa hóa tối thiểu cho contract hoàn thiện i18n.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/i18n-guide.md"
+  },
+  {
+    "id": "docs-i18n-vi-langgraph-integration-md",
+    "path": "docs/i18n/vi/langgraph-integration.md",
+    "title": "Hướng dẫn Tích hợp LangGraph",
+    "summary": "Hướng dẫn này giải thích cách sử dụng gói Python zeroclaw-tools để gọi tool nhất quán với bất kỳ LLM provider nào tương thích OpenAI.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/langgraph-integration.md"
+  },
+  {
+    "id": "docs-i18n-vi-matrix-e2ee-guide-md",
+    "path": "docs/i18n/vi/matrix-e2ee-guide.md",
+    "title": "Hướng dẫn Matrix E2EE",
+    "summary": "Hướng dẫn này giải thích cách chạy ZeroClaw ổn định trong các phòng Matrix, bao gồm các phòng mã hóa đầu cuối (E2EE).",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/matrix-e2ee-guide.md"
+  },
+  {
+    "id": "docs-i18n-vi-mattermost-setup-md",
+    "path": "docs/i18n/vi/mattermost-setup.md",
+    "title": "Hướng dẫn Tích hợp Mattermost",
+    "summary": "ZeroClaw hỗ trợ tích hợp native với Mattermost thông qua REST API v4. Tích hợp này lý tưởng cho các môi trường self-hosted, riêng tư hoặc air-gapped nơi giao tiếp nội bộ là yêu cầu bắt buộc.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/mattermost-setup.md"
+  },
+  {
+    "id": "docs-i18n-vi-network-deployment-md",
+    "path": "docs/i18n/vi/network-deployment.md",
+    "title": "Triển khai mạng — ZeroClaw trên Raspberry Pi và mạng nội bộ",
+    "summary": "Tài liệu này hướng dẫn triển khai ZeroClaw trên Raspberry Pi hoặc host khác trong mạng nội bộ, với các channel Telegram và webhook tùy chọn.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/network-deployment.md"
+  },
+  {
+    "id": "docs-i18n-vi-nextcloud-talk-setup-md",
+    "path": "docs/i18n/vi/nextcloud-talk-setup.md",
+    "title": "Thiết lập Nextcloud Talk (Tiếng Việt)",
+    "summary": "Trang này là bản địa hóa tối thiểu cho hướng dẫn tích hợp Nextcloud Talk.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/nextcloud-talk-setup.md"
+  },
+  {
+    "id": "docs-i18n-vi-nucleo-setup-md",
+    "path": "docs/i18n/vi/nucleo-setup.md",
+    "title": "ZeroClaw trên Nucleo-F401RE — Hướng dẫn từng bước",
+    "summary": "Chạy ZeroClaw trên Mac hoặc Linux. Kết nối Nucleo-F401RE qua USB. Điều khiển GPIO (LED, các pin) qua Telegram hoặc CLI.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/nucleo-setup.md"
+  },
+  {
+    "id": "docs-i18n-vi-one-click-bootstrap-md",
+    "path": "docs/i18n/vi/one-click-bootstrap.md",
+    "title": "Cài đặt một lệnh",
+    "summary": "Cách cài đặt và khởi tạo ZeroClaw nhanh nhất.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/one-click-bootstrap.md"
+  },
+  {
+    "id": "docs-i18n-vi-operations-runbook-md",
+    "path": "docs/i18n/vi/operations-runbook.md",
+    "title": "Sổ tay Vận hành ZeroClaw",
+    "summary": "Tài liệu này dành cho các operator chịu trách nhiệm duy trì tính sẵn sàng, tình trạng bảo mật và xử lý sự cố.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/operations-runbook.md"
+  },
+  {
+    "id": "docs-i18n-vi-operations-connectivity-probes-runbook-md",
+    "path": "docs/i18n/vi/operations/connectivity-probes-runbook.md",
+    "title": "Runbook Connectivity Probes (Tiếng Việt)",
+    "summary": "Trang này là bản địa hóa tối thiểu cho runbook vận hành probe kết nối provider trong CI.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/operations/connectivity-probes-runbook.md"
+  },
+  {
+    "id": "docs-i18n-vi-operations-readme-md",
+    "path": "docs/i18n/vi/operations/README.md",
+    "title": "Tài liệu vận hành và triển khai",
+    "summary": "Dành cho operator vận hành ZeroClaw liên tục hoặc trên production.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/operations/README.md"
+  },
+  {
+    "id": "docs-i18n-vi-pr-workflow-md",
+    "path": "docs/i18n/vi/pr-workflow.md",
+    "title": "Quy trình PR ZeroClaw (Cộng tác khối lượng cao)",
+    "summary": "Tài liệu này định nghĩa cách ZeroClaw xử lý khối lượng PR lớn trong khi vẫn duy trì:",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/pr-workflow.md"
+  },
+  {
+    "id": "docs-i18n-vi-project-triage-snapshot-2026-02-18-md",
+    "path": "docs/i18n/vi/project-triage-snapshot-2026-02-18.md",
+    "title": "Ảnh chụp Project Triage (2026-02-18, Tiếng Việt)",
+    "summary": "Trang này là bản địa hóa tối thiểu cho snapshot triage theo thời điểm.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/project-triage-snapshot-2026-02-18.md"
+  },
+  {
+    "id": "docs-i18n-vi-project-readme-md",
+    "path": "docs/i18n/vi/project/README.md",
+    "title": "Tài liệu snapshot và triage dự án",
+    "summary": "Snapshot trạng thái dự án có giới hạn thời gian cho tài liệu lập kế hoạch và công việc vận hành.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/project/README.md"
+  },
+  {
+    "id": "docs-i18n-vi-providers-reference-md",
+    "path": "docs/i18n/vi/providers-reference.md",
+    "title": "Tài liệu tham khảo Providers — ZeroClaw",
+    "summary": "Tài liệu này liệt kê các provider ID, alias và biến môi trường chứa thông tin xác thực.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/providers-reference.md"
+  },
+  {
+    "id": "docs-i18n-vi-proxy-agent-playbook-md",
+    "path": "docs/i18n/vi/proxy-agent-playbook.md",
+    "title": "Playbook Proxy Agent",
+    "summary": "Tài liệu này cung cấp các tool call có thể copy-paste để cấu hình hành vi proxy qua proxyconfig.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/proxy-agent-playbook.md"
+  },
+  {
+    "id": "docs-i18n-vi-readme-md",
+    "path": "docs/i18n/vi/README.md",
+    "title": "Tài liệu ZeroClaw (Tiếng Việt)",
+    "summary": "Đây là trang chủ tiếng Việt của hệ thống tài liệu.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/README.md"
+  },
+  {
+    "id": "docs-i18n-vi-reference-readme-md",
+    "path": "docs/i18n/vi/reference/README.md",
+    "title": "Danh mục tham chiếu",
+    "summary": "Tra cứu lệnh, provider, channel, config và tích hợp.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/reference/README.md"
+  },
+  {
+    "id": "docs-i18n-vi-release-process-md",
+    "path": "docs/i18n/vi/release-process.md",
+    "title": "Quy trình Release ZeroClaw",
+    "summary": "Runbook này định nghĩa quy trình release tiêu chuẩn của maintainer.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/release-process.md"
+  },
+  {
+    "id": "docs-i18n-vi-resource-limits-md",
+    "path": "docs/i18n/vi/resource-limits.md",
+    "title": "Giới hạn tài nguyên",
+    "summary": "ZeroClaw có rate limiting (20 actions/hour) nhưng chưa có giới hạn tài nguyên. Một agent bị lỗi lặp vòng có thể:",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/resource-limits.md"
+  },
+  {
+    "id": "docs-i18n-vi-reviewer-playbook-md",
+    "path": "docs/i18n/vi/reviewer-playbook.md",
+    "title": "Sổ tay Reviewer",
+    "summary": "Tài liệu này là người bạn đồng hành vận hành của docs/pr-workflow.md.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/reviewer-playbook.md"
+  },
+  {
+    "id": "docs-i18n-vi-sandboxing-md",
+    "path": "docs/i18n/vi/sandboxing.md",
+    "title": "Chiến lược sandboxing",
+    "summary": "ZeroClaw hiện có application-layer security (allowlists, path blocking, command injection protection) nhưng thiếu cơ chế cách ly cấp hệ điều hành. Nếu kẻ tấn công nằm trong allowlist, họ có thể chạy bất kỳ lệnh nào được ",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/sandboxing.md"
+  },
+  {
+    "id": "docs-i18n-vi-security-roadmap-md",
+    "path": "docs/i18n/vi/security-roadmap.md",
+    "title": "Lộ trình cải tiến bảo mật",
+    "summary": "ZeroClaw đã có application-layer security xuất sắc:",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/security-roadmap.md"
+  },
+  {
+    "id": "docs-i18n-vi-security-readme-md",
+    "path": "docs/i18n/vi/security/README.md",
+    "title": "Tài liệu bảo mật",
+    "summary": "Hướng dẫn bảo mật hiện tại và đề xuất cải tiến.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/security/README.md"
+  },
+  {
+    "id": "docs-i18n-vi-summary-md",
+    "path": "docs/i18n/vi/SUMMARY.md",
+    "title": "Mục lục tài liệu ZeroClaw (Tiếng Việt)",
+    "summary": "Đây là mục lục thống nhất cho hệ thống tài liệu tiếng Việt.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/SUMMARY.md"
+  },
+  {
+    "id": "docs-i18n-vi-troubleshooting-md",
+    "path": "docs/i18n/vi/troubleshooting.md",
+    "title": "Khắc phục sự cố ZeroClaw",
+    "summary": "Các lỗi thường gặp khi cài đặt và chạy, kèm cách khắc phục.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/troubleshooting.md"
+  },
+  {
+    "id": "docs-i18n-vi-zai-glm-setup-md",
+    "path": "docs/i18n/vi/zai-glm-setup.md",
+    "title": "Thiết lập Z.AI GLM",
+    "summary": "ZeroClaw hỗ trợ các model GLM của Z.AI thông qua các endpoint tương thích OpenAI.",
+    "section": "i18n/vi",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/zai-glm-setup.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-actions-source-policy-md",
+    "path": "docs/i18n/zh-CN/actions-source-policy.md",
+    "title": "本地化桥接文档：Actions Source Policy",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/actions-source-policy.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-adding-boards-and-tools-md",
+    "path": "docs/i18n/zh-CN/adding-boards-and-tools.md",
+    "title": "本地化桥接文档：Adding Boards And Tools",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/adding-boards-and-tools.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-agnostic-security-md",
+    "path": "docs/i18n/zh-CN/agnostic-security.md",
+    "title": "本地化桥接文档：Agnostic Security",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/agnostic-security.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-android-setup-md",
+    "path": "docs/i18n/zh-CN/android-setup.md",
+    "title": "本地化桥接文档：Android Setup",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/android-setup.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-arduino-uno-q-setup-md",
+    "path": "docs/i18n/zh-CN/arduino-uno-q-setup.md",
+    "title": "本地化桥接文档：Arduino Uno Q Setup",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/arduino-uno-q-setup.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-audit-event-schema-md",
+    "path": "docs/i18n/zh-CN/audit-event-schema.md",
+    "title": "本地化桥接文档：Audit Event Schema",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/audit-event-schema.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-audit-logging-md",
+    "path": "docs/i18n/zh-CN/audit-logging.md",
+    "title": "本地化桥接文档：Audit Logging",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/audit-logging.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-cargo-slicer-speedup-md",
+    "path": "docs/i18n/zh-CN/cargo-slicer-speedup.md",
+    "title": "本地化桥接文档：Cargo Slicer Speedup",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/cargo-slicer-speedup.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-channels-reference-md",
+    "path": "docs/i18n/zh-CN/channels-reference.md",
+    "title": "Channel 参考（简体中文）",
+    "summary": "这是 Wave 1 首版本地化页面，用于查阅各通信渠道能力与配置路径。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/channels-reference.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-ci-map-md",
+    "path": "docs/i18n/zh-CN/ci-map.md",
+    "title": "本地化桥接文档：Ci Map",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/ci-map.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-commands-reference-md",
+    "path": "docs/i18n/zh-CN/commands-reference.md",
+    "title": "命令参考（简体中文）",
+    "summary": "这是 Wave 1 首版本地化页面，用于快速定位 ZeroClaw CLI 命令。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/commands-reference.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-config-reference-md",
+    "path": "docs/i18n/zh-CN/config-reference.md",
+    "title": "配置参考（简体中文）",
+    "summary": "这是 Wave 1 首版本地化页面，用于查阅核心配置键、默认值与风险边界。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/config-reference.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-custom-providers-md",
+    "path": "docs/i18n/zh-CN/custom-providers.md",
+    "title": "本地化桥接文档：Custom Providers",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/custom-providers.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-doc-template-md",
+    "path": "docs/i18n/zh-CN/doc-template.md",
+    "title": "本地化桥接文档：Doc Template",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/doc-template.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-docs-audit-2026-02-24-md",
+    "path": "docs/i18n/zh-CN/docs-audit-2026-02-24.md",
+    "title": "本地化桥接文档：Docs Audit 2026 02 24",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/docs-audit-2026-02-24.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-docs-inventory-md",
+    "path": "docs/i18n/zh-CN/docs-inventory.md",
+    "title": "文档清单（简体中文）",
+    "summary": "该页面用于在 docs/i18n/zh-CN/ 下快速定位所有 top-level 文档。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/docs-inventory.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-frictionless-security-md",
+    "path": "docs/i18n/zh-CN/frictionless-security.md",
+    "title": "本地化桥接文档：Frictionless Security",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/frictionless-security.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-hardware-peripherals-design-md",
+    "path": "docs/i18n/zh-CN/hardware-peripherals-design.md",
+    "title": "本地化桥接文档：Hardware Peripherals Design",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/hardware-peripherals-design.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-i18n-coverage-md",
+    "path": "docs/i18n/zh-CN/i18n-coverage.md",
+    "title": "本地化桥接文档：I18n Coverage",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/i18n-coverage.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-i18n-gap-backlog-md",
+    "path": "docs/i18n/zh-CN/i18n-gap-backlog.md",
+    "title": "本地化桥接文档：I18n Gap Backlog",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/i18n-gap-backlog.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-i18n-guide-md",
+    "path": "docs/i18n/zh-CN/i18n-guide.md",
+    "title": "本地化桥接文档：I18n Guide",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/i18n-guide.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-langgraph-integration-md",
+    "path": "docs/i18n/zh-CN/langgraph-integration.md",
+    "title": "本地化桥接文档：Langgraph Integration",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/langgraph-integration.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-matrix-e2ee-guide-md",
+    "path": "docs/i18n/zh-CN/matrix-e2ee-guide.md",
+    "title": "本地化桥接文档：Matrix E2ee Guide",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/matrix-e2ee-guide.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-mattermost-setup-md",
+    "path": "docs/i18n/zh-CN/mattermost-setup.md",
+    "title": "本地化桥接文档：Mattermost Setup",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/mattermost-setup.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-network-deployment-md",
+    "path": "docs/i18n/zh-CN/network-deployment.md",
+    "title": "本地化桥接文档：Network Deployment",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/network-deployment.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-nextcloud-talk-setup-md",
+    "path": "docs/i18n/zh-CN/nextcloud-talk-setup.md",
+    "title": "本地化桥接文档：Nextcloud Talk Setup",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/nextcloud-talk-setup.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-nucleo-setup-md",
+    "path": "docs/i18n/zh-CN/nucleo-setup.md",
+    "title": "本地化桥接文档：Nucleo Setup",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/nucleo-setup.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-one-click-bootstrap-md",
+    "path": "docs/i18n/zh-CN/one-click-bootstrap.md",
+    "title": "本地化桥接文档：One Click Bootstrap",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/one-click-bootstrap.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-operations-runbook-md",
+    "path": "docs/i18n/zh-CN/operations-runbook.md",
+    "title": "运维 Runbook（简体中文）",
+    "summary": "这是 Wave 1 首版本地化页面，用于日常运维（Day-2）流程导航。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/operations-runbook.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-pr-workflow-md",
+    "path": "docs/i18n/zh-CN/pr-workflow.md",
+    "title": "本地化桥接文档：Pr Workflow",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/pr-workflow.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-project-triage-snapshot-2026-02-18-md",
+    "path": "docs/i18n/zh-CN/project-triage-snapshot-2026-02-18.md",
+    "title": "本地化桥接文档：Project Triage Snapshot 2026 02 18",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/project-triage-snapshot-2026-02-18.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-providers-reference-md",
+    "path": "docs/i18n/zh-CN/providers-reference.md",
+    "title": "Provider 参考（简体中文）",
+    "summary": "这是 Wave 1 首版本地化页面，用于快速查阅 provider 标识、别名与认证变量。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/providers-reference.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-proxy-agent-playbook-md",
+    "path": "docs/i18n/zh-CN/proxy-agent-playbook.md",
+    "title": "本地化桥接文档：Proxy Agent Playbook",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/proxy-agent-playbook.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-readme-md",
+    "path": "docs/i18n/zh-CN/README.md",
+    "title": "ZeroClaw 文档中心（简体中文）",
+    "summary": "这是中文文档在 docs/i18n// 结构下的标准入口。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/README.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-release-process-md",
+    "path": "docs/i18n/zh-CN/release-process.md",
+    "title": "本地化桥接文档：Release Process",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/release-process.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-resource-limits-md",
+    "path": "docs/i18n/zh-CN/resource-limits.md",
+    "title": "本地化桥接文档：Resource Limits",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/resource-limits.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-reviewer-playbook-md",
+    "path": "docs/i18n/zh-CN/reviewer-playbook.md",
+    "title": "本地化桥接文档：Reviewer Playbook",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/reviewer-playbook.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-sandboxing-md",
+    "path": "docs/i18n/zh-CN/sandboxing.md",
+    "title": "本地化桥接文档：Sandboxing",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/sandboxing.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-security-roadmap-md",
+    "path": "docs/i18n/zh-CN/security-roadmap.md",
+    "title": "本地化桥接文档：Security Roadmap",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/security-roadmap.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-summary-md",
+    "path": "docs/i18n/zh-CN/SUMMARY.md",
+    "title": "ZeroClaw 中文文档目录（i18n）",
+    "summary": "该文件是 docs/i18n/zh-CN/ 的导航目录。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/SUMMARY.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-troubleshooting-md",
+    "path": "docs/i18n/zh-CN/troubleshooting.md",
+    "title": "故障排查（简体中文）",
+    "summary": "这是 Wave 1 首版本地化页面，用于快速定位常见故障与恢复路径。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/troubleshooting.md"
+  },
+  {
+    "id": "docs-i18n-zh-cn-zai-glm-setup-md",
+    "path": "docs/i18n/zh-CN/zai-glm-setup.md",
+    "title": "本地化桥接文档：Zai Glm Setup",
+    "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
+    "section": "i18n/zh-CN",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/zai-glm-setup.md"
+  },
+  {
+    "id": "docs-langgraph-integration-md",
+    "path": "docs/langgraph-integration.md",
+    "title": "LangGraph Integration Guide",
+    "summary": "This guide explains how to use the zeroclaw-tools Python package for consistent tool calling with any OpenAI-compatible LLM provider.",
+    "section": "langgraph-integration.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/langgraph-integration.md"
+  },
+  {
+    "id": "docs-matrix-e2ee-guide-md",
+    "path": "docs/matrix-e2ee-guide.md",
+    "title": "Matrix E2EE Guide",
+    "summary": "This guide explains how to run ZeroClaw reliably in Matrix rooms, including end-to-end encrypted (E2EE) rooms.",
+    "section": "matrix-e2ee-guide.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/matrix-e2ee-guide.md"
+  },
+  {
+    "id": "docs-mattermost-setup-md",
+    "path": "docs/mattermost-setup.md",
+    "title": "Mattermost Integration Guide",
+    "summary": "ZeroClaw supports native integration with Mattermost via its REST API v4. This integration is ideal for self-hosted, private, or air-gapped environments where sovereign communication is a requirement.",
+    "section": "mattermost-setup.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/mattermost-setup.md"
+  },
+  {
+    "id": "docs-network-deployment-md",
+    "path": "docs/network-deployment.md",
+    "title": "Network Deployment — ZeroClaw on Raspberry Pi and Local Network",
+    "summary": "This document covers deploying ZeroClaw on a Raspberry Pi or other host on your local network, with Telegram and optional webhook channels.",
+    "section": "network-deployment.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/network-deployment.md"
+  },
+  {
+    "id": "docs-nextcloud-talk-setup-md",
+    "path": "docs/nextcloud-talk-setup.md",
+    "title": "Nextcloud Talk Setup",
+    "summary": "This guide covers native Nextcloud Talk integration for ZeroClaw.",
+    "section": "nextcloud-talk-setup.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/nextcloud-talk-setup.md"
+  },
+  {
+    "id": "docs-nucleo-setup-md",
+    "path": "docs/nucleo-setup.md",
+    "title": "ZeroClaw on Nucleo-F401RE — Step-by-Step Guide",
+    "summary": "Run ZeroClaw on your Mac or Linux host. Connect a Nucleo-F401RE via USB. Control GPIO (LED, pins) via Telegram or CLI.",
+    "section": "nucleo-setup.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/nucleo-setup.md"
+  },
+  {
+    "id": "docs-one-click-bootstrap-md",
+    "path": "docs/one-click-bootstrap.md",
+    "title": "One-Click Bootstrap",
+    "summary": "This page defines the fastest supported path to install and initialize ZeroClaw.",
+    "section": "one-click-bootstrap.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/one-click-bootstrap.md"
+  },
+  {
+    "id": "docs-one-click-bootstrap-vi-md",
+    "path": "docs/one-click-bootstrap.vi.md",
+    "title": "Vietnamese One-Click Bootstrap (Moved)",
+    "summary": "Compatibility shim only.",
+    "section": "one-click-bootstrap.vi.md",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/one-click-bootstrap.vi.md"
+  },
+  {
+    "id": "docs-operations-runbook-md",
+    "path": "docs/operations-runbook.md",
+    "title": "ZeroClaw Operations Runbook",
+    "summary": "This runbook is for operators who maintain availability, security posture, and incident response.",
+    "section": "operations-runbook.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations-runbook.md"
+  },
+  {
+    "id": "docs-operations-canary-gate-runbook-md",
+    "path": "docs/operations/canary-gate-runbook.md",
+    "title": "Canary Gate Runbook",
+    "summary": "Workflow: .github/workflows/ci-canary-gate.yml",
+    "section": "operations",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/canary-gate-runbook.md"
+  },
+  {
+    "id": "docs-operations-connectivity-probes-runbook-md",
+    "path": "docs/operations/connectivity-probes-runbook.md",
+    "title": "Connectivity Probes Runbook",
+    "summary": "This runbook defines how maintainers operate provider endpoint connectivity probes in CI.",
+    "section": "operations",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/connectivity-probes-runbook.md"
+  },
+  {
+    "id": "docs-operations-docs-deploy-policy-md",
+    "path": "docs/operations/docs-deploy-policy.md",
+    "title": "Docs Deploy Policy",
+    "summary": "This document defines the promotion and rollback validation contract for docs deployment.",
+    "section": "operations",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/docs-deploy-policy.md"
+  },
+  {
+    "id": "docs-operations-docs-deploy-runbook-md",
+    "path": "docs/operations/docs-deploy-runbook.md",
+    "title": "Docs Deploy Runbook",
+    "summary": "Workflow: .github/workflows/docs-deploy.yml",
+    "section": "operations",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/docs-deploy-runbook.md"
+  },
+  {
+    "id": "docs-operations-feature-matrix-runbook-md",
+    "path": "docs/operations/feature-matrix-runbook.md",
+    "title": "Feature Matrix Runbook",
+    "summary": "This runbook defines the feature matrix CI lanes used to validate key compile combinations.",
+    "section": "operations",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/feature-matrix-runbook.md"
+  },
+  {
+    "id": "docs-operations-ghcr-tag-policy-md",
+    "path": "docs/operations/ghcr-tag-policy.md",
+    "title": "GHCR Tag Policy",
+    "summary": "This document defines the production container tag contract for .github/workflows/pub-docker-img.yml.",
+    "section": "operations",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/ghcr-tag-policy.md"
+  },
+  {
+    "id": "docs-operations-ghcr-vulnerability-policy-md",
+    "path": "docs/operations/ghcr-vulnerability-policy.md",
+    "title": "GHCR Vulnerability Gate Policy",
+    "summary": "This document defines the vulnerability scanning gate contract for GHCR release publishes.",
+    "section": "operations",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/ghcr-vulnerability-policy.md"
+  },
+  {
+    "id": "docs-operations-nightly-all-features-runbook-md",
+    "path": "docs/operations/nightly-all-features-runbook.md",
+    "title": "Nightly All-Features Runbook",
+    "summary": "This runbook describes the nightly integration matrix execution and reporting flow.",
+    "section": "operations",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/nightly-all-features-runbook.md"
+  },
+  {
+    "id": "docs-operations-prerelease-stage-gates-md",
+    "path": "docs/operations/prerelease-stage-gates.md",
+    "title": "Pre-release Stage Gates",
+    "summary": "Workflow: .github/workflows/pub-prerelease.yml",
+    "section": "operations",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/prerelease-stage-gates.md"
+  },
+  {
+    "id": "docs-operations-readme-md",
+    "path": "docs/operations/README.md",
+    "title": "Operations & Deployment Docs",
+    "summary": "For operators running ZeroClaw in persistent or production-like environments.",
+    "section": "operations",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/README.md"
+  },
+  {
+    "id": "docs-operations-required-check-mapping-md",
+    "path": "docs/operations/required-check-mapping.md",
+    "title": "Required Check Mapping",
+    "summary": "This document maps merge-critical workflows to expected check names.",
+    "section": "operations",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/required-check-mapping.md"
+  },
+  {
+    "id": "docs-pr-workflow-md",
+    "path": "docs/pr-workflow.md",
+    "title": "ZeroClaw PR Workflow (High-Volume Collaboration)",
+    "summary": "This document defines how ZeroClaw handles high PR volume while maintaining:",
+    "section": "pr-workflow.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/pr-workflow.md"
+  },
+  {
+    "id": "docs-project-triage-snapshot-2026-02-18-md",
+    "path": "docs/project-triage-snapshot-2026-02-18.md",
+    "title": "ZeroClaw Project Triage Snapshot (2026-02-18)",
+    "summary": "As-of date: February 18, 2026.",
+    "section": "project-triage-snapshot-2026-02-18.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/project-triage-snapshot-2026-02-18.md"
+  },
+  {
+    "id": "docs-project-readme-md",
+    "path": "docs/project/README.md",
+    "title": "Project Snapshot & Triage Docs",
+    "summary": "Time-bound project status snapshots for planning documentation and operations work.",
+    "section": "project",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/project/README.md"
+  },
+  {
+    "id": "docs-providers-reference-md",
+    "path": "docs/providers-reference.md",
+    "title": "ZeroClaw Providers Reference",
+    "summary": "This document maps provider IDs, aliases, and credential environment variables.",
+    "section": "providers-reference.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/providers-reference.md"
+  },
+  {
+    "id": "docs-proxy-agent-playbook-md",
+    "path": "docs/proxy-agent-playbook.md",
+    "title": "Proxy Agent Playbook",
+    "summary": "This playbook provides copy-paste tool calls for configuring proxy behavior via proxyconfig.",
+    "section": "proxy-agent-playbook.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/proxy-agent-playbook.md"
+  },
+  {
+    "id": "docs-qwen-provider-test-report-md",
+    "path": "docs/qwen-provider-test-report.md",
+    "title": "Qwen Provider Integration Test Report",
+    "summary": "Qwen OAuth integration has been successfully validated and configured for ZeroClaw. The provider is ready for production use with the following characteristics:",
+    "section": "qwen-provider-test-report.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/qwen-provider-test-report.md"
+  },
+  {
+    "id": "docs-readme-md",
+    "path": "docs/README.md",
+    "title": "ZeroClaw Documentation Hub",
+    "summary": "This page is the primary entry point for the documentation system.",
+    "section": "README.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/README.md"
+  },
+  {
+    "id": "docs-reference-readme-md",
+    "path": "docs/reference/README.md",
+    "title": "Reference Catalogs",
+    "summary": "Structured reference index for commands, providers, channels, config, and integration guides.",
+    "section": "reference",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/reference/README.md"
+  },
+  {
+    "id": "docs-release-process-md",
+    "path": "docs/release-process.md",
+    "title": "ZeroClaw Release Process",
+    "summary": "This runbook defines the maintainers' standard release flow.",
+    "section": "release-process.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/release-process.md"
+  },
+  {
+    "id": "docs-resource-limits-md",
+    "path": "docs/resource-limits.md",
+    "title": "Resource Limits for ZeroClaw",
+    "summary": "ZeroClaw has rate limiting (20 actions/hour) but no resource caps. A runaway agent could:",
+    "section": "resource-limits.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/resource-limits.md"
+  },
+  {
+    "id": "docs-reviewer-playbook-md",
+    "path": "docs/reviewer-playbook.md",
+    "title": "Reviewer Playbook",
+    "summary": "This playbook is the operational companion to docs/pr-workflow.md.",
+    "section": "reviewer-playbook.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/reviewer-playbook.md"
+  },
+  {
+    "id": "docs-sandboxing-md",
+    "path": "docs/sandboxing.md",
+    "title": "ZeroClaw Sandboxing Strategies",
+    "summary": "ZeroClaw currently has application-layer security (allowlists, path blocking, command injection protection) but lacks OS-level containment. If an attacker is on the allowlist, they can run any allowed command with zerocl",
+    "section": "sandboxing.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/sandboxing.md"
+  },
+  {
+    "id": "docs-security-roadmap-md",
+    "path": "docs/security-roadmap.md",
+    "title": "ZeroClaw Security Improvement Roadmap",
+    "summary": "ZeroClaw already has excellent application-layer security:",
+    "section": "security-roadmap.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security-roadmap.md"
+  },
+  {
+    "id": "docs-security-advisory-maintainer-checklist-md",
+    "path": "docs/security/advisory-maintainer-checklist.md",
+    "title": "Security Advisory Maintainer Checklist",
+    "summary": "Use this checklist for high-impact vulnerabilities from private intake through disclosure.",
+    "section": "security",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/advisory-maintainer-checklist.md"
+  },
+  {
+    "id": "docs-security-advisory-maintainer-checklist-zh-cn-md",
+    "path": "docs/security/advisory-maintainer-checklist.zh-CN.md",
+    "title": "Security Advisory 维护者检查清单（中文）",
+    "summary": "本清单用于高影响安全漏洞从私密受理到公开披露的全流程执行。",
+    "section": "security",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/advisory-maintainer-checklist.zh-CN.md"
+  },
+  {
+    "id": "docs-security-advisory-metadata-template-md",
+    "path": "docs/security/advisory-metadata-template.md",
+    "title": "Security Advisory Metadata Template",
+    "summary": "Use this template when preparing advisory metadata before publication.",
+    "section": "security",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/advisory-metadata-template.md"
+  },
+  {
+    "id": "docs-security-advisory-metadata-template-zh-cn-md",
+    "path": "docs/security/advisory-metadata-template.zh-CN.md",
+    "title": "Security Advisory 元数据模板（中文）",
+    "summary": "用于发布前整理 advisory 元数据，确保字段完整且可被下游消费。",
+    "section": "security",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/advisory-metadata-template.zh-CN.md"
+  },
+  {
+    "id": "docs-security-private-vulnerability-report-template-md",
+    "path": "docs/security/private-vulnerability-report-template.md",
+    "title": "Private Vulnerability Report Template",
+    "summary": "Use this template when filing a private report via:",
+    "section": "security",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/private-vulnerability-report-template.md"
+  },
+  {
+    "id": "docs-security-private-vulnerability-report-template-zh-cn-md",
+    "path": "docs/security/private-vulnerability-report-template.zh-CN.md",
+    "title": "私密漏洞报告模板（中文）",
+    "summary": "Project documentation.",
+    "section": "security",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/private-vulnerability-report-template.zh-CN.md"
+  },
+  {
+    "id": "docs-security-readme-md",
+    "path": "docs/security/README.md",
+    "title": "Security Docs",
+    "summary": "This section mixes current hardening guidance and proposal/roadmap documents.",
+    "section": "security",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/README.md"
+  },
+  {
+    "id": "docs-security-syscall-anomaly-detection-md",
+    "path": "docs/security/syscall-anomaly-detection.md",
+    "title": "Syscall Anomaly Detection",
+    "summary": "ZeroClaw can monitor syscall-related telemetry emitted by sandboxed command execution",
+    "section": "security",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/syscall-anomaly-detection.md"
+  },
+  {
+    "id": "docs-sop-connectivity-md",
+    "path": "docs/sop/connectivity.md",
+    "title": "SOP Connectivity & Event Fan-In",
+    "summary": "This document describes how external events trigger SOP runs.",
+    "section": "sop",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/sop/connectivity.md"
+  },
+  {
+    "id": "docs-sop-cookbook-md",
+    "path": "docs/sop/cookbook.md",
+    "title": "SOP Cookbook",
+    "summary": "Practical SOP templates in the runtime-supported SOP.toml + SOP.md format.",
+    "section": "sop",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/sop/cookbook.md"
+  },
+  {
+    "id": "docs-sop-observability-md",
+    "path": "docs/sop/observability.md",
+    "title": "SOP Observability & Audit",
+    "summary": "This page covers where SOP execution evidence is stored and how to inspect it.",
+    "section": "sop",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/sop/observability.md"
+  },
+  {
+    "id": "docs-sop-readme-md",
+    "path": "docs/sop/README.md",
+    "title": "Standard Operating Procedures (SOP)",
+    "summary": "SOPs are deterministic procedures executed by the SopEngine. They provide explicit trigger matching, approval gates, and auditable run state.",
+    "section": "sop",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/sop/README.md"
+  },
+  {
+    "id": "docs-sop-syntax-md",
+    "path": "docs/sop/syntax.md",
+    "title": "SOP Syntax Reference",
+    "summary": "SOP definitions are loaded from subdirectories under sopsdir (default: /sops).",
+    "section": "sop",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/sop/syntax.md"
+  },
+  {
+    "id": "docs-structure-readme-md",
+    "path": "docs/structure/README.md",
+    "title": "ZeroClaw Docs Structure Map",
+    "summary": "This page defines the canonical documentation layout and compatibility layers.",
+    "section": "structure",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/structure/README.md"
+  },
+  {
+    "id": "docs-summary-el-md",
+    "path": "docs/SUMMARY.el.md",
+    "title": "Σύνοψη τεκμηρίωσης ZeroClaw (Ενιαίος πίνακας περιεχομένων)",
+    "summary": "Αυτό το αρχείο αποτελεί τον κανονικό (canonical) πίνακα περιεχομένων για το σύστημα τεκμηρίωσης.",
+    "section": "SUMMARY.el.md",
+    "language": "el",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.el.md"
+  },
+  {
+    "id": "docs-summary-fr-md",
+    "path": "docs/SUMMARY.fr.md",
+    "title": "Sommaire de la documentation ZeroClaw (Table des matières unifiée)",
+    "summary": "Ce fichier constitue la table des matières canonique du système de documentation.",
+    "section": "SUMMARY.fr.md",
+    "language": "fr",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.fr.md"
+  },
+  {
+    "id": "docs-summary-ja-md",
+    "path": "docs/SUMMARY.ja.md",
+    "title": "ZeroClaw ドキュメント目次（統合目次）",
+    "summary": "このファイルはドキュメントシステムの正規目次です。",
+    "section": "SUMMARY.ja.md",
+    "language": "ja",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.ja.md"
+  },
+  {
+    "id": "docs-summary-md",
+    "path": "docs/SUMMARY.md",
+    "title": "ZeroClaw Docs Summary (Unified TOC)",
+    "summary": "This file is the canonical table of contents for the documentation system.",
+    "section": "SUMMARY.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.md"
+  },
+  {
+    "id": "docs-summary-ru-md",
+    "path": "docs/SUMMARY.ru.md",
+    "title": "Содержание документации ZeroClaw (Единое оглавление)",
+    "summary": "Этот файл является каноническим оглавлением системы документации.",
+    "section": "SUMMARY.ru.md",
+    "language": "ru",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.ru.md"
+  },
+  {
+    "id": "docs-summary-vi-md",
+    "path": "docs/SUMMARY.vi.md",
+    "title": "Tóm tắt tài liệu ZeroClaw (Mục lục hợp nhất)",
+    "summary": "Tệp này là mục lục chuẩn của hệ thống tài liệu.",
+    "section": "SUMMARY.vi.md",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.vi.md"
+  },
+  {
+    "id": "docs-summary-zh-cn-md",
+    "path": "docs/SUMMARY.zh-CN.md",
+    "title": "ZeroClaw 文档目录（统一目录）",
+    "summary": "Project documentation.",
+    "section": "SUMMARY.zh-CN.md",
+    "language": "zh-CN",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.zh-CN.md"
+  },
+  {
+    "id": "docs-troubleshooting-md",
+    "path": "docs/troubleshooting.md",
+    "title": "ZeroClaw Troubleshooting",
+    "summary": "This guide focuses on common setup/runtime failures and fast resolution paths.",
+    "section": "troubleshooting.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/troubleshooting.md"
+  },
+  {
+    "id": "docs-troubleshooting-vi-md",
+    "path": "docs/troubleshooting.vi.md",
+    "title": "Vietnamese Troubleshooting (Moved)",
+    "summary": "Compatibility shim only.",
+    "section": "troubleshooting.vi.md",
+    "language": "vi",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/troubleshooting.vi.md"
+  },
+  {
+    "id": "docs-vi-datasheets-readme-md",
+    "path": "docs/vi/datasheets/README.md",
+    "title": "Vietnamese Datasheets Compatibility Index",
+    "summary": "This compatibility path redirects to canonical Vietnamese datasheets:",
+    "section": "vi",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/vi/datasheets/README.md"
+  },
+  {
+    "id": "docs-zai-glm-setup-md",
+    "path": "docs/zai-glm-setup.md",
+    "title": "Z.AI GLM Setup",
+    "summary": "ZeroClaw supports Z.AI's GLM models through OpenAI-compatible endpoints.",
+    "section": "zai-glm-setup.md",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/zai-glm-setup.md"
+  },
+  {
+    "id": "readme-md",
+    "path": "README.md",
+    "title": "Benchmark Snapshot (ZeroClaw vs OpenClaw, Reproducible)",
+    "summary": "⚡️ Runs on $10 hardware with",
+    "section": "root",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/README.md"
+  },
+  {
+    "id": "run-tests-md",
+    "path": "RUN_TESTS.md",
+    "title": "🧪 Test Execution Guide",
+    "summary": "1. Select Telegram channel",
+    "section": "root",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/RUN_TESTS.md"
+  },
+  {
+    "id": "security-md",
+    "path": "SECURITY.md",
+    "title": "Security Policy",
+    "summary": "Please do not open public GitHub issues for unpatched security vulnerabilities.",
+    "section": "root",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/SECURITY.md"
+  },
+  {
+    "id": "testing-telegram-md",
+    "path": "TESTING_TELEGRAM.md",
+    "title": "Telegram Integration Testing Guide",
+    "summary": "This guide covers testing the Telegram channel integration for ZeroClaw.",
+    "section": "root",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/TESTING_TELEGRAM.md"
+  },
+  {
+    "id": "trademark-md",
+    "path": "TRADEMARK.md",
+    "title": "ZeroClaw Trademark Policy",
+    "summary": "The following are trademarks of ZeroClaw Labs:",
+    "section": "root",
+    "language": "en",
+    "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/TRADEMARK.md"
+  }
+]

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -25,7 +25,7 @@
   --shadow-lg: 0 14px 40px rgba(0, 0, 0, 0.5);
   --shadow-md: 0 6px 20px rgba(0, 0, 0, 0.36);
 
-  --container: min(1240px, calc(100% - 2rem));
+  --container: min(1320px, calc(100% - 2rem));
 }
 
 :root[data-theme="light"] {
@@ -86,7 +86,8 @@ a {
 }
 
 button,
-input {
+input,
+select {
   font: inherit;
 }
 
@@ -96,7 +97,8 @@ button {
 
 button:focus-visible,
 a:focus-visible,
-input:focus-visible {
+input:focus-visible,
+select:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
@@ -444,7 +446,7 @@ main {
 .docs-head p {
   margin: 0.36rem 0 0;
   color: var(--text-muted);
-  max-width: 76ch;
+  max-width: 86ch;
 }
 
 .workspace-meta {
@@ -470,12 +472,13 @@ main {
 
 .docs-toolbar {
   margin-top: 0.72rem;
-  display: flex;
+  display: grid;
   gap: 0.56rem;
+  grid-template-columns: minmax(220px, 1fr) minmax(130px, 180px) minmax(130px, 180px) auto;
 }
 
-.docs-toolbar input {
-  flex: 1;
+.docs-toolbar input,
+.docs-toolbar select {
   min-width: 0;
   min-height: 42px;
   border-radius: 9px;
@@ -489,43 +492,39 @@ main {
   color: var(--text-muted);
 }
 
-.category-row {
-  margin-top: 0.72rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.42rem;
-}
-
-.category-row button {
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 0.78rem;
-  padding: 0.3rem 0.66rem;
-}
-
-.category-row button.active {
-  color: var(--text);
-  border-color: var(--line-strong);
-  background: color-mix(in srgb, var(--accent-soft) 72%, transparent);
-}
-
 .workspace-grid {
   margin-top: 0.76rem;
   display: grid;
-  grid-template-columns: minmax(270px, 350px) minmax(0, 1fr);
+  grid-template-columns: minmax(240px, 320px) minmax(0, 1fr) minmax(220px, 280px);
   align-items: start;
   gap: 0.75rem;
 }
 
-.doc-list {
+.doc-list,
+.doc-reader,
+.reader-side .side-card {
   border: 1px solid var(--line);
   border-radius: var(--radius-l);
-  background: color-mix(in srgb, var(--bg) 84%, transparent);
+  background: color-mix(in srgb, var(--bg-elevated) 92%, transparent);
+}
+
+.doc-list {
   padding: 0.52rem;
-  max-height: min(72vh, 860px);
+  max-height: min(76vh, 940px);
   overflow: auto;
+}
+
+.doc-group + .doc-group {
+  margin-top: 0.66rem;
+}
+
+.doc-group > h3 {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  padding: 0.28rem 0.36rem;
 }
 
 .doc-item {
@@ -589,11 +588,10 @@ main {
 }
 
 .doc-reader {
-  border: 1px solid var(--line);
-  border-radius: var(--radius-l);
-  background: color-mix(in srgb, var(--bg-elevated) 94%, transparent);
-  min-height: 520px;
+  min-height: 620px;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 .reader-head {
@@ -654,8 +652,30 @@ main {
 }
 
 .markdown-body {
+  flex: 1;
+  overflow: auto;
   padding: 0.95rem 0.96rem 1.2rem;
   color: var(--text-soft);
+}
+
+.markdown-body.width-normal {
+  max-width: 860px;
+}
+
+.markdown-body.width-wide {
+  max-width: 1160px;
+}
+
+.markdown-body.size-compact {
+  font-size: 0.92rem;
+}
+
+.markdown-body.size-comfortable {
+  font-size: 1rem;
+}
+
+.markdown-body.size-relaxed {
+  font-size: 1.08rem;
 }
 
 .markdown-body > *:first-child {
@@ -757,6 +777,123 @@ main {
   border: 1px solid var(--line);
 }
 
+.reader-nav {
+  border-top: 1px solid var(--line);
+  padding: 0.62rem 0.96rem;
+  display: flex;
+  gap: 0.42rem;
+  justify-content: flex-end;
+  background: color-mix(in srgb, var(--bg-soft) 90%, transparent);
+}
+
+.reader-nav button {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg) 90%, transparent);
+  color: var(--text-soft);
+  min-height: 34px;
+  padding: 0 0.65rem;
+  font-size: 0.8rem;
+}
+
+.reader-nav button:disabled {
+  opacity: 0.46;
+  cursor: not-allowed;
+}
+
+.reader-side {
+  display: grid;
+  gap: 0.72rem;
+  align-content: start;
+}
+
+.reader-side .side-card {
+  padding: 0.7rem;
+}
+
+.side-card h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.9rem;
+}
+
+.side-card p {
+  margin: 0.45rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.toc-list {
+  list-style: none;
+  margin: 0.56rem 0 0;
+  padding: 0;
+  max-height: 320px;
+  overflow: auto;
+}
+
+.toc-list li + li {
+  margin-top: 0.22rem;
+}
+
+.toc-list li[data-level="2"] {
+  margin-left: 0.65rem;
+}
+
+.toc-list li[data-level="3"] {
+  margin-left: 1.1rem;
+}
+
+.toc-list button {
+  width: 100%;
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  padding: 0.3rem 0.42rem;
+  font-size: 0.78rem;
+}
+
+.toc-list button:hover {
+  color: var(--text);
+  border-color: var(--line);
+  background: color-mix(in srgb, var(--accent-soft) 54%, transparent);
+}
+
+.side-control + .side-control {
+  margin-top: 0.58rem;
+}
+
+.side-control > p {
+  margin: 0;
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.pill-row {
+  margin-top: 0.3rem;
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+}
+
+.pill-row button {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 0.74rem;
+  min-height: 30px;
+  padding: 0 0.56rem;
+}
+
+.pill-row button.active {
+  color: var(--text);
+  border-color: var(--line-strong);
+  background: color-mix(in srgb, var(--accent-soft) 72%, transparent);
+}
+
 .footer {
   width: var(--container);
   margin: 1rem auto 1.7rem;
@@ -843,6 +980,17 @@ main {
   box-shadow: var(--shadow-md);
 }
 
+@media (max-width: 1240px) {
+  .workspace-grid {
+    grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
+  }
+
+  .reader-side {
+    grid-column: span 2;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 1120px) {
   .hero-layout {
     grid-template-columns: 1fr;
@@ -860,8 +1008,21 @@ main {
     grid-template-columns: 1fr;
   }
 
+  .reader-side {
+    grid-column: auto;
+    grid-template-columns: 1fr;
+  }
+
   .doc-list {
-    max-height: 320px;
+    max-height: 360px;
+  }
+
+  .docs-toolbar {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .docs-toolbar input {
+    grid-column: span 2;
   }
 }
 
@@ -885,7 +1046,7 @@ main {
 
 @media (max-width: 640px) {
   :root {
-    --container: min(1240px, calc(100% - 1rem));
+    --container: min(1320px, calc(100% - 1rem));
   }
 
   main {
@@ -898,7 +1059,11 @@ main {
   }
 
   .docs-toolbar {
-    flex-direction: column;
+    grid-template-columns: 1fr;
+  }
+
+  .docs-toolbar input {
+    grid-column: auto;
   }
 
   .reader-head {


### PR DESCRIPTION
## Linked Linear
- RMN-169

## Summary
### Problem
The GitHub Pages docs site still lacks full in-page rendering of the repository markdown corpus, making direct reading and navigation incomplete.

### Why It Matters
Users should be able to browse and read ZeroClaw docs directly on Pages with high readability and clear information architecture.

### What Changed
- Added generated docs manifest pipeline for all markdown docs.
- Added static docs-content packaging for Pages runtime markdown loading.
- Updated docs workspace UI to consume generated manifest and render docs directly in-page.

## Validation Evidence
### Commands
- `cd site && npm install --include=dev`
- `cd site && npm run build`

### Results
- Build succeeds.
- Manifest generation reports 386 markdown entries copied/indexed.
- Production assets generated under `gh-pages/`.

## Security Impact
### Risk
Low. Frontend/docs static rendering only.

### Mitigation
- No new backend endpoints or credential handling.
- Repository-controlled markdown/assets only.

## Privacy and Data Hygiene
- No PII collection added.
- No external analytics added.

## Rollback Plan
1. Revert this PR on `main`.
2. Re-run Pages deploy workflow.
3. Verify previous site is served.
