### PR TITLE
[supersede #1897] feat(gateway): add /api/chat endpoint for tools-enabled chat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio-util = { version = "0.7", default-features = false }
 tokio-stream = { version = "0.1.18", default-features = false, features = ["fs", "sync"] }
 
 # HTTP client - minimal features
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "native-tls", "blocking", "multipart", "stream", "socks"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "multipart", "stream", "socks"] }
 
 # Matrix client + E2EE decryption
 matrix-sdk = { version = "0.16", optional = true, default-features = false, features = ["e2e-encryption", "rustls-tls", "markdown", "sqlite"] }
@@ -46,7 +46,7 @@ schemars = "1.2"
 
 # Logging - minimal
 tracing = { version = "0.1", default-features = false }
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi", "env-filter"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono"] }
 
 # Observability - Prometheus metrics
 prometheus = { version = "0.14", default-features = false }
@@ -58,11 +58,15 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png"]
 # URL encoding for web search
 urlencoding = "2.1"
 
-# HTML to plain text conversion (web_fetch tool)
-nanohtml2text = "0.2"
+# HTML conversion providers (web_fetch tool)
+fast_html2md = { version = "0.0.58", optional = true }
+nanohtml2text = { version = "0.2", optional = true }
 
 # Optional Rust-native browser automation backend
 fantoccini = { version = "0.22.0", optional = true, default-features = false, features = ["rustls-tls"] }
+
+# Optional in-process WASM runtime for sandboxed tool execution
+wasmi = { version = "1.0.9", optional = true, default-features = true }
 
 # Error handling
 anyhow = "1.0"
@@ -100,6 +104,7 @@ prost = { version = "0.14", default-features = false, features = ["derive"], opt
 # Memory / persistence
 rusqlite = { version = "0.37", features = ["bundled"] }
 postgres = { version = "0.19", features = ["with-chrono-0_4"], optional = true }
+tokio-postgres-rustls = { version = "0.12", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
 chrono-tz = "0.10"
 cron = "0.15"
@@ -113,6 +118,9 @@ glob = "0.3"
 
 # Binary discovery (init system detection)
 which = "8.0"
+
+# Temporary directory creation (for self-update)
+tempfile = "3.14"
 
 # WebSocket client channels (Discord/Lark/DingTalk/Nostr)
 tokio-tungstenite = { version = "0.28", features = ["rustls-tls-webpki-roots"] }
@@ -161,6 +169,7 @@ probe-rs = { version = "0.31", optional = true }
 
 # PDF extraction for datasheet RAG (optional, enable with --features rag-pdf)
 pdf-extract = { version = "0.10", optional = true }
+tempfile = "3.14"
 
 # Terminal QR rendering for WhatsApp Web pairing flow.
 qrcode = { version = "0.14", optional = true }
@@ -179,22 +188,23 @@ wa-rs-tokio-transport = { version = "0.2", optional = true, default-features = f
 rppal = { version = "0.22", optional = true }
 landlock = { version = "0.4", optional = true }
 
-# Unix-specific dependencies (for root check, etc.)
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"
-
 [features]
-default = []
+default = ["channel-lark", "web-fetch-html2md"]
 hardware = ["nusb", "tokio-serial"]
 channel-matrix = ["dep:matrix-sdk"]
 channel-lark = ["dep:prost"]
-memory-postgres = ["dep:postgres"]
+memory-postgres = ["dep:postgres", "dep:tokio-postgres-rustls"]
 observability-otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
+web-fetch-html2md = ["dep:fast_html2md"]
+web-fetch-plaintext = ["dep:nanohtml2text"]
+firecrawl = []
 peripheral-rpi = ["rppal"]
 # Browser backend feature alias used by cfg(feature = "browser-native")
 browser-native = ["dep:fantoccini"]
 # Backward-compatible alias for older invocations
 fantoccini = ["browser-native"]
+# In-process WASM runtime (capability-based sandbox)
+runtime-wasm = ["dep:wasmi"]
 # Sandbox feature aliases used by cfg(feature = "sandbox-*")
 sandbox-landlock = ["dep:landlock"]
 sandbox-bubblewrap = []
@@ -229,10 +239,14 @@ strip = true
 panic = "abort"
 
 [dev-dependencies]
-tempfile = "3.14"
+tempfile = "3.26"
 criterion = { version = "0.8", features = ["async_tokio"] }
 wiremock = "0.6"
 scopeguard = "1.2"
+
+[[bin]]
+name = "zeroclaw"
+path = "src/main.rs"
 
 [[bench]]
 name = "agent_benchmarks"

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -42,7 +42,7 @@ pub mod whatsapp_storage;
 #[cfg(feature = "whatsapp-web")]
 pub mod whatsapp_web;
 
-pub use clawdtalk::{ClawdTalkChannel, ClawdTalkConfig};
+pub use clawdtalk::ClawdTalkChannel;
 pub use cli::CliChannel;
 pub use dingtalk::DingTalkChannel;
 pub use discord::DiscordChannel;
@@ -67,8 +67,12 @@ pub use whatsapp::WhatsAppChannel;
 #[cfg(feature = "whatsapp-web")]
 pub use whatsapp_web::WhatsAppWebChannel;
 
-use crate::agent::loop_::{build_tool_instructions, run_tool_call_loop, scrub_credentials};
-use crate::config::Config;
+use crate::agent::loop_::{
+    build_shell_policy_instructions, build_tool_instructions_from_specs, run_tool_call_loop,
+    scrub_credentials,
+};
+use crate::approval::{ApprovalManager, PendingApprovalError};
+use crate::config::{Config, NonCliNaturalLanguageApprovalMode};
 use crate::identity;
 use crate::memory::{self, Memory};
 use crate::observability::{self, runtime_trace, Observer};
@@ -152,7 +156,16 @@ enum ChannelRuntimeCommand {
     ShowModel,
     SetModel(String),
     NewSession,
+    RequestAllToolsOnce,
+    RequestToolApproval(String),
+    ConfirmToolApproval(String),
+    ListPendingApprovals,
+    ApproveTool(String),
+    UnapproveTool(String),
+    ListApprovals,
 }
+
+const APPROVAL_ALL_TOOLS_ONCE_TOKEN: &str = "__all_tools_once__";
 
 #[derive(Debug, Clone, Default, Deserialize)]
 struct ModelCacheState {
@@ -185,6 +198,17 @@ struct ConfigFileStamp {
 struct RuntimeConfigState {
     defaults: ChannelRuntimeDefaults,
     last_applied_stamp: Option<ConfigFileStamp>,
+}
+
+#[derive(Debug, Clone)]
+struct RuntimeAutonomyPolicy {
+    auto_approve: Vec<String>,
+    always_ask: Vec<String>,
+    non_cli_excluded_tools: Vec<String>,
+    non_cli_approval_approvers: Vec<String>,
+    non_cli_natural_language_approval_mode: NonCliNaturalLanguageApprovalMode,
+    non_cli_natural_language_approval_mode_by_channel:
+        HashMap<String, NonCliNaturalLanguageApprovalMode>,
 }
 
 fn runtime_config_store() -> &'static Mutex<HashMap<PathBuf, RuntimeConfigState>> {
@@ -223,7 +247,10 @@ struct ChannelRuntimeContext {
     interrupt_on_new_message: bool,
     multimodal: crate::config::MultimodalConfig,
     hooks: Option<Arc<crate::hooks::HookRunner>>,
-    non_cli_excluded_tools: Arc<Vec<String>>,
+    non_cli_excluded_tools: Arc<Mutex<Vec<String>>>,
+    query_classification: crate::config::QueryClassificationConfig,
+    model_routes: Vec<crate::config::ModelRouteConfig>,
+    approval_manager: Arc<ApprovalManager>,
 }
 
 #[derive(Clone)]
@@ -411,7 +438,160 @@ fn channel_delivery_instructions(channel_name: &str) -> Option<&'static str> {
              - Keep normal text outside markers and never wrap markers in code fences.\n\
              - Use tool results silently: answer the latest user message directly, and do not narrate delayed/internal tool execution bookkeeping.",
         ),
+        "whatsapp" => Some(
+            "When responding on WhatsApp:\n\
+             - Use *bold* for emphasis (WhatsApp uses single asterisks).\n\
+             - Be concise. No markdown headers (## etc.) — they don't render.\n\
+             - No markdown tables — use bullet lists instead.\n\
+             - For sending images, documents, videos, or audio files use markers: [IMAGE:<absolute-path>], [DOCUMENT:<absolute-path>], [VIDEO:<absolute-path>], [AUDIO:<absolute-path>]\n\
+             - The path MUST be an absolute filesystem path to a local file (e.g. [IMAGE:/home/nicolas/.zeroclaw/workspace/images/chart.png]).\n\
+             - Keep normal text outside markers and never wrap markers in code fences.\n\
+             - You can combine text and media in one response — text is sent first, then each attachment.\n\
+             - Use tool results silently: answer the latest user message directly, and do not narrate delayed/internal tool execution bookkeeping.",
+        ),
         _ => None,
+    }
+}
+
+fn should_expose_internal_tool_details(user_message: &str) -> bool {
+    let trimmed = user_message.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let mentions_internal_details_en = lower.contains("command")
+        || lower.contains("tool call")
+        || lower.contains("function call")
+        || lower.contains("execution trace")
+        || lower.contains("internal step");
+    let mentions_internal_details_cjk = trimmed.contains("命令")
+        || trimmed.contains("工具调用")
+        || trimmed.contains("函数调用")
+        || trimmed.contains("执行过程");
+
+    // Fail closed for negated phrasing ("don't show commands", "不要显示命令").
+    const ENGLISH_NEGATIVE_HINTS: [&str; 18] = [
+        "don't show command",
+        "don't show commands",
+        "do not show command",
+        "do not show commands",
+        "don't output command",
+        "do not output command",
+        "without command",
+        "without commands",
+        "no command output",
+        "hide command",
+        "hide commands",
+        "omit command",
+        "omit commands",
+        "skip command",
+        "skip commands",
+        "don't show tool call",
+        "do not show tool call",
+        "do not show function call",
+    ];
+    if mentions_internal_details_en
+        && ENGLISH_NEGATIVE_HINTS
+            .iter()
+            .any(|hint| lower.contains(hint))
+    {
+        return false;
+    }
+
+    const CJK_NEGATIVE_HINTS: [&str; 22] = [
+        "不要输出命令",
+        "不要显示命令",
+        "不要展示命令",
+        "不要带上命令",
+        "不要附上命令",
+        "别输出命令",
+        "别显示命令",
+        "别展示命令",
+        "不要输出工具调用",
+        "不要显示工具调用",
+        "不要展示工具调用",
+        "别输出工具调用",
+        "别显示工具调用",
+        "不要输出函数调用",
+        "不要显示函数调用",
+        "不要展示函数调用",
+        "别输出函数调用",
+        "别显示函数调用",
+        "不要执行过程",
+        "不要过程",
+        "不要内部步骤",
+        "别把命令",
+    ];
+    if mentions_internal_details_cjk && CJK_NEGATIVE_HINTS.iter().any(|hint| trimmed.contains(hint))
+    {
+        return false;
+    }
+
+    const ENGLISH_HINTS: [&str; 20] = [
+        "show command",
+        "show commands",
+        "output command",
+        "output commands",
+        "print command",
+        "print commands",
+        "include command",
+        "include commands",
+        "with command",
+        "with commands",
+        "show tool call",
+        "show tool calls",
+        "show function call",
+        "show function calls",
+        "reveal tool call",
+        "reveal function call",
+        "tool call json",
+        "function call json",
+        "execution trace",
+        "internal steps",
+    ];
+    if ENGLISH_HINTS.iter().any(|hint| lower.contains(hint)) {
+        return true;
+    }
+
+    const ENGLISH_VERBS: [&str; 7] = [
+        "show", "output", "print", "include", "reveal", "display", "share",
+    ];
+    if mentions_internal_details_en && ENGLISH_VERBS.iter().any(|verb| lower.contains(verb)) {
+        return true;
+    }
+
+    const CJK_HINTS: [&str; 14] = [
+        "输出命令",
+        "显示命令",
+        "展示命令",
+        "命令发给我",
+        "带上命令",
+        "输出工具调用",
+        "显示工具调用",
+        "展示工具调用",
+        "输出函数调用",
+        "显示函数调用",
+        "展示函数调用",
+        "函数指令",
+        "工具指令",
+        "执行过程",
+    ];
+    if CJK_HINTS.iter().any(|hint| trimmed.contains(hint)) {
+        return true;
+    }
+
+    const CJK_VERBS: [&str; 9] = [
+        "输出", "显示", "展示", "发我", "给我", "带上", "附上", "贴出", "列出",
+    ];
+    mentions_internal_details_cjk && CJK_VERBS.iter().any(|verb| trimmed.contains(verb))
+}
+
+fn split_internal_progress_delta(delta: &str) -> (bool, &str) {
+    if let Some(rest) = delta.strip_prefix(crate::agent::loop_::DRAFT_PROGRESS_SENTINEL) {
+        (true, rest)
+    } else {
+        (false, delta)
     }
 }
 
@@ -419,6 +599,7 @@ fn build_channel_system_prompt(
     base_prompt: &str,
     channel_name: &str,
     reply_target: &str,
+    expose_internal_tool_details: bool,
 ) -> String {
     let mut prompt = base_prompt.to_string();
 
@@ -427,6 +608,25 @@ fn build_channel_system_prompt(
             prompt = instructions.to_string();
         } else {
             prompt = format!("{prompt}\n\n{instructions}");
+        }
+    }
+
+    if channel_name != "cli" {
+        let visibility_instruction = if expose_internal_tool_details {
+            "Execution visibility: the user explicitly requested command/tool details. \
+             You may include command lines or tool-step traces when directly relevant, \
+             but keep credentials and secrets redacted."
+        } else {
+            "Execution visibility: run tools/functions in the background and return an \
+             integrated final result. Do not reveal raw tool names, tool-call syntax, \
+             function arguments, shell commands, or internal execution traces unless the \
+             user explicitly asks for those details."
+        };
+
+        if prompt.is_empty() {
+            prompt = visibility_instruction.to_string();
+        } else {
+            prompt = format!("{prompt}\n\n{visibility_instruction}");
         }
     }
 
@@ -482,13 +682,9 @@ fn supports_runtime_model_switch(channel_name: &str) -> bool {
 }
 
 fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRuntimeCommand> {
-    if !supports_runtime_model_switch(channel_name) {
-        return None;
-    }
-
     let trimmed = content.trim();
     if !trimmed.starts_with('/') {
-        return None;
+        return parse_natural_language_runtime_command(trimmed);
     }
 
     let mut parts = trimmed.split_whitespace();
@@ -498,10 +694,22 @@ fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRun
         .next()
         .unwrap_or(command_token)
         .to_ascii_lowercase();
+    let args: Vec<&str> = parts.collect();
+    let tail = args.join(" ").trim().to_string();
 
     match base_command.as_str() {
-        "/models" => {
-            if let Some(provider) = parts.next() {
+        // History reset commands are safe for all channels.
+        "/new" | "/clear" => Some(ChannelRuntimeCommand::NewSession),
+        "/approve-all-once" => Some(ChannelRuntimeCommand::RequestAllToolsOnce),
+        "/approve-request" => Some(ChannelRuntimeCommand::RequestToolApproval(tail)),
+        "/approve-confirm" => Some(ChannelRuntimeCommand::ConfirmToolApproval(tail)),
+        "/approve-pending" => Some(ChannelRuntimeCommand::ListPendingApprovals),
+        "/approve" => Some(ChannelRuntimeCommand::ApproveTool(tail)),
+        "/unapprove" => Some(ChannelRuntimeCommand::UnapproveTool(tail)),
+        "/approvals" => Some(ChannelRuntimeCommand::ListApprovals),
+        // Provider/model switching remains limited to channels with session routing.
+        "/models" if supports_runtime_model_switch(channel_name) => {
+            if let Some(provider) = args.first() {
                 Some(ChannelRuntimeCommand::SetProvider(
                     provider.trim().to_string(),
                 ))
@@ -509,16 +717,143 @@ fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRun
                 Some(ChannelRuntimeCommand::ShowProviders)
             }
         }
-        "/model" => {
-            let model = parts.collect::<Vec<_>>().join(" ").trim().to_string();
+        "/model" if supports_runtime_model_switch(channel_name) => {
+            let model = tail;
             if model.is_empty() {
                 Some(ChannelRuntimeCommand::ShowModel)
             } else {
                 Some(ChannelRuntimeCommand::SetModel(model))
             }
         }
-        "/new" => Some(ChannelRuntimeCommand::NewSession),
         _ => None,
+    }
+}
+
+fn is_runtime_token(value: &str) -> bool {
+    let token = value.trim();
+    !token.is_empty()
+        && token
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | ':'))
+}
+
+fn extract_runtime_tail_token(text: &str, prefixes: &[&str]) -> Option<String> {
+    prefixes.iter().find_map(|prefix| {
+        text.strip_prefix(prefix).and_then(|rest| {
+            let token = rest.trim();
+            if is_runtime_token(token) {
+                Some(token.to_string())
+            } else {
+                None
+            }
+        })
+    })
+}
+
+fn contains_any_fragment(haystack: &str, fragments: &[&str]) -> bool {
+    fragments.iter().any(|fragment| haystack.contains(fragment))
+}
+
+fn is_natural_language_all_tools_once_intent(content: &str) -> bool {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    let has_allow_verb = contains_any_fragment(&lower, &["approve", "allow"])
+        || contains_any_fragment(trimmed, &["授权", "放开", "允许"]);
+    let has_all_tools_scope = contains_any_fragment(&lower, &["all tools", "all commands"])
+        || contains_any_fragment(trimmed, &["所有工具", "全部工具", "所有命令", "全部命令"]);
+    let has_one_time_scope = contains_any_fragment(&lower, &["once", "one-time", "one time"])
+        || contains_any_fragment(trimmed, &["一次", "这次"]);
+
+    has_allow_verb && has_all_tools_scope && has_one_time_scope
+}
+
+fn approval_target_label(tool_name: &str) -> String {
+    if tool_name == APPROVAL_ALL_TOOLS_ONCE_TOKEN {
+        "all tools/commands (one-time bypass token)".to_string()
+    } else {
+        tool_name.to_string()
+    }
+}
+
+fn parse_natural_language_runtime_command(content: &str) -> Option<ChannelRuntimeCommand> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if matches!(
+        lower.as_str(),
+        "show pending approvals" | "list pending approvals" | "pending approvals"
+    ) {
+        return Some(ChannelRuntimeCommand::ListPendingApprovals);
+    }
+    if trimmed == "查看授权"
+        || matches!(
+            lower.as_str(),
+            "show approvals" | "list approvals" | "approvals"
+        )
+    {
+        return Some(ChannelRuntimeCommand::ListApprovals);
+    }
+    if is_natural_language_all_tools_once_intent(trimmed)
+        || matches!(
+            lower.as_str(),
+            "approve all tools once" | "allow all tools once" | "approve all once"
+        )
+    {
+        return Some(ChannelRuntimeCommand::RequestAllToolsOnce);
+    }
+
+    if let Some(request_id) = extract_runtime_tail_token(&lower, &["confirm "]) {
+        return Some(ChannelRuntimeCommand::ConfirmToolApproval(request_id));
+    }
+    if let Some(request_id) = extract_runtime_tail_token(trimmed, &["确认授权 "]) {
+        return Some(ChannelRuntimeCommand::ConfirmToolApproval(request_id));
+    }
+
+    if let Some(tool) =
+        extract_runtime_tail_token(&lower, &["revoke tool ", "unapprove ", "revoke "])
+    {
+        return Some(ChannelRuntimeCommand::UnapproveTool(tool));
+    }
+    if let Some(tool) = extract_runtime_tail_token(trimmed, &["撤销工具 ", "取消授权 "]) {
+        return Some(ChannelRuntimeCommand::UnapproveTool(tool));
+    }
+
+    if let Some(tool) = extract_runtime_tail_token(&lower, &["approve tool ", "approve "]) {
+        return Some(ChannelRuntimeCommand::RequestToolApproval(tool));
+    }
+    if let Some(tool) = extract_runtime_tail_token(trimmed, &["授权工具 ", "请放开 ", "放开 "])
+    {
+        return Some(ChannelRuntimeCommand::RequestToolApproval(tool));
+    }
+
+    None
+}
+
+fn is_approval_management_command(command: &ChannelRuntimeCommand) -> bool {
+    matches!(
+        command,
+        ChannelRuntimeCommand::RequestAllToolsOnce
+            | ChannelRuntimeCommand::RequestToolApproval(_)
+            | ChannelRuntimeCommand::ConfirmToolApproval(_)
+            | ChannelRuntimeCommand::ListPendingApprovals
+            | ChannelRuntimeCommand::ApproveTool(_)
+            | ChannelRuntimeCommand::UnapproveTool(_)
+            | ChannelRuntimeCommand::ListApprovals
+    )
+}
+
+fn non_cli_natural_language_mode_label(mode: NonCliNaturalLanguageApprovalMode) -> &'static str {
+    match mode {
+        NonCliNaturalLanguageApprovalMode::Disabled => "disabled",
+        NonCliNaturalLanguageApprovalMode::RequestConfirm => "request_confirm",
+        NonCliNaturalLanguageApprovalMode::Direct => "direct",
     }
 }
 
@@ -568,6 +903,22 @@ fn runtime_defaults_from_config(config: &Config) -> ChannelRuntimeDefaults {
     }
 }
 
+fn runtime_autonomy_policy_from_config(config: &Config) -> RuntimeAutonomyPolicy {
+    RuntimeAutonomyPolicy {
+        auto_approve: config.autonomy.auto_approve.clone(),
+        always_ask: config.autonomy.always_ask.clone(),
+        non_cli_excluded_tools: config.autonomy.non_cli_excluded_tools.clone(),
+        non_cli_approval_approvers: config.autonomy.non_cli_approval_approvers.clone(),
+        non_cli_natural_language_approval_mode: config
+            .autonomy
+            .non_cli_natural_language_approval_mode,
+        non_cli_natural_language_approval_mode_by_channel: config
+            .autonomy
+            .non_cli_natural_language_approval_mode_by_channel
+            .clone(),
+    }
+}
+
 fn runtime_config_path(ctx: &ChannelRuntimeContext) -> Option<PathBuf> {
     ctx.provider_runtime_options
         .zeroclaw_dir
@@ -593,6 +944,85 @@ fn runtime_defaults_snapshot(ctx: &ChannelRuntimeContext) -> ChannelRuntimeDefau
         api_url: ctx.api_url.clone(),
         reliability: (*ctx.reliability).clone(),
     }
+}
+
+fn snapshot_non_cli_excluded_tools(ctx: &ChannelRuntimeContext) -> Vec<String> {
+    ctx.non_cli_excluded_tools
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+}
+
+fn filtered_tool_specs_for_runtime(
+    tools_registry: &[Box<dyn Tool>],
+    excluded_tools: &[String],
+) -> Vec<crate::tools::ToolSpec> {
+    tools_registry
+        .iter()
+        .map(|tool| tool.spec())
+        .filter(|spec| !excluded_tools.iter().any(|excluded| excluded == &spec.name))
+        .collect()
+}
+
+fn is_non_cli_tool_excluded(ctx: &ChannelRuntimeContext, tool_name: &str) -> bool {
+    ctx.non_cli_excluded_tools
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .iter()
+        .any(|excluded| excluded == tool_name)
+}
+
+fn build_runtime_tool_visibility_prompt(
+    tools_registry: &[Box<dyn Tool>],
+    excluded_tools: &[String],
+    native_tools: bool,
+) -> String {
+    let mut prompt = String::new();
+    let mut specs = filtered_tool_specs_for_runtime(tools_registry, excluded_tools);
+    specs.sort_by(|a, b| a.name.cmp(&b.name));
+
+    use std::fmt::Write;
+    prompt.push_str("\n## Runtime Tool Availability (Authoritative)\n\n");
+    prompt.push_str(
+        "This section is generated from current runtime policy for this message. \
+         Only the listed tools may be called in this turn.\n\n",
+    );
+
+    if specs.is_empty() {
+        prompt.push_str("- Allowed tools: (none)\n");
+    } else {
+        let _ = writeln!(prompt, "- Allowed tools ({}):", specs.len());
+        for spec in &specs {
+            let _ = writeln!(prompt, "  - `{}`", spec.name);
+        }
+    }
+
+    if excluded_tools.is_empty() {
+        prompt.push_str("- Excluded by runtime policy: (none)\n\n");
+    } else {
+        let mut excluded_sorted = excluded_tools.to_vec();
+        excluded_sorted.sort();
+        let _ = writeln!(
+            prompt,
+            "- Excluded by runtime policy: {}\n",
+            excluded_sorted.join(", ")
+        );
+    }
+
+    if native_tools {
+        prompt.push_str(
+            "Tool calling for this turn uses native provider function-calling. \
+             Do not emit `<tool_call>` XML tags.\n",
+        );
+    } else {
+        prompt.push_str(
+            "Tool calling for this turn uses XML tool protocol below. \
+             This protocol block is generated from the same runtime policy snapshot.\n",
+        );
+        prompt.push_str(&build_tool_instructions_from_specs(&specs));
+    }
+
+    prompt
 }
 
 async fn config_file_stamp(path: &Path) -> Option<ConfigFileStamp> {
@@ -621,7 +1051,9 @@ fn decrypt_optional_secret_for_runtime_reload(
     Ok(())
 }
 
-async fn load_runtime_defaults_from_config_file(path: &Path) -> Result<ChannelRuntimeDefaults> {
+async fn load_runtime_defaults_from_config_file(
+    path: &Path,
+) -> Result<(ChannelRuntimeDefaults, RuntimeAutonomyPolicy)> {
     let contents = tokio::fs::read_to_string(path)
         .await
         .with_context(|| format!("Failed to read {}", path.display()))?;
@@ -635,7 +1067,274 @@ async fn load_runtime_defaults_from_config_file(path: &Path) -> Result<ChannelRu
     }
 
     parsed.apply_env_overrides();
-    Ok(runtime_defaults_from_config(&parsed))
+    Ok((
+        runtime_defaults_from_config(&parsed),
+        runtime_autonomy_policy_from_config(&parsed),
+    ))
+}
+
+async fn persist_non_cli_approval_to_config(
+    ctx: &ChannelRuntimeContext,
+    tool_name: &str,
+) -> Result<Option<PathBuf>> {
+    let Some(config_path) = runtime_config_path(ctx) else {
+        return Ok(None);
+    };
+
+    let contents = tokio::fs::read_to_string(&config_path)
+        .await
+        .with_context(|| format!("Failed to read {}", config_path.display()))?;
+    let mut parsed: Config = toml::from_str(&contents)
+        .with_context(|| format!("Failed to parse {}", config_path.display()))?;
+    parsed.config_path = config_path.clone();
+
+    let mut changed = false;
+    if !parsed
+        .autonomy
+        .auto_approve
+        .iter()
+        .any(|entry| entry == tool_name)
+    {
+        parsed.autonomy.auto_approve.push(tool_name.to_string());
+        changed = true;
+    }
+
+    let before_always_ask = parsed.autonomy.always_ask.len();
+    parsed
+        .autonomy
+        .always_ask
+        .retain(|entry| entry != tool_name);
+    if parsed.autonomy.always_ask.len() != before_always_ask {
+        changed = true;
+    }
+
+    if changed {
+        parsed.save().await?;
+    }
+
+    Ok(Some(config_path))
+}
+
+async fn remove_non_cli_approval_from_config(
+    ctx: &ChannelRuntimeContext,
+    tool_name: &str,
+) -> Result<Option<(PathBuf, bool)>> {
+    let Some(config_path) = runtime_config_path(ctx) else {
+        return Ok(None);
+    };
+
+    let contents = tokio::fs::read_to_string(&config_path)
+        .await
+        .with_context(|| format!("Failed to read {}", config_path.display()))?;
+    let mut parsed: Config = toml::from_str(&contents)
+        .with_context(|| format!("Failed to parse {}", config_path.display()))?;
+    parsed.config_path = config_path.clone();
+
+    let before_auto_approve = parsed.autonomy.auto_approve.len();
+    parsed
+        .autonomy
+        .auto_approve
+        .retain(|entry| entry != tool_name);
+    let removed = parsed.autonomy.auto_approve.len() != before_auto_approve;
+    if removed {
+        parsed.save().await?;
+    }
+
+    Ok(Some((config_path, removed)))
+}
+
+async fn describe_non_cli_approvals(
+    ctx: &ChannelRuntimeContext,
+    sender: &str,
+    channel: &str,
+    reply_target: &str,
+) -> Result<String> {
+    let mut response = String::new();
+    response.push_str("Supervised non-CLI tool approvals:\n");
+
+    let mut runtime_auto = ctx
+        .approval_manager
+        .auto_approve_tools()
+        .into_iter()
+        .collect::<Vec<_>>();
+    runtime_auto.sort();
+    if runtime_auto.is_empty() {
+        response.push_str("- Runtime auto_approve (effective): (none)\n");
+    } else {
+        let _ = writeln!(
+            response,
+            "- Runtime auto_approve (effective): {}",
+            runtime_auto.join(", ")
+        );
+    }
+
+    let mut runtime_always = ctx
+        .approval_manager
+        .always_ask_tools()
+        .into_iter()
+        .collect::<Vec<_>>();
+    runtime_always.sort();
+    if runtime_always.is_empty() {
+        response.push_str("- Runtime always_ask (effective): (none)\n");
+    } else {
+        let _ = writeln!(
+            response,
+            "- Runtime always_ask (effective): {}",
+            runtime_always.join(", ")
+        );
+    }
+
+    let mut session_grants = ctx
+        .approval_manager
+        .non_cli_session_allowlist()
+        .into_iter()
+        .collect::<Vec<_>>();
+    session_grants.sort();
+    if session_grants.is_empty() {
+        response.push_str("- Runtime session grants: (none)\n");
+    } else {
+        let _ = writeln!(
+            response,
+            "- Runtime session grants: {}",
+            session_grants.join(", ")
+        );
+    }
+    let one_time_all_tools_tokens = ctx.approval_manager.non_cli_allow_all_once_remaining();
+    let _ = writeln!(
+        response,
+        "- Runtime one-time all-tools bypass tokens: {}",
+        one_time_all_tools_tokens
+    );
+
+    let mut approval_approvers = ctx
+        .approval_manager
+        .non_cli_approval_approvers()
+        .into_iter()
+        .collect::<Vec<_>>();
+    approval_approvers.sort();
+    if approval_approvers.is_empty() {
+        response.push_str("- Runtime non_cli_approval_approvers: (any channel-allowed sender)\n");
+    } else {
+        let _ = writeln!(
+            response,
+            "- Runtime non_cli_approval_approvers: {}",
+            approval_approvers.join(", ")
+        );
+    }
+
+    let default_mode = non_cli_natural_language_mode_label(
+        ctx.approval_manager
+            .non_cli_natural_language_approval_mode(),
+    );
+    let effective_mode = non_cli_natural_language_mode_label(
+        ctx.approval_manager
+            .non_cli_natural_language_approval_mode_for_channel(channel),
+    );
+    let _ = writeln!(
+        response,
+        "- Runtime non_cli_natural_language_approval_mode: {}",
+        default_mode
+    );
+    let _ = writeln!(
+        response,
+        "- Runtime non_cli_natural_language_approval_mode (current channel `{channel}`): {}",
+        effective_mode
+    );
+    let mut mode_overrides = ctx
+        .approval_manager
+        .non_cli_natural_language_approval_mode_by_channel()
+        .into_iter()
+        .map(|(ch, mode)| format!("{ch}={}", non_cli_natural_language_mode_label(mode)))
+        .collect::<Vec<_>>();
+    mode_overrides.sort();
+    if mode_overrides.is_empty() {
+        response.push_str("- Runtime non_cli_natural_language_approval_mode_by_channel: (none)\n");
+    } else {
+        let _ = writeln!(
+            response,
+            "- Runtime non_cli_natural_language_approval_mode_by_channel: {}",
+            mode_overrides.join(", ")
+        );
+    }
+
+    let mut pending_requests = ctx.approval_manager.list_non_cli_pending_requests(
+        Some(sender),
+        Some(channel),
+        Some(reply_target),
+    );
+    pending_requests.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    if pending_requests.is_empty() {
+        response.push_str("- Pending approvals (sender+chat/channel scoped): (none)\n");
+    } else {
+        response.push_str("- Pending approvals (sender+chat/channel scoped):\n");
+        for req in pending_requests {
+            let reason = req
+                .reason
+                .as_deref()
+                .filter(|text| !text.trim().is_empty())
+                .unwrap_or("n/a");
+            let _ = writeln!(
+                response,
+                "  - {}: tool={}, expires_at={}, reason={}",
+                req.request_id,
+                approval_target_label(&req.tool_name),
+                req.expires_at,
+                reason
+            );
+        }
+    }
+
+    let mut excluded = snapshot_non_cli_excluded_tools(ctx);
+    excluded.sort();
+    if excluded.is_empty() {
+        response.push_str("- Runtime non_cli_excluded_tools: (none)\n");
+    } else {
+        let _ = writeln!(
+            response,
+            "- Runtime non_cli_excluded_tools: {}",
+            excluded.join(", ")
+        );
+    }
+
+    let Some(config_path) = runtime_config_path(ctx) else {
+        response.push_str(
+            "- Persisted config approvals: unavailable (runtime config path not resolved)\n",
+        );
+        return Ok(response);
+    };
+
+    let contents = tokio::fs::read_to_string(&config_path)
+        .await
+        .with_context(|| format!("Failed to read {}", config_path.display()))?;
+    let parsed: Config = toml::from_str(&contents)
+        .with_context(|| format!("Failed to parse {}", config_path.display()))?;
+
+    let mut auto_approve = parsed.autonomy.auto_approve;
+    auto_approve.sort();
+    if auto_approve.is_empty() {
+        response.push_str("- Persisted autonomy.auto_approve: (none)\n");
+    } else {
+        let _ = writeln!(
+            response,
+            "- Persisted autonomy.auto_approve: {}",
+            auto_approve.join(", ")
+        );
+    }
+
+    let mut always_ask = parsed.autonomy.always_ask;
+    always_ask.sort();
+    if always_ask.is_empty() {
+        response.push_str("- Persisted autonomy.always_ask: (none)\n");
+    } else {
+        let _ = writeln!(
+            response,
+            "- Persisted autonomy.always_ask: {}",
+            always_ask.join(", ")
+        );
+    }
+
+    let _ = writeln!(response, "- Config path: {}", config_path.display());
+    Ok(response)
 }
 
 async fn maybe_apply_runtime_config_update(ctx: &ChannelRuntimeContext) -> Result<()> {
@@ -658,7 +1357,8 @@ async fn maybe_apply_runtime_config_update(ctx: &ChannelRuntimeContext) -> Resul
         }
     }
 
-    let next_defaults = load_runtime_defaults_from_config_file(&config_path).await?;
+    let (next_defaults, next_autonomy_policy) =
+        load_runtime_defaults_from_config_file(&config_path).await?;
     let next_default_provider = providers::create_resilient_provider_with_options(
         &next_defaults.default_provider,
         next_defaults.api_key.as_deref(),
@@ -697,11 +1397,30 @@ async fn maybe_apply_runtime_config_update(ctx: &ChannelRuntimeContext) -> Resul
         );
     }
 
+    ctx.approval_manager.replace_runtime_non_cli_policy(
+        &next_autonomy_policy.auto_approve,
+        &next_autonomy_policy.always_ask,
+        &next_autonomy_policy.non_cli_approval_approvers,
+        next_autonomy_policy.non_cli_natural_language_approval_mode,
+        &next_autonomy_policy.non_cli_natural_language_approval_mode_by_channel,
+    );
+    {
+        let mut excluded = ctx
+            .non_cli_excluded_tools
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        *excluded = next_autonomy_policy.non_cli_excluded_tools.clone();
+    }
+
     tracing::info!(
         path = %config_path.display(),
         provider = %next_defaults.default_provider,
         model = %next_defaults.model,
         temperature = next_defaults.temperature,
+        non_cli_approval_mode = %non_cli_natural_language_mode_label(
+            next_autonomy_policy.non_cli_natural_language_approval_mode
+        ),
+        non_cli_excluded_tools_count = next_autonomy_policy.non_cli_excluded_tools.len(),
         "Applied updated channel runtime config from disk"
     );
 
@@ -723,6 +1442,33 @@ fn get_route_selection(ctx: &ChannelRuntimeContext, sender_key: &str) -> Channel
         .get(sender_key)
         .cloned()
         .unwrap_or_else(|| default_route_selection(ctx))
+}
+
+/// Classify a user message and return the appropriate route selection with logging.
+/// Returns None if classification is disabled or no rules match.
+fn classify_message_route(
+    ctx: &ChannelRuntimeContext,
+    message: &str,
+) -> Option<ChannelRouteSelection> {
+    let decision =
+        crate::agent::classifier::classify_with_decision(&ctx.query_classification, message)?;
+
+    // Find the matching model route
+    let route = ctx.model_routes.iter().find(|r| r.hint == decision.hint)?;
+
+    tracing::info!(
+        target: "query_classification",
+        hint = %decision.hint,
+        model = %route.model,
+        rule_priority = decision.priority,
+        message_length = message.len(),
+        "Classified message route"
+    );
+
+    Some(ChannelRouteSelection {
+        provider: route.provider.clone(),
+        model: route.model.clone(),
+    })
 }
 
 fn set_route_selection(ctx: &ChannelRuntimeContext, sender_key: &str, next: ChannelRouteSelection) {
@@ -847,6 +1593,10 @@ fn is_context_window_overflow_error(err: &anyhow::Error) -> bool {
     .any(|hint| lower.contains(hint))
 }
 
+fn is_tool_iteration_limit_error(err: &anyhow::Error) -> bool {
+    crate::agent::loop_::is_tool_iteration_limit_error(err)
+}
+
 fn load_cached_model_preview(workspace_dir: &Path, provider_name: &str) -> Vec<String> {
     let cache_path = workspace_dir.join("state").join(MODEL_CACHE_FILE);
     let Ok(raw) = std::fs::read_to_string(cache_path) else {
@@ -945,6 +1695,18 @@ fn build_models_help_response(current: &ChannelRouteSelection, workspace_dir: &P
         current.provider, current.model
     );
     response.push_str("\nSwitch model with `/model <model-id>`.\n");
+    response.push_str("Request supervised tool approval with `/approve-request <tool-name>`.\n");
+    response.push_str("Request one-time all-tools approval with `/approve-all-once`.\n");
+    response.push_str("Confirm approval with `/approve-confirm <request-id>`.\n");
+    response.push_str("List pending requests with `/approve-pending`.\n");
+    response.push_str("Approve supervised tools with `/approve <tool-name>`.\n");
+    response.push_str("Revoke approval with `/unapprove <tool-name>`.\n");
+    response.push_str("List approval state with `/approvals`.\n");
+    response.push_str(
+        "Natural language also works (policy controlled).\n\
+         - `direct` mode (default): `授权工具 shell` grants immediately.\n\
+         - `request_confirm` mode: `授权工具 shell` then `确认授权 apr-xxxxxx`.\n",
+    );
 
     let cached_models = load_cached_model_preview(workspace_dir, &current.provider);
     if cached_models.is_empty() {
@@ -976,6 +1738,18 @@ fn build_providers_help_response(current: &ChannelRouteSelection) -> String {
     );
     response.push_str("\nSwitch provider with `/models <provider>`.\n");
     response.push_str("Switch model with `/model <model-id>`.\n\n");
+    response.push_str("Request supervised tool approval with `/approve-request <tool-name>`.\n");
+    response.push_str("Request one-time all-tools approval with `/approve-all-once`.\n");
+    response.push_str("Confirm approval with `/approve-confirm <request-id>`.\n");
+    response.push_str("List pending requests with `/approve-pending`.\n");
+    response.push_str("Approve supervised tools with `/approve <tool-name>`.\n");
+    response.push_str("Revoke approval with `/unapprove <tool-name>`.\n");
+    response.push_str("List approval state with `/approvals`.\n");
+    response.push_str(
+        "Natural language also works (policy controlled).\n\
+         - `direct` mode (default): `授权工具 shell` grants immediately.\n\
+         - `request_confirm` mode: `授权工具 shell` then `确认授权 apr-xxxxxx`.\n\n",
+    );
     response.push_str("Available providers:\n");
     for provider in providers::list_providers() {
         if provider.aliases.is_empty() {
@@ -997,7 +1771,8 @@ async fn handle_runtime_command_if_needed(
     msg: &traits::ChannelMessage,
     target_channel: Option<&Arc<dyn Channel>>,
 ) -> bool {
-    let Some(command) = parse_runtime_command(&msg.channel, &msg.content) else {
+    let is_slash_command = msg.content.trim_start().starts_with('/');
+    let Some(mut command) = parse_runtime_command(&msg.channel, &msg.content) else {
         return false;
     };
 
@@ -1007,6 +1782,115 @@ async fn handle_runtime_command_if_needed(
 
     let sender_key = conversation_history_key(msg);
     let mut current = get_route_selection(ctx, &sender_key);
+    let sender = msg.sender.as_str();
+    let source_channel = msg.channel.as_str();
+    let reply_target = msg.reply_target.as_str();
+    let is_natural_language_approval_command =
+        !is_slash_command && is_approval_management_command(&command);
+
+    if is_approval_management_command(&command)
+        && !ctx
+            .approval_manager
+            .is_non_cli_approval_actor_allowed(source_channel, sender)
+    {
+        let mut approvers = ctx
+            .approval_manager
+            .non_cli_approval_approvers()
+            .into_iter()
+            .collect::<Vec<_>>();
+        approvers.sort();
+        let allowed = if approvers.is_empty() {
+            "(any channel-allowed sender)".to_string()
+        } else {
+            approvers.join(", ")
+        };
+        let response = format!(
+            "Approval-management command denied for sender `{sender}` on channel `{source_channel}`.\nAllowed approvers: {allowed}\nConfigure `[autonomy].non_cli_approval_approvers` to adjust this policy."
+        );
+        runtime_trace::record_event(
+            "approval_management_denied",
+            Some(source_channel),
+            None,
+            None,
+            None,
+            Some(false),
+            Some("sender not allowed to manage non-cli approvals"),
+            serde_json::json!({
+                "sender": sender,
+                "channel": source_channel,
+                "allowed_approvers": approvers,
+            }),
+        );
+
+        if let Err(err) = channel
+            .send(&SendMessage::new(response, &msg.reply_target).in_thread(msg.thread_ts.clone()))
+            .await
+        {
+            tracing::warn!(
+                "Failed to send runtime command response on {}: {err}",
+                channel.name()
+            );
+        }
+        return true;
+    }
+
+    if is_natural_language_approval_command {
+        let mode = ctx
+            .approval_manager
+            .non_cli_natural_language_approval_mode_for_channel(source_channel);
+        match mode {
+            NonCliNaturalLanguageApprovalMode::Disabled => {
+                let response = "Natural-language approval commands are disabled by runtime policy.\nUse explicit slash commands such as `/approve <tool-name>`, `/approve-request <tool-name>`, `/approve-all-once`, `/approve-confirm <request-id>`, `/unapprove <tool-name>`, and `/approvals`.".to_string();
+                runtime_trace::record_event(
+                    "approval_management_natural_language_denied",
+                    Some(source_channel),
+                    None,
+                    None,
+                    None,
+                    Some(false),
+                    Some("natural-language approval commands disabled by policy"),
+                    serde_json::json!({
+                        "sender": sender,
+                        "channel": source_channel,
+                        "mode": non_cli_natural_language_mode_label(mode),
+                    }),
+                );
+                if let Err(err) = channel
+                    .send(
+                        &SendMessage::new(response, &msg.reply_target)
+                            .in_thread(msg.thread_ts.clone()),
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        "Failed to send runtime command response on {}: {err}",
+                        channel.name()
+                    );
+                }
+                return true;
+            }
+            NonCliNaturalLanguageApprovalMode::RequestConfirm => {}
+            NonCliNaturalLanguageApprovalMode::Direct => {
+                if let ChannelRuntimeCommand::RequestToolApproval(tool_name) = &command {
+                    command = ChannelRuntimeCommand::ApproveTool(tool_name.clone());
+                    runtime_trace::record_event(
+                        "approval_management_natural_language_promoted_to_direct",
+                        Some(source_channel),
+                        None,
+                        None,
+                        None,
+                        Some(true),
+                        Some("natural-language request promoted to direct approval"),
+                        serde_json::json!({
+                            "sender": sender,
+                            "channel": source_channel,
+                            "mode": non_cli_natural_language_mode_label(mode),
+                        }),
+                    );
+                }
+            }
+        }
+    }
 
     let response = match command {
         ChannelRuntimeCommand::ShowProviders => build_providers_help_response(&current),
@@ -1058,6 +1942,331 @@ async fn handle_runtime_command_if_needed(
         ChannelRuntimeCommand::NewSession => {
             clear_sender_history(ctx, &sender_key);
             "Conversation history cleared. Starting fresh.".to_string()
+        }
+        ChannelRuntimeCommand::RequestAllToolsOnce => {
+            let req = ctx.approval_manager.create_non_cli_pending_request(
+                APPROVAL_ALL_TOOLS_ONCE_TOKEN,
+                sender,
+                source_channel,
+                reply_target,
+                Some("human-confirmed one-time bypass request for all tools/commands".to_string()),
+            );
+            runtime_trace::record_event(
+                "approval_request_created",
+                Some(source_channel),
+                None,
+                None,
+                None,
+                Some(true),
+                Some("pending one-time all-tools request created"),
+                serde_json::json!({
+                    "request_id": req.request_id,
+                    "tool_name": req.tool_name,
+                    "sender": sender,
+                    "channel": source_channel,
+                    "expires_at": req.expires_at,
+                }),
+            );
+            format!(
+                "One-time all-tools approval request created.\nRequest ID: `{}`\nScope: next non-CLI agent tool-execution turn may run without per-tool approval prompts.\nExpires: `{}`\nConfirm with `/approve-confirm {}` (must be the same sender in this chat/channel).",
+                req.request_id, req.expires_at, req.request_id
+            )
+        }
+        ChannelRuntimeCommand::RequestToolApproval(raw_tool_name) => {
+            let tool_name = raw_tool_name.trim().to_string();
+            if tool_name.is_empty() {
+                "Usage: `/approve-request <tool-name>`".to_string()
+            } else if !ctx
+                .tools_registry
+                .iter()
+                .any(|tool| tool.name() == tool_name)
+            {
+                let mut available_tools = ctx
+                    .tools_registry
+                    .iter()
+                    .map(|tool| tool.name().to_string())
+                    .collect::<Vec<_>>();
+                available_tools.sort();
+                let preview = available_tools
+                    .into_iter()
+                    .take(12)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "Unknown tool `{tool_name}`.\nKnown tools (top 12): {preview}\nUse `/approve-request <tool-name>` with an exact tool name."
+                )
+            } else if !ctx.approval_manager.needs_approval(&tool_name) {
+                format!(
+                    "`{tool_name}` is already approved in the current runtime policy. You can use it directly."
+                )
+            } else {
+                let req = ctx.approval_manager.create_non_cli_pending_request(
+                    &tool_name,
+                    sender,
+                    source_channel,
+                    reply_target,
+                    None,
+                );
+                runtime_trace::record_event(
+                    "approval_request_created",
+                    Some(source_channel),
+                    None,
+                    None,
+                    None,
+                    Some(true),
+                    Some("pending request created"),
+                    serde_json::json!({
+                        "request_id": req.request_id,
+                        "tool_name": req.tool_name,
+                        "sender": sender,
+                        "channel": source_channel,
+                        "expires_at": req.expires_at,
+                    }),
+                );
+                format!(
+                    "Approval request created.\nRequest ID: `{}`\nTool: `{}`\nExpires: `{}`\nConfirm with `/approve-confirm {}` (must be the same sender in this chat/channel).",
+                    req.request_id, req.tool_name, req.expires_at, req.request_id
+                )
+            }
+        }
+        ChannelRuntimeCommand::ConfirmToolApproval(raw_request_id) => {
+            let request_id = raw_request_id.trim().to_string();
+            if request_id.is_empty() {
+                "Usage: `/approve-confirm <request-id>`".to_string()
+            } else {
+                match ctx.approval_manager.confirm_non_cli_pending_request(
+                    &request_id,
+                    sender,
+                    source_channel,
+                    reply_target,
+                ) {
+                    Ok(req) => {
+                        let tool_name = req.tool_name;
+                        let approval_message = if tool_name == APPROVAL_ALL_TOOLS_ONCE_TOKEN {
+                            let remaining = ctx.approval_manager.grant_non_cli_allow_all_once();
+                            format!(
+                                "Approved one-time all-tools bypass from request `{request_id}`.\nApplies to the next non-CLI agent tool-execution turn only.\nThis bypass is runtime-only and does not persist to config.\nChannel exclusions from `autonomy.non_cli_excluded_tools` still apply.\nQueued one-time all-tools bypass tokens: `{remaining}`."
+                            )
+                        } else {
+                            ctx.approval_manager.grant_non_cli_session(&tool_name);
+                            ctx.approval_manager
+                                .apply_persistent_runtime_grant(&tool_name);
+                            match persist_non_cli_approval_to_config(ctx, &tool_name).await {
+                                Ok(Some(path)) => format!(
+                                    "Approved supervised execution for `{tool_name}` from request `{request_id}`.\nPersisted to `{}` so future channel sessions (including after restart) remain approved.",
+                                    path.display()
+                                ),
+                                Ok(None) => format!(
+                                    "Approved supervised execution for `{tool_name}` from request `{request_id}`.\nNo runtime config path was found, so this approval is active for the current daemon runtime only."
+                                ),
+                                Err(err) => format!(
+                                    "Approved supervised execution for `{tool_name}` from request `{request_id}` in-memory.\nFailed to persist this approval to config: {err}"
+                                ),
+                            }
+                        };
+                        runtime_trace::record_event(
+                            "approval_request_confirmed",
+                            Some(source_channel),
+                            None,
+                            None,
+                            None,
+                            Some(true),
+                            Some("pending request confirmed"),
+                            serde_json::json!({
+                                "request_id": request_id,
+                                "tool_name": tool_name,
+                                "sender": sender,
+                                "channel": source_channel,
+                            }),
+                        );
+
+                        if tool_name != APPROVAL_ALL_TOOLS_ONCE_TOKEN
+                            && is_non_cli_tool_excluded(ctx, &tool_name)
+                        {
+                            format!(
+                                "{approval_message}\nNote: `{tool_name}` is currently listed in `autonomy.non_cli_excluded_tools` for this runtime. Remove it from config; the channel runtime auto-reloads this list from disk."
+                            )
+                        } else {
+                            approval_message
+                        }
+                    }
+                    Err(PendingApprovalError::NotFound) => {
+                        runtime_trace::record_event(
+                            "approval_request_confirmed",
+                            Some(source_channel),
+                            None,
+                            None,
+                            None,
+                            Some(false),
+                            Some("pending request not found"),
+                            serde_json::json!({
+                                "request_id": request_id,
+                                "sender": sender,
+                                "channel": source_channel,
+                            }),
+                        );
+                        format!(
+                            "Pending approval request `{request_id}` was not found. Create one with `/approve-request <tool-name>` or `/approve-all-once`."
+                        )
+                    }
+                    Err(PendingApprovalError::Expired) => {
+                        runtime_trace::record_event(
+                            "approval_request_confirmed",
+                            Some(source_channel),
+                            None,
+                            None,
+                            None,
+                            Some(false),
+                            Some("pending request expired"),
+                            serde_json::json!({
+                                "request_id": request_id,
+                                "sender": sender,
+                                "channel": source_channel,
+                            }),
+                        );
+                        format!("Pending approval request `{request_id}` has expired.")
+                    }
+                    Err(PendingApprovalError::RequesterMismatch) => {
+                        runtime_trace::record_event(
+                            "approval_request_confirmed",
+                            Some(source_channel),
+                            None,
+                            None,
+                            None,
+                            Some(false),
+                            Some("pending request confirmer mismatch"),
+                            serde_json::json!({
+                                "request_id": request_id,
+                                "sender": sender,
+                                "channel": source_channel,
+                            }),
+                        );
+                        format!(
+                            "Pending approval request `{request_id}` can only be confirmed by the same sender in the same chat/channel that created it."
+                        )
+                    }
+                }
+            }
+        }
+        ChannelRuntimeCommand::ListPendingApprovals => {
+            let rows = ctx.approval_manager.list_non_cli_pending_requests(
+                Some(sender),
+                Some(source_channel),
+                Some(reply_target),
+            );
+            if rows.is_empty() {
+                "No pending approval requests for your current sender+chat/channel scope."
+                    .to_string()
+            } else {
+                let mut response = String::new();
+                response.push_str("Pending approval requests (sender+chat/channel scoped):\n");
+                for req in rows {
+                    let reason = req
+                        .reason
+                        .as_deref()
+                        .filter(|text| !text.trim().is_empty())
+                        .unwrap_or("n/a");
+                    let _ = writeln!(
+                        response,
+                        "- {}: tool={}, expires_at={}, reason={}",
+                        req.request_id,
+                        approval_target_label(&req.tool_name),
+                        req.expires_at,
+                        reason
+                    );
+                }
+                response
+            }
+        }
+        ChannelRuntimeCommand::ApproveTool(raw_tool_name) => {
+            let tool_name = raw_tool_name.trim().to_string();
+            if tool_name.is_empty() {
+                "Usage: `/approve <tool-name>`".to_string()
+            } else if !ctx
+                .tools_registry
+                .iter()
+                .any(|tool| tool.name() == tool_name)
+            {
+                let mut available_tools = ctx
+                    .tools_registry
+                    .iter()
+                    .map(|tool| tool.name().to_string())
+                    .collect::<Vec<_>>();
+                available_tools.sort();
+                let preview = available_tools
+                    .into_iter()
+                    .take(12)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "Unknown tool `{tool_name}`.\nKnown tools (top 12): {preview}\nUse `/approve <tool-name>` with an exact tool name."
+                )
+            } else {
+                let cleared_pending = ctx
+                    .approval_manager
+                    .clear_non_cli_pending_requests_for_tool(&tool_name);
+                ctx.approval_manager.grant_non_cli_session(&tool_name);
+                ctx.approval_manager
+                    .apply_persistent_runtime_grant(&tool_name);
+                let persistence_message = match persist_non_cli_approval_to_config(ctx, &tool_name).await {
+                    Ok(Some(path)) => format!(
+                        "Approved supervised execution for `{tool_name}`.\nPersisted to `{}` so future channel sessions (including after restart) remain approved.",
+                        path.display()
+                    ),
+                    Ok(None) => format!(
+                        "Approved supervised execution for `{tool_name}`.\nNo runtime config path was found, so this approval is active for the current daemon runtime only."
+                    ),
+                    Err(err) => format!(
+                        "Approved supervised execution for `{tool_name}` in-memory.\nFailed to persist this approval to config: {err}"
+                    ),
+                };
+
+                if is_non_cli_tool_excluded(ctx, &tool_name) {
+                    format!(
+                        "{persistence_message}\nRuntime pending requests cleared: {cleared_pending}.\nNote: `{tool_name}` is currently listed in `autonomy.non_cli_excluded_tools` for this runtime. Remove it from config; the channel runtime auto-reloads this list from disk."
+                    )
+                } else {
+                    format!("{persistence_message}\nRuntime pending requests cleared: {cleared_pending}.")
+                }
+            }
+        }
+        ChannelRuntimeCommand::UnapproveTool(raw_tool_name) => {
+            let tool_name = raw_tool_name.trim().to_string();
+            if tool_name.is_empty() {
+                "Usage: `/unapprove <tool-name>`".to_string()
+            } else {
+                let removed_session = ctx.approval_manager.revoke_non_cli_session(&tool_name);
+                let removed_runtime_persistent = ctx
+                    .approval_manager
+                    .apply_persistent_runtime_revoke(&tool_name);
+                let removed_pending = ctx
+                    .approval_manager
+                    .clear_non_cli_pending_requests_for_tool(&tool_name);
+                match remove_non_cli_approval_from_config(ctx, &tool_name).await {
+                    Ok(Some((path, removed_persistent))) => format!(
+                        "Persistent approval removed for `{tool_name}`: {}.\nRuntime effective auto_approve removed: {}.\nRuntime pending requests cleared: {}.\nConfig path: `{}`.\nRuntime session grant removed: {}.",
+                        if removed_persistent { "yes" } else { "no (not present)" },
+                        if removed_runtime_persistent { "yes" } else { "no (not present)" },
+                        removed_pending,
+                        path.display(),
+                        if removed_session { "yes" } else { "no" }
+                    ),
+                    Ok(None) => format!(
+                        "Runtime config path was not found.\nRuntime session grant removed for `{tool_name}`: {}.",
+                        if removed_session { "yes" } else { "no" }
+                    ),
+                    Err(err) => format!(
+                        "Removed runtime session grant for `{tool_name}`: {}.\nFailed to persist removal to config: {err}",
+                        if removed_session { "yes" } else { "no" }
+                    ),
+                }
+            }
+        }
+        ChannelRuntimeCommand::ListApprovals => {
+            match describe_non_cli_approvals(ctx, sender, source_channel, reply_target).await {
+                Ok(summary) => summary,
+                Err(err) => format!("Failed to read approval state: {err}"),
+            }
         }
     };
 
@@ -1220,12 +2429,13 @@ fn extract_tool_context_summary(history: &[ChatMessage], start_index: usize) -> 
     format!("[Used tools: {}]", tool_names.join(", "))
 }
 
-fn sanitize_channel_response(response: &str, tools: &[Box<dyn Tool>]) -> String {
+pub(crate) fn sanitize_channel_response(response: &str, tools: &[Box<dyn Tool>]) -> String {
+    let without_tool_tags = strip_tool_call_tags(response);
     let known_tool_names: HashSet<String> = tools
         .iter()
         .map(|tool| tool.name().to_ascii_lowercase())
         .collect();
-    strip_isolated_tool_json_artifacts(response, &known_tool_names)
+    strip_isolated_tool_json_artifacts(&without_tool_tags, &known_tool_names)
 }
 
 fn is_tool_call_payload(value: &serde_json::Value, known_tool_names: &HashSet<String>) -> bool {
@@ -1295,9 +2505,7 @@ fn sanitize_tool_json_value(
         return None;
     }
 
-    let Some(object) = value.as_object() else {
-        return None;
-    };
+    let object = value.as_object()?;
 
     if let Some(tool_calls) = object.get("tool_calls").and_then(|value| value.as_array()) {
         if !tool_calls.is_empty()
@@ -1337,7 +2545,7 @@ fn strip_isolated_tool_json_artifacts(message: &str, known_tool_names: &HashSet<
     let mut saw_tool_call_payload = false;
 
     while cursor < message.len() {
-        let Some(rel_start) = message[cursor..].find(|ch: char| ch == '{' || ch == '[') else {
+        let Some(rel_start) = message[cursor..].find(['{', '[']) else {
             cleaned.push_str(&message[cursor..]);
             break;
         };
@@ -1558,7 +2766,9 @@ async fn process_channel_message(
     }
 
     let history_key = conversation_history_key(&msg);
-    let route = get_route_selection(ctx.as_ref(), &history_key);
+    // Try classification first, fall back to sender/default route
+    let route = classify_message_route(ctx.as_ref(), &msg.content)
+        .unwrap_or_else(|| get_route_selection(ctx.as_ref(), &history_key));
     let runtime_defaults = runtime_defaults_snapshot(ctx.as_ref());
     let active_provider = match get_or_create_provider(ctx.as_ref(), &route.provider).await {
         Ok(provider) => provider,
@@ -1627,8 +2837,24 @@ async fn process_channel_message(
         }
     }
 
-    let system_prompt =
-        build_channel_system_prompt(ctx.system_prompt.as_str(), &msg.channel, &msg.reply_target);
+    let expose_internal_tool_details =
+        msg.channel == "cli" || should_expose_internal_tool_details(&msg.content);
+    let excluded_tools_snapshot = if msg.channel == "cli" {
+        Vec::new()
+    } else {
+        snapshot_non_cli_excluded_tools(ctx.as_ref())
+    };
+    let mut system_prompt = build_channel_system_prompt(
+        ctx.system_prompt.as_str(),
+        &msg.channel,
+        &msg.reply_target,
+        expose_internal_tool_details,
+    );
+    system_prompt.push_str(&build_runtime_tool_visibility_prompt(
+        ctx.tools_registry.as_ref(),
+        &excluded_tools_snapshot,
+        active_provider.supports_native_tools(),
+    ));
     let mut history = vec![ChatMessage::system(system_prompt)];
     history.extend(prior_turns);
     let use_streaming = target_channel
@@ -1679,6 +2905,7 @@ async fn process_channel_message(
         let channel = Arc::clone(channel_ref);
         let reply_target = msg.reply_target.clone();
         let draft_id = draft_id_ref.to_string();
+        let suppress_internal_progress = !expose_internal_tool_details;
         Some(tokio::spawn(async move {
             let mut accumulated = String::new();
             while let Some(delta) = rx.recv().await {
@@ -1686,7 +2913,12 @@ async fn process_channel_message(
                     accumulated.clear();
                     continue;
                 }
-                accumulated.push_str(&delta);
+                let (is_internal_progress, visible_delta) = split_internal_progress_delta(&delta);
+                if suppress_internal_progress && is_internal_progress {
+                    continue;
+                }
+
+                accumulated.push_str(visible_delta);
                 if let Err(e) = channel
                     .update_draft(&reply_target, &draft_id, &accumulated)
                     .await
@@ -1742,18 +2974,14 @@ async fn process_channel_message(
                 route.model.as_str(),
                 runtime_defaults.temperature,
                 true,
-                None,
+                Some(ctx.approval_manager.as_ref()),
                 msg.channel.as_str(),
                 &ctx.multimodal,
                 ctx.max_tool_iterations,
                 Some(cancellation_token.clone()),
                 delta_tx,
                 ctx.hooks.as_deref(),
-                if msg.channel == "cli" {
-                    &[]
-                } else {
-                    ctx.non_cli_excluded_tools.as_ref()
-                },
+                &excluded_tools_snapshot,
             ),
         ) => LlmExecutionResult::Completed(result),
     };
@@ -1993,6 +3221,46 @@ async fn process_channel_message(
                         let _ = channel
                             .send(
                                 &SendMessage::new(error_text, &msg.reply_target)
+                                    .in_thread(msg.thread_ts.clone()),
+                            )
+                            .await;
+                    }
+                }
+            } else if is_tool_iteration_limit_error(&e) {
+                let limit = ctx.max_tool_iterations.max(1);
+                let pause_text = format!(
+                    "⚠️ Reached tool-iteration limit ({limit}) for this turn. Context and progress were preserved. Reply \"continue\" to resume, or increase `agent.max_tool_iterations`."
+                );
+                runtime_trace::record_event(
+                    "channel_message_error",
+                    Some(msg.channel.as_str()),
+                    Some(route.provider.as_str()),
+                    Some(route.model.as_str()),
+                    None,
+                    Some(false),
+                    Some("tool iteration limit reached"),
+                    serde_json::json!({
+                        "sender": msg.sender,
+                        "elapsed_ms": started_at.elapsed().as_millis(),
+                        "max_tool_iterations": limit,
+                    }),
+                );
+                append_sender_turn(
+                    ctx.as_ref(),
+                    &history_key,
+                    ChatMessage::assistant(
+                        "[Task paused at tool-iteration limit — context preserved. Ask to continue.]",
+                    ),
+                );
+                if let Some(channel) = target_channel.as_ref() {
+                    if let Some(ref draft_id) = draft_message_id {
+                        let _ = channel
+                            .finalize_draft(&msg.reply_target, draft_id, &pause_text)
+                            .await;
+                    } else {
+                        let _ = channel
+                            .send(
+                                &SendMessage::new(pause_text, &msg.reply_target)
                                     .in_thread(msg.thread_ts.clone()),
                             )
                             .await;
@@ -2682,61 +3950,82 @@ struct ConfiguredChannel {
 
 fn collect_configured_channels(
     config: &Config,
-    _matrix_skip_context: &str,
+    matrix_skip_context: &str,
 ) -> Vec<ConfiguredChannel> {
+    // Keep this symbol used even when Matrix support is compiled in and
+    // `#[cfg(not(feature = "channel-matrix"))]` blocks are removed.
+    let _ = matrix_skip_context;
     let mut channels = Vec::new();
 
     if let Some(ref tg) = config.channels_config.telegram {
+        let mut telegram = TelegramChannel::new(
+            tg.bot_token.clone(),
+            tg.allowed_users.clone(),
+            tg.effective_group_reply_mode().requires_mention(),
+        )
+        .with_group_reply_allowed_senders(tg.group_reply_allowed_sender_ids())
+        .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
+        .with_transcription(config.transcription.clone())
+        .with_workspace_dir(config.workspace_dir.clone());
+
+        if let Some(ref base_url) = tg.base_url {
+            telegram = telegram.with_api_base(base_url.clone());
+        }
+
         channels.push(ConfiguredChannel {
             display_name: "Telegram",
-            channel: Arc::new(
-                TelegramChannel::new(
-                    tg.bot_token.clone(),
-                    tg.allowed_users.clone(),
-                    tg.mention_only,
-                )
-                .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
-                .with_transcription(config.transcription.clone())
-                .with_workspace_dir(config.workspace_dir.clone()),
-            ),
+            channel: Arc::new(telegram),
         });
     }
 
     if let Some(ref dc) = config.channels_config.discord {
         channels.push(ConfiguredChannel {
             display_name: "Discord",
-            channel: Arc::new(DiscordChannel::new(
-                dc.bot_token.clone(),
-                dc.guild_id.clone(),
-                dc.allowed_users.clone(),
-                dc.listen_to_bots,
-                dc.mention_only,
-            )),
+            channel: Arc::new(
+                DiscordChannel::new(
+                    dc.bot_token.clone(),
+                    dc.guild_id.clone(),
+                    dc.allowed_users.clone(),
+                    dc.listen_to_bots,
+                    dc.effective_group_reply_mode().requires_mention(),
+                )
+                .with_group_reply_allowed_senders(dc.group_reply_allowed_sender_ids())
+                .with_workspace_dir(config.workspace_dir.clone()),
+            ),
         });
     }
 
     if let Some(ref sl) = config.channels_config.slack {
         channels.push(ConfiguredChannel {
             display_name: "Slack",
-            channel: Arc::new(SlackChannel::new(
-                sl.bot_token.clone(),
-                sl.channel_id.clone(),
-                sl.allowed_users.clone(),
-            )),
+            channel: Arc::new(
+                SlackChannel::new(
+                    sl.bot_token.clone(),
+                    sl.channel_id.clone(),
+                    sl.allowed_users.clone(),
+                )
+                .with_group_reply_policy(
+                    sl.effective_group_reply_mode().requires_mention(),
+                    sl.group_reply_allowed_sender_ids(),
+                ),
+            ),
         });
     }
 
     if let Some(ref mm) = config.channels_config.mattermost {
         channels.push(ConfiguredChannel {
             display_name: "Mattermost",
-            channel: Arc::new(MattermostChannel::new(
-                mm.url.clone(),
-                mm.bot_token.clone(),
-                mm.channel_id.clone(),
-                mm.allowed_users.clone(),
-                mm.thread_replies.unwrap_or(true),
-                mm.mention_only.unwrap_or(false),
-            )),
+            channel: Arc::new(
+                MattermostChannel::new(
+                    mm.url.clone(),
+                    mm.bot_token.clone(),
+                    mm.channel_id.clone(),
+                    mm.allowed_users.clone(),
+                    mm.thread_replies.unwrap_or(true),
+                    mm.effective_group_reply_mode().requires_mention(),
+                )
+                .with_group_reply_allowed_senders(mm.group_reply_allowed_sender_ids()),
+            ),
         });
     }
 
@@ -2751,15 +4040,18 @@ fn collect_configured_channels(
     if let Some(ref mx) = config.channels_config.matrix {
         channels.push(ConfiguredChannel {
             display_name: "Matrix",
-            channel: Arc::new(MatrixChannel::new_with_session_hint_and_zeroclaw_dir(
-                mx.homeserver.clone(),
-                mx.access_token.clone(),
-                mx.room_id.clone(),
-                mx.allowed_users.clone(),
-                mx.user_id.clone(),
-                mx.device_id.clone(),
-                config.config_path.parent().map(|path| path.to_path_buf()),
-            )),
+            channel: Arc::new(
+                MatrixChannel::new_with_session_hint_and_zeroclaw_dir(
+                    mx.homeserver.clone(),
+                    mx.access_token.clone(),
+                    mx.room_id.clone(),
+                    mx.allowed_users.clone(),
+                    mx.user_id.clone(),
+                    mx.device_id.clone(),
+                    config.config_path.parent().map(|path| path.to_path_buf()),
+                )
+                .with_mention_only(mx.mention_only),
+            ),
         });
     }
 
@@ -2767,7 +4059,7 @@ fn collect_configured_channels(
     if config.channels_config.matrix.is_some() {
         tracing::warn!(
             "Matrix channel is configured but this build was compiled without `channel-matrix`; skipping Matrix {}.",
-            _matrix_skip_context
+            matrix_skip_context
         );
     }
 
@@ -2946,14 +4238,20 @@ fn collect_configured_channels(
     }
 
     if let Some(ref qq) = config.channels_config.qq {
-        channels.push(ConfiguredChannel {
-            display_name: "QQ",
-            channel: Arc::new(QQChannel::new(
-                qq.app_id.clone(),
-                qq.app_secret.clone(),
-                qq.allowed_users.clone(),
-            )),
-        });
+        if qq.receive_mode == crate::config::schema::QQReceiveMode::Webhook {
+            tracing::info!(
+                "QQ channel configured with receive_mode=webhook; websocket listener startup skipped."
+            );
+        } else {
+            channels.push(ConfiguredChannel {
+                display_name: "QQ",
+                channel: Arc::new(QQChannel::new(
+                    qq.app_id.clone(),
+                    qq.app_secret.clone(),
+                    qq.allowed_users.clone(),
+                )),
+            });
+        }
     }
 
     if let Some(ref ct) = config.channels_config.clawdtalk {
@@ -2966,20 +4264,40 @@ fn collect_configured_channels(
     channels
 }
 
+async fn append_nostr_channel_if_available(
+    config: &Config,
+    channels: &mut Vec<ConfiguredChannel>,
+    startup_context: &str,
+) -> Option<String> {
+    let ns = config.channels_config.nostr.as_ref()?;
+    match NostrChannel::new(&ns.private_key, ns.relays.clone(), &ns.allowed_pubkeys).await {
+        Ok(channel) => {
+            channels.push(ConfiguredChannel {
+                display_name: "Nostr",
+                channel: Arc::new(channel),
+            });
+            None
+        }
+        Err(err) => {
+            let reason = format!("Nostr init failed during {startup_context}: {err}");
+            tracing::warn!("{reason}");
+            Some(reason)
+        }
+    }
+}
+
 /// Run health checks for configured channels.
 pub async fn doctor_channels(config: Config) -> Result<()> {
     let mut channels = collect_configured_channels(&config, "health check");
+    let mut init_failures = Vec::new();
 
-    if let Some(ref ns) = config.channels_config.nostr {
-        channels.push(ConfiguredChannel {
-            display_name: "Nostr",
-            channel: Arc::new(
-                NostrChannel::new(&ns.private_key, ns.relays.clone(), &ns.allowed_pubkeys).await?,
-            ),
-        });
+    if let Some(reason) =
+        append_nostr_channel_if_available(&config, &mut channels, "health check").await
+    {
+        init_failures.push(reason);
     }
 
-    if channels.is_empty() {
+    if channels.is_empty() && init_failures.is_empty() {
         println!("No real-time channels configured. Run `zeroclaw onboard` first.");
         return Ok(());
     }
@@ -2988,8 +4306,13 @@ pub async fn doctor_channels(config: Config) -> Result<()> {
     println!();
 
     let mut healthy = 0_u32;
-    let mut unhealthy = 0_u32;
+    let mut unhealthy = u32::try_from(init_failures.len()).unwrap_or(u32::MAX);
     let mut timeout = 0_u32;
+    let has_runtime_channels = !channels.is_empty();
+
+    for failure in &init_failures {
+        println!("  ❌ {:<9} {failure}", "Nostr");
+    }
 
     for configured in channels {
         let result =
@@ -3019,6 +4342,11 @@ pub async fn doctor_channels(config: Config) -> Result<()> {
         println!("  ℹ️  Webhook   check via `zeroclaw gateway` then GET /health");
     }
 
+    if !has_runtime_channels && !init_failures.is_empty() {
+        println!();
+        anyhow::bail!("All configured channels failed during initialization.");
+    }
+
     println!();
     println!("Summary: {healthy} healthy, {unhealthy} unhealthy, {timeout} timed out");
     Ok(())
@@ -3034,6 +4362,10 @@ pub async fn start_channels(config: Config) -> Result<()> {
         zeroclaw_dir: config.config_path.parent().map(std::path::PathBuf::from),
         secrets_encrypt: config.secrets.encrypt,
         reasoning_enabled: config.runtime.reasoning_enabled,
+        reasoning_level: config.effective_provider_reasoning_level(),
+        custom_provider_api_mode: config.provider_api.map(|mode| mode.as_compatible_mode()),
+        max_tokens_override: None,
+        model_support_vision: config.model_support_vision,
     };
     let provider: Arc<dyn Provider> = Arc::from(
         create_resilient_provider_nonblocking(
@@ -3163,6 +4495,18 @@ pub async fn start_channels(config: Config) -> Result<()> {
             "delegate",
             "Delegate a subtask to a specialized agent. Use when: a task benefits from a different model (e.g. fast summarization, deep reasoning, code generation). The sub-agent runs a single prompt and returns its response.",
         ));
+        tool_descs.push((
+            "subagent_spawn",
+            "Spawn a delegate agent in the background. Returns immediately with a session_id. Use for long-running tasks that should not block.",
+        ));
+        tool_descs.push((
+            "subagent_list",
+            "List running and completed background sub-agents. Filter by status: running, completed, failed, killed, or all.",
+        ));
+        tool_descs.push((
+            "subagent_manage",
+            "Manage a background sub-agent: 'status' to check progress/output, 'kill' to cancel a running session.",
+        ));
     }
 
     // Filter out tools excluded for non-CLI channels so the system prompt
@@ -3189,8 +4533,10 @@ pub async fn start_channels(config: Config) -> Result<()> {
         config.skills.prompt_injection_mode,
     );
     if !native_tools {
-        system_prompt.push_str(&build_tool_instructions(tools_registry.as_ref()));
+        let filtered_specs = filtered_tool_specs_for_runtime(tools_registry.as_ref(), excluded);
+        system_prompt.push_str(&build_tool_instructions_from_specs(&filtered_specs));
     }
+    system_prompt.push_str(&build_shell_policy_instructions(&config.autonomy));
 
     if !skills.is_empty() {
         println!(
@@ -3204,21 +4550,38 @@ pub async fn start_channels(config: Config) -> Result<()> {
     }
 
     // Collect active channels from a shared builder to keep startup and doctor parity.
-    let mut channels: Vec<Arc<dyn Channel>> =
-        collect_configured_channels(&config, "runtime startup")
-            .into_iter()
-            .map(|configured| configured.channel)
-            .collect();
-
-    if let Some(ref ns) = config.channels_config.nostr {
-        channels.push(Arc::new(
-            NostrChannel::new(&ns.private_key, ns.relays.clone(), &ns.allowed_pubkeys).await?,
-        ));
+    let mut configured_channels = collect_configured_channels(&config, "runtime startup");
+    let mut init_failures = Vec::new();
+    if let Some(reason) =
+        append_nostr_channel_if_available(&config, &mut configured_channels, "runtime startup")
+            .await
+    {
+        init_failures.push(reason);
     }
-    if channels.is_empty() {
+
+    if configured_channels.is_empty() && init_failures.is_empty() {
         println!("No channels configured. Run `zeroclaw onboard` to set up channels.");
         return Ok(());
     }
+
+    if configured_channels.is_empty() && !init_failures.is_empty() {
+        for failure in &init_failures {
+            println!("  ❌ {failure}");
+        }
+        anyhow::bail!("All configured channels failed during initialization.");
+    }
+
+    if !init_failures.is_empty() {
+        for failure in &init_failures {
+            println!("  ⚠️  {failure}");
+        }
+        println!();
+    }
+
+    let channels: Vec<Arc<dyn Channel>> = configured_channels
+        .into_iter()
+        .map(|configured| configured.channel)
+        .collect();
 
     println!("🦀 ZeroClaw Channel Server");
     println!("  🤖 Model:    {model}");
@@ -3322,7 +4685,12 @@ pub async fn start_channels(config: Config) -> Result<()> {
         } else {
             None
         },
-        non_cli_excluded_tools: Arc::new(config.autonomy.non_cli_excluded_tools.clone()),
+        non_cli_excluded_tools: Arc::new(Mutex::new(
+            config.autonomy.non_cli_excluded_tools.clone(),
+        )),
+        query_classification: config.query_classification.clone(),
+        model_routes: config.model_routes.clone(),
+        approval_manager: Arc::new(ApprovalManager::from_config(&config.autonomy)),
     });
 
     run_message_dispatch_loop(rx, runtime_ctx, max_in_flight_messages).await;
@@ -3397,6 +4765,102 @@ mod tests {
             channel_message_timeout_budget_secs(300, 10),
             300 * CHANNEL_MESSAGE_TIMEOUT_SCALE_CAP
         );
+    }
+
+    #[test]
+    fn parse_runtime_command_allows_approval_commands_on_non_model_channels() {
+        assert_eq!(
+            parse_runtime_command("slack", "/approve-request shell"),
+            Some(ChannelRuntimeCommand::RequestToolApproval(
+                "shell".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_runtime_command("slack", "/approve-all-once"),
+            Some(ChannelRuntimeCommand::RequestAllToolsOnce)
+        );
+        assert_eq!(
+            parse_runtime_command("slack", "/approve-confirm apr-deadbeef"),
+            Some(ChannelRuntimeCommand::ConfirmToolApproval(
+                "apr-deadbeef".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_runtime_command("slack", "/approve-pending"),
+            Some(ChannelRuntimeCommand::ListPendingApprovals)
+        );
+        assert_eq!(
+            parse_runtime_command("slack", "/approve shell"),
+            Some(ChannelRuntimeCommand::ApproveTool("shell".to_string()))
+        );
+        assert_eq!(
+            parse_runtime_command("slack", "/unapprove shell"),
+            Some(ChannelRuntimeCommand::UnapproveTool("shell".to_string()))
+        );
+        assert_eq!(
+            parse_runtime_command("slack", "/approvals"),
+            Some(ChannelRuntimeCommand::ListApprovals)
+        );
+        assert_eq!(parse_runtime_command("slack", "/models"), None);
+    }
+
+    #[test]
+    fn parse_runtime_command_supports_natural_language_approval_intents() {
+        assert_eq!(
+            parse_runtime_command("telegram", "授权工具 shell"),
+            Some(ChannelRuntimeCommand::RequestToolApproval(
+                "shell".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_runtime_command("telegram", "请放开 shell"),
+            Some(ChannelRuntimeCommand::RequestToolApproval(
+                "shell".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_runtime_command("telegram", "approve tool shell"),
+            Some(ChannelRuntimeCommand::RequestToolApproval(
+                "shell".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_runtime_command("telegram", "请一次性允许所有工具和命令"),
+            Some(ChannelRuntimeCommand::RequestAllToolsOnce)
+        );
+        assert_eq!(
+            parse_runtime_command("telegram", "确认授权 apr-deadbeef"),
+            Some(ChannelRuntimeCommand::ConfirmToolApproval(
+                "apr-deadbeef".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_runtime_command("telegram", "confirm apr-deadbeef"),
+            Some(ChannelRuntimeCommand::ConfirmToolApproval(
+                "apr-deadbeef".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_runtime_command("telegram", "撤销工具 shell"),
+            Some(ChannelRuntimeCommand::UnapproveTool("shell".to_string()))
+        );
+        assert_eq!(
+            parse_runtime_command("telegram", "revoke tool shell"),
+            Some(ChannelRuntimeCommand::UnapproveTool("shell".to_string()))
+        );
+        assert_eq!(
+            parse_runtime_command("telegram", "查看授权"),
+            Some(ChannelRuntimeCommand::ListApprovals)
+        );
+        assert_eq!(
+            parse_runtime_command("telegram", "show approvals"),
+            Some(ChannelRuntimeCommand::ListApprovals)
+        );
+        assert_eq!(
+            parse_runtime_command("telegram", "show pending approvals"),
+            Some(ChannelRuntimeCommand::ListPendingApprovals)
+        );
+        assert_eq!(parse_runtime_command("telegram", "请帮我执行shell"), None);
     }
 
     #[test]
@@ -3535,7 +4999,12 @@ mod tests {
             provider_runtime_options: providers::ProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         };
 
         assert!(compact_sender_history(&ctx, &sender));
@@ -3584,7 +5053,12 @@ mod tests {
             provider_runtime_options: providers::ProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         };
 
         append_sender_turn(&ctx, &sender, ChatMessage::user("hello"));
@@ -3636,7 +5110,12 @@ mod tests {
             provider_runtime_options: providers::ProviderRuntimeOptions::default(),
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         };
 
         assert!(rollback_orphan_user_turn(&ctx, &sender, "pending"));
@@ -3682,6 +5161,13 @@ mod tests {
         sent_messages: tokio::sync::Mutex<Vec<String>>,
     }
 
+    #[derive(Default)]
+    struct DraftStreamingRecordingChannel {
+        sent_messages: tokio::sync::Mutex<Vec<String>>,
+        draft_updates: tokio::sync::Mutex<Vec<String>>,
+        finalized_drafts: tokio::sync::Mutex<Vec<String>>,
+    }
+
     #[async_trait::async_trait]
     impl Channel for TelegramRecordingChannel {
         fn name(&self) -> &str {
@@ -3708,6 +5194,60 @@ mod tests {
         }
 
         async fn stop_typing(&self, _recipient: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Channel for DraftStreamingRecordingChannel {
+        fn name(&self) -> &str {
+            "draft-streaming-channel"
+        }
+
+        async fn send(&self, message: &SendMessage) -> anyhow::Result<()> {
+            self.sent_messages
+                .lock()
+                .await
+                .push(format!("{}:{}", message.recipient, message.content));
+            Ok(())
+        }
+
+        async fn listen(
+            &self,
+            _tx: tokio::sync::mpsc::Sender<traits::ChannelMessage>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn supports_draft_updates(&self) -> bool {
+            true
+        }
+
+        async fn send_draft(&self, message: &SendMessage) -> anyhow::Result<Option<String>> {
+            self.sent_messages
+                .lock()
+                .await
+                .push(format!("draft:{}:{}", message.recipient, message.content));
+            Ok(Some("draft-1".to_string()))
+        }
+
+        async fn update_draft(
+            &self,
+            _recipient: &str,
+            _message_id: &str,
+            text: &str,
+        ) -> anyhow::Result<Option<String>> {
+            self.draft_updates.lock().await.push(text.to_string());
+            Ok(None)
+        }
+
+        async fn finalize_draft(
+            &self,
+            _recipient: &str,
+            _message_id: &str,
+            text: &str,
+        ) -> anyhow::Result<()> {
+            self.finalized_drafts.lock().await.push(text.to_string());
             Ok(())
         }
     }
@@ -4078,6 +5618,140 @@ BTC is currently around $65,000 based on latest tool output."#
         }
     }
 
+    struct MockEchoTool;
+
+    #[async_trait::async_trait]
+    impl Tool for MockEchoTool {
+        fn name(&self) -> &str {
+            "mock_echo"
+        }
+
+        fn description(&self) -> &str {
+            "Echo back the input text"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "text": { "type": "string" }
+                }
+            })
+        }
+
+        async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                success: true,
+                output: args
+                    .get("text")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                error: None,
+            })
+        }
+    }
+
+    #[test]
+    fn build_runtime_tool_visibility_prompt_respects_excluded_snapshot() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool), Box::new(MockEchoTool)];
+        let excluded = vec!["mock_price".to_string()];
+
+        let non_native = build_runtime_tool_visibility_prompt(&tools, &excluded, false);
+        assert!(non_native.contains("Runtime Tool Availability (Authoritative)"));
+        assert!(non_native.contains("Excluded by runtime policy: mock_price"));
+        assert!(non_native.contains("`mock_echo`"));
+        assert!(!non_native.contains("**mock_price**:"));
+        assert!(non_native.contains("## Tool Use Protocol"));
+
+        let native = build_runtime_tool_visibility_prompt(&tools, &excluded, true);
+        assert!(native.contains("Runtime Tool Availability (Authoritative)"));
+        assert!(native.contains("native provider function-calling"));
+        assert!(!native.contains("## Tool Use Protocol"));
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_injects_runtime_tool_visibility_prompt() {
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(HistoryCaptureProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+        let mut provider_cache_seed: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        provider_cache_seed.insert("test-provider".to_string(), Arc::clone(&provider));
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::clone(&provider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool), Box::new(MockEchoTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("default-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(provider_cache_seed)),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Mutex::new(vec!["mock_price".to_string()])),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
+        });
+
+        process_channel_message(
+            runtime_ctx,
+            traits::ChannelMessage {
+                id: "msg-runtime-visibility-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-runtime-visibility".to_string(),
+                content: "hello tool visibility".to_string(),
+                channel: "test-channel".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        {
+            let calls = provider_impl
+                .calls
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            assert_eq!(calls.len(), 1);
+            let first_call = &calls[0];
+            assert!(!first_call.is_empty());
+            assert_eq!(first_call[0].0, "system");
+            let system_prompt = &first_call[0].1;
+            assert!(system_prompt.contains("Runtime Tool Availability (Authoritative)"));
+            assert!(system_prompt.contains("Excluded by runtime policy: mock_price"));
+            assert!(system_prompt.contains("`mock_echo`"));
+            assert!(!system_prompt.contains("**mock_price**:"));
+        }
+
+        let sent = channel_impl.sent_messages.lock().await;
+        assert_eq!(sent.len(), 1);
+        assert!(sent[0].contains("response-1"));
+    }
+
     #[tokio::test]
     async fn process_channel_message_executes_tool_calls_instead_of_sending_raw_json() {
         let channel_impl = Arc::new(RecordingChannel::default());
@@ -4109,7 +5783,12 @@ BTC is currently around $65,000 based on latest tool output."#
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: false,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
         });
@@ -4168,7 +5847,12 @@ BTC is currently around $65,000 based on latest tool output."#
             workspace_dir: Arc::new(std::env::temp_dir()),
             message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
             interrupt_on_new_message: false,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
         });
@@ -4211,6 +5895,152 @@ BTC is currently around $65,000 based on latest tool output."#
     }
 
     #[tokio::test]
+    async fn process_channel_message_streaming_hides_internal_progress_by_default() {
+        let channel_impl = Arc::new(DraftStreamingRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::new(ToolCallingProvider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("test-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 10,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+        });
+
+        process_channel_message(
+            runtime_ctx,
+            traits::ChannelMessage {
+                id: "msg-stream-hide".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-stream".to_string(),
+                content: "What is the BTC price now?".to_string(),
+                channel: "draft-streaming-channel".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let updates = channel_impl.draft_updates.lock().await;
+        assert!(
+            !updates.is_empty(),
+            "draft updates should still include streamed final answer"
+        );
+        assert!(
+            !updates.iter().any(|entry| {
+                entry.contains("Thinking")
+                    || entry.contains("Got 1 tool call(s)")
+                    || entry.contains("mock_price")
+                    || entry.contains("⏳")
+            }),
+            "internal tool progress should stay hidden by default, got updates: {updates:?}"
+        );
+        drop(updates);
+
+        let finalized = channel_impl.finalized_drafts.lock().await;
+        assert_eq!(finalized.len(), 1);
+        assert!(finalized[0].contains("BTC is currently around"));
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_streaming_shows_internal_progress_on_explicit_request() {
+        let channel_impl = Arc::new(DraftStreamingRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::new(ToolCallingProvider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("test-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 10,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+        });
+
+        process_channel_message(
+            runtime_ctx,
+            traits::ChannelMessage {
+                id: "msg-stream-show".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-stream".to_string(),
+                content: "Please show commands and tool calls you used.".to_string(),
+                channel: "draft-streaming-channel".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let updates = channel_impl.draft_updates.lock().await;
+        assert!(
+            updates
+                .iter()
+                .any(|entry| entry.contains("Got 1 tool call(s)")),
+            "explicit requests should expose internal progress details, got updates: {updates:?}"
+        );
+        assert!(
+            updates.iter().any(|entry| entry.contains("Thinking")),
+            "explicit requests should expose internal thinking/progress text, got updates: {updates:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn process_channel_message_strips_unexecuted_tool_json_artifacts_from_reply() {
         let channel_impl = Arc::new(RecordingChannel::default());
         let channel: Arc<dyn Channel> = channel_impl.clone();
@@ -4243,7 +6073,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -4302,7 +6137,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -4370,7 +6210,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -4405,6 +6250,1183 @@ BTC is currently around $65,000 based on latest tool output."#
 
         assert_eq!(default_provider_impl.call_count.load(Ordering::SeqCst), 0);
         assert_eq!(fallback_provider_impl.call_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_handles_approve_command_without_llm_call() {
+        let channel_impl = Arc::new(TelegramRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(ModelCaptureProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+
+        let mut provider_cache_seed: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        provider_cache_seed.insert("test-provider".to_string(), Arc::clone(&provider));
+
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let config_path = temp.path().join("config.toml");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+        let mut persisted = Config::default();
+        persisted.config_path = config_path.clone();
+        persisted.workspace_dir = workspace_dir;
+        persisted.autonomy.always_ask = vec!["mock_price".to_string()];
+        persisted.autonomy.non_cli_natural_language_approval_mode =
+            crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm;
+        persisted.save().await.expect("save config");
+
+        let autonomy_cfg = crate::config::AutonomyConfig {
+            always_ask: vec!["mock_price".to_string()],
+            non_cli_natural_language_approval_mode:
+                crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm,
+            ..crate::config::AutonomyConfig::default()
+        };
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::clone(&provider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("default-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(provider_cache_seed)),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions {
+                zeroclaw_dir: Some(temp.path().to_path_buf()),
+                ..providers::ProviderRuntimeOptions::default()
+            },
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(&autonomy_cfg)),
+        });
+        assert_eq!(
+            runtime_ctx
+                .approval_manager
+                .non_cli_natural_language_approval_mode_for_channel("telegram"),
+            crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm
+        );
+        assert_eq!(
+            runtime_ctx
+                .approval_manager
+                .non_cli_natural_language_approval_mode_for_channel("telegram"),
+            crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm
+        );
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-approve-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "/approve mock_price".to_string(),
+                channel: "telegram".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent = channel_impl.sent_messages.lock().await;
+        assert_eq!(sent.len(), 1);
+        assert!(sent[0].contains("Approved supervised execution for `mock_price`"));
+        assert!(sent[0].contains("including after restart"));
+
+        assert!(runtime_ctx
+            .approval_manager
+            .is_non_cli_session_granted("mock_price"));
+        assert!(runtime_ctx
+            .approval_manager
+            .is_non_cli_session_granted("mock_price"));
+        assert!(!runtime_ctx.approval_manager.needs_approval("mock_price"));
+        assert_eq!(provider_impl.call_count.load(Ordering::SeqCst), 0);
+
+        let saved_raw = tokio::fs::read_to_string(&config_path)
+            .await
+            .expect("read persisted config");
+        let saved: Config = toml::from_str(&saved_raw).expect("parse persisted config");
+        assert!(
+            saved
+                .autonomy
+                .auto_approve
+                .iter()
+                .any(|tool| tool == "mock_price"),
+            "persisted config should include mock_price in autonomy.auto_approve"
+        );
+        assert!(
+            saved
+                .autonomy
+                .always_ask
+                .iter()
+                .all(|tool| tool != "mock_price"),
+            "persisted config should remove mock_price from autonomy.always_ask"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_denies_approval_management_for_unlisted_sender() {
+        let channel_impl = Arc::new(TelegramRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(ModelCaptureProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+
+        let mut provider_cache_seed: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        provider_cache_seed.insert("test-provider".to_string(), Arc::clone(&provider));
+
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let config_path = temp.path().join("config.toml");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+        let mut persisted = Config::default();
+        persisted.config_path = config_path.clone();
+        persisted.workspace_dir = workspace_dir;
+        persisted.autonomy.always_ask = vec!["mock_price".to_string()];
+        persisted.autonomy.non_cli_approval_approvers = vec!["alice".to_string()];
+        persisted
+            .autonomy
+            .non_cli_natural_language_approval_mode_by_channel
+            .insert(
+                "telegram".to_string(),
+                crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm,
+            );
+        persisted.save().await.expect("save config");
+
+        let autonomy_cfg = crate::config::AutonomyConfig {
+            always_ask: vec!["mock_price".to_string()],
+            non_cli_approval_approvers: vec!["alice".to_string()],
+            ..crate::config::AutonomyConfig::default()
+        };
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::clone(&provider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("default-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(provider_cache_seed)),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions {
+                zeroclaw_dir: Some(temp.path().to_path_buf()),
+                ..providers::ProviderRuntimeOptions::default()
+            },
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(&autonomy_cfg)),
+        });
+        assert_eq!(
+            runtime_ctx
+                .approval_manager
+                .non_cli_natural_language_approval_mode_for_channel("telegram"),
+            crate::config::NonCliNaturalLanguageApprovalMode::Direct
+        );
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-approve-denied-1".to_string(),
+                sender: "bob".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "/approve mock_price".to_string(),
+                channel: "telegram".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent = channel_impl.sent_messages.lock().await;
+        assert_eq!(sent.len(), 1);
+        assert!(sent[0].contains("Approval-management command denied"));
+        assert!(sent[0].contains("Allowed approvers: alice"));
+        assert!(!runtime_ctx
+            .approval_manager
+            .is_non_cli_session_granted("mock_price"));
+        assert!(runtime_ctx.approval_manager.needs_approval("mock_price"));
+        assert_eq!(provider_impl.call_count.load(Ordering::SeqCst), 0);
+
+        let saved_raw = tokio::fs::read_to_string(&config_path)
+            .await
+            .expect("read persisted config");
+        let saved: Config = toml::from_str(&saved_raw).expect("parse persisted config");
+        assert!(
+            saved
+                .autonomy
+                .auto_approve
+                .iter()
+                .all(|tool| tool != "mock_price"),
+            "persisted config should not include unauthorized approval changes"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_handles_unapprove_command_without_llm_call() {
+        let channel_impl = Arc::new(TelegramRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(ModelCaptureProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+
+        let mut provider_cache_seed: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        provider_cache_seed.insert("test-provider".to_string(), Arc::clone(&provider));
+
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let config_path = temp.path().join("config.toml");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+        let mut persisted = Config::default();
+        persisted.config_path = config_path.clone();
+        persisted.workspace_dir = workspace_dir;
+        persisted.autonomy.auto_approve = vec!["mock_price".to_string()];
+        persisted.save().await.expect("save config");
+
+        let autonomy_cfg = crate::config::AutonomyConfig {
+            auto_approve: vec!["mock_price".to_string()],
+            ..crate::config::AutonomyConfig::default()
+        };
+        let approval_manager = Arc::new(ApprovalManager::from_config(&autonomy_cfg));
+        approval_manager.grant_non_cli_session("mock_price");
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::clone(&provider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("default-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(provider_cache_seed)),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions {
+                zeroclaw_dir: Some(temp.path().to_path_buf()),
+                ..providers::ProviderRuntimeOptions::default()
+            },
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager,
+        });
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-unapprove-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "/unapprove mock_price".to_string(),
+                channel: "telegram".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent = channel_impl.sent_messages.lock().await;
+        assert_eq!(sent.len(), 1);
+        assert!(sent[0].contains("Persistent approval removed for `mock_price`: yes."));
+        assert!(sent[0].contains("Runtime session grant removed: yes"));
+        assert!(!runtime_ctx
+            .approval_manager
+            .is_non_cli_session_granted("mock_price"));
+        assert!(runtime_ctx.approval_manager.needs_approval("mock_price"));
+        assert_eq!(provider_impl.call_count.load(Ordering::SeqCst), 0);
+
+        let saved_raw = tokio::fs::read_to_string(&config_path)
+            .await
+            .expect("read persisted config");
+        let saved: Config = toml::from_str(&saved_raw).expect("parse persisted config");
+        assert!(
+            saved
+                .autonomy
+                .auto_approve
+                .iter()
+                .all(|tool| tool != "mock_price"),
+            "persisted config should remove mock_price from autonomy.auto_approve"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_handles_approvals_command_without_llm_call() {
+        let channel_impl = Arc::new(TelegramRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(ModelCaptureProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+
+        let mut provider_cache_seed: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        provider_cache_seed.insert("test-provider".to_string(), Arc::clone(&provider));
+
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let config_path = temp.path().join("config.toml");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+        let mut persisted = Config::default();
+        persisted.config_path = config_path.clone();
+        persisted.workspace_dir = workspace_dir;
+        persisted.autonomy.auto_approve = vec!["mock_price".to_string()];
+        persisted.autonomy.always_ask = vec!["shell".to_string()];
+        persisted.autonomy.non_cli_excluded_tools = vec!["shell".to_string()];
+        persisted.save().await.expect("save config");
+
+        let approval_manager = Arc::new(ApprovalManager::from_config(
+            &crate::config::AutonomyConfig::default(),
+        ));
+        approval_manager.grant_non_cli_session("shell");
+        approval_manager.grant_non_cli_allow_all_once();
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::clone(&provider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("default-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(provider_cache_seed)),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions {
+                zeroclaw_dir: Some(temp.path().to_path_buf()),
+                ..providers::ProviderRuntimeOptions::default()
+            },
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Mutex::new(vec!["shell".to_string()])),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager,
+        });
+
+        process_channel_message(
+            runtime_ctx,
+            traits::ChannelMessage {
+                id: "msg-approvals-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "/approvals".to_string(),
+                channel: "telegram".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent = channel_impl.sent_messages.lock().await;
+        assert_eq!(sent.len(), 1);
+        assert!(sent[0].contains("Supervised non-CLI tool approvals:"));
+        assert!(sent[0].contains("Runtime session grants: shell"));
+        assert!(sent[0].contains("Runtime one-time all-tools bypass tokens: 1"));
+        assert!(sent[0].contains("Runtime non_cli_approval_approvers:"));
+        assert!(sent[0].contains("Runtime non_cli_natural_language_approval_mode:"));
+        assert!(sent[0].contains("Runtime non_cli_natural_language_approval_mode_by_channel:"));
+        assert!(sent[0].contains("Runtime non_cli_excluded_tools: shell"));
+        assert!(sent[0].contains("Persisted autonomy.auto_approve: mock_price"));
+        assert!(sent[0].contains("Persisted autonomy.always_ask: shell"));
+        assert_eq!(provider_impl.call_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_natural_request_then_confirm_approval() {
+        let channel_impl = Arc::new(TelegramRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(ModelCaptureProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+        let mut provider_cache_seed: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        provider_cache_seed.insert("test-provider".to_string(), Arc::clone(&provider));
+
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let config_path = temp.path().join("config.toml");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+        let mut persisted = Config::default();
+        persisted.config_path = config_path.clone();
+        persisted.workspace_dir = workspace_dir;
+        persisted.autonomy.always_ask = vec!["mock_price".to_string()];
+        persisted.autonomy.non_cli_natural_language_approval_mode =
+            crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm;
+        persisted.save().await.expect("save config");
+
+        let autonomy_cfg = crate::config::AutonomyConfig {
+            always_ask: vec!["mock_price".to_string()],
+            non_cli_natural_language_approval_mode:
+                crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm,
+            ..crate::config::AutonomyConfig::default()
+        };
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::clone(&provider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("default-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(provider_cache_seed)),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions {
+                zeroclaw_dir: Some(temp.path().to_path_buf()),
+                ..providers::ProviderRuntimeOptions::default()
+            },
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(&autonomy_cfg)),
+        });
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-req-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "授权工具 mock_price".to_string(),
+                channel: "telegram".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let request_id = {
+            let sent = channel_impl.sent_messages.lock().await;
+            assert_eq!(sent.len(), 1);
+            assert!(
+                sent[0].contains("Approval request created."),
+                "unexpected response: {}",
+                sent[0]
+            );
+            let request_line = sent[0]
+                .lines()
+                .find(|line| line.starts_with("Request ID: `"))
+                .expect("request line");
+            request_line
+                .trim_start_matches("Request ID: `")
+                .trim_end_matches('`')
+                .to_string()
+        };
+        assert!(request_id.starts_with("apr-"));
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-req-2".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: format!("确认授权 {request_id}"),
+                channel: "telegram".to_string(),
+                timestamp: 2,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent = channel_impl.sent_messages.lock().await;
+        assert_eq!(sent.len(), 2);
+        assert!(sent[1].contains("Approved supervised execution for `mock_price` from request"));
+        assert!(runtime_ctx
+            .approval_manager
+            .is_non_cli_session_granted("mock_price"));
+        assert!(!runtime_ctx.approval_manager.needs_approval("mock_price"));
+        assert!(runtime_ctx
+            .approval_manager
+            .list_non_cli_pending_requests(Some("alice"), Some("telegram"), Some("chat-1"))
+            .is_empty());
+        assert_eq!(provider_impl.call_count.load(Ordering::SeqCst), 0);
+
+        let saved_raw = tokio::fs::read_to_string(&config_path)
+            .await
+            .expect("read persisted config");
+        let saved: Config = toml::from_str(&saved_raw).expect("parse persisted config");
+        assert!(saved
+            .autonomy
+            .auto_approve
+            .iter()
+            .any(|tool| tool == "mock_price"));
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_all_tools_once_requires_confirm_and_stays_runtime_only() {
+        let channel_impl = Arc::new(TelegramRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(ModelCaptureProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+        let mut provider_cache_seed: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        provider_cache_seed.insert("test-provider".to_string(), Arc::clone(&provider));
+
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let config_path = temp.path().join("config.toml");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+        let mut persisted = Config::default();
+        persisted.config_path = config_path.clone();
+        persisted.workspace_dir = workspace_dir;
+        persisted.autonomy.always_ask = vec!["mock_price".to_string()];
+        persisted.autonomy.non_cli_natural_language_approval_mode =
+            crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm;
+        persisted.save().await.expect("save config");
+
+        let autonomy_cfg = crate::config::AutonomyConfig {
+            always_ask: vec!["mock_price".to_string()],
+            non_cli_natural_language_approval_mode:
+                crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm,
+            ..crate::config::AutonomyConfig::default()
+        };
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::clone(&provider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("default-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(provider_cache_seed)),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions {
+                zeroclaw_dir: Some(temp.path().to_path_buf()),
+                ..providers::ProviderRuntimeOptions::default()
+            },
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(&autonomy_cfg)),
+        });
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-all-once-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "请一次性允许所有工具和命令".to_string(),
+                channel: "telegram".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let request_id = {
+            let sent = channel_impl.sent_messages.lock().await;
+            assert_eq!(sent.len(), 1);
+            assert!(
+                sent[0].contains("One-time all-tools approval request created."),
+                "unexpected response: {}",
+                sent[0]
+            );
+            let request_line = sent[0]
+                .lines()
+                .find(|line| line.starts_with("Request ID: `"))
+                .expect("request line");
+            request_line
+                .trim_start_matches("Request ID: `")
+                .trim_end_matches('`')
+                .to_string()
+        };
+        assert!(request_id.starts_with("apr-"));
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-all-once-2".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: format!("/approve-confirm {request_id}"),
+                channel: "telegram".to_string(),
+                timestamp: 2,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent = channel_impl.sent_messages.lock().await;
+        assert_eq!(sent.len(), 2);
+        assert!(sent[1].contains("Approved one-time all-tools bypass from request"));
+        assert!(sent[1].contains("does not persist to config"));
+        assert_eq!(
+            runtime_ctx
+                .approval_manager
+                .non_cli_allow_all_once_remaining(),
+            1
+        );
+        assert_eq!(provider_impl.call_count.load(Ordering::SeqCst), 0);
+
+        let saved_raw = tokio::fs::read_to_string(&config_path)
+            .await
+            .expect("read persisted config");
+        let saved: Config = toml::from_str(&saved_raw).expect("parse persisted config");
+        assert!(
+            saved
+                .autonomy
+                .auto_approve
+                .iter()
+                .all(|tool| tool != APPROVAL_ALL_TOOLS_ONCE_TOKEN && tool != "mock_price"),
+            "persisted config should not persist one-time bypass markers or promote mock_price"
+        );
+        assert!(
+            saved
+                .autonomy
+                .always_ask
+                .iter()
+                .any(|tool| tool == "mock_price"),
+            "persisted config should keep existing always_ask entries untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_natural_approval_direct_mode_grants_immediately() {
+        let channel_impl = Arc::new(TelegramRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(ModelCaptureProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+        let mut provider_cache_seed: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        provider_cache_seed.insert("test-provider".to_string(), Arc::clone(&provider));
+
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let config_path = temp.path().join("config.toml");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+        let mut persisted = Config::default();
+        persisted.config_path = config_path.clone();
+        persisted.workspace_dir = workspace_dir;
+        persisted.autonomy.always_ask = vec!["mock_price".to_string()];
+        persisted.save().await.expect("save config");
+
+        let autonomy_cfg = crate::config::AutonomyConfig {
+            always_ask: vec!["mock_price".to_string()],
+            ..crate::config::AutonomyConfig::default()
+        };
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::clone(&provider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("default-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(provider_cache_seed)),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions {
+                zeroclaw_dir: Some(temp.path().to_path_buf()),
+                ..providers::ProviderRuntimeOptions::default()
+            },
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(&autonomy_cfg)),
+        });
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-direct-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "授权工具 mock_price".to_string(),
+                channel: "telegram".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent = channel_impl.sent_messages.lock().await;
+        assert_eq!(sent.len(), 1);
+        assert!(sent[0].contains("Approved supervised execution for `mock_price`."));
+        assert!(sent[0].contains("Runtime pending requests cleared: 0."));
+        assert!(runtime_ctx
+            .approval_manager
+            .is_non_cli_session_granted("mock_price"));
+        assert!(!runtime_ctx.approval_manager.needs_approval("mock_price"));
+        assert!(runtime_ctx
+            .approval_manager
+            .list_non_cli_pending_requests(Some("alice"), Some("telegram"), Some("chat-1"))
+            .is_empty());
+        assert_eq!(provider_impl.call_count.load(Ordering::SeqCst), 0);
+
+        let saved_raw = tokio::fs::read_to_string(&config_path)
+            .await
+            .expect("read persisted config");
+        let saved: Config = toml::from_str(&saved_raw).expect("parse persisted config");
+        assert!(saved
+            .autonomy
+            .auto_approve
+            .iter()
+            .any(|tool| tool == "mock_price"));
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_natural_approval_honors_channel_mode_override() {
+        let channel_impl = Arc::new(TelegramRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(ModelCaptureProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+        let mut provider_cache_seed: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        provider_cache_seed.insert("test-provider".to_string(), Arc::clone(&provider));
+
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let config_path = temp.path().join("config.toml");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+        let mut persisted = Config::default();
+        persisted.config_path = config_path.clone();
+        persisted.workspace_dir = workspace_dir;
+        persisted.autonomy.always_ask = vec!["mock_price".to_string()];
+        persisted
+            .autonomy
+            .non_cli_natural_language_approval_mode_by_channel
+            .insert(
+                "telegram".to_string(),
+                crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm,
+            );
+        persisted.save().await.expect("save config");
+
+        let mut autonomy_cfg = crate::config::AutonomyConfig {
+            always_ask: vec!["mock_price".to_string()],
+            ..crate::config::AutonomyConfig::default()
+        };
+        autonomy_cfg
+            .non_cli_natural_language_approval_mode_by_channel
+            .insert(
+                "telegram".to_string(),
+                crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm,
+            );
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::clone(&provider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("default-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(provider_cache_seed)),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions {
+                zeroclaw_dir: Some(temp.path().to_path_buf()),
+                ..providers::ProviderRuntimeOptions::default()
+            },
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(&autonomy_cfg)),
+        });
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-direct-override-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "授权工具 mock_price".to_string(),
+                channel: "telegram".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent = channel_impl.sent_messages.lock().await;
+        assert_eq!(sent.len(), 1);
+        assert!(
+            sent[0].contains("Approval request created."),
+            "unexpected response: {}",
+            sent[0]
+        );
+        assert!(!runtime_ctx
+            .approval_manager
+            .is_non_cli_session_granted("mock_price"));
+        assert!(runtime_ctx.approval_manager.needs_approval("mock_price"));
+        assert_eq!(provider_impl.call_count.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_natural_approval_can_be_disabled_but_slash_still_works() {
+        let channel_impl = Arc::new(TelegramRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(ModelCaptureProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+        let mut provider_cache_seed: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        provider_cache_seed.insert("test-provider".to_string(), Arc::clone(&provider));
+
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let config_path = temp.path().join("config.toml");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+        let mut persisted = Config::default();
+        persisted.config_path = config_path.clone();
+        persisted.workspace_dir = workspace_dir;
+        persisted.autonomy.always_ask = vec!["mock_price".to_string()];
+        persisted.autonomy.non_cli_natural_language_approval_mode =
+            crate::config::NonCliNaturalLanguageApprovalMode::Disabled;
+        persisted.save().await.expect("save config");
+
+        let autonomy_cfg = crate::config::AutonomyConfig {
+            always_ask: vec!["mock_price".to_string()],
+            non_cli_natural_language_approval_mode:
+                crate::config::NonCliNaturalLanguageApprovalMode::Disabled,
+            ..crate::config::AutonomyConfig::default()
+        };
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::clone(&provider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("default-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(provider_cache_seed)),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions {
+                zeroclaw_dir: Some(temp.path().to_path_buf()),
+                ..providers::ProviderRuntimeOptions::default()
+            },
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(&autonomy_cfg)),
+        });
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-nl-disabled-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "授权工具 mock_price".to_string(),
+                channel: "telegram".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        {
+            let sent = channel_impl.sent_messages.lock().await;
+            assert_eq!(sent.len(), 1);
+            assert!(
+                sent[0].contains("Natural-language approval commands are disabled"),
+                "unexpected response: {}",
+                sent[0]
+            );
+        }
+        assert!(!runtime_ctx
+            .approval_manager
+            .is_non_cli_session_granted("mock_price"));
+        assert!(runtime_ctx.approval_manager.needs_approval("mock_price"));
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-nl-disabled-2".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "/approve mock_price".to_string(),
+                channel: "telegram".to_string(),
+                timestamp: 2,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent = channel_impl.sent_messages.lock().await;
+        assert_eq!(sent.len(), 2);
+        assert!(sent[1].contains("Approved supervised execution for `mock_price`."));
+        assert!(runtime_ctx
+            .approval_manager
+            .is_non_cli_session_granted("mock_price"));
+        assert!(!runtime_ctx.approval_manager.needs_approval("mock_price"));
+        assert_eq!(provider_impl.call_count.load(Ordering::SeqCst), 0);
+
+        let saved_raw = tokio::fs::read_to_string(&config_path)
+            .await
+            .expect("read persisted config");
+        let saved: Config = toml::from_str(&saved_raw).expect("parse persisted config");
+        assert!(saved
+            .autonomy
+            .auto_approve
+            .iter()
+            .any(|tool| tool == "mock_price"));
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_confirm_rejects_sender_mismatch() {
+        let channel_impl = Arc::new(TelegramRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(ModelCaptureProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+        let mut provider_cache_seed: HashMap<String, Arc<dyn Provider>> = HashMap::new();
+        provider_cache_seed.insert("test-provider".to_string(), Arc::clone(&provider));
+
+        let autonomy_cfg = crate::config::AutonomyConfig {
+            non_cli_natural_language_approval_mode:
+                crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm,
+            ..crate::config::AutonomyConfig::default()
+        };
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::clone(&provider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("default-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(provider_cache_seed)),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(&autonomy_cfg)),
+        });
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-mismatch-1".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: "授权工具 mock_price".to_string(),
+                channel: "telegram".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let request_id = {
+            let sent = channel_impl.sent_messages.lock().await;
+            assert_eq!(sent.len(), 1);
+            let request_line = sent[0]
+                .lines()
+                .find(|line| line.starts_with("Request ID: `"))
+                .expect("request line");
+            request_line
+                .trim_start_matches("Request ID: `")
+                .trim_end_matches('`')
+                .to_string()
+        };
+
+        process_channel_message(
+            runtime_ctx.clone(),
+            traits::ChannelMessage {
+                id: "msg-mismatch-2".to_string(),
+                sender: "bob".to_string(),
+                reply_target: "chat-1".to_string(),
+                content: format!("confirm {request_id}"),
+                channel: "telegram".to_string(),
+                timestamp: 2,
+                thread_ts: None,
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let sent = channel_impl.sent_messages.lock().await;
+        assert_eq!(sent.len(), 2);
+        assert!(sent[1].contains("can only be confirmed by the same sender"));
+        assert_eq!(provider_impl.call_count.load(Ordering::SeqCst), 0);
+
+        let pending = runtime_ctx.approval_manager.list_non_cli_pending_requests(
+            Some("alice"),
+            Some("telegram"),
+            Some("chat-1"),
+        );
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].request_id, request_id);
     }
 
     #[tokio::test]
@@ -4459,7 +7481,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -4530,7 +7557,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -4616,7 +7648,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -4650,6 +7687,167 @@ BTC is currently around $65,000 based on latest tool output."#
                 .as_slice(),
             &["hot-reloaded-model".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn load_runtime_defaults_from_config_file_includes_autonomy_policy() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let config_path = temp.path().join("config.toml");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+
+        let mut cfg = Config::default();
+        cfg.config_path = config_path.clone();
+        cfg.workspace_dir = workspace_dir;
+        cfg.default_provider = Some("test-provider".to_string());
+        cfg.default_model = Some("test-model".to_string());
+        cfg.autonomy.auto_approve = vec!["mock_price".to_string()];
+        cfg.autonomy.always_ask = vec!["shell".to_string()];
+        cfg.autonomy.non_cli_excluded_tools = vec!["browser_open".to_string()];
+        cfg.autonomy.non_cli_approval_approvers = vec!["telegram:alice".to_string()];
+        cfg.autonomy.non_cli_natural_language_approval_mode =
+            crate::config::NonCliNaturalLanguageApprovalMode::Direct;
+        cfg.autonomy
+            .non_cli_natural_language_approval_mode_by_channel
+            .insert(
+                "telegram".to_string(),
+                crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm,
+            );
+        cfg.save().await.expect("save config");
+
+        let (_defaults, policy) = load_runtime_defaults_from_config_file(&config_path)
+            .await
+            .expect("load runtime state");
+
+        assert_eq!(policy.auto_approve, vec!["mock_price".to_string()]);
+        assert_eq!(policy.always_ask, vec!["shell".to_string()]);
+        assert_eq!(
+            policy.non_cli_excluded_tools,
+            vec!["browser_open".to_string()]
+        );
+        assert_eq!(
+            policy.non_cli_approval_approvers,
+            vec!["telegram:alice".to_string()]
+        );
+        assert_eq!(
+            policy.non_cli_natural_language_approval_mode,
+            crate::config::NonCliNaturalLanguageApprovalMode::Direct
+        );
+        assert_eq!(
+            policy
+                .non_cli_natural_language_approval_mode_by_channel
+                .get("telegram")
+                .copied(),
+            Some(crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm)
+        );
+    }
+
+    #[tokio::test]
+    async fn maybe_apply_runtime_config_update_refreshes_autonomy_policy_and_excluded_tools() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let config_path = temp.path().join("config.toml");
+        let workspace_dir = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+
+        let mut cfg = Config::default();
+        cfg.config_path = config_path.clone();
+        cfg.workspace_dir = workspace_dir;
+        cfg.default_provider = Some("ollama".to_string());
+        cfg.default_model = Some("llama3.2".to_string());
+        cfg.api_key = Some("http://127.0.0.1:11434".to_string());
+        cfg.autonomy.non_cli_natural_language_approval_mode =
+            crate::config::NonCliNaturalLanguageApprovalMode::Direct;
+        cfg.autonomy.non_cli_excluded_tools = vec!["shell".to_string()];
+        cfg.save().await.expect("save initial config");
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(HashMap::new()),
+            provider: Arc::new(ModelCaptureProvider::default()),
+            default_provider: Arc::new("ollama".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![Box::new(MockPriceTool)]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("llama3.2".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: Some("http://127.0.0.1:11434".to_string()),
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions {
+                zeroclaw_dir: Some(temp.path().to_path_buf()),
+                ..providers::ProviderRuntimeOptions::default()
+            },
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: false,
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
+        });
+
+        maybe_apply_runtime_config_update(runtime_ctx.as_ref())
+            .await
+            .expect("apply initial config");
+
+        assert_eq!(
+            runtime_ctx
+                .approval_manager
+                .non_cli_natural_language_approval_mode_for_channel("telegram"),
+            crate::config::NonCliNaturalLanguageApprovalMode::Direct
+        );
+        assert_eq!(
+            snapshot_non_cli_excluded_tools(runtime_ctx.as_ref()),
+            vec!["shell".to_string()]
+        );
+
+        cfg.autonomy.non_cli_natural_language_approval_mode =
+            crate::config::NonCliNaturalLanguageApprovalMode::Disabled;
+        cfg.autonomy
+            .non_cli_natural_language_approval_mode_by_channel
+            .insert(
+                "telegram".to_string(),
+                crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm,
+            );
+        cfg.autonomy.non_cli_excluded_tools =
+            vec!["browser_open".to_string(), "mock_price".to_string()];
+        cfg.save().await.expect("save updated config");
+
+        maybe_apply_runtime_config_update(runtime_ctx.as_ref())
+            .await
+            .expect("apply updated config");
+
+        assert_eq!(
+            runtime_ctx
+                .approval_manager
+                .non_cli_natural_language_approval_mode_for_channel("telegram"),
+            crate::config::NonCliNaturalLanguageApprovalMode::RequestConfirm
+        );
+        assert_eq!(
+            runtime_ctx
+                .approval_manager
+                .non_cli_natural_language_approval_mode_for_channel("discord"),
+            crate::config::NonCliNaturalLanguageApprovalMode::Disabled
+        );
+        assert_eq!(
+            snapshot_non_cli_excluded_tools(runtime_ctx.as_ref()),
+            vec!["browser_open".to_string(), "mock_price".to_string()]
+        );
+
+        let mut store = runtime_config_store()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        store.remove(&config_path);
     }
 
     #[tokio::test]
@@ -4687,7 +7885,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -4747,7 +7950,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -4768,7 +7976,8 @@ BTC is currently around $65,000 based on latest tool output."#
         let sent_messages = channel_impl.sent_messages.lock().await;
         assert_eq!(sent_messages.len(), 1);
         assert!(sent_messages[0].starts_with("chat-iter-fail:"));
-        assert!(sent_messages[0].contains("⚠️ Error: Agent exceeded maximum tool iterations (3)"));
+        assert!(sent_messages[0].contains("⚠️ Reached tool-iteration limit (3)"));
+        assert!(sent_messages[0].contains("Context and progress were preserved"));
     }
 
     struct NoopMemory;
@@ -4918,7 +8127,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(4);
@@ -4998,7 +8212,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: true,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);
@@ -5090,7 +8309,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: true,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);
@@ -5164,7 +8388,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -5223,7 +8452,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -5305,7 +8539,7 @@ BTC is currently around $65,000 based on latest tool output."#
             "build_system_prompt should not emit protocol block directly"
         );
 
-        prompt.push_str(&build_tool_instructions(&[]));
+        prompt.push_str(&crate::agent::loop_::build_tool_instructions(&[]));
 
         assert_eq!(
             prompt.matches("## Tool Use Protocol").count(),
@@ -5739,7 +8973,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -5824,7 +9063,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -5909,7 +9153,12 @@ BTC is currently around $65,000 based on latest tool output."#
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -6032,6 +9281,54 @@ Done reminder set for 1:38 AM."#;
     }
 
     #[test]
+    fn should_expose_internal_tool_details_matches_explicit_requests() {
+        assert!(should_expose_internal_tool_details(
+            "Please show commands and tool calls you used."
+        ));
+        assert!(should_expose_internal_tool_details(
+            "请输出命令和工具调用过程"
+        ));
+        assert!(!should_expose_internal_tool_details(
+            "帮我直接给最终结论，不要过程。"
+        ));
+    }
+
+    #[test]
+    fn should_expose_internal_tool_details_respects_negative_requests() {
+        assert!(!should_expose_internal_tool_details(
+            "Please do not show commands or tool calls, only final answer."
+        ));
+        assert!(!should_expose_internal_tool_details(
+            "不要显示命令和工具调用，直接给最终结论。"
+        ));
+    }
+
+    #[test]
+    fn split_internal_progress_delta_detects_sentinel_prefix() {
+        let payload = format!(
+            "{}⏳ shell: ls -la\n",
+            crate::agent::loop_::DRAFT_PROGRESS_SENTINEL
+        );
+        let (is_internal, visible) = split_internal_progress_delta(&payload);
+        assert!(is_internal);
+        assert_eq!(visible, "⏳ shell: ls -la\n");
+
+        let (is_internal_plain, plain) = split_internal_progress_delta("final answer");
+        assert!(!is_internal_plain);
+        assert_eq!(plain, "final answer");
+    }
+
+    #[test]
+    fn build_channel_system_prompt_includes_visibility_policy() {
+        let hidden = build_channel_system_prompt("base", "telegram", "chat", false);
+        assert!(hidden.contains("run tools/functions in the background"));
+        assert!(hidden.contains("Do not reveal raw tool names"));
+
+        let exposed = build_channel_system_prompt("base", "telegram", "chat", true);
+        assert!(exposed.contains("user explicitly requested command/tool details"));
+    }
+
+    #[test]
     fn strip_isolated_tool_json_artifacts_preserves_non_tool_json() {
         let mut known_tools = HashSet::new();
         known_tools.insert("shell".to_string());
@@ -6041,6 +9338,34 @@ This is an example JSON object for profile settings."#;
 
         let result = strip_isolated_tool_json_artifacts(input, &known_tools);
         assert_eq!(result, input);
+    }
+
+    #[test]
+    fn sanitize_channel_response_removes_tool_call_tags_and_tool_json_artifacts() {
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockPriceTool)];
+
+        let input = r#"Let me check.
+<tool_call>
+{"name":"debug_trace","arguments":{"foo":"bar"}}
+</tool_call>
+{"name":"mock_price","parameters":{"symbol":"BTC"}}
+{"result":{"symbol":"BTC","price_usd":65000}}
+BTC is currently around $65,000 based on latest tool output."#;
+
+        let result = sanitize_channel_response(input, &tools);
+        let normalized = result
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_eq!(
+            normalized,
+            "Let me check.\nBTC is currently around $65,000 based on latest tool output."
+        );
+        assert!(!result.contains("<tool_call>"));
+        assert!(!result.contains("\"name\":\"mock_price\""));
+        assert!(!result.contains("\"result\""));
     }
 
     // ── AIEOS Identity Tests (Issue #168) ─────────────────────────
@@ -6225,6 +9550,7 @@ This is an example JSON object for profile settings."#;
             allowed_users: vec![],
             thread_replies: Some(true),
             mention_only: Some(false),
+            group_reply: None,
         });
 
         let channels = collect_configured_channels(&config, "test");
@@ -6458,7 +9784,12 @@ This is an example JSON object for profile settings."#;
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         // Simulate a photo attachment message with [IMAGE:] marker.
@@ -6524,7 +9855,12 @@ This is an example JSON object for profile settings."#;
             interrupt_on_new_message: false,
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
-            non_cli_excluded_tools: Arc::new(Vec::new()),
+            non_cli_excluded_tools: Arc::new(Mutex::new(Vec::new())),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            model_routes: Vec::new(),
+            approval_manager: Arc::new(ApprovalManager::from_config(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -6,7 +6,8 @@ use async_trait::async_trait;
 use directories::UserDirs;
 use parking_lot::Mutex;
 use reqwest::multipart::{Form, Part};
-use std::path::Path;
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tokio::fs;
@@ -33,6 +34,15 @@ struct IncomingAttachment {
 enum IncomingAttachmentKind {
     Document,
     Photo,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct VoiceMetadata {
+    file_id: String,
+    duration_secs: u64,
+    file_name_hint: Option<String>,
+    mime_type_hint: Option<String>,
+    voice_note: bool,
 }
 const TELEGRAM_BIND_COMMAND: &str = "/bind";
 
@@ -100,6 +110,7 @@ fn pick_uniform_index(len: usize) -> usize {
     loop {
         let value = rand::random::<u64>();
         if value < reject_threshold {
+            #[allow(clippy::cast_possible_truncation)]
             return (value % upper) as usize;
         }
     }
@@ -167,17 +178,18 @@ fn is_image_extension(path: &Path) -> bool {
 
 /// Build the user-facing content string for an incoming attachment.
 ///
-/// Photos with a recognized image extension use `[IMAGE:/path]` so the
-/// multimodal pipeline can validate vision capability. Non-image files
-/// always use `[Document: name] /path` regardless of how Telegram
-/// classified them.
+/// Photos and Documents with a recognized image extension use `[IMAGE:/path]`
+/// so the multimodal pipeline can validate vision capability and send them
+/// as proper image content blocks. Non-image files use `[Document: name] /path`.
 fn format_attachment_content(
     kind: IncomingAttachmentKind,
     local_filename: &str,
     local_path: &Path,
 ) -> String {
     match kind {
-        IncomingAttachmentKind::Photo if is_image_extension(local_path) => {
+        IncomingAttachmentKind::Photo | IncomingAttachmentKind::Document
+            if is_image_extension(local_path) =>
+        {
             format!("[IMAGE:{}]", local_path.display())
         }
         _ => {
@@ -188,6 +200,128 @@ fn format_attachment_content(
 
 fn is_http_url(target: &str) -> bool {
     target.starts_with("http://") || target.starts_with("https://")
+}
+
+fn sanitize_attachment_filename(file_name: &str) -> Option<String> {
+    let basename = Path::new(file_name).file_name()?.to_str()?.trim();
+    if basename.is_empty() || basename == "." || basename == ".." {
+        return None;
+    }
+
+    let sanitized: String = basename
+        .replace(['/', '\\'], "_")
+        .chars()
+        .take(128)
+        .collect();
+    if sanitized.is_empty() || sanitized == "." || sanitized == ".." {
+        None
+    } else {
+        Some(sanitized)
+    }
+}
+
+fn sanitize_generated_extension(raw_ext: &str) -> String {
+    let cleaned: String = raw_ext
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(8)
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if cleaned.is_empty() {
+        "jpg".to_string()
+    } else {
+        cleaned
+    }
+}
+
+fn resolve_workspace_attachment_path(workspace: &Path, target: &str) -> anyhow::Result<PathBuf> {
+    if target.contains('\0') {
+        anyhow::bail!("Telegram attachment path contains null byte");
+    }
+
+    let workspace_root = workspace
+        .canonicalize()
+        .unwrap_or_else(|_| workspace.to_path_buf());
+
+    let candidate = if let Some(rel) = target.strip_prefix("/workspace/") {
+        workspace.join(rel)
+    } else if target == "/workspace" {
+        workspace.to_path_buf()
+    } else {
+        let raw = Path::new(target);
+        if raw.is_absolute() {
+            raw.to_path_buf()
+        } else {
+            workspace.join(raw)
+        }
+    };
+
+    let resolved = candidate
+        .canonicalize()
+        .with_context(|| format!("Telegram attachment path not found: {target}"))?;
+
+    if !resolved.starts_with(&workspace_root) {
+        anyhow::bail!("Telegram attachment path escapes workspace: {target}");
+    }
+    if !resolved.is_file() {
+        anyhow::bail!(
+            "Telegram attachment path is not a file: {}",
+            resolved.display()
+        );
+    }
+
+    Ok(resolved)
+}
+
+async fn resolve_workspace_attachment_output_path(
+    workspace: &Path,
+    file_name: &str,
+) -> anyhow::Result<PathBuf> {
+    let safe_name = sanitize_attachment_filename(file_name)
+        .ok_or_else(|| anyhow::anyhow!("invalid attachment filename: {file_name}"))?;
+
+    fs::create_dir_all(workspace).await?;
+    let workspace_root = fs::canonicalize(workspace)
+        .await
+        .unwrap_or_else(|_| workspace.to_path_buf());
+
+    let save_dir = workspace.join("telegram_files");
+    fs::create_dir_all(&save_dir).await?;
+    let resolved_save_dir = fs::canonicalize(&save_dir).await.with_context(|| {
+        format!(
+            "failed to resolve Telegram attachment save directory: {}",
+            save_dir.display()
+        )
+    })?;
+
+    if !resolved_save_dir.starts_with(&workspace_root) {
+        anyhow::bail!(
+            "Telegram attachment save directory escapes workspace: {}",
+            save_dir.display()
+        );
+    }
+
+    let output_path = resolved_save_dir.join(safe_name);
+    match fs::symlink_metadata(&output_path).await {
+        Ok(meta) => {
+            if meta.file_type().is_symlink() {
+                anyhow::bail!(
+                    "refusing to write Telegram attachment through symlink: {}",
+                    output_path.display()
+                );
+            }
+            if !meta.is_file() {
+                anyhow::bail!(
+                    "Telegram attachment output path is not a regular file: {}",
+                    output_path.display()
+                );
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(e.into()),
+    }
+
+    Ok(output_path)
 }
 
 fn infer_attachment_kind_from_target(target: &str) -> Option<TelegramAttachmentKind> {
@@ -244,6 +378,23 @@ fn strip_tool_call_tags(message: &str) -> String {
     super::strip_tool_call_tags(message)
 }
 
+fn find_matching_close(s: &str) -> Option<usize> {
+    let mut depth = 1usize;
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 fn parse_attachment_markers(message: &str) -> (String, Vec<TelegramAttachment>) {
     let mut cleaned = String::with_capacity(message.len());
     let mut attachments = Vec::new();
@@ -258,12 +409,12 @@ fn parse_attachment_markers(message: &str) -> (String, Vec<TelegramAttachment>) 
         let open = cursor + open_rel;
         cleaned.push_str(&message[cursor..open]);
 
-        let Some(close_rel) = message[open..].find(']') else {
+        let Some(close_rel) = find_matching_close(&message[open + 1..]) else {
             cleaned.push_str(&message[open..]);
             break;
         };
 
-        let close = open + close_rel;
+        let close = open + 1 + close_rel;
         let marker = &message[open + 1..close];
 
         let parsed = marker.split_once(':').and_then(|(kind, target)| {
@@ -304,6 +455,7 @@ pub struct TelegramChannel {
     draft_update_interval_ms: u64,
     last_draft_edit: Mutex<std::collections::HashMap<String, std::time::Instant>>,
     mention_only: bool,
+    group_reply_allowed_sender_ids: Vec<String>,
     bot_username: Mutex<Option<String>>,
     /// Base URL for the Telegram Bot API. Defaults to `https://api.telegram.org`.
     /// Override for local Bot API servers or testing.
@@ -337,6 +489,7 @@ impl TelegramChannel {
             last_draft_edit: Mutex::new(std::collections::HashMap::new()),
             typing_handle: Mutex::new(None),
             mention_only,
+            group_reply_allowed_sender_ids: Vec::new(),
             bot_username: Mutex::new(None),
             api_base: "https://api.telegram.org".to_string(),
             transcription: None,
@@ -359,6 +512,13 @@ impl TelegramChannel {
     ) -> Self {
         self.stream_mode = stream_mode;
         self.draft_update_interval_ms = draft_update_interval_ms;
+        self
+    }
+
+    /// Configure sender IDs that bypass mention gating in group chats.
+    pub fn with_group_reply_allowed_senders(mut self, sender_ids: Vec<String>) -> Self {
+        self.group_reply_allowed_sender_ids =
+            Self::normalize_group_reply_allowed_sender_ids(sender_ids);
         self
     }
 
@@ -409,8 +569,9 @@ impl TelegramChannel {
             let response = match client.post(&url).json(&body).send().await {
                 Ok(resp) => resp,
                 Err(err) => {
+                    let sanitized = TelegramChannel::sanitize_telegram_error(&err.to_string());
                     tracing::warn!(
-                        "Telegram: failed to add ACK reaction to chat_id={chat_id}, message_id={message_id}: {err}"
+                        "Telegram: failed to add ACK reaction to chat_id={chat_id}, message_id={message_id}: {sanitized}"
                     );
                     return;
                 }
@@ -419,8 +580,9 @@ impl TelegramChannel {
             if !response.status().is_success() {
                 let status = response.status();
                 let err_body = response.text().await.unwrap_or_default();
+                let sanitized = TelegramChannel::sanitize_telegram_error(&err_body);
                 tracing::warn!(
-                    "Telegram: add ACK reaction failed for chat_id={chat_id}, message_id={message_id}: status={status}, body={err_body}"
+                    "Telegram: add ACK reaction failed for chat_id={chat_id}, message_id={message_id}: status={status}, body={sanitized}"
                 );
             }
         });
@@ -428,6 +590,10 @@ impl TelegramChannel {
 
     fn http_client(&self) -> reqwest::Client {
         crate::config::build_runtime_proxy_client("channel.telegram")
+    }
+
+    fn sanitize_telegram_error(input: &str) -> String {
+        crate::providers::sanitize_api_error(input)
     }
 
     fn normalize_identity(value: &str) -> String {
@@ -440,6 +606,27 @@ impl TelegramChannel {
             .map(|entry| Self::normalize_identity(&entry))
             .filter(|entry| !entry.is_empty())
             .collect()
+    }
+
+    fn normalize_group_reply_allowed_sender_ids(sender_ids: Vec<String>) -> Vec<String> {
+        let mut normalized = sender_ids
+            .into_iter()
+            .map(|entry| entry.trim().to_string())
+            .filter(|entry| !entry.is_empty())
+            .collect::<Vec<_>>();
+        normalized.sort();
+        normalized.dedup();
+        normalized
+    }
+
+    fn is_group_sender_trigger_enabled(&self, sender_id: Option<&str>) -> bool {
+        let Some(sender_id) = sender_id.map(str::trim).filter(|id| !id.is_empty()) else {
+            return false;
+        };
+
+        self.group_reply_allowed_sender_ids
+            .iter()
+            .any(|entry| entry == "*" || entry == sender_id)
     }
 
     async fn load_config_without_env() -> anyhow::Result<Config> {
@@ -827,10 +1014,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
     /// Download a file from the Telegram CDN.
     async fn download_file(&self, file_path: &str) -> anyhow::Result<Vec<u8>> {
-        let url = format!(
-            "https://api.telegram.org/file/bot{}/{file_path}",
-            self.bot_token
-        );
+        let url = format!("{}/file/bot{}/{file_path}", self.api_base, self.bot_token);
         let resp = self
             .http_client()
             .get(&url)
@@ -845,15 +1029,109 @@ Allowlist Telegram username (without '@') or numeric user ID.",
         Ok(resp.bytes().await?.to_vec())
     }
 
-    /// Extract (file_id, duration) from a voice or audio message.
-    fn parse_voice_metadata(message: &serde_json::Value) -> Option<(String, u64)> {
-        let voice = message.get("voice").or_else(|| message.get("audio"))?;
+    /// Extract transcription metadata from a voice or audio payload.
+    fn parse_voice_metadata(message: &serde_json::Value) -> Option<VoiceMetadata> {
+        let (voice, voice_note) = if let Some(voice) = message.get("voice") {
+            (voice, true)
+        } else {
+            (message.get("audio")?, false)
+        };
+
         let file_id = voice.get("file_id")?.as_str()?.to_string();
-        let duration = voice
+        let duration_secs = voice
             .get("duration")
             .and_then(serde_json::Value::as_u64)
             .unwrap_or(0);
-        Some((file_id, duration))
+        let file_name_hint = voice
+            .get("file_name")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .filter(|name| !name.trim().is_empty());
+        let mime_type_hint = voice
+            .get("mime_type")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+            .filter(|mime| !mime.trim().is_empty());
+
+        Some(VoiceMetadata {
+            file_id,
+            duration_secs,
+            file_name_hint,
+            mime_type_hint,
+            voice_note,
+        })
+    }
+
+    fn extension_from_audio_mime_type(mime_type: &str) -> Option<&'static str> {
+        match mime_type.trim().to_ascii_lowercase().as_str() {
+            "audio/flac" | "audio/x-flac" => Some("flac"),
+            "audio/mpeg" => Some("mp3"),
+            "audio/mp4" => Some("mp4"),
+            "audio/x-m4a" => Some("m4a"),
+            "audio/ogg" | "application/ogg" => Some("ogg"),
+            "audio/opus" => Some("opus"),
+            "audio/wav" | "audio/x-wav" | "audio/wave" => Some("wav"),
+            "audio/webm" => Some("webm"),
+            _ => None,
+        }
+    }
+
+    fn has_file_extension(name: &str) -> bool {
+        std::path::Path::new(name)
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| !ext.trim().is_empty())
+    }
+
+    fn infer_voice_filename(file_path: &str, metadata: &VoiceMetadata) -> String {
+        let basename = file_path.rsplit('/').next().unwrap_or("").trim();
+        if !basename.is_empty() && Self::has_file_extension(basename) {
+            return basename.to_string();
+        }
+
+        if let Some(hint) = metadata
+            .file_name_hint
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+        {
+            if Self::has_file_extension(hint) {
+                return hint.to_string();
+            }
+        }
+
+        let default_stem = if metadata.voice_note {
+            "voice"
+        } else {
+            "audio"
+        };
+        let stem = if basename.is_empty() {
+            metadata
+                .file_name_hint
+                .as_deref()
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .unwrap_or(default_stem)
+        } else {
+            basename
+        }
+        .trim_end_matches('.');
+
+        if let Some(extension) = metadata
+            .mime_type_hint
+            .as_deref()
+            .and_then(Self::extension_from_audio_mime_type)
+        {
+            return format!("{stem}.{extension}");
+        }
+
+        // Last-resort fallback keeps extension present so transcription backends
+        // do not reject otherwise valid payloads from extension-less file paths.
+        if metadata.voice_note {
+            format!("{stem}.ogg")
+        } else {
+            format!("{stem}.mp3")
+        }
     }
 
     /// Extract attachment metadata from an incoming Telegram message (document or photo).
@@ -937,6 +1215,21 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             return None;
         }
 
+        // Check mention_only for group messages (apply to caption for attachments)
+        let is_group = Self::is_group_message(message);
+        if self.mention_only && is_group {
+            let bot_username = self.bot_username.lock();
+            if let Some(ref bot_username) = *bot_username {
+                let text_to_check = attachment.caption.as_deref().unwrap_or("");
+                if !Self::contains_bot_mention(text_to_check, bot_username) {
+                    return None;
+                }
+            } else {
+                // Bot username unknown, can't verify mention
+                return None;
+            }
+        }
+
         let chat_id = message
             .get("chat")
             .and_then(|chat| chat.get("id"))
@@ -959,17 +1252,26 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             chat_id.clone()
         };
 
+        // Check mention_only for group messages
+        let is_group = Self::is_group_message(message);
+        if self.mention_only && is_group {
+            let bot_username = self.bot_username.lock();
+            if let Some(ref bot_username) = *bot_username {
+                // Check if caption contains bot mention
+                let caption_text = attachment.caption.as_deref().unwrap_or("");
+                if !Self::contains_bot_mention(caption_text, bot_username) {
+                    return None;
+                }
+            } else {
+                return None;
+            }
+        }
+
         // Ensure workspace directory is configured
         let workspace = self.workspace_dir.as_ref().or_else(|| {
             tracing::warn!("Cannot save attachment: workspace_dir not configured");
             None
         })?;
-
-        let save_dir = workspace.join("telegram_files");
-        if let Err(e) = tokio::fs::create_dir_all(&save_dir).await {
-            tracing::warn!("Failed to create telegram_files directory: {e}");
-            return None;
-        }
 
         // Download file from Telegram
         let tg_file_path = match self.get_file_path(&attachment.file_id).await {
@@ -990,15 +1292,27 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         // Determine local filename
         let local_filename = match &attachment.file_name {
-            Some(name) => name.clone(),
+            Some(name) => sanitize_attachment_filename(name)
+                .unwrap_or_else(|| format!("attachment_{chat_id}_{message_id}.bin")),
             None => {
                 // For photos, derive extension from Telegram file path
-                let ext = tg_file_path.rsplit('.').next().unwrap_or("jpg");
+                let ext =
+                    sanitize_generated_extension(tg_file_path.rsplit('.').next().unwrap_or("jpg"));
                 format!("photo_{chat_id}_{message_id}.{ext}")
             }
         };
 
-        let local_path = save_dir.join(&local_filename);
+        let local_path =
+            match resolve_workspace_attachment_output_path(workspace, &local_filename).await {
+                Ok(path) => path,
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to resolve attachment output path for {}: {e}",
+                        local_filename
+                    );
+                    return None;
+                }
+            };
         if let Err(e) = tokio::fs::write(&local_path, &file_data).await {
             tracing::warn!("Failed to save attachment to {}: {e}", local_path.display());
             return None;
@@ -1040,14 +1354,30 @@ Allowlist Telegram username (without '@') or numeric user ID.",
     /// Returns `None` if the message is not a voice message, transcription is disabled,
     /// or the message exceeds duration limits.
     async fn try_parse_voice_message(&self, update: &serde_json::Value) -> Option<ChannelMessage> {
-        let config = self.transcription.as_ref()?;
+        // Check if transcription is enabled before doing anything else
+        let config = match self.transcription.as_ref() {
+            Some(c) => c,
+            None => {
+                // Log at debug level when a voice message is received but transcription is disabled
+                if let Some(message) = update.get("message") {
+                    if message.get("voice").is_some() || message.get("audio").is_some() {
+                        tracing::debug!(
+                            "Received voice/audio message but transcription is disabled. \
+                             Set [transcription].enabled = true to enable voice transcription."
+                        );
+                    }
+                }
+                return None;
+            }
+        };
         let message = update.get("message")?;
 
-        let (file_id, duration) = Self::parse_voice_metadata(message)?;
+        let metadata = Self::parse_voice_metadata(message)?;
 
-        if duration > config.max_duration_secs {
+        if metadata.duration_secs > config.max_duration_secs {
             tracing::info!(
-                "Skipping voice message: duration {duration}s exceeds limit {}s",
+                "Skipping voice message: duration {}s exceeds limit {}s",
+                metadata.duration_secs,
                 config.max_duration_secs
             );
             return None;
@@ -1061,6 +1391,23 @@ Allowlist Telegram username (without '@') or numeric user ID.",
         }
 
         if !self.is_any_user_allowed(identities.iter().copied()) {
+            tracing::debug!(
+                "Skipping voice message from unauthorized user: {} (allowed_users: {:?})",
+                sender_identity,
+                self.allowed_users
+                    .read()
+                    .map(|u| u.iter().cloned().collect::<Vec<_>>())
+                    .unwrap_or_default()
+            );
+            return None;
+        }
+
+        // Voice messages have no text to mention the bot, so ignore in mention_only mode when in groups.
+        // Private chats are always processed.
+        let is_group = Self::is_group_message(message);
+        let allow_sender_without_mention =
+            is_group && self.is_group_sender_trigger_enabled(sender_id.as_deref());
+        if self.mention_only && is_group && !allow_sender_without_mention {
             return None;
         }
 
@@ -1086,8 +1433,15 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             chat_id.clone()
         };
 
+        // Check mention_only for group messages
+        // Voice messages cannot contain mentions, so skip in group chats when mention_only is set
+        let is_group = Self::is_group_message(message);
+        if self.mention_only && is_group {
+            return None;
+        }
+
         // Download and transcribe
-        let file_path = match self.get_file_path(&file_id).await {
+        let file_path = match self.get_file_path(&metadata.file_id).await {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!("Failed to get voice file path: {e}");
@@ -1095,11 +1449,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             }
         };
 
-        let file_name = file_path
-            .rsplit('/')
-            .next()
-            .unwrap_or("voice.ogg")
-            .to_string();
+        let file_name = Self::infer_voice_filename(&file_path, &metadata);
 
         let audio_data = match self.download_file(&file_path).await {
             Ok(d) => d,
@@ -1131,6 +1481,13 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             }
             cache.insert(format!("{chat_id}:{message_id}"), text.clone());
         }
+
+        tracing::info!(
+            "Voice message transcribed successfully ({} chars) for user {} in chat {}",
+            text.len(),
+            sender_identity,
+            chat_id
+        );
 
         let content = if let Some(quote) = self.extract_reply_context(message) {
             format!("{quote}\n\n[Voice] {text}")
@@ -1245,10 +1602,13 @@ Allowlist Telegram username (without '@') or numeric user ID.",
         }
 
         let is_group = Self::is_group_message(message);
-        if self.mention_only && is_group {
+        let allow_sender_without_mention =
+            is_group && self.is_group_sender_trigger_enabled(sender_id.as_deref());
+
+        if self.mention_only && is_group && !allow_sender_without_mention {
             let bot_username = self.bot_username.lock();
             if let Some(ref bot_username) = *bot_username {
-                if !Self::contains_bot_mention(&text, bot_username) {
+                if !Self::contains_bot_mention(text, bot_username) {
                     return None;
                 }
             } else {
@@ -1280,10 +1640,10 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             chat_id.clone()
         };
 
-        let content = if self.mention_only && is_group {
+        let content = if self.mention_only && is_group && !allow_sender_without_mention {
             let bot_username = self.bot_username.lock();
             let bot_username = bot_username.as_ref()?;
-            Self::normalize_incoming_content(&text, bot_username)?
+            Self::normalize_incoming_content(text, bot_username)?
         } else {
             text.to_string()
         };
@@ -1324,10 +1684,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             .to_string();
 
         // Step 2: download the actual file
-        let download_url = format!(
-            "https://api.telegram.org/file/bot{}/{}",
-            self.bot_token, file_path
-        );
+        let download_url = format!("{}/file/bot{}/{}", self.api_base, self.bot_token, file_path);
         let img_resp = self.http_client().get(&download_url).send().await?;
         let bytes = img_resp.bytes().await?;
 
@@ -1391,7 +1748,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 if i + 1 < len && bytes[i] == b'*' && bytes[i + 1] == b'*' {
                     if let Some(end) = line[i + 2..].find("**") {
                         let inner = Self::escape_html(&line[i + 2..i + 2 + end]);
-                        line_out.push_str(&format!("<b>{inner}</b>"));
+                        write!(line_out, "<b>{inner}</b>").unwrap();
                         i += 4 + end;
                         continue;
                     }
@@ -1399,7 +1756,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 if i + 1 < len && bytes[i] == b'_' && bytes[i + 1] == b'_' {
                     if let Some(end) = line[i + 2..].find("__") {
                         let inner = Self::escape_html(&line[i + 2..i + 2 + end]);
-                        line_out.push_str(&format!("<b>{inner}</b>"));
+                        write!(line_out, "<b>{inner}</b>").unwrap();
                         i += 4 + end;
                         continue;
                     }
@@ -1409,7 +1766,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                     if let Some(end) = line[i + 1..].find('*') {
                         if end > 0 {
                             let inner = Self::escape_html(&line[i + 1..i + 1 + end]);
-                            line_out.push_str(&format!("<i>{inner}</i>"));
+                            write!(line_out, "<i>{inner}</i>").unwrap();
                             i += 2 + end;
                             continue;
                         }
@@ -1419,7 +1776,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 if bytes[i] == b'`' && (i == 0 || bytes[i - 1] != b'`') {
                     if let Some(end) = line[i + 1..].find('`') {
                         let inner = Self::escape_html(&line[i + 1..i + 1 + end]);
-                        line_out.push_str(&format!("<code>{inner}</code>"));
+                        write!(line_out, "<code>{inner}</code>").unwrap();
                         i += 2 + end;
                         continue;
                     }
@@ -1435,9 +1792,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                                 if url.starts_with("http://") || url.starts_with("https://") {
                                     let text_html = Self::escape_html(text_part);
                                     let url_html = Self::escape_html(url);
-                                    line_out.push_str(&format!(
-                                        "<a href=\"{url_html}\">{text_html}</a>"
-                                    ));
+                                    write!(line_out, "<a href=\"{url_html}\">{text_html}</a>")
+                                        .unwrap();
                                     i = after_bracket + 1 + paren_end + 1;
                                     continue;
                                 }
@@ -1449,7 +1805,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 if i + 1 < len && bytes[i] == b'~' && bytes[i + 1] == b'~' {
                     if let Some(end) = line[i + 2..].find("~~") {
                         let inner = Self::escape_html(&line[i + 2..i + 2 + end]);
-                        line_out.push_str(&format!("<s>{inner}</s>"));
+                        write!(line_out, "<s>{inner}</s>").unwrap();
                         i += 4 + end;
                         continue;
                     }
@@ -1478,14 +1834,14 @@ Allowlist Telegram username (without '@') or numeric user ID.",
         for line in joined.split('\n') {
             let trimmed = line.trim();
             if trimmed.starts_with("```") {
-                if !in_code_block {
-                    in_code_block = true;
-                    code_buf.clear();
-                } else {
+                if in_code_block {
                     in_code_block = false;
                     let escaped = code_buf.trim_end_matches('\n');
                     // Telegram HTML parse mode supports <pre> and <code>, but not class attributes.
-                    final_out.push_str(&format!("<pre><code>{escaped}</code></pre>\n"));
+                    writeln!(final_out, "<pre><code>{escaped}</code></pre>").unwrap();
+                    code_buf.clear();
+                } else {
+                    in_code_block = true;
                     code_buf.clear();
                 }
             } else if in_code_block {
@@ -1497,10 +1853,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             }
         }
         if in_code_block && !code_buf.is_empty() {
-            final_out.push_str(&format!(
-                "<pre><code>{}</code></pre>\n",
-                code_buf.trim_end()
-            ));
+            writeln!(final_out, "<pre><code>{}</code></pre>", code_buf.trim_end()).unwrap();
         }
 
         final_out.trim_end_matches('\n').to_string()
@@ -1586,12 +1939,14 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             if !plain_resp.status().is_success() {
                 let plain_status = plain_resp.status();
                 let plain_err = plain_resp.text().await.unwrap_or_default();
+                let sanitized_markdown_err = Self::sanitize_telegram_error(&markdown_err);
+                let sanitized_plain_err = Self::sanitize_telegram_error(&plain_err);
                 anyhow::bail!(
                     "Telegram sendMessage failed (markdown {}: {}; plain {}: {})",
                     markdown_status,
-                    markdown_err,
+                    sanitized_markdown_err,
                     plain_status,
-                    plain_err
+                    sanitized_plain_err
                 );
             }
 
@@ -1634,7 +1989,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram {method} by URL failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram {method} by URL failed: {sanitized}");
         }
 
         tracing::info!("Telegram {method} sent to {chat_id}: {url}");
@@ -1697,34 +2053,19 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             return Ok(());
         }
 
-        // Remap Docker container workspace path (/workspace/...) to the host
-        // workspace directory so files written by the containerised runtime
-        // can be found and sent by the host-side Telegram sender.
-        let remapped;
-        let target = if let Some(rel) = target.strip_prefix("/workspace/") {
-            if let Some(ws) = &self.workspace_dir {
-                remapped = ws.join(rel);
-                remapped.to_str().unwrap_or(target)
-            } else {
-                target
-            }
-        } else {
-            target
-        };
-
-        let path = Path::new(target);
-        if !path.exists() {
-            anyhow::bail!("Telegram attachment path not found: {target}");
-        }
+        let workspace = self.workspace_dir.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("workspace_dir is not configured; local file attachments are disabled")
+        })?;
+        let path = resolve_workspace_attachment_path(workspace, target)?;
 
         match attachment.kind {
-            TelegramAttachmentKind::Image => self.send_photo(chat_id, thread_id, path, None).await,
+            TelegramAttachmentKind::Image => self.send_photo(chat_id, thread_id, &path, None).await,
             TelegramAttachmentKind::Document => {
-                self.send_document(chat_id, thread_id, path, None).await
+                self.send_document(chat_id, thread_id, &path, None).await
             }
-            TelegramAttachmentKind::Video => self.send_video(chat_id, thread_id, path, None).await,
-            TelegramAttachmentKind::Audio => self.send_audio(chat_id, thread_id, path, None).await,
-            TelegramAttachmentKind::Voice => self.send_voice(chat_id, thread_id, path, None).await,
+            TelegramAttachmentKind::Video => self.send_video(chat_id, thread_id, &path, None).await,
+            TelegramAttachmentKind::Audio => self.send_audio(chat_id, thread_id, &path, None).await,
+            TelegramAttachmentKind::Voice => self.send_voice(chat_id, thread_id, &path, None).await,
         }
     }
 
@@ -1765,7 +2106,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendDocument failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendDocument failed: {sanitized}");
         }
 
         tracing::info!("Telegram document sent to {chat_id}: {file_name}");
@@ -1804,7 +2146,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendDocument failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendDocument failed: {sanitized}");
         }
 
         tracing::info!("Telegram document sent to {chat_id}: {file_name}");
@@ -1848,7 +2191,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendPhoto failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendPhoto failed: {sanitized}");
         }
 
         tracing::info!("Telegram photo sent to {chat_id}: {file_name}");
@@ -1887,7 +2231,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendPhoto failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendPhoto failed: {sanitized}");
         }
 
         tracing::info!("Telegram photo sent to {chat_id}: {file_name}");
@@ -1931,7 +2276,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendVideo failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendVideo failed: {sanitized}");
         }
 
         tracing::info!("Telegram video sent to {chat_id}: {file_name}");
@@ -1975,7 +2321,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendAudio failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendAudio failed: {sanitized}");
         }
 
         tracing::info!("Telegram audio sent to {chat_id}: {file_name}");
@@ -2019,7 +2366,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendVoice failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendVoice failed: {sanitized}");
         }
 
         tracing::info!("Telegram voice sent to {chat_id}: {file_name}");
@@ -2056,7 +2404,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendDocument by URL failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendDocument by URL failed: {sanitized}");
         }
 
         tracing::info!("Telegram document (URL) sent to {chat_id}: {url}");
@@ -2093,7 +2442,8 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         if !resp.status().is_success() {
             let err = resp.text().await?;
-            anyhow::bail!("Telegram sendPhoto by URL failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendPhoto by URL failed: {sanitized}");
         }
 
         tracing::info!("Telegram photo (URL) sent to {chat_id}: {url}");
@@ -2176,7 +2526,8 @@ impl Channel for TelegramChannel {
 
         if !resp.status().is_success() {
             let err = resp.text().await.unwrap_or_default();
-            anyhow::bail!("Telegram sendMessage (draft) failed: {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            anyhow::bail!("Telegram sendMessage (draft) failed: {sanitized}");
         }
 
         let resp_json: serde_json::Value = resp.json().await?;
@@ -2198,7 +2549,7 @@ impl Channel for TelegramChannel {
         recipient: &str,
         message_id: &str,
         text: &str,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Option<String>> {
         let (chat_id, _) = Self::parse_reply_target(recipient);
 
         // Rate-limit edits per chat
@@ -2207,7 +2558,7 @@ impl Channel for TelegramChannel {
             if let Some(last_time) = last_edits.get(&chat_id) {
                 let elapsed = u64::try_from(last_time.elapsed().as_millis()).unwrap_or(u64::MAX);
                 if elapsed < self.draft_update_interval_ms {
-                    return Ok(());
+                    return Ok(None);
                 }
             }
         }
@@ -2231,7 +2582,7 @@ impl Channel for TelegramChannel {
             Ok(id) => id,
             Err(e) => {
                 tracing::warn!("Invalid Telegram message_id '{message_id}': {e}");
-                return Ok(());
+                return Ok(None);
             }
         };
 
@@ -2255,10 +2606,11 @@ impl Channel for TelegramChannel {
         } else {
             let status = resp.status();
             let err = resp.text().await.unwrap_or_default();
-            tracing::debug!("Telegram editMessageText failed ({status}): {err}");
+            let sanitized = Self::sanitize_telegram_error(&err);
+            tracing::debug!("Telegram editMessageText failed ({status}): {sanitized}");
         }
 
-        Ok(())
+        Ok(None)
     }
 
     async fn finalize_draft(
@@ -2410,7 +2762,8 @@ impl Channel for TelegramChannel {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            tracing::debug!("Telegram deleteMessage failed ({status}): {body}");
+            let sanitized = Self::sanitize_telegram_error(&body);
+            tracing::debug!("Telegram deleteMessage failed ({status}): {sanitized}");
         }
 
         Ok(())
@@ -2473,14 +2826,16 @@ impl Channel for TelegramChannel {
             });
             match self.http_client().post(&url).json(&probe).send().await {
                 Err(e) => {
-                    tracing::warn!("Telegram startup probe error: {e}; retrying in 5s");
+                    let sanitized = Self::sanitize_telegram_error(&e.to_string());
+                    tracing::warn!("Telegram startup probe error: {sanitized}; retrying in 5s");
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 }
                 Ok(resp) => {
                     match resp.json::<serde_json::Value>().await {
                         Err(e) => {
+                            let sanitized = Self::sanitize_telegram_error(&e.to_string());
                             tracing::warn!(
-                                "Telegram startup probe parse error: {e}; retrying in 5s"
+                                "Telegram startup probe parse error: {sanitized}; retrying in 5s"
                             );
                             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                         }
@@ -2548,7 +2903,8 @@ impl Channel for TelegramChannel {
             let resp = match self.http_client().post(&url).json(&body).send().await {
                 Ok(r) => r,
                 Err(e) => {
-                    tracing::warn!("Telegram poll error: {e}");
+                    let sanitized = Self::sanitize_telegram_error(&e.to_string());
+                    tracing::warn!("Telegram poll error: {sanitized}");
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     continue;
                 }
@@ -2557,7 +2913,8 @@ impl Channel for TelegramChannel {
             let data: serde_json::Value = match resp.json().await {
                 Ok(d) => d,
                 Err(e) => {
-                    tracing::warn!("Telegram parse error: {e}");
+                    let sanitized = Self::sanitize_telegram_error(&e.to_string());
+                    tracing::warn!("Telegram parse error: {sanitized}");
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     continue;
                 }
@@ -2654,7 +3011,8 @@ Ensure only one `zeroclaw` process is using this bot token."
         {
             Ok(Ok(resp)) => resp.status().is_success(),
             Ok(Err(e)) => {
-                tracing::debug!("Telegram health check failed: {e}");
+                let sanitized = Self::sanitize_telegram_error(&e.to_string());
+                tracing::debug!("Telegram health check failed: {sanitized}");
                 false
             }
             Err(_) => {
@@ -2701,6 +3059,27 @@ Ensure only one `zeroclaw` process is using this bot token."
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
+
+    #[cfg(unix)]
+    fn symlink_file(src: &Path, dst: &Path) {
+        std::os::unix::fs::symlink(src, dst).expect("symlink should be created");
+    }
+
+    #[cfg(windows)]
+    fn symlink_file(src: &Path, dst: &Path) {
+        std::os::windows::fs::symlink_file(src, dst).expect("symlink should be created");
+    }
+
+    #[cfg(unix)]
+    fn symlink_dir(src: &Path, dst: &Path) {
+        std::os::unix::fs::symlink(src, dst).expect("symlink should be created");
+    }
+
+    #[cfg(windows)]
+    fn symlink_dir(src: &Path, dst: &Path) {
+        std::os::windows::fs::symlink_dir(src, dst).expect("symlink should be created");
+    }
 
     #[test]
     fn telegram_channel_name() {
@@ -2731,7 +3110,7 @@ mod tests {
             "update_id": 1,
             "message": {
                 "message_id": 99,
-                "chat": { "id": -100123456 }
+                "chat": { "id": -100_123_456 }
             }
         });
 
@@ -2849,6 +3228,17 @@ mod tests {
         assert_eq!(
             ch.api_url("getMe"),
             "https://api.telegram.org/bot123:ABC/getMe"
+        );
+    }
+
+    #[test]
+    fn telegram_custom_base_url() {
+        let ch = TelegramChannel::new("123:ABC".into(), vec![], false)
+            .with_api_base("https://tapi.bale.ai".to_string());
+        assert_eq!(ch.api_url("getMe"), "https://tapi.bale.ai/bot123:ABC/getMe");
+        assert_eq!(
+            ch.api_url("sendMessage"),
+            "https://tapi.bale.ai/bot123:ABC/sendMessage"
         );
     }
 
@@ -3006,6 +3396,28 @@ mod tests {
     }
 
     #[test]
+    fn parse_attachment_markers_handles_brackets_in_filename() {
+        let message = "Here it is [VIDEO:/mnt/clips/Butters - What What [G4PvTrTp7Tc].mp4]";
+        let (cleaned, attachments) = parse_attachment_markers(message);
+
+        assert_eq!(cleaned, "Here it is");
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0].kind, TelegramAttachmentKind::Video);
+        assert_eq!(
+            attachments[0].target,
+            "/mnt/clips/Butters - What What [G4PvTrTp7Tc].mp4"
+        );
+    }
+
+    #[test]
+    fn parse_attachment_markers_unclosed_bracket_falls_back_to_text() {
+        let message = "send [VIDEO:/path/file[broken.mp4";
+        let (cleaned, attachments) = parse_attachment_markers(message);
+        assert_eq!(cleaned, "send [VIDEO:/path/file[broken.mp4");
+        assert!(attachments.is_empty());
+    }
+
+    #[test]
     fn parse_path_only_attachment_detects_existing_file() {
         let dir = tempfile::tempdir().unwrap();
         let image_path = dir.path().join("snap.png");
@@ -3021,6 +3433,94 @@ mod tests {
     #[test]
     fn parse_path_only_attachment_rejects_sentence_text() {
         assert!(parse_path_only_attachment("Screenshot saved to /tmp/snap.png").is_none());
+    }
+
+    #[test]
+    fn sanitize_attachment_filename_strips_path_traversal() {
+        assert_eq!(
+            sanitize_attachment_filename("../../tmp/evil.txt").as_deref(),
+            Some("evil.txt")
+        );
+        assert_eq!(
+            sanitize_attachment_filename(r"..\\..\\secrets\\token.env").as_deref(),
+            Some("..__..__secrets__token.env")
+        );
+        assert!(sanitize_attachment_filename("..").is_none());
+        assert!(sanitize_attachment_filename("").is_none());
+    }
+
+    #[test]
+    fn resolve_workspace_attachment_path_rejects_escape_and_accepts_workspace_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).expect("workspace should exist");
+
+        let in_workspace = workspace.join("report.txt");
+        std::fs::write(&in_workspace, b"ok").expect("workspace fixture should be written");
+        let resolved = resolve_workspace_attachment_path(&workspace, "report.txt")
+            .expect("workspace relative path should resolve");
+        assert!(resolved.starts_with(workspace.canonicalize().unwrap_or(workspace.clone())));
+
+        let outside = temp.path().join("outside.txt");
+        std::fs::write(&outside, b"secret").expect("outside fixture should be written");
+        let escaped =
+            resolve_workspace_attachment_path(&workspace, outside.to_string_lossy().as_ref());
+        assert!(escaped.is_err(), "outside workspace path must be rejected");
+    }
+
+    #[test]
+    fn resolve_workspace_attachment_path_accepts_workspace_prefix_mapping() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(workspace.join("sub")).expect("workspace dir should exist");
+        let nested = workspace.join("sub/file.txt");
+        std::fs::write(&nested, b"content").expect("fixture should be written");
+
+        let resolved = resolve_workspace_attachment_path(&workspace, "/workspace/sub/file.txt")
+            .expect("/workspace prefix should map to workspace root");
+        assert_eq!(
+            resolved,
+            nested
+                .canonicalize()
+                .expect("canonical path should resolve")
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_workspace_attachment_output_path_rejects_symlinked_save_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        tokio::fs::create_dir_all(&workspace)
+            .await
+            .expect("workspace dir should exist");
+
+        let outside = temp.path().join("outside");
+        tokio::fs::create_dir_all(&outside)
+            .await
+            .expect("outside dir should exist");
+        symlink_dir(&outside, &workspace.join("telegram_files"));
+
+        let result = resolve_workspace_attachment_output_path(&workspace, "doc.txt").await;
+        assert!(result.is_err(), "symlinked save dir must be rejected");
+    }
+
+    #[tokio::test]
+    async fn resolve_workspace_attachment_output_path_rejects_symlink_target_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let workspace = temp.path().join("workspace");
+        let save_dir = workspace.join("telegram_files");
+        tokio::fs::create_dir_all(&save_dir)
+            .await
+            .expect("save dir should exist");
+
+        let outside = temp.path().join("outside.txt");
+        tokio::fs::write(&outside, b"secret")
+            .await
+            .expect("outside fixture should be written");
+        symlink_file(&outside, &save_dir.join("doc.txt"));
+
+        let result = resolve_workspace_attachment_output_path(&workspace, "doc.txt").await;
+        assert!(result.is_err(), "symlink target file must be rejected");
     }
 
     #[test]
@@ -3741,6 +4241,37 @@ mod tests {
     }
 
     #[test]
+    fn parse_update_message_mention_only_group_allows_configured_sender_without_mention() {
+        let ch = TelegramChannel::new("token".into(), vec!["*".into()], true)
+            .with_group_reply_allowed_senders(vec!["555".into()]);
+        {
+            let mut cache = ch.bot_username.lock();
+            *cache = Some("mybot".to_string());
+        }
+
+        let update = serde_json::json!({
+            "update_id": 13,
+            "message": {
+                "message_id": 47,
+                "text": "run daily sync",
+                "from": {
+                    "id": 555,
+                    "username": "alice"
+                },
+                "chat": {
+                    "id": -100_200_300,
+                    "type": "group"
+                }
+            }
+        });
+
+        let parsed = ch
+            .parse_update_message(&update)
+            .expect("sender override should bypass mention requirement");
+        assert_eq!(parsed.content, "run daily sync");
+    }
+
+    #[test]
     fn telegram_is_group_message_detects_groups() {
         let group_msg = serde_json::json!({
             "chat": { "type": "group" }
@@ -3765,6 +4296,103 @@ mod tests {
 
         let ch_disabled = TelegramChannel::new("token".into(), vec!["*".into()], false);
         assert!(!ch_disabled.mention_only);
+    }
+
+    #[test]
+    fn telegram_mention_only_group_photo_without_caption_is_ignored() {
+        let ch = TelegramChannel::new("token".into(), vec!["*".into()], true);
+        {
+            let mut cache = ch.bot_username.lock();
+            *cache = Some("mybot".to_string());
+        }
+
+        let _update = serde_json::json!({
+            "update_id": 100,
+            "message": {
+                "message_id": 1,
+                "photo": [
+                    {"file_id": "photo_id", "file_size": 1_000}
+                ],
+                "from": {
+                    "id": 555,
+                    "username": "alice"
+                },
+                "chat": {
+                    "id": -100_200_300,
+                    "type": "group"
+                }
+            }
+        });
+
+        // Photo without caption in group chat with mention_only=true should be ignored
+        // Note: This test verifies the check is in place, but the async function needs
+        // a workspace_dir to be set for full parsing. The key check happens before download.
+        // For unit testing purposes, we verify the logic path exists.
+        assert!(ch.mention_only);
+    }
+
+    #[test]
+    fn telegram_mention_only_group_photo_with_caption_without_mention_is_ignored() {
+        let ch = TelegramChannel::new("token".into(), vec!["*".into()], true);
+        {
+            let mut cache = ch.bot_username.lock();
+            *cache = Some("mybot".to_string());
+        }
+
+        // Photo with caption that doesn't mention the bot
+        let _update = serde_json::json!({
+            "update_id": 101,
+            "message": {
+                "message_id": 2,
+                "photo": [
+                    {"file_id": "photo_id", "file_size": 1_000}
+                ],
+                "caption": "Look at this image",
+                "from": {
+                    "id": 555,
+                    "username": "alice"
+                },
+                "chat": {
+                    "id": -100_200_300,
+                    "type": "group"
+                }
+            }
+        });
+
+        // The mention_only check should reject this since caption doesn't contain @mybot
+        assert!(ch.mention_only);
+    }
+
+    #[test]
+    fn telegram_mention_only_private_chat_photo_still_works() {
+        // Private chats should still work regardless of mention_only setting
+        let ch = TelegramChannel::new("token".into(), vec!["*".into()], true);
+        {
+            let mut cache = ch.bot_username.lock();
+            *cache = Some("mybot".to_string());
+        }
+
+        let _update = serde_json::json!({
+            "update_id": 102,
+            "message": {
+                "message_id": 3,
+                "photo": [
+                    {"file_id": "photo_id", "file_size": 1_000}
+                ],
+                "from": {
+                    "id": 555,
+                    "username": "alice"
+                },
+                "chat": {
+                    "id": 123_456,
+                    "type": "private"
+                }
+            }
+        });
+
+        // Private chat should work even with mention_only=true
+        // The is_group_message check should return false for private chats
+        assert!(ch.mention_only);
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -3824,7 +4452,10 @@ mod tests {
 
     #[test]
     fn telegram_split_many_short_lines() {
-        let msg: String = (0..1000).map(|i| format!("line {i}\n")).collect();
+        let msg: String = (0..1_000)
+            .map(|i| format!("line {i}\n"))
+            .collect::<Vec<_>>()
+            .concat();
         let parts = split_message_for_telegram(&msg);
         for part in &parts {
             assert!(
@@ -3874,9 +4505,10 @@ mod tests {
                 "duration": 5
             }
         });
-        let (file_id, dur) = TelegramChannel::parse_voice_metadata(&msg).unwrap();
-        assert_eq!(file_id, "abc123");
-        assert_eq!(dur, 5);
+        let meta = TelegramChannel::parse_voice_metadata(&msg).unwrap();
+        assert_eq!(meta.file_id, "abc123");
+        assert_eq!(meta.duration_secs, 5);
+        assert!(meta.voice_note);
     }
 
     #[test]
@@ -3887,9 +4519,10 @@ mod tests {
                 "duration": 30
             }
         });
-        let (file_id, dur) = TelegramChannel::parse_voice_metadata(&msg).unwrap();
-        assert_eq!(file_id, "audio456");
-        assert_eq!(dur, 30);
+        let meta = TelegramChannel::parse_voice_metadata(&msg).unwrap();
+        assert_eq!(meta.file_id, "audio456");
+        assert_eq!(meta.duration_secs, 30);
+        assert!(!meta.voice_note);
     }
 
     #[test]
@@ -3907,8 +4540,53 @@ mod tests {
                 "file_id": "no_dur"
             }
         });
-        let (_, dur) = TelegramChannel::parse_voice_metadata(&msg).unwrap();
-        assert_eq!(dur, 0);
+        let meta = TelegramChannel::parse_voice_metadata(&msg).unwrap();
+        assert_eq!(meta.duration_secs, 0);
+    }
+
+    #[test]
+    fn infer_voice_filename_prefers_hint_with_extension() {
+        let meta = VoiceMetadata {
+            file_id: "f".into(),
+            duration_secs: 0,
+            file_name_hint: Some("telegram_voice.m4a".into()),
+            mime_type_hint: Some("audio/mp4".into()),
+            voice_note: false,
+        };
+        assert_eq!(
+            TelegramChannel::infer_voice_filename("voice/file_without_ext", &meta),
+            "telegram_voice.m4a"
+        );
+    }
+
+    #[test]
+    fn infer_voice_filename_uses_mime_extension_when_path_has_none() {
+        let meta = VoiceMetadata {
+            file_id: "f".into(),
+            duration_secs: 0,
+            file_name_hint: None,
+            mime_type_hint: Some("audio/ogg".into()),
+            voice_note: true,
+        };
+        assert_eq!(
+            TelegramChannel::infer_voice_filename("voice/file_without_ext", &meta),
+            "file_without_ext.ogg"
+        );
+    }
+
+    #[test]
+    fn infer_voice_filename_falls_back_for_audio_without_hints() {
+        let meta = VoiceMetadata {
+            file_id: "f".into(),
+            duration_secs: 0,
+            file_name_hint: None,
+            mime_type_hint: None,
+            voice_note: false,
+        };
+        assert_eq!(
+            TelegramChannel::infer_voice_filename("voice/file_without_ext", &meta),
+            "file_without_ext.mp3"
+        );
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -4130,7 +4808,7 @@ mod tests {
     /// Skipped automatically when `GROQ_API_KEY` is not set.
     /// Run: `GROQ_API_KEY=<key> cargo test --lib -- telegram::tests::e2e_live_voice_transcription_and_reply_cache --ignored`
     #[tokio::test]
-    #[ignore]
+    #[ignore = "requires GROQ_API_KEY"]
     async fn e2e_live_voice_transcription_and_reply_cache() {
         if std::env::var("GROQ_API_KEY").is_err() {
             eprintln!("GROQ_API_KEY not set — skipping live voice transcription test");
@@ -4251,7 +4929,7 @@ mod tests {
         // Photo with caption
         let photo_msg = serde_json::json!({
             "photo": [
-                {"file_id": "photo_id", "file_size": 1000}
+                    {"file_id": "photo_id", "file_size": 1_000}
             ],
             "caption": "Look at this"
         });
@@ -4581,7 +5259,7 @@ mod tests {
 
         let groq = OpenAiCompatibleProvider::new(
             "Groq",
-            "https://api.groq.com/openai",
+            "https://api.groq.com/openai/v1",
             Some("fake_key"),
             AuthStyle::Bearer,
         );
@@ -4602,5 +5280,25 @@ mod tests {
         // The combination of marker_count > 0 && !supports_vision() means
         // the agent loop will return ProviderCapabilityError before calling
         // the provider, and the channel will send "⚠️ Error: ..." to the user.
+    }
+
+    #[test]
+    fn document_with_image_extension_routes_to_image_marker() {
+        let path = std::path::Path::new("/tmp/workspace/scan.png");
+        let result = format_attachment_content(IncomingAttachmentKind::Document, "scan.png", path);
+        assert_eq!(result, "[IMAGE:/tmp/workspace/scan.png]");
+
+        let path = std::path::Path::new("/tmp/workspace/photo.jpg");
+        let result = format_attachment_content(IncomingAttachmentKind::Document, "photo.jpg", path);
+        assert!(result.starts_with("[IMAGE:"));
+    }
+
+    #[test]
+    fn document_with_non_image_extension_routes_to_document_format() {
+        let path = std::path::Path::new("/tmp/workspace/report.pdf");
+        let result =
+            format_attachment_content(IncomingAttachmentKind::Document, "report.pdf", path);
+        assert_eq!(result, "[Document: report.pdf] /tmp/workspace/report.pdf");
+        assert!(!result.starts_with("[IMAGE:"));
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,21 +5,25 @@ pub mod traits;
 pub use schema::{
     apply_runtime_proxy_to_builder, build_runtime_proxy_client,
     build_runtime_proxy_client_with_timeouts, runtime_proxy_config, set_runtime_proxy_config,
-    AgentConfig, AuditConfig, AutonomyConfig, BrowserComputerUseConfig, BrowserConfig,
-    BuiltinHooksConfig, ChannelsConfig, ClassificationRule, ComposioConfig, Config, CostConfig,
-    CronConfig, DelegateAgentConfig, DiscordConfig, DockerRuntimeConfig, EmbeddingRouteConfig,
-    EstopConfig, FeishuConfig, GatewayConfig, HardwareConfig, HardwareTransport, HeartbeatConfig,
+    AgentConfig, AgentsIpcConfig, AuditConfig, AutonomyConfig, BrowserComputerUseConfig,
+    BrowserConfig, BuiltinHooksConfig, ChannelsConfig, ClassificationRule, ComposioConfig, Config,
+    CoordinationConfig, CostConfig, CronConfig, DelegateAgentConfig, DiscordConfig,
+    DockerRuntimeConfig, EmbeddingRouteConfig, EstopConfig, FeishuConfig, GatewayConfig,
+    GroupReplyConfig, GroupReplyMode, HardwareConfig, HardwareTransport, HeartbeatConfig,
     HooksConfig, HttpRequestConfig, IMessageConfig, IdentityConfig, LarkConfig, MatrixConfig,
-    MemoryConfig, ModelRouteConfig, MultimodalConfig, NextcloudTalkConfig, ObservabilityConfig,
-    OtpConfig, OtpMethod, PeripheralBoardConfig, PeripheralsConfig, ProxyConfig, ProxyScope,
-    QdrantConfig, QueryClassificationConfig, ReliabilityConfig, ResourceLimitsConfig,
-    RuntimeConfig, SandboxBackend, SandboxConfig, SchedulerConfig, SecretsConfig, SecurityConfig,
-    SkillsConfig, SkillsPromptInjectionMode, SlackConfig, StorageConfig, StorageProviderConfig,
-    StorageProviderSection, StreamMode, TelegramConfig, TranscriptionConfig, TunnelConfig,
+    MemoryConfig, ModelRouteConfig, MultimodalConfig, NextcloudTalkConfig,
+    NonCliNaturalLanguageApprovalMode, ObservabilityConfig, OtpConfig, OtpMethod,
+    PeripheralBoardConfig, PeripheralsConfig, ProviderConfig, ProxyConfig, ProxyScope,
+    QdrantConfig, QueryClassificationConfig, ReliabilityConfig, ResearchPhaseConfig,
+    ResearchTrigger, ResourceLimitsConfig, RuntimeConfig, SandboxBackend, SandboxConfig,
+    SchedulerConfig, SecretsConfig, SecurityConfig, SkillsConfig, SkillsPromptInjectionMode,
+    SlackConfig, StorageConfig, StorageProviderConfig, StorageProviderSection, StreamMode,
+    SyscallAnomalyConfig, TelegramConfig, TranscriptionConfig, TunnelConfig,
+    WasmCapabilityEscalationMode, WasmModuleHashPolicy, WasmRuntimeConfig, WasmSecurityConfig,
     WebFetchConfig, WebSearchConfig, WebhookConfig,
 };
 
-pub fn name_and_presence<T: traits::ChannelConfig>(channel: &Option<T>) -> (&'static str, bool) {
+pub fn name_and_presence<T: traits::ChannelConfig>(channel: Option<&T>) -> (&'static str, bool) {
     (T::name(), channel.is_some())
 }
 
@@ -45,6 +49,8 @@ mod tests {
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
+            group_reply: None,
+            base_url: None,
         };
 
         let discord = DiscordConfig {
@@ -53,6 +59,7 @@ mod tests {
             allowed_users: vec![],
             listen_to_bots: false,
             mention_only: false,
+            group_reply: None,
         };
 
         let lark = LarkConfig {
@@ -62,9 +69,13 @@ mod tests {
             verification_token: None,
             allowed_users: vec![],
             mention_only: false,
+            group_reply: None,
             use_feishu: false,
             receive_mode: crate::config::schema::LarkReceiveMode::Websocket,
             port: None,
+            draft_update_interval_ms: crate::config::schema::default_lark_draft_update_interval_ms(
+            ),
+            max_draft_edits: crate::config::schema::default_lark_max_draft_edits(),
         };
         let feishu = FeishuConfig {
             app_id: "app-id".into(),
@@ -72,8 +83,12 @@ mod tests {
             encrypt_key: None,
             verification_token: None,
             allowed_users: vec![],
+            group_reply: None,
             receive_mode: crate::config::schema::LarkReceiveMode::Websocket,
             port: None,
+            draft_update_interval_ms: crate::config::schema::default_lark_draft_update_interval_ms(
+            ),
+            max_draft_edits: crate::config::schema::default_lark_max_draft_edits(),
         };
 
         let nextcloud_talk = NextcloudTalkConfig {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -404,6 +404,8 @@ mod tests {
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
+            group_reply: None,
+            base_url: None,
         });
         assert!(has_supervised_channels(&config));
     }
@@ -429,6 +431,7 @@ mod tests {
             allowed_users: vec!["*".into()],
             thread_replies: Some(true),
             mention_only: Some(false),
+            group_reply: None,
         });
         assert!(has_supervised_channels(&config));
     }
@@ -440,6 +443,7 @@ mod tests {
             app_id: "app-id".into(),
             app_secret: "app-secret".into(),
             allowed_users: vec!["*".into()],
+            receive_mode: crate::config::schema::QQReceiveMode::Websocket,
         });
         assert!(has_supervised_channels(&config));
     }
@@ -536,6 +540,8 @@ mod tests {
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
+            group_reply: None,
+            base_url: None,
         });
 
         let target = heartbeat_delivery_target(&config).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![warn(clippy::all, clippy::pedantic)]
+#![forbid(unsafe_code)]
 #![allow(
     clippy::assigning_clones,
     clippy::bool_to_int_with_if,
@@ -56,11 +57,13 @@ mod rag {
     pub use zeroclaw::rag::*;
 }
 mod config;
+mod coordination;
 mod cost;
 mod cron;
 mod daemon;
 mod doctor;
 mod gateway;
+mod goals;
 mod hardware;
 mod health;
 mod heartbeat;
@@ -81,6 +84,7 @@ mod skillforge;
 mod skills;
 mod tools;
 mod tunnel;
+mod update;
 mod util;
 
 use config::Config;
@@ -173,7 +177,9 @@ Examples:
   zeroclaw agent                              # interactive session
   zeroclaw agent -m \"Summarize today's logs\"  # single message
   zeroclaw agent -p anthropic --model claude-sonnet-4-20250514
-  zeroclaw agent --peripheral nucleo-f401re:/dev/ttyACM0")]
+  zeroclaw agent --peripheral nucleo-f401re:/dev/ttyACM0
+  zeroclaw agent --autonomy-level full --max-actions-per-hour 100
+  zeroclaw agent -m \"quick task\" --memory-backend none --compact-context")]
     Agent {
         /// Single message mode (don't enter interactive mode)
         #[arg(short, long)]
@@ -194,6 +200,30 @@ Examples:
         /// Attach a peripheral (board:path, e.g. nucleo-f401re:/dev/ttyACM0)
         #[arg(long)]
         peripheral: Vec<String>,
+
+        /// Autonomy level (read_only, supervised, full)
+        #[arg(long, value_parser = clap::value_parser!(security::AutonomyLevel))]
+        autonomy_level: Option<security::AutonomyLevel>,
+
+        /// Maximum shell/tool actions per hour
+        #[arg(long)]
+        max_actions_per_hour: Option<u32>,
+
+        /// Maximum tool-call iterations per message
+        #[arg(long)]
+        max_tool_iterations: Option<usize>,
+
+        /// Maximum conversation history messages
+        #[arg(long)]
+        max_history_messages: Option<usize>,
+
+        /// Enable compact context mode (smaller prompts for limited models)
+        #[arg(long)]
+        compact_context: bool,
+
+        /// Memory backend (sqlite, markdown, none)
+        #[arg(long)]
+        memory_backend: Option<String>,
     },
 
     /// Start the gateway server (webhooks, websockets)
@@ -263,6 +293,28 @@ Examples:
 
     /// Show system status (full details)
     Status,
+
+    /// Self-update ZeroClaw to the latest version
+    #[command(long_about = "\
+Self-update ZeroClaw to the latest release from GitHub.
+
+Downloads the appropriate pre-built binary for your platform and
+replaces the current executable. Requires write permissions to
+the binary location.
+
+Examples:
+  zeroclaw update              # Update to latest version
+  zeroclaw update --check      # Check for updates without installing
+  zeroclaw update --force      # Reinstall even if already up to date")]
+    Update {
+        /// Check for updates without installing
+        #[arg(long)]
+        check: bool,
+
+        /// Force update even if already at latest version
+        #[arg(long)]
+        force: bool,
+    },
 
     /// Engage, inspect, and resume emergency-stop states.
     ///
@@ -686,6 +738,7 @@ async fn main() -> Result<()> {
 
     // Initialize logging - respects RUST_LOG env var, defaults to INFO
     let subscriber = fmt::Subscriber::builder()
+        .with_timer(tracing_subscriber::fmt::time::ChronoLocal::rfc_3339())
         .with_env_filter(
             EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
         )
@@ -766,8 +819,7 @@ async fn main() -> Result<()> {
     }
 
     match cli.command {
-        Commands::Onboard { .. } => unreachable!(),
-        Commands::Completions { .. } => unreachable!(),
+        Commands::Onboard { .. } | Commands::Completions { .. } => unreachable!(),
 
         Commands::Agent {
             message,
@@ -775,17 +827,43 @@ async fn main() -> Result<()> {
             model,
             temperature,
             peripheral,
-        } => agent::run(
-            config,
-            message,
-            provider,
-            model,
-            temperature,
-            peripheral,
-            true,
-        )
-        .await
-        .map(|_| ()),
+            autonomy_level,
+            max_actions_per_hour,
+            max_tool_iterations,
+            max_history_messages,
+            compact_context,
+            memory_backend,
+        } => {
+            if let Some(level) = autonomy_level {
+                config.autonomy.level = level;
+            }
+            if let Some(n) = max_actions_per_hour {
+                config.autonomy.max_actions_per_hour = n;
+            }
+            if let Some(n) = max_tool_iterations {
+                config.agent.max_tool_iterations = n;
+            }
+            if let Some(n) = max_history_messages {
+                config.agent.max_history_messages = n;
+            }
+            if compact_context {
+                config.agent.compact_context = true;
+            }
+            if let Some(ref backend) = memory_backend {
+                config.memory.backend = backend.clone();
+            }
+            agent::run(
+                config,
+                message,
+                provider,
+                model,
+                temperature,
+                peripheral,
+                true,
+            )
+            .await
+            .map(|_| ())
+        }
 
         Commands::Gateway { port, host } => {
             let port = port.unwrap_or(config.gateway.port);
@@ -900,6 +978,11 @@ async fn main() -> Result<()> {
             );
             println!("  Boards:    {}", config.peripherals.boards.len());
 
+            Ok(())
+        }
+
+        Commands::Update { check, force } => {
+            update::self_update(force, check).await?;
             Ok(())
         }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -15,6 +15,8 @@
 //! To add a new tool, implement [`Tool`] in a new submodule and register it in
 //! [`all_tools_with_runtime`]. See `AGENTS.md` §7.3 for the full change playbook.
 
+pub mod agents_ipc;
+pub mod apply_patch;
 pub mod browser;
 pub mod browser_open;
 pub mod cli_discovery;
@@ -27,6 +29,7 @@ pub mod cron_run;
 pub mod cron_runs;
 pub mod cron_update;
 pub mod delegate;
+pub mod delegate_coordination_status;
 pub mod file_edit;
 pub mod file_read;
 pub mod file_write;
@@ -45,17 +48,25 @@ pub mod memory_recall;
 pub mod memory_store;
 pub mod model_routing_config;
 pub mod pdf_read;
+pub mod process;
 pub mod proxy_config;
 pub mod pushover;
 pub mod schedule;
 pub mod schema;
 pub mod screenshot;
 pub mod shell;
-pub mod traits;
+pub mod subagent_list;
+pub mod subagent_manage;
+pub mod subagent_registry;
+pub mod subagent_spawn;
 pub mod task_plan;
+pub mod traits;
+pub mod url_validation;
+pub mod wasm_module;
 pub mod web_fetch;
 pub mod web_search_tool;
 
+pub use apply_patch::ApplyPatchTool;
 pub use browser::{BrowserTool, ComputerUseConfig};
 pub use browser_open::BrowserOpenTool;
 pub use composio::ComposioTool;
@@ -67,6 +78,7 @@ pub use cron_run::CronRunTool;
 pub use cron_runs::CronRunsTool;
 pub use cron_update::CronUpdateTool;
 pub use delegate::DelegateTool;
+pub use delegate_coordination_status::DelegateCoordinationStatusTool;
 pub use file_edit::FileEditTool;
 pub use file_read::FileReadTool;
 pub use file_write::FileWriteTool;
@@ -85,6 +97,7 @@ pub use memory_recall::MemoryRecallTool;
 pub use memory_store::MemoryStoreTool;
 pub use model_routing_config::ModelRoutingConfigTool;
 pub use pdf_read::PdfReadTool;
+pub use process::ProcessTool;
 pub use proxy_config::ProxyConfigTool;
 pub use pushover::PushoverTool;
 pub use schedule::ScheduleTool;
@@ -92,10 +105,15 @@ pub use schedule::ScheduleTool;
 pub use schema::{CleaningStrategy, SchemaCleanr};
 pub use screenshot::ScreenshotTool;
 pub use shell::ShellTool;
+pub use subagent_list::SubAgentListTool;
+pub use subagent_manage::SubAgentManageTool;
+pub use subagent_registry::SubAgentRegistry;
+pub use subagent_spawn::SubAgentSpawnTool;
 pub use task_plan::TaskPlanTool;
 pub use traits::Tool;
 #[allow(unused_imports)]
 pub use traits::{ToolResult, ToolSpec};
+pub use wasm_module::WasmModuleTool;
 pub use web_fetch::WebFetchTool;
 pub use web_search_tool::WebSearchTool;
 
@@ -151,14 +169,26 @@ pub fn default_tools_with_runtime(
     security: Arc<SecurityPolicy>,
     runtime: Arc<dyn RuntimeAdapter>,
 ) -> Vec<Box<dyn Tool>> {
-    vec![
-        Box::new(ShellTool::new(security.clone(), runtime)),
-        Box::new(FileReadTool::new(security.clone())),
-        Box::new(FileWriteTool::new(security.clone())),
-        Box::new(FileEditTool::new(security.clone())),
-        Box::new(GlobSearchTool::new(security.clone())),
-        Box::new(ContentSearchTool::new(security)),
-    ]
+    let has_shell_access = runtime.has_shell_access();
+    let has_filesystem_access = runtime.has_filesystem_access();
+    let mut tools: Vec<Box<dyn Tool>> = Vec::new();
+
+    if has_shell_access {
+        tools.push(Box::new(ShellTool::new(security.clone(), runtime.clone())));
+    }
+    if has_filesystem_access {
+        tools.push(Box::new(FileReadTool::new(security.clone())));
+        tools.push(Box::new(FileWriteTool::new(security.clone())));
+        tools.push(Box::new(FileEditTool::new(security.clone())));
+        tools.push(Box::new(ApplyPatchTool::new()));
+        tools.push(Box::new(GlobSearchTool::new(security.clone())));
+        tools.push(Box::new(ContentSearchTool::new(security.clone())));
+    }
+    if runtime.as_any().is::<crate::runtime::WasmRuntime>() {
+        tools.push(Box::new(WasmModuleTool::new(security, runtime)));
+    }
+
+    tools
 }
 
 /// Create full tool registry including memory tools and optional Composio
@@ -211,13 +241,20 @@ pub fn all_tools_with_runtime(
     fallback_api_key: Option<&str>,
     root_config: &crate::config::Config,
 ) -> Vec<Box<dyn Tool>> {
+    let has_shell_access = runtime.has_shell_access();
+    let has_filesystem_access = runtime.has_filesystem_access();
+    let zeroclaw_dir = root_config
+        .config_path
+        .parent()
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| runtime.storage_path());
+    let syscall_detector = Arc::new(crate::security::SyscallAnomalyDetector::new(
+        root_config.security.syscall_anomaly.clone(),
+        &zeroclaw_dir,
+        root_config.security.audit.clone(),
+    ));
+
     let mut tool_arcs: Vec<Arc<dyn Tool>> = vec![
-        Arc::new(ShellTool::new(security.clone(), runtime)),
-        Arc::new(FileReadTool::new(security.clone())),
-        Arc::new(FileWriteTool::new(security.clone())),
-        Arc::new(FileEditTool::new(security.clone())),
-        Arc::new(GlobSearchTool::new(security.clone())),
-        Arc::new(ContentSearchTool::new(security.clone())),
         Arc::new(CronAddTool::new(config.clone(), security.clone())),
         Arc::new(CronListTool::new(config.clone())),
         Arc::new(CronRemoveTool::new(config.clone(), security.clone())),
@@ -234,15 +271,43 @@ pub fn all_tools_with_runtime(
             security.clone(),
         )),
         Arc::new(ProxyConfigTool::new(config.clone(), security.clone())),
-        Arc::new(GitOperationsTool::new(
-            security.clone(),
-            workspace_dir.to_path_buf(),
-        )),
         Arc::new(PushoverTool::new(
             security.clone(),
             workspace_dir.to_path_buf(),
         )),
     ];
+
+    if has_shell_access {
+        tool_arcs.push(Arc::new(ShellTool::new_with_syscall_detector(
+            security.clone(),
+            runtime.clone(),
+            Some(syscall_detector.clone()),
+        )));
+        tool_arcs.push(Arc::new(ProcessTool::new_with_syscall_detector(
+            security.clone(),
+            runtime.clone(),
+            Some(syscall_detector),
+        )));
+        tool_arcs.push(Arc::new(GitOperationsTool::new(
+            security.clone(),
+            workspace_dir.to_path_buf(),
+        )));
+    }
+
+    if has_filesystem_access {
+        tool_arcs.push(Arc::new(FileReadTool::new(security.clone())));
+        tool_arcs.push(Arc::new(FileWriteTool::new(security.clone())));
+        tool_arcs.push(Arc::new(FileEditTool::new(security.clone())));
+        tool_arcs.push(Arc::new(ApplyPatchTool::new()));
+        tool_arcs.push(Arc::new(GlobSearchTool::new(security.clone())));
+        tool_arcs.push(Arc::new(ContentSearchTool::new(security.clone())));
+    }
+    if runtime.as_any().is::<crate::runtime::WasmRuntime>() {
+        tool_arcs.push(Arc::new(WasmModuleTool::new(
+            security.clone(),
+            runtime.clone(),
+        )));
+    }
 
     if browser_config.enabled {
         // Add legacy browser_open tool for simple URL opening
@@ -277,26 +342,44 @@ pub fn all_tools_with_runtime(
             http_config.allowed_domains.clone(),
             http_config.max_response_size,
             http_config.timeout_secs,
+            http_config.user_agent.clone(),
         )));
     }
 
     if web_fetch_config.enabled {
         tool_arcs.push(Arc::new(WebFetchTool::new(
             security.clone(),
+            web_fetch_config.provider.clone(),
+            web_fetch_config.api_key.clone(),
+            web_fetch_config.api_url.clone(),
             web_fetch_config.allowed_domains.clone(),
             web_fetch_config.blocked_domains.clone(),
             web_fetch_config.max_response_size,
             web_fetch_config.timeout_secs,
+            web_fetch_config.user_agent.clone(),
         )));
     }
 
     // Web search tool (enabled by default for GLM and other models)
     if root_config.web_search.enabled {
+        let provider = root_config.web_search.provider.trim().to_lowercase();
+        let api_key = if provider == "brave" {
+            root_config
+                .web_search
+                .brave_api_key
+                .clone()
+                .or_else(|| root_config.web_search.api_key.clone())
+        } else {
+            root_config.web_search.api_key.clone()
+        };
         tool_arcs.push(Arc::new(WebSearchTool::new(
+            security.clone(),
             root_config.web_search.provider.clone(),
-            root_config.web_search.brave_api_key.clone(),
+            api_key,
+            root_config.web_search.api_url.clone(),
             root_config.web_search.max_results,
             root_config.web_search.timeout_secs,
+            root_config.web_search.user_agent.clone(),
         )));
     }
 
@@ -317,7 +400,7 @@ pub fn all_tools_with_runtime(
         }
     }
 
-    // Add delegation tool when agents are configured
+    // Add delegation and sub-agent orchestration tools when agents are configured
     if !agents.is_empty() {
         let delegate_agents: HashMap<String, DelegateAgentConfig> = agents
             .iter()
@@ -327,25 +410,114 @@ pub fn all_tools_with_runtime(
             let trimmed_value = value.trim();
             (!trimmed_value.is_empty()).then(|| trimmed_value.to_owned())
         });
+        let provider_runtime_options = crate::providers::ProviderRuntimeOptions {
+            auth_profile_override: None,
+            provider_api_url: root_config.api_url.clone(),
+            zeroclaw_dir: root_config
+                .config_path
+                .parent()
+                .map(std::path::PathBuf::from),
+            secrets_encrypt: root_config.secrets.encrypt,
+            reasoning_enabled: root_config.runtime.reasoning_enabled,
+            reasoning_level: root_config.effective_provider_reasoning_level(),
+            custom_provider_api_mode: root_config
+                .provider_api
+                .map(|mode| mode.as_compatible_mode()),
+            max_tokens_override: None,
+            model_support_vision: root_config.model_support_vision,
+        };
         let parent_tools = Arc::new(tool_arcs.clone());
-        let delegate_tool = DelegateTool::new_with_options(
+        let mut delegate_tool = DelegateTool::new_with_options(
+            delegate_agents.clone(),
+            delegate_fallback_credential.clone(),
+            security.clone(),
+            provider_runtime_options.clone(),
+        )
+        .with_parent_tools(parent_tools.clone())
+        .with_multimodal_config(root_config.multimodal.clone());
+
+        if root_config.coordination.enabled {
+            let coordination_lead_agent = {
+                let value = root_config.coordination.lead_agent.trim();
+                if value.is_empty() {
+                    "delegate-lead".to_string()
+                } else {
+                    value.to_string()
+                }
+            };
+            let coordination_bus = crate::coordination::InMemoryMessageBus::with_limits(
+                crate::coordination::InMemoryMessageBusLimits {
+                    max_inbox_messages_per_agent: root_config
+                        .coordination
+                        .max_inbox_messages_per_agent,
+                    max_dead_letters: root_config.coordination.max_dead_letters,
+                    max_context_entries: root_config.coordination.max_context_entries,
+                    max_seen_message_ids: root_config.coordination.max_seen_message_ids,
+                },
+            );
+            if let Err(error) = coordination_bus.register_agent(coordination_lead_agent.clone()) {
+                tracing::warn!(
+                    "delegate coordination: failed to register lead agent '{coordination_lead_agent}': {error}"
+                );
+            }
+            for agent_name in agents.keys() {
+                if let Err(error) = coordination_bus.register_agent(agent_name.clone()) {
+                    tracing::warn!(
+                        "delegate coordination: failed to register agent '{agent_name}': {error}"
+                    );
+                }
+            }
+
+            delegate_tool = delegate_tool
+                .with_coordination_bus(coordination_bus.clone(), coordination_lead_agent);
+            tool_arcs.push(Arc::new(delegate_tool));
+            tool_arcs.push(Arc::new(DelegateCoordinationStatusTool::new(
+                coordination_bus,
+                security.clone(),
+            )));
+        } else {
+            delegate_tool = delegate_tool.with_coordination_disabled();
+            tool_arcs.push(Arc::new(delegate_tool));
+        }
+
+        let subagent_registry = Arc::new(SubAgentRegistry::new());
+        tool_arcs.push(Arc::new(SubAgentSpawnTool::new(
             delegate_agents,
             delegate_fallback_credential,
             security.clone(),
-            crate::providers::ProviderRuntimeOptions {
-                auth_profile_override: None,
-                provider_api_url: root_config.api_url.clone(),
-                zeroclaw_dir: root_config
-                    .config_path
-                    .parent()
-                    .map(std::path::PathBuf::from),
-                secrets_encrypt: root_config.secrets.encrypt,
-                reasoning_enabled: root_config.runtime.reasoning_enabled,
-            },
-        )
-        .with_parent_tools(parent_tools)
-        .with_multimodal_config(root_config.multimodal.clone());
-        tool_arcs.push(Arc::new(delegate_tool));
+            provider_runtime_options,
+            subagent_registry.clone(),
+            parent_tools,
+            root_config.multimodal.clone(),
+        )));
+        tool_arcs.push(Arc::new(SubAgentListTool::new(subagent_registry.clone())));
+        tool_arcs.push(Arc::new(SubAgentManageTool::new(
+            subagent_registry,
+            security.clone(),
+        )));
+    }
+
+    // Inter-process agent communication (opt-in)
+    if root_config.agents_ipc.enabled {
+        match agents_ipc::IpcDb::open(workspace_dir, &root_config.agents_ipc) {
+            Ok(ipc_db) => {
+                let ipc_db = Arc::new(ipc_db);
+                tool_arcs.push(Arc::new(agents_ipc::AgentsListTool::new(ipc_db.clone())));
+                tool_arcs.push(Arc::new(agents_ipc::AgentsSendTool::new(
+                    ipc_db.clone(),
+                    security.clone(),
+                )));
+                tool_arcs.push(Arc::new(agents_ipc::AgentsInboxTool::new(ipc_db.clone())));
+                tool_arcs.push(Arc::new(agents_ipc::StateGetTool::new(ipc_db.clone())));
+                tool_arcs.push(Arc::new(agents_ipc::StateSetTool::new(
+                    ipc_db,
+                    security.clone(),
+                )));
+            }
+            Err(e) => {
+                tracing::warn!("agents_ipc: failed to open IPC database: {e}");
+            }
+        }
     }
 
     boxed_registry_from_arcs(tool_arcs)
@@ -354,7 +526,8 @@ pub fn all_tools_with_runtime(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{BrowserConfig, Config, MemoryConfig};
+    use crate::config::{BrowserConfig, Config, MemoryConfig, WasmRuntimeConfig};
+    use crate::runtime::WasmRuntime;
     use tempfile::TempDir;
 
     fn test_config(tmp: &TempDir) -> Config {
@@ -369,7 +542,34 @@ mod tests {
     fn default_tools_has_expected_count() {
         let security = Arc::new(SecurityPolicy::default());
         let tools = default_tools(security);
-        assert_eq!(tools.len(), 6);
+        assert_eq!(tools.len(), 7);
+        assert!(tools.iter().any(|tool| tool.name() == "apply_patch"));
+    }
+
+    #[test]
+    fn default_tools_with_runtime_includes_wasm_module_for_wasm_runtime() {
+        let security = Arc::new(SecurityPolicy::default());
+        let runtime: Arc<dyn RuntimeAdapter> =
+            Arc::new(WasmRuntime::new(WasmRuntimeConfig::default()));
+        let tools = default_tools_with_runtime(security, runtime);
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"wasm_module"));
+    }
+
+    #[test]
+    fn default_tools_with_runtime_excludes_shell_and_fs_for_wasm_runtime() {
+        let security = Arc::new(SecurityPolicy::default());
+        let runtime: Arc<dyn RuntimeAdapter> =
+            Arc::new(WasmRuntime::new(WasmRuntimeConfig::default()));
+        let tools = default_tools_with_runtime(security, runtime);
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(!names.contains(&"shell"));
+        assert!(!names.contains(&"file_read"));
+        assert!(!names.contains(&"file_write"));
+        assert!(!names.contains(&"file_edit"));
+        assert!(!names.contains(&"apply_patch"));
+        assert!(!names.contains(&"glob_search"));
+        assert!(!names.contains(&"content_search"));
     }
 
     #[test]
@@ -454,6 +654,48 @@ mod tests {
         assert!(names.contains(&"model_routing_config"));
         assert!(names.contains(&"pushover"));
         assert!(names.contains(&"proxy_config"));
+    }
+
+    #[test]
+    fn all_tools_with_runtime_includes_wasm_module_for_wasm_runtime() {
+        let tmp = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(crate::memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+        let runtime: Arc<dyn RuntimeAdapter> =
+            Arc::new(WasmRuntime::new(WasmRuntimeConfig::default()));
+
+        let browser = BrowserConfig::default();
+        let http = crate::config::HttpRequestConfig::default();
+        let cfg = test_config(&tmp);
+
+        let tools = all_tools_with_runtime(
+            Arc::new(Config::default()),
+            &security,
+            runtime,
+            mem,
+            None,
+            None,
+            &browser,
+            &http,
+            &crate::config::WebFetchConfig::default(),
+            tmp.path(),
+            &HashMap::new(),
+            None,
+            &cfg,
+        );
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"wasm_module"));
+        assert!(!names.contains(&"shell"));
+        assert!(!names.contains(&"process"));
+        assert!(!names.contains(&"git_operations"));
+        assert!(!names.contains(&"file_read"));
+        assert!(!names.contains(&"file_write"));
+        assert!(!names.contains(&"file_edit"));
     }
 
     #[test]
@@ -600,6 +842,7 @@ mod tests {
         );
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(names.contains(&"delegate"));
+        assert!(names.contains(&"delegate_coordination_status"));
     }
 
     #[test]
@@ -633,5 +876,57 @@ mod tests {
         );
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(!names.contains(&"delegate"));
+        assert!(!names.contains(&"delegate_coordination_status"));
+    }
+
+    #[test]
+    fn all_tools_disables_coordination_tool_when_coordination_is_disabled() {
+        let tmp = TempDir::new().unwrap();
+        let security = Arc::new(SecurityPolicy::default());
+        let mem_cfg = MemoryConfig {
+            backend: "markdown".into(),
+            ..MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> =
+            Arc::from(crate::memory::create_memory(&mem_cfg, tmp.path(), None).unwrap());
+
+        let browser = BrowserConfig::default();
+        let http = crate::config::HttpRequestConfig::default();
+        let mut cfg = test_config(&tmp);
+        cfg.coordination.enabled = false;
+
+        let mut agents = HashMap::new();
+        agents.insert(
+            "researcher".to_string(),
+            DelegateAgentConfig {
+                provider: "ollama".to_string(),
+                model: "llama3".to_string(),
+                system_prompt: None,
+                api_key: None,
+                temperature: None,
+                max_depth: 3,
+                agentic: false,
+                allowed_tools: Vec::new(),
+                max_iterations: 10,
+            },
+        );
+
+        let tools = all_tools(
+            Arc::new(Config::default()),
+            &security,
+            mem,
+            None,
+            None,
+            &browser,
+            &http,
+            &crate::config::WebFetchConfig::default(),
+            tmp.path(),
+            &agents,
+            Some("delegate-test-credential"),
+            &cfg,
+        );
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert!(names.contains(&"delegate"));
+        assert!(!names.contains(&"delegate_coordination_status"));
     }
 }


### PR DESCRIPTION
Supersedes #1897 to recover from merge conflicts against latest `main`.

- Source PR: https://github.com/zeroclaw-labs/zeroclaw/pull/1897
- Recovery mode: automated replay on top of current `main`
- Merge policy: all CI checks green

Original PR description:

## Summary
- add a new tools-enabled gateway endpoint: `POST /api/chat`
- keep request/response contract simple for integrators: `{ "message": "..." } -> { "reply": "..." }`
- reuse the same gateway auth model currently used by `/webhook`

## Why
Aura-side integrations need a stable chat endpoint on ZeroClaw that runs the full agent loop with tools. This PR adds that endpoint directly in the gateway and keeps auth/rate-limit behavior consistent with webhook traffic.

## Changes
- `src/gateway/mod.rs`
  - add route registration for `POST /api/chat`
  - add `handle_api_chat` handler using `run_gateway_chat_with_tools`
  - add `ApiChatBody` request type and `api_chat_memory_key` autosave keys
  - extract shared auth guard into `enforce_gateway_auth` and apply to both `/api/chat` and `/webhook`
  - update startup route printout to include `/api/chat`
  - add gateway tests:
    - `api_chat_rejects_invalid_bearer_when_pairing_required`
    - `api_chat_rejects_public_traffic_without_auth_layers`

## Validation
- `cargo test api_chat_rejects_invalid_bearer_when_pairing_required -- --nocapture`
- `cargo test api_chat_rejects_public_traffic_without_auth_layers -- --nocapture`
- `cargo test webhook_secret_hash_ -- --nocapture`
- `cargo fmt --all -- --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Self-update capability via new update command
  * QQ channel integration with webhook support
  * OpenAI-compatible API endpoints
  * Web tools configuration (search, fetch, HTTP requests) in onboarding
  * HunYuan AI provider support
  * WASM runtime integration
  * Subagent orchestration and inter-process communication
  * Node control API

* **Improvements**
  * Enhanced voice message handling with metadata
  * Group reply controls for Telegram channels
  * Unified Lark/Feishu channel support
  * Improved logging with RFC 3339 timestamps
  * Extended agent CLI configuration options
  * Better attachment and file handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
