### PR TITLE
[supersede #1968] [supersede #1853] feat(tools): add Feishu document operation tool with 13 actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   value if the input used the legacy `enc:` format
 - `SecretStore::needs_migration()` — Check if a value uses the legacy `enc:` format
 - `SecretStore::is_secure_encrypted()` — Check if a value uses the secure `enc2:` format
+- `feishu_doc` tool — Feishu/Lark document operations (`read`, `write`, `append`, `create`, `list_blocks`, `get_block`, `update_block`, `delete_block`, `create_table`, `write_table_cells`, `create_table_with_values`, `upload_image`, `upload_file`)
 - **Telegram mention_only mode** — New config option `mention_only` for Telegram channel.
   When enabled, bot only responds to messages that @-mention the bot in group chats.
   Direct messages always work regardless of this setting. Default: `false`.


### PR DESCRIPTION
## Summary

### Problem
Current PR #1986 failed to merge due branch drift and repeated merge conflicts against the latest integration branch.

### Why It Matters
This PR introduces a Feishu document tool with 13 actions. Keeping it blocked delays channel-lark feature delivery and leaves duplicate supersede tracks unresolved.

### What Changed
- Rebased `supersede-pr-1968-20260226164943-141738-theirs` onto latest `origin/dev`.
- Resolved tool-registry conflicts in `src/tools/mod.rs` while preserving Feishu tool registration.
- Kept the Feishu implementation + review-fix commit stack intact (`src/tools/feishu_doc.rs`, `src/main.rs`, `tests/agent_e2e.rs`).
- Dropped the transient lockfile-only replay commit after moving to `dev` baseline (not needed on `dev`).

## Change Metadata
- Change type: `feature` + `rebase/conflict-resolution`
- Primary scope: `tools`, `channel-lark`
- PR type: supersede continuation

## Linked Issue
- Linear: `RMN-140`
- Supersedes: #1968, #1853

## Supersede Attribution
- Source PR lineage: #1853 -> #1968 -> #1986
- This PR keeps the same functional scope and resolves base-drift conflicts on current `dev`.

## Validation Evidence

### Commands
- `cargo check --locked --features channel-lark`
- `cargo check --features channel-lark`

### Results
- Both commands pass locally on the rebased branch.

## Security Impact

### Risk
- Moderate: introduces external API write operations for Feishu docs/files/images.

### Mitigation
- Tool remains behind `channel-lark` feature path and existing security policy gates.
- Uses existing credential config path (`channels_config.feishu` / `channels_config.lark`) and keeps explicit operation routing.

## Privacy and Data Hygiene
- No new telemetry sink introduced.
- Tool operates on caller-supplied document/file payloads only.
- No additional persistent secrets beyond existing configured app credentials.

## Compatibility
- No config schema migration required.
- Non-`channel-lark` builds remain unaffected.

## Rollback Plan
- Revert this PR commit stack from `supersede-pr-1968-20260226164943-141738-theirs`.
- If needed, disable by excluding the `channel-lark` feature path.

## Human Verification
- Confirmed PR branch is conflict-free and mergeable after rebase to `dev`.
- Confirmed local compile checks pass with `--locked`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added feishu_doc tool documentation detailing support for Feishu/Lark document operations including read, write, append, create, block management, table operations, and file uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->