### PR TITLE
fix(web): add collapsible mobile sidebar and responsive offset

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useLocation } from 'react-router-dom';
-import { LogOut } from 'lucide-react';
+import { LogOut, Menu } from 'lucide-react';
 import { t } from '@/lib/i18n';
 import type { Locale } from '@/lib/i18n';
 import { useLocaleContext } from '@/App';
@@ -20,7 +20,11 @@ const routeTitles: Record<string, string> = {
 
 const localeCycle: Locale[] = ['en', 'tr', 'zh-CN'];
 
-export default function Header() {
+interface HeaderProps {
+  onToggleSidebar: () => void;
+}
+
+export default function Header({ onToggleSidebar }: HeaderProps) {
   const location = useLocation();
   const { logout } = useAuth();
   const { locale, setAppLocale } = useLocaleContext();
@@ -35,13 +39,20 @@ export default function Header() {
   };
 
   return (
-    <header className="h-14 bg-gray-800 border-b border-gray-700 flex items-center justify-between px-6">
-      {/* Page title */}
-      <h1 className="text-lg font-semibold text-white">{pageTitle}</h1>
+    <header className="h-14 bg-gray-800 border-b border-gray-700 flex items-center justify-between px-4 md:px-6">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onToggleSidebar}
+          aria-label="Open navigation"
+          className="md:hidden p-1.5 rounded-md text-gray-300 hover:bg-gray-700 hover:text-white transition-colors"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
+        <h1 className="text-lg font-semibold text-white">{pageTitle}</h1>
+      </div>
 
-      {/* Right-side controls */}
-      <div className="flex items-center gap-4">
-        {/* Language switcher */}
+      <div className="flex items-center gap-2 md:gap-4">
         <button
           type="button"
           onClick={toggleLanguage}
@@ -50,14 +61,13 @@ export default function Header() {
           {locale === 'en' ? 'EN' : locale === 'tr' ? 'TR' : '中文'}
         </button>
 
-        {/* Logout */}
         <button
           type="button"
           onClick={logout}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors"
         >
           <LogOut className="h-4 w-4" />
-          <span>{t('auth.logout')}</span>
+          <span className="hidden sm:inline">{t('auth.logout')}</span>
         </button>
       </div>
     </header>

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,18 +1,18 @@
 import { Outlet } from 'react-router-dom';
+import { useState } from 'react';
 import Sidebar from '@/components/layout/Sidebar';
 import Header from '@/components/layout/Header';
 
 export default function Layout() {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   return (
     <div className="min-h-screen bg-gray-950 text-white">
-      {/* Fixed sidebar */}
-      <Sidebar />
+      <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
-      {/* Main area offset by sidebar width (240px / w-60) */}
-      <div className="ml-60 flex flex-col min-h-screen">
-        <Header />
+      <div className="md:ml-60 flex flex-col min-h-screen">
+        <Header onToggleSidebar={() => setSidebarOpen((open) => !open)} />
 
-        {/* Page content */}
         <main className="flex-1 overflow-y-auto">
           <Outlet />
         </main>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   DollarSign,
   Activity,
   Stethoscope,
+  X,
 } from 'lucide-react';
 import { t } from '@/lib/i18n';
 
@@ -26,40 +27,72 @@ const navItems = [
   { to: '/doctor', icon: Stethoscope, labelKey: 'nav.doctor' },
 ];
 
-export default function Sidebar() {
-  return (
-    <aside className="fixed top-0 left-0 h-screen w-60 bg-gray-900 flex flex-col border-r border-gray-800">
-      {/* Logo / Title */}
-      <div className="flex items-center gap-2 px-5 py-5 border-b border-gray-800">
-        <div className="h-8 w-8 rounded-lg bg-blue-600 flex items-center justify-center text-white font-bold text-sm">
-          ZC
-        </div>
-        <span className="text-lg font-semibold text-white tracking-wide">
-          ZeroClaw
-        </span>
-      </div>
+interface SidebarProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
 
-      {/* Navigation */}
-      <nav className="flex-1 overflow-y-auto py-4 px-3 space-y-1">
-        {navItems.map(({ to, icon: Icon, labelKey }) => (
-          <NavLink
-            key={to}
-            to={to}
-            end={to === '/'}
-            className={({ isActive }) =>
-              [
-                'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors',
-                isActive
-                  ? 'bg-blue-600 text-white'
-                  : 'text-gray-300 hover:bg-gray-800 hover:text-white',
-              ].join(' ')
-            }
+export default function Sidebar({ isOpen, onClose }: SidebarProps) {
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Close navigation"
+        onClick={onClose}
+        className={[
+          'fixed inset-0 z-30 bg-black/50 transition-opacity md:hidden',
+          isOpen ? 'opacity-100' : 'pointer-events-none opacity-0',
+        ].join(' ')}
+      />
+      <aside
+        className={[
+          'fixed top-0 left-0 z-40 h-screen w-60 bg-gray-900 flex flex-col border-r border-gray-800',
+          'transform transition-transform duration-200 ease-out',
+          isOpen ? 'translate-x-0' : '-translate-x-full',
+          'md:translate-x-0',
+        ].join(' ')}
+      >
+        <div className="flex items-center justify-between px-5 py-5 border-b border-gray-800">
+          <div className="flex items-center gap-2">
+            <div className="h-8 w-8 rounded-lg bg-blue-600 flex items-center justify-center text-white font-bold text-sm">
+              ZC
+            </div>
+            <span className="text-lg font-semibold text-white tracking-wide">
+              ZeroClaw
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close navigation"
+            className="md:hidden p-1.5 rounded-md text-gray-300 hover:bg-gray-800 hover:text-white transition-colors"
           >
-            <Icon className="h-5 w-5 flex-shrink-0" />
-            <span>{t(labelKey)}</span>
-          </NavLink>
-        ))}
-      </nav>
-    </aside>
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <nav className="flex-1 overflow-y-auto py-4 px-3 space-y-1">
+          {navItems.map(({ to, icon: Icon, labelKey }) => (
+            <NavLink
+              key={to}
+              to={to}
+              end={to === '/'}
+              onClick={onClose}
+              className={({ isActive }) =>
+                [
+                  'flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors',
+                  isActive
+                    ? 'bg-blue-600 text-white'
+                    : 'text-gray-300 hover:bg-gray-800 hover:text-white',
+                ].join(' ')
+              }
+            >
+              <Icon className="h-5 w-5 flex-shrink-0" />
+              <span>{t(labelKey)}</span>
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add mobile menu toggle in header
- convert sidebar to off-canvas drawer on small screens with overlay/close actions
- use `md:ml-60` content offset so mobile content is full width

## Validation
- npm ci (web)
- npm run build (web)

Closes #1723