### PR TITLE
docs(security): publish official anti-fraud channels statement

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,6 +32,20 @@ Preferred reporting paths:
 - Suggested mitigation or patch direction (if known)
 - Any known workaround
 
+## Official Channels and Anti-Fraud Notice
+
+Impersonation scams are a real risk in open communities.
+
+Security-critical rule:
+
+- ZeroClaw maintainers will not ask for cryptocurrency, wallet seed phrases, or private financial credentials.
+- Treat direct-message payment requests as fraudulent unless independently verified in the repository.
+- Verify announcements using repository sources first.
+
+Canonical statement and reporting guidance:
+
+- [docs/security/official-channels-and-fraud-prevention.md](docs/security/official-channels-and-fraud-prevention.md)
+
 ## Maintainer Handling Workflow (GitHub-Native)
 
 ### 1. Intake and triage (private)

--- a/docs/README.md
+++ b/docs/README.md
@@ -79,6 +79,7 @@ Localized hubs: [简体中文](i18n/zh-CN/README.md) · [日本語](i18n/ja/READ
 > Note: this area includes proposal/roadmap docs. For current behavior, start with [config-reference.md](config-reference.md), [operations-runbook.md](operations-runbook.md), and [troubleshooting.md](troubleshooting.md).
 
 - [security/README.md](security/README.md)
+- [security/official-channels-and-fraud-prevention.md](security/official-channels-and-fraud-prevention.md)
 - [agnostic-security.md](agnostic-security.md)
 - [frictionless-security.md](frictionless-security.md)
 - [sandboxing.md](sandboxing.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -64,6 +64,7 @@ Last refreshed: **February 25, 2026**.
 ### 4) Security Design & Proposals
 
 - [security/README.md](security/README.md)
+- [security/official-channels-and-fraud-prevention.md](security/official-channels-and-fraud-prevention.md)
 - [agnostic-security.md](agnostic-security.md)
 - [frictionless-security.md](frictionless-security.md)
 - [sandboxing.md](sandboxing.md)

--- a/docs/docs-inventory.md
+++ b/docs/docs-inventory.md
@@ -94,6 +94,7 @@ Compatibility shims such as `docs/SUMMARY.<locale>.md` and `docs/vi/**` remain v
 | `docs/datasheets/arduino-uno.md` | Current Hardware Reference | hardware builders |
 | `docs/datasheets/esp32.md` | Current Hardware Reference | hardware builders |
 | `docs/audit-event-schema.md` | Current CI/Security Reference | maintainers/security reviewers |
+| `docs/security/official-channels-and-fraud-prevention.md` | Current Security Guide | users/operators |
 
 ## Policy / Process Docs
 

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -7,6 +7,7 @@ This section mixes current hardening guidance and proposal/roadmap documents.
 For current runtime behavior, start here:
 
 - Repository security policy and vulnerability handling workflow: [../../SECURITY.md](../../SECURITY.md)
+- Official channels and fraud-prevention statement: [official-channels-and-fraud-prevention.md](official-channels-and-fraud-prevention.md)
 - Private vulnerability report template: [private-vulnerability-report-template.md](private-vulnerability-report-template.md)
 - 私密漏洞报告模板（中文）: [private-vulnerability-report-template.zh-CN.md](private-vulnerability-report-template.zh-CN.md)
 - Advisory maintainer checklist: [advisory-maintainer-checklist.md](advisory-maintainer-checklist.md)

--- a/docs/security/official-channels-and-fraud-prevention.md
+++ b/docs/security/official-channels-and-fraud-prevention.md
@@ -1,0 +1,44 @@
+# Official Channels And Fraud Prevention
+
+This page is the evergreen security statement for community safety and impersonation defense.
+
+## Fraud Warning
+
+Scammers may impersonate ZeroClaw maintainers, contributors, or community members.
+
+Assume fraud if someone claiming to represent ZeroClaw asks for:
+
+- cryptocurrency transfers
+- wallet access or seed phrases
+- private financial information
+- private credentials outside official security reporting flow
+
+ZeroClaw maintainers do not request money or private wallet/financial credentials via direct messages.
+
+## Official Sources Of Truth
+
+Use these sources to verify announcements:
+
+- GitHub repository: `zeroclaw-labs/zeroclaw`
+- GitHub Security policy and advisories: [../../SECURITY.md](../../SECURITY.md)
+
+Treat third-party links and social posts as untrusted until confirmed in the GitHub repository.
+
+## How To Verify Announcements
+
+1. Check whether the same announcement exists in GitHub issues, PRs, releases, or docs.
+2. Confirm the posting account is an expected project maintainer/org account.
+3. Prefer links that originate from repository pages rather than forwarded DMs.
+
+## Reporting Suspicious Activity
+
+If you see impersonation attempts or scam outreach:
+
+1. Do not engage or send funds/data.
+2. Capture evidence (screenshots, usernames, URLs, timestamps).
+3. Open a GitHub issue in `zeroclaw-labs/zeroclaw` with sanitized details.
+
+For vulnerability disclosure, use private reporting:
+
+- Security policy: [../../SECURITY.md](../../SECURITY.md)
+- Private report template: [private-vulnerability-report-template.md](private-vulnerability-report-template.md)

--- a/docs/structure/by-function.md
+++ b/docs/structure/by-function.md
@@ -34,6 +34,7 @@ Use this when you know what you need to do, but not where the doc lives.
 ## Security And Trust
 
 - Security collection: [../security/README.md](../security/README.md)
+- Official channels and fraud prevention: [../security/official-channels-and-fraud-prevention.md](../security/official-channels-and-fraud-prevention.md)
 - Security roadmap: [../security-roadmap.md](../security-roadmap.md)
 - Sandboxing: [../sandboxing.md](../sandboxing.md)
 - Audit logging: [../audit-logging.md](../audit-logging.md)


### PR DESCRIPTION
## Summary
- convert issue-thread security notice into a durable policy doc: `docs/security/official-channels-and-fraud-prevention.md`
- add anti-fraud guidance to `SECURITY.md` and link canonical statement
- wire the new statement into docs navigation (`docs/security/README.md`, `docs/README.md`, `docs/SUMMARY.md`, `docs/docs-inventory.md`, `docs/structure/by-function.md`)

## Why
- issue #527 contains important community safety guidance that should live in stable, versioned docs rather than only in an issue thread

## Validation
- docs-only change; verified all updated links are repo-local paths

Closes #527
