### PR TITLE
ci: cautious phase-2 trigger dedupe and e2e path gating

### DIFF
--- a/.github/workflows/main-branch-flow.md
+++ b/.github/workflows/main-branch-flow.md
@@ -101,8 +101,8 @@ Notes:
 4. Approval gate possibility:
    - if Actions settings require maintainer approval for fork workflows, the `pull_request` run stays in `action_required`/waiting state until approved.
 5. Event fan-out after labeling:
-   - `pr-labeler.yml` and manual label changes emit `labeled`/`unlabeled` events.
-   - those events retrigger `pull_request_target` automation (`pr-labeler.yml` and `pr-auto-response.yml`), creating extra run volume/noise.
+   - manual label changes emit `labeled`/`unlabeled` events.
+   - those events retrigger only label-driven `pull_request_target` automation (`pr-auto-response.yml`); `pr-labeler.yml` now runs only on PR lifecycle events (`opened`/`reopened`/`synchronize`/`ready_for_review`) to reduce churn.
 6. When contributor pushes new commits to fork branch (`synchronize`):
    - reruns: `pr-intake-checks.yml`, `pr-labeler.yml`, `ci-run.yml`, `sec-audit.yml`, and matching path-scoped PR workflows.
    - does not rerun `pr-auto-response.yml` unless label/open events occur.

--- a/.github/workflows/pr-auto-response.yml
+++ b/.github/workflows/pr-auto-response.yml
@@ -7,6 +7,10 @@ on:
     branches: [dev, main]
     types: [opened, labeled, unlabeled]
 
+concurrency:
+  group: pr-auto-response-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions: {}
 
 env:

--- a/.github/workflows/pr-intake-checks.yml
+++ b/.github/workflows/pr-intake-checks.yml
@@ -3,7 +3,7 @@ name: PR Intake Checks
 on:
     pull_request_target:
         branches: [dev, main]
-        types: [opened, reopened, synchronize, edited, ready_for_review]
+        types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
     group: pr-intake-checks-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -3,7 +3,7 @@ name: PR Labeler
 on:
     pull_request_target:
         branches: [dev, main]
-        types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+        types: [opened, reopened, synchronize, ready_for_review]
     workflow_dispatch:
         inputs:
             mode:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -3,6 +3,14 @@ name: Test E2E
 on:
     push:
         branches: [dev, main]
+        paths:
+            - "Cargo.toml"
+            - "Cargo.lock"
+            - "src/**"
+            - "crates/**"
+            - "tests/**"
+            - "scripts/**"
+            - ".github/workflows/test-e2e.yml"
     workflow_dispatch:
 
 concurrency:

--- a/docs/ci-map.md
+++ b/docs/ci-map.md
@@ -79,7 +79,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
     - Additional behavior: final label set is priority-sorted (`risk:*` first, then `size:*`, then contributor tier, then module/path labels)
     - Additional behavior: managed label colors follow display order to produce a smooth left-to-right gradient when many labels are present
     - Manual governance: supports `workflow_dispatch` with `mode=audit|repair` to inspect/fix managed label metadata drift across the whole repository
-    - Additional behavior: risk + size labels are auto-corrected on manual PR label edits (`labeled`/`unlabeled` events); apply `risk: manual` when maintainers intentionally override automated risk selection
+    - Additional behavior: risk + size labels are recomputed on PR lifecycle events (`opened`/`reopened`/`synchronize`/`ready_for_review`); maintainers can use manual `workflow_dispatch` (`mode=repair`) to re-sync managed label metadata after exceptional manual edits
     - High-risk heuristic paths: `src/security/**`, `src/runtime/**`, `src/gateway/**`, `src/tools/**`, `.github/workflows/**`
     - Guardrail: maintainers can apply `risk: manual` to freeze automated risk recalculation
 - `.github/workflows/pr-auto-response.yml` (`PR Auto Responder`)
@@ -106,10 +106,11 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - `Workflow Sanity`: PR/push when `.github/workflows/**`, `.github/*.yml`, or `.github/*.yaml` change
 - `Main Promotion Gate`: PRs to `main` only; requires PR author `willsarg`/`theonlyhennygod` and head branch `dev` in the same repository
 - `Dependabot`: all update PRs target `dev` (not `main`)
-- `PR Intake Checks`: `pull_request_target` on opened/reopened/synchronize/edited/ready_for_review
+- `PR Intake Checks`: `pull_request_target` on opened/reopened/synchronize/ready_for_review
 - `Label Policy Sanity`: PR/push when `.github/label-policy.json`, `.github/workflows/pr-labeler.yml`, or `.github/workflows/pr-auto-response.yml` changes
-- `PR Labeler`: `pull_request_target` lifecycle events
+- `PR Labeler`: `pull_request_target` on opened/reopened/synchronize/ready_for_review
 - `PR Auto Responder`: issue opened/labeled, `pull_request_target` opened/labeled
+- `Test E2E`: push to `dev`/`main` for Rust-impacting paths (`Cargo*`, `src/**`, `crates/**`, `tests/**`, `scripts/**`) and manual dispatch
 - `Stale PR Check`: daily schedule, manual dispatch
 - `PR Hygiene`: every 12 hours schedule, manual dispatch
 


### PR DESCRIPTION
## Summary
This is a low-risk CI/CD load-shedding follow-up focused on trigger hygiene only.

Changes:
- `PR Labeler`: narrow `pull_request_target` types to `opened/reopened/synchronize/ready_for_review` (remove `edited/labeled/unlabeled`).
- `PR Intake Checks`: remove `edited` trigger to avoid non-code description churn runs.
- `PR Auto Responder`: add workflow-level concurrency cancelation to keep only the latest run per PR/issue.
- `Test E2E`: add push path gating so docs/governance-only commits do not consume E2E capacity.
- Update docs mapping:
  - `docs/ci-map.md`
  - `.github/workflows/main-branch-flow.md`

## Why this is safe
- No security gates removed.
- No test logic changed.
- No workflow permissions expanded.
- Only trigger surfaces and run dedupe behavior were tightened.

## Expected impact
- Lower queue pressure from control-plane churn (`pull_request_target` label/edit fan-out).
- Fewer unnecessary `Test E2E` runs on non-Rust pushes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined CI/CD workflow triggers and added concurrency controls to reduce redundant runs
  * Workflows now execute only on relevant changes for faster feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->