### PR TITLE
fix(agent): stop misparsing bare URLs as shell(curl) tool calls

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -4229,11 +4229,33 @@ Done."#;
 
     #[test]
     fn parse_glm_style_plain_url() {
+        // Bare URLs must NOT be interpreted as tool calls (fixes #1941).
         let response = "https://example.com/api";
         let calls = parse_glm_style_tool_calls(response);
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, "shell");
-        assert!(calls[0].1["command"].as_str().unwrap().contains("curl"));
+        assert!(
+            calls.is_empty(),
+            "bare URLs must not be parsed as tool calls"
+        );
+    }
+
+    #[test]
+    fn parse_glm_style_ignores_urls_in_text() {
+        let response = "Reference link:\nhttps://example.com\nYou can visit it.";
+        let calls = parse_glm_style_tool_calls(response);
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn parse_tool_calls_does_not_convert_plain_url_to_shell() {
+        let response = "Here is the link:\nhttps://example.com\nEnjoy!";
+        let (text, calls) = parse_tool_calls(response);
+        assert!(
+            calls.is_empty(),
+            "plain URL in text must not become a tool call"
+        );
+        assert!(text.contains("Here is the link:"));
+        assert!(text.contains("https://example.com"));
+        assert!(text.contains("Enjoy!"));
     }
 
     #[test]

--- a/src/agent/loop_/parsing.rs
+++ b/src/agent/loop_/parsing.rs
@@ -957,15 +957,6 @@ pub(super) fn parse_glm_style_tool_calls(
                 }
             }
         }
-
-        // Plain URL
-        if let Some(command) = build_curl_command(line) {
-            calls.push((
-                "shell".to_string(),
-                serde_json::json!({ "command": command }),
-                Some(line.to_string()),
-            ));
-        }
     }
 
     calls


### PR DESCRIPTION
## Summary

- Base branch target: `dev`
- Problem: GLM-style fallback parser converts bare URLs in LLM text to `shell(curl)` calls, causing unintended command execution and history pollution
- Why it matters: S1 bug — blocks normal workflow for users with non-native function-calling models (e.g. GLM-5)
- What changed: Removed the plain-URL-to-shell catch-all in `parse_glm_style_tool_calls()`; updated and added regression tests
- What did **not** change: Explicit GLM-format calls with tool name prefix (`browser_open/url>...`, `shell/command>...`) remain fully supported

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: XS` (auto-managed)
- Scope labels: `agent`
- Module labels: `agent: loop`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `runtime`

## Linked Issue

- Closes #1941
- Linear issue key(s): N/A (external contributor, no Linear access)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings  # pass (pre-existing large_futures warnings only, zero new warnings)
cargo test  # pass (210/210 agent tests, 9/9 GLM parsing tests)
```

- Evidence provided: all parsing tests pass, including updated `parse_glm_style_plain_url` and 2 new regression tests (`parse_glm_style_ignores_urls_in_text`, `parse_tool_calls_does_not_convert_plain_url_to_shell`)
- If any command is intentionally skipped: N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No — this change *removes* unintended network calls
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A — all answers are No

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes — uses `example.com` placeholder per coding guidelines

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (no docs or user-facing wording changes)

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: bare URL in text, URL in multi-line text, GLM-format `browser_open/url>`, `shell/command>`, `http_request/url>`, JSON args
- Edge cases checked: `javascript:` URL rejection, multiple GLM calls in one response
- What was not verified: live GLM-5 model (no access), only unit tests

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: GLM-style fallback tool-call parsing path only
- Potential unintended effects: if a model outputs a bare URL *intending* it as a fetch command, it will no longer be auto-executed (model should use `browser_open/url>` format instead)
- Guardrails/monitoring for early detection: existing `detect_tool_call_parse_issue()` will flag if a response looks like a tool payload but no calls were parsed

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (code analysis, implementation, testing, PR creation)
- Workflow/plan summary: root cause analysis → minimal deletion fix → test update + regression tests → PR
- Verification focus: all 9 GLM-style parsing tests + full agent test suite (210 tests)
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: none needed (single commit)
- Observable failure symptoms: GLM-format tool calls stop working → revert immediately

## Risks and Mitigations

- Risk: Models that relied on bare-URL-to-curl behavior lose that ability
  - Mitigation: All such models have the explicit `tool_name/param>value` format available; the bare URL path was undocumented and contradicted the codebase's own security comments (parsing.rs line 1493-1501: "Tool calls MUST be explicitly wrapped")


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed URL handling in agent instruction parsing to prevent plain URLs from being incorrectly converted into executable shell commands.
- URLs within text are now properly ignored during tool call parsing instead of being mistakenly interpreted as tool calls, improving safety and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->