### PR TITLE
fix(ci): restore Debian/Ubuntu compatibility for prerelease binary

### DIFF
--- a/.github/workflows/pub-prerelease.yml
+++ b/.github/workflows/pub-prerelease.yml
@@ -175,7 +175,9 @@ jobs:
     build-prerelease:
         name: Build Pre-release Artifact
         needs: [prerelease-guard]
-        runs-on: [self-hosted, aws-india]
+        # Keep GNU Linux prerelease artifacts on Ubuntu 22.04 so runtime GLIBC
+        # symbols remain compatible with Debian 12 / Ubuntu 22.04 hosts.
+        runs-on: ubuntu-22.04
         timeout-minutes: 45
         steps:
             - name: Checkout tag


### PR DESCRIPTION
## Summary
- pin `build-prerelease` GNU Linux build job to `ubuntu-22.04`
- avoid glibc 2.39 symbol requirements leaking from newer runner images
- keep prerelease `x86_64-unknown-linux-gnu` artifact compatible with Debian 12 / Ubuntu 22.04 users

## Validation
- workflow-only change reviewed via diff
- verified no other workflow behavior changed

Closes #2084
Closes #2083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated prerelease build pipeline from self-hosted to GitHub-hosted runners for improved build consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->