### PR TITLE
feat(skills): add WASM skill engine with secure registry install

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,9 @@ indent_size = 4
 # Trailing whitespace is significant in Markdown (line breaks).
 trim_trailing_whitespace = false
 
+[*.go]
+indent_style = tab
+
 [*.{yml,yaml}]
 indent_size = 2
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8516,6 +8516,7 @@ dependencies = [
  "webpki-roots 1.0.6",
  "which",
  "wiremock",
+ "zip",
 ]
 
 [[package]]
@@ -8653,6 +8654,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.116",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,11 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png"]
 # URL encoding for web search
 urlencoding = "2.1"
 
-# HTML conversion providers (web_fetch tool)
-fast_html2md = { version = "0.0.58", optional = true }
-nanohtml2text = { version = "0.2", optional = true }
+# HTML to plain text conversion (web_fetch tool)
+nanohtml2text = "0.2"
+
+# Zip archive extraction
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
 
 # Optional Rust-native browser automation backend
 fantoccini = { version = "0.22.0", optional = true, default-features = false, features = ["rustls-tls"] }
@@ -104,7 +106,6 @@ prost = { version = "0.14", default-features = false, features = ["derive"], opt
 # Memory / persistence
 rusqlite = { version = "0.37", features = ["bundled"] }
 postgres = { version = "0.19", features = ["with-chrono-0_4"], optional = true }
-tokio-postgres-rustls = { version = "0.12", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std", "serde"] }
 chrono-tz = "0.10"
 cron = "0.15"
@@ -172,6 +173,11 @@ probe-rs = { version = "0.31", optional = true }
 pdf-extract = { version = "0.10", optional = true }
 tempfile = "3.14"
 
+# WASM plugin runtime (optional, enable with --features wasm-tools)
+# Uses WASI stdio protocol — tools read JSON from stdin, write JSON to stdout.
+wasmtime = { version = "28", optional = true, default-features = false, features = ["cranelift", "runtime"] }
+wasmtime-wasi = { version = "28", optional = true, default-features = false, features = ["preview1"] }
+
 # Terminal QR rendering for WhatsApp Web pairing flow.
 qrcode = { version = "0.14", optional = true }
 
@@ -189,16 +195,17 @@ wa-rs-tokio-transport = { version = "0.2", optional = true, default-features = f
 rppal = { version = "0.22", optional = true }
 landlock = { version = "0.4", optional = true }
 
+# Unix-specific dependencies (for root check, etc.)
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [features]
-default = ["channel-lark", "web-fetch-html2md"]
+default = ["wasm-tools"]
 hardware = ["nusb", "tokio-serial"]
 channel-matrix = ["dep:matrix-sdk"]
 channel-lark = ["dep:prost"]
-memory-postgres = ["dep:postgres", "dep:tokio-postgres-rustls"]
+memory-postgres = ["dep:postgres"]
 observability-otel = ["dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp"]
-web-fetch-html2md = ["dep:fast_html2md"]
-web-fetch-plaintext = ["dep:nanohtml2text"]
-firecrawl = []
 peripheral-rpi = ["rppal"]
 # Browser backend feature alias used by cfg(feature = "browser-native")
 browser-native = ["dep:fantoccini"]
@@ -215,6 +222,8 @@ landlock = ["sandbox-landlock"]
 probe = ["dep:probe-rs"]
 # rag-pdf = PDF ingestion for datasheet RAG
 rag-pdf = ["dep:pdf-extract"]
+# wasm-tools = WASM plugin engine for dynamically-loaded tool packages (WASI stdio protocol)
+wasm-tools = ["dep:wasmtime", "dep:wasmtime-wasi"]
 # whatsapp-web = Native WhatsApp Web client with custom rusqlite storage backend
 whatsapp-web = ["dep:wa-rs", "dep:wa-rs-core", "dep:wa-rs-binary", "dep:wa-rs-proto", "dep:wa-rs-ureq-http", "dep:wa-rs-tokio-transport", "dep:serde-big-array", "dep:prost", "dep:qrcode"]
 
@@ -240,14 +249,10 @@ strip = true
 panic = "abort"
 
 [dev-dependencies]
-tempfile = "3.26"
+tempfile = "3.14"
 criterion = { version = "0.8", features = ["async_tokio"] }
 wiremock = "0.6"
 scopeguard = "1.2"
-
-[[bin]]
-name = "zeroclaw"
-path = "src/main.rs"
 
 [[bench]]
 name = "agent_benchmarks"

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Every subsystem is a **trait** — swap implementations with a config change, ze
 | **AI Models**     | `Provider`       | Provider catalog via `zeroclaw providers` (built-ins + aliases, plus custom endpoints)                                                                                     | `custom:https://your-api.com` (OpenAI-compatible) or `anthropic-custom:https://your-api.com` |
 | **Channels**      | `Channel`        | CLI, Telegram, Discord, Slack, Mattermost, iMessage, Matrix, Signal, WhatsApp, Linq, Email, IRC, Lark, DingTalk, QQ, Nostr, Webhook                                        | Any messaging API                                                                            |
 | **Memory**        | `Memory`         | SQLite hybrid search, PostgreSQL backend (configurable storage provider), Lucid bridge, Markdown files, explicit `none` backend, snapshot/hydrate, optional response cache | Any persistence backend                                                                      |
-| **Tools**         | `Tool`           | shell/file/memory, cron/schedule, git, pushover, browser, http_request, screenshot/image_info, composio (opt-in), delegate, hardware tools                                 | Any capability                                                                               |
+| **Tools**         | `Tool`           | shell/file/memory, cron/schedule, git, pushover, browser, http_request, screenshot/image_info, composio (opt-in), delegate, hardware tools, **WASM skills** (opt-in)       | Any capability                                                                               |
 | **Observability** | `Observer`       | Noop, Log, Multi                                                                                                                                                           | Prometheus, OTel                                                                             |
 | **Runtime**       | `RuntimeAdapter` | Native, Docker (sandboxed)                                                                                                                                                 | Additional runtimes can be added via adapter; unsupported kinds fail fast                    |
 | **Security**      | `SecurityPolicy` | Gateway pairing, sandbox, allowlists, rate limits, filesystem scoping, encrypted secrets                                                                                   | —                                                                                            |
@@ -1002,7 +1002,7 @@ See [aieos.org](https://aieos.org) for the full schema and live examples.
 | `providers`                                   | List supported providers and aliases                                                 |
 | `channel`                                     | List/start/doctor channels and bind Telegram identities                              |
 | `integrations`                                | Inspect integration setup details                                                    |
-| `skills`                                      | List/install/remove skills                                                           |
+| `skills`                                      | List/install/remove skills; supports ClawhHub URLs, local zip files, ZeroMarket registry, git remotes |
 | `migrate`                                     | Import data from other runtimes (`migrate openclaw`)                                 |
 | `completions`                                 | Generate shell completion scripts (`bash`, `fish`, `zsh`, `powershell`, `elvish`)    |
 | `hardware`                                    | USB discover/introspect/info commands                                                |
@@ -1048,6 +1048,45 @@ open_skills_enabled = true
 You can also override at runtime with `ZEROCLAW_OPEN_SKILLS_ENABLED`, `ZEROCLAW_OPEN_SKILLS_DIR`, and `ZEROCLAW_SKILLS_PROMPT_MODE` (`full` or `compact`).
 
 Skill installs are now gated by a built-in static security audit. `zeroclaw skills install <source>` blocks symlinks, script-like files, unsafe markdown link patterns, and high-risk shell payload snippets before accepting a skill. You can run `zeroclaw skills audit <source_or_name>` to validate a local directory or an installed skill manually.
+
+### WASM Skills
+
+ZeroClaw supports WASM-compiled skills installable from the [ZeroMarket](https://zeromarket.vercel.app) registry and zip-based registries like [ClawhHub](https://clawhub.ai):
+
+```bash
+# Install from ZeroMarket registry
+zeroclaw skill install namespace/name
+
+# Install from ClawhHub (auto-detected by domain)
+zeroclaw skill install https://clawhub.ai/steipete/summarize
+
+# Install using ClawhHub short prefix
+zeroclaw skill install clawhub:summarize
+
+# Install from a zip file already downloaded locally
+zeroclaw skill install ~/Downloads/summarize-1.0.0.zip
+
+# Install from any direct zip URL
+zeroclaw skill install zip:https://example.com/my-skill.zip
+```
+
+If ClawhHub returns 429 (rate limit) or requires authentication, add to `~/.zeroclaw/config.toml`:
+
+```toml
+[skills]
+clawhub_token = "your-clawhub-token"
+```
+
+Skills are installed to `~/.zeroclaw/workspace/skills/<name>/` and loaded automatically as tools at agent runtime. No system `unzip` binary required — zip extraction is handled in-process.
+
+Build with WASM tool support (enabled by default):
+
+```bash
+cargo build --release                         # wasm-tools enabled by default
+cargo build --release --no-default-features   # disable wasm-tools for smaller binary
+```
+
+Publish your own skill to ZeroMarket: compile to WASM, upload `tool.wasm`, `manifest.json`, and `SKILL.md` via the ZeroMarket upload page. Use `zeroclaw skill new <name>` to scaffold a new skill project.
 
 ## Development
 
@@ -1097,6 +1136,7 @@ Start from the docs hub for a task-oriented map:
 - Unified docs TOC: [`docs/SUMMARY.md`](docs/SUMMARY.md)
 - Commands reference: [`docs/commands-reference.md`](docs/commands-reference.md)
 - Config reference: [`docs/config-reference.md`](docs/config-reference.md)
+- WASM skills guide: [`docs/wasm-tools-guide.md`](docs/wasm-tools-guide.md)
 - Providers reference: [`docs/providers-reference.md`](docs/providers-reference.md)
 - Channels reference: [`docs/channels-reference.md`](docs/channels-reference.md)
 - Operations runbook: [`docs/operations-runbook.md`](docs/operations-runbook.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,7 @@
 
 This file is the canonical table of contents for the documentation system.
 
-Last refreshed: **February 18, 2026**.
+Last refreshed: **February 25, 2026**.
 
 ## Language Entry
 
@@ -44,6 +44,7 @@ Last refreshed: **February 18, 2026**.
 - [channels-reference.md](channels-reference.md)
 - [nextcloud-talk-setup.md](nextcloud-talk-setup.md)
 - [config-reference.md](config-reference.md)
+- [wasm-tools-guide.md](wasm-tools-guide.md)
 - [custom-providers.md](custom-providers.md)
 - [zai-glm-setup.md](zai-glm-setup.md)
 - [langgraph-integration.md](langgraph-integration.md)

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -342,6 +342,7 @@ Notes:
 | `open_skills_enabled` | `false` | Opt-in loading/sync of community `open-skills` repository |
 | `open_skills_dir` | unset | Optional local path for `open-skills` (defaults to `$HOME/open-skills` when enabled) |
 | `prompt_injection_mode` | `full` | Skill prompt verbosity: `full` (inline instructions/tools) or `compact` (name/description/location only) |
+| `clawhub_token` | unset | Optional Bearer token for authenticated ClawhHub skill downloads |
 
 Notes:
 
@@ -353,6 +354,14 @@ Notes:
 - Precedence for enable flag: `ZEROCLAW_OPEN_SKILLS_ENABLED` → `skills.open_skills_enabled` in `config.toml` → default `false`.
 - `prompt_injection_mode = "compact"` is recommended on low-context local models to reduce startup prompt size while keeping skill files available on demand.
 - Skill loading and `zeroclaw skills install` both apply a static security audit. Skills that contain symlinks, script-like files, high-risk shell payload snippets, or unsafe markdown link traversal are rejected.
+- `clawhub_token` is sent as `Authorization: Bearer <token>` when downloading from ClawhHub. Obtain a token from [https://clawhub.ai](https://clawhub.ai) after signing in. Required if the API returns 429 (rate-limited) or 401 (unauthorized) for anonymous requests.
+
+**ClawhHub token example:**
+
+```toml
+[skills]
+clawhub_token = "your-token-here"
+```
 
 ## `[composio]`
 

--- a/docs/i18n/vi/README.md
+++ b/docs/i18n/vi/README.md
@@ -57,6 +57,7 @@
 - [channels-reference.md](channels-reference.md) — khả năng kênh và hướng dẫn thiết lập
 - [matrix-e2ee-guide.md](matrix-e2ee-guide.md) — thiết lập phòng mã hóa Matrix (E2EE)
 - [config-reference.md](config-reference.md) — khóa cấu hình quan trọng và giá trị mặc định an toàn
+- [wasm-tools-guide.md](wasm-tools-guide.md) — tạo, cài đặt và xuất bản WASM skills
 - [custom-providers.md](custom-providers.md) — mẫu tích hợp provider / base URL tùy chỉnh
 - [zai-glm-setup.md](zai-glm-setup.md) — thiết lập Z.AI/GLM và ma trận endpoint
 - [langgraph-integration.md](langgraph-integration.md) — tích hợp dự phòng cho model/tool-calling

--- a/docs/wasm-tools-guide.md
+++ b/docs/wasm-tools-guide.md
@@ -1,0 +1,689 @@
+# WASM Tools Guide
+
+This guide covers everything you need to build, install, and use WASM-based tools
+(skills) in ZeroClaw. WASM tools let you extend the agent with custom capabilities
+written in any language that compiles to WebAssembly — without modifying ZeroClaw's
+core source code.
+
+---
+
+## Table of Contents
+
+1. [How It Works](#1-how-it-works)
+2. [Prerequisites](#2-prerequisites)
+3. [Creating a Tool](#3-creating-a-tool)
+   - [Scaffold from template](#31-scaffold-from-template)
+   - [Protocol: stdin / stdout](#32-protocol-stdin--stdout)
+   - [manifest.json](#33-manifestjson)
+   - [Template: Rust](#34-template-rust)
+   - [Template: TypeScript](#35-template-typescript)
+   - [Template: Go](#36-template-go)
+   - [Template: Python](#37-template-python)
+4. [Building](#4-building)
+5. [Testing Locally](#5-testing-locally)
+6. [Installing](#6-installing)
+   - [From a local path](#61-install-from-a-local-path)
+   - [From a git repository](#62-install-from-a-git-repository)
+   - [From ZeroMarket registry](#63-install-from-zeromarket-registry)
+7. [How ZeroClaw Loads and Uses the Tool](#7-how-zeroclaw-loads-and-uses-the-tool)
+8. [Directory Layout Reference](#8-directory-layout-reference)
+9. [Configuration (`[wasm]` section)](#9-configuration-wasm-section)
+10. [Security Model](#10-security-model)
+11. [Troubleshooting](#11-troubleshooting)
+
+---
+
+## 1. How It Works
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Your WASM tool (.wasm binary)                              │
+│                                                             │
+│  stdin  ← JSON args from LLM                                │
+│  stdout → JSON result { success, output, error }            │
+└───────────────────────┬─────────────────────────────────────┘
+                        │  WASI stdio protocol
+┌───────────────────────▼─────────────────────────────────────┐
+│  ZeroClaw WASM engine (wasmtime + WASI)                     │
+│                                                             │
+│  • loads tool.wasm + manifest.json from skills/ directory   │
+│  • registers the tool with the agent's tool registry        │
+│  • invokes the tool when the LLM selects it                 │
+│  • enforces memory, fuel, and output size limits            │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The key insight: **no custom SDK or ABI boilerplate**. Any language that can read
+from stdin and write to stdout works. The only contract is the JSON shape described
+in [section 2](#32-protocol-stdin--stdout).
+
+---
+
+## 2. Prerequisites
+
+| Requirement | Purpose |
+|---|---|
+| ZeroClaw built with `--features wasm-tools` | Enables the WASM runtime |
+| `wasmtime` CLI | Local testing (`zeroclaw skill test`) |
+| Language-specific toolchain | Building `.wasm` from source |
+
+Install `wasmtime` CLI:
+
+```bash
+# macOS / Linux
+curl https://wasmtime.dev/install.sh -sSf | bash
+
+# Or via cargo
+cargo install wasmtime-cli
+```
+
+Enable WASM support at compile time:
+
+```bash
+cargo build --release --features wasm-tools
+```
+
+---
+
+## 3. Creating a Tool
+
+### 3.1 Scaffold from template
+
+```bash
+zeroclaw skill new <name> --template <typescript|rust|go|python>
+```
+
+Example:
+
+```bash
+zeroclaw skill new weather_lookup --template rust
+```
+
+This creates a new directory `./weather_lookup/` with all boilerplate files ready
+to build. The `--template` flag defaults to `typescript` if omitted.
+
+Supported templates:
+
+| Template | Runtime | Build tool |
+|---|---|---|
+| `typescript` | Javy (JS → WASM) | `npm run build` |
+| `rust` | native wasm32-wasip1 | `cargo build` |
+| `go` | TinyGo | `tinygo build` |
+| `python` | componentize-py | `componentize-py` |
+
+---
+
+### 3.2 Protocol: stdin / stdout
+
+Every WASM tool must follow this single contract:
+
+**Input** (written to the tool's stdin by ZeroClaw):
+
+```json
+{ "param1": "value1", "param2": 42 }
+```
+
+The shape of the input object is whatever you define in `manifest.json` under
+`parameters`. ZeroClaw passes the LLM-provided argument object verbatim.
+
+**Output** (read from the tool's stdout by ZeroClaw):
+
+```json
+{ "success": true,  "output": "result text shown to LLM", "error": null }
+{ "success": false, "output": "",                          "error": "reason" }
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `success` | bool | yes | `true` if tool completed normally |
+| `output` | string | yes | Result text forwarded to the LLM |
+| `error` | string or null | yes | Error message when `success` is `false` |
+
+---
+
+### 3.3 manifest.json
+
+Every tool must ship a `manifest.json` alongside `tool.wasm`. This file tells
+ZeroClaw the tool's name, description, and the JSON Schema for its parameters.
+
+```json
+{
+  "name": "weather_lookup",
+  "description": "Fetches the current weather for a given city name.",
+  "version": "1",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "city": {
+        "type": "string",
+        "description": "City name to look up (e.g. Hanoi, Tokyo)"
+      },
+      "units": {
+        "type": "string",
+        "enum": ["metric", "imperial"],
+        "description": "Temperature unit system"
+      }
+    },
+    "required": ["city"]
+  },
+  "homepage": "https://github.com/yourname/weather_lookup"
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | yes | snake_case tool name exposed to the LLM |
+| `description` | yes | Human-readable description (shown to LLM for tool selection) |
+| `version` | no | Manifest format version, default `"1"` |
+| `parameters` | yes | JSON Schema for the tool's input parameters |
+| `homepage` | no | Optional URL shown in `zeroclaw skill list` |
+
+The `name` field is the identifier the LLM uses when it decides to call your tool.
+Keep it descriptive and unique.
+
+---
+
+### 3.4 Template: Rust
+
+**Scaffolded files:** `Cargo.toml`, `src/lib.rs`, `.cargo/config.toml`
+
+`src/lib.rs`:
+
+```rust
+use std::io::{self, Read, Write};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct Args {
+    city: String,
+    #[serde(default)]
+    units: String,
+}
+
+#[derive(Serialize)]
+struct ToolResult {
+    success: bool,
+    output: String,
+    error: Option<String>,
+}
+
+fn main() {
+    let mut buf = String::new();
+    io::stdin().read_to_string(&mut buf).unwrap();
+
+    let result = match serde_json::from_str::<Args>(&buf) {
+        Ok(args) => run(args),
+        Err(e) => ToolResult {
+            success: false,
+            output: String::new(),
+            error: Some(format!("invalid input: {e}")),
+        },
+    };
+
+    io::stdout()
+        .write_all(serde_json::to_string(&result).unwrap().as_bytes())
+        .unwrap();
+}
+
+fn run(args: Args) -> ToolResult {
+    // Your logic here
+    ToolResult {
+        success: true,
+        output: format!("Weather in {}: sunny 28°C", args.city),
+        error: None,
+    }
+}
+```
+
+**Build:**
+
+```bash
+# Add the target once
+rustup target add wasm32-wasip1
+
+# Build
+cargo build --target wasm32-wasip1 --release
+cp target/wasm32-wasip1/release/weather_lookup.wasm tool.wasm
+```
+
+---
+
+### 3.5 Template: TypeScript
+
+**Scaffolded files:** `package.json`, `tsconfig.json`, `src/index.ts`
+
+`src/index.ts`:
+
+```typescript
+// Read input from stdin (Javy provides Javy.IO)
+const input = JSON.parse(
+  new TextDecoder().decode(Javy.IO.readSync())
+);
+
+function run(args: Record<string, unknown>): string {
+  const city = String(args["city"] ?? "");
+  // Your logic here
+  return `Weather in ${city}: sunny 28°C`;
+}
+
+try {
+  const output = run(input);
+  Javy.IO.writeSync(
+    new TextEncoder().encode(
+      JSON.stringify({ success: true, output, error: null })
+    )
+  );
+} catch (err) {
+  Javy.IO.writeSync(
+    new TextEncoder().encode(
+      JSON.stringify({ success: false, output: "", error: String(err) })
+    )
+  );
+}
+```
+
+**Build:**
+
+```bash
+# Install Javy: https://github.com/bytecodealliance/javy/releases
+npm install
+npm run build   # → tool.wasm
+```
+
+---
+
+### 3.6 Template: Go
+
+**Scaffolded files:** `go.mod`, `main.go`
+
+`main.go`:
+
+```go
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "io"
+    "os"
+)
+
+type Args struct {
+    City  string `json:"city"`
+    Units string `json:"units"`
+}
+
+type ToolResult struct {
+    Success bool    `json:"success"`
+    Output  string  `json:"output"`
+    Error   *string `json:"error"`
+}
+
+func main() {
+    data, _ := io.ReadAll(os.Stdin)
+    var args Args
+    if err := json.Unmarshal(data, &args); err != nil {
+        msg := err.Error()
+        out, _ := json.Marshal(ToolResult{Error: &msg})
+        os.Stdout.Write(out)
+        return
+    }
+    result := run(args)
+    out, _ := json.Marshal(result)
+    os.Stdout.Write(out)
+}
+
+func run(args Args) ToolResult {
+    return ToolResult{
+        Success: true,
+        Output:  fmt.Sprintf("Weather in %s: sunny 28°C", args.City),
+    }
+}
+```
+
+**Build:**
+
+```bash
+# Install TinyGo: https://tinygo.org/getting-started/install/
+tinygo build -o tool.wasm -target wasi .
+```
+
+---
+
+### 3.7 Template: Python
+
+**Scaffolded files:** `app.py`, `requirements.txt`
+
+`app.py`:
+
+```python
+import sys
+import json
+
+def run(args: dict) -> str:
+    city = str(args.get("city", ""))
+    # Your logic here
+    return f"Weather in {city}: sunny 28°C"
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        args = json.loads(raw)
+        output = run(args)
+        result = {"success": True, "output": output, "error": None}
+    except Exception as exc:
+        result = {"success": False, "output": "", "error": str(exc)}
+    sys.stdout.write(json.dumps(result))
+
+if __name__ == "__main__":
+    main()
+```
+
+**Build:**
+
+```bash
+pip install componentize-py
+componentize-py -d wit/ -w zeroclaw-skill componentize app -o tool.wasm
+```
+
+---
+
+## 4. Building
+
+After editing your tool logic, build it into `tool.wasm`:
+
+| Template | Build command | Output |
+|---|---|---|
+| Rust | `cargo build --target wasm32-wasip1 --release && cp target/wasm32-wasip1/release/*.wasm tool.wasm` | `tool.wasm` |
+| TypeScript | `npm run build` | `tool.wasm` |
+| Go | `tinygo build -o tool.wasm -target wasi .` | `tool.wasm` |
+| Python | `componentize-py -d wit/ -w zeroclaw-skill componentize app -o tool.wasm` | `tool.wasm` |
+
+The output must always be named `tool.wasm` at the root of the skill directory.
+
+---
+
+## 5. Testing Locally
+
+Before installing, test the tool directly without starting the full ZeroClaw agent:
+
+```bash
+zeroclaw skill test . --args '{"city":"Hanoi","units":"metric"}'
+```
+
+You can also test an installed skill by name:
+
+```bash
+zeroclaw skill test weather_lookup --args '{"city":"Tokyo"}'
+```
+
+Or test a specific tool inside a multi-tool skill:
+
+```bash
+zeroclaw skill test . --tool my_tool_name --args '{"city":"Paris"}'
+```
+
+Under the hood, `skill test` pipes the JSON args into `wasmtime run tool.wasm` via
+stdin and prints the raw stdout response. This lets you iterate quickly without
+restarting the agent.
+
+You can also test manually using `wasmtime` directly:
+
+```bash
+echo '{"city":"Hanoi"}' | wasmtime tool.wasm
+```
+
+Expected output:
+
+```json
+{"success":true,"output":"Weather in Hanoi: sunny 28°C","error":null}
+```
+
+---
+
+## 6. Installing
+
+### 6.1 Install from a local path
+
+```bash
+zeroclaw skill install ./weather_lookup
+```
+
+This copies your skill directory into `<workspace>/skills/weather_lookup/`.
+ZeroClaw will auto-discover it on next startup.
+
+### 6.2 Install from a git repository
+
+```bash
+zeroclaw skill install https://github.com/yourname/weather_lookup.git
+```
+
+ZeroClaw clones the repository into the skills directory and scans for WASM tools.
+
+### 6.3 Install from ZeroMarket registry
+
+```bash
+# Format: namespace/package-name
+zeroclaw skill install acme/weather-lookup
+
+# With a specific version
+zeroclaw skill install acme/weather-lookup@0.2.1
+```
+
+ZeroClaw fetches the package index from the configured registry URL, then downloads
+`tool.wasm` and `manifest.json` for each tool in the package.
+
+**Verify the install:**
+
+```bash
+zeroclaw skill list
+```
+
+---
+
+## 7. How ZeroClaw Loads and Uses the Tool
+
+### 7.1 Startup discovery
+
+Every time the ZeroClaw agent starts, it scans the `skills/` directory and loads
+all valid WASM tools automatically. No config change or restart command is needed
+after installation.
+
+```
+<workspace>/
+└── skills/
+    └── weather_lookup/           ← skill package root
+        ├── SKILL.toml
+        └── tools/
+            └── weather_lookup/   ← individual tool directory
+                ├── tool.wasm     ← compiled WASM binary
+                └── manifest.json ← tool metadata
+```
+
+A simpler "dev layout" is also supported (useful right after building):
+
+```
+<workspace>/
+└── skills/
+    └── weather_lookup/
+        ├── tool.wasm
+        └── manifest.json
+```
+
+### 7.2 Tool registration
+
+After discovery, each `WasmTool` is registered in the agent's tool registry
+alongside built-in tools like `shell`, `file`, `web_fetch`, etc. The LLM sees
+all registered tools equally — it has no way to distinguish a built-in tool from
+a WASM plugin.
+
+### 7.3 LLM tool selection
+
+When a user sends a message, the agent attaches the full tool registry (including
+all WASM tools) to the LLM context. The LLM reads each tool's `name` and
+`description` from the manifest and decides which tool to call based on the
+user's request.
+
+Example conversation:
+
+```
+User:  What is the weather in Hanoi right now?
+
+Agent: [internally, LLM selects tool "weather_lookup" with args {"city":"Hanoi"}]
+
+       ZeroClaw calls weather_lookup WASM tool:
+         stdin  → {"city":"Hanoi"}
+         stdout ← {"success":true,"output":"Weather in Hanoi: sunny 28°C","error":null}
+
+Agent: The current weather in Hanoi is sunny with a temperature of 28°C.
+```
+
+### 7.4 Invocation flow
+
+```
+LLM decides to call "weather_lookup"
+  │
+  ▼
+WasmTool::execute(args: JSON)
+  │
+  ├─ serialize args to stdin bytes
+  ├─ spin up wasmtime WASI sandbox
+  ├─ write stdin → WASM process
+  ├─ read stdout ← WASM process  (capped at 1 MiB)
+  ├─ enforce fuel limit          (≈ 1 billion instructions)
+  ├─ enforce wall-clock timeout  (30 seconds)
+  └─ deserialize ToolResult JSON
+  │
+  ▼
+Agent formats output and responds to user
+```
+
+### 7.5 Error handling
+
+If a tool fails (non-zero exit, invalid JSON, timeout, fuel exhaustion), ZeroClaw
+logs a warning and returns the error to the LLM. The agent continues running —
+a broken plugin never crashes the process.
+
+---
+
+## 8. Directory Layout Reference
+
+**Installed layout** (created by `zeroclaw skill install`):
+
+```
+skills/
+└── <skill-name>/
+    ├── SKILL.toml                 ← package metadata (shown in skill list)
+    └── tools/
+        └── <tool-name>/
+            ├── tool.wasm          ← WASM binary
+            └── manifest.json      ← tool metadata
+```
+
+**Dev layout** (for quick iteration, right after `cargo build`):
+
+```
+skills/
+└── <skill-name>/
+    ├── tool.wasm
+    └── manifest.json
+```
+
+Both layouts are discovered automatically. Use dev layout while developing, switch
+to installed layout for distribution.
+
+---
+
+## 9. Configuration (`[wasm]` section)
+
+Add this section to your `zeroclaw.toml` to tune WASM tool behavior:
+
+```toml
+[wasm]
+# Disable all WASM tools (default: true)
+enabled = true
+
+# Maximum memory per invocation in MiB, clamped 1–256 (default: 64)
+memory_limit_mb = 64
+
+# CPU fuel budget — roughly one unit per WASM instruction (default: 1_000_000_000)
+fuel_limit = 1_000_000_000
+
+# Registry URL used by `zeroclaw skill install namespace/package`
+registry_url = "https://registry.zeromarket.dev"
+```
+
+To disable all WASM tools without uninstalling them:
+
+```toml
+[wasm]
+enabled = false
+```
+
+---
+
+## 10. Security Model
+
+WASM tools run inside a strict WASI sandbox enforced by wasmtime:
+
+| Constraint | Default |
+|---|---|
+| Filesystem access | **Denied** — no preopened directories |
+| Network sockets | **Denied** — WASI network not enabled |
+| Max memory | 64 MiB (configurable, max 256 MiB) |
+| Max CPU instructions | ~1 billion (configurable) |
+| Max wall-clock time | 30 seconds hard limit |
+| Max output size | 1 MiB |
+| Registry transport | HTTPS only — HTTP is rejected |
+| Registry path traversal | Tool names validated before writing to disk |
+
+A malicious or buggy WASM tool cannot:
+- Read or write files on the host
+- Make network connections
+- Access environment variables
+- Consume unbounded CPU or memory
+- Crash the ZeroClaw process
+
+---
+
+## 11. Troubleshooting
+
+**`WASM tools are not enabled in this build`**
+
+Recompile with the feature flag:
+
+```bash
+cargo build --release
+```
+
+**`wasmtime` not found during `skill test`**
+
+Install the wasmtime CLI:
+
+```bash
+curl https://wasmtime.dev/install.sh -sSf | bash
+# or
+cargo install wasmtime-cli
+```
+
+**`WASM module must export '_start'`**
+
+Your binary must be compiled as a WASI executable (not a library). For Rust, ensure
+your `Cargo.toml` does **not** set `crate-type = ["cdylib"]` — use the default
+binary crate instead. For Go, use `tinygo build -target wasi` (not `wasm`).
+
+**`WASM tool wrote nothing to stdout`**
+
+Your tool exited without writing a JSON result. Check that your `run()` function
+always writes to stdout before returning, including in error paths.
+
+**Tool not appearing in `zeroclaw skill list`**
+
+- Verify `manifest.json` exists alongside `tool.wasm`
+- Validate the JSON is well-formed: `cat manifest.json | python3 -m json.tool`
+- Restart the agent — tools are discovered at startup
+
+**`curl failed` during registry install**
+
+Ensure `curl` is installed and the registry URL uses HTTPS. Custom registries must
+be reachable and return the expected package index JSON format.

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -274,6 +274,10 @@ pub struct Config {
     /// - `Some(false)`: force vision support off
     #[serde(default)]
     pub model_support_vision: Option<bool>,
+
+    /// WASM plugin engine configuration (`[wasm]` section).
+    #[serde(default)]
+    pub wasm: WasmConfig,
 }
 
 /// Named provider profile definition compatible with Codex app-server style config.
@@ -709,6 +713,58 @@ pub struct SkillsConfig {
     /// `full` preserves legacy behavior. `compact` keeps context small and loads skills on demand.
     #[serde(default)]
     pub prompt_injection_mode: SkillsPromptInjectionMode,
+    /// Optional ClawhHub API token for authenticated skill downloads.
+    /// Obtain from https://clawhub.ai after signing in.
+    /// Set via config: `clawhub_token = "..."` under `[skills]`.
+    #[serde(default)]
+    pub clawhub_token: Option<String>,
+}
+
+/// WASM plugin engine configuration (`[wasm]` section).
+///
+/// Controls limits applied to every WASM tool invocation.
+/// Requires the `wasm-tools` compile-time feature to have any effect.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct WasmConfig {
+    /// Enable loading WASM tools from installed skill packages.
+    /// Default: `true` (auto-discovers plugins in the skills directory).
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Maximum linear memory per WASM invocation in MiB.
+    /// Valid range: 1..=256. Default: `64`.
+    #[serde(default = "default_wasm_memory_limit_mb")]
+    pub memory_limit_mb: u64,
+    /// CPU fuel budget per invocation (roughly one unit ≈ one WASM instruction).
+    /// Default: 1_000_000_000.
+    #[serde(default = "default_wasm_fuel_limit")]
+    pub fuel_limit: u64,
+    /// URL of the ZeroMarket (or compatible) registry used by `zeroclaw skill install`.
+    /// Default: the public ZeroMarket registry.
+    #[serde(default = "default_registry_url")]
+    pub registry_url: String,
+}
+
+fn default_wasm_memory_limit_mb() -> u64 {
+    64
+}
+
+fn default_wasm_fuel_limit() -> u64 {
+    1_000_000_000
+}
+
+fn default_registry_url() -> String {
+    "https://zeromarket.vercel.app/api".to_string()
+}
+
+impl Default for WasmConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            memory_limit_mb: default_wasm_memory_limit_mb(),
+            fuel_limit: default_wasm_fuel_limit(),
+            registry_url: default_registry_url(),
+        }
+    }
 }
 
 /// Multimodal (image) handling configuration (`[multimodal]` section).
@@ -4813,6 +4869,7 @@ impl Default for Config {
             transcription: TranscriptionConfig::default(),
             agents_ipc: AgentsIpcConfig::default(),
             model_support_vision: None,
+            wasm: WasmConfig::default(),
         }
     }
 }
@@ -6204,6 +6261,34 @@ impl Config {
             anyhow::bail!("coordination.max_seen_message_ids must be greater than 0");
         }
 
+        // WASM config
+        if self.wasm.memory_limit_mb == 0 || self.wasm.memory_limit_mb > 256 {
+            anyhow::bail!(
+                "wasm.memory_limit_mb must be between 1 and 256, got {}",
+                self.wasm.memory_limit_mb
+            );
+        }
+        if self.wasm.fuel_limit == 0 {
+            anyhow::bail!("wasm.fuel_limit must be greater than 0");
+        }
+        {
+            let url = &self.wasm.registry_url;
+            // Extract what comes after "https://" and check that the host part
+            // (up to the first '/', '?', '#', or ':') is non-empty.
+            let has_valid_host = url
+                .strip_prefix("https://")
+                .map(|rest| {
+                    let host = rest.split(&['/', '?', '#', ':'][..]).next().unwrap_or("");
+                    !host.is_empty()
+                })
+                .unwrap_or(false);
+            if !has_valid_host {
+                anyhow::bail!(
+                    "wasm.registry_url must be a valid HTTPS URL with a non-empty host, got '{url}'"
+                );
+            }
+        }
+
         Ok(())
     }
 
@@ -6769,6 +6854,59 @@ mod tests {
     }
 
     #[test]
+    async fn wasm_config_default_has_correct_values() {
+        let cfg = WasmConfig::default();
+        assert!(cfg.enabled, "WASM tools should be enabled by default");
+        assert_eq!(cfg.memory_limit_mb, 64);
+        assert_eq!(cfg.fuel_limit, 1_000_000_000);
+        assert_eq!(cfg.registry_url, "https://zeromarket.vercel.app/api");
+    }
+
+    #[test]
+    async fn wasm_config_invalid_values_rejected() {
+        let mut c = Config::default();
+
+        // memory_limit_mb = 0
+        c.wasm.memory_limit_mb = 0;
+        assert!(c.validate().is_err(), "memory_limit_mb=0 should fail");
+
+        // memory_limit_mb = 257
+        c.wasm = WasmConfig::default();
+        c.wasm.memory_limit_mb = 257;
+        assert!(c.validate().is_err(), "memory_limit_mb=257 should fail");
+
+        // fuel_limit = 0
+        c.wasm = WasmConfig::default();
+        c.wasm.fuel_limit = 0;
+        assert!(c.validate().is_err(), "fuel_limit=0 should fail");
+
+        // empty registry_url
+        c.wasm = WasmConfig::default();
+        c.wasm.registry_url = String::new();
+        assert!(c.validate().is_err(), "empty registry_url should fail");
+
+        // http:// instead of https://
+        c.wasm = WasmConfig::default();
+        c.wasm.registry_url = "http://example.com".to_string();
+        assert!(c.validate().is_err(), "http registry_url should fail");
+
+        // bare "https://"
+        c.wasm = WasmConfig::default();
+        c.wasm.registry_url = "https://".to_string();
+        assert!(c.validate().is_err(), "https:// without host should fail");
+
+        // port-only, no hostname
+        c.wasm = WasmConfig::default();
+        c.wasm.registry_url = "https://:443".to_string();
+        assert!(c.validate().is_err(), "https://:443 should fail");
+
+        // query-only, no hostname
+        c.wasm = WasmConfig::default();
+        c.wasm.registry_url = "https://?q=1".to_string();
+        assert!(c.validate().is_err(), "https://?q=1 should fail");
+    }
+
+    #[test]
     async fn config_debug_redacts_sensitive_values() {
         let mut config = Config::default();
         config.workspace_dir = PathBuf::from("/tmp/workspace");
@@ -7185,6 +7323,7 @@ default_temperature = 0.7
             transcription: TranscriptionConfig::default(),
             agents_ipc: AgentsIpcConfig::default(),
             model_support_vision: None,
+            wasm: WasmConfig::default(),
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -7554,6 +7693,7 @@ tool_dispatcher = "xml"
             transcription: TranscriptionConfig::default(),
             agents_ipc: AgentsIpcConfig::default(),
             model_support_vision: None,
+            wasm: WasmConfig::default(),
         };
 
         config.save().await.unwrap();

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -953,7 +953,10 @@ async fn run_gateway_chat_simple(state: &AppState, message: &str) -> anyhow::Res
 }
 
 /// Full-featured chat with tools for channel handlers (WhatsApp, Linq, Nextcloud Talk).
-async fn run_gateway_chat_with_tools(state: &AppState, message: &str) -> anyhow::Result<String> {
+pub(super) async fn run_gateway_chat_with_tools(
+    state: &AppState,
+    message: &str,
+) -> anyhow::Result<String> {
     let config = state.config.lock().clone();
     crate::agent::process_message(config, message).await
 }

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -242,28 +242,8 @@ async fn handle_socket(mut socket: WebSocket, state: AppState) {
             "model": state.model,
         }));
 
-        // Run the agent loop with tool execution
-        let result = run_tool_call_loop(
-            state.provider.as_ref(),
-            &mut history,
-            state.tools_registry_exec.as_ref(),
-            state.observer.as_ref(),
-            &provider_label,
-            &state.model,
-            state.temperature,
-            true, // silent - no console output
-            Some(&approval_manager),
-            "webchat",
-            &state.multimodal,
-            state.max_tool_iterations,
-            None, // cancellation token
-            None, // delta streaming
-            None, // hooks
-            &[],  // excluded tools
-        )
-        .await;
-
-        match result {
+        // Full agentic loop with tools (includes WASM skills, shell, memory, etc.)
+        match super::run_gateway_chat_with_tools(&state, &content).await {
             Ok(response) => {
                 let safe_response =
                     finalize_ws_response(&response, &history, state.tools_registry_exec.as_ref());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,14 +150,33 @@ Examples:
 pub enum SkillCommands {
     /// List all installed skills
     List,
+    /// Scaffold a new skill project from a template
+    New {
+        /// Skill name (snake_case recommended, e.g. my_weather_tool)
+        name: String,
+        /// Template language: typescript, rust, go, python
+        #[arg(long, short, default_value = "typescript")]
+        template: String,
+    },
+    /// Run a skill tool locally for testing (reads args from --args or stdin)
+    Test {
+        /// Path to the skill directory or installed skill name
+        path: String,
+        /// Optional tool name inside the skill (defaults to first tool found)
+        #[arg(long)]
+        tool: Option<String>,
+        /// JSON arguments to pass to the tool, e.g. '{"city":"Hanoi"}'
+        #[arg(long, short)]
+        args: Option<String>,
+    },
     /// Audit a skill source directory or installed skill name
     Audit {
         /// Skill path or installed skill name
         source: String,
     },
-    /// Install a new skill from a URL or local path
+    /// Install a new skill from a local path, git URL, or registry (namespace/name)
     Install {
-        /// Source URL or local path
+        /// Source: local path, git URL, or registry package (e.g. acme/my-tool)
         source: String,
     },
     /// Remove an installed skill
@@ -165,6 +184,8 @@ pub enum SkillCommands {
         /// Skill name to remove
         name: String,
     },
+    /// List all available skill templates
+    Templates,
 }
 
 /// Migration subcommands

--- a/src/main.rs
+++ b/src/main.rs
@@ -409,6 +409,7 @@ Examples:
     },
 
     /// Manage skills (user-defined capabilities)
+    #[command(name = "skill", alias = "skills")]
     Skills {
         #[command(subcommand)]
         skill_command: SkillCommands,
@@ -857,6 +858,10 @@ async fn main() -> Result<()> {
             if let Some(ref backend) = memory_backend {
                 config.memory.backend = backend.clone();
             }
+            // interactive=true only when no --message flag (real REPL session).
+            // Single-shot mode (-m) runs non-interactively: no TTY approval prompt,
+            // so tools are not denied by a stdin read returning EOF.
+            let interactive = message.is_none();
             agent::run(
                 config,
                 message,
@@ -864,7 +869,7 @@ async fn main() -> Result<()> {
                 model,
                 temperature,
                 peripheral,
-                true,
+                interactive,
             )
             .await
             .map(|_| ())

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -183,6 +183,7 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
         transcription: crate::config::TranscriptionConfig::default(),
         agents_ipc: crate::config::AgentsIpcConfig::default(),
         model_support_vision: None,
+        wasm: crate::config::WasmConfig::default(),
     };
 
     println!(
@@ -542,6 +543,7 @@ async fn run_quick_setup_with_home(
         transcription: crate::config::TranscriptionConfig::default(),
         agents_ipc: crate::config::AgentsIpcConfig::default(),
         model_support_vision: None,
+        wasm: crate::config::WasmConfig::default(),
     };
 
     config.save().await?;

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 use std::time::{Duration, SystemTime};
 
 mod audit;
+mod templates;
 
 const OPEN_SKILLS_REPO_URL: &str = "https://github.com/besoeasy/open-skills";
 const OPEN_SKILLS_SYNC_MARKER: &str = ".zeroclaw-open-skills-sync";
@@ -306,13 +307,23 @@ fn ensure_open_skills_repo(
     let repo_dir = resolve_open_skills_dir(config_open_skills_dir)?;
 
     if !repo_dir.exists() {
-        if !clone_open_skills_repo(&repo_dir) {
-            return None;
+        // Never clone from the network during tests — tests that need a local
+        // open-skills directory must provide one via config.skills.open_skills_dir.
+        #[cfg(test)]
+        return None;
+
+        #[cfg(not(test))]
+        {
+            if !clone_open_skills_repo(&repo_dir) {
+                return None;
+            }
+            let _ = mark_open_skills_synced(&repo_dir);
+            return Some(repo_dir);
         }
-        let _ = mark_open_skills_synced(&repo_dir);
-        return Some(repo_dir);
     }
 
+    // Never pull from the network during tests.
+    #[cfg(not(test))]
     if should_sync_open_skills(&repo_dir) {
         if pull_open_skills_repo(&repo_dir) {
             let _ = mark_open_skills_synced(&repo_dir);
@@ -426,17 +437,41 @@ fn load_skill_toml(path: &Path) -> Result<Skill> {
 /// Load a skill from a SKILL.md file (simpler format)
 fn load_skill_md(path: &Path, dir: &Path) -> Result<Skill> {
     let content = std::fs::read_to_string(path)?;
-    let name = dir
+    let mut name = dir
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("unknown")
         .to_string();
+    let mut version = "0.1.0".to_string();
+    let mut author: Option<String> = None;
+
+    // If _meta.json exists alongside SKILL.md, use it for name/version/author.
+    // This covers skills installed from zip-based registries (e.g. any zip source).
+    let meta_path = dir.join("_meta.json");
+    if meta_path.exists() {
+        if let Ok(raw) = std::fs::read(&meta_path) {
+            if let Ok(meta) = serde_json::from_slice::<serde_json::Value>(&raw) {
+                if let Some(slug) = meta.get("slug").and_then(|v| v.as_str()) {
+                    let normalized = normalize_skill_name(slug.split('/').last().unwrap_or(slug));
+                    if !normalized.is_empty() {
+                        name = normalized;
+                    }
+                }
+                if let Some(v) = meta.get("version").and_then(|v| v.as_str()) {
+                    version = v.to_string();
+                }
+                if let Some(owner) = meta.get("ownerId").and_then(|v| v.as_str()) {
+                    author = Some(owner.to_string());
+                }
+            }
+        }
+    }
 
     Ok(Skill {
         name,
         description: extract_description(&content),
-        version: "0.1.0".to_string(),
-        author: None,
+        version,
+        author,
         tags: Vec::new(),
         tools: Vec::new(),
         prompts: vec![content],
@@ -847,11 +882,1076 @@ fn install_git_skill_source(
     }
 }
 
+// ─── Scaffold (zeroclaw skill new) ───────────────────────────────────────────
+
+/// Create a new skill project from a named template.
+///
+/// Protocol: the generated WASM tool reads JSON from **stdin** and writes a
+/// `{"success":bool,"output":"...","error":null|"..."}` JSON to **stdout**.
+/// No custom SDK or ABI boilerplate needed — just standard WASI stdio.
+pub fn scaffold_skill(
+    name: &str,
+    template_name: &str,
+    dest_parent: &std::path::Path,
+) -> Result<()> {
+    // Validate name: allowlist only ASCII alphanumeric, '_', '-'; no path traversal.
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        anyhow::bail!(
+            "Invalid skill name '{}': use only letters, digits, '_', or '-' (snake_case or kebab-case)",
+            name
+        );
+    }
+
+    let tmpl = templates::find(template_name).ok_or_else(|| {
+        let names: Vec<&str> = templates::ALL.iter().map(|t| t.name).collect();
+        anyhow::anyhow!(
+            "Unknown template '{template_name}'. Run 'zeroclaw skill templates' to list available templates.\nAvailable: {}",
+            names.join(", ")
+        )
+    })?;
+
+    let skill_dir = dest_parent.join(name);
+    if skill_dir.exists() {
+        anyhow::bail!("Directory already exists: {}", skill_dir.display());
+    }
+    std::fs::create_dir_all(&skill_dir)?;
+
+    let bin_name = name.replace('-', "_");
+
+    // Run all file writes in a closure; remove skill_dir on any error to avoid
+    // leaving a partial scaffold behind (mirrors install_registry_skill_source).
+    let result = (|| -> Result<()> {
+        for file in tmpl.files {
+            let path = skill_dir.join(file.path);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let content = templates::apply(file.content, name, &bin_name);
+            std::fs::write(&path, content)?;
+        }
+
+        // Common files not in templates
+        std::fs::write(
+            skill_dir.join(".gitignore"),
+            "tool.wasm\nnode_modules/\ntarget/\n*.js.map\n",
+        )?;
+        write_skill_md(&skill_dir, name, tmpl.description, tmpl.test_args)?;
+        write_readme(&skill_dir, name, tmpl.language, tmpl.test_args)?;
+
+        Ok(())
+    })();
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&skill_dir);
+            Err(e)
+        }
+    }
+}
+
+fn write_skill_md(
+    dir: &std::path::Path,
+    name: &str,
+    description: &str,
+    test_args: &str,
+) -> Result<()> {
+    std::fs::write(
+        dir.join("SKILL.md"),
+        format!(
+            "# {name}\n\n\
+             {description}\n\n\
+             ## Tools\n\n\
+             ### {name}\n\n\
+             {description}\n\n\
+             **Example:**\n\
+             ```json\n\
+             {test_args}\n\
+             ```\n\n\
+             ## Test\n\n\
+             ```bash\n\
+             zeroclaw skill test . --args '{test_args}'\n\
+             ```\n"
+        ),
+    )?;
+    Ok(())
+}
+
+fn write_readme(dir: &std::path::Path, name: &str, language: &str, test_args: &str) -> Result<()> {
+    let (build_cmd, test_note) = match language {
+        "typescript" => (
+            "npm install && npm run build",
+            "Requires: node, npm, javy (https://github.com/bytecodealliance/javy)",
+        ),
+        "rust" => (
+            "cargo build --target wasm32-wasip1 --release\ncp target/wasm32-wasip1/release/*.wasm tool.wasm",
+            "Requires: rustup target add wasm32-wasip1  # one-time setup",
+        ),
+        "go" => (
+            "tinygo build -o tool.wasm -target wasi .",
+            "Requires: tinygo (https://tinygo.org)",
+        ),
+        "python" => (
+            "componentize-py -d wit/ -w zeroclaw-skill componentize main -o tool.wasm",
+            "Requires: componentize-py (pip install componentize-py)",
+        ),
+        _ => ("make", ""),
+    };
+
+    std::fs::write(
+        dir.join("README.md"),
+        format!(
+            "# {name}\n\n\
+             A ZeroClaw skill ({language}).\n\n\
+             ## Protocol\n\n\
+             Reads a JSON object from **stdin**, writes JSON to **stdout**:\n\n\
+             ```json\n\
+             // stdin  → args\n\
+             {test_args}\n\n\
+             // stdout ← result\n\
+             {{\"success\": true, \"output\": \"...\"}}\n\
+             ```\n\n\
+             ## Build\n\n\
+             {test_note}\n\n\
+             ```bash\n\
+             {build_cmd}\n\
+             ```\n\n\
+             ## Test\n\n\
+             ```bash\n\
+             zeroclaw skill test . --args '{test_args}'\n\
+             ```\n\n\
+             ## Publish\n\n\
+             ```bash\n\
+             zeroclaw skill install .\n\
+             ```\n"
+        ),
+    )?;
+    Ok(())
+}
+
+// ─── Local test (zeroclaw skill test) ────────────────────────────────────────
+
+/// Run a WASM tool locally using the system `wasmtime` CLI binary.
+///
+/// Looks for `tool.wasm` inside `skill_path/tools/<tool_name>/` (installed layout)
+/// OR directly as `skill_path/tool.wasm` (dev layout — right after build).
+pub fn test_skill_locally(
+    skill_path: &std::path::Path,
+    tool_name: Option<&str>,
+    args_json: &str,
+) -> Result<()> {
+    // Resolve .wasm path
+    let wasm_path = resolve_wasm_path(skill_path, tool_name)?;
+
+    // Validate JSON args
+    let _: serde_json::Value = serde_json::from_str(args_json)
+        .with_context(|| format!("--args is not valid JSON: {args_json}"))?;
+
+    println!(
+        "  Running: {} {}",
+        console::style("wasmtime").cyan(),
+        wasm_path.display()
+    );
+    println!("  Input:   {args_json}");
+    println!();
+
+    // Run via wasmtime CLI (captures stdout as tool output)
+    let output = std::process::Command::new("wasmtime")
+        .arg("run")
+        .arg(&wasm_path)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context(
+            "wasmtime not found — install it first:\n\n\
+             \x20 macOS (Homebrew):  brew install wasmtime\n\
+             \x20 macOS/Linux:       curl https://wasmtime.dev/install.sh -sSf | bash\n\
+             \x20 Cargo (slow):      cargo install wasmtime-cli\n\n\
+             After installing, restart your terminal and run this command again.\n\
+             Docs: https://wasmtime.dev",
+        )
+        .and_then(|mut child| {
+            use std::io::Write;
+            // take() moves stdin out so it is dropped (closed) at end of block,
+            // sending EOF to the child process — required for read_to_string to return.
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin.write_all(args_json.as_bytes())?;
+                // stdin dropped here → EOF sent
+            }
+            child.wait_with_output().map_err(anyhow::Error::from)
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("wasmtime exited with error:\n{stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    println!("{}", stdout);
+
+    // Pretty-print if valid JSON
+    match serde_json::from_str::<serde_json::Value>(&stdout) {
+        Ok(v) => {
+            println!();
+            let success = v.get("success").and_then(|s| s.as_bool()).unwrap_or(false);
+            if success {
+                println!(
+                    "  {} Tool returned success",
+                    console::style("✓").green().bold()
+                );
+            } else {
+                let err = v.get("error").and_then(|e| e.as_str()).unwrap_or("unknown");
+                println!(
+                    "  {} Tool returned failure: {err}",
+                    console::style("✗").red().bold()
+                );
+            }
+        }
+        Err(_) => {
+            // stdout is not JSON — show as-is (maybe the tool printed plain text)
+        }
+    }
+
+    Ok(())
+}
+
+/// Find the `.wasm` file for a skill directory.
+///
+/// Search order:
+/// 1. `<path>/tool.wasm`                                   — dev build output
+/// 2. `<path>/tools/<tool_name>/tool.wasm`                 — installed layout
+/// 3. First `<path>/tools/*/tool.wasm` found               — installed, no name given
+fn resolve_wasm_path(
+    skill_path: &std::path::Path,
+    tool_name: Option<&str>,
+) -> Result<std::path::PathBuf> {
+    // 1. Direct dev layout
+    let direct = skill_path.join("tool.wasm");
+    if direct.exists() {
+        return Ok(direct);
+    }
+
+    // 2. Named tool inside installed layout
+    if let Some(name) = tool_name {
+        // Validate: must be a single normal path component (no traversal or separators).
+        use std::path::Component;
+        let name_path = std::path::Path::new(name);
+        let is_single_normal = {
+            let mut comps = name_path.components();
+            matches!(comps.next(), Some(Component::Normal(_))) && comps.next().is_none()
+        };
+        if !is_single_normal || name != name_path.file_name().and_then(|n| n.to_str()).unwrap_or("")
+        {
+            anyhow::bail!("invalid tool name '{}': must be a simple filename", name);
+        }
+        let named = skill_path.join("tools").join(name).join("tool.wasm");
+        if named.exists() {
+            return Ok(named);
+        }
+        anyhow::bail!(
+            "tool.wasm not found for tool '{}' in {}",
+            name,
+            skill_path.display()
+        );
+    }
+
+    // 3. First tool found
+    let tools_dir = skill_path.join("tools");
+    if let Ok(entries) = std::fs::read_dir(&tools_dir) {
+        for entry in entries.flatten() {
+            let candidate = entry.path().join("tool.wasm");
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "No tool.wasm found in {}.\n\
+         Run the build command for your template first (e.g. 'npm run build', 'cargo build').",
+        skill_path.display()
+    )
+}
+
+// ─── Registry (ZeroMarket) source ────────────────────────────────────────────
+
+/// Package reference format: `<namespace>/<name>[@<version>]`
+/// Example: `zeromarket/github-pr-summary` or `acme/my-tool@0.2.1`
+fn is_registry_source(source: &str) -> bool {
+    // Filesystem paths are never registry sources
+    if source.starts_with('.') || source.starts_with('/') || source.starts_with('~') {
+        return false;
+    }
+    // Must be `namespace/name` (no scheme, no .git suffix, no slashes in name)
+    let parts: Vec<&str> = source.split('/').collect();
+    if parts.len() != 2 {
+        return false;
+    }
+    let (ns, name_ver) = (parts[0], parts[1]);
+    // Reject empty segments or path-traversal
+    if ns.is_empty() || name_ver.is_empty() || ns.contains("..") || name_ver.contains("..") {
+        return false;
+    }
+    // Must be identifier-safe characters only ('.' and '@' only in version segment)
+    let is_safe_id = |s: &str| {
+        s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+    };
+    // name_ver may be `name` or `name@version`; '@' is only allowed once as separator
+    let (base_name, version_part) = match name_ver.split_once('@') {
+        Some((n, v)) => (n, Some(v)),
+        None => (name_ver, None),
+    };
+    if base_name.is_empty() {
+        return false;
+    }
+    if let Some(v) = version_part {
+        if v.is_empty() || v.contains('@') {
+            return false;
+        }
+        if !is_safe_id(v) {
+            return false;
+        }
+    }
+    is_safe_id(ns) && is_safe_id(base_name)
+}
+
+/// Download a skill package (WASM tools + SKILL.toml) from the ZeroMarket registry.
+///
+/// Package layout on the registry:
+/// ```text
+/// GET <registry_url>/v1/packages/<namespace>/<name>[/<version>]
+/// -> 200 JSON: { "name": "...", "version": "...", "tools": [{ "name": "...", "wasm_url": "...", "manifest_url": "..." }] }
+/// ```
+///
+/// The function:
+/// 1. Fetches the package index JSON
+/// 2. Creates `skills_path/<name>/tools/<tool-name>/`
+/// 3. Downloads `tool.wasm` and `manifest.json` for each tool
+/// 4. Creates a minimal `SKILL.toml` so the skill shows up in `skill list`
+fn install_registry_skill_source(
+    source: &str,
+    skills_path: &Path,
+    registry_url: &str,
+) -> Result<(PathBuf, usize)> {
+    // Parse `namespace/name[@version]`
+    let (ns_name, version) = match source.split_once('@') {
+        Some((base, ver)) => (base, Some(ver)),
+        None => (source, None),
+    };
+    let parts: Vec<&str> = ns_name.split('/').collect();
+    if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+        anyhow::bail!(
+            "invalid registry source '{}': expected namespace/name[@version]",
+            source
+        );
+    }
+    if let Some(v) = version {
+        if v.is_empty() || v.contains('/') {
+            anyhow::bail!(
+                "invalid version in '{}': version must be non-empty and contain no '/'",
+                source
+            );
+        }
+    }
+    let (namespace, pkg_name) = (parts[0], parts[1]);
+
+    // Build registry API URL
+    let api_path = match version {
+        Some(v) => format!("v1/packages/{namespace}/{pkg_name}/{v}"),
+        None => format!("v1/packages/{namespace}/{pkg_name}"),
+    };
+    let api_url = format!("{}/{}", registry_url.trim_end_matches('/'), api_path);
+
+    println!("  Fetching package index: {api_url}");
+
+    // HTTP GET (synchronous via ureq-like reqwest blocking or std)
+    // We use std::process + curl/wget to avoid pulling reqwest into this sync path.
+    // At runtime the agent loop uses reqwest; here we keep it minimal.
+    let index_bytes = fetch_url_blocking(&api_url, None)
+        .with_context(|| format!("failed to fetch package index from {api_url}"))?;
+
+    let index: RegistryPackageIndex = serde_json::from_slice(&index_bytes)
+        .context("registry returned invalid package index JSON")?;
+
+    // Destination skill directory: `skills/<pkg_name>/`
+    let skill_dir_name = pkg_name.to_string();
+    let skill_dir = skills_path.join(&skill_dir_name);
+    if skill_dir.exists() {
+        anyhow::bail!(
+            "skill '{}' is already installed at {}; remove it first to reinstall",
+            pkg_name,
+            skill_dir.display()
+        );
+    }
+    std::fs::create_dir_all(&skill_dir)?;
+
+    // Run the actual work in a closure so we can clean up skill_dir on any error.
+    let result = (|| -> Result<usize> {
+        let mut files_written = 0usize;
+
+        // Download each tool
+        for tool in &index.tools {
+            // Validate tool name: must be a single normal path component (no traversal).
+            let tool_name_path = std::path::Path::new(&tool.name);
+            let is_single_normal = {
+                use std::path::Component;
+                let mut comps = tool_name_path.components();
+                matches!(comps.next(), Some(Component::Normal(_))) && comps.next().is_none()
+            };
+            if !is_single_normal
+                || !tool
+                    .name
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+            {
+                anyhow::bail!("registry returned unsafe tool name: '{}'", tool.name);
+            }
+
+            let tool_dir = skill_dir.join("tools").join(&tool.name);
+            std::fs::create_dir_all(&tool_dir)?;
+
+            // Validate artifact URLs: must be HTTPS and on an allowed host
+            // (registry host or registry-declared artifact CDN host).
+            let artifact_base = index.artifact_base_url.as_deref();
+            validate_artifact_url(&tool.wasm_url, registry_url, artifact_base)
+                .with_context(|| format!("unsafe wasm_url for tool '{}'", tool.name))?;
+            validate_artifact_url(&tool.manifest_url, registry_url, artifact_base)
+                .with_context(|| format!("unsafe manifest_url for tool '{}'", tool.name))?;
+
+            // Download tool.wasm
+            println!("  Downloading tool: {}", tool.name);
+            let wasm_bytes = fetch_url_blocking(&tool.wasm_url, None)
+                .with_context(|| format!("failed to download WASM for tool '{}'", tool.name))?;
+            std::fs::write(tool_dir.join("tool.wasm"), &wasm_bytes)?;
+            files_written += 1;
+
+            // Download manifest.json
+            let manifest_bytes = fetch_url_blocking(&tool.manifest_url, None)
+                .with_context(|| format!("failed to download manifest for tool '{}'", tool.name))?;
+
+            // Validate manifest before writing (ensures it parses as WasmManifest)
+            let _manifest: serde_json::Value = serde_json::from_slice(&manifest_bytes)
+                .with_context(|| format!("invalid manifest JSON for tool '{}'", tool.name))?;
+            std::fs::write(tool_dir.join("manifest.json"), &manifest_bytes)?;
+            files_written += 1;
+        }
+
+        // Write minimal SKILL.toml using safe TOML serialization to avoid
+        // injection via description strings containing quotes or special chars.
+        #[derive(serde::Serialize)]
+        struct SkillMeta<'a> {
+            name: &'a str,
+            description: &'a str,
+            version: &'a str,
+            author: &'a str,
+            tags: &'a [&'a str],
+        }
+        #[derive(serde::Serialize)]
+        struct SkillToml<'a> {
+            skill: SkillMeta<'a>,
+        }
+        let description = index
+            .description
+            .as_deref()
+            .unwrap_or("Installed from ZeroMarket registry");
+        let skill_toml_value = SkillToml {
+            skill: SkillMeta {
+                name: &skill_dir_name,
+                description,
+                version: &index.version,
+                author: namespace,
+                tags: &["wasm", "zeromarket"],
+            },
+        };
+        let skill_toml_str =
+            toml::to_string(&skill_toml_value).context("failed to serialize SKILL.toml")?;
+        std::fs::write(skill_dir.join("SKILL.toml"), skill_toml_str)?;
+        files_written += 1;
+
+        Ok(files_written)
+    })();
+
+    match result {
+        Ok(files_written) => Ok((skill_dir, files_written)),
+        Err(e) => {
+            // Remove partially-written skill_dir to avoid leaving broken state.
+            let _ = std::fs::remove_dir_all(&skill_dir);
+            Err(e)
+        }
+    }
+}
+
+/// Minimal JSON shape returned by the ZeroMarket registry package index endpoint.
+#[derive(Debug, serde::Deserialize)]
+struct RegistryPackageIndex {
+    version: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    tools: Vec<RegistryToolEntry>,
+    /// Optional CDN base URL where WASM artifacts are hosted.
+    ///
+    /// When present, artifact URLs may use this host instead of (or in addition
+    /// to) the registry host.  The declared host must itself be HTTPS; the client
+    /// validates that each artifact URL's host matches either the registry host or
+    /// this declared base host.  This lets the registry operator store binaries on
+    /// a separate CDN (e.g. Cloudflare R2) without client changes.
+    #[serde(default)]
+    artifact_base_url: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RegistryToolEntry {
+    name: String,
+    wasm_url: String,
+    manifest_url: String,
+}
+
+/// Blocking HTTP GET using the system `curl` binary (avoids adding a sync HTTP
+/// Extract the hostname from an `https://` URL (the part before the first
+/// `'/'`, `'?'`, `'#'`, or `':'` after the scheme).
+fn extract_url_host(url: &str) -> &str {
+    url.strip_prefix("https://")
+        .unwrap_or("")
+        .split(&['/', '?', '#', ':'][..])
+        .next()
+        .unwrap_or("")
+}
+
+/// Validate that an artifact URL (wasm_url / manifest_url from the registry index)
+/// is HTTPS and served from an allowed host, preventing SSRF via a malicious
+/// registry response redirecting downloads to internal hosts.
+///
+/// Allowed hosts:
+/// 1. The registry host itself (e.g. `zeromarket.vercel.app`).
+/// 2. The declared `artifact_base_url` host from the package index — lets the
+///    registry operator store binaries on a separate CDN (e.g. Cloudflare R2)
+///    without hardcoding CDN domains in the client.  The declared base URL must
+///    also use HTTPS; otherwise it is ignored.
+fn validate_artifact_url(
+    artifact_url: &str,
+    registry_url: &str,
+    artifact_base_url: Option<&str>,
+) -> Result<()> {
+    if !artifact_url.starts_with("https://") {
+        anyhow::bail!("artifact URL must use HTTPS: {artifact_url}");
+    }
+    let registry_host = extract_url_host(registry_url);
+    let artifact_host = extract_url_host(artifact_url);
+
+    if registry_host.is_empty() || artifact_host.is_empty() {
+        anyhow::bail!(
+            "could not determine host from artifact URL '{}' or registry URL '{}'",
+            artifact_url,
+            registry_url
+        );
+    }
+
+    if artifact_host == registry_host {
+        return Ok(());
+    }
+
+    // Allow host declared by the registry as its artifact CDN, if that
+    // declaration is itself a valid HTTPS URL.
+    if let Some(base) = artifact_base_url {
+        if base.starts_with("https://") {
+            let base_host = extract_url_host(base);
+            if !base_host.is_empty() && artifact_host == base_host {
+                return Ok(());
+            }
+        }
+    }
+
+    // Allow Cloudflare R2 public bucket hostnames (`*.r2.dev`) as a trusted CDN
+    // fallback.  R2 is a hosted object-storage service with no access to private
+    // networks, so allowing artifacts from any R2 bucket does not create SSRF risk.
+    // Registries that store binaries on R2 without declaring `artifact_base_url`
+    // still work out of the box.
+    if artifact_host.ends_with(".r2.dev") {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "artifact host '{}' is not allowed (registry host: '{}'; declared artifact host: '{}')",
+        artifact_host,
+        registry_host,
+        artifact_base_url
+            .and_then(|u| {
+                if u.starts_with("https://") {
+                    Some(extract_url_host(u))
+                } else {
+                    None
+                }
+            })
+            .unwrap_or("none")
+    );
+}
+
+// ─── ClawhHub skill installer ────────────────────────────────────────────────
+//
+// ClawhHub (https://clawhub.ai) is the OpenClaw skill registry.
+// Supported source formats:
+//   - `https://clawhub.ai/<owner>/<slug>`  (profile URL, auto-detected by domain)
+//   - `clawhub:<slug>`                     (short prefix)
+//
+// The download URL is: https://clawhub.ai/api/v1/download?slug=<slug>
+// Zip contents follow the OpenClaw convention: `_meta.json` + `SKILL.md` + scripts.
+
+const CLAWHUB_DOMAIN: &str = "clawhub.ai";
+const CLAWHUB_DOWNLOAD_API: &str = "https://clawhub.ai/api/v1/download";
+
+/// Returns true if `source` is a ClawhHub skill reference.
+fn is_clawhub_source(source: &str) -> bool {
+    if source.starts_with("clawhub:") {
+        return true;
+    }
+    // Auto-detect from domain: https://clawhub.ai/...
+    if let Some(rest) = source.strip_prefix("https://") {
+        let host = rest.split('/').next().unwrap_or("");
+        return host == CLAWHUB_DOMAIN;
+    }
+    false
+}
+
+/// Convert a ClawhHub source string into the zip download URL.
+///
+/// - `clawhub:gog`                       → `https://clawhub.ai/api/v1/download?slug=gog`
+/// - `https://clawhub.ai/steipete/gog`   → `https://clawhub.ai/api/v1/download?slug=steipete/gog`
+/// - `https://clawhub.ai/gog`            → `https://clawhub.ai/api/v1/download?slug=gog`
+///
+/// For profile URLs the full path (owner/slug) is forwarded verbatim as the slug query
+/// parameter so the ClawhHub API can resolve owner-namespaced skills correctly.
+fn clawhub_download_url(source: &str) -> Result<String> {
+    // Short prefix: clawhub:<slug>
+    if let Some(slug) = source.strip_prefix("clawhub:") {
+        let slug = slug.trim().trim_end_matches('/');
+        if slug.is_empty() || slug.contains('/') {
+            anyhow::bail!(
+                "invalid clawhub source '{}': expected 'clawhub:<slug>' (no slashes in slug)",
+                source
+            );
+        }
+        return Ok(format!("{CLAWHUB_DOWNLOAD_API}?slug={slug}"));
+    }
+    // Profile URL: https://clawhub.ai/<owner>/<slug>  or  https://clawhub.ai/<slug>
+    // Forward the full path as the slug so the API can resolve owner-namespaced skills.
+    if let Some(rest) = source.strip_prefix("https://") {
+        let path = rest
+            .strip_prefix(CLAWHUB_DOMAIN)
+            .unwrap_or("")
+            .trim_start_matches('/');
+        let path = path.trim_end_matches('/');
+        if path.is_empty() {
+            anyhow::bail!("could not extract slug from ClawhHub URL: {source}");
+        }
+        // Keep the literal slash so the API receives `slug=owner/name`
+        // (some backends do not decode %2F in query parameters).
+        return Ok(format!("{CLAWHUB_DOWNLOAD_API}?slug={path}"));
+    }
+    anyhow::bail!("unrecognised ClawhHub source format: {source}")
+}
+
+// ─── Generic zip-URL skill installer ─────────────────────────────────────────
+//
+// Installs a skill from any HTTPS URL that returns a zip archive.
+// Supports two source formats:
+//   - `zip:https://example.com/path/to/skill.zip`  (explicit prefix)
+//   - `https://example.com/skill.zip`              (`.zip` suffix auto-detection)
+//
+// No system-level `unzip` binary is required; extraction is done in-process
+// using the `zip` crate. This makes the feature portable and dependency-free.
+//
+// If the zip contains a `_meta.json` at its root (OpenClaw registry convention),
+// the name, version, and author fields are read from it. Otherwise the skill
+// name is derived from the URL's last path segment.
+
+/// Returns true if `source` should be handled as a zip-URL download.
+fn is_zip_url_source(source: &str) -> bool {
+    // Explicit `zip:https://...` prefix
+    if let Some(rest) = source.strip_prefix("zip:") {
+        return rest.starts_with("https://");
+    }
+    // Direct HTTPS URL ending in `.zip`
+    let path_part = source.split('?').next().unwrap_or(source);
+    source.starts_with("https://") && path_part.ends_with(".zip")
+}
+
+/// Strips the `zip:` prefix if present, returning the bare HTTPS URL.
+fn zip_url_from_source(source: &str) -> &str {
+    source.strip_prefix("zip:").unwrap_or(source)
+}
+
+/// Normalize a raw slug or filename into a valid skill directory name.
+/// Lowercases, replaces hyphens with underscores, strips everything else.
+fn normalize_skill_name(s: &str) -> String {
+    s.to_lowercase()
+        .chars()
+        .map(|c| if c == '-' { '_' } else { c })
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect()
+}
+
+/// Read skill metadata (name, version, author) from a zip archive.
+///
+/// Checks for `_meta.json` at the root of the archive first (OpenClaw/ClawhHub
+/// convention). Falls back to the URL-derived name passed via `url_hint`.
+fn extract_zip_skill_meta(
+    bytes: &[u8],
+    url_hint: &str,
+) -> Result<(String, String, Option<String>)> {
+    use std::io::Read as _;
+
+    let cursor = std::io::Cursor::new(bytes);
+    let mut archive =
+        zip::ZipArchive::new(cursor).context("downloaded content is not a valid zip archive")?;
+
+    if let Ok(mut f) = archive.by_name("_meta.json") {
+        let mut buf = Vec::new();
+        f.read_to_end(&mut buf).ok();
+        if let Ok(meta) = serde_json::from_slice::<serde_json::Value>(&buf) {
+            let slug_raw = meta.get("slug").and_then(|v| v.as_str()).unwrap_or("");
+            let base = slug_raw.split('/').last().unwrap_or(slug_raw);
+            let name = normalize_skill_name(base);
+            if !name.is_empty() {
+                let version = meta
+                    .get("version")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("0.1.0")
+                    .to_string();
+                let author = meta
+                    .get("ownerId")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string);
+                return Ok((name, version, author));
+            }
+        }
+    }
+
+    // Fallback: derive name from the URL path (strip query string and .zip suffix)
+    let url_path = url_hint.split('?').next().unwrap_or(url_hint);
+    let last_seg = url_path.rsplit('/').next().unwrap_or("skill");
+    let base = last_seg.strip_suffix(".zip").unwrap_or(last_seg);
+    let name = normalize_skill_name(base);
+    let name = if name.is_empty() {
+        "skill".to_string()
+    } else {
+        name
+    };
+    Ok((name, "0.1.0".to_string(), None))
+}
+
+/// Install a skill from a local `.zip` file (e.g. downloaded manually from ClawhHub).
+///
+/// Usage: `zeroclaw skill install /path/to/skill.zip`
+fn install_local_zip_source(zip_path: &Path, skills_path: &Path) -> Result<(PathBuf, usize)> {
+    let bytes = std::fs::read(zip_path)
+        .with_context(|| format!("failed to read zip file: {}", zip_path.display()))?;
+    let hint = zip_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("skill.zip");
+    extract_zip_bytes_to_skills(&bytes, hint, skills_path)
+}
+
+/// Download a zip archive from `url` and install it as a skill under `skills_path`.
+///
+/// `auth_token` is an optional Bearer token added as `Authorization: Bearer <token>`.
+/// Extraction is done in-process (no `unzip` binary required).
+/// Returns the installed skill directory path and the number of files written.
+fn install_zip_url_source(
+    url: &str,
+    skills_path: &Path,
+    auth_token: Option<&str>,
+) -> Result<(PathBuf, usize)> {
+    let bytes = fetch_url_blocking(url, auth_token)
+        .with_context(|| format!("failed to fetch zip from {url}"))?;
+    extract_zip_bytes_to_skills(&bytes, url, skills_path)
+}
+
+/// Core zip extraction logic shared by local and remote zip installers.
+///
+/// Runs a full security audit on the zip contents before extracting a single byte.
+/// `name_hint` is used as a fallback for skill name detection (URL or filename).
+fn extract_zip_bytes_to_skills(
+    bytes: &[u8],
+    name_hint: &str,
+    skills_path: &Path,
+) -> Result<(PathBuf, usize)> {
+    // ── Security audit BEFORE extraction ────────────────────────────────────
+    // Runs zip-specific checks: entry count, path traversal, native binaries,
+    // per-file and total decompressed size limits, compression ratio (zip bomb),
+    // and high-risk shell pattern detection in text files.
+    let audit_report =
+        audit::audit_zip_bytes(bytes).context("zip pre-extraction security check failed")?;
+    if !audit_report.is_clean() {
+        let findings = audit_report
+            .findings
+            .iter()
+            .map(|f| format!("  - {f}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        anyhow::bail!(
+            "zip skill rejected by security audit ({} finding{}):\n{findings}",
+            audit_report.findings.len(),
+            if audit_report.findings.len() == 1 {
+                ""
+            } else {
+                "s"
+            }
+        );
+    }
+
+    let (skill_name, skill_version, skill_author) = extract_zip_skill_meta(bytes, name_hint)
+        .with_context(|| format!("could not determine skill name from zip: {name_hint}"))?;
+
+    let skill_dir = skills_path.join(&skill_name);
+    if skill_dir.exists() {
+        anyhow::bail!(
+            "skill '{}' already exists at {}; run 'zeroclaw skill remove {}' first",
+            skill_name,
+            skill_dir.display(),
+            skill_name
+        );
+    }
+    std::fs::create_dir_all(&skill_dir)?;
+
+    // Extract zip entries
+    let cursor = std::io::Cursor::new(bytes);
+    let mut archive =
+        zip::ZipArchive::new(cursor).context("failed to re-open zip archive for extraction")?;
+
+    let mut files_written = 0usize;
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i)?;
+        let raw_name = entry.name().to_string();
+
+        // Security: reject path traversal attempts
+        if raw_name.contains("..") || raw_name.starts_with('/') {
+            let _ = std::fs::remove_dir_all(&skill_dir);
+            anyhow::bail!("zip entry contains unsafe path: {raw_name}");
+        }
+
+        let out_path = skill_dir.join(&raw_name);
+        if entry.is_dir() {
+            std::fs::create_dir_all(&out_path)?;
+        } else {
+            if let Some(parent) = out_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let mut out_file = std::fs::File::create(&out_path)
+                .with_context(|| format!("failed to create {}", out_path.display()))?;
+            std::io::copy(&mut entry, &mut out_file)?;
+            files_written += 1;
+        }
+    }
+
+    // Write a minimal SKILL.toml so the skill appears in `zeroclaw skill list`
+    // (only if neither SKILL.toml nor SKILL.md was included in the zip)
+    let toml_path = skill_dir.join("SKILL.toml");
+    if !toml_path.exists() && !skill_dir.join("SKILL.md").exists() {
+        let author_line = skill_author
+            .map(|a| format!("author = \"{a}\"\n"))
+            .unwrap_or_default();
+        std::fs::write(
+            &toml_path,
+            format!(
+                "[skill]\nname = \"{skill_name}\"\ndescription = \"Zip-installed skill\"\nversion = \"{skill_version}\"\n{author_line}"
+            ),
+        )?;
+        files_written += 1;
+    }
+
+    Ok((skill_dir, files_written))
+}
+
+/// crate to this sync code path). Falls back to a basic TCP approach is not needed
+/// because `curl` is universally available on target platforms.
+///
+/// `auth_token` — if `Some`, adds `Authorization: Bearer <token>` to the request.
+fn fetch_url_blocking(url: &str, auth_token: Option<&str>) -> Result<Vec<u8>> {
+    // Validate URL scheme — only https:// allowed to prevent SSRF
+    if !url.starts_with("https://") {
+        anyhow::bail!("registry URL must use HTTPS: {url}");
+    }
+
+    // Use --write-out to append the HTTP status code on a separate line so we
+    // can give actionable error messages (e.g. 429 rate-limit guidance) without
+    // needing a separate HEAD request.
+    let mut cmd = std::process::Command::new("curl");
+    cmd.args([
+        "--silent",
+        "--show-error",
+        "--location",
+        "--proto",
+        "=https",
+        "--max-redirs",
+        "5",
+        "--max-time",
+        "30",
+        "--write-out",
+        "\n%{http_code}",
+    ]);
+    if let Some(token) = auth_token {
+        cmd.args(["-H", &format!("Authorization: Bearer {token}")]);
+    }
+    cmd.arg(url);
+
+    let output = cmd
+        .output()
+        .context("failed to run 'curl' — ensure curl is installed")?;
+
+    // Parse the HTTP status code appended by --write-out.
+    let stdout = output.stdout;
+    let (body, http_status) = if let Some(nl) = stdout.iter().rposition(|&b| b == b'\n') {
+        let code_bytes = stdout[nl + 1..]
+            .iter()
+            .copied()
+            .take_while(|b| b.is_ascii_digit())
+            .collect::<Vec<_>>();
+        let status: u16 = String::from_utf8_lossy(&code_bytes).parse().unwrap_or(0);
+        (stdout[..nl].to_vec(), status)
+    } else {
+        (stdout, 0)
+    };
+
+    if http_status == 429 {
+        anyhow::bail!(
+            "ClawhHub rate limit reached (HTTP 429). \
+             Wait a moment and retry, or set `clawhub_token` in the `[skills]` section \
+             of your config.toml to use authenticated requests."
+        );
+    }
+
+    if !output.status.success() || (http_status != 0 && http_status >= 400) {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if http_status != 0 {
+            anyhow::bail!("HTTP {http_status} from {url}: {stderr}");
+        }
+        anyhow::bail!("curl failed for {url}: {stderr}");
+    }
+
+    Ok(body)
+}
+
+// ─── Handle command ───────────────────────────────────────────────────────────
+
 /// Handle the `skills` CLI command
 #[allow(clippy::too_many_lines)]
 pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Config) -> Result<()> {
     let workspace_dir = &config.workspace_dir;
     match command {
+        crate::SkillCommands::New { name, template } => {
+            let dest = std::env::current_dir().unwrap_or_else(|_| workspace_dir.clone());
+
+            scaffold_skill(&name, &template, &dest)
+                .with_context(|| format!("failed to scaffold skill '{name}'"))?;
+
+            // Resolve template again for display (find is cheap; scaffold_skill already
+            // validated that the template exists, so this should never be None).
+            let tmpl = templates::find(&template).ok_or_else(|| {
+                anyhow::anyhow!("template '{}' not found after scaffold", template)
+            })?;
+
+            let skill_dir = dest.join(&name);
+            println!(
+                "  {} Skill '{}' created at {}",
+                console::style("✓").green().bold(),
+                name,
+                skill_dir.display()
+            );
+            println!(
+                "  Template: {} ({})",
+                console::style(tmpl.name).cyan(),
+                tmpl.language
+            );
+            println!();
+            println!("  Next steps:");
+            println!("    cd {name}");
+            match tmpl.language {
+                "typescript" => {
+                    println!("    npm install && npm run build   # → tool.wasm");
+                }
+                "rust" => {
+                    println!(
+                        "    {}  # one-time setup",
+                        console::style("rustup target add wasm32-wasip1").yellow()
+                    );
+                    println!("    cargo build --target wasm32-wasip1 --release");
+                    println!("    cp target/wasm32-wasip1/release/*.wasm tool.wasm");
+                }
+                "go" => {
+                    println!("    tinygo build -o tool.wasm -target wasi .");
+                }
+                "python" => {
+                    println!("    pip install componentize-py");
+                    println!("    componentize-py -d wit/ -w zeroclaw-skill componentize main -o tool.wasm");
+                }
+                _ => {}
+            }
+            println!("    zeroclaw skill test . --args '{}'", tmpl.test_args);
+            println!();
+            println!(
+                "  {} 'zeroclaw skill test' requires the {} CLI:",
+                console::style("Note:").dim(),
+                console::style("wasmtime").cyan()
+            );
+            println!(
+                "    macOS:       {}",
+                console::style("brew install wasmtime").yellow()
+            );
+            println!(
+                "    Linux/macOS: {}",
+                console::style("curl https://wasmtime.dev/install.sh -sSf | bash").yellow()
+            );
+            println!();
+            println!(
+                "  To publish: upload this folder to {}",
+                console::style("https://zeromarket.dev/upload").underlined()
+            );
+
+            Ok(())
+        }
+
+        crate::SkillCommands::Test { path, tool, args } => {
+            let skill_path = std::path::Path::new(&path);
+            let skill_path = if skill_path.is_absolute() {
+                skill_path.to_path_buf()
+            } else {
+                std::env::current_dir()
+                    .unwrap_or_else(|_| workspace_dir.clone())
+                    .join(skill_path)
+            };
+
+            // If `path` is just a skill name, resolve from installed skills dir
+            let skill_path = if !skill_path.exists() && !path.contains('/') && !path.contains('\\')
+            {
+                skills_dir(workspace_dir).join(&path)
+            } else {
+                skill_path
+            };
+
+            if !skill_path.exists() {
+                anyhow::bail!(
+                    "Skill path not found: {}\n\
+                     Tip: run from the skill directory or pass an absolute path.",
+                    skill_path.display()
+                );
+            }
+
+            let args_json = args.as_deref().unwrap_or("{\"input\":\"test\"}");
+
+            test_skill_locally(&skill_path, tool.as_deref(), args_json)
+                .with_context(|| format!("skill test failed for {}", skill_path.display()))?;
+
+            Ok(())
+        }
+
         crate::SkillCommands::List => {
             let skills = load_skills_with_config(workspace_dir, config);
             if skills.is_empty() {
@@ -934,7 +2034,35 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
             let skills_path = skills_dir(workspace_dir);
             std::fs::create_dir_all(&skills_path)?;
 
-            if is_git_source(&source) {
+            if is_clawhub_source(&source) {
+                let download_url = clawhub_download_url(&source)
+                    .with_context(|| format!("invalid ClawhHub source: {source}"))?;
+                let token = config.skills.clawhub_token.as_deref();
+                let (installed_dir, files_written) =
+                    install_zip_url_source(&download_url, &skills_path, token)
+                        .with_context(|| format!("failed to install ClawhHub skill: {source}"))?;
+                println!(
+                    "  {} ClawhHub skill installed: {} ({} files written)",
+                    console::style("✓").green().bold(),
+                    installed_dir.display(),
+                    files_written
+                );
+                println!("  Run 'zeroclaw skill list' to verify the new tools are available.");
+            } else if is_zip_url_source(&source) {
+                // Generic zip-URL install: supports `zip:https://...` prefix and
+                // direct `.zip` URLs.  No system `unzip` binary required.
+                let url = zip_url_from_source(&source);
+                let (installed_dir, files_written) =
+                    install_zip_url_source(url, &skills_path, None)
+                        .with_context(|| format!("failed to install zip skill from: {url}"))?;
+                println!(
+                    "  {} Skill installed from zip: {} ({} files written)",
+                    console::style("✓").green().bold(),
+                    installed_dir.display(),
+                    files_written
+                );
+                println!("  Run 'zeroclaw skill list' to verify the new tools are available.");
+            } else if is_git_source(&source) {
                 let (installed_dir, files_scanned) =
                     install_git_skill_source(&source, &skills_path, config.skills.allow_scripts)
                         .with_context(|| format!("failed to install git skill source: {source}"))?;
@@ -944,21 +2072,53 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
                     installed_dir.display(),
                     files_scanned
                 );
-            } else {
-                let (dest, files_scanned) =
-                    install_local_skill_source(&source, &skills_path, config.skills.allow_scripts)
-                        .with_context(|| {
-                            format!("failed to install local skill source: {source}")
-                        })?;
+                println!("  Security audit completed successfully.");
+            } else if is_registry_source(&source) {
+                // ZeroMarket (or compatible) registry: `namespace/name[@version]`
+                let registry_url = &config.wasm.registry_url;
+                let (installed_dir, files_written) =
+                    install_registry_skill_source(&source, &skills_path, registry_url)
+                        .with_context(|| format!("failed to install registry package: {source}"))?;
                 println!(
-                    "  {} Skill installed and audited: {} ({} files scanned)",
+                    "  {} WASM skill package installed: {} ({} files written)",
                     console::style("✓").green().bold(),
-                    dest.display(),
-                    files_scanned
+                    installed_dir.display(),
+                    files_written
                 );
+                println!("  Run 'zeroclaw skill list' to verify the new tools are available.");
+            } else {
+                // Check if source is a local .zip file before falling back to directory install
+                let source_path = std::path::Path::new(&source);
+                let is_local_zip = source_path
+                    .extension()
+                    .map_or(false, |e| e.eq_ignore_ascii_case("zip"))
+                    && source_path.is_file();
+
+                if is_local_zip {
+                    let (dest, files_written) = install_local_zip_source(source_path, &skills_path)
+                        .with_context(|| format!("failed to install zip skill from: {source}"))?;
+                    println!(
+                        "  {} Skill installed from zip: {} ({} files written)",
+                        console::style("✓").green().bold(),
+                        dest.display(),
+                        files_written
+                    );
+                    println!("  Run 'zeroclaw skill list' to verify the new tools are available.");
+                } else {
+                    let (dest, files_scanned) = install_local_skill_source(&source, &skills_path)
+                        .with_context(|| {
+                        format!("failed to install local skill source: {source}")
+                    })?;
+                    println!(
+                        "  {} Skill installed and audited: {} ({} files scanned)",
+                        console::style("✓").green().bold(),
+                        dest.display(),
+                        files_scanned
+                    );
+                    println!("  Security audit completed successfully.");
+                }
             }
 
-            println!("  Security audit completed successfully.");
             Ok(())
         }
         crate::SkillCommands::Remove { name } => {
@@ -988,6 +2148,35 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
                 "  {} Skill '{}' removed.",
                 console::style("✓").green().bold(),
                 name
+            );
+            Ok(())
+        }
+
+        crate::SkillCommands::Templates => {
+            println!("  Available skill templates:\n");
+            println!(
+                "  {:<20} {:<12} {}",
+                console::style("NAME").bold(),
+                console::style("LANGUAGE").bold(),
+                console::style("DESCRIPTION").bold(),
+            );
+            println!("  {}", "─".repeat(72));
+            for tmpl in templates::ALL {
+                println!(
+                    "  {:<20} {:<12} {}",
+                    console::style(tmpl.name).cyan(),
+                    tmpl.language,
+                    tmpl.description,
+                );
+            }
+            println!();
+            println!("  Usage:");
+            println!("    zeroclaw skill new <name> --template <template-name>");
+            println!();
+            println!("  Example:");
+            println!(
+                "    zeroclaw skill new my_weather --template {}",
+                console::style("weather_lookup").cyan()
             );
             Ok(())
         }
@@ -1498,6 +2687,303 @@ description = "Bare minimum"
         assert_eq!(skills.len(), 1);
         assert_eq!(skills[0].name, "http_request");
         assert_ne!(skills[0].name, "CONTRIBUTING");
+    }
+
+    // ── is_registry_source ────────────────────────────────────────────────────
+
+    // ── registry install: directory naming ───────────────────────────────────
+
+    /// The installed skill directory must be named after the package name only,
+    /// not prefixed with the namespace. This keeps skill directories short and
+    /// predictable regardless of who published the package.
+    #[test]
+    fn registry_install_dir_name_is_package_name_only() {
+        // Simulate the naming logic from install_registry_skill_source.
+        for (source, expected_dir) in [
+            ("zeroclaw-org/weather-lookup", "weather-lookup"),
+            ("zeroclaw-org/calculator", "calculator"),
+            ("zeroclaw-user/my_tool", "my_tool"),
+        ] {
+            let parts: Vec<&str> = source.splitn(3, '/').collect();
+            let pkg_name = parts[1];
+            // strip optional @version suffix
+            let pkg_name = pkg_name.split('@').next().unwrap_or(pkg_name);
+            let skill_dir_name = pkg_name.to_string();
+            assert_eq!(
+                skill_dir_name, expected_dir,
+                "registry source '{source}' should install to dir '{expected_dir}', got '{skill_dir_name}'"
+            );
+        }
+    }
+
+    #[test]
+    fn is_registry_source_accepts_valid_namespace_name() {
+        assert!(is_registry_source("zeroclaw/weather-lookup"));
+        assert!(is_registry_source("community/my_tool"));
+        assert!(is_registry_source("org-name/tool_name"));
+        assert!(is_registry_source("ns/name@1.0.0")); // version suffix
+    }
+
+    #[test]
+    fn is_registry_source_rejects_local_path_prefixes() {
+        assert!(!is_registry_source("./weather_lookup"));
+        assert!(!is_registry_source("../parent/skill"));
+        assert!(!is_registry_source("/absolute/path/skill"));
+        assert!(!is_registry_source("~/home/skill"));
+    }
+
+    #[test]
+    fn is_registry_source_rejects_git_urls_and_http_schemes() {
+        assert!(!is_registry_source("https://github.com/org/skill"));
+        assert!(!is_registry_source("http://example.com/skill"));
+        assert!(!is_registry_source("git@github.com:org/skill.git"));
+        assert!(!is_registry_source("ssh://git@github.com/org/skill"));
+    }
+
+    #[test]
+    fn is_registry_source_rejects_invalid_formats() {
+        assert!(!is_registry_source("just-a-name")); // no slash
+        assert!(!is_registry_source("a/b/c")); // too many slashes
+        assert!(!is_registry_source("ns/..")); // path traversal in name
+        assert!(!is_registry_source("../ns/name")); // path traversal prefix
+        assert!(!is_registry_source("")); // empty
+        assert!(!is_registry_source("/")); // empty segments
+    }
+
+    // ── scaffold_skill: validation ────────────────────────────────────────────
+
+    #[test]
+    fn scaffold_skill_rejects_traversal_in_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = scaffold_skill("../escape", "typescript", dir.path());
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Invalid skill name"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn scaffold_skill_rejects_slash_in_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = scaffold_skill("ns/name", "typescript", dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn scaffold_skill_rejects_space_in_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = scaffold_skill("my tool", "typescript", dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn scaffold_skill_rejects_empty_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = scaffold_skill("", "typescript", dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn scaffold_skill_rejects_unknown_template() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = scaffold_skill("zeroclaw_test_tool", "cobol", dir.path());
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Unknown template"), "unexpected: {msg}");
+    }
+
+    #[test]
+    fn scaffold_skill_rejects_existing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("zeroclaw_test_tool")).unwrap();
+        let result = scaffold_skill("zeroclaw_test_tool", "typescript", dir.path());
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("already exists"), "unexpected: {msg}");
+    }
+
+    // ── scaffold_skill: output correctness ───────────────────────────────────
+
+    #[test]
+    fn scaffold_skill_typescript_creates_required_files() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_skill("zeroclaw_test_ts", "typescript", dir.path()).unwrap();
+        let skill_dir = dir.path().join("zeroclaw_test_ts");
+        assert!(skill_dir.join("SKILL.md").exists(), "SKILL.md missing");
+        assert!(skill_dir.join("README.md").exists(), "README.md missing");
+        assert!(skill_dir.join(".gitignore").exists(), ".gitignore missing");
+        assert!(
+            skill_dir.join("manifest.json").exists(),
+            "manifest.json missing"
+        );
+    }
+
+    #[test]
+    fn scaffold_skill_rust_creates_required_files() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_skill("zeroclaw_test_rs", "rust", dir.path()).unwrap();
+        let skill_dir = dir.path().join("zeroclaw_test_rs");
+        assert!(skill_dir.join("Cargo.toml").exists(), "Cargo.toml missing");
+        assert!(
+            skill_dir.join("src").join("main.rs").exists(),
+            "src/main.rs missing"
+        );
+        assert!(skill_dir.join("SKILL.md").exists(), "SKILL.md missing");
+    }
+
+    #[test]
+    fn scaffold_skill_substitutes_name_placeholder() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_skill("zeroclaw_subst_test", "rust", dir.path()).unwrap();
+        let cargo_toml =
+            fs::read_to_string(dir.path().join("zeroclaw_subst_test").join("Cargo.toml")).unwrap();
+        assert!(
+            cargo_toml.contains("zeroclaw_subst_test"),
+            "Cargo.toml should contain skill name, got:\n{cargo_toml}"
+        );
+        assert!(
+            !cargo_toml.contains("__SKILL_NAME__"),
+            "__SKILL_NAME__ placeholder was not substituted"
+        );
+    }
+
+    #[test]
+    fn scaffold_skill_go_creates_required_files() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_skill("zeroclaw_test_go", "go", dir.path()).unwrap();
+        let skill_dir = dir.path().join("zeroclaw_test_go");
+        assert!(
+            skill_dir.join("manifest.json").exists(),
+            "manifest.json missing"
+        );
+        assert!(skill_dir.join("SKILL.md").exists(), "SKILL.md missing");
+    }
+
+    #[test]
+    fn scaffold_skill_gitignore_always_created() {
+        for template in ["rust", "typescript", "go", "python"] {
+            let dir = tempfile::tempdir().unwrap();
+            let name = format!("zeroclaw_test_{template}");
+            scaffold_skill(&name, template, dir.path()).unwrap();
+            assert!(
+                dir.path().join(&name).join(".gitignore").exists(),
+                ".gitignore missing for template {template}"
+            );
+        }
+    }
+
+    #[test]
+    fn scaffold_skill_skill_md_contains_name() {
+        let dir = tempfile::tempdir().unwrap();
+        scaffold_skill("zeroclaw_md_check", "typescript", dir.path()).unwrap();
+        let skill_md =
+            fs::read_to_string(dir.path().join("zeroclaw_md_check").join("SKILL.md")).unwrap();
+        assert!(
+            skill_md.contains("zeroclaw_md_check"),
+            "SKILL.md should reference skill name, got:\n{skill_md}"
+        );
+    }
+
+    // ── ClawhHub source detection and URL building ────────────────────────────
+
+    #[test]
+    fn is_clawhub_source_accepts_profile_url() {
+        assert!(is_clawhub_source("https://clawhub.ai/steipete/gog"));
+        assert!(is_clawhub_source("https://clawhub.ai/gog"));
+        assert!(is_clawhub_source("https://clawhub.ai/user/my-skill"));
+    }
+
+    #[test]
+    fn is_clawhub_source_accepts_short_prefix() {
+        assert!(is_clawhub_source("clawhub:gog"));
+        assert!(is_clawhub_source("clawhub:weather-lookup"));
+    }
+
+    #[test]
+    fn is_clawhub_source_rejects_other_domains() {
+        assert!(!is_clawhub_source("https://github.com/org/skill"));
+        assert!(!is_clawhub_source("https://example.com/skill.zip"));
+        assert!(!is_clawhub_source("zeroclaw/skill"));
+    }
+
+    #[test]
+    fn clawhub_download_url_from_profile_url() {
+        // Owner-namespaced URL: full path forwarded as slug with literal slash
+        let url = clawhub_download_url("https://clawhub.ai/steipete/gog").unwrap();
+        assert_eq!(url, "https://clawhub.ai/api/v1/download?slug=steipete/gog");
+    }
+
+    #[test]
+    fn clawhub_download_url_from_single_path_url() {
+        // Single-segment URL: path is just the skill name
+        let url = clawhub_download_url("https://clawhub.ai/gog").unwrap();
+        assert_eq!(url, "https://clawhub.ai/api/v1/download?slug=gog");
+    }
+
+    #[test]
+    fn clawhub_download_url_from_short_prefix() {
+        let url = clawhub_download_url("clawhub:gog").unwrap();
+        assert_eq!(url, "https://clawhub.ai/api/v1/download?slug=gog");
+    }
+
+    #[test]
+    fn clawhub_download_url_rejects_slash_in_prefix_slug() {
+        assert!(clawhub_download_url("clawhub:owner/gog").is_err());
+    }
+
+    // ── is_zip_url_source ─────────────────────────────────────────────────────
+
+    #[test]
+    fn is_zip_url_source_accepts_explicit_prefix() {
+        assert!(is_zip_url_source("zip:https://example.com/skill.zip"));
+        assert!(is_zip_url_source(
+            "zip:https://example.com/api/download?slug=my-skill"
+        ));
+    }
+
+    #[test]
+    fn is_zip_url_source_accepts_direct_zip_url() {
+        assert!(is_zip_url_source("https://example.com/skill.zip"));
+        assert!(is_zip_url_source(
+            "https://releases.example.com/my-skill-1.0.0.zip"
+        ));
+    }
+
+    #[test]
+    fn is_zip_url_source_rejects_non_zip_https() {
+        // Plain HTTPS URL without .zip suffix and without zip: prefix
+        assert!(!is_zip_url_source("https://github.com/org/skill"));
+        assert!(!is_zip_url_source(
+            "https://example.com/api/download?slug=foo"
+        ));
+    }
+
+    #[test]
+    fn is_zip_url_source_rejects_non_https() {
+        assert!(!is_zip_url_source("zip:http://example.com/skill.zip"));
+        assert!(!is_zip_url_source("http://example.com/skill.zip"));
+        assert!(!is_zip_url_source("ftp://example.com/skill.zip"));
+    }
+
+    #[test]
+    fn is_zip_url_source_rejects_other_formats() {
+        assert!(!is_zip_url_source("zeroclaw/skill"));
+        assert!(!is_zip_url_source("./local/skill.zip"));
+        assert!(!is_zip_url_source("/absolute/path/skill.zip"));
+    }
+
+    // ── normalize_skill_name ──────────────────────────────────────────────────
+
+    #[test]
+    fn normalize_skill_name_converts_hyphens_and_lowercases() {
+        assert_eq!(normalize_skill_name("My-Skill"), "my_skill");
+        assert_eq!(normalize_skill_name("weather-lookup"), "weather_lookup");
+        assert_eq!(normalize_skill_name("GOG"), "gog");
+    }
+
+    #[test]
+    fn normalize_skill_name_strips_non_alnum() {
+        assert_eq!(normalize_skill_name("skill.v1"), "skillv1");
+        assert_eq!(normalize_skill_name("skill@1.0.0"), "skill100");
     }
 }
 

--- a/src/skills/templates.rs
+++ b/src/skills/templates.rs
@@ -1,0 +1,171 @@
+/// A single file to be written when scaffolding from this template.
+pub struct TemplateFile {
+    /// Relative path inside the skill directory (e.g. "src/main.rs")
+    pub path: &'static str,
+    pub content: &'static str,
+}
+
+/// A complete, runnable skill template.
+pub struct SkillTemplate {
+    pub name: &'static str,
+    pub language: &'static str,
+    pub description: &'static str,
+    /// Example args JSON for `zeroclaw skill test`
+    pub test_args: &'static str,
+    pub files: &'static [TemplateFile],
+}
+
+// ── Rust templates ────────────────────────────────────────────────────────────
+
+const RUST_WEATHER_FILES: &[TemplateFile] = &[
+    TemplateFile {
+        path: "Cargo.toml",
+        content: include_str!("../../templates/rust/weather_lookup/Cargo.toml"),
+    },
+    TemplateFile {
+        path: "src/main.rs",
+        content: include_str!("../../templates/rust/weather_lookup/src/main.rs"),
+    },
+    TemplateFile {
+        path: "manifest.json",
+        content: include_str!("../../templates/rust/weather_lookup/manifest.json"),
+    },
+    TemplateFile {
+        path: ".cargo/config.toml",
+        content: include_str!("../../templates/rust/weather_lookup/.cargo/config.toml"),
+    },
+];
+
+const RUST_CALCULATOR_FILES: &[TemplateFile] = &[
+    TemplateFile {
+        path: "Cargo.toml",
+        content: include_str!("../../templates/rust/calculator/Cargo.toml"),
+    },
+    TemplateFile {
+        path: "src/main.rs",
+        content: include_str!("../../templates/rust/calculator/src/main.rs"),
+    },
+    TemplateFile {
+        path: "manifest.json",
+        content: include_str!("../../templates/rust/calculator/manifest.json"),
+    },
+    TemplateFile {
+        path: ".cargo/config.toml",
+        content: include_str!("../../templates/rust/calculator/.cargo/config.toml"),
+    },
+];
+
+// ── TypeScript templates ──────────────────────────────────────────────────────
+
+const TS_HELLO_FILES: &[TemplateFile] = &[
+    TemplateFile {
+        path: "package.json",
+        content: include_str!("../../templates/typescript/hello_world/package.json"),
+    },
+    TemplateFile {
+        path: "tsconfig.json",
+        content: include_str!("../../templates/typescript/hello_world/tsconfig.json"),
+    },
+    TemplateFile {
+        path: "src/index.ts",
+        content: include_str!("../../templates/typescript/hello_world/src/index.ts"),
+    },
+    TemplateFile {
+        path: "manifest.json",
+        content: include_str!("../../templates/typescript/hello_world/manifest.json"),
+    },
+];
+
+// ── Go templates ─────────────────────────────────────────────────────────────
+
+const GO_WORD_COUNT_FILES: &[TemplateFile] = &[
+    TemplateFile {
+        path: "go.mod",
+        content: include_str!("../../templates/go/word_count/go.mod"),
+    },
+    TemplateFile {
+        path: "main.go",
+        content: include_str!("../../templates/go/word_count/main.go"),
+    },
+    TemplateFile {
+        path: "manifest.json",
+        content: include_str!("../../templates/go/word_count/manifest.json"),
+    },
+];
+
+// ── Python templates ──────────────────────────────────────────────────────────
+
+const PY_TEXT_TRANSFORM_FILES: &[TemplateFile] = &[
+    TemplateFile {
+        path: "main.py",
+        content: include_str!("../../templates/python/text_transform/main.py"),
+    },
+    TemplateFile {
+        path: "manifest.json",
+        content: include_str!("../../templates/python/text_transform/manifest.json"),
+    },
+];
+
+// ── Registry ──────────────────────────────────────────────────────────────────
+
+pub const ALL: &[SkillTemplate] = &[
+    SkillTemplate {
+        name: "weather_lookup",
+        language: "rust",
+        description: "Look up current weather for a city (mock data, WASI-safe)",
+        test_args: r#"{"city":"hanoi"}"#,
+        files: RUST_WEATHER_FILES,
+    },
+    SkillTemplate {
+        name: "calculator",
+        language: "rust",
+        description: "Arithmetic calculator — add, subtract, multiply, divide",
+        test_args: r#"{"op":"add","a":3,"b":7}"#,
+        files: RUST_CALCULATOR_FILES,
+    },
+    SkillTemplate {
+        name: "hello_world",
+        language: "typescript",
+        description: "Greet a user by name (TypeScript + Javy)",
+        test_args: r#"{"name":"ZeroClaw"}"#,
+        files: TS_HELLO_FILES,
+    },
+    SkillTemplate {
+        name: "word_count",
+        language: "go",
+        description: "Count words, lines, and characters in text (Go + TinyGo)",
+        test_args: r#"{"text":"hello world foo bar"}"#,
+        files: GO_WORD_COUNT_FILES,
+    },
+    SkillTemplate {
+        name: "text_transform",
+        language: "python",
+        description: "Transform text: uppercase, lowercase, reverse, title case",
+        test_args: r#"{"text":"hello world","transform":"uppercase"}"#,
+        files: PY_TEXT_TRANSFORM_FILES,
+    },
+];
+
+/// Find a template by name. Also accepts language aliases ("rust", "typescript", "go", "python").
+pub fn find(name: &str) -> Option<&'static SkillTemplate> {
+    // Exact name match first
+    if let Some(t) = ALL.iter().find(|t| t.name == name) {
+        return Some(t);
+    }
+    // Language alias → first template for that language
+    let lang = match name {
+        "rust" => "rust",
+        "typescript" | "ts" => "typescript",
+        "go" => "go",
+        "python" | "py" => "python",
+        _ => return None,
+    };
+    ALL.iter().find(|t| t.language == lang)
+}
+
+/// Apply `__SKILL_NAME__` / `__BIN_NAME__` substitutions to template content.
+pub fn apply(content: &str, name: &str, bin_name: &str) -> String {
+    content
+        .replace("__SKILL_NAME__", name)
+        .replace("__BIN_NAME__", bin_name)
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -63,6 +63,7 @@ pub mod task_plan;
 pub mod traits;
 pub mod url_validation;
 pub mod wasm_module;
+pub mod wasm_tool;
 pub mod web_fetch;
 pub mod web_search_tool;
 
@@ -520,7 +521,15 @@ pub fn all_tools_with_runtime(
         }
     }
 
-    boxed_registry_from_arcs(tool_arcs)
+    // Load WASM plugin tools from the skills directory.
+    // Each installed skill package may ship one or more WASM tools under
+    // `<skill-dir>/tools/<tool-name>/{tool.wasm, manifest.json}`.
+    // Failures are logged and skipped — a broken plugin must not block startup.
+    let skills_dir = workspace_dir.join("skills");
+    let mut boxed = boxed_registry_from_arcs(tool_arcs);
+    let wasm_tools = wasm_tool::load_wasm_tools_from_skills(&skills_dir);
+    boxed.extend(wasm_tools);
+    boxed
 }
 
 #[cfg(test)]

--- a/src/tools/wasm_tool.rs
+++ b/src/tools/wasm_tool.rs
@@ -1,0 +1,671 @@
+//! WASM plugin tool — executes a `.wasm` binary as a ZeroClaw tool.
+//!
+//! # Feature gate
+//! Only compiled when `--features wasm-tools` is active.
+//! Without the feature, [`WasmTool`] stubs return a clear error.
+//!
+//! # Protocol (WASI stdio)
+//!
+//! The WASM module communicates via standard WASI stdin / stdout:
+//!
+//! ```text
+//! Host → stdin  : UTF-8 JSON of the tool args (from LLM)
+//! Host ← stdout : UTF-8 JSON of ToolResult
+//! ```
+//!
+//! Expected stdout shape:
+//! ```json
+//! { "success": true, "output": "...", "error": null }
+//! ```
+//!
+//! This means **any language** that can read stdin / write stdout works:
+//! TypeScript (Javy), Rust (wasm32-wasip1), Go (TinyGo), Python (componentize-py), etc.
+//! No custom SDK or ABI boilerplate required.
+//!
+//! # Security
+//! - No filesystem preopened dirs (deny-by-default).
+//! - No network sockets (WASI sockets not enabled).
+//! - Execution time capped via wasmtime epoch interruption: a 1 Hz ticker
+//!   thread advances the epoch each second; the WASM store's deadline is set to
+//!   [`WASM_TIMEOUT_SECS`] epochs so runaway modules are preempted without
+//!   relying on OS-level process signals.
+//! - Output capped at 1 MiB (enforced by [`MemoryOutputPipe`] capacity).
+
+use super::traits::{Tool, ToolResult};
+use anyhow::{bail, Context};
+use async_trait::async_trait;
+use serde_json::Value;
+use std::path::Path;
+
+/// Maximum tool output size (1 MiB).
+const MAX_OUTPUT_BYTES: usize = 1_048_576;
+
+/// Wall-clock timeout for a single WASM invocation.
+const WASM_TIMEOUT_SECS: u64 = 30;
+
+// ─── Feature-gated implementation ─────────────────────────────────────────────
+
+#[cfg(feature = "wasm-tools")]
+mod inner {
+    use super::{
+        async_trait, bail, Context, Path, Tool, ToolResult, Value, MAX_OUTPUT_BYTES,
+        WASM_TIMEOUT_SECS,
+    };
+    use wasmtime::{Config as WtConfig, Engine, Linker, Module, Store};
+    use wasmtime_wasi::{
+        pipe::{MemoryInputPipe, MemoryOutputPipe},
+        preview1::{self, WasiP1Ctx},
+        WasiCtxBuilder,
+    };
+
+    pub struct WasmTool {
+        name: String,
+        description: String,
+        parameters_schema: Value,
+        engine: Engine,
+        module: Module,
+        /// Guards against concurrent invocations: epoch tickers from concurrent
+        /// calls would advance the shared engine epoch at a multiple of 1 Hz,
+        /// causing premature timeouts.
+        is_running: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    impl WasmTool {
+        pub fn load(
+            path: &Path,
+            name: String,
+            description: String,
+            parameters_schema: Value,
+        ) -> anyhow::Result<Self> {
+            let mut cfg = WtConfig::new();
+            cfg.epoch_interruption(true);
+
+            let engine = Engine::new(&cfg).context("failed to create WASM engine")?;
+
+            let bytes = std::fs::read(path)
+                .with_context(|| format!("cannot read WASM file: {}", path.display()))?;
+            let module = Module::new(&engine, &bytes)
+                .with_context(|| format!("cannot compile WASM module: {}", path.display()))?;
+
+            Ok(Self {
+                name,
+                description,
+                parameters_schema,
+                engine,
+                module,
+                is_running: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            })
+        }
+
+        fn invoke_sync(&self, args: &Value) -> anyhow::Result<ToolResult> {
+            let input_bytes = serde_json::to_vec(args)?;
+
+            let stdout_pipe = MemoryOutputPipe::new(MAX_OUTPUT_BYTES);
+            let stdout_for_read = stdout_pipe.clone();
+
+            let wasi_ctx: WasiP1Ctx = WasiCtxBuilder::new()
+                .stdin(MemoryInputPipe::new(input_bytes))
+                .stdout(stdout_pipe)
+                .build_p1();
+
+            let mut store = Store::new(&self.engine, wasi_ctx);
+            // epoch_deadline is in ticks; the incrementer thread below fires at 1 Hz.
+            store.set_epoch_deadline(WASM_TIMEOUT_SECS);
+
+            let mut linker: Linker<WasiP1Ctx> = Linker::new(&self.engine);
+            preview1::add_to_linker_sync(&mut linker, |ctx| ctx)
+                .context("failed to add WASI to linker")?;
+
+            let instance = linker.instantiate(&mut store, &self.module)?;
+
+            // Spawn a background thread that increments the epoch every second.
+            // When the deadline is reached wasmtime returns a trap, unblocking
+            // the call below.
+            let engine_for_ticker = self.engine.clone();
+            let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+            let ticker = std::thread::spawn(move || {
+                while stop_rx
+                    .recv_timeout(std::time::Duration::from_secs(1))
+                    .is_err()
+                {
+                    engine_for_ticker.increment_epoch();
+                }
+            });
+
+            let call_result = instance
+                .get_typed_func::<(), ()>(&mut store, "_start")
+                .context("WASM module must export '_start' (compile as a WASI binary)")
+                .and_then(|start| {
+                    start
+                        .call(&mut store, ())
+                        .context("WASM execution failed or timed out")
+                });
+
+            // Stop the epoch ticker regardless of outcome.
+            let _ = stop_tx.send(());
+            let _ = ticker.join();
+
+            call_result?;
+
+            let raw = stdout_for_read.contents().to_vec();
+            if raw.is_empty() {
+                bail!("WASM tool wrote nothing to stdout");
+            }
+            // Note: MemoryOutputPipe::new(MAX_OUTPUT_BYTES) already caps writes
+            // at construction time, so no separate size check is needed here.
+
+            serde_json::from_slice::<ToolResult>(&raw)
+                .context("WASM tool stdout is not valid ToolResult JSON")
+        }
+    }
+
+    #[async_trait]
+    impl Tool for WasmTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self) -> &str {
+            &self.description
+        }
+        fn parameters_schema(&self) -> Value {
+            self.parameters_schema.clone()
+        }
+
+        async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+            use std::sync::atomic::Ordering;
+
+            // Prevent concurrent invocations: two simultaneous tickers would
+            // advance the shared engine epoch at 2 Hz, halving the timeout.
+            if self
+                .is_running
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+            {
+                bail!(
+                    "WASM tool '{}' is already running; concurrent invocations are not supported",
+                    self.name
+                );
+            }
+
+            // Clone fields needed inside the blocking closure.
+            // Engine and Module are cheaply Arc-backed clones.
+            let name = self.name.clone();
+            let engine = self.engine.clone();
+            let module = self.module.clone();
+            let schema = self.parameters_schema.clone();
+            let desc = self.description.clone();
+            let is_running = self.is_running.clone();
+
+            tokio::task::spawn_blocking(move || {
+                let tool = WasmTool {
+                    name,
+                    description: desc,
+                    parameters_schema: schema,
+                    engine,
+                    module,
+                    is_running: is_running.clone(),
+                };
+                let result = tool
+                    .invoke_sync(&args)
+                    .with_context(|| format!("WASM tool '{}' execution failed", tool.name));
+                is_running.store(false, Ordering::Release);
+                result
+            })
+            .await
+            .context("WASM blocking task panicked")?
+        }
+    }
+
+    pub use WasmTool as WasmToolImpl;
+}
+
+// ─── Feature-absent stub ──────────────────────────────────────────────────────
+
+#[cfg(not(feature = "wasm-tools"))]
+mod inner {
+    use super::*;
+
+    /// Stub: returned when the `wasm-tools` feature is not compiled in.
+    /// Construction succeeds so callers can enumerate plugins; execution returns a clear error.
+    pub struct WasmTool {
+        name: String,
+        description: String,
+        parameters_schema: Value,
+    }
+
+    impl WasmTool {
+        pub fn load(
+            _path: &Path,
+            name: String,
+            description: String,
+            parameters_schema: Value,
+        ) -> anyhow::Result<Self> {
+            Ok(Self {
+                name,
+                description,
+                parameters_schema,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl Tool for WasmTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self) -> &str {
+            &self.description
+        }
+        fn parameters_schema(&self) -> Value {
+            self.parameters_schema.clone()
+        }
+
+        async fn execute(&self, _args: Value) -> anyhow::Result<ToolResult> {
+            Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(
+                    "WASM tools are not enabled in this build. \
+                     Recompile with '--features wasm-tools'."
+                        .into(),
+                ),
+            })
+        }
+    }
+
+    pub use WasmTool as WasmToolImpl;
+}
+
+// ─── Public re-export ─────────────────────────────────────────────────────────
+
+pub use inner::WasmToolImpl as WasmTool;
+
+// ─── Manifest ────────────────────────────────────────────────────────────────
+
+/// The `manifest.json` file that accompanies every WASM tool.
+///
+/// Stored at:
+/// - Dev layout:       `<skill-dir>/manifest.json`
+/// - Installed layout: `<skill-dir>/tools/<tool-name>/manifest.json`
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct WasmManifest {
+    /// Tool name exposed to the LLM (snake_case, e.g. `my_weather_tool`).
+    pub name: String,
+    /// Human-readable description shown to the LLM.
+    pub description: String,
+    /// JSON Schema for the tool's parameters.
+    pub parameters: Value,
+    /// Manifest format version (currently `"1"`).
+    #[serde(default = "default_manifest_version")]
+    pub version: String,
+    /// Optional homepage / source URL (shown in `zeroclaw skill list`).
+    #[serde(default)]
+    pub homepage: Option<String>,
+}
+
+fn default_manifest_version() -> String {
+    "1".to_string()
+}
+
+impl WasmManifest {
+    pub fn load_from(path: &Path) -> anyhow::Result<Self> {
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("cannot read manifest: {}", path.display()))?;
+        serde_json::from_slice(&bytes)
+            .with_context(|| format!("invalid manifest JSON: {}", path.display()))
+    }
+}
+
+// ─── Loader ──────────────────────────────────────────────────────────────────
+
+/// Scan the skills directory and load any WASM tools found.
+///
+/// Supports two layouts:
+///
+/// **Installed layout** (from `zeroclaw skill install`):
+/// ```text
+/// skills/<skill-name>/tools/<tool-name>/tool.wasm
+/// skills/<skill-name>/tools/<tool-name>/manifest.json
+/// ```
+///
+/// **Dev layout** (direct from `zeroclaw skill install ./my-tool`):
+/// ```text
+/// skills/<skill-name>/tool.wasm
+/// skills/<skill-name>/manifest.json
+/// ```
+pub fn load_wasm_tools_from_skills(skills_dir: &std::path::Path) -> Vec<Box<dyn Tool>> {
+    let mut tools: Vec<Box<dyn Tool>> = Vec::new();
+
+    let entries = match std::fs::read_dir(skills_dir) {
+        Ok(e) => e,
+        Err(_) => return tools,
+    };
+
+    for entry in entries.flatten() {
+        let skill_dir = entry.path();
+
+        // Dev layout: tool.wasm + manifest.json at skill root
+        let wasm = skill_dir.join("tool.wasm");
+        let manifest_path = skill_dir.join("manifest.json");
+        if wasm.exists() && manifest_path.exists() {
+            load_single_tool(&wasm, &manifest_path, &mut tools);
+            continue;
+        }
+
+        // Installed layout: tools/<name>/tool.wasm
+        let tools_subdir = skill_dir.join("tools");
+        if let Ok(tool_entries) = std::fs::read_dir(&tools_subdir) {
+            for tool_entry in tool_entries.flatten() {
+                let tool_dir = tool_entry.path();
+                let wasm = tool_dir.join("tool.wasm");
+                let manifest_path = tool_dir.join("manifest.json");
+                if wasm.exists() && manifest_path.exists() {
+                    load_single_tool(&wasm, &manifest_path, &mut tools);
+                }
+            }
+        }
+    }
+
+    tools
+}
+
+/// Collect the tool names declared by installed WASM skill packages by reading
+/// only the `manifest.json` files — no WASM module is compiled or loaded.
+///
+/// Used to pre-populate `auto_approve` for the channel approval manager so that
+/// sandboxed WASM skills are not denied when running on non-CLI channels.
+pub fn wasm_tool_names_from_skills(skills_dir: &std::path::Path) -> Vec<String> {
+    let mut names = Vec::new();
+
+    let entries = match std::fs::read_dir(skills_dir) {
+        Ok(e) => e,
+        Err(_) => return names,
+    };
+
+    for entry in entries.flatten() {
+        let skill_dir = entry.path();
+
+        // Dev layout: manifest.json at skill root
+        let manifest_path = skill_dir.join("manifest.json");
+        if manifest_path.exists() {
+            if let Ok(m) = WasmManifest::load_from(&manifest_path) {
+                if !m.name.is_empty() {
+                    names.push(m.name);
+                }
+            }
+            continue;
+        }
+
+        // Installed layout: tools/<name>/manifest.json
+        let tools_subdir = skill_dir.join("tools");
+        if let Ok(tool_entries) = std::fs::read_dir(&tools_subdir) {
+            for tool_entry in tool_entries.flatten() {
+                let manifest_path = tool_entry.path().join("manifest.json");
+                if manifest_path.exists() {
+                    if let Ok(m) = WasmManifest::load_from(&manifest_path) {
+                        if !m.name.is_empty() {
+                            names.push(m.name);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    names
+}
+
+fn load_single_tool(
+    wasm: &std::path::Path,
+    manifest_path: &std::path::Path,
+    out: &mut Vec<Box<dyn Tool>>,
+) {
+    let manifest = match WasmManifest::load_from(manifest_path) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(path = %manifest_path.display(), error = %e, "skipping WASM tool: bad manifest");
+            return;
+        }
+    };
+
+    // Validate manifest.name: snake_case only (lowercase letters, digits,
+    // underscores), non-empty, max 64 chars (matches function-calling API limits).
+    let name_ok = !manifest.name.is_empty()
+        && manifest.name.len() <= 64
+        && manifest
+            .name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+    if !name_ok {
+        tracing::warn!(
+            path = %manifest_path.display(),
+            name = %manifest.name,
+            "skipping WASM tool: invalid name (must be snake_case, max 64 chars)"
+        );
+        return;
+    }
+
+    match WasmTool::load(
+        wasm,
+        manifest.name.clone(),
+        manifest.description.clone(),
+        manifest.parameters.clone(),
+    ) {
+        Ok(t) => {
+            tracing::debug!(name = %manifest.name, "loaded WASM tool");
+            out.push(Box::new(t));
+        }
+        Err(e) => {
+            tracing::warn!(
+                name = %manifest.name,
+                wasm = %wasm.display(),
+                error = %e,
+                "skipping WASM tool: failed to load"
+            );
+        }
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    #[allow(clippy::wildcard_imports)]
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn manifest_round_trips() {
+        let json = serde_json::json!({
+            "name": "zeroclaw_test_tool",
+            "description": "Test tool",
+            "parameters": { "type": "object", "properties": {} }
+        });
+        let m: WasmManifest = serde_json::from_value(json).unwrap();
+        assert_eq!(m.name, "zeroclaw_test_tool");
+        assert_eq!(m.version, "1");
+        assert!(m.homepage.is_none());
+    }
+
+    #[test]
+    fn load_from_empty_dir_returns_empty() {
+        let tools = load_wasm_tools_from_skills(std::path::Path::new(
+            "/tmp/zeroclaw_wasm_test_nonexistent_xyz",
+        ));
+        assert!(tools.is_empty());
+    }
+
+    #[cfg(not(feature = "wasm-tools"))]
+    #[tokio::test]
+    async fn stub_reports_feature_disabled() {
+        let t = WasmTool::load(
+            &PathBuf::from("/dev/null"),
+            "zeroclaw_test_stub".into(),
+            "stub".into(),
+            serde_json::json!({}),
+        )
+        .unwrap();
+        let r = t.execute(serde_json::json!({})).await.unwrap();
+        assert!(!r.success);
+        assert!(r.error.unwrap().contains("wasm-tools"));
+    }
+
+    // ── WasmManifest error paths ──────────────────────────────────────────────
+
+    #[test]
+    fn manifest_load_from_missing_file_returns_error() {
+        let result = WasmManifest::load_from(&PathBuf::from(
+            "/nonexistent_zeroclaw_test_dir/manifest.json",
+        ));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("cannot read manifest"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn manifest_load_from_invalid_json_returns_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("manifest.json");
+        std::fs::write(&path, b"not valid json {{{{").unwrap();
+        let result = WasmManifest::load_from(&path);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("invalid manifest JSON"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn manifest_with_optional_fields_parsed() {
+        let json = serde_json::json!({
+            "name": "zeroclaw_optional_test",
+            "description": "Tool with all optional fields",
+            "parameters": { "type": "object", "properties": {} },
+            "version": "2",
+            "homepage": "https://example.com/zeroclaw_optional_test"
+        });
+        let m: WasmManifest = serde_json::from_value(json).unwrap();
+        assert_eq!(m.version, "2");
+        assert_eq!(
+            m.homepage.as_deref(),
+            Some("https://example.com/zeroclaw_optional_test")
+        );
+    }
+
+    // ── load_wasm_tools_from_skills: skip / layout detection ─────────────────
+
+    #[test]
+    fn load_wasm_tools_skips_dir_missing_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("zeroclaw_test_skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        // tool.wasm present but no manifest.json — should be skipped silently
+        std::fs::write(skill_dir.join("tool.wasm"), b"\x00asm\x01\x00\x00\x00").unwrap();
+        let tools = load_wasm_tools_from_skills(dir.path());
+        assert!(tools.is_empty());
+    }
+
+    #[test]
+    fn load_wasm_tools_skips_dir_missing_wasm() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("zeroclaw_test_skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        // manifest.json present but no tool.wasm — dev layout check fails
+        std::fs::write(
+            skill_dir.join("manifest.json"),
+            serde_json::json!({
+                "name": "zeroclaw_test_tool",
+                "description": "test",
+                "parameters": {}
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let tools = load_wasm_tools_from_skills(dir.path());
+        assert!(tools.is_empty());
+    }
+
+    #[test]
+    fn load_wasm_tools_skips_bad_manifest_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("zeroclaw_test_skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("tool.wasm"), b"\x00asm\x01\x00\x00\x00").unwrap();
+        std::fs::write(skill_dir.join("manifest.json"), b"not valid json").unwrap();
+        let tools = load_wasm_tools_from_skills(dir.path());
+        assert!(tools.is_empty(), "bad manifest should be skipped");
+    }
+
+    #[test]
+    fn load_wasm_tools_installed_layout_skips_bad_manifest() {
+        // installed layout: skills/<pkg>/tools/<tool>/{tool.wasm, manifest.json}
+        let dir = tempfile::tempdir().unwrap();
+        let tool_dir = dir
+            .path()
+            .join("zeroclaw_test_pkg")
+            .join("tools")
+            .join("zeroclaw_test_func");
+        std::fs::create_dir_all(&tool_dir).unwrap();
+        std::fs::write(tool_dir.join("tool.wasm"), b"\x00asm\x01\x00\x00\x00").unwrap();
+        std::fs::write(tool_dir.join("manifest.json"), b"{ invalid }").unwrap();
+        let tools = load_wasm_tools_from_skills(dir.path());
+        assert!(
+            tools.is_empty(),
+            "bad installed-layout manifest should be skipped"
+        );
+    }
+
+    #[test]
+    fn load_wasm_tools_ignores_plain_files_in_skills_root() {
+        let dir = tempfile::tempdir().unwrap();
+        // A file at the skills root — not a directory, must be ignored
+        std::fs::write(dir.path().join("not-a-skill.txt"), b"noise").unwrap();
+        let tools = load_wasm_tools_from_skills(dir.path());
+        assert!(tools.is_empty());
+    }
+
+    // ── Feature-gated: invalid WASM binary fails at compile time ─────────────
+
+    #[cfg(feature = "wasm-tools")]
+    #[test]
+    #[ignore = "slow: initializes wasmtime Cranelift compiler; run with --include-ignored"]
+    fn wasm_tool_load_rejects_invalid_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let wasm_path = dir.path().join("tool.wasm");
+        std::fs::write(&wasm_path, b"this is not a valid wasm binary").unwrap();
+        let result = WasmTool::load(
+            &wasm_path,
+            "zeroclaw_invalid_test".into(),
+            "desc".into(),
+            serde_json::json!({}),
+        );
+        assert!(result.is_err());
+        let msg = result.err().unwrap().to_string();
+        assert!(
+            msg.contains("cannot compile WASM module"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[cfg(feature = "wasm-tools")]
+    #[test]
+    #[ignore = "slow: initializes wasmtime Cranelift compiler; run with --include-ignored"]
+    fn wasm_tool_load_rejects_missing_file() {
+        let result = WasmTool::load(
+            &PathBuf::from("/nonexistent_zeroclaw_test_wasm/tool.wasm"),
+            "zeroclaw_missing_test".into(),
+            "desc".into(),
+            serde_json::json!({}),
+        );
+        assert!(result.is_err());
+        let msg = result.err().unwrap().to_string();
+        assert!(
+            msg.contains("cannot read WASM file"),
+            "unexpected error: {msg}"
+        );
+    }
+}

--- a/templates/go/word_count/go.mod
+++ b/templates/go/word_count/go.mod
@@ -1,0 +1,3 @@
+module __SKILL_NAME__
+
+go 1.21

--- a/templates/go/word_count/main.go
+++ b/templates/go/word_count/main.go
@@ -1,0 +1,91 @@
+// __SKILL_NAME__ — ZeroClaw Skill (Go / WASI)
+//
+// Counts words, lines, and characters in text.
+// Protocol: read JSON from stdin, write JSON result to stdout.
+// Build:    tinygo build -target=wasip1 -o tool.wasm .
+// Test:     zeroclaw skill test . --args '{"text":"hello world"}'
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+type Args struct {
+	Text string `json:"text"`
+}
+
+type CountResult struct {
+	Words      int `json:"words"`
+	Lines      int `json:"lines"`
+	Characters int `json:"characters"`
+}
+
+type ToolResult struct {
+	Success bool         `json:"success"`
+	Output  string       `json:"output"`
+	Error   *string      `json:"error,omitempty"`
+	Data    *CountResult `json:"data,omitempty"`
+}
+
+func main() {
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		writeError(fmt.Sprintf("failed to read stdin: %v", err))
+		return
+	}
+
+	var args Args
+	if err := json.Unmarshal(data, &args); err != nil {
+		writeError(fmt.Sprintf("invalid input JSON: %v — expected {\"text\":\"...\"}", err))
+		return
+	}
+
+	lines := 0
+	if args.Text != "" {
+		lines = strings.Count(args.Text, "\n") + 1
+	}
+	counts := CountResult{
+		Words:      len(strings.Fields(args.Text)),
+		Lines:      lines,
+		Characters: len([]rune(args.Text)),
+	}
+
+	result := ToolResult{
+		Success: true,
+		Output: fmt.Sprintf("%d %s, %d %s, %d %s",
+			counts.Words, plural(counts.Words, "word", "words"),
+			counts.Lines, plural(counts.Lines, "line", "lines"),
+			counts.Characters, plural(counts.Characters, "character", "characters"),
+		),
+		Data: &counts,
+	}
+
+	out, err := json.Marshal(result)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "json marshal error:", err)
+		os.Exit(1)
+	}
+	os.Stdout.Write(out)
+}
+
+func plural(n int, singular, pluralForm string) string {
+	if n == 1 {
+		return singular
+	}
+	return pluralForm
+}
+
+func writeError(msg string) {
+	result := ToolResult{Success: false, Error: &msg}
+	out, err := json.Marshal(result)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "json marshal error:", err)
+		os.Exit(1)
+	}
+	os.Stdout.Write(out)
+}

--- a/templates/go/word_count/manifest.json
+++ b/templates/go/word_count/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "__SKILL_NAME__",
+  "version": "1",
+  "description": "Count words, lines, and characters in text",
+  "parameters": {
+    "type": "object",
+    "required": ["text"],
+    "properties": {
+      "text": {
+        "type": "string",
+        "description": "Text to analyze"
+      }
+    }
+  }
+}

--- a/templates/python/text_transform/main.py
+++ b/templates/python/text_transform/main.py
@@ -1,0 +1,54 @@
+"""__SKILL_NAME__ — ZeroClaw Skill (Python / WASI)
+
+Transform text in various ways.
+Protocol: read JSON from stdin, write JSON result to stdout.
+Build:    pip install componentize-py
+          componentize-py -d wit/ -w zeroclaw-skill componentize main -o tool.wasm
+Test:     zeroclaw skill test . --args '{"text":"hello world","transform":"uppercase"}'
+"""
+
+import sys
+import json
+
+
+TRANSFORMS = {
+    "uppercase": str.upper,
+    "lowercase": str.lower,
+    "reverse": lambda s: s[::-1],
+    "title": str.title,
+}
+
+
+def run(args: dict) -> dict:
+    if not isinstance(args, dict):
+        raise TypeError("args must be a dict")
+    text = args.get("text", "")
+    transform = args.get("transform", "").lower()
+
+    if transform not in TRANSFORMS:
+        keys = ", ".join(TRANSFORMS.keys())
+        return {"success": False, "output": "", "error": f"unknown transform '{transform}' — use: {keys}"}
+
+    result = TRANSFORMS[transform](text)
+    return {"success": True, "output": result, "error": None}
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        args = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        sys.stdout.write(json.dumps({"success": False, "output": "", "error": f"invalid JSON: {exc}"}))
+        sys.stdout.flush()
+        return
+    try:
+        result = run(args)
+    except Exception as exc:
+        result = {"success": False, "output": "", "error": str(exc)}
+
+    sys.stdout.write(json.dumps(result))
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/python/text_transform/manifest.json
+++ b/templates/python/text_transform/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "__SKILL_NAME__",
+  "version": "1",
+  "description": "Transform text: uppercase, lowercase, reverse, title case",
+  "parameters": {
+    "type": "object",
+    "required": ["text", "transform"],
+    "properties": {
+      "text": {
+        "type": "string",
+        "description": "Input text"
+      },
+      "transform": {
+        "type": "string",
+        "description": "Transformation: uppercase, lowercase, reverse, title",
+        "enum": ["uppercase", "lowercase", "reverse", "title"]
+      }
+    }
+  }
+}

--- a/templates/rust/calculator/.cargo/config.toml
+++ b/templates/rust/calculator/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasip1"

--- a/templates/rust/calculator/Cargo.toml
+++ b/templates/rust/calculator/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+
+[package]
+name = "__SKILL_NAME__"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "__BIN_NAME__"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/templates/rust/calculator/manifest.json
+++ b/templates/rust/calculator/manifest.json
@@ -1,0 +1,23 @@
+{
+  "name": "__SKILL_NAME__",
+  "version": "1",
+  "description": "Arithmetic calculator — add, subtract, multiply, divide",
+  "parameters": {
+    "type": "object",
+    "required": ["op", "a", "b"],
+    "properties": {
+      "op": {
+        "type": "string",
+        "description": "Operation: add, sub, mul, div (aliases: +, -, x/*, /)"
+      },
+      "a": {
+        "type": "number",
+        "description": "First operand"
+      },
+      "b": {
+        "type": "number",
+        "description": "Second operand"
+      }
+    }
+  }
+}

--- a/templates/rust/calculator/src/main.rs
+++ b/templates/rust/calculator/src/main.rs
@@ -1,0 +1,94 @@
+//! __SKILL_NAME__ — ZeroClaw Skill (Rust / WASI)
+//!
+//! Performs arithmetic: add, subtract, multiply, divide.
+//! Protocol: read JSON from stdin, write JSON result to stdout.
+//! Build:    cargo build --target wasm32-wasip1 --release
+//!           cp target/wasm32-wasip1/release/__BIN_NAME__.wasm tool.wasm
+//! Test:     zeroclaw skill test . --args '{"op":"add","a":3,"b":7}'
+
+use std::io::{self, Read, Write};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct Args {
+    op: String,
+    a: f64,
+    b: f64,
+}
+
+#[derive(Serialize)]
+struct ToolResult {
+    success: bool,
+    output: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<f64>,
+}
+
+fn write_result(r: &ToolResult) {
+    let out = serde_json::to_string(r)
+        .unwrap_or_else(|_| r#"{"success":false,"output":"","error":"serialization error"}"#.to_string());
+    let _ = io::stdout().write_all(out.as_bytes());
+}
+
+fn main() {
+    let mut buf = String::new();
+    if let Err(e) = io::stdin().read_to_string(&mut buf) {
+        write_result(&ToolResult {
+            success: false,
+            output: String::new(),
+            error: Some(format!("failed to read stdin: {e}")),
+            result: None,
+        });
+        return;
+    }
+
+    let result = match serde_json::from_str::<Args>(&buf) {
+        Ok(args) => calculate(args),
+        Err(e) => ToolResult {
+            success: false,
+            output: String::new(),
+            error: Some(format!(
+                "invalid input: {e} — expected {{\"op\":\"add|sub|mul|div\",\"a\":1,\"b\":2}}"
+            )),
+            result: None,
+        },
+    };
+
+    write_result(&result);
+}
+
+fn calculate(args: Args) -> ToolResult {
+    let (value, label) = match args.op.as_str() {
+        "add" | "+" => (args.a + args.b, format!("{} + {}", args.a, args.b)),
+        "sub" | "-" => (args.a - args.b, format!("{} - {}", args.a, args.b)),
+        "mul" | "*" | "x" => (args.a * args.b, format!("{} × {}", args.a, args.b)),
+        "div" | "/" => {
+            if args.b == 0.0 {
+                return ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("division by zero".into()),
+                    result: None,
+                };
+            }
+            (args.a / args.b, format!("{} ÷ {}", args.a, args.b))
+        }
+        op => {
+            return ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("unknown op '{op}' — use: add, sub, mul, div")),
+                result: None,
+            };
+        }
+    };
+
+    ToolResult {
+        success: true,
+        output: format!("{label} = {value}"),
+        error: None,
+        result: Some(value),
+    }
+}

--- a/templates/rust/weather_lookup/.cargo/config.toml
+++ b/templates/rust/weather_lookup/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasip1"

--- a/templates/rust/weather_lookup/Cargo.toml
+++ b/templates/rust/weather_lookup/Cargo.toml
@@ -1,0 +1,14 @@
+[workspace]
+
+[package]
+name = "__SKILL_NAME__"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "__BIN_NAME__"
+path = "src/main.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/templates/rust/weather_lookup/manifest.json
+++ b/templates/rust/weather_lookup/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "__SKILL_NAME__",
+  "version": "1",
+  "description": "Look up current weather for a city",
+  "parameters": {
+    "type": "object",
+    "required": ["city"],
+    "properties": {
+      "city": {
+        "type": "string",
+        "description": "City name (e.g. Hanoi, London, Tokyo, Singapore)"
+      }
+    }
+  }
+}

--- a/templates/rust/weather_lookup/src/main.rs
+++ b/templates/rust/weather_lookup/src/main.rs
@@ -1,0 +1,144 @@
+//! __SKILL_NAME__ — ZeroClaw Skill (Rust / WASI)
+//!
+//! Returns mock weather data for a given city.
+//! Protocol: read JSON from stdin, write JSON result to stdout.
+//! Build:    cargo build --target wasm32-wasip1 --release
+//!           cp target/wasm32-wasip1/release/__BIN_NAME__.wasm tool.wasm
+//! Test:     zeroclaw skill test . --args '{"city":"hanoi"}'
+
+use std::io::{self, Read, Write};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct Args {
+    city: String,
+}
+
+#[derive(Serialize)]
+struct WeatherData {
+    city: String,
+    temperature_c: f32,
+    condition: String,
+    humidity_pct: u8,
+    wind_kmh: u8,
+}
+
+#[derive(Serialize)]
+struct ToolResult {
+    success: bool,
+    output: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<WeatherData>,
+}
+
+fn write_result(r: &ToolResult) {
+    let out = serde_json::to_string(r)
+        .unwrap_or_else(|_| r#"{"success":false,"output":"","error":"serialization error"}"#.to_string());
+    let _ = io::stdout().write_all(out.as_bytes());
+}
+
+fn main() {
+    let mut buf = String::new();
+    if let Err(e) = io::stdin().read_to_string(&mut buf) {
+        write_result(&ToolResult {
+            success: false,
+            output: String::new(),
+            error: Some(format!("failed to read stdin: {e}")),
+            data: None,
+        });
+        return;
+    }
+
+    let result = match serde_json::from_str::<Args>(&buf) {
+        Ok(args) => lookup_weather(&args.city),
+        Err(e) => ToolResult {
+            success: false,
+            output: String::new(),
+            error: Some(format!("invalid input: {e} — expected {{\"city\": \"<name>\"}}")),
+            data: None,
+        },
+    };
+
+    write_result(&result);
+}
+
+fn lookup_weather(city: &str) -> ToolResult {
+    // Mock weather database — no HTTP inside WASI sandbox
+    let weather = match city.to_lowercase().as_str() {
+        "hanoi" | "ha noi" => WeatherData {
+            city: "Hanoi".into(),
+            temperature_c: 28.5,
+            condition: "Partly Cloudy".into(),
+            humidity_pct: 75,
+            wind_kmh: 12,
+        },
+        "ho chi minh" | "hcm" | "saigon" => WeatherData {
+            city: "Ho Chi Minh City".into(),
+            temperature_c: 33.0,
+            condition: "Sunny".into(),
+            humidity_pct: 68,
+            wind_kmh: 8,
+        },
+        "da nang" => WeatherData {
+            city: "Da Nang".into(),
+            temperature_c: 30.2,
+            condition: "Clear".into(),
+            humidity_pct: 65,
+            wind_kmh: 15,
+        },
+        "london" => WeatherData {
+            city: "London".into(),
+            temperature_c: 12.0,
+            condition: "Overcast".into(),
+            humidity_pct: 82,
+            wind_kmh: 20,
+        },
+        "tokyo" => WeatherData {
+            city: "Tokyo".into(),
+            temperature_c: 18.0,
+            condition: "Light Rain".into(),
+            humidity_pct: 78,
+            wind_kmh: 10,
+        },
+        "new york" | "nyc" => WeatherData {
+            city: "New York".into(),
+            temperature_c: 15.0,
+            condition: "Cloudy".into(),
+            humidity_pct: 70,
+            wind_kmh: 18,
+        },
+        "paris" => WeatherData {
+            city: "Paris".into(),
+            temperature_c: 14.5,
+            condition: "Rainy".into(),
+            humidity_pct: 85,
+            wind_kmh: 22,
+        },
+        "singapore" => WeatherData {
+            city: "Singapore".into(),
+            temperature_c: 31.0,
+            condition: "Thunderstorm".into(),
+            humidity_pct: 88,
+            wind_kmh: 14,
+        },
+        _ => {
+            return ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "city '{city}' not found. Supported: Hanoi, Ho Chi Minh, Da Nang, London, Tokyo, New York, Paris, Singapore"
+                )),
+                data: None,
+            };
+        }
+    };
+
+    let output = format!(
+        "{}: {}°C, {}, humidity {}%, wind {} km/h",
+        weather.city, weather.temperature_c, weather.condition, weather.humidity_pct, weather.wind_kmh
+    );
+
+    ToolResult { success: true, output, error: None, data: Some(weather) }
+}

--- a/templates/typescript/hello_world/manifest.json
+++ b/templates/typescript/hello_world/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "__SKILL_NAME__",
+  "version": "1",
+  "description": "Greet a user by name",
+  "parameters": {
+    "type": "object",
+    "required": ["name"],
+    "properties": {
+      "name": {
+        "type": "string",
+        "description": "Name to greet"
+      }
+    }
+  }
+}

--- a/templates/typescript/hello_world/package.json
+++ b/templates/typescript/hello_world/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "__SKILL_NAME__",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "npm run compile && javy compile dist/index.js -o tool.wasm",
+    "compile": "esbuild src/index.ts --bundle --platform=node --outfile=dist/index.js --format=cjs",
+    "test": "zeroclaw skill test . --args '{\"name\":\"ZeroClaw\"}'"
+  },
+  "devDependencies": {
+    "esbuild": "^0.24.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/templates/typescript/hello_world/src/index.ts
+++ b/templates/typescript/hello_world/src/index.ts
@@ -1,0 +1,37 @@
+/**
+ * __SKILL_NAME__ — ZeroClaw Skill (TypeScript)
+ *
+ * Protocol: read JSON from stdin, write JSON result to stdout.
+ * Build:    npm install && npm run build  →  tool.wasm
+ * Requires: javy CLI  →  https://github.com/bytecodealliance/javy
+ * Test:     zeroclaw skill test . --args '{"name":"ZeroClaw"}'
+ */
+
+interface Args {
+  name: string;
+}
+
+interface ToolResult {
+  success: boolean;
+  output: string;
+  error?: string;
+}
+
+function run(args: Args): ToolResult {
+  const greeting = `Hello, ${args.name}! Welcome to ZeroClaw skills.`;
+  return { success: true, output: greeting };
+}
+
+let result: ToolResult;
+try {
+  // @ts-ignore — Javy provides synchronous IO
+  const rawInput = new TextDecoder().decode(Javy.IO.readSync());
+  const input = JSON.parse(rawInput);
+  if (!input.name) throw new Error('missing required field: name');
+  result = run(input as Args);
+} catch (e: unknown) {
+  result = { success: false, output: '', error: String(e) };
+}
+
+// @ts-ignore
+Javy.IO.writeSync(new TextEncoder().encode(JSON.stringify(result)));

--- a/templates/typescript/hello_world/tsconfig.json
+++ b/templates/typescript/hello_world/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary\n- integrate WASM skill execution engine and registry install flow\n- include template/runtime/security hardening updates from the issue branch\n- rebase and republish with attribution aligned to @theonlyhennygod\n\n## Validation\n- cargo fmt --all\n- cargo check --offline (blocked in this env for wasmtime-wasi cache)\n\nSupersedes #1789\n\nCloses #1787