### PR TITLE
RMN-169: feat(site): ship taxonomy-first docs reading UX

### DIFF
--- a/site/src/generated/docs-manifest.json
+++ b/site/src/generated/docs-manifest.json
@@ -6,6 +6,17 @@
     "summary": "This file defines the default working protocol for coding agents in this repository.",
     "section": "root",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "newcomer",
+      "root",
+      "start"
+    ],
+    "readingMinutes": 16,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/AGENTS.md"
   },
   {
@@ -15,6 +26,17 @@
     "summary": "All notable changes to ZeroClaw will be documented in this file.",
     "section": "root",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "newcomer",
+      "root",
+      "start"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/CHANGELOG.md"
   },
   {
@@ -24,6 +46,17 @@
     "summary": "This Contributor License Agreement (\"CLA\") clarifies the intellectual",
     "section": "root",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "newcomer",
+      "root",
+      "start"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/CLA.md"
   },
   {
@@ -33,6 +66,17 @@
     "summary": "This file defines the default working protocol for Claude agents in this repository.",
     "section": "root",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "newcomer",
+      "root",
+      "start"
+    ],
+    "readingMinutes": 16,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/CLAUDE.md"
   },
   {
@@ -42,6 +86,18 @@
     "summary": "We as members, contributors, and leaders pledge to make participation in our",
     "section": "root",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "newcomer",
+      "operations",
+      "root",
+      "start"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/CODE_OF_CONDUCT.md"
   },
   {
@@ -51,6 +107,18 @@
     "summary": "Σας ευχαριστούμε για το ενδιαφέρον σας να συνεισφέρετε στο ZeroClaw! Αυτός ο οδηγός θα σας βοηθήσει να ξεκινήσετε.",
     "section": "root",
     "language": "el",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "guide",
+      "newcomer",
+      "root",
+      "start"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/CONTRIBUTING.el.md"
   },
   {
@@ -60,6 +128,18 @@
     "summary": "Thanks for your interest in contributing to ZeroClaw! This guide will help you get started.",
     "section": "root",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "guide",
+      "newcomer",
+      "root",
+      "start"
+    ],
+    "readingMinutes": 11,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/CONTRIBUTING.md"
   },
   {
@@ -69,6 +149,17 @@
     "summary": "This document defines the current GitHub Actions source-control policy for this repository.",
     "section": "actions-source-policy.md",
     "language": "en",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "policy",
+    "tags": [
+      "actions-source-policy.md",
+      "build",
+      "builder",
+      "policy"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/actions-source-policy.md"
   },
   {
@@ -78,6 +169,18 @@
     "summary": "This guide explains how to add new hardware boards and custom tools to ZeroClaw.",
     "section": "adding-boards-and-tools.md",
     "language": "en",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "guide",
+    "tags": [
+      "adding-boards-and-tools.md",
+      "build",
+      "builder",
+      "guide",
+      "hardware"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/adding-boards-and-tools.md"
   },
   {
@@ -87,6 +190,17 @@
     "summary": "1. ❓ Fast cross-compilation builds?",
     "section": "agnostic-security.md",
     "language": "en",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "guide",
+    "tags": [
+      "agnostic-security.md",
+      "guide",
+      "secure",
+      "security"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/agnostic-security.md"
   },
   {
@@ -96,6 +210,18 @@
     "summary": "ZeroClaw provides prebuilt binaries for Android devices.",
     "section": "android-setup.md",
     "language": "en",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "guide",
+    "tags": [
+      "android-setup.md",
+      "build",
+      "builder",
+      "guide",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/android-setup.md"
   },
   {
@@ -105,6 +231,17 @@
     "summary": "Run ZeroClaw on the Arduino Uno Q's Linux side. Telegram works over WiFi; GPIO control uses the Bridge (requires a minimal App Lab app).",
     "section": "arduino-uno-q-setup.md",
     "language": "en",
+    "journey": "hardware",
+    "audience": "hardware",
+    "kind": "guide",
+    "tags": [
+      "arduino-uno-q-setup.md",
+      "guide",
+      "hardware",
+      "onboarding"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/arduino-uno-q-setup.md"
   },
   {
@@ -114,6 +251,18 @@
     "summary": "This document defines the normalized audit event envelope used by CI/CD and security workflows.",
     "section": "audit-event-schema.md",
     "language": "en",
+    "journey": "reference",
+    "audience": "builder",
+    "kind": "reference",
+    "tags": [
+      "audit-event-schema.md",
+      "builder",
+      "operations",
+      "reference",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/audit-event-schema.md"
   },
   {
@@ -123,6 +272,17 @@
     "summary": "ZeroClaw logs actions but lacks tamper-evident audit trails for:",
     "section": "audit-logging.md",
     "language": "en",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "guide",
+    "tags": [
+      "audit-logging.md",
+      "guide",
+      "secure",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/audit-logging.md"
   },
   {
@@ -132,6 +292,17 @@
     "summary": "cargo-slicer is a RUSTCWRAPPER that stubs unreachable library functions at the MIR level, skipping LLVM codegen for code the final binary never calls.",
     "section": "cargo-slicer-speedup.md",
     "language": "en",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "guide",
+    "tags": [
+      "build",
+      "builder",
+      "cargo-slicer-speedup.md",
+      "guide"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/cargo-slicer-speedup.md"
   },
   {
@@ -141,6 +312,16 @@
     "summary": "This document is the canonical reference for channel configuration in ZeroClaw.",
     "section": "channels-reference.md",
     "language": "en",
+    "journey": "reference",
+    "audience": "builder",
+    "kind": "reference",
+    "tags": [
+      "builder",
+      "channels-reference.md",
+      "reference"
+    ],
+    "readingMinutes": 11,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/channels-reference.md"
   },
   {
@@ -150,6 +331,18 @@
     "summary": "This document explains what each GitHub workflow does, when it runs, and whether it should block merges.",
     "section": "ci-map.md",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "guide",
+    "tags": [
+      "ci-map.md",
+      "guide",
+      "operate",
+      "operations",
+      "operator"
+    ],
+    "readingMinutes": 9,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/ci-map.md"
   },
   {
@@ -159,6 +352,16 @@
     "summary": "This reference is derived from the current CLI surface (zeroclaw --help).",
     "section": "commands-reference.md",
     "language": "en",
+    "journey": "reference",
+    "audience": "builder",
+    "kind": "reference",
+    "tags": [
+      "builder",
+      "commands-reference.md",
+      "reference"
+    ],
+    "readingMinutes": 6,
+    "startHere": true,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/commands-reference.md"
   },
   {
@@ -168,6 +371,16 @@
     "summary": "Compatibility shim only.",
     "section": "commands-reference.vi.md",
     "language": "vi",
+    "journey": "reference",
+    "audience": "builder",
+    "kind": "reference",
+    "tags": [
+      "builder",
+      "commands-reference.vi.md",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/commands-reference.vi.md"
   },
   {
@@ -177,6 +390,16 @@
     "summary": "This is a high-signal reference for common config sections and defaults.",
     "section": "config-reference.md",
     "language": "en",
+    "journey": "reference",
+    "audience": "builder",
+    "kind": "reference",
+    "tags": [
+      "builder",
+      "config-reference.md",
+      "reference"
+    ],
+    "readingMinutes": 24,
+    "startHere": true,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/config-reference.md"
   },
   {
@@ -186,6 +409,16 @@
     "summary": "Compatibility shim only.",
     "section": "config-reference.vi.md",
     "language": "vi",
+    "journey": "reference",
+    "audience": "builder",
+    "kind": "reference",
+    "tags": [
+      "builder",
+      "config-reference.vi.md",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/config-reference.vi.md"
   },
   {
@@ -195,6 +428,19 @@
     "summary": "For contributors, reviewers, and maintainers.",
     "section": "contributing",
     "language": "en",
+    "journey": "contribute",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contribute",
+      "contributing",
+      "contributor",
+      "guide",
+      "onboarding",
+      "operations"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/contributing/README.md"
   },
   {
@@ -204,6 +450,19 @@
     "summary": "ZeroClaw supports custom API endpoints for both OpenAI-compatible and Anthropic-compatible providers.",
     "section": "custom-providers.md",
     "language": "en",
+    "journey": "integrate",
+    "audience": "integrator",
+    "kind": "guide",
+    "tags": [
+      "custom-providers.md",
+      "guide",
+      "integrate",
+      "integrations",
+      "integrator",
+      "reference"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/custom-providers.md"
   },
   {
@@ -213,6 +472,16 @@
     "summary": "Arduino Uno is a microcontroller board based on the ATmega328P. It has 14 digital I/O pins (0–13) and 6 analog inputs (A0–A5).",
     "section": "datasheets",
     "language": "en",
+    "journey": "hardware",
+    "audience": "hardware",
+    "kind": "guide",
+    "tags": [
+      "datasheets",
+      "guide",
+      "hardware"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/datasheets/arduino-uno.md"
   },
   {
@@ -222,6 +491,17 @@
     "summary": "ZeroClaw host sends JSON over serial (115200 baud):",
     "section": "datasheets",
     "language": "en",
+    "journey": "hardware",
+    "audience": "hardware",
+    "kind": "guide",
+    "tags": [
+      "datasheets",
+      "guide",
+      "hardware",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/datasheets/esp32.md"
   },
   {
@@ -231,6 +511,17 @@
     "summary": "Project documentation.",
     "section": "datasheets",
     "language": "en",
+    "journey": "hardware",
+    "audience": "hardware",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "datasheets",
+      "guide",
+      "hardware"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/datasheets/nucleo-f401re.md"
   },
   {
@@ -240,6 +531,18 @@
     "summary": "Board-level reference sheets for supported hardware.",
     "section": "datasheets",
     "language": "en",
+    "journey": "hardware",
+    "audience": "hardware",
+    "kind": "guide",
+    "tags": [
+      "datasheets",
+      "guide",
+      "hardware",
+      "onboarding",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/datasheets/README.md"
   },
   {
@@ -249,6 +552,17 @@
     "summary": "Use this template when adding a new operational or engineering document under docs/.",
     "section": "doc-template.md",
     "language": "en",
+    "journey": "contribute",
+    "audience": "contributor",
+    "kind": "template",
+    "tags": [
+      "contribute",
+      "contributor",
+      "doc-template.md",
+      "template"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/doc-template.md"
   },
   {
@@ -258,6 +572,19 @@
     "summary": "This guide explains how to run ZeroClaw in Docker mode, including bootstrap, onboarding, and daily usage.",
     "section": "docker-setup.md",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "deployment",
+      "docker-setup.md",
+      "guide",
+      "newcomer",
+      "onboarding",
+      "start"
+    ],
+    "readingMinutes": 2,
+    "startHere": true,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/docker-setup.md"
   },
   {
@@ -267,6 +594,19 @@
     "summary": "This snapshot records a deep documentation audit focused on completeness, navigation clarity, and i18n structure.",
     "section": "docs-audit-2026-02-24.md",
     "language": "en",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "report",
+    "tags": [
+      "build",
+      "builder",
+      "docs-audit-2026-02-24.md",
+      "i18n",
+      "report",
+      "security"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/docs-audit-2026-02-24.md"
   },
   {
@@ -276,6 +616,17 @@
     "summary": "This inventory classifies documentation by intent and canonical location.",
     "section": "docs-inventory.md",
     "language": "en",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "report",
+    "tags": [
+      "build",
+      "builder",
+      "docs-inventory.md",
+      "report"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/docs-inventory.md"
   },
   {
@@ -285,6 +636,18 @@
     "summary": "Only when user changes something:",
     "section": "frictionless-security.md",
     "language": "en",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "guide",
+    "tags": [
+      "build",
+      "builder",
+      "frictionless-security.md",
+      "guide",
+      "security"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/frictionless-security.md"
   },
   {
@@ -294,6 +657,18 @@
     "summary": "This page documents supported update and uninstall procedures for ZeroClaw on macOS (OS X).",
     "section": "getting-started",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "getting-started",
+      "guide",
+      "newcomer",
+      "onboarding",
+      "start"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/getting-started/macos-update-uninstall.md"
   },
   {
@@ -303,6 +678,18 @@
     "summary": "For first-time setup and quick orientation.",
     "section": "getting-started",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "getting-started",
+      "guide",
+      "newcomer",
+      "onboarding",
+      "start"
+    ],
+    "readingMinutes": 1,
+    "startHere": true,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/getting-started/README.md"
   },
   {
@@ -312,6 +699,18 @@
     "summary": "ZeroClaw enables microcontrollers (MCUs) and Single Board Computers (SBCs) to dynamically interpret natural language commands, generate hardware-specific code, and execute peripheral interactions in real-time.",
     "section": "hardware-peripherals-design.md",
     "language": "en",
+    "journey": "hardware",
+    "audience": "hardware",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "hardware",
+      "hardware-peripherals-design.md",
+      "operations",
+      "reference"
+    ],
+    "readingMinutes": 7,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/hardware-peripherals-design.md"
   },
   {
@@ -321,6 +720,16 @@
     "summary": "For board integration, firmware flow, and peripheral architecture.",
     "section": "hardware",
     "language": "en",
+    "journey": "hardware",
+    "audience": "hardware",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "hardware",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/hardware/README.md"
   },
   {
@@ -330,6 +739,18 @@
     "summary": "This document defines the localization structure for ZeroClaw docs and tracks current coverage.",
     "section": "i18n-coverage.md",
     "language": "en",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n-coverage.md",
+      "localize"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n-coverage.md"
   },
   {
@@ -339,6 +760,18 @@
     "summary": "This file tracks localization parity gaps and closure state.",
     "section": "i18n-gap-backlog.md",
     "language": "en",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n-gap-backlog.md",
+      "localize"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n-gap-backlog.md"
   },
   {
@@ -348,6 +781,18 @@
     "summary": "This guide defines how to keep multilingual documentation complete and consistent when docs change.",
     "section": "i18n-guide.md",
     "language": "en",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n-guide.md",
+      "localize"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n-guide.md"
   },
   {
@@ -357,6 +802,18 @@
     "summary": "Αυτό το έγγραφο ορίζει την πολιτική ελέγχου προέλευσης για τα GitHub Actions σε αυτό το αποθετήριο.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "policy"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/actions-source-policy.md"
   },
   {
@@ -366,6 +823,18 @@
     "summary": "Αυτός ο οδηγός εξηγεί πώς να προσθέσετε νέες πλακέτες υλικού και προσαρμοσμένα εργαλεία στο ZeroClaw.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/adding-boards-and-tools.md"
   },
   {
@@ -375,6 +844,19 @@
     "summary": "Θα προκαλέσουν οι λειτουργίες ασφαλείας προβλήματα στην:",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/agnostic-security.md"
   },
   {
@@ -384,6 +866,19 @@
     "summary": "Το ZeroClaw παρέχει προκατασκευασμένα εκτελέσιμα αρχεία (binaries) για συσκευές Android.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/android-setup.md"
   },
   {
@@ -393,6 +888,20 @@
     "summary": "Αυτός ο οδηγός περιγράφει τη διαδικασία εγκατάστασης και ρύθμισης του ZeroClaw στην πλευρά Linux του Arduino Uno Q.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/arduino-uno-q-setup.md"
   },
   {
@@ -402,6 +911,20 @@
     "summary": "Αυτή η σελίδα είναι συνοπτική τοπικοποιημένη γέφυρα για το σχήμα συμβάντων audit.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "operations",
+      "reference",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/audit-event-schema.md"
   },
   {
@@ -411,6 +934,19 @@
     "summary": "Το ZeroClaw απαιτεί έναν μηχανισμό καταγραφής ελέγχου (audit trails) με προστασία από παραποίηση, προκειμένου να τεκμηριώνονται:",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/audit-logging.md"
   },
   {
@@ -420,6 +956,18 @@
     "summary": "Το cargo-slicer είναι ένα εργαλείο βελτιστοποίησης που μειώνει τους χρόνους κατασκευής (build times) του ZeroClaw. Λειτουργεί αντικαθιστώντας αχρησιμοποίητες συναρτήσεις βιβλιοθηκών με κενές υλοποιήσεις (stubs), μειώνοντ",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/cargo-slicer-speedup.md"
   },
   {
@@ -429,6 +977,18 @@
     "summary": "Αυτός ο οδηγός περιγράφει τη διαδικασία διαμόρφωσης των καναλιών επικοινωνίας (Telegram, Discord, κ.λπ.) στο ZeroClaw.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/channels-reference.md"
   },
   {
@@ -438,6 +998,19 @@
     "summary": "Το παρόν έγγραφο περιγράφει τη δομή και τις λειτουργίες των αυτοματοποιημένων ελέγχων (GitHub Actions) στο ZeroClaw.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "operations"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/ci-map.md"
   },
   {
@@ -447,6 +1020,18 @@
     "summary": "Αυτός ο οδηγός περιλαμβάνει το πλήρες σύνολο των εντολών που είναι διαθέσιμες στη διεπαφή γραμμής εντολών (CLI) του ZeroClaw.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/commands-reference.md"
   },
   {
@@ -456,6 +1041,18 @@
     "summary": "Αυτός ο οδηγός εξηγεί τις πιο σημαντικές ρυθμίσεις που μπορείτε να κάνετε στο αρχείο config.toml.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/config-reference.md"
   },
   {
@@ -465,6 +1062,21 @@
     "summary": "Αυτός ο φάκελος περιέχει τεκμηρίωση για τους συνεισφέροντες (contributors), τους αναθεωρητές (reviewers) και τους συντηρητές (maintainers) του ZeroClaw.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding",
+      "operations"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/contributing/README.md"
   },
   {
@@ -474,6 +1086,20 @@
     "summary": "Το ZeroClaw σας επιτρέπει να συνδεθείτε με δικές σας υπηρεσίες AI, όπως τοπικούς διακομιστές ή εταιρικά δίκτυα.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "integrations",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/custom-providers.md"
   },
   {
@@ -483,6 +1109,19 @@
     "summary": "Το Arduino Uno είναι μια πλακέτα μικροελεγκτή βασισμένη στον ATmega328P. Διαθέτει 14 ψηφιακούς ακροδέκτες εισόδου/εξόδου (I/O) και 6 αναλογικές εισόδους (A0–A5).",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/el",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/datasheets/arduino-uno.md"
   },
   {
@@ -492,6 +1131,19 @@
     "summary": "Ο κεντρικός υπολογιστής (Host) του ZeroClaw επικοινωνεί μέσω σειριακής διεπαφής (115200 baud) χρησιμοποιώντας JSON:",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/el",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/datasheets/esp32.md"
   },
   {
@@ -501,6 +1153,20 @@
     "summary": "Project documentation.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/el",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/datasheets/nucleo-f401re.md"
   },
   {
@@ -510,6 +1176,20 @@
     "summary": "Συγκεντρωτικός κατάλογος φύλλων δεδομένων για τις υποστηριζόμενες πλακέτες.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/datasheets/README.md"
   },
   {
@@ -519,6 +1199,18 @@
     "summary": "Χρησιμοποιήστε αυτό το πρότυπο όταν θέλετε να γράψετε ένα νέο αρχείο βοήθειας ή τεχνικής αναφοράς στον φάκελο docs/.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "template",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "template"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/doc-template.md"
   },
   {
@@ -528,6 +1220,19 @@
     "summary": "Αυτή η σελίδα είναι συνοπτική τοπικοποιημένη γέφυρα για το audit snapshot της 2026-02-24.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "report",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/docs-audit-2026-02-24.md"
   },
   {
@@ -537,6 +1242,18 @@
     "summary": "Αυτή η σελίδα σας βοηθάει να βρείτε γρήγορα το έγγραφο που χρειάζεστε, ανάλογα με το τι θέλετε να κάνετε.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "report"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/docs-inventory.md"
   },
   {
@@ -546,6 +1263,19 @@
     "summary": "Αυτό το έγγραφο περιγράφει μια ιδέα για το πώς η ασφάλεια στο ZeroClaw μπορεί να γίνει \"σαν τον αερόσακο\": να είναι πάντα εκεί για να σας προστατεύει, αλλά να μην την βλέπετε μέχρι να χρειαστεί.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/frictionless-security.md"
   },
   {
@@ -555,6 +1285,19 @@
     "summary": "Αυτή η σελίδα τεκμηριώνει τις υποστηριζόμενες διαδικασίες ενημέρωσης και απεγκατάστασης του ZeroClaw στο macOS (OS X).",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/getting-started/macos-update-uninstall.md"
   },
   {
@@ -564,6 +1307,19 @@
     "summary": "Οδηγίες για την αρχική εγκατάσταση και την εξοικείωση με το οικοσύστημα του ZeroClaw.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/getting-started/README.md"
   },
   {
@@ -573,6 +1329,19 @@
     "summary": "Το ZeroClaw μπορεί να ελέγχει ηλεκτρονικές πλακέτες (όπως το Arduino, το ESP32 ή το Raspberry Pi) χρησιμοποιώντας απλά λόγια. Για παράδειγμα, μπορείτε να του πείτε \"Άναψε το λαμπάκι (LED)\" και αυτό θα βρει πώς να το κάνε",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/el",
+      "localize"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/hardware-peripherals-design.md"
   },
   {
@@ -582,6 +1351,20 @@
     "summary": "Οδηγίες για την ενσωμάτωση πλακετών, τη διαχείριση υλικολογισμικού (firmware) και την αρχιτεκτονική περιφερειακών του ZeroClaw.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/hardware/README.md"
   },
   {
@@ -591,6 +1374,18 @@
     "summary": "Αυτή η σελίδα είναι συνοπτική τοπικοποιημένη γέφυρα για τον πίνακα κάλυψης i18n.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/i18n-coverage.md"
   },
   {
@@ -600,6 +1395,18 @@
     "summary": "Αυτή η σελίδα είναι συνοπτική τοπικοποιημένη γέφυρα για το backlog κενών i18n.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/i18n-gap-backlog.md"
   },
   {
@@ -609,6 +1416,18 @@
     "summary": "Αυτή η σελίδα είναι συνοπτική τοπικοποιημένη γέφυρα για τον οδηγό i18n completion.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/i18n-guide.md"
   },
   {
@@ -618,6 +1437,19 @@
     "summary": "Αυτός ο οδηγός εξηγεί πώς να χρησιμοποιήσετε το πακέτο zeroclaw-tools στην Python για να κάνετε την AI πιο σταθερή όταν χρησιμοποιεί εργαλεία.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/langgraph-integration.md"
   },
   {
@@ -627,6 +1459,19 @@
     "summary": "Αυτός ο οδηγός σας βοηθάει να συνδέσετε το ZeroClaw με το Matrix και να λύσετε προβλήματα, ειδικά σε δωμάτια με κρυπτογράφηση (E2EE).",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/matrix-e2ee-guide.md"
   },
   {
@@ -636,6 +1481,20 @@
     "summary": "Το ZeroClaw παρέχει εγγενή υποστήριξη για το Mattermost μέσω του REST API v4. Η ενσωμάτωση αυτή είναι ιδανική για περιβάλλοντα αυτοφιλοξενούμενα (self-hosted), ιδιωτικά ή απομονωμένα (air-gapped), όπου η προστασία των δε",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/mattermost-setup.md"
   },
   {
@@ -645,6 +1504,19 @@
     "summary": "Αυτό το έγγραφο καλύπτει την ανάπτυξη του ZeroClaw σε ένα Raspberry Pi ή σε άλλον κεντρικό υπολογιστή στο τοπικό σας δίκτυο, με κανάλια Telegram και προαιρετικά κανάλια webhook.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "deployment",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/network-deployment.md"
   },
   {
@@ -654,6 +1526,20 @@
     "summary": "Αυτός ο οδηγός περιγράφει τη διαδικασία ενσωμάτωσης του Nextcloud Talk με το ZeroClaw.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/nextcloud-talk-setup.md"
   },
   {
@@ -663,6 +1549,20 @@
     "summary": "Εκτελέστε το ZeroClaw στον κεντρικό υπολογιστή σας (Mac ή Linux). Συνδέστε ένα Nucleo-F401RE μέσω USB. Ελέγξτε τα GPIO (LED, ακίδες) μέσω Telegram ή CLI.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/nucleo-setup.md"
   },
   {
@@ -672,6 +1572,19 @@
     "summary": "Αυτός ο οδηγός περιγράφει την ταχύτερη μέθοδο για την εγκατάσταση και την αρχικοποίηση του ZeroClaw.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/one-click-bootstrap.md"
   },
   {
@@ -681,6 +1594,19 @@
     "summary": "Αυτό το εγχειρίδιο προορίζεται για τους διαχειριστές του συστήματος που είναι υπεύθυνοι για τη διαθεσιμότητα, την ασφάλεια και την απόκριση σε περιστατικά.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/operations-runbook.md"
   },
   {
@@ -690,6 +1616,19 @@
     "summary": "Αυτή η σελίδα είναι συνοπτική τοπικοποιημένη γέφυρα για το runbook probes συνδεσιμότητας provider στο CI.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/operations/connectivity-probes-runbook.md"
   },
   {
@@ -699,6 +1638,21 @@
     "summary": "Τεχνική τεκμηρίωση για τον χειρισμό, τη συντήρηση και την ανάπτυξη του ZeroClaw σε περιβάλλοντα παραγωγής.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "deployment",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/operations/README.md"
   },
   {
@@ -708,6 +1662,20 @@
     "summary": "Αυτό το έγγραφο περιγράφει τη διαδικασία διαχείρισης των Pull Requests (PR) στο ZeroClaw, με στόχο τη διασφάλιση υψηλής απόδοσης, ασφάλειας και σταθερότητας του κώδικα.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "operations"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/pr-workflow.md"
   },
   {
@@ -717,6 +1685,19 @@
     "summary": "Το παρόν έγγραφο αποτελεί μια στατική καταγραφή των ανοιχτών αιτημάτων (PR) και ζητημάτων (Issues) με σκοπό την καθοδήγηση των εργασιών τεκμηρίωσης και της αρχιτεκτονικής πληροφοριών.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributing",
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "report"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/project-triage-snapshot-2026-02-18.md"
   },
   {
@@ -726,6 +1707,20 @@
     "summary": "Αυτή η ενότητα περιλαμβάνει χρονικά περιορισμένα στιγμιότυπα (snapshots) της κατάστασης του έργου για τον σχεδιασμό και τον συντονισμό των εργασιών.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/project/README.md"
   },
   {
@@ -735,6 +1730,18 @@
     "summary": "Αυτό το έγγραφο περιγράφει τα ID των παρόχων, τα ψευδώνυμα (aliases) και τις μεταβλητές περιβάλλοντος για τη διαχείριση των διαπιστευτηρίων.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/providers-reference.md"
   },
   {
@@ -744,6 +1751,19 @@
     "summary": "Αυτό το εγχειρίδιο περιέχει έτοιμες κλήσεις εργαλείων για τη διαμόρφωση της συμπεριφοράς διαμεσολάβησης (proxy) μέσω της ρύθμισης proxyconfig.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "reference",
+      "runbook"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/proxy-agent-playbook.md"
   },
   {
@@ -753,6 +1773,19 @@
     "summary": "Αυτή η σελίδα αποτελεί το κεντρικό σημείο πρόσβασης για το σύστημα τεκμηρίωσης του ZeroClaw.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/README.md"
   },
   {
@@ -762,6 +1795,19 @@
     "summary": "Δομημένο ευρετήριο τεχνικών αναφορών για εντολές CLI, παρόχους AI (Providers), κανάλια επικοινωνίας και παραμέτρους συστήματος.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/reference/README.md"
   },
   {
@@ -771,6 +1817,19 @@
     "summary": "Αυτό το εγχειρίδιο περιγράφει την τυπική ροή εργασιών έκδοσης νέων εκδόσεων για τους συντηρητές του ZeroClaw.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "operations",
+      "policy"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/release-process.md"
   },
   {
@@ -780,6 +1839,18 @@
     "summary": "Το ZeroClaw εφαρμόζει περιορισμό ρυθμού (Rate Limiting - 20 ενέργειες/ώρα), αλλά δεν διαθέτει ανώτατα όρια χρήσης πόρων συστήματος. Χωρίς αυτούς τους περιορισμούς, ένας πράκτορας ενδέχεται να:",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/resource-limits.md"
   },
   {
@@ -789,6 +1860,20 @@
     "summary": "Αυτό το εγχειρίδιο αποτελεί το λειτουργικό συμπλήρωμα του οδηγού PR Workflow.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributing",
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/reviewer-playbook.md"
   },
   {
@@ -798,6 +1883,19 @@
     "summary": "Το ZeroClaw εφαρμόζει ασφάλεια σε επίπεδο εφαρμογής (allowlists, path validation, injection prevention), αλλά δεν διαθέτει απομόνωση σε επίπεδο λειτουργικού συστήματος. Χωρίς sandboxing, ένας εξουσιοδοτημένος χρήστης μπο",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/sandboxing.md"
   },
   {
@@ -807,6 +1905,19 @@
     "summary": "Το ZeroClaw διαθέτει ήδη ισχυρά θεμέλια ασφάλειας στο επίπεδο της εφαρμογής:",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "policy",
+      "security"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/security-roadmap.md"
   },
   {
@@ -816,6 +1927,20 @@
     "summary": "Αυτή η ενότητα περιλαμβάνει οδηγούς θωράκισης (Hardening) για την τρέχουσα λειτουργία του συστήματος, καθώς και μελλοντικές προτάσεις ασφαλείας.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/security/README.md"
   },
   {
@@ -825,6 +1950,19 @@
     "summary": "Αυτό το έγγραφο περιγράφει πώς τα εξωτερικά συμβάντα ενεργοποιούν εκτελέσεις SOP.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/sop/connectivity.md"
   },
   {
@@ -834,6 +1972,19 @@
     "summary": "Πρακτικά πρότυπα SOP στη μορφή SOP.toml + SOP.md που υποστηρίζεται από το runtime.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/sop/cookbook.md"
   },
   {
@@ -843,6 +1994,19 @@
     "summary": "Αυτή η σελίδα καλύπτει πού αποθηκεύονται τα αποδεικτικά στοιχεία εκτέλεσης SOP και πώς να τα επιθεωρείτε.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/sop/observability.md"
   },
   {
@@ -852,6 +2016,20 @@
     "summary": "Οι SOPs είναι ντετερμινιστικές διαδικασίες που εκτελούνται από το SopEngine. Παρέχουν αντιστοίχιση ενεργοποιητών, πύλες έγκρισης και ελέγξιμη κατάσταση εκτέλεσης.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/sop/README.md"
   },
   {
@@ -861,6 +2039,19 @@
     "summary": "Οι ορισμοί SOP φορτώνονται από υποκαταλόγους κάτω από το sopsdir (προεπιλογή: /sops).",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/sop/syntax.md"
   },
   {
@@ -870,6 +2061,19 @@
     "summary": "Αυτή η σελίδα ορίζει τη δομή της τεκμηρίωσης κατά τρεις άξονες:",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/structure/README.md"
   },
   {
@@ -879,6 +2083,18 @@
     "summary": "Αυτό το αρχείο αποτελεί τον κεντρικό οδηγό πλοήγησης για το σύστημα τεκμηρίωσης.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/SUMMARY.md"
   },
   {
@@ -888,6 +2104,19 @@
     "summary": "Αυτός ο οδηγός περιγράφει λύσεις για κοινά ζητήματα εγκατάστασης και εκτέλεσης του ZeroClaw.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "localize",
+      "troubleshooting"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/troubleshooting.md"
   },
   {
@@ -897,6 +2126,20 @@
     "summary": "Το ZeroClaw υποστηρίζει τα μοντέλα GLM της Z.AI μέσω διεπαφών συμβατών με το OpenAI API.",
     "section": "i18n/el",
     "language": "el",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/el",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/el/zai-glm-setup.md"
   },
   {
@@ -906,6 +2149,18 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "policy"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/actions-source-policy.md"
   },
   {
@@ -915,6 +2170,18 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/adding-boards-and-tools.md"
   },
   {
@@ -924,6 +2191,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/agnostic-security.md"
   },
   {
@@ -933,6 +2213,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/android-setup.md"
   },
   {
@@ -942,6 +2235,20 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/arduino-uno-q-setup.md"
   },
   {
@@ -951,6 +2258,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "reference",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/audit-event-schema.md"
   },
   {
@@ -960,6 +2280,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/audit-logging.md"
   },
   {
@@ -969,6 +2302,18 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/cargo-slicer-speedup.md"
   },
   {
@@ -978,6 +2323,19 @@
     "summary": "Cette page est une localisation initiale Wave 1 pour les capacités de canaux et les chemins de configuration.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "operations",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/channels-reference.md"
   },
   {
@@ -987,6 +2345,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "operations"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/ci-map.md"
   },
   {
@@ -996,6 +2367,18 @@
     "summary": "Cette page est une localisation initiale Wave 1 pour retrouver rapidement les commandes CLI ZeroClaw.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/commands-reference.md"
   },
   {
@@ -1005,6 +2388,18 @@
     "summary": "Cette page est une localisation initiale Wave 1 pour les clés de configuration et les valeurs par défaut.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/config-reference.md"
   },
   {
@@ -1014,6 +2409,20 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "integrations",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/custom-providers.md"
   },
   {
@@ -1023,6 +2432,18 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "template",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "template"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/doc-template.md"
   },
   {
@@ -1032,6 +2453,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "report",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/docs-audit-2026-02-24.md"
   },
   {
@@ -1041,6 +2475,18 @@
     "summary": "Cette page sert d'index rapide des documents top-level dans docs/i18n/fr/.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "report"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/docs-inventory.md"
   },
   {
@@ -1050,6 +2496,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/frictionless-security.md"
   },
   {
@@ -1059,6 +2518,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/fr",
+      "localize"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/hardware-peripherals-design.md"
   },
   {
@@ -1068,6 +2540,18 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/i18n-coverage.md"
   },
   {
@@ -1077,6 +2561,18 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/i18n-gap-backlog.md"
   },
   {
@@ -1086,6 +2582,18 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/i18n-guide.md"
   },
   {
@@ -1095,6 +2603,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/langgraph-integration.md"
   },
   {
@@ -1104,6 +2625,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/matrix-e2ee-guide.md"
   },
   {
@@ -1113,6 +2647,20 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/mattermost-setup.md"
   },
   {
@@ -1122,6 +2670,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "deployment",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/network-deployment.md"
   },
   {
@@ -1131,6 +2692,20 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/nextcloud-talk-setup.md"
   },
   {
@@ -1140,6 +2715,20 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/nucleo-setup.md"
   },
   {
@@ -1149,6 +2738,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/one-click-bootstrap.md"
   },
   {
@@ -1158,6 +2760,19 @@
     "summary": "Cette page est une localisation initiale Wave 1 pour les procédures day-2.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/operations-runbook.md"
   },
   {
@@ -1167,6 +2782,20 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "operations"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/pr-workflow.md"
   },
   {
@@ -1176,6 +2805,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributing",
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "report"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/project-triage-snapshot-2026-02-18.md"
   },
   {
@@ -1185,6 +2827,18 @@
     "summary": "Cette page est une localisation initiale Wave 1 pour vérifier les IDs provider, alias et variables d'authentification.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/providers-reference.md"
   },
   {
@@ -1194,6 +2848,18 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "runbook"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/proxy-agent-playbook.md"
   },
   {
@@ -1203,6 +2869,19 @@
     "summary": "Cette page est le hub français aligné sur la structure canonique docs/i18n//.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/README.md"
   },
   {
@@ -1212,6 +2891,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "operations",
+      "policy"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/release-process.md"
   },
   {
@@ -1221,6 +2913,18 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/resource-limits.md"
   },
   {
@@ -1230,6 +2934,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributing",
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "runbook"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/reviewer-playbook.md"
   },
   {
@@ -1239,6 +2956,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/sandboxing.md"
   },
   {
@@ -1248,6 +2978,19 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "policy",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/security-roadmap.md"
   },
   {
@@ -1257,6 +3000,18 @@
     "summary": "Ce fichier est l'index de navigation pour docs/i18n/fr/.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/SUMMARY.md"
   },
   {
@@ -1266,6 +3021,19 @@
     "summary": "Cette page est une localisation initiale Wave 1 pour diagnostiquer rapidement les pannes courantes.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "localize",
+      "troubleshooting"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/troubleshooting.md"
   },
   {
@@ -1275,6 +3043,20 @@
     "summary": "Cette page est une passerelle enrichie. Elle fournit le positionnement du sujet, un guidage par sections source et des conseils d'exécution.",
     "section": "i18n/fr",
     "language": "fr",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/fr",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/fr/zai-glm-setup.md"
   },
   {
@@ -1284,6 +3066,18 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "policy"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/actions-source-policy.md"
   },
   {
@@ -1293,6 +3087,18 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/adding-boards-and-tools.md"
   },
   {
@@ -1302,6 +3108,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/agnostic-security.md"
   },
   {
@@ -1311,6 +3130,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/android-setup.md"
   },
   {
@@ -1320,6 +3152,20 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/arduino-uno-q-setup.md"
   },
   {
@@ -1329,6 +3175,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "reference",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/audit-event-schema.md"
   },
   {
@@ -1338,6 +3197,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/audit-logging.md"
   },
   {
@@ -1347,6 +3219,18 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/cargo-slicer-speedup.md"
   },
   {
@@ -1356,6 +3240,18 @@
     "summary": "このページは Wave 1 の初版ローカライズです。チャネル機能と設定経路の確認用です。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/channels-reference.md"
   },
   {
@@ -1365,6 +3261,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "operations"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/ci-map.md"
   },
   {
@@ -1374,6 +3283,18 @@
     "summary": "このページは Wave 1 の初版ローカライズです。ZeroClaw CLI コマンドを素早く参照するための入口です。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/commands-reference.md"
   },
   {
@@ -1383,6 +3304,18 @@
     "summary": "このページは Wave 1 の初版ローカライズです。主要設定キー、既定値、リスク境界を確認します。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/config-reference.md"
   },
   {
@@ -1392,6 +3325,20 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "integrations",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/custom-providers.md"
   },
   {
@@ -1401,6 +3348,18 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "template",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "template"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/doc-template.md"
   },
   {
@@ -1410,6 +3369,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "report",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/docs-audit-2026-02-24.md"
   },
   {
@@ -1419,6 +3391,18 @@
     "summary": "このページは docs/i18n/ja/ の top-level 文書を素早く参照するための索引です。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "report"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/docs-inventory.md"
   },
   {
@@ -1428,6 +3412,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/frictionless-security.md"
   },
   {
@@ -1437,6 +3434,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/ja",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/hardware-peripherals-design.md"
   },
   {
@@ -1446,6 +3456,18 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/i18n-coverage.md"
   },
   {
@@ -1455,6 +3477,18 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/i18n-gap-backlog.md"
   },
   {
@@ -1464,6 +3498,18 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/i18n-guide.md"
   },
   {
@@ -1473,6 +3519,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/langgraph-integration.md"
   },
   {
@@ -1482,6 +3541,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/matrix-e2ee-guide.md"
   },
   {
@@ -1491,6 +3563,20 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/mattermost-setup.md"
   },
   {
@@ -1500,6 +3586,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "deployment",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/network-deployment.md"
   },
   {
@@ -1509,6 +3608,20 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/nextcloud-talk-setup.md"
   },
   {
@@ -1518,6 +3631,20 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/nucleo-setup.md"
   },
   {
@@ -1527,6 +3654,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/one-click-bootstrap.md"
   },
   {
@@ -1536,6 +3676,19 @@
     "summary": "このページは Wave 1 の初版ローカライズです。Day-2 運用の標準手順を参照する入口です。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/operations-runbook.md"
   },
   {
@@ -1545,6 +3698,20 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "operations"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/pr-workflow.md"
   },
   {
@@ -1554,6 +3721,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributing",
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "report"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/project-triage-snapshot-2026-02-18.md"
   },
   {
@@ -1563,6 +3743,18 @@
     "summary": "このページは Wave 1 の初版ローカライズです。provider ID、別名、認証環境変数の確認に使います。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/providers-reference.md"
   },
   {
@@ -1572,6 +3764,18 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/proxy-agent-playbook.md"
   },
   {
@@ -1581,6 +3785,19 @@
     "summary": "このファイルは docs/i18n// 構造における日本語ハブです。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/README.md"
   },
   {
@@ -1590,6 +3807,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "operations",
+      "policy"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/release-process.md"
   },
   {
@@ -1599,6 +3829,18 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/resource-limits.md"
   },
   {
@@ -1608,6 +3850,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributing",
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/reviewer-playbook.md"
   },
   {
@@ -1617,6 +3872,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/sandboxing.md"
   },
   {
@@ -1626,6 +3894,19 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "policy",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/security-roadmap.md"
   },
   {
@@ -1635,6 +3916,18 @@
     "summary": "このファイルは docs/i18n/ja/ のナビゲーション目です。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/SUMMARY.md"
   },
   {
@@ -1644,6 +3937,19 @@
     "summary": "このページは Wave 1 の初版ローカライズです。よくある障害の切り分け入口です。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "localize",
+      "troubleshooting"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/troubleshooting.md"
   },
   {
@@ -1653,6 +3959,20 @@
     "summary": "このページは強化版ブリッジです。テーマの位置付け、原文セクション導線、実行時の注意点をまとめています。",
     "section": "i18n/ja",
     "language": "ja",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ja",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ja/zai-glm-setup.md"
   },
   {
@@ -1662,6 +3982,19 @@
     "summary": "Canonical localized documentation trees live here.",
     "section": "i18n/README.md",
     "language": "en",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/README.md",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/README.md"
   },
   {
@@ -1671,6 +4004,18 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "policy"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/actions-source-policy.md"
   },
   {
@@ -1680,6 +4025,18 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/adding-boards-and-tools.md"
   },
   {
@@ -1689,6 +4046,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/agnostic-security.md"
   },
   {
@@ -1698,6 +4068,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/android-setup.md"
   },
   {
@@ -1707,6 +4090,20 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/arduino-uno-q-setup.md"
   },
   {
@@ -1716,6 +4113,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "reference",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/audit-event-schema.md"
   },
   {
@@ -1725,6 +4135,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/audit-logging.md"
   },
   {
@@ -1734,6 +4157,18 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/cargo-slicer-speedup.md"
   },
   {
@@ -1743,6 +4178,18 @@
     "summary": "Это первичная локализация Wave 1 для обзора возможностей каналов и путей настройки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/channels-reference.md"
   },
   {
@@ -1752,6 +4199,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "operations"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/ci-map.md"
   },
   {
@@ -1761,6 +4221,18 @@
     "summary": "Это первичная локализация Wave 1 для быстрого поиска CLI-команд ZeroClaw.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/commands-reference.md"
   },
   {
@@ -1770,6 +4242,18 @@
     "summary": "Это первичная локализация Wave 1 для работы с ключами конфигурации и безопасными дефолтами.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/config-reference.md"
   },
   {
@@ -1779,6 +4263,20 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "integrations",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/custom-providers.md"
   },
   {
@@ -1788,6 +4286,18 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "template",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "template"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/doc-template.md"
   },
   {
@@ -1797,6 +4307,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "report",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/docs-audit-2026-02-24.md"
   },
   {
@@ -1806,6 +4329,18 @@
     "summary": "Эта страница — быстрый индекс top-level документов в docs/i18n/ru/.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "report"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/docs-inventory.md"
   },
   {
@@ -1815,6 +4350,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/frictionless-security.md"
   },
   {
@@ -1824,6 +4372,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/ru",
+      "localize"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/hardware-peripherals-design.md"
   },
   {
@@ -1833,6 +4394,18 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/i18n-coverage.md"
   },
   {
@@ -1842,6 +4415,18 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/i18n-gap-backlog.md"
   },
   {
@@ -1851,6 +4436,18 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/i18n-guide.md"
   },
   {
@@ -1860,6 +4457,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/langgraph-integration.md"
   },
   {
@@ -1869,6 +4479,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/matrix-e2ee-guide.md"
   },
   {
@@ -1878,6 +4501,20 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/mattermost-setup.md"
   },
   {
@@ -1887,6 +4524,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "deployment",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/network-deployment.md"
   },
   {
@@ -1896,6 +4546,20 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/nextcloud-talk-setup.md"
   },
   {
@@ -1905,6 +4569,20 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/nucleo-setup.md"
   },
   {
@@ -1914,6 +4592,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/one-click-bootstrap.md"
   },
   {
@@ -1923,6 +4614,19 @@
     "summary": "Это первичная локализация Wave 1 для day-2 эксплуатации и стандартных процедур.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/operations-runbook.md"
   },
   {
@@ -1932,6 +4636,20 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "operations"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/pr-workflow.md"
   },
   {
@@ -1941,6 +4659,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributing",
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "report"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/project-triage-snapshot-2026-02-18.md"
   },
   {
@@ -1950,6 +4681,18 @@
     "summary": "Это первичная локализация Wave 1 для проверки provider ID, алиасов и переменных окружения.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/providers-reference.md"
   },
   {
@@ -1959,6 +4702,18 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "runbook"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/proxy-agent-playbook.md"
   },
   {
@@ -1968,6 +4723,19 @@
     "summary": "Этот файл — русскоязычный хаб в канонической структуре docs/i18n//.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/README.md"
   },
   {
@@ -1977,6 +4745,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "operations",
+      "policy"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/release-process.md"
   },
   {
@@ -1986,6 +4767,18 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/resource-limits.md"
   },
   {
@@ -1995,6 +4788,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributing",
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "runbook"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/reviewer-playbook.md"
   },
   {
@@ -2004,6 +4810,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/sandboxing.md"
   },
   {
@@ -2013,6 +4832,19 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "policy",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/security-roadmap.md"
   },
   {
@@ -2022,6 +4854,18 @@
     "summary": "Этот файл — навигационный индекс для docs/i18n/ru/.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/SUMMARY.md"
   },
   {
@@ -2031,6 +4875,19 @@
     "summary": "Это первичная локализация Wave 1 для быстрого поиска типовых неисправностей.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "localize",
+      "troubleshooting"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/troubleshooting.md"
   },
   {
@@ -2040,6 +4897,20 @@
     "summary": "Это усиленная bridge-страница. Здесь собраны позиционирование темы, навигация по разделам оригинала и практические подсказки.",
     "section": "i18n/ru",
     "language": "ru",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/ru",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/ru/zai-glm-setup.md"
   },
   {
@@ -2049,6 +4920,18 @@
     "summary": "Tài liệu này định nghĩa chính sách kiểm soát nguồn GitHub Actions hiện tại cho repository này.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "policy"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/actions-source-policy.md"
   },
   {
@@ -2058,6 +4941,18 @@
     "summary": "Hướng dẫn này giải thích cách thêm board phần cứng mới và tool tùy chỉnh vào ZeroClaw.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/adding-boards-and-tools.md"
   },
   {
@@ -2067,6 +4962,19 @@
     "summary": "1. ❓ Quá trình cross-compilation nhanh?",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/agnostic-security.md"
   },
   {
@@ -2076,6 +4984,19 @@
     "summary": "Trang này là bản địa hóa tối thiểu cho hướng dẫn Android.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/android-setup.md"
   },
   {
@@ -2085,6 +5006,20 @@
     "summary": "Chạy ZeroClaw trên phía Linux của Arduino Uno Q. Telegram hoạt động qua WiFi; điều khiển GPIO dùng Bridge (yêu cầu một ứng dụng App Lab tối giản).",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/arduino-uno-q-setup.md"
   },
   {
@@ -2094,6 +5029,20 @@
     "summary": "Trang này là bản địa hóa tối thiểu cho tài liệu lược đồ sự kiện kiểm toán.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "operations",
+      "reference",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/audit-event-schema.md"
   },
   {
@@ -2103,6 +5052,19 @@
     "summary": "ZeroClaw ghi log các hành động nhưng thiếu audit trail chống giả mạo cho:",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/audit-logging.md"
   },
   {
@@ -2112,6 +5074,18 @@
     "summary": "Trang này là bản địa hóa tối thiểu cho hướng dẫn tối ưu tốc độ build bằng cargo-slicer.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/cargo-slicer-speedup.md"
   },
   {
@@ -2121,6 +5095,18 @@
     "summary": "Tài liệu này là nguồn tham khảo chính thức về cấu hình channel trong ZeroClaw.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 10,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/channels-reference.md"
   },
   {
@@ -2130,6 +5116,19 @@
     "summary": "Tài liệu này giải thích từng GitHub workflow làm gì, khi nào chạy và liệu nó có nên chặn merge hay không.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "operations"
+    ],
+    "readingMinutes": 10,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/ci-map.md"
   },
   {
@@ -2139,6 +5138,18 @@
     "summary": "Dựa trên CLI hiện tại (zeroclaw --help).",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/commands-reference.md"
   },
   {
@@ -2148,6 +5159,18 @@
     "summary": "Các mục cấu hình thường dùng và giá trị mặc định.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 17,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/config-reference.md"
   },
   {
@@ -2157,6 +5180,21 @@
     "summary": "Dành cho contributor, reviewer và maintainer.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding",
+      "operations"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/contributing/README.md"
   },
   {
@@ -2166,6 +5204,20 @@
     "summary": "ZeroClaw hỗ trợ endpoint API tùy chỉnh cho cả provider tương thích OpenAI lẫn Anthropic.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "integrations",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/custom-providers.md"
   },
   {
@@ -2175,6 +5227,19 @@
     "summary": "Arduino Uno là board vi điều khiển dựa trên ATmega328P. Có 14 pin digital I/O (0–13) và 6 đầu vào analog (A0–A5).",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/vi",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/datasheets/arduino-uno.md"
   },
   {
@@ -2184,6 +5249,19 @@
     "summary": "ZeroClaw host gửi JSON qua serial (115200 baud):",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/vi",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/datasheets/esp32.md"
   },
   {
@@ -2193,6 +5271,20 @@
     "summary": "Project documentation.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/vi",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/datasheets/nucleo-f401re.md"
   },
   {
@@ -2202,6 +5294,20 @@
     "summary": "Tập hợp tài liệu tham chiếu datasheet cho các board được hỗ trợ.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/datasheets/README.md"
   },
   {
@@ -2211,6 +5317,18 @@
     "summary": "Trang này là cầu nối bản địa hóa cho mẫu tài liệu chuẩn.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "template",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "template"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/doc-template.md"
   },
   {
@@ -2220,6 +5338,19 @@
     "summary": "Trang này là bản địa hóa tối thiểu cho kết quả audit tài liệu ngày 2026-02-24.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "report",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/docs-audit-2026-02-24.md"
   },
   {
@@ -2229,6 +5360,18 @@
     "summary": "Trang này là bản địa hóa tối thiểu cho inventory tài liệu.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "report"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/docs-inventory.md"
   },
   {
@@ -2238,6 +5381,19 @@
     "summary": "Chỉ khi người dùng thay đổi:",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/frictionless-security.md"
   },
   {
@@ -2247,6 +5403,19 @@
     "summary": "Dành cho cài đặt lần đầu và làm quen nhanh.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/getting-started/README.md"
   },
   {
@@ -2256,6 +5425,19 @@
     "summary": "ZeroClaw cho phép các vi điều khiển (MCU) và máy tính nhúng (SBC) phân tích lệnh ngôn ngữ tự nhiên theo thời gian thực, tổng hợp code phù hợp với từng phần cứng, và thực thi tương tác với ngoại vi trực tiếp.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/vi",
+      "localize"
+    ],
+    "readingMinutes": 9,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/hardware-peripherals-design.md"
   },
   {
@@ -2265,6 +5447,20 @@
     "summary": "Tích hợp board, firmware và ngoại vi.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/hardware/README.md"
   },
   {
@@ -2274,6 +5470,19 @@
     "summary": "Trang này là bản địa hóa tối thiểu cho coverage matrix i18n.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/i18n-coverage.md"
   },
   {
@@ -2283,6 +5492,18 @@
     "summary": "Trang này là bản địa hóa tối thiểu cho backlog khoảng trống i18n.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/i18n-gap-backlog.md"
   },
   {
@@ -2292,6 +5513,18 @@
     "summary": "Trang này là bản địa hóa tối thiểu cho contract hoàn thiện i18n.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/i18n-guide.md"
   },
   {
@@ -2301,6 +5534,19 @@
     "summary": "Hướng dẫn này giải thích cách sử dụng gói Python zeroclaw-tools để gọi tool nhất quán với bất kỳ LLM provider nào tương thích OpenAI.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/langgraph-integration.md"
   },
   {
@@ -2310,6 +5556,19 @@
     "summary": "Hướng dẫn này giải thích cách chạy ZeroClaw ổn định trong các phòng Matrix, bao gồm các phòng mã hóa đầu cuối (E2EE).",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/matrix-e2ee-guide.md"
   },
   {
@@ -2319,6 +5578,20 @@
     "summary": "ZeroClaw hỗ trợ tích hợp native với Mattermost thông qua REST API v4. Tích hợp này lý tưởng cho các môi trường self-hosted, riêng tư hoặc air-gapped nơi giao tiếp nội bộ là yêu cầu bắt buộc.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/mattermost-setup.md"
   },
   {
@@ -2328,6 +5601,19 @@
     "summary": "Tài liệu này hướng dẫn triển khai ZeroClaw trên Raspberry Pi hoặc host khác trong mạng nội bộ, với các channel Telegram và webhook tùy chọn.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "deployment",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/network-deployment.md"
   },
   {
@@ -2337,6 +5623,20 @@
     "summary": "Trang này là bản địa hóa tối thiểu cho hướng dẫn tích hợp Nextcloud Talk.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/nextcloud-talk-setup.md"
   },
   {
@@ -2346,6 +5646,20 @@
     "summary": "Chạy ZeroClaw trên Mac hoặc Linux. Kết nối Nucleo-F401RE qua USB. Điều khiển GPIO (LED, các pin) qua Telegram hoặc CLI.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/nucleo-setup.md"
   },
   {
@@ -2355,6 +5669,19 @@
     "summary": "Cách cài đặt và khởi tạo ZeroClaw nhanh nhất.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/one-click-bootstrap.md"
   },
   {
@@ -2364,6 +5691,19 @@
     "summary": "Tài liệu này dành cho các operator chịu trách nhiệm duy trì tính sẵn sàng, tình trạng bảo mật và xử lý sự cố.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/operations-runbook.md"
   },
   {
@@ -2373,6 +5713,19 @@
     "summary": "Trang này là bản địa hóa tối thiểu cho runbook vận hành probe kết nối provider trong CI.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/operations/connectivity-probes-runbook.md"
   },
   {
@@ -2382,6 +5735,20 @@
     "summary": "Dành cho operator vận hành ZeroClaw liên tục hoặc trên production.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/operations/README.md"
   },
   {
@@ -2391,6 +5758,20 @@
     "summary": "Tài liệu này định nghĩa cách ZeroClaw xử lý khối lượng PR lớn trong khi vẫn duy trì:",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "operations"
+    ],
+    "readingMinutes": 12,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/pr-workflow.md"
   },
   {
@@ -2400,6 +5781,19 @@
     "summary": "Trang này là bản địa hóa tối thiểu cho snapshot triage theo thời điểm.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributing",
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "report"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/project-triage-snapshot-2026-02-18.md"
   },
   {
@@ -2409,6 +5803,20 @@
     "summary": "Snapshot trạng thái dự án có giới hạn thời gian cho tài liệu lập kế hoạch và công việc vận hành.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/project/README.md"
   },
   {
@@ -2418,6 +5826,18 @@
     "summary": "Tài liệu này liệt kê các provider ID, alias và biến môi trường chứa thông tin xác thực.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 7,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/providers-reference.md"
   },
   {
@@ -2427,6 +5847,19 @@
     "summary": "Tài liệu này cung cấp các tool call có thể copy-paste để cấu hình hành vi proxy qua proxyconfig.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "reference",
+      "runbook"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/proxy-agent-playbook.md"
   },
   {
@@ -2436,6 +5869,19 @@
     "summary": "Đây là trang chủ tiếng Việt của hệ thống tài liệu.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/README.md"
   },
   {
@@ -2445,6 +5891,19 @@
     "summary": "Tra cứu lệnh, provider, channel, config và tích hợp.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/reference/README.md"
   },
   {
@@ -2454,6 +5913,19 @@
     "summary": "Runbook này định nghĩa quy trình release tiêu chuẩn của maintainer.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "operations",
+      "policy"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/release-process.md"
   },
   {
@@ -2463,6 +5935,18 @@
     "summary": "ZeroClaw có rate limiting (20 actions/hour) nhưng chưa có giới hạn tài nguyên. Một agent bị lỗi lặp vòng có thể:",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/resource-limits.md"
   },
   {
@@ -2472,6 +5956,20 @@
     "summary": "Tài liệu này là người bạn đồng hành vận hành của docs/pr-workflow.md.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributing",
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 7,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/reviewer-playbook.md"
   },
   {
@@ -2481,6 +5979,19 @@
     "summary": "ZeroClaw hiện có application-layer security (allowlists, path blocking, command injection protection) nhưng thiếu cơ chế cách ly cấp hệ điều hành. Nếu kẻ tấn công nằm trong allowlist, họ có thể chạy bất kỳ lệnh nào được ",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/sandboxing.md"
   },
   {
@@ -2490,6 +6001,19 @@
     "summary": "ZeroClaw đã có application-layer security xuất sắc:",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "policy",
+      "security"
+    ],
+    "readingMinutes": 5,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/security-roadmap.md"
   },
   {
@@ -2499,6 +6023,20 @@
     "summary": "Hướng dẫn bảo mật hiện tại và đề xuất cải tiến.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "onboarding",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/security/README.md"
   },
   {
@@ -2508,6 +6046,18 @@
     "summary": "Đây là mục lục thống nhất cho hệ thống tài liệu tiếng Việt.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/SUMMARY.md"
   },
   {
@@ -2517,6 +6067,19 @@
     "summary": "Các lỗi thường gặp khi cài đặt và chạy, kèm cách khắc phục.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "localize",
+      "troubleshooting"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/troubleshooting.md"
   },
   {
@@ -2526,6 +6089,20 @@
     "summary": "ZeroClaw hỗ trợ các model GLM của Z.AI thông qua các endpoint tương thích OpenAI.",
     "section": "i18n/vi",
     "language": "vi",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/vi",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/vi/zai-glm-setup.md"
   },
   {
@@ -2535,6 +6112,18 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "policy"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/actions-source-policy.md"
   },
   {
@@ -2544,6 +6133,18 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/adding-boards-and-tools.md"
   },
   {
@@ -2553,6 +6154,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/agnostic-security.md"
   },
   {
@@ -2562,6 +6176,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/android-setup.md"
   },
   {
@@ -2571,6 +6198,20 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/arduino-uno-q-setup.md"
   },
   {
@@ -2580,6 +6221,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "reference",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/audit-event-schema.md"
   },
   {
@@ -2589,6 +6243,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/audit-logging.md"
   },
   {
@@ -2598,6 +6265,18 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/cargo-slicer-speedup.md"
   },
   {
@@ -2607,6 +6286,18 @@
     "summary": "这是 Wave 1 首版本地化页面，用于查阅各通信渠道能力与配置路径。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/channels-reference.md"
   },
   {
@@ -2616,6 +6307,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "operations"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/ci-map.md"
   },
   {
@@ -2625,6 +6329,18 @@
     "summary": "这是 Wave 1 首版本地化页面，用于快速定位 ZeroClaw CLI 命令。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/commands-reference.md"
   },
   {
@@ -2634,6 +6350,18 @@
     "summary": "这是 Wave 1 首版本地化页面，用于查阅核心配置键、默认值与风险边界。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/config-reference.md"
   },
   {
@@ -2643,6 +6371,20 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "integrations",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/custom-providers.md"
   },
   {
@@ -2652,6 +6394,18 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "template",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "template"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/doc-template.md"
   },
   {
@@ -2661,6 +6415,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "report",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/docs-audit-2026-02-24.md"
   },
   {
@@ -2670,6 +6437,18 @@
     "summary": "该页面用于在 docs/i18n/zh-CN/ 下快速定位所有 top-level 文档。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "report"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/docs-inventory.md"
   },
   {
@@ -2679,6 +6458,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/frictionless-security.md"
   },
   {
@@ -2688,6 +6480,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/zh-CN",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/hardware-peripherals-design.md"
   },
   {
@@ -2697,6 +6502,18 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/i18n-coverage.md"
   },
   {
@@ -2706,6 +6523,18 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/i18n-gap-backlog.md"
   },
   {
@@ -2715,6 +6544,18 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/i18n-guide.md"
   },
   {
@@ -2724,6 +6565,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/langgraph-integration.md"
   },
   {
@@ -2733,6 +6587,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "integrations",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/matrix-e2ee-guide.md"
   },
   {
@@ -2742,6 +6609,20 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/mattermost-setup.md"
   },
   {
@@ -2751,6 +6632,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "deployment",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/network-deployment.md"
   },
   {
@@ -2760,6 +6654,20 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/nextcloud-talk-setup.md"
   },
   {
@@ -2769,6 +6677,20 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "hardware",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/nucleo-setup.md"
   },
   {
@@ -2778,6 +6700,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/one-click-bootstrap.md"
   },
   {
@@ -2787,6 +6722,19 @@
     "summary": "这是 Wave 1 首版本地化页面，用于日常运维（Day-2）流程导航。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "operations",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/operations-runbook.md"
   },
   {
@@ -2796,6 +6744,20 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributing",
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "operations"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/pr-workflow.md"
   },
   {
@@ -2805,6 +6767,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contributing",
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "report"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/project-triage-snapshot-2026-02-18.md"
   },
   {
@@ -2814,6 +6789,18 @@
     "summary": "这是 Wave 1 首版本地化页面，用于快速查阅 provider 标识、别名与认证变量。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/providers-reference.md"
   },
   {
@@ -2823,6 +6810,18 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/proxy-agent-playbook.md"
   },
   {
@@ -2832,6 +6831,19 @@
     "summary": "这是中文文档在 docs/i18n// 结构下的标准入口。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/README.md"
   },
   {
@@ -2841,6 +6853,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "operations",
+      "policy"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/release-process.md"
   },
   {
@@ -2850,6 +6875,18 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/resource-limits.md"
   },
   {
@@ -2859,6 +6896,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contributing",
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/reviewer-playbook.md"
   },
   {
@@ -2868,6 +6918,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/sandboxing.md"
   },
   {
@@ -2877,6 +6940,19 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "policy",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "policy",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/security-roadmap.md"
   },
   {
@@ -2886,6 +6962,18 @@
     "summary": "该文件是 docs/i18n/zh-CN/ 的导航目录。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "reference",
+    "tags": [
+      "contributor",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/SUMMARY.md"
   },
   {
@@ -2895,6 +6983,19 @@
     "summary": "这是 Wave 1 首版本地化页面，用于快速定位常见故障与恢复路径。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "localize",
+      "troubleshooting"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/troubleshooting.md"
   },
   {
@@ -2904,6 +7005,20 @@
     "summary": "这是增强型 bridge 页面。它提供该主题的定位、原文章节导览和执行提示，帮助你在不丢失英文规范语义的情况下快速落地。",
     "section": "i18n/zh-CN",
     "language": "zh-CN",
+    "journey": "localize",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contributor",
+      "guide",
+      "i18n",
+      "i18n/zh-CN",
+      "integrations",
+      "localize",
+      "onboarding"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/i18n/zh-CN/zai-glm-setup.md"
   },
   {
@@ -2913,6 +7028,18 @@
     "summary": "This guide explains how to use the zeroclaw-tools Python package for consistent tool calling with any OpenAI-compatible LLM provider.",
     "section": "langgraph-integration.md",
     "language": "en",
+    "journey": "integrate",
+    "audience": "integrator",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "integrate",
+      "integrations",
+      "integrator",
+      "langgraph-integration.md"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/langgraph-integration.md"
   },
   {
@@ -2922,6 +7049,18 @@
     "summary": "This guide explains how to run ZeroClaw reliably in Matrix rooms, including end-to-end encrypted (E2EE) rooms.",
     "section": "matrix-e2ee-guide.md",
     "language": "en",
+    "journey": "integrate",
+    "audience": "integrator",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "integrate",
+      "integrations",
+      "integrator",
+      "matrix-e2ee-guide.md"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/matrix-e2ee-guide.md"
   },
   {
@@ -2931,6 +7070,19 @@
     "summary": "ZeroClaw supports native integration with Mattermost via its REST API v4. This integration is ideal for self-hosted, private, or air-gapped environments where sovereign communication is a requirement.",
     "section": "mattermost-setup.md",
     "language": "en",
+    "journey": "integrate",
+    "audience": "integrator",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "integrate",
+      "integrations",
+      "integrator",
+      "mattermost-setup.md",
+      "onboarding"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/mattermost-setup.md"
   },
   {
@@ -2940,6 +7092,19 @@
     "summary": "This document covers deploying ZeroClaw on a Raspberry Pi or other host on your local network, with Telegram and optional webhook channels.",
     "section": "network-deployment.md",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "deployment",
+      "guide",
+      "network-deployment.md",
+      "newcomer",
+      "reference",
+      "start"
+    ],
+    "readingMinutes": 5,
+    "startHere": true,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/network-deployment.md"
   },
   {
@@ -2949,6 +7114,19 @@
     "summary": "This guide covers native Nextcloud Talk integration for ZeroClaw.",
     "section": "nextcloud-talk-setup.md",
     "language": "en",
+    "journey": "integrate",
+    "audience": "integrator",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "integrate",
+      "integrations",
+      "integrator",
+      "nextcloud-talk-setup.md",
+      "onboarding"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/nextcloud-talk-setup.md"
   },
   {
@@ -2958,6 +7136,17 @@
     "summary": "Run ZeroClaw on your Mac or Linux host. Connect a Nucleo-F401RE via USB. Control GPIO (LED, pins) via Telegram or CLI.",
     "section": "nucleo-setup.md",
     "language": "en",
+    "journey": "hardware",
+    "audience": "hardware",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "hardware",
+      "nucleo-setup.md",
+      "onboarding"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/nucleo-setup.md"
   },
   {
@@ -2967,6 +7156,18 @@
     "summary": "This page defines the fastest supported path to install and initialize ZeroClaw.",
     "section": "one-click-bootstrap.md",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "newcomer",
+      "onboarding",
+      "one-click-bootstrap.md",
+      "start"
+    ],
+    "readingMinutes": 2,
+    "startHere": true,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/one-click-bootstrap.md"
   },
   {
@@ -2976,6 +7177,18 @@
     "summary": "Compatibility shim only.",
     "section": "one-click-bootstrap.vi.md",
     "language": "vi",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "newcomer",
+      "onboarding",
+      "one-click-bootstrap.vi.md",
+      "start"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/one-click-bootstrap.vi.md"
   },
   {
@@ -2985,6 +7198,19 @@
     "summary": "This runbook is for operators who maintain availability, security posture, and incident response.",
     "section": "operations-runbook.md",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "operate",
+      "operations",
+      "operations-runbook.md",
+      "operator",
+      "runbook",
+      "security"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations-runbook.md"
   },
   {
@@ -2994,6 +7220,17 @@
     "summary": "Workflow: .github/workflows/ci-canary-gate.yml",
     "section": "operations",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "operate",
+      "operations",
+      "operator",
+      "runbook"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/canary-gate-runbook.md"
   },
   {
@@ -3003,6 +7240,17 @@
     "summary": "This runbook defines how maintainers operate provider endpoint connectivity probes in CI.",
     "section": "operations",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "operate",
+      "operations",
+      "operator",
+      "runbook"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/connectivity-probes-runbook.md"
   },
   {
@@ -3012,6 +7260,18 @@
     "summary": "This document defines the promotion and rollback validation contract for docs deployment.",
     "section": "operations",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "deployment",
+      "operate",
+      "operations",
+      "operator",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/docs-deploy-policy.md"
   },
   {
@@ -3021,6 +7281,18 @@
     "summary": "Workflow: .github/workflows/docs-deploy.yml",
     "section": "operations",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "deployment",
+      "operate",
+      "operations",
+      "operator",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/docs-deploy-runbook.md"
   },
   {
@@ -3030,6 +7302,18 @@
     "summary": "This runbook defines the feature matrix CI lanes used to validate key compile combinations.",
     "section": "operations",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "integrations",
+      "operate",
+      "operations",
+      "operator",
+      "runbook"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/feature-matrix-runbook.md"
   },
   {
@@ -3039,6 +7323,18 @@
     "summary": "This document defines the production container tag contract for .github/workflows/pub-docker-img.yml.",
     "section": "operations",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "deployment",
+      "operate",
+      "operations",
+      "operator",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/ghcr-tag-policy.md"
   },
   {
@@ -3048,6 +7344,17 @@
     "summary": "This document defines the vulnerability scanning gate contract for GHCR release publishes.",
     "section": "operations",
     "language": "en",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "runbook",
+    "tags": [
+      "operations",
+      "runbook",
+      "secure",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/ghcr-vulnerability-policy.md"
   },
   {
@@ -3057,6 +7364,18 @@
     "summary": "This runbook describes the nightly integration matrix execution and reporting flow.",
     "section": "operations",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "integrations",
+      "operate",
+      "operations",
+      "operator",
+      "runbook"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/nightly-all-features-runbook.md"
   },
   {
@@ -3066,6 +7385,17 @@
     "summary": "Workflow: .github/workflows/pub-prerelease.yml",
     "section": "operations",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "operate",
+      "operations",
+      "operator",
+      "runbook"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/prerelease-stage-gates.md"
   },
   {
@@ -3075,6 +7405,19 @@
     "summary": "For operators running ZeroClaw in persistent or production-like environments.",
     "section": "operations",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "deployment",
+      "onboarding",
+      "operate",
+      "operations",
+      "operator",
+      "runbook"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/README.md"
   },
   {
@@ -3084,6 +7427,17 @@
     "summary": "This document maps merge-critical workflows to expected check names.",
     "section": "operations",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "operate",
+      "operations",
+      "operator",
+      "runbook"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/operations/required-check-mapping.md"
   },
   {
@@ -3093,6 +7447,19 @@
     "summary": "This document defines how ZeroClaw handles high PR volume while maintaining:",
     "section": "pr-workflow.md",
     "language": "en",
+    "journey": "contribute",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contribute",
+      "contributing",
+      "contributor",
+      "guide",
+      "operations",
+      "pr-workflow.md"
+    ],
+    "readingMinutes": 9,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/pr-workflow.md"
   },
   {
@@ -3102,6 +7469,18 @@
     "summary": "As-of date: February 18, 2026.",
     "section": "project-triage-snapshot-2026-02-18.md",
     "language": "en",
+    "journey": "contribute",
+    "audience": "contributor",
+    "kind": "report",
+    "tags": [
+      "contribute",
+      "contributing",
+      "contributor",
+      "project-triage-snapshot-2026-02-18.md",
+      "report"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/project-triage-snapshot-2026-02-18.md"
   },
   {
@@ -3111,6 +7490,20 @@
     "summary": "Time-bound project status snapshots for planning documentation and operations work.",
     "section": "project",
     "language": "en",
+    "journey": "contribute",
+    "audience": "contributor",
+    "kind": "guide",
+    "tags": [
+      "contribute",
+      "contributing",
+      "contributor",
+      "guide",
+      "onboarding",
+      "operations",
+      "project"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/project/README.md"
   },
   {
@@ -3120,6 +7513,16 @@
     "summary": "This document maps provider IDs, aliases, and credential environment variables.",
     "section": "providers-reference.md",
     "language": "en",
+    "journey": "reference",
+    "audience": "builder",
+    "kind": "reference",
+    "tags": [
+      "builder",
+      "providers-reference.md",
+      "reference"
+    ],
+    "readingMinutes": 8,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/providers-reference.md"
   },
   {
@@ -3129,6 +7532,18 @@
     "summary": "This playbook provides copy-paste tool calls for configuring proxy behavior via proxyconfig.",
     "section": "proxy-agent-playbook.md",
     "language": "en",
+    "journey": "integrate",
+    "audience": "integrator",
+    "kind": "runbook",
+    "tags": [
+      "integrate",
+      "integrator",
+      "proxy-agent-playbook.md",
+      "reference",
+      "runbook"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/proxy-agent-playbook.md"
   },
   {
@@ -3138,6 +7553,19 @@
     "summary": "Qwen OAuth integration has been successfully validated and configured for ZeroClaw. The provider is ready for production use with the following characteristics:",
     "section": "qwen-provider-test-report.md",
     "language": "en",
+    "journey": "integrate",
+    "audience": "integrator",
+    "kind": "report",
+    "tags": [
+      "integrate",
+      "integrations",
+      "integrator",
+      "qwen-provider-test-report.md",
+      "reference",
+      "report"
+    ],
+    "readingMinutes": 7,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/qwen-provider-test-report.md"
   },
   {
@@ -3147,6 +7575,18 @@
     "summary": "This page is the primary entry point for the documentation system.",
     "section": "README.md",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "newcomer",
+      "onboarding",
+      "README.md",
+      "start"
+    ],
+    "readingMinutes": 3,
+    "startHere": true,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/README.md"
   },
   {
@@ -3156,6 +7596,16 @@
     "summary": "Structured reference index for commands, providers, channels, config, and integration guides.",
     "section": "reference",
     "language": "en",
+    "journey": "reference",
+    "audience": "builder",
+    "kind": "reference",
+    "tags": [
+      "builder",
+      "onboarding",
+      "reference"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/reference/README.md"
   },
   {
@@ -3165,6 +7615,18 @@
     "summary": "This runbook defines the maintainers' standard release flow.",
     "section": "release-process.md",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "policy",
+    "tags": [
+      "operate",
+      "operations",
+      "operator",
+      "policy",
+      "release-process.md"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/release-process.md"
   },
   {
@@ -3174,6 +7636,17 @@
     "summary": "ZeroClaw has rate limiting (20 actions/hour) but no resource caps. A runaway agent could:",
     "section": "resource-limits.md",
     "language": "en",
+    "journey": "reference",
+    "audience": "builder",
+    "kind": "guide",
+    "tags": [
+      "builder",
+      "guide",
+      "reference",
+      "resource-limits.md"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/resource-limits.md"
   },
   {
@@ -3183,6 +7656,19 @@
     "summary": "This playbook is the operational companion to docs/pr-workflow.md.",
     "section": "reviewer-playbook.md",
     "language": "en",
+    "journey": "contribute",
+    "audience": "contributor",
+    "kind": "runbook",
+    "tags": [
+      "contribute",
+      "contributing",
+      "contributor",
+      "operations",
+      "reviewer-playbook.md",
+      "runbook"
+    ],
+    "readingMinutes": 5,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/reviewer-playbook.md"
   },
   {
@@ -3192,6 +7678,17 @@
     "summary": "ZeroClaw currently has application-layer security (allowlists, path blocking, command injection protection) but lacks OS-level containment. If an attacker is on the allowlist, they can run any allowed command with zerocl",
     "section": "sandboxing.md",
     "language": "en",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "sandboxing.md",
+      "secure",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/sandboxing.md"
   },
   {
@@ -3201,6 +7698,17 @@
     "summary": "ZeroClaw already has excellent application-layer security:",
     "section": "security-roadmap.md",
     "language": "en",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "policy",
+    "tags": [
+      "policy",
+      "secure",
+      "security",
+      "security-roadmap.md"
+    ],
+    "readingMinutes": 4,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security-roadmap.md"
   },
   {
@@ -3210,6 +7718,16 @@
     "summary": "Use this checklist for high-impact vulnerabilities from private intake through disclosure.",
     "section": "security",
     "language": "en",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "template",
+    "tags": [
+      "secure",
+      "security",
+      "template"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/advisory-maintainer-checklist.md"
   },
   {
@@ -3219,6 +7737,16 @@
     "summary": "本清单用于高影响安全漏洞从私密受理到公开披露的全流程执行。",
     "section": "security",
     "language": "zh-CN",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "template",
+    "tags": [
+      "secure",
+      "security",
+      "template"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/advisory-maintainer-checklist.zh-CN.md"
   },
   {
@@ -3228,6 +7756,16 @@
     "summary": "Use this template when preparing advisory metadata before publication.",
     "section": "security",
     "language": "en",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "template",
+    "tags": [
+      "secure",
+      "security",
+      "template"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/advisory-metadata-template.md"
   },
   {
@@ -3237,6 +7775,16 @@
     "summary": "用于发布前整理 advisory 元数据，确保字段完整且可被下游消费。",
     "section": "security",
     "language": "zh-CN",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "template",
+    "tags": [
+      "secure",
+      "security",
+      "template"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/advisory-metadata-template.zh-CN.md"
   },
   {
@@ -3246,6 +7794,16 @@
     "summary": "Use this template when filing a private report via:",
     "section": "security",
     "language": "en",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "template",
+    "tags": [
+      "secure",
+      "security",
+      "template"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/private-vulnerability-report-template.md"
   },
   {
@@ -3255,6 +7813,17 @@
     "summary": "Project documentation.",
     "section": "security",
     "language": "zh-CN",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "template",
+    "tags": [
+      "contributing",
+      "secure",
+      "security",
+      "template"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/private-vulnerability-report-template.zh-CN.md"
   },
   {
@@ -3264,6 +7833,17 @@
     "summary": "This section mixes current hardening guidance and proposal/roadmap documents.",
     "section": "security",
     "language": "en",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "onboarding",
+      "secure",
+      "security"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/README.md"
   },
   {
@@ -3273,6 +7853,16 @@
     "summary": "ZeroClaw can monitor syscall-related telemetry emitted by sandboxed command execution",
     "section": "security",
     "language": "en",
+    "journey": "secure",
+    "audience": "security",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "secure",
+      "security"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/security/syscall-anomaly-detection.md"
   },
   {
@@ -3282,6 +7872,18 @@
     "summary": "This document describes how external events trigger SOP runs.",
     "section": "sop",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "operate",
+      "operations",
+      "operator",
+      "runbook",
+      "sop"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/sop/connectivity.md"
   },
   {
@@ -3291,6 +7893,18 @@
     "summary": "Practical SOP templates in the runtime-supported SOP.toml + SOP.md format.",
     "section": "sop",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "operate",
+      "operations",
+      "operator",
+      "runbook",
+      "sop"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/sop/cookbook.md"
   },
   {
@@ -3300,6 +7914,19 @@
     "summary": "This page covers where SOP execution evidence is stored and how to inspect it.",
     "section": "sop",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "operate",
+      "operations",
+      "operator",
+      "runbook",
+      "security",
+      "sop"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/sop/observability.md"
   },
   {
@@ -3309,6 +7936,20 @@
     "summary": "SOPs are deterministic procedures executed by the SopEngine. They provide explicit trigger matching, approval gates, and auditable run state.",
     "section": "sop",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "onboarding",
+      "operate",
+      "operations",
+      "operator",
+      "runbook",
+      "security",
+      "sop"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/sop/README.md"
   },
   {
@@ -3318,6 +7959,19 @@
     "summary": "SOP definitions are loaded from subdirectories under sopsdir (default: /sops).",
     "section": "sop",
     "language": "en",
+    "journey": "operate",
+    "audience": "operator",
+    "kind": "runbook",
+    "tags": [
+      "operate",
+      "operations",
+      "operator",
+      "reference",
+      "runbook",
+      "sop"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/sop/syntax.md"
   },
   {
@@ -3327,6 +7981,18 @@
     "summary": "This page defines the canonical documentation layout and compatibility layers.",
     "section": "structure",
     "language": "en",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "guide",
+    "tags": [
+      "build",
+      "builder",
+      "guide",
+      "onboarding",
+      "structure"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/structure/README.md"
   },
   {
@@ -3336,6 +8002,17 @@
     "summary": "Αυτό το αρχείο αποτελεί τον κανονικό (canonical) πίνακα περιεχομένων για το σύστημα τεκμηρίωσης.",
     "section": "SUMMARY.el.md",
     "language": "el",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "guide",
+    "tags": [
+      "build",
+      "builder",
+      "guide",
+      "SUMMARY.el.md"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.el.md"
   },
   {
@@ -3345,6 +8022,17 @@
     "summary": "Ce fichier constitue la table des matières canonique du système de documentation.",
     "section": "SUMMARY.fr.md",
     "language": "fr",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "guide",
+    "tags": [
+      "build",
+      "builder",
+      "guide",
+      "SUMMARY.fr.md"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.fr.md"
   },
   {
@@ -3354,6 +8042,17 @@
     "summary": "このファイルはドキュメントシステムの正規目次です。",
     "section": "SUMMARY.ja.md",
     "language": "ja",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "guide",
+    "tags": [
+      "build",
+      "builder",
+      "guide",
+      "SUMMARY.ja.md"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.ja.md"
   },
   {
@@ -3363,6 +8062,17 @@
     "summary": "This file is the canonical table of contents for the documentation system.",
     "section": "SUMMARY.md",
     "language": "en",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "reference",
+    "tags": [
+      "build",
+      "builder",
+      "reference",
+      "SUMMARY.md"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.md"
   },
   {
@@ -3372,6 +8082,17 @@
     "summary": "Этот файл является каноническим оглавлением системы документации.",
     "section": "SUMMARY.ru.md",
     "language": "ru",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "guide",
+    "tags": [
+      "build",
+      "builder",
+      "guide",
+      "SUMMARY.ru.md"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.ru.md"
   },
   {
@@ -3381,6 +8102,17 @@
     "summary": "Tệp này là mục lục chuẩn của hệ thống tài liệu.",
     "section": "SUMMARY.vi.md",
     "language": "vi",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "guide",
+    "tags": [
+      "build",
+      "builder",
+      "guide",
+      "SUMMARY.vi.md"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.vi.md"
   },
   {
@@ -3390,6 +8122,18 @@
     "summary": "Project documentation.",
     "section": "SUMMARY.zh-CN.md",
     "language": "zh-CN",
+    "journey": "build",
+    "audience": "builder",
+    "kind": "guide",
+    "tags": [
+      "build",
+      "builder",
+      "contributing",
+      "guide",
+      "SUMMARY.zh-CN.md"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/SUMMARY.zh-CN.md"
   },
   {
@@ -3399,6 +8143,19 @@
     "summary": "This guide focuses on common setup/runtime failures and fast resolution paths.",
     "section": "troubleshooting.md",
     "language": "en",
+    "journey": "troubleshoot",
+    "audience": "operator",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "onboarding",
+      "operator",
+      "troubleshoot",
+      "troubleshooting",
+      "troubleshooting.md"
+    ],
+    "readingMinutes": 3,
+    "startHere": true,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/troubleshooting.md"
   },
   {
@@ -3408,6 +8165,18 @@
     "summary": "Compatibility shim only.",
     "section": "troubleshooting.vi.md",
     "language": "vi",
+    "journey": "troubleshoot",
+    "audience": "operator",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "operator",
+      "troubleshoot",
+      "troubleshooting",
+      "troubleshooting.vi.md"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/troubleshooting.vi.md"
   },
   {
@@ -3417,6 +8186,17 @@
     "summary": "This compatibility path redirects to canonical Vietnamese datasheets:",
     "section": "vi",
     "language": "en",
+    "journey": "hardware",
+    "audience": "hardware",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "hardware",
+      "onboarding",
+      "vi"
+    ],
+    "readingMinutes": 1,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/vi/datasheets/README.md"
   },
   {
@@ -3426,6 +8206,19 @@
     "summary": "ZeroClaw supports Z.AI's GLM models through OpenAI-compatible endpoints.",
     "section": "zai-glm-setup.md",
     "language": "en",
+    "journey": "integrate",
+    "audience": "integrator",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "integrate",
+      "integrations",
+      "integrator",
+      "onboarding",
+      "zai-glm-setup.md"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/docs/zai-glm-setup.md"
   },
   {
@@ -3435,6 +8228,20 @@
     "summary": "⚡️ Runs on $10 hardware with",
     "section": "root",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "hardware",
+      "newcomer",
+      "onboarding",
+      "operations",
+      "root",
+      "start"
+    ],
+    "readingMinutes": 18,
+    "startHere": true,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/README.md"
   },
   {
@@ -3444,6 +8251,17 @@
     "summary": "1. Select Telegram channel",
     "section": "root",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "newcomer",
+      "root",
+      "start"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/RUN_TESTS.md"
   },
   {
@@ -3453,6 +8271,18 @@
     "summary": "Please do not open public GitHub issues for unpatched security vulnerabilities.",
     "section": "root",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "newcomer",
+      "root",
+      "security",
+      "start"
+    ],
+    "readingMinutes": 6,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/SECURITY.md"
   },
   {
@@ -3462,6 +8292,17 @@
     "summary": "This guide covers testing the Telegram channel integration for ZeroClaw.",
     "section": "root",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "newcomer",
+      "root",
+      "start"
+    ],
+    "readingMinutes": 2,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/TESTING_TELEGRAM.md"
   },
   {
@@ -3471,6 +8312,17 @@
     "summary": "The following are trademarks of ZeroClaw Labs:",
     "section": "root",
     "language": "en",
+    "journey": "start",
+    "audience": "newcomer",
+    "kind": "guide",
+    "tags": [
+      "guide",
+      "newcomer",
+      "root",
+      "start"
+    ],
+    "readingMinutes": 3,
+    "startHere": false,
     "sourceUrl": "https://github.com/zeroclaw-labs/zeroclaw/blob/main/TRADEMARK.md"
   }
 ]

--- a/site/src/styles.css
+++ b/site/src/styles.css
@@ -470,11 +470,152 @@ main {
   font-weight: 600;
 }
 
+.pathway-shell {
+  margin-top: 0.72rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-l);
+  background: color-mix(in srgb, var(--bg-soft) 80%, transparent);
+  padding: 0.68rem;
+}
+
+.pathway-head h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.pathway-head p {
+  margin: 0.3rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.pathway-grid {
+  margin-top: 0.6rem;
+  display: grid;
+  gap: 0.48rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.pathway-card {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
+  color: var(--text-soft);
+  text-align: left;
+  display: grid;
+  gap: 0.24rem;
+  padding: 0.56rem 0.62rem;
+  transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.pathway-card:hover {
+  border-color: var(--line-strong);
+  background: color-mix(in srgb, var(--accent-soft) 54%, transparent);
+}
+
+.pathway-card.active {
+  border-color: var(--line-strong);
+  background: color-mix(in srgb, var(--accent-soft) 72%, transparent);
+}
+
+.pathway-title {
+  color: var(--text);
+  font-size: 0.86rem;
+  font-weight: 600;
+}
+
+.pathway-detail {
+  color: var(--text-muted);
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+.pathway-count {
+  justify-self: start;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  min-width: 28px;
+  min-height: 22px;
+  padding: 0 0.46rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  color: var(--accent);
+  font-family: "Geist Mono", "IBM Plex Mono", monospace;
+}
+
+.starter-shell {
+  margin-top: 0.72rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-l);
+  background: color-mix(in srgb, var(--bg-soft) 84%, transparent);
+  padding: 0.68rem;
+}
+
+.starter-head h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.starter-head p {
+  margin: 0.3rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.82rem;
+}
+
+.starter-list {
+  margin-top: 0.55rem;
+  display: grid;
+  gap: 0.4rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.starter-item {
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--bg-elevated) 90%, transparent);
+  color: var(--text-soft);
+  text-align: left;
+  display: grid;
+  gap: 0.22rem;
+  padding: 0.5rem 0.56rem;
+  transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.starter-item:hover {
+  border-color: var(--line-strong);
+  background: color-mix(in srgb, var(--accent-soft) 56%, transparent);
+}
+
+.starter-item.active {
+  border-color: var(--line-strong);
+  background: color-mix(in srgb, var(--accent-soft) 72%, transparent);
+}
+
+.starter-title {
+  color: var(--text);
+  font-size: 0.82rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.starter-meta {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
 .docs-toolbar {
   margin-top: 0.72rem;
   display: grid;
   gap: 0.56rem;
-  grid-template-columns: minmax(220px, 1fr) minmax(130px, 180px) minmax(130px, 180px) auto;
+  grid-template-columns:
+    minmax(220px, 1.4fr)
+    repeat(6, minmax(128px, 0.75fr))
+    minmax(120px, auto)
+    minmax(120px, auto);
 }
 
 .docs-toolbar input,
@@ -490,6 +631,10 @@ main {
 
 .docs-toolbar input::placeholder {
   color: var(--text-muted);
+}
+
+.docs-toolbar .btn {
+  min-height: 42px;
 }
 
 .workspace-grid {
@@ -555,11 +700,37 @@ main {
 }
 
 .doc-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.24rem;
   color: var(--accent);
-  font-size: 0.68rem;
+  font-size: 0.66rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   font-family: "Geist Mono", "IBM Plex Mono", monospace;
+}
+
+.doc-meta span {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.08rem 0.32rem;
+  background: color-mix(in srgb, var(--bg-soft) 86%, transparent);
+}
+
+.doc-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.28rem;
+}
+
+.doc-chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.1rem 0.38rem;
+  color: var(--text-muted);
+  font-size: 0.67rem;
+  font-family: "Geist Mono", "IBM Plex Mono", monospace;
+  background: color-mix(in srgb, var(--bg-soft) 86%, transparent);
 }
 
 .doc-title {
@@ -618,11 +789,60 @@ main {
   font-size: 0.98rem;
 }
 
+.doc-breadcrumb {
+  margin-top: 0.26rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.28rem;
+  color: var(--text-muted);
+  font-size: 0.74rem;
+  font-family: "Geist Mono", "IBM Plex Mono", monospace;
+}
+
 .reader-head code {
   color: var(--text-muted);
   font-size: 0.72rem;
   font-family: "Geist Mono", "IBM Plex Mono", monospace;
   overflow-wrap: anywhere;
+}
+
+.reader-meta-line {
+  margin-top: 0.4rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.34rem;
+}
+
+.reader-meta-line span {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.14rem 0.48rem;
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  background: color-mix(in srgb, var(--bg-soft) 82%, transparent);
+}
+
+.reader-meta-line strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.reader-tags {
+  margin-top: 0.4rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.reader-tags span {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 0.1rem 0.44rem;
+  color: var(--accent);
+  font-size: 0.68rem;
+  font-family: "Geist Mono", "IBM Plex Mono", monospace;
+  background: color-mix(in srgb, var(--accent-soft) 56%, transparent);
 }
 
 .reader-actions {
@@ -860,6 +1080,39 @@ main {
   background: color-mix(in srgb, var(--accent-soft) 54%, transparent);
 }
 
+.related-list {
+  margin-top: 0.5rem;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.related-list button {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--bg-soft) 86%, transparent);
+  color: var(--text-soft);
+  text-align: left;
+  display: grid;
+  gap: 0.22rem;
+  padding: 0.42rem 0.48rem;
+}
+
+.related-list button:hover {
+  border-color: var(--line-strong);
+  background: color-mix(in srgb, var(--accent-soft) 56%, transparent);
+}
+
+.related-list span {
+  color: var(--text);
+  font-size: 0.8rem;
+}
+
+.related-list small {
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
 .side-control + .side-control {
   margin-top: 0.58rem;
 }
@@ -981,6 +1234,22 @@ main {
 }
 
 @media (max-width: 1240px) {
+  .pathway-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .starter-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .docs-toolbar {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .docs-toolbar input {
+    grid-column: span 2;
+  }
+
   .workspace-grid {
     grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
   }
@@ -1008,6 +1277,11 @@ main {
     grid-template-columns: 1fr;
   }
 
+  .pathway-grid,
+  .starter-list {
+    grid-template-columns: 1fr;
+  }
+
   .reader-side {
     grid-column: auto;
     grid-template-columns: 1fr;
@@ -1021,7 +1295,8 @@ main {
     grid-template-columns: 1fr 1fr;
   }
 
-  .docs-toolbar input {
+  .docs-toolbar input,
+  .docs-toolbar .btn:last-child {
     grid-column: span 2;
   }
 }
@@ -1062,8 +1337,13 @@ main {
     grid-template-columns: 1fr;
   }
 
-  .docs-toolbar input {
+  .docs-toolbar input,
+  .docs-toolbar .btn:last-child {
     grid-column: auto;
+  }
+
+  .workspace-meta span {
+    width: 100%;
   }
 
   .reader-head {


### PR DESCRIPTION
## Linked Linear
- RMN-169

## Summary
### Problem
Main branch Pages currently lacks the improved taxonomy-first docs reading experience delivered on dev.

### Why It Matters
Publishing this upgrade to main is required so users can immediately benefit from guided reading paths, richer categorization, and better doc discoverability on GitHub Pages.

### What Changed
- Promoted docs IA upgrade from dev to main via release branch.
- Includes semantic doc metadata pipeline and UX improvements for pathways, starter docs, filtering, grouping, and related-doc recommendations.

## Validation Evidence
### Commands
- `cd site && npm run build`

### Results
- Build succeeds.
- Manifest generated with 386 docs.
- Static assets generated under `gh-pages/`.

## Security Impact
### Risk
Low. Frontend/docs metadata and rendering only.

### Mitigation
- No backend or secret-handling changes.
- Repository-controlled markdown/docs sources only.

## Privacy and Data Hygiene
- No PII collection introduced.
- No third-party analytics added.

## Rollback Plan
1. Revert this PR on `main`.
2. Re-run Pages deploy workflow for previous artifact.
3. Verify previous docs UX is restored.
