### PR TITLE
feat: support config-level api_key for transcription

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1079,6 +1079,11 @@ async fn load_runtime_defaults_from_config_file(
     if let Some(zeroclaw_dir) = path.parent() {
         let store = crate::security::SecretStore::new(zeroclaw_dir, parsed.secrets.encrypt);
         decrypt_optional_secret_for_runtime_reload(&store, &mut parsed.api_key, "config.api_key")?;
+        decrypt_optional_secret_for_runtime_reload(
+            &store,
+            &mut parsed.transcription.api_key,
+            "config.transcription.api_key",
+        )?;
     }
 
     parsed.apply_env_overrides();

--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -607,6 +607,7 @@ fn mask_sensitive_fields(config: &crate::config::Config) -> crate::config::Confi
     mask_optional_secret(&mut masked.proxy.http_proxy);
     mask_optional_secret(&mut masked.proxy.https_proxy);
     mask_optional_secret(&mut masked.proxy.all_proxy);
+    mask_optional_secret(&mut masked.transcription.api_key);
     mask_optional_secret(&mut masked.browser.computer_use.api_key);
     mask_optional_secret(&mut masked.web_fetch.api_key);
     mask_optional_secret(&mut masked.web_search.api_key);
@@ -705,6 +706,7 @@ fn restore_masked_sensitive_fields(
     restore_optional_secret(&mut incoming.proxy.http_proxy, &current.proxy.http_proxy);
     restore_optional_secret(&mut incoming.proxy.https_proxy, &current.proxy.https_proxy);
     restore_optional_secret(&mut incoming.proxy.all_proxy, &current.proxy.all_proxy);
+    restore_optional_secret(&mut incoming.transcription.api_key, &current.transcription.api_key);
     restore_optional_secret(
         &mut incoming.browser.computer_use.api_key,
         &current.browser.computer_use.api_key,
@@ -917,6 +919,7 @@ mod tests {
         current.config_path = std::path::PathBuf::from("/tmp/current/config.toml");
         current.workspace_dir = std::path::PathBuf::from("/tmp/current/workspace");
         current.api_key = Some("real-key".to_string());
+        current.transcription.api_key = Some("transcription-real-key".to_string());
         current.reliability.api_keys = vec!["r1".to_string(), "r2".to_string()];
 
         let mut incoming = mask_sensitive_fields(&current);
@@ -929,6 +932,7 @@ mod tests {
         assert_eq!(hydrated.config_path, current.config_path);
         assert_eq!(hydrated.workspace_dir, current.workspace_dir);
         assert_eq!(hydrated.api_key, current.api_key);
+        assert_eq!(hydrated.transcription.api_key, current.transcription.api_key);
         assert_eq!(hydrated.default_model.as_deref(), Some("gpt-4.1-mini"));
         assert_eq!(
             hydrated.reliability.api_keys,
@@ -964,6 +968,7 @@ mod tests {
         cfg.proxy.http_proxy = Some("http://user:pass@proxy.internal:8080".to_string());
         cfg.proxy.https_proxy = Some("https://user:pass@proxy.internal:8443".to_string());
         cfg.proxy.all_proxy = Some("socks5://user:pass@proxy.internal:1080".to_string());
+        cfg.transcription.api_key = Some("transcription-real-key".to_string());
         cfg.tunnel.cloudflare = Some(CloudflareTunnelConfig {
             token: "cloudflare-real-token".to_string(),
         });
@@ -998,6 +1003,7 @@ mod tests {
         assert_eq!(masked.proxy.http_proxy.as_deref(), Some(MASKED_SECRET));
         assert_eq!(masked.proxy.https_proxy.as_deref(), Some(MASKED_SECRET));
         assert_eq!(masked.proxy.all_proxy.as_deref(), Some(MASKED_SECRET));
+        assert_eq!(masked.transcription.api_key.as_deref(), Some(MASKED_SECRET));
         assert_eq!(
             masked
                 .tunnel


### PR DESCRIPTION
## Summary
- add `transcription.api_key` to config schema
- encrypt/decrypt and dashboard mask/restore this credential
- use config-level key in transcription with `GROQ_API_KEY` fallback

## Testing
- cargo test --lib uses_config_api_key_without_groq_env

Closes #2108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transcription API key can now be configured in the configuration file with encrypted storage support
  * Updated credential resolution to prioritize configuration file settings over environment variables

* **Bug Fixes**
  * Improved error messages for missing transcription credentials with clearer configuration guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->