### PR TITLE
fix(gateway): align ws webchat prompt with runtime tool protocol

### DIFF
--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -10,7 +10,9 @@
 //! ```
 
 use super::AppState;
-use crate::agent::loop_::run_tool_call_loop;
+use crate::agent::loop_::{
+    build_shell_policy_instructions, build_tool_instructions_from_specs, run_tool_call_loop,
+};
 use crate::approval::ApprovalManager;
 use crate::providers::ChatMessage;
 use axum::{
@@ -111,6 +113,45 @@ fn finalize_ws_response(
     EMPTY_WS_RESPONSE_FALLBACK.to_string()
 }
 
+fn build_ws_system_prompt(
+    config: &crate::config::Config,
+    model: &str,
+    tools_registry: &[Box<dyn crate::tools::Tool>],
+    native_tools: bool,
+) -> String {
+    let mut tool_specs: Vec<crate::tools::ToolSpec> =
+        tools_registry.iter().map(|tool| tool.spec()).collect();
+    tool_specs.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let tool_descs: Vec<(&str, &str)> = tool_specs
+        .iter()
+        .map(|spec| (spec.name.as_str(), spec.description.as_str()))
+        .collect();
+
+    let bootstrap_max_chars = if config.agent.compact_context {
+        Some(6000)
+    } else {
+        None
+    };
+
+    let mut prompt = crate::channels::build_system_prompt_with_mode(
+        &config.workspace_dir,
+        model,
+        &tool_descs,
+        &[],
+        Some(&config.identity),
+        bootstrap_max_chars,
+        native_tools,
+        config.skills.prompt_injection_mode,
+    );
+    if !native_tools {
+        prompt.push_str(&build_tool_instructions_from_specs(&tool_specs));
+    }
+    prompt.push_str(&build_shell_policy_instructions(&config.autonomy));
+
+    prompt
+}
+
 /// GET /ws/chat — WebSocket upgrade for agent chat
 pub async fn handle_ws_chat(
     State(state): State<AppState>,
@@ -140,13 +181,11 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
     // Build system prompt once for the session
     let system_prompt = {
         let config_guard = state.config.lock();
-        crate::channels::build_system_prompt(
-            &config_guard.workspace_dir,
+        build_ws_system_prompt(
+            &config_guard,
             &state.model,
-            &[],
-            &[],
-            Some(&config_guard.identity),
-            None,
+            state.tools_registry_exec.as_ref(),
+            state.provider.supports_native_tools(),
         )
     };
 
@@ -406,6 +445,30 @@ Reminder set successfully."#;
         assert_eq!(result, "Reminder set successfully.");
         assert!(!result.contains("\"name\":\"schedule\""));
         assert!(!result.contains("\"result\""));
+    }
+
+    #[test]
+    fn build_ws_system_prompt_includes_tool_protocol_for_prompt_mode() {
+        let config = crate::config::Config::default();
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockScheduleTool)];
+
+        let prompt = build_ws_system_prompt(&config, "test-model", &tools, false);
+
+        assert!(prompt.contains("## Tool Use Protocol"));
+        assert!(prompt.contains("**schedule**"));
+        assert!(prompt.contains("## Shell Policy"));
+    }
+
+    #[test]
+    fn build_ws_system_prompt_omits_xml_protocol_for_native_mode() {
+        let config = crate::config::Config::default();
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(MockScheduleTool)];
+
+        let prompt = build_ws_system_prompt(&config, "test-model", &tools, true);
+
+        assert!(!prompt.contains("## Tool Use Protocol"));
+        assert!(prompt.contains("**schedule**"));
+        assert!(prompt.contains("## Shell Policy"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): `dev`
- Problem: webchat websocket sessions can emit markdown command text instead of executable tool calls.
- Why it matters: web UI agent appears non-functional for tool-required tasks although CLI/channel flows work.
- What changed: aligned `/ws/chat` system prompt with runtime tool-spec + shell-policy injection used in other runtime paths.
- What did **not** change (scope boundary): no tool execution policy changes, no config schema changes, no channel-loop behavior changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium` (gateway runtime path)
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): expected `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `gateway,runtime,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `gateway: ws-chat`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `runtime`

## Linked Issue

- Closes #2005
- Related #1759
- Depends on # (if stacked): N/A
- Supersedes # (if replacing older PR): N/A
- Linear issue key(s) (required, e.g. `RMN-123`): `TBD (awaiting maintainer-provided key)`
- Linear issue URL(s): N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): no superseded PR code carried over
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
  - `cargo fmt --all -- --check` ?
  - `cargo check --lib` ?
  - `cargo check --bin zeroclaw` ?
  - new ws unit tests added in `src/gateway/ws.rs`
- If any command is intentionally skipped, explain why:
  - `cargo clippy --all-targets -- -D warnings` and `cargo test` skipped in this Windows environment due linker `LNK1318` (PDB LIMIT) unrelated to code logic.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no user/private data added
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: prompt assembly includes tool protocol in non-native mode and omits it in native mode.
- Edge cases checked: shell policy block remains appended in both modes.
- What was not verified: full end-to-end gateway runtime test on Linux with live model.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: websocket chat prompt generation in gateway only.
- Potential unintended effects: prompt length increases slightly due tool list + policy block.
- Guardrails/monitoring for early detection: existing ws sanitize/fallback behavior and unit coverage.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local git/rust toolchain + GitHub REST API.
- Workflow/plan summary (if any): isolate worktree, minimal patch in `src/gateway/ws.rs`, add focused tests, rebase to latest `upstream/dev`.
- Verification focus: prompt-contract parity and compile integrity.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `9bed256d`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: ws chat no longer emits tool calls / falls back to markdown command text.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: larger ws system prompt may increase token usage per request.
  - Mitigation: scoped to ws chat only; compact-context gate is respected (`bootstrap_max_chars` logic preserved).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal WebSocket session initialization logic to improve overall code reliability, maintainability, and consistency across the system. This is a backend improvement with no changes to external functionality or user-visible features.

* **Tests**
  * Added comprehensive test suite to validate WebSocket initialization behavior across different configurations, enhancing overall system stability and operational reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->