### PR TITLE
[supersede #1691] feat(channel): add base_url option to Telegram config for Bale/compatible APIs

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2687,18 +2687,23 @@ fn collect_configured_channels(
     let mut channels = Vec::new();
 
     if let Some(ref tg) = config.channels_config.telegram {
+        let mut telegram = TelegramChannel::new(
+            tg.bot_token.clone(),
+            tg.allowed_users.clone(),
+            tg.mention_only,
+        )
+        .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
+        .with_transcription(config.transcription.clone())
+        .with_workspace_dir(config.workspace_dir.clone());
+
+        // Use custom base URL if configured (e.g., for Bale messenger)
+        if let Some(ref base_url) = tg.base_url {
+            telegram = telegram.with_api_base(base_url.clone());
+        }
+
         channels.push(ConfiguredChannel {
             display_name: "Telegram",
-            channel: Arc::new(
-                TelegramChannel::new(
-                    tg.bot_token.clone(),
-                    tg.allowed_users.clone(),
-                    tg.mention_only,
-                )
-                .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
-                .with_transcription(config.transcription.clone())
-                .with_workspace_dir(config.workspace_dir.clone()),
-            ),
+            channel: Arc::new(telegram),
         });
     }
 

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -828,8 +828,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
     /// Download a file from the Telegram CDN.
     async fn download_file(&self, file_path: &str) -> anyhow::Result<Vec<u8>> {
         let url = format!(
-            "https://api.telegram.org/file/bot{}/{file_path}",
-            self.bot_token
+            "{}/file/bot{}/{file_path}",
+            self.api_base, self.bot_token
         );
         let resp = self
             .http_client()
@@ -1325,8 +1325,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         // Step 2: download the actual file
         let download_url = format!(
-            "https://api.telegram.org/file/bot{}/{}",
-            self.bot_token, file_path
+            "{}/file/bot{}/{}",
+            self.api_base, self.bot_token, file_path
         );
         let img_resp = self.http_client().get(&download_url).send().await?;
         let bytes = img_resp.bytes().await?;
@@ -2849,6 +2849,28 @@ mod tests {
         assert_eq!(
             ch.api_url("getMe"),
             "https://api.telegram.org/bot123:ABC/getMe"
+        );
+    }
+
+    #[test]
+    fn telegram_custom_base_url() {
+        // Test default base URL
+        let ch = TelegramChannel::new("123:ABC".into(), vec![], false);
+        assert_eq!(
+            ch.api_url("getMe"),
+            "https://api.telegram.org/bot123:ABC/getMe"
+        );
+
+        // Test custom base URL (e.g., for Bale messenger)
+        let ch = TelegramChannel::new("123:ABC".into(), vec![], false)
+            .with_api_base("https://tapi.bale.ai".to_string());
+        assert_eq!(
+            ch.api_url("getMe"),
+            "https://tapi.bale.ai/bot123:ABC/getMe"
+        );
+        assert_eq!(
+            ch.api_url("sendMessage"),
+            "https://tapi.bale.ai/bot123:ABC/sendMessage"
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,6 +45,7 @@ mod tests {
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
+            base_url: None,
         };
 
         let discord = DiscordConfig {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2761,6 +2761,11 @@ pub struct TelegramConfig {
     /// Direct messages are always processed.
     #[serde(default)]
     pub mention_only: bool,
+    /// Optional custom base URL for Telegram-compatible APIs.
+    /// Defaults to "https://api.telegram.org" if not specified.
+    /// Example for Bale messenger: "https://tapi.bale.ai"
+    #[serde(default)]
+    pub base_url: Option<String>,
 }
 
 impl ChannelConfig for TelegramConfig {
@@ -5119,6 +5124,7 @@ default_temperature = 0.7
                     draft_update_interval_ms: default_draft_update_interval_ms(),
                     interrupt_on_new_message: false,
                     mention_only: false,
+                    base_url: None,
                 }),
                 discord: None,
                 slack: None,
@@ -5490,6 +5496,7 @@ tool_dispatcher = "xml"
             draft_update_interval_ms: 500,
             interrupt_on_new_message: true,
             mention_only: false,
+            base_url: None,
         };
         let json = serde_json::to_string(&tc).unwrap();
         let parsed: TelegramConfig = serde_json::from_str(&json).unwrap();
@@ -5507,6 +5514,14 @@ tool_dispatcher = "xml"
         assert_eq!(parsed.stream_mode, StreamMode::Off);
         assert_eq!(parsed.draft_update_interval_ms, 1000);
         assert!(!parsed.interrupt_on_new_message);
+        assert!(parsed.base_url.is_none());
+    }
+
+    #[test]
+    async fn telegram_config_custom_base_url() {
+        let json = r#"{"bot_token":"tok","allowed_users":[],"base_url":"https://tapi.bale.ai"}"#;
+        let parsed: TelegramConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.base_url, Some("https://tapi.bale.ai".to_string()));
     }
 
     #[test]

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -404,6 +404,7 @@ mod tests {
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
+            base_url: None,
         });
         assert!(has_supervised_channels(&config));
     }
@@ -536,6 +537,7 @@ mod tests {
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
+            base_url: None,
         });
 
         let target = heartbeat_delivery_target(&config).unwrap();

--- a/src/integrations/registry.rs
+++ b/src/integrations/registry.rs
@@ -792,7 +792,6 @@ mod tests {
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
-            group_reply: None,
             base_url: None,
         });
         let entries = all_integrations();

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -3618,6 +3618,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     draft_update_interval_ms: 1000,
                     interrupt_on_new_message: false,
                     mention_only: false,
+                    base_url: None,
                 });
             }
             ChannelMenuChoice::Discord => {


### PR DESCRIPTION
Supersedes #1691 to recover from merge conflicts against latest `main`.

- Source PR: https://github.com/zeroclaw-labs/zeroclaw/pull/1691
- Recovery mode: automated replay on top of current `main`
- Merge policy: all CI checks green

Original PR description:

## Summary
- Adds optional `base_url` parameter to Telegram channel configuration
- Enables use with Telegram-compatible APIs like Bale messenger
- Zero breaking changes - defaults to official Telegram API

## Configuration

```toml
[channel.telegram]
bot_token = "YOUR_BOT_TOKEN"
allowed_users = ["user1"]
base_url = "https://tapi.bale.ai"  # Optional, for Bale messenger
```

## Use Cases
- **Bale messenger** - 34M+ users in Iran, 100% Telegram API compatible
- **Local Bot API servers** - Self-hosted Telegram Bot API instances
- **Testing** - Custom endpoints for development/testing

## Changes
- Added `base_url: Option<String>` to `TelegramConfig` in config schema
- Updated `TelegramChannel::download_file()` to use `api_base` instead of hardcoded URL
- Updated channel creation to pass `base_url` if configured
- Added tests for custom base_url functionality

## Test Plan
- [x] All 3022 unit tests pass
- [x] Added `telegram_custom_base_url` test
- [x] Added `telegram_config_custom_base_url` config test
- [x] Verified backward compatibility (defaults work)

## Files Changed
- `src/config/schema.rs` - Added `base_url` field to `TelegramConfig`
- `src/channels/telegram.rs` - Use `api_base` for file downloads, added test
- `src/channels/mod.rs` - Pass `base_url` when creating Telegram channel
- Test fixtures updated in `wizard.rs`, `daemon/mod.rs`, `integrations/registry.rs`, `config/mod.rs`

Closes #1464

🦀 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram channels now support optional custom API base URL configuration, enabling integration with alternative or self-hosted Telegram API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
