### PR TITLE
feat(http_request): add env-backed credential profiles and onboarding policy presets

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -605,6 +605,7 @@ Notes:
 | `max_response_size` | `1000000` | Maximum response size in bytes (default: 1 MB) |
 | `timeout_secs` | `30` | Request timeout in seconds |
 | `user_agent` | `ZeroClaw/1.0` | User-Agent header for outbound HTTP requests |
+| `credential_profiles` | `{}` | Optional named env-backed auth profiles used by tool arg `credential_profile` |
 
 Notes:
 
@@ -612,6 +613,36 @@ Notes:
 - Use exact domain or subdomain matching (e.g. `"api.example.com"`, `"example.com"`), or `"*"` to allow any public domain.
 - Local/private targets are still blocked even when `"*"` is configured.
 - Shell `curl`/`wget` are classified as high-risk and may be blocked by autonomy policy. Prefer `http_request` for direct HTTP calls.
+- `credential_profiles` lets the harness inject auth headers from environment variables, so agents can call authenticated APIs without raw tokens in tool arguments.
+
+Example:
+
+```toml
+[http_request]
+enabled = true
+allowed_domains = ["api.github.com", "api.linear.app"]
+
+[http_request.credential_profiles.github]
+header_name = "Authorization"
+env_var = "GITHUB_TOKEN"
+value_prefix = "Bearer "
+
+[http_request.credential_profiles.linear]
+header_name = "Authorization"
+env_var = "LINEAR_API_KEY"
+value_prefix = ""
+```
+
+Then call `http_request` with:
+
+```json
+{
+  "url": "https://api.github.com/user",
+  "credential_profile": "github"
+}
+```
+
+When using `credential_profile`, do not also set the same header key in `args.headers` (case-insensitive), or the request will be rejected as a header conflict.
 
 ## `[web_fetch]`
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,18 +11,18 @@ pub use schema::{
     EconomicConfig, EconomicTokenPricing,
     DockerRuntimeConfig, EmbeddingRouteConfig, EstopConfig, FeishuConfig, GatewayConfig,
     GroupReplyConfig, GroupReplyMode, HardwareConfig, HardwareTransport, HeartbeatConfig,
-    HooksConfig, HttpRequestConfig, IMessageConfig, IdentityConfig, LarkConfig, MatrixConfig,
-    MemoryConfig, ModelRouteConfig, MultimodalConfig, NextcloudTalkConfig,
-    NonCliNaturalLanguageApprovalMode, ObservabilityConfig, OtpChallengeDelivery, OtpConfig,
-    OtpMethod, PeripheralBoardConfig, PeripheralsConfig, PerplexityFilterConfig, PluginEntryConfig,
-    PluginsConfig, ProviderConfig, ProxyConfig, ProxyScope, QdrantConfig,
-    QueryClassificationConfig, ReliabilityConfig, ResearchPhaseConfig, ResearchTrigger,
-    ResourceLimitsConfig, RuntimeConfig, SandboxBackend, SandboxConfig, SchedulerConfig,
-    SecretsConfig, SecurityConfig, SecurityRoleConfig, SkillsConfig, SkillsPromptInjectionMode,
-    SlackConfig, StorageConfig, StorageProviderConfig, StorageProviderSection, StreamMode,
-    SyscallAnomalyConfig, TelegramConfig, TranscriptionConfig, TunnelConfig, UrlAccessConfig,
-    WasmCapabilityEscalationMode, WasmConfig, WasmModuleHashPolicy, WasmRuntimeConfig,
-    WasmSecurityConfig, WebFetchConfig, WebSearchConfig, WebhookConfig,
+    HooksConfig, HttpRequestConfig, HttpRequestCredentialProfile, IMessageConfig, IdentityConfig,
+    LarkConfig, MatrixConfig, MemoryConfig, ModelRouteConfig, MultimodalConfig,
+    NextcloudTalkConfig, NonCliNaturalLanguageApprovalMode, ObservabilityConfig,
+    OtpChallengeDelivery, OtpConfig, OtpMethod, PeripheralBoardConfig, PeripheralsConfig,
+    PerplexityFilterConfig, PluginEntryConfig, PluginsConfig, ProviderConfig, ProxyConfig,
+    ProxyScope, QdrantConfig, QueryClassificationConfig, ReliabilityConfig, ResearchPhaseConfig,
+    ResearchTrigger, ResourceLimitsConfig, RuntimeConfig, SandboxBackend, SandboxConfig,
+    SchedulerConfig, SecretsConfig, SecurityConfig, SecurityRoleConfig, SkillsConfig,
+    SkillsPromptInjectionMode, SlackConfig, StorageConfig, StorageProviderConfig,
+    StorageProviderSection, StreamMode, SyscallAnomalyConfig, TelegramConfig, TranscriptionConfig,
+    TunnelConfig, UrlAccessConfig, WasmCapabilityEscalationMode, WasmConfig, WasmModuleHashPolicy,
+    WasmRuntimeConfig, WasmSecurityConfig, WebFetchConfig, WebSearchConfig, WebhookConfig,
 };
 
 pub fn name_and_presence<T: traits::ChannelConfig>(channel: Option<&T>) -> (&'static str, bool) {
@@ -105,5 +105,18 @@ mod tests {
         assert_eq!(lark.app_id, "app-id");
         assert_eq!(feishu.app_id, "app-id");
         assert_eq!(nextcloud_talk.base_url, "https://cloud.example.com");
+    }
+
+    #[test]
+    fn reexported_http_request_credential_profile_is_constructible() {
+        let profile = HttpRequestCredentialProfile {
+            header_name: "Authorization".into(),
+            env_var: "OPENROUTER_API_KEY".into(),
+            value_prefix: "Bearer ".into(),
+        };
+
+        assert_eq!(profile.header_name, "Authorization");
+        assert_eq!(profile.env_var, "OPENROUTER_API_KEY");
+        assert_eq!(profile.value_prefix, "Bearer ");
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -371,6 +371,7 @@ pub fn all_tools_with_runtime(
             http_config.max_response_size,
             http_config.timeout_secs,
             http_config.user_agent.clone(),
+            http_config.credential_profiles.clone(),
         )));
     }
 


### PR DESCRIPTION
## Summary
### Problem
`http_request` calls currently require callers to pass raw auth headers/tokens directly in tool arguments, which increases secret-handling risk and onboarding friction.

### Why It Matters
Users need a safer default for authenticated HTTP automation and a guided onboarding path for common integrations.

### What Changed
- Added env-backed `http_request.credential_profiles` config (header name + env var + optional value prefix).
- Added config validation for profile names, env var names, and header names.
- Updated `http_request` runtime to:
  - inject credential headers from profile + environment values,
  - detect explicit header conflicts,
  - redact injected secret values in output.
- Added onboarding wizard presets for `http_request` policy modes and optional credential-profile setup.
- Updated docs in `docs/config-reference.md`.

## Label Snapshot
- `config: core`
- `docs`
- `onboard: wizard`
- `risk: high`
- `size: L`
- `tool: http_request`

## Change Metadata
- PR: #2148
- Branch: `issue-reddit-hardening-onboard-cred-flow`
- Base: `main`
- Author: `@theonlyhennygod`

## Linked Issue
- GitHub: Refs #2137 (already closed upstream)
- Linear: Resolves RMN-211

## Validation Evidence
Commands executed locally in this pass:
- `cargo test credential_profile -- --nocapture`
- `cargo fmt --all -- --check`

Current outcome:
- Build/test currently fail in baseline code paths unrelated to this PR scope (channel/tool symbols missing in current repo state), and CI runner health has also shown infra issues (disk space/install failures) on prior runs.
- Rebase has been pushed to refresh CI against latest `main`.

## Security Impact
- Reduces accidental plaintext credential handling by shifting auth values to environment variables.
- Adds header-conflict checks to prevent ambiguous or duplicated auth headers.
- Adds explicit secret redaction in `http_request` output paths.

## Privacy and Data Hygiene
- No personal data added.
- No secrets hardcoded.
- Docs and examples use placeholder env vars/values only.

## Compatibility
- Backward compatible for existing `http_request` usage without `credential_profile`.
- New profile configuration is opt-in.

## i18n Follow-Through
- No new non-English UI/runtime strings introduced.

## Human Verification
- Reviewed PR diff and conflict resolution after rebase.
- Verified scoped files remained within feature intent.

## Side Effects
- Expanded onboarding flow for users configuring web tools.
- Additional config validation may reject previously accepted malformed profile entries.

## Rollback Plan
1. Revert PR `#2148` from `main`.
2. Remove `credential_profiles` usage from runtime and config.
3. Restore prior onboarding branch behavior.

## Risks and Mitigations
- Risk: misconfigured env/profile names causing request failures.
- Mitigation: validation at config-load time + explicit runtime error messages.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configure HTTP request authentication using environment variables without exposing credentials in tool arguments.
  * Interactive setup wizard for credential profile configuration with validation and header conflict detection.
  * Automatic sensitive value redaction in logs and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->