### PR TITLE
feat(memory): add sqlite_qdrant_hybrid backend

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2128,7 +2128,7 @@ impl Default for StorageProviderConfig {
 /// Controls conversation memory storage, embeddings, hybrid search, response caching,
 /// and memory snapshot/hydration.
 /// Configuration for Qdrant vector database backend (`[memory.qdrant]`).
-/// Used when `[memory].backend = "qdrant"`.
+/// Used when `[memory].backend = "qdrant"` or `"sqlite_qdrant_hybrid"`.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct QdrantConfig {
     /// Qdrant server URL (e.g. "http://localhost:6333").
@@ -2162,10 +2162,10 @@ impl Default for QdrantConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct MemoryConfig {
-    /// "sqlite" | "lucid" | "postgres" | "qdrant" | "markdown" | "none" (`none` = explicit no-op memory)
+    /// "sqlite" | "sqlite_qdrant_hybrid" | "lucid" | "postgres" | "qdrant" | "markdown" | "none" (`none` = explicit no-op memory)
     ///
     /// `postgres` requires `[storage.provider.config]` with `db_url` (`dbURL` alias supported).
-    /// `qdrant` uses `[memory.qdrant]` config or `QDRANT_URL` env var.
+    /// `qdrant` and `sqlite_qdrant_hybrid` use `[memory.qdrant]` config or `QDRANT_URL` env var.
     pub backend: String,
     /// Auto-save user-stated conversation input to memory (assistant output is excluded)
     pub auto_save: bool,
@@ -2238,7 +2238,7 @@ pub struct MemoryConfig {
 
     // ── Qdrant backend options ─────────────────────────────────
     /// Configuration for Qdrant vector database backend.
-    /// Only used when `backend = "qdrant"`.
+    /// Used when `backend = "qdrant"` or `backend = "sqlite_qdrant_hybrid"`.
     #[serde(default)]
     pub qdrant: QdrantConfig,
 }

--- a/src/memory/hybrid.rs
+++ b/src/memory/hybrid.rs
@@ -1,0 +1,332 @@
+use super::traits::{Memory, MemoryCategory, MemoryEntry};
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+/// Composite memory backend:
+/// - SQLite remains authoritative for metadata/content/filtering.
+/// - Qdrant provides semantic ranking candidates.
+pub struct SqliteQdrantHybridMemory {
+    sqlite: Arc<dyn Memory>,
+    qdrant: Arc<dyn Memory>,
+}
+
+impl SqliteQdrantHybridMemory {
+    pub fn new(sqlite: Arc<dyn Memory>, qdrant: Arc<dyn Memory>) -> Self {
+        Self { sqlite, qdrant }
+    }
+}
+
+#[async_trait]
+impl Memory for SqliteQdrantHybridMemory {
+    fn name(&self) -> &str {
+        "sqlite_qdrant_hybrid"
+    }
+
+    async fn store(
+        &self,
+        key: &str,
+        content: &str,
+        category: MemoryCategory,
+        session_id: Option<&str>,
+    ) -> Result<()> {
+        // SQLite is authoritative. Fail only if local persistence fails.
+        self.sqlite
+            .store(key, content, category.clone(), session_id)
+            .await?;
+
+        // Best-effort vector sync to Qdrant.
+        if let Err(err) = self.qdrant.store(key, content, category, session_id).await {
+            tracing::warn!(
+                key,
+                error = %err,
+                "Hybrid memory vector sync failed; SQLite entry was stored"
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn recall(
+        &self,
+        query: &str,
+        limit: usize,
+        session_id: Option<&str>,
+    ) -> Result<Vec<MemoryEntry>> {
+        let trimmed_query = query.trim();
+        if trimmed_query.is_empty() {
+            return self.sqlite.recall(query, limit, session_id).await;
+        }
+
+        let qdrant_candidates = match self
+            .qdrant
+            .recall(trimmed_query, limit.max(1).saturating_mul(3), session_id)
+            .await
+        {
+            Ok(candidates) => candidates,
+            Err(err) => {
+                tracing::warn!(
+                    query = trimmed_query,
+                    error = %err,
+                    "Hybrid memory semantic recall failed; falling back to SQLite recall"
+                );
+                return self.sqlite.recall(trimmed_query, limit, session_id).await;
+            }
+        };
+
+        if qdrant_candidates.is_empty() {
+            return self.sqlite.recall(trimmed_query, limit, session_id).await;
+        }
+
+        let mut seen_keys = HashSet::new();
+        let mut merged = Vec::with_capacity(limit);
+
+        for candidate in qdrant_candidates {
+            if !seen_keys.insert(candidate.key.clone()) {
+                continue;
+            }
+
+            match self.sqlite.get(&candidate.key).await {
+                Ok(Some(mut entry)) => {
+                    if let Some(filter_sid) = session_id {
+                        if entry.session_id.as_deref() != Some(filter_sid) {
+                            continue;
+                        }
+                    }
+                    entry.score = candidate.score;
+                    merged.push(entry);
+                    if merged.len() >= limit {
+                        break;
+                    }
+                }
+                Ok(None) => {
+                    // Ignore Qdrant candidates that no longer exist in SQLite.
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        key = candidate.key,
+                        error = %err,
+                        "Hybrid memory failed to load SQLite row for Qdrant candidate"
+                    );
+                }
+            }
+        }
+
+        if merged.is_empty() {
+            return self.sqlite.recall(trimmed_query, limit, session_id).await;
+        }
+
+        Ok(merged)
+    }
+
+    async fn get(&self, key: &str) -> Result<Option<MemoryEntry>> {
+        self.sqlite.get(key).await
+    }
+
+    async fn list(
+        &self,
+        category: Option<&MemoryCategory>,
+        session_id: Option<&str>,
+    ) -> Result<Vec<MemoryEntry>> {
+        self.sqlite.list(category, session_id).await
+    }
+
+    async fn forget(&self, key: &str) -> Result<bool> {
+        let removed = self.sqlite.forget(key).await?;
+        if let Err(err) = self.qdrant.forget(key).await {
+            tracing::warn!(
+                key,
+                error = %err,
+                "Hybrid memory vector delete failed; SQLite delete result preserved"
+            );
+        }
+        Ok(removed)
+    }
+
+    async fn count(&self) -> Result<usize> {
+        self.sqlite.count().await
+    }
+
+    async fn health_check(&self) -> bool {
+        let sqlite_ok = self.sqlite.health_check().await;
+        if !sqlite_ok {
+            return false;
+        }
+
+        if !self.qdrant.health_check().await {
+            tracing::warn!("Hybrid memory Qdrant health check failed; SQLite remains available");
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::{Memory, MemoryCategory, MemoryEntry, SqliteMemory};
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    struct StubQdrantMemory {
+        recall_results: Vec<MemoryEntry>,
+        fail_store: bool,
+        fail_recall: bool,
+        forget_calls: Mutex<Vec<String>>,
+    }
+
+    impl StubQdrantMemory {
+        fn new(recall_results: Vec<MemoryEntry>, fail_store: bool, fail_recall: bool) -> Self {
+            Self {
+                recall_results,
+                fail_store,
+                fail_recall,
+                forget_calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Memory for StubQdrantMemory {
+        fn name(&self) -> &str {
+            "qdrant_stub"
+        }
+
+        async fn store(
+            &self,
+            _key: &str,
+            _content: &str,
+            _category: MemoryCategory,
+            _session_id: Option<&str>,
+        ) -> Result<()> {
+            if self.fail_store {
+                anyhow::bail!("simulated qdrant store failure");
+            }
+            Ok(())
+        }
+
+        async fn recall(
+            &self,
+            _query: &str,
+            _limit: usize,
+            _session_id: Option<&str>,
+        ) -> Result<Vec<MemoryEntry>> {
+            if self.fail_recall {
+                anyhow::bail!("simulated qdrant recall failure");
+            }
+            Ok(self.recall_results.clone())
+        }
+
+        async fn get(&self, _key: &str) -> Result<Option<MemoryEntry>> {
+            Ok(None)
+        }
+
+        async fn list(
+            &self,
+            _category: Option<&MemoryCategory>,
+            _session_id: Option<&str>,
+        ) -> Result<Vec<MemoryEntry>> {
+            Ok(Vec::new())
+        }
+
+        async fn forget(&self, key: &str) -> Result<bool> {
+            self.forget_calls
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(key.to_string());
+            Ok(true)
+        }
+
+        async fn count(&self) -> Result<usize> {
+            Ok(self.recall_results.len())
+        }
+
+        async fn health_check(&self) -> bool {
+            true
+        }
+    }
+
+    fn temp_sqlite() -> (TempDir, Arc<dyn Memory>) {
+        let tmp = TempDir::new().unwrap();
+        let sqlite = SqliteMemory::new(tmp.path()).unwrap();
+        (tmp, Arc::new(sqlite))
+    }
+
+    fn make_qdrant_entry(key: &str, score: f64) -> MemoryEntry {
+        MemoryEntry {
+            id: format!("vec-{key}"),
+            key: key.to_string(),
+            content: "vector payload".to_string(),
+            category: MemoryCategory::Core,
+            timestamp: "2026-02-27T00:00:00Z".to_string(),
+            session_id: None,
+            score: Some(score),
+        }
+    }
+
+    #[tokio::test]
+    async fn store_keeps_sqlite_when_qdrant_sync_fails() {
+        let (_tmp, sqlite) = temp_sqlite();
+        let qdrant: Arc<dyn Memory> = Arc::new(StubQdrantMemory::new(Vec::new(), true, false));
+        let hybrid = SqliteQdrantHybridMemory::new(Arc::clone(&sqlite), qdrant);
+
+        hybrid
+            .store("fav_lang", "Rust", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+
+        let stored = sqlite.get("fav_lang").await.unwrap();
+        assert!(stored.is_some(), "SQLite should remain authoritative");
+    }
+
+    #[tokio::test]
+    async fn recall_joins_qdrant_ranking_with_sqlite_rows() {
+        let (_tmp, sqlite) = temp_sqlite();
+        sqlite
+            .store("a", "alpha from sqlite", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        sqlite
+            .store("b", "beta from sqlite", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+
+        let qdrant: Arc<dyn Memory> = Arc::new(StubQdrantMemory::new(
+            vec![make_qdrant_entry("b", 0.91), make_qdrant_entry("a", 0.72)],
+            false,
+            false,
+        ));
+        let hybrid = SqliteQdrantHybridMemory::new(Arc::clone(&sqlite), qdrant);
+
+        let recalled = hybrid.recall("rank semantically", 2, None).await.unwrap();
+        assert_eq!(recalled.len(), 2);
+        assert_eq!(recalled[0].key, "b");
+        assert_eq!(recalled[0].content, "beta from sqlite");
+        assert_eq!(recalled[0].score, Some(0.91));
+        assert_eq!(recalled[1].key, "a");
+        assert_eq!(recalled[1].score, Some(0.72));
+    }
+
+    #[tokio::test]
+    async fn recall_falls_back_to_sqlite_when_qdrant_fails() {
+        let (_tmp, sqlite) = temp_sqlite();
+        sqlite
+            .store(
+                "topic",
+                "hybrid fallback should still find this",
+                MemoryCategory::Core,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let qdrant: Arc<dyn Memory> = Arc::new(StubQdrantMemory::new(Vec::new(), false, true));
+        let hybrid = SqliteQdrantHybridMemory::new(Arc::clone(&sqlite), qdrant);
+
+        let recalled = hybrid.recall("fallback", 5, None).await.unwrap();
+        assert!(
+            recalled.iter().any(|entry| entry.key == "topic"),
+            "SQLite fallback should provide recall results when Qdrant is unavailable"
+        );
+    }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2,6 +2,7 @@ pub mod backend;
 pub mod chunker;
 pub mod cli;
 pub mod embeddings;
+pub mod hybrid;
 pub mod hygiene;
 pub mod lucid;
 pub mod markdown;
@@ -20,6 +21,7 @@ pub use backend::{
     classify_memory_backend, default_memory_backend_key, memory_backend_profile,
     selectable_memory_backends, MemoryBackendKind, MemoryBackendProfile,
 };
+pub use hybrid::SqliteQdrantHybridMemory;
 pub use lucid::LucidMemory;
 pub use markdown::MarkdownMemory;
 pub use none::NoneMemory;
@@ -49,7 +51,9 @@ where
     G: FnMut() -> anyhow::Result<Box<dyn Memory>>,
 {
     match classify_memory_backend(backend_name) {
-        MemoryBackendKind::Sqlite => Ok(Box::new(sqlite_builder()?)),
+        MemoryBackendKind::Sqlite | MemoryBackendKind::SqliteQdrantHybrid => {
+            Ok(Box::new(sqlite_builder()?))
+        }
         MemoryBackendKind::Lucid => {
             let local = sqlite_builder()?;
             Ok(Box::new(LucidMemory::new(workspace_dir, local)))
@@ -210,7 +214,9 @@ pub fn create_memory_with_storage_and_routes(
         && config.snapshot_on_hygiene
         && matches!(
             backend_kind,
-            MemoryBackendKind::Sqlite | MemoryBackendKind::Lucid
+            MemoryBackendKind::Sqlite
+                | MemoryBackendKind::SqliteQdrantHybrid
+                | MemoryBackendKind::Lucid
         )
     {
         if let Err(e) = snapshot::export_snapshot(workspace_dir) {
@@ -223,7 +229,9 @@ pub fn create_memory_with_storage_and_routes(
     if config.auto_hydrate
         && matches!(
             backend_kind,
-            MemoryBackendKind::Sqlite | MemoryBackendKind::Lucid
+            MemoryBackendKind::Sqlite
+                | MemoryBackendKind::SqliteQdrantHybrid
+                | MemoryBackendKind::Lucid
         )
         && snapshot::should_hydrate(workspace_dir)
     {
@@ -299,7 +307,10 @@ pub fn create_memory_with_storage_and_routes(
         );
     }
 
-    if matches!(backend_kind, MemoryBackendKind::Qdrant) {
+    fn build_qdrant_memory(
+        config: &MemoryConfig,
+        resolved_embedding: &ResolvedEmbeddingConfig,
+    ) -> anyhow::Result<QdrantMemory> {
         let url = config
             .qdrant
             .url
@@ -332,12 +343,26 @@ pub fn create_memory_with_storage_and_routes(
             url,
             collection
         );
-        return Ok(Box::new(QdrantMemory::new_lazy(
+        Ok(QdrantMemory::new_lazy(
             &url,
             &collection,
             qdrant_api_key,
             embedder,
-        )));
+        ))
+    }
+
+    if matches!(backend_kind, MemoryBackendKind::Qdrant) {
+        return Ok(Box::new(build_qdrant_memory(config, &resolved_embedding)?));
+    }
+
+    if matches!(backend_kind, MemoryBackendKind::SqliteQdrantHybrid) {
+        let sqlite: Arc<dyn Memory> = Arc::new(build_sqlite_memory(
+            config,
+            workspace_dir,
+            &resolved_embedding,
+        )?);
+        let qdrant: Arc<dyn Memory> = Arc::new(build_qdrant_memory(config, &resolved_embedding)?);
+        return Ok(Box::new(SqliteQdrantHybridMemory::new(sqlite, qdrant)));
     }
 
     create_memory_with_builders(
@@ -452,6 +477,21 @@ mod tests {
     }
 
     #[test]
+    fn factory_sqlite_qdrant_hybrid() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = MemoryConfig {
+            backend: "sqlite_qdrant_hybrid".into(),
+            qdrant: crate::config::QdrantConfig {
+                url: Some("http://localhost:6333".into()),
+                ..crate::config::QdrantConfig::default()
+            },
+            ..MemoryConfig::default()
+        };
+        let mem = create_memory(&cfg, tmp.path(), None).unwrap();
+        assert_eq!(mem.name(), "sqlite_qdrant_hybrid");
+    }
+
+    #[test]
     fn factory_none_uses_noop_memory() {
         let tmp = TempDir::new().unwrap();
         let cfg = MemoryConfig {
@@ -524,6 +564,26 @@ mod tests {
         } else {
             assert!(error.to_string().contains("memory-postgres"));
         }
+    }
+
+    #[test]
+    fn factory_hybrid_requires_qdrant_url() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = MemoryConfig {
+            backend: "sqlite_qdrant_hybrid".into(),
+            qdrant: crate::config::QdrantConfig {
+                url: None,
+                ..crate::config::QdrantConfig::default()
+            },
+            ..MemoryConfig::default()
+        };
+
+        let error = create_memory(&cfg, tmp.path(), None)
+            .err()
+            .expect("hybrid backend should require qdrant url");
+        assert!(error
+            .to_string()
+            .contains("Qdrant memory backend requires url"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #2089

## Summary
- add a new sqlite_qdrant_hybrid memory backend that uses SQLite as source of truth and Qdrant for semantic candidate ranking
- join Qdrant recall candidates back to SQLite entries by key and preserve vector scores
- keep hybrid operations resilient with SQLite fallback when Qdrant sync/search fails
- wire factory/classification support and update memory backend docs/comments
- add focused unit tests for hybrid recall/join/fallback and factory validation

## Validation
- cargo test hybrid -- --nocapture
- cargo test sqlite_qdrant_hybrid -- --nocapture