### PR TITLE
fix(model-routing): detect env-backed provider credentials

### DIFF
--- a/src/tools/model_routing_config.rs
+++ b/src/tools/model_routing_config.rs
@@ -216,10 +216,10 @@ impl ModelRoutingConfigTool {
             "hint": route.hint,
             "provider": route.provider,
             "model": route.model,
-            "api_key_configured": route
-                .api_key
-                .as_ref()
-                .is_some_and(|value| !value.trim().is_empty()),
+            "api_key_configured": crate::providers::has_provider_credential(
+                &route.provider,
+                route.api_key.as_deref(),
+            ),
             "classification": classification,
         })
     }
@@ -264,10 +264,10 @@ impl ModelRoutingConfigTool {
                     "provider": agent.provider,
                     "model": agent.model,
                     "system_prompt": agent.system_prompt,
-                    "api_key_configured": agent
-                        .api_key
-                        .as_ref()
-                        .is_some_and(|value| !value.trim().is_empty()),
+                    "api_key_configured": crate::providers::has_provider_credential(
+                        &agent.provider,
+                        agent.api_key.as_deref(),
+                    ),
                     "temperature": agent.temperature,
                     "max_depth": agent.max_depth,
                     "agentic": agent.agentic,


### PR DESCRIPTION
## Summary
Compute api_key_configured via provider credential resolution so environment-backed API keys report correctly in model_routing_config output.

## Validation
- \
- \ currently fails on existing unrelated mainline regressions outside this patch scope

Closes #1983


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests validating credential resolution from environment variables and explicit overrides.

* **Refactor**
  * Consolidated credential presence validation into a unified helper for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->