### PR TITLE
fix(config): default compact_context to true

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -76,7 +76,7 @@ Operational note for container users:
 
 | Key | Default | Purpose |
 |---|---|---|
-| `compact_context` | `false` | When true: bootstrap_max_chars=6000, rag_chunk_limit=2. Use for 13B or smaller models |
+| `compact_context` | `true` | When true: bootstrap_max_chars=6000, rag_chunk_limit=2. Use for 13B or smaller models |
 | `max_tool_iterations` | `10` | Maximum tool-call loop turns per user message across CLI, gateway, and channels |
 | `max_history_messages` | `50` | Maximum conversation history messages retained per session |
 | `parallel_tools` | `false` | Enable parallel tool execution within a single iteration |

--- a/docs/vi/config-reference.md
+++ b/docs/vi/config-reference.md
@@ -65,7 +65,7 @@ Lưu ý cho người dùng container:
 
 | Khóa | Mặc định | Mục đích |
 |---|---|---|
-| `compact_context` | `false` | Khi bật: bootstrap_max_chars=6000, rag_chunk_limit=2. Dùng cho model 13B trở xuống |
+| `compact_context` | `true` | Khi bật: bootstrap_max_chars=6000, rag_chunk_limit=2. Dùng cho model 13B trở xuống |
 | `max_tool_iterations` | `10` | Số vòng lặp tool-call tối đa mỗi tin nhắn trên CLI, gateway và channels |
 | `max_history_messages` | `50` | Số tin nhắn lịch sử tối đa giữ lại mỗi phiên |
 | `parallel_tools` | `false` | Bật thực thi tool song song trong một lượt |

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -658,7 +658,7 @@ fn default_agent_tool_dispatcher() -> String {
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
-            compact_context: false,
+            compact_context: true,
             max_tool_iterations: default_agent_max_tool_iterations(),
             max_history_messages: default_agent_max_history_messages(),
             parallel_tools: false,
@@ -7175,7 +7175,7 @@ reasoning_level = "high"
     #[test]
     async fn agent_config_defaults() {
         let cfg = AgentConfig::default();
-        assert!(!cfg.compact_context);
+        assert!(cfg.compact_context);
         assert_eq!(cfg.max_tool_iterations, 20);
         assert_eq!(cfg.max_history_messages, 50);
         assert!(!cfg.parallel_tools);

--- a/tests/config_persistence.rs
+++ b/tests/config_persistence.rs
@@ -73,11 +73,11 @@ fn agent_config_default_tool_dispatcher() {
 }
 
 #[test]
-fn agent_config_default_compact_context_off() {
+fn agent_config_default_compact_context_on() {
     let agent = AgentConfig::default();
     assert!(
-        !agent.compact_context,
-        "compact_context should default to false"
+        agent.compact_context,
+        "compact_context should default to true"
     );
 }
 
@@ -201,7 +201,7 @@ default_temperature = 0.7
     // Agent config should use defaults
     assert_eq!(parsed.agent.max_tool_iterations, 20);
     assert_eq!(parsed.agent.max_history_messages, 50);
-    assert!(!parsed.agent.compact_context);
+    assert!(parsed.agent.compact_context);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Set compact_context default to true to reduce unrecoverable overflow loops in daemon/channel conversations, and align config tests/docs with the new default.

## Validation
- \
- \ currently fails on existing unrelated mainline regressions outside this patch scope

Closes #1984


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Changes**
  * Updated Agent configuration defaults to enable compact context handling by default, affecting how context is processed during agent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->