### PR TITLE
feat{providers): add qwen coding plan provider url

### DIFF
--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -707,6 +707,9 @@ const MINIMAX_ONBOARD_MODELS: [(&str, &str); 5] = [
 ];
 
 fn default_model_for_provider(provider: &str) -> String {
+    if matches!(provider, "qwen-coding-plan") {
+        return "qwen3-coder-plus".into();
+    }
     match canonical_provider_name(provider) {
         "anthropic" => "claude-sonnet-4-5-20250929".into(),
         "openai" => "gpt-5.2".into(),
@@ -739,6 +742,22 @@ fn default_model_for_provider(provider: &str) -> String {
 }
 
 fn curated_models_for_provider(provider_name: &str) -> Vec<(String, String)> {
+    if matches!(provider_name, "qwen-coding-plan") {
+        return vec![
+            (
+                "qwen3-coder-plus".to_string(),
+                "Qwen3 Coder Plus (recommended for coding workflows)".to_string(),
+            ),
+            (
+                "qwen3.5-plus".to_string(),
+                "Qwen3.5 Plus (reasoning + coding)".to_string(),
+            ),
+            (
+                "qwen3-max-2026-01-23".to_string(),
+                "Qwen3 Max (high-capability coding model)".to_string(),
+            ),
+        ];
+    }
     match canonical_provider_name(provider_name) {
         "openrouter" => vec![
             (
@@ -1202,6 +1221,9 @@ fn models_endpoint_for_provider(provider_name: &str) -> Option<&'static str> {
     match provider_name {
         "qwen-intl" => Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models"),
         "dashscope-us" => Some("https://dashscope-us.aliyuncs.com/compatible-mode/v1/models"),
+        "qwen-coding-plan" => {
+            Some("https://coding.dashscope.aliyuncs.com/v1/models")
+        }
         "moonshot-cn" | "kimi-cn" => Some("https://api.moonshot.cn/v1/models"),
         "glm-cn" | "bigmodel" => Some("https://open.bigmodel.cn/api/paas/v4/models"),
         "zai-cn" | "z.ai-cn" => Some("https://open.bigmodel.cn/api/coding/paas/v4/models"),
@@ -2222,6 +2244,10 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
             ("qwen", "Qwen — DashScope China endpoint"),
             ("qwen-intl", "Qwen — DashScope international endpoint"),
             ("qwen-us", "Qwen — DashScope US endpoint"),
+            (
+                "qwen-coding-plan",
+                "Qwen — DashScope coding plan endpoint (coding.dashscope.aliyuncs.com)",
+            ),
             ("hunyuan", "Hunyuan — Tencent large models (T1, Turbo, Pro)"),
             ("qianfan", "Qianfan — Baidu AI models (China endpoint)"),
             ("zai", "Z.AI — global coding endpoint"),
@@ -6704,6 +6730,7 @@ mod tests {
         assert_eq!(default_model_for_provider("qwen"), "qwen-plus");
         assert_eq!(default_model_for_provider("qwen-intl"), "qwen-plus");
         assert_eq!(default_model_for_provider("qwen-code"), "qwen3-coder-plus");
+        assert_eq!(default_model_for_provider("qwen-coding-plan"), "qwen3-coder-plus");
         assert_eq!(default_model_for_provider("glm-cn"), "glm-5");
         assert_eq!(default_model_for_provider("minimax-cn"), "MiniMax-M2.5");
         assert_eq!(default_model_for_provider("zai-cn"), "glm-5");
@@ -6748,6 +6775,7 @@ mod tests {
         assert_eq!(canonical_provider_name("dashscope-us"), "qwen");
         assert_eq!(canonical_provider_name("qwen-code"), "qwen-code");
         assert_eq!(canonical_provider_name("qwen-oauth"), "qwen-code");
+        assert_eq!(canonical_provider_name("qwen-coding-plan"), "qwen");
         assert_eq!(canonical_provider_name("codex"), "openai-codex");
         assert_eq!(canonical_provider_name("openai_codex"), "openai-codex");
         assert_eq!(canonical_provider_name("moonshot-intl"), "moonshot");
@@ -6878,6 +6906,18 @@ mod tests {
     }
 
     #[test]
+    fn curated_models_for_qwen_coding_plan_match_qwen_code_coding_models() {
+        let ids: Vec<String> = curated_models_for_provider("qwen-coding-plan")
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect();
+
+        assert!(ids.contains(&"qwen3-coder-plus".to_string()));
+        assert!(ids.contains(&"qwen3.5-plus".to_string()));
+        assert!(ids.contains(&"qwen3-max-2026-01-23".to_string()));
+    }
+
+    #[test]
     fn supports_live_model_fetch_for_supported_and_unsupported_providers() {
         assert!(supports_live_model_fetch("openai"));
         assert!(supports_live_model_fetch("anthropic"));
@@ -6978,6 +7018,10 @@ mod tests {
         assert_eq!(
             models_endpoint_for_provider("qwen-intl"),
             Some("https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models")
+        );
+        assert_eq!(
+            models_endpoint_for_provider("qwen-coding-plan"),
+            Some("https://coding.dashscope.aliyuncs.com/v1/models")
         );
     }
 
@@ -7287,6 +7331,7 @@ mod tests {
         assert_eq!(provider_env_var("dashscope-us"), "DASHSCOPE_API_KEY");
         assert_eq!(provider_env_var("qwen-code"), "QWEN_OAUTH_TOKEN");
         assert_eq!(provider_env_var("qwen-oauth"), "QWEN_OAUTH_TOKEN");
+        assert_eq!(provider_env_var("qwen-coding-plan"), "DASHSCOPE_API_KEY");
         assert_eq!(provider_env_var("glm-cn"), "GLM_API_KEY");
         assert_eq!(provider_env_var("minimax-cn"), "MINIMAX_API_KEY");
         assert_eq!(provider_env_var("kimi-code"), "KIMI_CODE_API_KEY");

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -62,6 +62,7 @@ const MOONSHOT_CN_BASE_URL: &str = "https://api.moonshot.cn/v1";
 const QWEN_CN_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
 const QWEN_INTL_BASE_URL: &str = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
 const QWEN_US_BASE_URL: &str = "https://dashscope-us.aliyuncs.com/compatible-mode/v1";
+const QWEN_CODING_BASE_URL: &str = "https://coding.dashscope.aliyuncs.com/v1";
 const QWEN_OAUTH_BASE_FALLBACK_URL: &str = QWEN_CN_BASE_URL;
 const QWEN_OAUTH_TOKEN_ENDPOINT: &str = "https://chat.qwen.ai/api/v1/oauth2/token";
 const QWEN_OAUTH_PLACEHOLDER: &str = "qwen-oauth";
@@ -142,6 +143,10 @@ pub(crate) fn is_qwen_us_alias(name: &str) -> bool {
     matches!(name, "qwen-us" | "dashscope-us")
 }
 
+pub(crate) fn is_qwen_coding_alias(name: &str) -> bool {
+    name == "qwen-coding-plan"
+}
+
 pub(crate) fn is_qwen_oauth_alias(name: &str) -> bool {
     matches!(name, "qwen-code" | "qwen-oauth" | "qwen_oauth")
 }
@@ -150,6 +155,7 @@ pub(crate) fn is_qwen_alias(name: &str) -> bool {
     is_qwen_cn_alias(name)
         || is_qwen_intl_alias(name)
         || is_qwen_us_alias(name)
+        || is_qwen_coding_alias(name)
         || is_qwen_oauth_alias(name)
 }
 
@@ -656,6 +662,8 @@ fn qwen_base_url(name: &str) -> Option<&'static str> {
         Some(QWEN_INTL_BASE_URL)
     } else if is_qwen_us_alias(name) {
         Some(QWEN_US_BASE_URL)
+    } else if is_qwen_coding_alias(name) {
+        Some(QWEN_CODING_BASE_URL)
     } else {
         None
     }
@@ -1705,6 +1713,7 @@ pub fn list_providers() -> Vec<ProviderInfo> {
                 "dashscope-intl",
                 "qwen-us",
                 "dashscope-us",
+                "qwen-coding-plan",
                 "qwen-code",
                 "qwen-oauth",
                 "qwen_oauth",
@@ -2041,8 +2050,10 @@ mod tests {
         assert!(is_qwen_alias("dashscope"));
         assert!(is_qwen_alias("qwen-us"));
         assert!(is_qwen_alias("qwen-code"));
+        assert!(is_qwen_alias("qwen-coding-plan"));
         assert!(is_qwen_oauth_alias("qwen-code"));
         assert!(is_qwen_oauth_alias("qwen_oauth"));
+        assert!(is_qwen_coding_alias("qwen-coding-plan"));
         assert!(is_zai_alias("z.ai"));
         assert!(is_zai_alias("zai-cn"));
         assert!(is_qianfan_alias("qianfan"));
@@ -2071,6 +2082,7 @@ mod tests {
         assert_eq!(canonical_china_provider_name("qwen"), Some("qwen"));
         assert_eq!(canonical_china_provider_name("dashscope-us"), Some("qwen"));
         assert_eq!(canonical_china_provider_name("qwen-code"), Some("qwen"));
+        assert_eq!(canonical_china_provider_name("qwen-coding-plan"), Some("qwen"));
         assert_eq!(canonical_china_provider_name("zai"), Some("zai"));
         assert_eq!(canonical_china_provider_name("z.ai-cn"), Some("zai"));
         assert_eq!(canonical_china_provider_name("qianfan"), Some("qianfan"));
@@ -2106,6 +2118,7 @@ mod tests {
         assert_eq!(qwen_base_url("qwen-intl"), Some(QWEN_INTL_BASE_URL));
         assert_eq!(qwen_base_url("qwen-us"), Some(QWEN_US_BASE_URL));
         assert_eq!(qwen_base_url("qwen-code"), Some(QWEN_CN_BASE_URL));
+        assert_eq!(qwen_base_url("qwen-coding-plan"), Some(QWEN_CODING_BASE_URL));
 
         assert_eq!(zai_base_url("zai"), Some(ZAI_GLOBAL_BASE_URL));
         assert_eq!(zai_base_url("z.ai"), Some(ZAI_GLOBAL_BASE_URL));
@@ -2302,6 +2315,7 @@ mod tests {
         assert!(create_provider("dashscope-international", Some("key")).is_ok());
         assert!(create_provider("qwen-us", Some("key")).is_ok());
         assert!(create_provider("dashscope-us", Some("key")).is_ok());
+        assert!(create_provider("qwen-coding-plan", Some("key")).is_ok());
         assert!(create_provider("qwen-code", Some("key")).is_ok());
         assert!(create_provider("qwen-oauth", Some("key")).is_ok());
     }

--- a/src/providers/quota_adapter.rs
+++ b/src/providers/quota_adapter.rs
@@ -262,6 +262,7 @@ impl UniversalQuotaExtractor {
         extractors.insert("qwen".to_string(), Box::new(QwenQuotaExtractor));
         extractors.insert("qwen-code".to_string(), Box::new(QwenQuotaExtractor)); // OAuth alias
         extractors.insert("qwen-oauth".to_string(), Box::new(QwenQuotaExtractor)); // OAuth alias
+        extractors.insert("qwen-coding-plan".to_string(), Box::new(QwenQuotaExtractor)); // DashScope coding plan API
         extractors.insert("dashscope".to_string(), Box::new(QwenQuotaExtractor)); // DashScope API key
 
         Self { extractors }


### PR DESCRIPTION
## Summary

- Added provider `qwen-coding-plan` with base URL `https://coding.dashscope.aliyuncs.com/v1`, exposed in quick onboard, interactive wizard, `zeroclaw providers`, `models refresh`, and agent; reuse `DASHSCOPE_API_KEY`; default model `qwen3-coder-plus`; quota adapter registration; unit tests.

## Label Snapshot (required)

- **Risk label:** `risk: low`
- **Size label:** `size: XS` (auto-managed/read-only)
- **Scope labels:** `provider`, `onboard`, `config`
- **Module labels:** `provider: qwen`, `onboard: wizard`

## Related Issue

- Closes #1955

## Security Impact (required)

- **New permissions/capabilities?** No
- **New external network calls?** Yes — same host family (aliyuncs.com), new path (coding.dashscope.aliyuncs.com). Same API key as existing Qwen provider.
- **Secrets/tokens handling changed?** No — reuses `DASHSCOPE_API_KEY`
- **File system access scope changed?** No
- **If any Yes, describe risk and mitigation:** New HTTPS calls to coding.dashscope.aliyuncs.com; same credential as existing DashScope usage; no new secrets.

## Privacy and Data Hygiene (required)

- **Data-hygiene status:** pass
- **Redaction/anonymization notes:** No PII in code or logs
- **Neutral wording confirmation:** Use “Qwen” in user-facing text; no sensitive/vendor-specific wording beyond endpoint URLs

## Human Verification (required)

- **Verified scenarios:** 
  - interactive wizard shows new option; 
  - `zeroclaw providers` lists alias.

## Rollback Plan (required)

- **Fast rollback command/path:** Revert PR; no migration. Users with `default_provider = "qwen-coding-plan"` must set another provider.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** Requests to coding.dashscope.aliyuncs.com would 404 or fail if endpoint is removed; same as any provider endpoint change.

## Agent Collaboration Notes (recommended)

- **Agent tools used:**  Cursor



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for "qwen-coding-plan" provider with a curated selection of coding-optimized models including Qwen3 Coder Plus, Qwen3.5 Plus, and Qwen3 Max variants.
  * Configured provider-specific endpoint routing and environment variable mappings for seamless onboarding and quota extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->