### PR TITLE
fix(windows): resolve compile failure on current main

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,8 +20,8 @@ pub use schema::{
     SecretsConfig, SecurityConfig, SecurityRoleConfig, SkillsConfig, SkillsPromptInjectionMode,
     SlackConfig, StorageConfig, StorageProviderConfig, StorageProviderSection, StreamMode,
     SyscallAnomalyConfig, TelegramConfig, TranscriptionConfig, TunnelConfig, UrlAccessConfig,
-    WasmCapabilityEscalationMode, WasmModuleHashPolicy, WasmRuntimeConfig, WasmSecurityConfig,
-    WebFetchConfig, WebSearchConfig, WebhookConfig,
+    WasmCapabilityEscalationMode, WasmConfig, WasmModuleHashPolicy, WasmRuntimeConfig,
+    WasmSecurityConfig, WebFetchConfig, WebSearchConfig, WebhookConfig,
 };
 
 pub fn name_and_presence<T: traits::ChannelConfig>(channel: Option<&T>) -> (&'static str, bool) {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2751,11 +2751,11 @@ pub struct WasmRuntimeConfig {
     pub tools_dir: String,
 
     /// Fuel limit per invocation (instruction budget).
-    #[serde(default = "default_wasm_fuel_limit")]
+    #[serde(default = "default_runtime_wasm_fuel_limit")]
     pub fuel_limit: u64,
 
     /// Memory limit per invocation in MB.
-    #[serde(default = "default_wasm_memory_limit_mb")]
+    #[serde(default = "default_runtime_wasm_memory_limit_mb")]
     pub memory_limit_mb: u64,
 
     /// Maximum `.wasm` module size in MB.
@@ -2860,11 +2860,11 @@ fn default_wasm_tools_dir() -> String {
     "tools/wasm".into()
 }
 
-fn default_wasm_fuel_limit() -> u64 {
+fn default_runtime_wasm_fuel_limit() -> u64 {
     1_000_000
 }
 
-fn default_wasm_memory_limit_mb() -> u64 {
+fn default_runtime_wasm_memory_limit_mb() -> u64 {
     64
 }
 
@@ -2890,8 +2890,8 @@ impl Default for WasmRuntimeConfig {
     fn default() -> Self {
         Self {
             tools_dir: default_wasm_tools_dir(),
-            fuel_limit: default_wasm_fuel_limit(),
-            memory_limit_mb: default_wasm_memory_limit_mb(),
+            fuel_limit: default_runtime_wasm_fuel_limit(),
+            memory_limit_mb: default_runtime_wasm_memory_limit_mb(),
             max_module_size_mb: default_wasm_max_module_size_mb(),
             allow_workspace_read: false,
             allow_workspace_write: false,

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -2105,10 +2105,12 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
                     );
                     println!("  Run 'zeroclaw skill list' to verify the new tools are available.");
                 } else {
-                    let (dest, files_scanned) = install_local_skill_source(&source, &skills_path)
-                        .with_context(|| {
-                        format!("failed to install local skill source: {source}")
-                    })?;
+                    let (dest, files_scanned) = install_local_skill_source(
+                        &source,
+                        &skills_path,
+                        config.skills.allow_scripts,
+                    )
+                    .with_context(|| format!("failed to install local skill source: {source}"))?;
                     println!(
                         "  {} Skill installed and audited: {} ({} files scanned)",
                         console::style("✓").green().bold(),


### PR DESCRIPTION
## Summary
- fix duplicate WASM default helper symbol collisions in config schema
- re-export WasmConfig from crate::config so onboarding wizard paths resolve
- pass allow_scripts through local skill install path to match function signature

## Validation
- cargo check --offline (passes)

Closes #2032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Local skill installation now respects script permission settings from configuration.

* **Refactor**
  * Reorganized internal configuration structure and exports for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->