### PR TITLE
feat(release): support FreeBSD amd64 prebuilt artifacts

### DIFF
--- a/.github/release/release-artifact-contract.json
+++ b/.github/release/release-artifact-contract.json
@@ -8,6 +8,7 @@
     "zeroclaw-armv7-unknown-linux-gnueabihf.tar.gz",
     "zeroclaw-armv7-linux-androideabi.tar.gz",
     "zeroclaw-aarch64-linux-android.tar.gz",
+    "zeroclaw-x86_64-unknown-freebsd.tar.gz",
     "zeroclaw-x86_64-apple-darwin.tar.gz",
     "zeroclaw-aarch64-apple-darwin.tar.gz",
     "zeroclaw-x86_64-pc-windows-msvc.zip"

--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -225,6 +225,14 @@ jobs:
                       linker: ""
                       android_ndk: true
                       android_api: 21
+                    - os: self-hosted
+                      target: x86_64-unknown-freebsd
+                      artifact: zeroclaw
+                      archive_ext: tar.gz
+                      cross_compiler: ""
+                      linker_env: ""
+                      linker: ""
+                      use_cross: true
                     - os: macos-15-intel
                       target: x86_64-apple-darwin
                       artifact: zeroclaw
@@ -260,7 +268,7 @@ jobs:
             - uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5 # v3
               if: runner.os != 'Windows'
 
-            - name: Install cross for MUSL targets
+            - name: Install cross for cross-built targets
               if: matrix.use_cross
               run: |
                   cargo install cross --git https://github.com/cross-rs/cross

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -149,6 +149,9 @@ detect_release_target() {
     Darwin:arm64|Darwin:aarch64)
       echo "aarch64-apple-darwin"
       ;;
+    FreeBSD:amd64|FreeBSD:x86_64)
+      echo "x86_64-unknown-freebsd"
+      ;;
     *)
       return 1
       ;;


### PR DESCRIPTION
## Summary
- add `x86_64-unknown-freebsd` to the release build matrix so publish workflows generate a FreeBSD amd64 prebuilt archive
- add the FreeBSD archive name to the release artifact contract
- teach bootstrap prebuilt detection to map `FreeBSD:amd64|x86_64` to `x86_64-unknown-freebsd`

## Why
Issue #1924 requests first-class FreeBSD amd64 prebuilt support so users on FreeBSD/TrueNAS do not need to compile from source for every install.

## Changes
- `.github/workflows/pub-release.yml`
  - add release matrix target: `x86_64-unknown-freebsd` (cross-built lane)
  - rename cross install step label to be target-agnostic
- `.github/release/release-artifact-contract.json`
  - add `zeroclaw-x86_64-unknown-freebsd.tar.gz`
- `scripts/bootstrap.sh`
  - `detect_release_target()` now maps `FreeBSD:amd64|FreeBSD:x86_64` -> `x86_64-unknown-freebsd`

## Validation
- `bash -n scripts/bootstrap.sh`
- `python3 -m json.tool .github/release/release-artifact-contract.json >/dev/null`
- YAML parse check for `.github/workflows/pub-release.yml` via `python3` + `yaml.safe_load`

Closes #1924


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added FreeBSD x86_64 platform support to the release and build process, enabling cross-compilation and distribution of builds for this target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->