### PR TITLE
fix(telegram): redact bot token path in api error logs

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -7,7 +7,7 @@ use directories::UserDirs;
 use parking_lot::Mutex;
 use reqwest::multipart::{Form, Part};
 use std::path::Path;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Duration;
 use tokio::fs;
 
@@ -17,6 +17,8 @@ const TELEGRAM_MAX_MESSAGE_LENGTH: usize = 4096;
 /// worst case is "(continued)\n\n" + chunk + "\n\n(continues...)" = 30 extra chars
 const TELEGRAM_CONTINUATION_OVERHEAD: usize = 30;
 const TELEGRAM_ACK_REACTIONS: &[&str] = &["⚡️", "👌", "👀", "🔥", "👍"];
+const TELEGRAM_BOT_PATH_TOKEN_PATTERN: &str = r"/bot\d{8,10}:[A-Za-z0-9_-]{35}";
+static TELEGRAM_BOT_PATH_TOKEN_RE: OnceLock<regex::Regex> = OnceLock::new();
 
 /// Metadata for an incoming document or photo attachment.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -419,8 +421,9 @@ impl TelegramChannel {
             if !response.status().is_success() {
                 let status = response.status();
                 let err_body = response.text().await.unwrap_or_default();
+                let sanitized = TelegramChannel::sanitize_telegram_error(&err_body);
                 tracing::warn!(
-                    "Telegram: add ACK reaction failed for chat_id={chat_id}, message_id={message_id}: status={status}, body={err_body}"
+                    "Telegram: add ACK reaction failed for chat_id={chat_id}, message_id={message_id}: status={status}, body={sanitized}"
                 );
             }
         });
@@ -428,6 +431,16 @@ impl TelegramChannel {
 
     fn http_client(&self) -> reqwest::Client {
         crate::config::build_runtime_proxy_client("channel.telegram")
+    }
+
+    fn sanitize_telegram_error(input: &str) -> String {
+        let redacted = TELEGRAM_BOT_PATH_TOKEN_RE
+            .get_or_init(|| {
+                regex::Regex::new(TELEGRAM_BOT_PATH_TOKEN_PATTERN)
+                    .expect("telegram token regex pattern must compile")
+            })
+            .replace_all(input, "/bot[REDACTED]");
+        crate::providers::sanitize_api_error(redacted.as_ref())
     }
 
     fn normalize_identity(value: &str) -> String {
@@ -2737,6 +2750,40 @@ mod tests {
 
         let target = TelegramChannel::extract_update_message_target(&update);
         assert_eq!(target, Some(("-100123456".to_string(), 99)));
+    }
+
+    #[test]
+    fn sanitize_telegram_error_redacts_bot_path_token_and_keeps_method_suffix() {
+        let raw = "poll failed for url (https://api.telegram.org/bot1234567890:A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r/getUpdates?timeout=30)";
+        let sanitized = TelegramChannel::sanitize_telegram_error(raw);
+        assert!(sanitized.contains("/bot[REDACTED]/getUpdates?timeout=30"));
+        assert!(!sanitized.contains("1234567890:A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r"));
+    }
+
+    #[test]
+    fn sanitize_telegram_error_redacts_file_api_path_token() {
+        let raw = "download failed: https://api.telegram.org/file/bot12345678:Z9y8X7w6V5u4T3s2R1q0P9o8N7m6L5k4J3i/photos/file_123.jpg";
+        let sanitized = TelegramChannel::sanitize_telegram_error(raw);
+        assert!(sanitized.contains("/file/bot[REDACTED]/photos/file_123.jpg"));
+        assert!(!sanitized.contains("12345678:Z9y8X7w6V5u4T3s2R1q0P9o8N7m6L5k4J3i"));
+    }
+
+    #[test]
+    fn sanitize_telegram_error_ignores_non_matching_bot_fragment() {
+        let raw = "unexpected path /bot123:short/getUpdates";
+        let sanitized = TelegramChannel::sanitize_telegram_error(raw);
+        assert_eq!(sanitized, raw);
+    }
+
+    #[test]
+    fn sanitize_telegram_error_redacts_multiple_bot_tokens_in_single_string() {
+        let raw = "poll a: https://api.telegram.org/bot1234567890:A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r/getUpdates | poll b: https://api.telegram.org/bot2345678901:Z9y8X7w6V5u4T3s2R1q0P9o8N7m6L5k4J3i/getMe";
+        let sanitized = TelegramChannel::sanitize_telegram_error(raw);
+        assert_eq!(sanitized.matches("/bot[REDACTED]").count(), 2);
+        assert!(sanitized.contains("/bot[REDACTED]/getUpdates"));
+        assert!(sanitized.contains("/bot[REDACTED]/getMe"));
+        assert!(!sanitized.contains("1234567890:A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r"));
+        assert!(!sanitized.contains("2345678901:Z9y8X7w6V5u4T3s2R1q0P9o8N7m6L5k4J3i"));
     }
 
     #[test]


### PR DESCRIPTION
 ## Summary

  Describe this PR in 2-5 bullets:

  - Base branch target (dev for normal contributions; main only for dev promotion): dev
  - Problem: Telegram API error strings can include raw bot-token path segments (for example /bot<id>:<token>/...) and leak secrets into logs.
  - Why it matters: Bot token exposure in logs increases credential leakage risk and incident response cost.
  - What changed: Added Telegram-specific bot-path token redaction in sanitize_telegram_error before provider-level sanitization, using a compiled regex cached via
    OnceLock.
  - What changed: Added focused unit tests for API URL, file URL, non-matching fragments, and multiple-token redaction cases.
  - What did not change (scope boundary): No changes to Telegram request execution/auth flow, permissions, config schema, or other channel/provider behavior.

  ## Label Snapshot (required)

  - Risk label: `low`
  - Size label: `S`
  - Scope labels: `channel`, `security`
  - Module labels: `channel: telegram`
  - Contributor tier label: `new`

  ## Change Metadata

  - Change type: `security`
  - Primary scope: `channel`

  ## Validation Evidence (required)

  Commands and result summary:

  cargo fmt --all -- --check
  cargo clippy --all-targets -- -D warnings
  cargo test

  - Evidence provided (test/log/trace/screenshot/perf): Author-reported local validation completed; all checks pass.
  - If any command is intentionally skipped, explain why: In this Codex session, checks were skipped per requester instruction because validation was already run locally.

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No): No
  - New external network calls? (Yes/No): No
  - Secrets/tokens handling changed? (Yes/No): Yes
  - File system access scope changed? (Yes/No): No
  - If any Yes, describe risk and mitigation: Token-containing Telegram URL path segments are now redacted to /bot[REDACTED] before logging/surfacing errors, reducing
    secret leakage risk while preserving endpoint context.

  ## Privacy and Data Hygiene (required)

  - Data-hygiene status (pass|needs-follow-up): pass
  - Redaction/anonymization notes: Telegram bot path tokens are redacted in sanitized error output.
  - Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Confirmed.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No): Yes
  - Config/env changes? (Yes/No): No
  - Migration needed? (Yes/No): No
  - If yes, exact upgrade steps: N/A

  ## i18n Follow-Through (required when docs or user-facing wording changes)

  - i18n follow-through triggered? (Yes/No): No
  - If Yes, locale navigation parity updated in README*, docs/README*, and docs/SUMMARY.md for supported locales (en, zh-CN, ja, ru, fr, vi)? (Yes/No): N/A
  - If Yes, localized runtime-contract docs updated where equivalents exist (minimum for fr/vi: commands-reference, config-reference, troubleshooting)? (Yes/No/N.A.): N/A
  - If Yes, Vietnamese canonical docs under docs/i18n/vi/** synced and compatibility shims under docs/*.vi.md validated? (Yes/No/N.A.): N/A
  - If any No/N.A., link follow-up issue/PR and explain scope decision: N/A

  ## Human Verification (required)

  What was personally validated beyond CI:

  - Verified scenarios: Error strings containing Telegram API bot-token paths are redacted and retain method/path suffixes.
  - Edge cases checked: File API paths are redacted; non-matching short fragments are left unchanged; multiple tokens in one string are all redacted.
  - What was not verified: No runtime behavior changes outside error sanitization path were manually exercised in this PR context.

  ## Side Effects / Blast Radius (required)

  - Affected subsystems/workflows: src/channels/telegram.rs error sanitization and related unit tests.
  - Potential unintended effects: Overly strict/loose token pattern could miss uncommon token formats or redact false positives in rare strings.
  - Guardrails/monitoring for early detection: Existing/new unit tests for sanitize behavior; monitor logs for unexpected unredacted /bot<id>:<token> fragments.

  ## Agent Collaboration Notes (recommended)

  - Agent tools used (if any): Local repo inspection (git log, git show, template read).
  - Workflow/plan summary (if any): Read template -> inspected branch commit/diff -> generated populated PR body.
  - Verification focus: Scope accuracy, security impact, and template completeness.
  - Confirmation: naming + architecture boundaries followed (AGENTS.md + CONTRIBUTING.md): Yes

  ## Rollback Plan (required)

  - Fast rollback command/path: git revert bbfcba51
  - Feature flags or config toggles (if any): None
  - Observable failure symptoms: Telegram error messages may show unexpected redaction behavior (missing method suffix context or missed token masking).

  ## Risks and Mitigations

  List real risks in this PR (or write None).

  - Risk: Regex does not match a future Telegram token shape.
  - Mitigation: Keep redaction unit tests and update pattern with explicit fixtures if Telegram format changes.
  - Risk: Pattern over-matches non-token strings that look similar.
  - Mitigation: Pattern is constrained to /bot<digits>:<35-char token-like> path format and covered by negative test case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by redacting sensitive authentication tokens from Telegram error messages to prevent accidental exposure in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->