### PR TITLE
fix(agent): expose browser automation tool in prompt inventory

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -421,8 +421,8 @@ Notes:
 
 | Key | Default | Purpose |
 |---|---|---|
-| `enabled` | `false` | Enable `browser_open` tool (opens URLs in the system browser without scraping) |
-| `allowed_domains` | `[]` | Allowed domains for `browser_open` (exact/subdomain match, or `"*"` for all public domains) |
+| `enabled` | `false` | Enable browser tools (`browser_open` and `browser`) |
+| `allowed_domains` | `[]` | Allowed domains for `browser_open` and `browser` (exact/subdomain match, or `"*"` for all public domains) |
 | `session_name` | unset | Browser session name (for agent-browser automation) |
 | `backend` | `agent_browser` | Browser automation backend: `"agent_browser"`, `"rust_native"`, `"computer_use"`, or `"auto"` |
 | `native_headless` | `true` | Headless mode for rust-native backend |
@@ -443,6 +443,7 @@ Notes:
 
 Notes:
 
+- `browser_open` is a simple URL opener; `browser` is full browser automation (open/click/type/scroll/screenshot).
 - When `backend = "computer_use"`, the agent delegates browser actions to the sidecar at `computer_use.endpoint`.
 - `allow_remote_endpoint = false` (default) rejects any non-loopback endpoint to prevent accidental public exposure.
 - Use `window_allowlist` to restrict which OS windows the sidecar can interact with.

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1599,6 +1599,10 @@ pub async fn run(
             "browser_open",
             "Open approved HTTPS URLs in system browser (allowlist-only, no scraping)",
         ));
+        tool_descs.push((
+            "browser",
+            "Automate browser actions (open/click/type/scroll/screenshot) with backend-aware safety checks.",
+        ));
     }
     if config.composio.enabled {
         tool_descs.push((
@@ -2017,6 +2021,7 @@ pub async fn process_message(config: Config, message: &str) -> Result<String> {
     ];
     if config.browser.enabled {
         tool_descs.push(("browser_open", "Open approved URLs in browser."));
+        tool_descs.push(("browser", "Automate browser interactions."));
     }
     if config.composio.enabled {
         tool_descs.push(("composio", "Execute actions on 1000+ apps via Composio."));

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4690,6 +4690,10 @@ pub async fn start_channels(config: Config) -> Result<()> {
             "browser_open",
             "Open approved HTTPS URLs in system browser (allowlist-only, no scraping)",
         ));
+        tool_descs.push((
+            "browser",
+            "Automate browser actions (open/click/type/scroll/screenshot) with backend-aware safety checks.",
+        ));
     }
     if config.composio.enabled {
         tool_descs.push((


### PR DESCRIPTION
## Summary
- include `browser` alongside `browser_open` in CLI/channel tool descriptions
- clarify `[browser]` docs that `enabled` controls both browser tools
- document the difference between URL opener and full browser automation

## Validation
- cargo check

Closes #1722