### PR TITLE
feat(cron): add lark and feishu delivery targets

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -127,7 +127,14 @@ tokio::task_local! {
     static TOOL_LOOP_REPLY_TARGET: Option<String>;
 }
 
-const AUTO_CRON_DELIVERY_CHANNELS: &[&str] = &["telegram", "discord", "slack", "mattermost"];
+const AUTO_CRON_DELIVERY_CHANNELS: &[&str] = &[
+    "telegram",
+    "discord",
+    "slack",
+    "mattermost",
+    "lark",
+    "feishu",
+];
 
 const NON_CLI_APPROVAL_WAIT_TIMEOUT_SECS: u64 = 300;
 const NON_CLI_APPROVAL_POLL_INTERVAL_MS: u64 = 250;
@@ -2179,6 +2186,25 @@ mod tests {
         maybe_inject_cron_add_delivery("cron_add", &mut args, "telegram", Some("-10012345"));
 
         assert!(args.get("delivery").is_none());
+    }
+
+    #[test]
+    fn maybe_inject_cron_add_delivery_supports_lark_and_feishu_channels() {
+        let mut lark_args = serde_json::json!({
+            "job_type": "agent",
+            "prompt": "daily summary"
+        });
+        maybe_inject_cron_add_delivery("cron_add", &mut lark_args, "lark", Some("oc_xxx"));
+        assert_eq!(lark_args["delivery"]["channel"], "lark");
+        assert_eq!(lark_args["delivery"]["to"], "oc_xxx");
+
+        let mut feishu_args = serde_json::json!({
+            "job_type": "agent",
+            "prompt": "daily summary"
+        });
+        maybe_inject_cron_add_delivery("cron_add", &mut feishu_args, "feishu", Some("oc_yyy"));
+        assert_eq!(feishu_args["delivery"]["channel"], "feishu");
+        assert_eq!(feishu_args["delivery"]["to"], "oc_yyy");
     }
 
     use crate::memory::{Memory, MemoryCategory, SqliteMemory};

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "channel-lark")]
+use crate::channels::LarkChannel;
 use crate::channels::{
     Channel, DiscordChannel, EmailChannel, MattermostChannel, QQChannel, SendMessage, SlackChannel,
     TelegramChannel,
@@ -378,6 +380,38 @@ pub(crate) async fn deliver_announcement(
                 qq.allowed_users.clone(),
             );
             channel.send(&SendMessage::new(output, target)).await?;
+        }
+        "lark" => {
+            #[cfg(feature = "channel-lark")]
+            {
+                let lark = config
+                    .channels_config
+                    .lark
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("lark channel not configured"))?;
+                let channel = LarkChannel::from_lark_config(lark);
+                channel.send(&SendMessage::new(output, target)).await?;
+            }
+            #[cfg(not(feature = "channel-lark"))]
+            {
+                anyhow::bail!("lark delivery channel requires `channel-lark` feature");
+            }
+        }
+        "feishu" => {
+            #[cfg(feature = "channel-lark")]
+            {
+                let feishu = config
+                    .channels_config
+                    .feishu
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("feishu channel not configured"))?;
+                let channel = LarkChannel::from_feishu_config(feishu);
+                channel.send(&SendMessage::new(output, target)).await?;
+            }
+            #[cfg(not(feature = "channel-lark"))]
+            {
+                anyhow::bail!("feishu delivery channel requires `channel-lark` feature");
+            }
         }
         "email" => {
             let email = config

--- a/src/tools/cron_add.rs
+++ b/src/tools/cron_add.rs
@@ -56,7 +56,7 @@ impl Tool for CronAddTool {
     fn description(&self) -> &str {
         "Create a scheduled cron job (shell or agent) with cron/at/every schedules. \
          Use job_type='agent' with a prompt to run the AI agent on schedule. \
-         To deliver output to a channel (Discord, Telegram, Slack, Mattermost, QQ, Email), set \
+         To deliver output to a channel (Discord, Telegram, Slack, Mattermost, QQ, Lark, Feishu, Email), set \
          delivery={\"mode\":\"announce\",\"channel\":\"discord\",\"to\":\"<channel_id_or_chat_id>\"}. \
          This is the preferred tool for sending scheduled/delayed messages to users via channels."
     }
@@ -80,7 +80,7 @@ impl Tool for CronAddTool {
                     "description": "Delivery config to send job output to a channel. Example: {\"mode\":\"announce\",\"channel\":\"discord\",\"to\":\"<channel_id>\"}",
                     "properties": {
                         "mode": { "type": "string", "enum": ["none", "announce"], "description": "Set to 'announce' to deliver output to a channel" },
-                        "channel": { "type": "string", "enum": ["telegram", "discord", "slack", "mattermost", "qq", "email"], "description": "Channel type to deliver to" },
+                        "channel": { "type": "string", "enum": ["telegram", "discord", "slack", "mattermost", "qq", "lark", "feishu", "email"], "description": "Channel type to deliver to" },
                         "to": { "type": "string", "description": "Target: Discord channel ID, Telegram chat ID, Slack channel, etc." },
                         "best_effort": { "type": "boolean", "description": "If true, delivery failure does not fail the job" }
                     }

--- a/src/tools/schedule.rs
+++ b/src/tools/schedule.rs
@@ -29,7 +29,7 @@ impl Tool for ScheduleTool {
     fn description(&self) -> &str {
         "Manage scheduled shell-only tasks. Actions: create/add/once/list/get/cancel/remove/pause/resume. \
          WARNING: This tool creates shell jobs whose output is only logged, NOT delivered to any channel. \
-         To send a scheduled message to Discord/Telegram/Slack, use the cron_add tool with job_type='agent' \
+         To send a scheduled message to Discord/Telegram/Slack/Mattermost/QQ/Lark/Feishu/Email, use the cron_add tool with job_type='agent' \
          and a delivery config like {\"mode\":\"announce\",\"channel\":\"discord\",\"to\":\"<channel_id>\"}."
     }
 


### PR DESCRIPTION
Closes #1715

## Summary
- add lark and feishu as valid delivery channel values for cron_add
- route scheduler announce delivery through LarkChannel::from_lark_config and LarkChannel::from_feishu_config
- extend auto-injected cron delivery support for lark and feishu chat contexts

## Validation
- attempted targeted cargo tests, but repository currently fails to compile due pre-existing unrelated baseline errors in src/config/schema.rs, src/onboard/wizard.rs, and src/skills/mod.rs