### PR TITLE
fix(qq): add sandbox mode and passive msg id fallback

### DIFF
--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -459,11 +459,13 @@ app_id = "qq-app-id"
 app_secret = "qq-app-secret"
 allowed_users = ["*"]
 receive_mode = "webhook" # webhook (default) or websocket (legacy fallback)
+environment = "production" # production (default) or sandbox
 ```
 
 Notes:
 
 - `webhook` mode is now the default and serves inbound callbacks at `POST /qq`.
+- Set `environment = "sandbox"` to target `https://sandbox.api.sgroup.qq.com` for unpublished bot testing.
 - QQ validation challenge payloads (`op = 13`) are auto-signed using `app_secret`.
 - `X-Bot-Appid` is checked when present and must match `app_id`.
 - Set `receive_mode = "websocket"` to keep the legacy gateway WS receive path.

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4463,10 +4463,11 @@ fn collect_configured_channels(
         } else {
             channels.push(ConfiguredChannel {
                 display_name: "QQ",
-                channel: Arc::new(QQChannel::new(
+                channel: Arc::new(QQChannel::new_with_environment(
                     qq.app_id.clone(),
                     qq.app_secret.clone(),
                     qq.allowed_users.clone(),
+                    qq.environment.clone(),
                 )),
             });
         }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4879,6 +4879,15 @@ pub enum QQReceiveMode {
     Webhook,
 }
 
+/// QQ API environment.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum QQEnvironment {
+    #[default]
+    Production,
+    Sandbox,
+}
+
 /// QQ Official Bot configuration (Tencent QQ Bot SDK)
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct QQConfig {
@@ -4892,6 +4901,9 @@ pub struct QQConfig {
     /// Event receive mode: "webhook" (default) or "websocket".
     #[serde(default)]
     pub receive_mode: QQReceiveMode,
+    /// API environment: "production" (default) or "sandbox".
+    #[serde(default)]
+    pub environment: QQEnvironment,
 }
 
 impl ChannelConfig for QQConfig {
@@ -10382,6 +10394,7 @@ default_model = "legacy-model"
         let json = r#"{"app_id":"123","app_secret":"secret"}"#;
         let parsed: QQConfig = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.receive_mode, QQReceiveMode::Webhook);
+        assert_eq!(parsed.environment, QQEnvironment::Production);
         assert!(parsed.allowed_users.is_empty());
     }
 
@@ -10392,10 +10405,12 @@ default_model = "legacy-model"
             app_secret: "secret".into(),
             allowed_users: vec!["*".into()],
             receive_mode: QQReceiveMode::Websocket,
+            environment: QQEnvironment::Sandbox,
         };
         let toml_str = toml::to_string(&qc).unwrap();
         let parsed: QQConfig = toml::from_str(&toml_str).unwrap();
         assert_eq!(parsed.receive_mode, QQReceiveMode::Websocket);
+        assert_eq!(parsed.environment, QQEnvironment::Sandbox);
         assert_eq!(parsed.allowed_users, vec!["*"]);
     }
 

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -372,10 +372,11 @@ pub(crate) async fn deliver_announcement(
                 .qq
                 .as_ref()
                 .ok_or_else(|| anyhow::anyhow!("qq channel not configured"))?;
-            let channel = QQChannel::new(
+            let channel = QQChannel::new_with_environment(
                 qq.app_id.clone(),
                 qq.app_secret.clone(),
                 qq.allowed_users.clone(),
+                qq.environment.clone(),
             );
             channel.send(&SendMessage::new(output, target)).await?;
         }

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -503,6 +503,7 @@ mod tests {
             app_secret: "app-secret".into(),
             allowed_users: vec!["*".into()],
             receive_mode: crate::config::schema::QQReceiveMode::Websocket,
+            environment: crate::config::schema::QQEnvironment::Production,
         });
         assert!(has_supervised_channels(&config));
     }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -516,10 +516,11 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
 
     // QQ channel (if configured)
     let qq_channel: Option<Arc<QQChannel>> = config.channels_config.qq.as_ref().map(|qq_cfg| {
-        Arc::new(QQChannel::new(
+        Arc::new(QQChannel::new_with_environment(
             qq_cfg.app_id.clone(),
             qq_cfg.app_secret.clone(),
             qq_cfg.allowed_users.clone(),
+            qq_cfg.environment.clone(),
         ))
     });
     let qq_webhook_enabled = config

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -1,7 +1,7 @@
 use crate::config::schema::{
     default_nostr_relays, DingTalkConfig, IrcConfig, LarkReceiveMode, LinqConfig,
-    NextcloudTalkConfig, NostrConfig, QQConfig, QQReceiveMode, SignalConfig, StreamMode,
-    WhatsAppConfig,
+    NextcloudTalkConfig, NostrConfig, QQConfig, QQEnvironment, QQReceiveMode, SignalConfig,
+    StreamMode, WhatsAppConfig,
 };
 use crate::config::{
     AutonomyConfig, BrowserConfig, ChannelsConfig, ComposioConfig, Config, DiscordConfig,
@@ -5010,11 +5010,23 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     QQReceiveMode::Websocket
                 };
 
+                let environment_choice = Select::new()
+                    .with_prompt("  API environment")
+                    .items(["Production", "Sandbox (for unpublished bot testing)"])
+                    .default(0)
+                    .interact()?;
+                let environment = if environment_choice == 0 {
+                    QQEnvironment::Production
+                } else {
+                    QQEnvironment::Sandbox
+                };
+
                 config.qq = Some(QQConfig {
                     app_id,
                     app_secret,
                     allowed_users,
                     receive_mode,
+                    environment,
                 });
             }
             ChannelMenuChoice::LarkFeishu => {
@@ -7673,6 +7685,7 @@ mod tests {
             app_secret: "app-secret".into(),
             allowed_users: vec!["*".into()],
             receive_mode: crate::config::schema::QQReceiveMode::Websocket,
+            environment: crate::config::schema::QQEnvironment::Production,
         });
         assert!(has_launchable_channels(&channels));
 


### PR DESCRIPTION
Closes #1714

## Summary
- add channels_config.qq.environment (production/sandbox) with default production
- route QQ API send and gateway endpoints by configured environment, including sandbox.api.sgroup.qq.com support
- wire QQ environment through runtime channel constructors in startup, gateway, and cron delivery paths
- accept payload msg_id as fallback when id is missing to preserve passive-reply threading
- add tests, docs, and wizard prompts for QQ sandbox configuration

## Validation
- attempted targeted cargo tests, but repository currently fails to compile due pre-existing unrelated baseline errors in src/config/schema.rs, src/onboard/wizard.rs, and src/skills/mod.rs