### PR TITLE
fix(bootstrap): initialize container arrays under set -u

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -685,6 +685,8 @@ is_zeroclaw_resource_name() {
 maybe_stop_running_zeroclaw_containers() {
   local -a running_ids running_rows
   local id name image command row
+  running_ids=()
+  running_rows=()
 
   while IFS=$'\t' read -r id name image command; do
     if [[ -z "$id" ]]; then


### PR DESCRIPTION
## Summary
Initialize `running_ids` and `running_rows` as empty arrays in `maybe_stop_running_zeroclaw_containers` to avoid Bash `set -u` unbound-variable failures when no matching containers exist.

## Validation
- `bash -n scripts/bootstrap.sh`

Closes #1950

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal system stability by ensuring proper initialization of data structures to prevent undefined behavior during operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->