### PR TITLE
fix(docker): unblock feature builds and include templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
     if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
-      cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
+      cargo build --release --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \
       cargo build --release --locked; \
     fi
@@ -36,6 +36,7 @@ COPY src/ src/
 COPY benches/ benches/
 COPY crates/ crates/
 COPY firmware/ firmware/
+COPY templates/ templates/
 COPY web/ web/
 # Keep release builds resilient when frontend dist assets are not prebuilt in Git.
 RUN mkdir -p web/dist && \
@@ -58,7 +59,7 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
     if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
-      cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
+      cargo build --release --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \
       cargo build --release --locked; \
     fi && \


### PR DESCRIPTION
## Summary
- Problem: Docker feature builds with `ZEROCLAW_CARGO_FEATURES` failed because the Dockerfile used `--locked` in feature mode, and builder stages omitted `templates/`, causing `include_str!` path failures.
- Why it matters: This blocks documented feature builds (for example `channel-matrix`) and breaks containerized bootstrap/build workflows.
- What changed: Removed `--locked` only from the feature-enabled Docker build path (kept `--locked` for default path), and added `COPY templates/ templates/` to the builder stage.

## Validation Evidence (required)
Commands and result summary:
```text
cargo check --locked
=> pass

cargo check --locked --features channel-matrix
=> pass

docker build --build-arg ZEROCLAW_CARGO_FEATURES="channel-matrix" -t zeroclaw:matrix-test .
=> no lockfile-update error
=> no missing templates/include_str! error
=> later failed with host memory exhaustion (SIGKILL), unrelated to the reported issue symptoms
```

## Security Impact (required)
- New permissions/capabilities? (`Yes/No`): No
- Security notes: Build-time behavior only; no runtime auth, policy, or network-surface changes.

## Privacy and Data Hygiene (required)
- Data-hygiene status (`pass|needs-follow-up`): pass
- Notes: No personal/sensitive data introduced; no data collection changes.

## Rollback Plan (required)
- Fast rollback command/path: `git revert dbd02573`

Refs RMN-190
Closes #2062
Closes #2066


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to include template assets in the build context.
  * Modified dependency resolution approach for feature-enabled builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->