### PR TITLE
feat(provider): add qwen-coding-plan endpoint alias

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -62,6 +62,7 @@ const MOONSHOT_CN_BASE_URL: &str = "https://api.moonshot.cn/v1";
 const QWEN_CN_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
 const QWEN_INTL_BASE_URL: &str = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
 const QWEN_US_BASE_URL: &str = "https://dashscope-us.aliyuncs.com/compatible-mode/v1";
+const QWEN_CODING_PLAN_BASE_URL: &str = "https://coding.dashscope.aliyuncs.com/v1";
 const QWEN_OAUTH_BASE_FALLBACK_URL: &str = QWEN_CN_BASE_URL;
 const QWEN_OAUTH_TOKEN_ENDPOINT: &str = "https://chat.qwen.ai/api/v1/oauth2/token";
 const QWEN_OAUTH_PLACEHOLDER: &str = "qwen-oauth";
@@ -146,11 +147,16 @@ pub(crate) fn is_qwen_oauth_alias(name: &str) -> bool {
     matches!(name, "qwen-code" | "qwen-oauth" | "qwen_oauth")
 }
 
+pub(crate) fn is_qwen_coding_plan_alias(name: &str) -> bool {
+    matches!(name, "qwen-coding-plan")
+}
+
 pub(crate) fn is_qwen_alias(name: &str) -> bool {
     is_qwen_cn_alias(name)
         || is_qwen_intl_alias(name)
         || is_qwen_us_alias(name)
         || is_qwen_oauth_alias(name)
+        || is_qwen_coding_plan_alias(name)
 }
 
 pub(crate) fn is_zai_global_alias(name: &str) -> bool {
@@ -650,7 +656,9 @@ fn moonshot_base_url(name: &str) -> Option<&'static str> {
 }
 
 fn qwen_base_url(name: &str) -> Option<&'static str> {
-    if is_qwen_cn_alias(name) || is_qwen_oauth_alias(name) {
+    if is_qwen_coding_plan_alias(name) {
+        Some(QWEN_CODING_PLAN_BASE_URL)
+    } else if is_qwen_cn_alias(name) || is_qwen_oauth_alias(name) {
         Some(QWEN_CN_BASE_URL)
     } else if is_qwen_intl_alias(name) {
         Some(QWEN_INTL_BASE_URL)
@@ -1713,6 +1721,7 @@ pub fn list_providers() -> Vec<ProviderInfo> {
                 "dashscope-intl",
                 "qwen-us",
                 "dashscope-us",
+                "qwen-coding-plan",
                 "qwen-code",
                 "qwen-oauth",
                 "qwen_oauth",
@@ -2048,6 +2057,7 @@ mod tests {
         assert!(is_minimax_alias("minimax-portal-cn"));
         assert!(is_qwen_alias("dashscope"));
         assert!(is_qwen_alias("qwen-us"));
+        assert!(is_qwen_alias("qwen-coding-plan"));
         assert!(is_qwen_alias("qwen-code"));
         assert!(is_qwen_oauth_alias("qwen-code"));
         assert!(is_qwen_oauth_alias("qwen_oauth"));
@@ -2078,6 +2088,10 @@ mod tests {
         assert_eq!(canonical_china_provider_name("minimax-cn"), Some("minimax"));
         assert_eq!(canonical_china_provider_name("qwen"), Some("qwen"));
         assert_eq!(canonical_china_provider_name("dashscope-us"), Some("qwen"));
+        assert_eq!(
+            canonical_china_provider_name("qwen-coding-plan"),
+            Some("qwen")
+        );
         assert_eq!(canonical_china_provider_name("qwen-code"), Some("qwen"));
         assert_eq!(canonical_china_provider_name("zai"), Some("zai"));
         assert_eq!(canonical_china_provider_name("z.ai-cn"), Some("zai"));
@@ -2113,6 +2127,10 @@ mod tests {
         assert_eq!(qwen_base_url("qwen-cn"), Some(QWEN_CN_BASE_URL));
         assert_eq!(qwen_base_url("qwen-intl"), Some(QWEN_INTL_BASE_URL));
         assert_eq!(qwen_base_url("qwen-us"), Some(QWEN_US_BASE_URL));
+        assert_eq!(
+            qwen_base_url("qwen-coding-plan"),
+            Some(QWEN_CODING_PLAN_BASE_URL)
+        );
         assert_eq!(qwen_base_url("qwen-code"), Some(QWEN_CN_BASE_URL));
 
         assert_eq!(zai_base_url("zai"), Some(ZAI_GLOBAL_BASE_URL));
@@ -2310,6 +2328,7 @@ mod tests {
         assert!(create_provider("dashscope-international", Some("key")).is_ok());
         assert!(create_provider("qwen-us", Some("key")).is_ok());
         assert!(create_provider("dashscope-us", Some("key")).is_ok());
+        assert!(create_provider("qwen-coding-plan", Some("key")).is_ok());
         assert!(create_provider("qwen-code", Some("key")).is_ok());
         assert!(create_provider("qwen-oauth", Some("key")).is_ok());
     }
@@ -2761,6 +2780,7 @@ mod tests {
             "qwen-intl",
             "qwen-cn",
             "qwen-us",
+            "qwen-coding-plan",
             "qwen-code",
             "lmstudio",
             "llamacpp",

--- a/src/providers/quota_adapter.rs
+++ b/src/providers/quota_adapter.rs
@@ -260,6 +260,7 @@ impl UniversalQuotaExtractor {
         extractors.insert("gemini".to_string(), Box::new(GeminiQuotaExtractor));
         extractors.insert("openrouter".to_string(), Box::new(OpenAIQuotaExtractor)); // OpenRouter uses OpenAI format
         extractors.insert("qwen".to_string(), Box::new(QwenQuotaExtractor));
+        extractors.insert("qwen-coding-plan".to_string(), Box::new(QwenQuotaExtractor));
         extractors.insert("qwen-code".to_string(), Box::new(QwenQuotaExtractor)); // OAuth alias
         extractors.insert("qwen-oauth".to_string(), Box::new(QwenQuotaExtractor)); // OAuth alias
         extractors.insert("dashscope".to_string(), Box::new(QwenQuotaExtractor)); // DashScope API key

--- a/src/providers/quota_cli.rs
+++ b/src/providers/quota_cli.rs
@@ -377,7 +377,14 @@ fn add_qwen_oauth_static_quota(
     provider_filter: Option<&str>,
 ) -> Result<()> {
     // Check if qwen-code or qwen-oauth is requested
-    let qwen_aliases = ["qwen", "qwen-code", "qwen-oauth", "qwen_oauth", "dashscope"];
+    let qwen_aliases = [
+        "qwen",
+        "qwen-coding-plan",
+        "qwen-code",
+        "qwen-oauth",
+        "qwen_oauth",
+        "dashscope",
+    ];
     let should_add_qwen = provider_filter
         .map(|f| qwen_aliases.contains(&f))
         .unwrap_or(true); // If no filter, always try to add
@@ -414,8 +421,8 @@ fn add_qwen_oauth_static_quota(
         profiles: vec![ProfileQuotaInfo {
             profile_name: "OAuth (portal.qwen.ai)".to_string(),
             status: QuotaStatus::Ok,
-            rate_limit_remaining: None, // Unknown without local tracking
-            rate_limit_reset_at: None,  // Daily reset (exact time unknown)
+            rate_limit_remaining: None,   // Unknown without local tracking
+            rate_limit_reset_at: None,    // Daily reset (exact time unknown)
             rate_limit_total: Some(1000), // OAuth free tier limit
         }],
     });


### PR DESCRIPTION
Closes #1955

## Summary
- add `qwen-coding-plan` as a first-class Qwen alias routed to `https://coding.dashscope.aliyuncs.com/v1`
- keep canonical grouping under `qwen` while preserving existing `qwen-code` OAuth semantics
- wire onboarding defaults/models endpoint/selection text so coding-plan users get `qwen3-coder-plus` and `/v1/models`
- register `qwen-coding-plan` in quota adapters that already handle Qwen semantics

## Validation
- `cargo fmt -- src/onboard/wizard.rs src/providers/mod.rs src/providers/quota_adapter.rs src/providers/quota_cli.rs`
- attempted targeted tests, but baseline compile currently fails on unrelated pre-existing errors in `src/config/schema.rs` and `src/skills/mod.rs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "qwen-coding-plan" as a new Qwen provider variant with three specialized coding models (qwen3-coder-plus, qwen3.5-plus, qwen3-max-2026-01-23) optimized for code generation, completion, and development tasks
  * Configured dedicated API endpoint with integrated quota extraction, credential mapping, and automatic provider alias support

* **Tests**
  * Extended test coverage to validate provider alias recognition, model endpoint routing, quota extraction, and credential handling for the new variant

<!-- end of auto-generated comment: release notes by coderabbit.ai -->