### PR TITLE
feat(security): unify URL validation with configurable CIDR/domain allowlist

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -148,6 +148,31 @@ Notes:
 - Corrupted/unreadable estop state falls back to fail-closed `kill_all`.
 - Use CLI command `zeroclaw estop` to engage and `zeroclaw estop resume` to clear levels.
 
+## `[security.url_access]`
+
+| Key | Default | Purpose |
+|---|---|---|
+| `block_private_ip` | `true` | Block local/private/link-local/multicast addresses by default |
+| `allow_cidrs` | `[]` | CIDR ranges allowed to bypass private-IP blocking (`100.64.0.0/10`, `198.18.0.0/15`) |
+| `allow_domains` | `[]` | Domain patterns that bypass private-IP blocking before DNS checks (`internal.example`, `*.svc.local`) |
+| `allow_loopback` | `false` | Permit loopback targets (`localhost`, `127.0.0.1`, `::1`) |
+
+Notes:
+
+- This policy is shared by `browser_open`, `http_request`, and `web_fetch`.
+- Tool-level allowlists still apply. `allow_domains` / `allow_cidrs` only override private/local blocking.
+- DNS rebinding protection remains enabled: resolved local/private IPs are denied unless explicitly allowlisted.
+
+Example:
+
+```toml
+[security.url_access]
+block_private_ip = true
+allow_cidrs = ["100.64.0.0/10", "198.18.0.0/15"]
+allow_domains = ["internal.example", "*.svc.local"]
+allow_loopback = false
+```
+
 ## `[security.syscall_anomaly]`
 
 | Key | Default | Purpose |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -19,9 +19,9 @@ pub use schema::{
     SandboxBackend, SandboxConfig, SchedulerConfig, SecretsConfig, SecurityConfig,
     SecurityRoleConfig, SkillsConfig, SkillsPromptInjectionMode, SlackConfig, StorageConfig,
     StorageProviderConfig, StorageProviderSection, StreamMode, SyscallAnomalyConfig,
-    TelegramConfig, TranscriptionConfig, TunnelConfig, WasmCapabilityEscalationMode,
-    WasmModuleHashPolicy, WasmRuntimeConfig, WasmSecurityConfig, WebFetchConfig, WebSearchConfig,
-    WebhookConfig,
+    TelegramConfig, TranscriptionConfig, TunnelConfig, UrlAccessConfig,
+    WasmCapabilityEscalationMode, WasmModuleHashPolicy, WasmRuntimeConfig, WasmSecurityConfig,
+    WebFetchConfig, WebSearchConfig, WebhookConfig,
 };
 
 pub fn name_and_presence<T: traits::ChannelConfig>(channel: Option<&T>) -> (&'static str, bool) {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -314,6 +314,7 @@ pub fn all_tools_with_runtime(
         tool_arcs.push(Arc::new(BrowserOpenTool::new(
             security.clone(),
             browser_config.allowed_domains.clone(),
+            root_config.security.url_access.clone(),
         )));
         // Add full browser automation tool (pluggable backend)
         tool_arcs.push(Arc::new(BrowserTool::new_with_backend(
@@ -340,6 +341,7 @@ pub fn all_tools_with_runtime(
         tool_arcs.push(Arc::new(HttpRequestTool::new(
             security.clone(),
             http_config.allowed_domains.clone(),
+            root_config.security.url_access.clone(),
             http_config.max_response_size,
             http_config.timeout_secs,
             http_config.user_agent.clone(),
@@ -354,6 +356,7 @@ pub fn all_tools_with_runtime(
             web_fetch_config.api_url.clone(),
             web_fetch_config.allowed_domains.clone(),
             web_fetch_config.blocked_domains.clone(),
+            root_config.security.url_access.clone(),
             web_fetch_config.max_response_size,
             web_fetch_config.timeout_secs,
             web_fetch_config.user_agent.clone(),

--- a/src/tools/url_validation.rs
+++ b/src/tools/url_validation.rs
@@ -1,4 +1,6 @@
-use anyhow::Result;
+use crate::config::UrlAccessConfig;
+use anyhow::{Context, Result};
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 
 #[derive(Debug, Clone, Copy)]
 pub enum UrlSchemePolicy {
@@ -15,6 +17,7 @@ pub struct DomainPolicy<'a> {
     pub empty_allowed_message: &'a str,
     pub scheme_policy: UrlSchemePolicy,
     pub ipv6_error_context: &'a str,
+    pub url_access: Option<&'a UrlAccessConfig>,
 }
 
 pub fn validate_url(raw_url: &str, policy: &DomainPolicy<'_>) -> Result<String> {
@@ -34,10 +37,6 @@ pub fn validate_url(raw_url: &str, policy: &DomainPolicy<'_>) -> Result<String> 
 
     let host = extract_host(url, policy.scheme_policy, policy.ipv6_error_context)?;
 
-    if is_private_or_local_host(&host) {
-        anyhow::bail!("Blocked local/private host: {host}");
-    }
-
     if let Some(blocked_field_name) = policy.blocked_field_name {
         if host_matches_allowlist(&host, policy.blocked_domains) {
             anyhow::bail!("Host '{host}' is in {blocked_field_name}");
@@ -48,7 +47,135 @@ pub fn validate_url(raw_url: &str, policy: &DomainPolicy<'_>) -> Result<String> 
         anyhow::bail!("Host '{host}' is not in {}", policy.allowed_field_name);
     }
 
+    enforce_private_host_policy(&host, policy.url_access)?;
+
     Ok(url.to_string())
+}
+
+fn enforce_private_host_policy(host: &str, url_access: Option<&UrlAccessConfig>) -> Result<()> {
+    let config = url_access.cloned().unwrap_or_default();
+    if !config.block_private_ip {
+        return Ok(());
+    }
+
+    // Domain allowlist has highest priority for private/local blocking.
+    if host_matches_allowlist(host, &config.allow_domains) {
+        return Ok(());
+    }
+
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if is_non_global_ip(ip) && !is_ip_explicitly_allowed(ip, &config) {
+            anyhow::bail!("Blocked local/private host: {host}");
+        }
+        return Ok(());
+    }
+
+    if is_local_hostname(host) && !config.allow_loopback {
+        anyhow::bail!("Blocked local/private host: {host}");
+    }
+
+    // DNS rebinding defense: resolve host and deny if any resolved address is
+    // private/local unless explicitly allowlisted.
+    let mut resolved = Vec::new();
+    for default_port in [80_u16, 443_u16] {
+        let lookup = (host, default_port).to_socket_addrs();
+        if let Ok(addrs) = lookup {
+            resolved.extend(addrs.map(|addr: SocketAddr| addr.ip()));
+            if !resolved.is_empty() {
+                break;
+            }
+        }
+    }
+
+    for ip in resolved {
+        if is_non_global_ip(ip) && !is_ip_explicitly_allowed(ip, &config) {
+            anyhow::bail!("Blocked local/private host after DNS resolution: {host} -> {ip}");
+        }
+    }
+
+    Ok(())
+}
+
+fn is_ip_explicitly_allowed(ip: IpAddr, config: &UrlAccessConfig) -> bool {
+    if config.allow_loopback && ip.is_loopback() {
+        return true;
+    }
+
+    config
+        .allow_cidrs
+        .iter()
+        .filter_map(|raw| parse_cidr(raw).ok())
+        .any(|cidr| cidr_contains_ip(cidr, ip))
+}
+
+fn is_non_global_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_non_global_v4(v4),
+        IpAddr::V6(v6) => is_non_global_v6(v6),
+    }
+}
+
+fn parse_cidr(raw: &str) -> anyhow::Result<(IpAddr, u8)> {
+    let (ip_raw, prefix_raw) = raw
+        .trim()
+        .split_once('/')
+        .ok_or_else(|| anyhow::anyhow!("missing '/' separator"))?;
+    let ip = ip_raw
+        .trim()
+        .parse::<IpAddr>()
+        .with_context(|| format!("invalid IP '{ip_raw}'"))?;
+    let prefix = prefix_raw
+        .trim()
+        .parse::<u8>()
+        .with_context(|| format!("invalid prefix '{prefix_raw}'"))?;
+    let max_prefix = match ip {
+        IpAddr::V4(_) => 32,
+        IpAddr::V6(_) => 128,
+    };
+    if prefix > max_prefix {
+        anyhow::bail!("prefix {prefix} exceeds max {max_prefix}");
+    }
+    Ok((ip, prefix))
+}
+
+fn cidr_contains_ip(cidr: (IpAddr, u8), ip: IpAddr) -> bool {
+    match (cidr.0, ip) {
+        (IpAddr::V4(net), IpAddr::V4(candidate)) => {
+            let net_u32 = u32::from(net);
+            let ip_u32 = u32::from(candidate);
+            let prefix = cidr.1;
+            let mask = if prefix == 0 {
+                0
+            } else {
+                u32::MAX << (32 - prefix)
+            };
+            (net_u32 & mask) == (ip_u32 & mask)
+        }
+        (IpAddr::V6(net), IpAddr::V6(candidate)) => {
+            let net_u128 = u128::from(net);
+            let ip_u128 = u128::from(candidate);
+            let prefix = cidr.1;
+            let mask = if prefix == 0 {
+                0
+            } else {
+                u128::MAX << (128 - prefix)
+            };
+            (net_u128 & mask) == (ip_u128 & mask)
+        }
+        _ => false,
+    }
+}
+
+fn is_local_hostname(host: &str) -> bool {
+    let bare = host
+        .strip_prefix('[')
+        .and_then(|h| h.strip_suffix(']'))
+        .unwrap_or(host);
+    let has_local_tld = bare
+        .rsplit('.')
+        .next()
+        .is_some_and(|label| label == "local");
+    bare == "localhost" || bare.ends_with(".localhost") || has_local_tld
 }
 
 pub fn normalize_allowed_domains(domains: Vec<String>) -> Vec<String> {
@@ -157,12 +284,7 @@ pub fn is_private_or_local_host(host: &str) -> bool {
         .and_then(|h| h.strip_suffix(']'))
         .unwrap_or(host);
 
-    let has_local_tld = bare
-        .rsplit('.')
-        .next()
-        .is_some_and(|label| label == "local");
-
-    if bare == "localhost" || bare.ends_with(".localhost") || has_local_tld {
+    if is_local_hostname(bare) {
         return true;
     }
 
@@ -349,6 +471,7 @@ mod tests {
             empty_allowed_message: "allowed domains must be configured",
             scheme_policy: UrlSchemePolicy::HttpOrHttps,
             ipv6_error_context: "web_fetch",
+            url_access: None,
         }
     }
 
@@ -399,5 +522,47 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("allowed domains must be configured"));
+    }
+
+    #[test]
+    fn validate_url_allows_private_ip_when_cidr_allowlisted() {
+        let allowed = vec!["*".to_string()];
+        let blocked: Vec<String> = Vec::new();
+        let url_access = UrlAccessConfig {
+            allow_cidrs: vec!["10.0.0.0/8".to_string()],
+            ..UrlAccessConfig::default()
+        };
+        let policy = DomainPolicy {
+            url_access: Some(&url_access),
+            ..policy(&allowed, &blocked)
+        };
+        let got = validate_url("https://10.1.2.3", &policy).unwrap();
+        assert_eq!(got, "https://10.1.2.3");
+    }
+
+    #[test]
+    fn validate_url_allows_localhost_when_domain_allowlisted() {
+        let allowed = vec!["localhost".to_string()];
+        let blocked: Vec<String> = Vec::new();
+        let url_access = UrlAccessConfig {
+            allow_domains: vec!["localhost".to_string()],
+            ..UrlAccessConfig::default()
+        };
+        let policy = DomainPolicy {
+            url_access: Some(&url_access),
+            ..policy(&allowed, &blocked)
+        };
+        let got = validate_url("https://localhost:8080", &policy).unwrap();
+        assert_eq!(got, "https://localhost:8080");
+    }
+
+    #[test]
+    fn validate_url_rejects_localhost_when_not_allowlisted() {
+        let allowed = vec!["*".to_string()];
+        let blocked: Vec<String> = Vec::new();
+        let err = validate_url("https://localhost:8080", &policy(&allowed, &blocked))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("local/private"));
     }
 }

--- a/src/tools/web_fetch.rs
+++ b/src/tools/web_fetch.rs
@@ -2,6 +2,7 @@ use super::traits::{Tool, ToolResult};
 use super::url_validation::{
     normalize_allowed_domains, validate_url, DomainPolicy, UrlSchemePolicy,
 };
+use crate::config::UrlAccessConfig;
 use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use serde_json::json;
@@ -21,6 +22,7 @@ pub struct WebFetchTool {
     api_url: Option<String>,
     allowed_domains: Vec<String>,
     blocked_domains: Vec<String>,
+    url_access: UrlAccessConfig,
     max_response_size: usize,
     timeout_secs: u64,
     user_agent: String,
@@ -35,6 +37,7 @@ impl WebFetchTool {
         api_url: Option<String>,
         allowed_domains: Vec<String>,
         blocked_domains: Vec<String>,
+        url_access: UrlAccessConfig,
         max_response_size: usize,
         timeout_secs: u64,
         user_agent: String,
@@ -51,6 +54,7 @@ impl WebFetchTool {
             api_url,
             allowed_domains: normalize_allowed_domains(allowed_domains),
             blocked_domains: normalize_allowed_domains(blocked_domains),
+            url_access,
             max_response_size,
             timeout_secs,
             user_agent,
@@ -68,6 +72,7 @@ impl WebFetchTool {
                 empty_allowed_message: "web_fetch tool is enabled but no allowed_domains are configured. Add [web_fetch].allowed_domains in config.toml",
                 scheme_policy: UrlSchemePolicy::HttpOrHttps,
                 ipv6_error_context: "web_fetch",
+                url_access: Some(&self.url_access),
             },
         )
     }
@@ -393,6 +398,7 @@ mod tests {
             api_url.map(ToOwned::to_owned),
             allowed_domains.into_iter().map(String::from).collect(),
             blocked_domains.into_iter().map(String::from).collect(),
+            UrlAccessConfig::default(),
             500_000,
             30,
             "ZeroClaw/1.0".to_string(),
@@ -500,6 +506,7 @@ mod tests {
             None,
             vec![],
             vec![],
+            UrlAccessConfig::default(),
             500_000,
             30,
             "test".to_string(),
@@ -567,6 +574,7 @@ mod tests {
             None,
             vec!["example.com".into()],
             vec![],
+            UrlAccessConfig::default(),
             500_000,
             30,
             "test".to_string(),
@@ -592,6 +600,7 @@ mod tests {
             None,
             vec!["example.com".into()],
             vec![],
+            UrlAccessConfig::default(),
             500_000,
             30,
             "test".to_string(),
@@ -620,6 +629,7 @@ mod tests {
             None,
             vec!["example.com".into()],
             vec![],
+            UrlAccessConfig::default(),
             10,
             30,
             "test".to_string(),


### PR DESCRIPTION
## Summary\n- unify URL validation in network tools\n- add shared [security.url_access] policy with CIDR/domain/loopback controls\n- wire policy into browser_open, http_request, and web_fetch\n- add validation tests and config docs\n\n## Validation\n- cargo fmt --all\n- cargo check --offline\n- cargo test --offline security_validation_rejects_invalid_url_access_cidr -- --nocapture\n- cargo test --offline security_validation_rejects_blank_url_access_domain -- --nocapture\n\nCloses #1800