### PR TITLE
docs(structure): make docs navigation explicit by function

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -90,6 +90,7 @@ Localized hubs: [简体中文](i18n/zh-CN/README.md) · [日本語](i18n/ja/READ
 
 - Unified TOC: [SUMMARY.md](SUMMARY.md)
 - Docs structure map (language/part/function): [structure/README.md](structure/README.md)
+- Docs map by function: [structure/by-function.md](structure/by-function.md)
 - Documentation inventory/classification: [docs-inventory.md](docs-inventory.md)
 - i18n docs index: [i18n/README.md](i18n/README.md)
 - i18n coverage map: [i18n-coverage.md](i18n-coverage.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,6 +7,7 @@ Last refreshed: **February 25, 2026**.
 ## Language Entry
 
 - Docs Structure Map (language/part/function): [structure/README.md](structure/README.md)
+- Docs Map (by function): [structure/by-function.md](structure/by-function.md)
 - English README: [../README.md](../README.md)
 - Chinese README: [docs/i18n/zh-CN/README.md](i18n/zh-CN/README.md)
 - Japanese README: [docs/i18n/ja/README.md](i18n/ja/README.md)

--- a/docs/docs-inventory.md
+++ b/docs/docs-inventory.md
@@ -33,6 +33,7 @@ Last reviewed: **February 24, 2026**.
 | `docs/README.md` | Current Guide (hub) | all readers |
 | `docs/SUMMARY.md` | Current Guide (unified TOC) | all readers |
 | `docs/structure/README.md` | Current Guide (structure map) | maintainers |
+| `docs/structure/by-function.md` | Current Guide (function map) | maintainers/operators |
 | `docs/i18n-guide.md` | Current Guide (i18n completion contract) | contributors/agents |
 | `docs/i18n/README.md` | Current Guide (locale index) | maintainers/translators |
 | `docs/i18n-coverage.md` | Current Guide (coverage matrix) | maintainers/translators |

--- a/docs/structure/README.md
+++ b/docs/structure/README.md
@@ -4,6 +4,11 @@ This page defines the canonical documentation layout and compatibility layers.
 
 Last refreshed: **February 24, 2026**.
 
+Companion indexes:
+- Function-oriented map: [by-function.md](by-function.md)
+- Hub entry point: [../README.md](../README.md)
+- Unified TOC: [../SUMMARY.md](../SUMMARY.md)
+
 ## 1) Directory Spine (Canonical)
 
 ### Layer A: global entry points

--- a/docs/structure/by-function.md
+++ b/docs/structure/by-function.md
@@ -1,0 +1,64 @@
+# ZeroClaw Docs By Function
+
+This index groups documentation by operational function instead of folder path.
+
+Use this when you know what you need to do, but not where the doc lives.
+
+## Setup And Onboarding
+
+- Core quick start: [../../README.md](../../README.md)
+- Docs hub: [../README.md](../README.md)
+- One-click bootstrap: [../one-click-bootstrap.md](../one-click-bootstrap.md)
+- Android setup: [../android-setup.md](../android-setup.md)
+- Docker setup: [../docker-setup.md](../docker-setup.md)
+- Getting started collection: [../getting-started/README.md](../getting-started/README.md)
+
+## Commands, Config, And Providers
+
+- Commands reference: [../commands-reference.md](../commands-reference.md)
+- Config reference: [../config-reference.md](../config-reference.md)
+- Providers reference: [../providers-reference.md](../providers-reference.md)
+- Channels reference: [../channels-reference.md](../channels-reference.md)
+- Custom providers: [../custom-providers.md](../custom-providers.md)
+- Z.AI/GLM setup: [../zai-glm-setup.md](../zai-glm-setup.md)
+- Reference collection: [../reference/README.md](../reference/README.md)
+
+## Operations And Deployment
+
+- Operations runbook: [../operations-runbook.md](../operations-runbook.md)
+- Troubleshooting: [../troubleshooting.md](../troubleshooting.md)
+- Network deployment: [../network-deployment.md](../network-deployment.md)
+- Release process: [../release-process.md](../release-process.md)
+- Operations collection: [../operations/README.md](../operations/README.md)
+
+## Security And Trust
+
+- Security collection: [../security/README.md](../security/README.md)
+- Security roadmap: [../security-roadmap.md](../security-roadmap.md)
+- Sandboxing: [../sandboxing.md](../sandboxing.md)
+- Audit logging: [../audit-logging.md](../audit-logging.md)
+- Resource limits: [../resource-limits.md](../resource-limits.md)
+
+## Hardware And Peripherals
+
+- Hardware collection: [../hardware/README.md](../hardware/README.md)
+- Add boards/tools: [../adding-boards-and-tools.md](../adding-boards-and-tools.md)
+- Nucleo setup: [../nucleo-setup.md](../nucleo-setup.md)
+- Arduino setup: [../arduino-uno-q-setup.md](../arduino-uno-q-setup.md)
+- Datasheets index: [../datasheets/README.md](../datasheets/README.md)
+
+## Contributing And CI
+
+- Contribution collection: [../contributing/README.md](../contributing/README.md)
+- PR workflow: [../pr-workflow.md](../pr-workflow.md)
+- Reviewer playbook: [../reviewer-playbook.md](../reviewer-playbook.md)
+- CI map: [../ci-map.md](../ci-map.md)
+- Actions source policy: [../actions-source-policy.md](../actions-source-policy.md)
+
+## Localization And Information Architecture
+
+- i18n index: [../i18n/README.md](../i18n/README.md)
+- i18n coverage map: [../i18n-coverage.md](../i18n-coverage.md)
+- i18n guide: [../i18n-guide.md](../i18n-guide.md)
+- Docs inventory: [../docs-inventory.md](../docs-inventory.md)
+- Docs structure map: [README.md](README.md)


### PR DESCRIPTION
## Summary
- add a dedicated docs map grouped by function: `docs/structure/by-function.md`
- link function-oriented navigation from the docs hub (`docs/README.md`) and unified TOC (`docs/SUMMARY.md`)
- register the new artifact in docs governance/inventory (`docs/docs-inventory.md`) and structure map (`docs/structure/README.md`)

## Why
- issue #1272 asks for clearer docs structure by language, part, and function
- language and part views already existed; this completes the function view from first-hop entry points

## Validation
- docs-only change; verified links/paths in edited files

Closes #1272


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new function-based documentation index that organizes guides by operational purpose rather than folder structure, making it easier to find relevant docs based on what you need to accomplish.
  * Includes seven functional categories: Setup, Commands & Config, Operations & Deployment, Security, Hardware, Contributing, and Localization, each with relevant documentation links.
  * Updated documentation navigation to include multiple entry points to the new index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->