### PR TITLE
fix: add initial arrays for zeroclaw containers variables

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -754,7 +754,7 @@ is_zeroclaw_resource_name() {
 }
 
 maybe_stop_running_zeroclaw_containers() {
-  local -a running_ids running_rows
+  local -a running_ids=() running_rows=()
   local id name image command row
 
   while IFS=$'\t' read -r id name image command; do


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`main`): dev
- Problem: `./bootstrap.sh --docker` fails on Linux with unbound variable when no ZeroClaw containers are running.
- Why it matters: Breaks strict-mode execution (`set -u`) on Bash 4/5 (default on Linux) and causes inconsistent behavior between macOS and Linux.
- What changed: Explicitly initialized local arrays (`running_ids=()` and `running_rows=()`) to ensure they are bound across Bash versions.
- What did **not** change (scope boundary): No logic changes, no Docker behavior changes, no runtime/container logic modifications.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): scripts,dev
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): scripts: bootstrap
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): runtime

## Linked Issue

- Closes #1950
- Related #1950
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)
- External tracking link(s) (optional):

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- File system access scope changed? (`Yes/No`)
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`)
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - Linux (Bash 5.2) with no ZeroClaw containers running → no error
  - Linux with active ZeroClaw containers → prompt + stop logic works
  - macOS (Bash 3.2) → behavior unchanged
- Edge cases checked:
  - Empty container list
  - Non-interactive mode
  - Multiple matching containers
- What was not verified:
  - Alternative shell environments (zsh/dash) explicitly

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Docker bootstrap script only
- Potential unintended effects: N/A
- Guardrails/monitoring for early detection: Strict-mode execution (`set -euo pipefail`) remains active

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): ChatGPT
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>`
- Feature flags or config toggles (if any): N/A
- Observable failure symptoms: Reappearance of unbound variable when no containers are running

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
- Mitigation:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code robustness by explicitly initializing array variables in shell scripts to ensure proper behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->