### PR TITLE
fix(agent): stop converting plain URLs into shell calls

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1096,14 +1096,6 @@ fn parse_glm_style_tool_calls(text: &str) -> Vec<(String, serde_json::Value, Opt
             }
         }
 
-        // Plain URL
-        if let Some(command) = build_curl_command(line) {
-            calls.push((
-                "shell".to_string(),
-                serde_json::json!({ "command": command }),
-                Some(line.to_string()),
-            ));
-        }
     }
 
     calls
@@ -5067,9 +5059,21 @@ Done."#;
     fn parse_glm_style_plain_url() {
         let response = "https://example.com/api";
         let calls = parse_glm_style_tool_calls(response);
-        assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0].0, "shell");
-        assert!(calls[0].1["command"].as_str().unwrap().contains("curl"));
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn parse_glm_style_ignores_urls_in_text() {
+        let response = "Google homepage:\nhttps://www.google.com";
+        let calls = parse_glm_style_tool_calls(response);
+        assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn parse_tool_calls_does_not_convert_plain_url_to_shell() {
+        let response = "Google homepage:\nhttps://www.google.com";
+        let (_text, calls) = parse_tool_calls(response);
+        assert!(calls.is_empty());
     }
 
     #[test]

--- a/src/agent/loop_/parsing.rs
+++ b/src/agent/loop_/parsing.rs
@@ -910,14 +910,6 @@ pub(super) fn parse_glm_style_tool_calls(
             }
         }
 
-        // Plain URL
-        if let Some(command) = build_curl_command(line) {
-            calls.push((
-                "shell".to_string(),
-                serde_json::json!({ "command": command }),
-                Some(line.to_string()),
-            ));
-        }
     }
 
     calls


### PR DESCRIPTION
## Summary
Remove the plain-URL fallback in GLM-style parser paths so standalone URLs are no longer coerced into implicit `shell(curl ...)` tool calls.

## Tests
- Updated parser expectations for plain URLs
- Added regression tests to confirm plain text URLs do not become tool calls

## Validation Notes
Targeted cargo tests are currently blocked by pre-existing compile failures on main (unrelated unresolved imports/type mismatches in channels/config/tools modules).

Closes #1941