### PR TITLE
fix(channels): restore lark/feishu config constructors

### DIFF
--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -296,6 +296,8 @@ pub struct LarkChannel {
     /// Bot open_id resolved at runtime via `/bot/v3/info`.
     resolved_bot_open_id: Arc<StdRwLock<Option<String>>>,
     mention_only: bool,
+    /// Endpoint family and runtime behavior for Lark vs Feishu.
+    platform: LarkPlatform,
     /// When true, use Feishu (CN) endpoints; when false, use Lark (international).
     use_feishu: bool,
     /// How to receive events: WebSocket long-connection or HTTP webhook.
@@ -321,6 +323,7 @@ impl LarkChannel {
             verification_token,
             port,
             allowed_users,
+            mention_only,
             LarkPlatform::Lark,
         )
     }
@@ -331,6 +334,7 @@ impl LarkChannel {
         verification_token: String,
         port: Option<u16>,
         allowed_users: Vec<String>,
+        mention_only: bool,
         platform: LarkPlatform,
     ) -> Self {
         Self {
@@ -341,7 +345,8 @@ impl LarkChannel {
             allowed_users,
             resolved_bot_open_id: Arc::new(StdRwLock::new(None)),
             mention_only,
-            use_feishu: true,
+            platform,
+            use_feishu: platform == LarkPlatform::Feishu,
             receive_mode: crate::config::schema::LarkReceiveMode::default(),
             tenant_token: Arc::new(RwLock::new(None)),
             ws_seen_ids: Arc::new(RwLock::new(HashMap::new())),
@@ -363,6 +368,38 @@ impl LarkChannel {
             config.port,
             config.allowed_users.clone(),
             config.mention_only,
+            platform,
+        );
+        ch.receive_mode = config.receive_mode.clone();
+        ch
+    }
+
+    /// Build from `LarkConfig` while forcing Lark (international) endpoints.
+    /// This ignores the legacy `use_feishu` flag.
+    pub fn from_lark_config(config: &crate::config::schema::LarkConfig) -> Self {
+        let mut ch = Self::new_with_platform(
+            config.app_id.clone(),
+            config.app_secret.clone(),
+            config.verification_token.clone().unwrap_or_default(),
+            config.port,
+            config.allowed_users.clone(),
+            config.mention_only,
+            LarkPlatform::Lark,
+        );
+        ch.receive_mode = config.receive_mode.clone();
+        ch
+    }
+
+    /// Build from `FeishuConfig` using Feishu endpoints.
+    pub fn from_feishu_config(config: &crate::config::schema::FeishuConfig) -> Self {
+        let mut ch = Self::new_with_platform(
+            config.app_id.clone(),
+            config.app_secret.clone(),
+            config.verification_token.clone().unwrap_or_default(),
+            config.port,
+            config.allowed_users.clone(),
+            false,
+            LarkPlatform::Feishu,
         );
         ch.receive_mode = config.receive_mode.clone();
         ch


### PR DESCRIPTION
## Summary
Restore Lark/Feishu constructor wiring and platform state after split; unblocks channel-lark builds by reintroducing from_lark_config/from_feishu_config paths used in channel bootstrap.

## Validation
- \
- \ currently fails on existing unrelated mainline regressions outside this patch scope

Closes #1991


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved platform distinction between Lark and Feishu integrations with more explicit configuration handling, ensuring each platform's endpoints and behavior are properly initialized and maintained across different setup paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->