### PR TITLE
feat(slack): add Socket Mode fallback for Slack

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4358,6 +4358,7 @@ fn collect_configured_channels(
             channel: Arc::new(
                 SlackChannel::new(
                     sl.bot_token.clone(),
+                    sl.app_token.clone(),
                     sl.channel_id.clone(),
                     sl.allowed_users.clone(),
                 )

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -347,6 +347,7 @@ pub(crate) async fn deliver_announcement(
                 .ok_or_else(|| anyhow::anyhow!("slack channel not configured"))?;
             let channel = SlackChannel::new(
                 sl.bot_token.clone(),
+                sl.app_token.clone(),
                 sl.channel_id.clone(),
                 sl.allowed_users.clone(),
             );


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): `main`
- Problem: Slack channel only used 3-second HTTP polling and did not use configured `app_token` Socket Mode.
- Why it matters: Polling increases API usage/latency and scales poorly compared to push-based events.
- What changed: Added Socket Mode websocket listener (`apps.connections.open` + envelope ack + reconnect), wired `app_token` into `SlackChannel`, and kept polling as fallback when `app_token` is absent.
- What did **not** change (scope boundary): No change to Slack send API behavior or non-Slack channels.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: M`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel,config,cron`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `channel: slack`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #2047
- Related # N/A
- Depends on # (if stacked) N/A
- Supersedes # (if replacing older PR) N/A
- Linear issue key(s) (required, e.g. `RMN-123`): `RMN-196`
- Linear issue URL(s): https://linear.app/zeroclawlabs/issue/RMN-196/feature-slack-socket-mode-channel

## Validation Evidence (required)

Commands and result summary:

```bash
cargo test configured_app_token -- --nocapture
```

- Evidence provided (test/log/trace/screenshot/perf): new app-token normalization tests pass and Slack channel compiles with Socket Mode path.
- If any command is intentionally skipped, explain why: full CI matrix is delegated to PR checks; local run focused on Slack delta.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): Yes
- New external network calls? (`Yes/No`): Yes
- Secrets/tokens handling changed? (`Yes/No`): Yes
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: Socket Mode uses `app_token` to open websocket sessions; token usage remains in-memory only, request/response errors are sanitized, and existing allowlist + mention policies remain enforced.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: No user data shape changes beyond existing Slack message fields.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Rollback Plan (required)

- Fast rollback command/path: Revert this PR commit from `main`.
- Feature flags or config toggles (if any): Clear `channels_config.slack.app_token` to force polling mode.
- Observable failure symptoms: Slack listener websocket reconnect loops; fallback is to remove `app_token` and resume polling.

Resolves RMN-196


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Slack Socket Mode support for applications requiring real-time and reliable Slack integration. When configured with an app token, your application can use Socket Mode to connect directly to Slack, providing bidirectional messaging capabilities, more responsive event handling, and improved reliability compared to traditional webhook-based integration approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->