### PR TITLE
feat(agent): add result-aware loop detection for tool-call loop

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -94,6 +94,9 @@ Operational note for container users:
 | `max_history_messages` | `50` | Maximum conversation history messages retained per session |
 | `parallel_tools` | `false` | Enable parallel tool execution within a single iteration |
 | `tool_dispatcher` | `auto` | Tool dispatch strategy |
+| `loop_detection_no_progress_threshold` | `3` | Same tool+args producing identical output this many times triggers loop detection. `0` disables |
+| `loop_detection_ping_pong_cycles` | `2` | A→B→A→B alternating pattern cycle count threshold. `0` disables |
+| `loop_detection_failure_streak` | `3` | Same tool consecutive failure count threshold. `0` disables |
 
 Notes:
 
@@ -101,6 +104,7 @@ Notes:
 - If a channel message exceeds this value, the runtime returns: `Agent exceeded maximum tool iterations (<value>)`.
 - In CLI, gateway, and channel tool loops, multiple independent tool calls are executed concurrently by default when the pending calls do not require approval gating; result order remains stable.
 - `parallel_tools` applies to the `Agent::turn()` API surface. It does not gate the runtime loop used by CLI, gateway, or channel handlers.
+- **Loop detection** intervenes before `max_tool_iterations` is exhausted. On first detection the agent receives a self-correction prompt; if the loop persists the agent is stopped early. Detection is result-aware: repeated calls with *different* outputs (genuine progress) do not trigger. Set any threshold to `0` to disable that detector.
 
 ## `[security.otp]`
 

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -1,6 +1,7 @@
 use crate::agent::dispatcher::{
     NativeToolDispatcher, ParsedToolCall, ToolDispatcher, ToolExecutionResult, XmlToolDispatcher,
 };
+use crate::agent::loop_::detection::{DetectionVerdict, LoopDetectionConfig, LoopDetector};
 use crate::agent::memory_loader::{DefaultMemoryLoader, MemoryLoader};
 use crate::agent::prompt::{PromptContext, SystemPromptBuilder};
 use crate::agent::research;
@@ -557,8 +558,13 @@ impl Agent {
             .push(ConversationMessage::Chat(ChatMessage::user(enriched)));
 
         let effective_model = self.classify_model(user_message);
+        let mut loop_detector = LoopDetector::new(LoopDetectionConfig {
+            no_progress_threshold: self.config.loop_detection_no_progress_threshold,
+            ping_pong_cycles: self.config.loop_detection_ping_pong_cycles,
+            failure_streak_threshold: self.config.loop_detection_failure_streak,
+        });
 
-        for _ in 0..self.config.max_tool_iterations {
+        for iteration in 0..self.config.max_tool_iterations {
             let messages = self.tool_dispatcher.to_provider_messages(&self.history);
             let response = match self
                 .provider
@@ -613,9 +619,34 @@ impl Agent {
             });
 
             let results = self.execute_tools(&calls).await;
+
+            // ── Loop detection: record calls ─────────────────────
+            for (call, result) in calls.iter().zip(results.iter()) {
+                let args_sig =
+                    serde_json::to_string(&call.arguments).unwrap_or_else(|_| "{}".into());
+                loop_detector.record_call(&call.name, &args_sig, &result.output, result.success);
+            }
+
             let formatted = self.tool_dispatcher.format_results(&results);
             self.history.push(formatted);
             self.trim_history();
+
+            // ── Loop detection: check verdict ────────────────────
+            match loop_detector.check() {
+                DetectionVerdict::Continue => {}
+                DetectionVerdict::InjectWarning(warning) => {
+                    self.history
+                        .push(ConversationMessage::Chat(ChatMessage::user(warning)));
+                }
+                DetectionVerdict::HardStop(reason) => {
+                    anyhow::bail!(
+                        "Agent stopped early due to detected loop pattern (iteration {}/{}): {}",
+                        iteration + 1,
+                        self.config.max_tool_iterations,
+                        reason
+                    );
+                }
+            }
         }
 
         anyhow::bail!(

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -28,11 +28,13 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 mod context;
+pub(crate) mod detection;
 mod execution;
 mod history;
 mod parsing;
 
 use context::{build_context, build_hardware_context};
+use detection::{DetectionVerdict, LoopDetectionConfig, LoopDetector};
 use execution::{
     execute_tools_parallel, execute_tools_sequential, should_execute_tools_in_parallel,
     ToolExecutionOutcome,
@@ -286,6 +288,7 @@ pub(crate) struct NonCliApprovalContext {
 
 tokio::task_local! {
     static TOOL_LOOP_NON_CLI_APPROVAL_CONTEXT: Option<NonCliApprovalContext>;
+    static LOOP_DETECTION_CONFIG: LoopDetectionConfig;
 }
 
 /// Extract a short hint from tool call arguments for progress display.
@@ -571,6 +574,14 @@ pub(crate) fn is_tool_iteration_limit_error(err: &anyhow::Error) -> bool {
     })
 }
 
+pub(crate) fn is_loop_detection_error(err: &anyhow::Error) -> bool {
+    err.chain().any(|source| {
+        source
+            .to_string()
+            .contains("Agent stopped early due to detected loop pattern")
+    })
+}
+
 /// Execute a single turn of the agent loop: send messages, parse tool calls,
 /// execute tools, and loop until the LLM produces a final text response.
 /// When `silent` is true, suppresses stdout (for channel use).
@@ -771,6 +782,11 @@ pub(crate) async fn run_tool_call_loop(
     let mut seen_tool_signatures: HashSet<(String, String)> = HashSet::new();
     let mut missing_tool_call_retry_used = false;
     let mut missing_tool_call_retry_prompt: Option<String> = None;
+    let ld_config = LOOP_DETECTION_CONFIG
+        .try_with(Clone::clone)
+        .unwrap_or_default();
+    let mut loop_detector = LoopDetector::new(ld_config);
+    let mut loop_detection_prompt: Option<String> = None;
     let bypass_non_cli_approval_for_turn =
         approval.is_some_and(|mgr| channel_name != "cli" && mgr.consume_non_cli_allow_all_once());
     if bypass_non_cli_approval_for_turn {
@@ -812,6 +828,9 @@ pub(crate) async fn run_tool_call_loop(
             multimodal::prepare_messages_for_provider(history, multimodal_config).await?;
         let mut request_messages = prepared_messages.messages.clone();
         if let Some(prompt) = missing_tool_call_retry_prompt.take() {
+            request_messages.push(ChatMessage::user(prompt));
+        }
+        if let Some(prompt) = loop_detection_prompt.take() {
             request_messages.push(ChatMessage::user(prompt));
         }
 
@@ -1441,6 +1460,12 @@ pub(crate) async fn run_tool_call_loop(
                     .await;
             }
 
+            // ── Loop detection: record call ──────────────────────
+            {
+                let sig = tool_call_signature(&call.name, &call.arguments);
+                loop_detector.record_call(&sig.0, &sig.1, &outcome.output, outcome.success);
+            }
+
             ordered_results[*idx] = Some((call.name.clone(), call.tool_call_id.clone(), outcome));
         }
 
@@ -1484,6 +1509,49 @@ pub(crate) async fn run_tool_call_loop(
                     "content": result,
                 });
                 history.push(ChatMessage::tool(tool_msg.to_string()));
+            }
+        }
+
+        // ── Loop detection: check verdict ────────────────────────
+        match loop_detector.check() {
+            DetectionVerdict::Continue => {}
+            DetectionVerdict::InjectWarning(warning) => {
+                runtime_trace::record_event(
+                    "loop_detected_warning",
+                    Some(channel_name),
+                    Some(provider_name),
+                    Some(model),
+                    Some(&turn_id),
+                    Some(false),
+                    Some("loop pattern detected, injecting self-correction prompt"),
+                    serde_json::json!({ "iteration": iteration + 1, "warning": &warning }),
+                );
+                if let Some(ref tx) = on_delta {
+                    let _ = tx
+                        .send(format!(
+                            "{DRAFT_PROGRESS_SENTINEL}\u{26a0}\u{fe0f} Loop detected, attempting self-correction\n"
+                        ))
+                        .await;
+                }
+                loop_detection_prompt = Some(warning);
+            }
+            DetectionVerdict::HardStop(reason) => {
+                runtime_trace::record_event(
+                    "loop_detected_hard_stop",
+                    Some(channel_name),
+                    Some(provider_name),
+                    Some(model),
+                    Some(&turn_id),
+                    Some(false),
+                    Some("loop persisted after warning, stopping early"),
+                    serde_json::json!({ "iteration": iteration + 1, "reason": &reason }),
+                );
+                anyhow::bail!(
+                    "Agent stopped early due to detected loop pattern (iteration {}/{}): {}",
+                    iteration + 1,
+                    max_iterations,
+                    reason
+                );
             }
         }
     }
@@ -1928,25 +1996,34 @@ pub async fn run(
             ChatMessage::user(&enriched),
         ];
 
-        let response = run_tool_call_loop(
-            provider.as_ref(),
-            &mut history,
-            &tools_registry,
-            observer.as_ref(),
-            provider_name,
-            model_name,
-            temperature,
-            false,
-            approval_manager.as_ref(),
-            channel_name,
-            &config.multimodal,
-            config.agent.max_tool_iterations,
-            None,
-            None,
-            None,
-            &[],
-        )
-        .await?;
+        let ld_cfg = LoopDetectionConfig {
+            no_progress_threshold: config.agent.loop_detection_no_progress_threshold,
+            ping_pong_cycles: config.agent.loop_detection_ping_pong_cycles,
+            failure_streak_threshold: config.agent.loop_detection_failure_streak,
+        };
+        let response = LOOP_DETECTION_CONFIG
+            .scope(
+                ld_cfg,
+                run_tool_call_loop(
+                    provider.as_ref(),
+                    &mut history,
+                    &tools_registry,
+                    observer.as_ref(),
+                    provider_name,
+                    model_name,
+                    temperature,
+                    false,
+                    approval_manager.as_ref(),
+                    channel_name,
+                    &config.multimodal,
+                    config.agent.max_tool_iterations,
+                    None,
+                    None,
+                    None,
+                    &[],
+                ),
+            )
+            .await?;
         final_output = response.clone();
         println!("{response}");
         observer.record_event(&ObserverEvent::TurnComplete);
@@ -2053,25 +2130,34 @@ pub async fn run(
 
             history.push(ChatMessage::user(&enriched));
 
-            let response = match run_tool_call_loop(
-                provider.as_ref(),
-                &mut history,
-                &tools_registry,
-                observer.as_ref(),
-                provider_name,
-                model_name,
-                temperature,
-                false,
-                approval_manager.as_ref(),
-                channel_name,
-                &config.multimodal,
-                config.agent.max_tool_iterations,
-                None,
-                None,
-                None,
-                &[],
-            )
-            .await
+            let ld_cfg = LoopDetectionConfig {
+                no_progress_threshold: config.agent.loop_detection_no_progress_threshold,
+                ping_pong_cycles: config.agent.loop_detection_ping_pong_cycles,
+                failure_streak_threshold: config.agent.loop_detection_failure_streak,
+            };
+            let response = match LOOP_DETECTION_CONFIG
+                .scope(
+                    ld_cfg,
+                    run_tool_call_loop(
+                        provider.as_ref(),
+                        &mut history,
+                        &tools_registry,
+                        observer.as_ref(),
+                        provider_name,
+                        model_name,
+                        temperature,
+                        false,
+                        approval_manager.as_ref(),
+                        channel_name,
+                        &config.multimodal,
+                        config.agent.max_tool_iterations,
+                        None,
+                        None,
+                        None,
+                        &[],
+                    ),
+                )
+                .await
             {
                 Ok(resp) => resp,
                 Err(e) => {
@@ -2083,6 +2169,15 @@ pub async fn run(
                         );
                         history.push(ChatMessage::assistant(&pause_notice));
                         eprintln!("\n{pause_notice}\n");
+                        continue;
+                    }
+                    if is_loop_detection_error(&e) {
+                        let notice =
+                            "\u{26a0}\u{fe0f} Loop pattern detected and agent stopped early. \
+                            Context preserved. Reply \"continue\" to resume, or adjust \
+                            loop_detection_* thresholds in config.";
+                        history.push(ChatMessage::assistant(notice));
+                        eprintln!("\n{notice}\n");
                         continue;
                     }
                     eprintln!("\nError: {e}\n");

--- a/src/agent/loop_/detection.rs
+++ b/src/agent/loop_/detection.rs
@@ -1,0 +1,389 @@
+//! Loop detection for the agent tool-call loop.
+//!
+//! Detects three patterns of unproductive looping:
+//! 1. **No-progress repeat** — same tool + same args + same output hash.
+//! 2. **Ping-pong** — two calls alternating (A→B→A→B) with no progress.
+//! 3. **Consecutive failure streak** — same tool failing repeatedly.
+//!
+//! On first detection an `InjectWarning` verdict gives the LLM a chance to
+//! self-correct.  If the pattern persists the next check returns `HardStop`.
+
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+/// Maximum bytes of tool output considered when hashing results.
+/// Keeps hashing fast and bounded for large outputs.
+const OUTPUT_HASH_PREFIX_BYTES: usize = 4096;
+
+// ─── Configuration ───────────────────────────────────────────────────────────
+
+/// Tuning knobs for each detection strategy.
+#[derive(Debug, Clone)]
+pub(crate) struct LoopDetectionConfig {
+    /// Identical (tool + args + output) repetitions before triggering.
+    /// `0` = disabled.  Default: `3`.
+    pub no_progress_threshold: usize,
+    /// Full A-B cycles before triggering ping-pong detection.
+    /// `0` = disabled.  Default: `2`.
+    pub ping_pong_cycles: usize,
+    /// Consecutive failures of the *same* tool before triggering.
+    /// `0` = disabled.  Default: `3`.
+    pub failure_streak_threshold: usize,
+}
+
+impl Default for LoopDetectionConfig {
+    fn default() -> Self {
+        Self {
+            no_progress_threshold: 3,
+            ping_pong_cycles: 2,
+            failure_streak_threshold: 3,
+        }
+    }
+}
+
+// ─── Verdict ─────────────────────────────────────────────────────────────────
+
+/// Action the caller should take after `LoopDetector::check()`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum DetectionVerdict {
+    /// No loop detected — proceed normally.
+    Continue,
+    /// First detection — inject this self-correction prompt, then continue.
+    InjectWarning(String),
+    /// Pattern persisted after warning — terminate the loop.
+    HardStop(String),
+}
+
+// ─── Internal record ─────────────────────────────────────────────────────────
+
+struct CallRecord {
+    tool_name: String,
+    args_sig: String,
+    result_hash: u64,
+    success: bool,
+}
+
+// ─── Detector ────────────────────────────────────────────────────────────────
+
+pub(crate) struct LoopDetector {
+    config: LoopDetectionConfig,
+    history: Vec<CallRecord>,
+    consecutive_failures: HashMap<String, usize>,
+    warning_injected: bool,
+}
+
+impl LoopDetector {
+    pub fn new(config: LoopDetectionConfig) -> Self {
+        Self {
+            config,
+            history: Vec::new(),
+            consecutive_failures: HashMap::new(),
+            warning_injected: false,
+        }
+    }
+
+    /// Record a completed tool invocation.
+    ///
+    /// * `tool_name` — canonical tool name (lowercased by caller).
+    /// * `args_sig`  — canonical JSON args string from `tool_call_signature()`.
+    /// * `output`    — raw tool output text.
+    /// * `success`   — whether the tool reported success.
+    pub fn record_call(&mut self, tool_name: &str, args_sig: &str, output: &str, success: bool) {
+        let result_hash = hash_output(output);
+        self.history.push(CallRecord {
+            tool_name: tool_name.to_owned(),
+            args_sig: args_sig.to_owned(),
+            result_hash,
+            success,
+        });
+
+        if success {
+            self.consecutive_failures.remove(tool_name);
+        } else {
+            *self
+                .consecutive_failures
+                .entry(tool_name.to_owned())
+                .or_insert(0) += 1;
+        }
+    }
+
+    /// Evaluate the current history and return a verdict.
+    pub fn check(&mut self) -> DetectionVerdict {
+        let reason = self
+            .check_no_progress_repeat()
+            .or_else(|| self.check_ping_pong())
+            .or_else(|| self.check_failure_streak());
+
+        match reason {
+            None => DetectionVerdict::Continue,
+            Some(msg) => {
+                if self.warning_injected {
+                    DetectionVerdict::HardStop(msg)
+                } else {
+                    self.warning_injected = true;
+                    DetectionVerdict::InjectWarning(format_warning(&msg))
+                }
+            }
+        }
+    }
+
+    // ── Strategy 1: no-progress repeat ───────────────────────────────────
+
+    fn check_no_progress_repeat(&self) -> Option<String> {
+        let threshold = self.config.no_progress_threshold;
+        if threshold == 0 || self.history.is_empty() {
+            return None;
+        }
+        let last = self.history.last().unwrap();
+        let streak = self
+            .history
+            .iter()
+            .rev()
+            .take_while(|r| {
+                r.tool_name == last.tool_name
+                    && r.args_sig == last.args_sig
+                    && r.result_hash == last.result_hash
+            })
+            .count();
+        if streak >= threshold {
+            Some(format!(
+                "Tool '{}' called {} times with identical arguments and identical results \
+                 — no progress detected",
+                last.tool_name, streak
+            ))
+        } else {
+            None
+        }
+    }
+
+    // ── Strategy 2: ping-pong ────────────────────────────────────────────
+
+    fn check_ping_pong(&self) -> Option<String> {
+        let cycles = self.config.ping_pong_cycles;
+        if cycles == 0 || self.history.len() < 4 {
+            return None;
+        }
+        let len = self.history.len();
+        let a = &self.history[len - 2];
+        let b = &self.history[len - 1];
+
+        // The two sides of the ping-pong must differ.
+        if a.tool_name == b.tool_name && a.args_sig == b.args_sig {
+            return None;
+        }
+
+        let min_entries = cycles * 2;
+        if len < min_entries {
+            return None;
+        }
+        let tail = &self.history[len - min_entries..];
+        let is_ping_pong = tail.chunks(2).all(|pair| {
+            pair.len() == 2
+                && pair[0].tool_name == a.tool_name
+                && pair[0].args_sig == a.args_sig
+                && pair[0].result_hash == a.result_hash
+                && pair[1].tool_name == b.tool_name
+                && pair[1].args_sig == b.args_sig
+                && pair[1].result_hash == b.result_hash
+        });
+
+        if is_ping_pong {
+            Some(format!(
+                "Ping-pong loop detected: '{}' and '{}' alternating {} times with no progress",
+                a.tool_name, b.tool_name, cycles
+            ))
+        } else {
+            None
+        }
+    }
+
+    // ── Strategy 3: consecutive failure streak ───────────────────────────
+
+    fn check_failure_streak(&self) -> Option<String> {
+        let threshold = self.config.failure_streak_threshold;
+        if threshold == 0 {
+            return None;
+        }
+        for (tool, count) in &self.consecutive_failures {
+            if *count >= threshold {
+                return Some(format!(
+                    "Tool '{}' failed {} consecutive times",
+                    tool, count
+                ));
+            }
+        }
+        None
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn hash_output(output: &str) -> u64 {
+    let prefix = if output.len() > OUTPUT_HASH_PREFIX_BYTES {
+        &output[..OUTPUT_HASH_PREFIX_BYTES]
+    } else {
+        output
+    };
+    let mut hasher = DefaultHasher::new();
+    prefix.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn format_warning(reason: &str) -> String {
+    format!(
+        "IMPORTANT: A loop pattern has been detected in your tool usage. {reason}. \
+         You must change your approach: \
+         (1) Try a different tool or different arguments, \
+         (2) If polling a process, increase wait time or check if it's stuck, \
+         (3) If the task cannot be completed, explain why and stop. \
+         Do NOT repeat the same tool call with the same arguments."
+    )
+}
+
+// ─── Unit tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> LoopDetectionConfig {
+        LoopDetectionConfig::default()
+    }
+
+    fn disabled_config() -> LoopDetectionConfig {
+        LoopDetectionConfig {
+            no_progress_threshold: 0,
+            ping_pong_cycles: 0,
+            failure_streak_threshold: 0,
+        }
+    }
+
+    // 1. Below threshold → Continue
+    #[test]
+    fn below_threshold_does_not_trigger() {
+        let mut det = LoopDetector::new(default_config());
+        det.record_call("echo", r#"{"msg":"hi"}"#, "hello", true);
+        det.record_call("echo", r#"{"msg":"hi"}"#, "hello", true);
+        assert_eq!(det.check(), DetectionVerdict::Continue);
+    }
+
+    // 2. No-progress repeat triggers warning at threshold
+    #[test]
+    fn no_progress_repeat_triggers_warning() {
+        let mut det = LoopDetector::new(default_config());
+        for _ in 0..3 {
+            det.record_call("echo", r#"{"msg":"hi"}"#, "hello", true);
+        }
+        match det.check() {
+            DetectionVerdict::InjectWarning(msg) => {
+                assert!(msg.contains("no progress"), "msg: {msg}");
+            }
+            other => panic!("expected InjectWarning, got {other:?}"),
+        }
+    }
+
+    // 3. Same input but different output → no trigger (progress detected)
+    #[test]
+    fn same_input_different_output_does_not_trigger() {
+        let mut det = LoopDetector::new(default_config());
+        det.record_call("echo", r#"{"msg":"hi"}"#, "result_1", true);
+        det.record_call("echo", r#"{"msg":"hi"}"#, "result_2", true);
+        det.record_call("echo", r#"{"msg":"hi"}"#, "result_3", true);
+        assert_eq!(det.check(), DetectionVerdict::Continue);
+    }
+
+    // 4. Warning then continued loop → HardStop
+    #[test]
+    fn warning_then_continued_loop_triggers_hard_stop() {
+        let mut det = LoopDetector::new(default_config());
+        for _ in 0..3 {
+            det.record_call("echo", r#"{"msg":"hi"}"#, "same", true);
+        }
+        assert!(matches!(det.check(), DetectionVerdict::InjectWarning(_)));
+        // One more identical call
+        det.record_call("echo", r#"{"msg":"hi"}"#, "same", true);
+        match det.check() {
+            DetectionVerdict::HardStop(msg) => {
+                assert!(msg.contains("no progress"), "msg: {msg}");
+            }
+            other => panic!("expected HardStop, got {other:?}"),
+        }
+    }
+
+    // 5. Ping-pong detection
+    #[test]
+    fn ping_pong_triggers_warning() {
+        let mut det = LoopDetector::new(default_config());
+        // 2 cycles: A-B-A-B
+        det.record_call("tool_a", r#"{"x":1}"#, "out_a", true);
+        det.record_call("tool_b", r#"{"y":2}"#, "out_b", true);
+        det.record_call("tool_a", r#"{"x":1}"#, "out_a", true);
+        det.record_call("tool_b", r#"{"y":2}"#, "out_b", true);
+        match det.check() {
+            DetectionVerdict::InjectWarning(msg) => {
+                assert!(msg.contains("Ping-pong"), "msg: {msg}");
+            }
+            other => panic!("expected InjectWarning, got {other:?}"),
+        }
+    }
+
+    // 6. Ping-pong with progress does not trigger
+    #[test]
+    fn ping_pong_with_progress_does_not_trigger() {
+        let mut det = LoopDetector::new(default_config());
+        det.record_call("tool_a", r#"{"x":1}"#, "out_a_1", true);
+        det.record_call("tool_b", r#"{"y":2}"#, "out_b_1", true);
+        det.record_call("tool_a", r#"{"x":1}"#, "out_a_2", true); // different output
+        det.record_call("tool_b", r#"{"y":2}"#, "out_b_2", true); // different output
+        assert_eq!(det.check(), DetectionVerdict::Continue);
+    }
+
+    // 7. Consecutive failure streak (different args each time to avoid no-progress trigger)
+    #[test]
+    fn failure_streak_triggers_warning() {
+        let mut det = LoopDetector::new(default_config());
+        det.record_call("shell", r#"{"cmd":"bad1"}"#, "error: not found 1", false);
+        det.record_call("shell", r#"{"cmd":"bad2"}"#, "error: not found 2", false);
+        det.record_call("shell", r#"{"cmd":"bad3"}"#, "error: not found 3", false);
+        match det.check() {
+            DetectionVerdict::InjectWarning(msg) => {
+                assert!(msg.contains("failed 3 consecutive"), "msg: {msg}");
+            }
+            other => panic!("expected InjectWarning, got {other:?}"),
+        }
+    }
+
+    // 8. Failure streak resets on success
+    #[test]
+    fn failure_streak_resets_on_success() {
+        let mut det = LoopDetector::new(default_config());
+        det.record_call("shell", r#"{"cmd":"bad"}"#, "err", false);
+        det.record_call("shell", r#"{"cmd":"bad"}"#, "err", false);
+        det.record_call("shell", r#"{"cmd":"good"}"#, "ok", true); // resets
+        det.record_call("shell", r#"{"cmd":"bad"}"#, "err", false);
+        det.record_call("shell", r#"{"cmd":"bad"}"#, "err", false);
+        assert_eq!(det.check(), DetectionVerdict::Continue);
+    }
+
+    // 9. All thresholds zero → disabled
+    #[test]
+    fn all_disabled_never_triggers() {
+        let mut det = LoopDetector::new(disabled_config());
+        for _ in 0..20 {
+            det.record_call("echo", r#"{"msg":"hi"}"#, "same", true);
+        }
+        assert_eq!(det.check(), DetectionVerdict::Continue);
+    }
+
+    // 10. Mixed tools → no false positive
+    #[test]
+    fn mixed_tools_no_false_positive() {
+        let mut det = LoopDetector::new(default_config());
+        det.record_call("file_read", r#"{"path":"a.rs"}"#, "content_a", true);
+        det.record_call("shell", r#"{"cmd":"ls"}"#, "file_list", true);
+        det.record_call("memory_store", r#"{"key":"x"}"#, "stored", true);
+        det.record_call("file_read", r#"{"path":"b.rs"}"#, "content_b", true);
+        det.record_call("shell", r#"{"cmd":"cargo test"}"#, "ok", true);
+        assert_eq!(det.check(), DetectionVerdict::Continue);
+    }
+}

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -714,6 +714,21 @@ pub struct AgentConfig {
     /// Tool dispatch strategy (e.g. `"auto"`). Default: `"auto"`.
     #[serde(default = "default_agent_tool_dispatcher")]
     pub tool_dispatcher: String,
+    /// Loop detection: no-progress repeat threshold.
+    /// Triggers when the same tool+args produces identical output this many times.
+    /// Set to `0` to disable. Default: `3`.
+    #[serde(default = "default_loop_detection_no_progress_threshold")]
+    pub loop_detection_no_progress_threshold: usize,
+    /// Loop detection: ping-pong cycle threshold.
+    /// Detects A→B→A→B alternating patterns with no progress.
+    /// Value is number of full cycles (A-B = 1 cycle). Set to `0` to disable. Default: `2`.
+    #[serde(default = "default_loop_detection_ping_pong_cycles")]
+    pub loop_detection_ping_pong_cycles: usize,
+    /// Loop detection: consecutive failure streak threshold.
+    /// Triggers when the same tool fails this many times in a row.
+    /// Set to `0` to disable. Default: `3`.
+    #[serde(default = "default_loop_detection_failure_streak")]
+    pub loop_detection_failure_streak: usize,
 }
 
 fn default_agent_max_tool_iterations() -> usize {
@@ -728,6 +743,18 @@ fn default_agent_tool_dispatcher() -> String {
     "auto".into()
 }
 
+fn default_loop_detection_no_progress_threshold() -> usize {
+    3
+}
+
+fn default_loop_detection_ping_pong_cycles() -> usize {
+    2
+}
+
+fn default_loop_detection_failure_streak() -> usize {
+    3
+}
+
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
@@ -736,6 +763,9 @@ impl Default for AgentConfig {
             max_history_messages: default_agent_max_history_messages(),
             parallel_tools: false,
             tool_dispatcher: default_agent_tool_dispatcher(),
+            loop_detection_no_progress_threshold: default_loop_detection_no_progress_threshold(),
+            loop_detection_ping_pong_cycles: default_loop_detection_ping_pong_cycles(),
+            loop_detection_failure_streak: default_loop_detection_failure_streak(),
         }
     }
 }

--- a/tests/agent_loop_robustness.rs
+++ b/tests/agent_loop_robustness.rs
@@ -448,3 +448,141 @@ async fn agent_handles_sequential_tool_then_text() {
         "should produce final text after tool execution"
     );
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// TG4.6: Loop detection
+// ═════════════════════════════════════════════════════════════════════════════
+
+/// No-progress repeat: provider returns same tool call every turn with identical
+/// output (EchoTool with fixed input).  Loop detection should stop early.
+#[tokio::test]
+async fn loop_detection_no_progress_repeat_stops_early() {
+    let responses: Vec<ChatResponse> = (0..10)
+        .map(|i| {
+            tool_response(vec![ToolCall {
+                id: format!("tc_{i}"),
+                name: "echo".into(),
+                arguments: r#"{"message": "same"}"#.into(),
+            }])
+        })
+        .collect();
+
+    let provider = Box::new(MockProvider::new(responses));
+    let mut agent = build_agent(provider, vec![Box::new(EchoTool)]);
+    let result = agent.turn("repeat forever").await;
+    assert!(result.is_err(), "should error due to loop detection");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("detected loop pattern"),
+        "error should mention loop pattern: {err_msg}"
+    );
+}
+
+/// Repeated calls with *different* outputs should NOT trigger loop detection.
+/// EchoTool returns the input, so varying inputs → varying outputs = progress.
+#[tokio::test]
+async fn loop_detection_different_outputs_no_false_positive() {
+    let mut responses: Vec<ChatResponse> = (0..5)
+        .map(|i| {
+            tool_response(vec![ToolCall {
+                id: format!("tc_{i}"),
+                name: "echo".into(),
+                arguments: format!(r#"{{"message": "msg_{i}"}}"#),
+            }])
+        })
+        .collect();
+    responses.push(text_response("All done"));
+
+    let provider = Box::new(MockProvider::new(responses));
+    let mut agent = build_agent(provider, vec![Box::new(EchoTool)]);
+    let result = agent.turn("varying calls").await;
+    assert!(
+        result.is_ok(),
+        "should complete normally with varying outputs: {:?}",
+        result.err()
+    );
+}
+
+/// Ping-pong: alternating between two tools with fixed input/output.
+#[tokio::test]
+async fn loop_detection_ping_pong_stops_early() {
+    // A-B-A-B-A-B pattern (3 cycles, threshold=2)
+    let mut responses: Vec<ChatResponse> = Vec::new();
+    for i in 0..6 {
+        let (name, args) = if i % 2 == 0 {
+            ("echo", r#"{"message": "ping"}"#)
+        } else {
+            ("echo", r#"{"message": "pong"}"#)
+        };
+        responses.push(tool_response(vec![ToolCall {
+            id: format!("tc_{i}"),
+            name: name.into(),
+            arguments: args.into(),
+        }]));
+    }
+
+    // Note: ping-pong detection works when tool names differ OR args differ.
+    // Here we use same tool with different args, which counts as different signatures.
+    let provider = Box::new(MockProvider::new(responses));
+    let mut agent = build_agent(provider, vec![Box::new(EchoTool)]);
+    let result = agent.turn("ping pong").await;
+    // The detector should fire (warning then hard stop) within the iterations
+    assert!(
+        result.is_err(),
+        "should error due to ping-pong loop detection"
+    );
+}
+
+/// Consecutive failures trigger loop detection.
+#[tokio::test]
+async fn loop_detection_failure_streak_stops_early() {
+    let responses: Vec<ChatResponse> = (0..10)
+        .map(|i| {
+            tool_response(vec![ToolCall {
+                id: format!("tc_{i}"),
+                name: "failing_tool".into(),
+                arguments: "{}".into(),
+            }])
+        })
+        .collect();
+
+    let provider = Box::new(MockProvider::new(responses));
+    let mut agent = build_agent(provider, vec![Box::new(FailingTool)]);
+    let result = agent.turn("keep failing").await;
+    assert!(
+        result.is_err(),
+        "should error due to failure streak detection"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("detected loop pattern"),
+        "error should mention loop pattern: {err_msg}"
+    );
+}
+
+/// Normal varied tool usage should not trigger any detection.
+#[tokio::test]
+async fn loop_detection_normal_flow_no_false_positive() {
+    let responses = vec![
+        tool_response(vec![ToolCall {
+            id: "tc1".into(),
+            name: "echo".into(),
+            arguments: r#"{"message": "hello"}"#.into(),
+        }]),
+        tool_response(vec![ToolCall {
+            id: "tc2".into(),
+            name: "echo".into(),
+            arguments: r#"{"message": "world"}"#.into(),
+        }]),
+        text_response("Final answer"),
+    ];
+
+    let provider = Box::new(MockProvider::new(responses));
+    let mut agent = build_agent(provider, vec![Box::new(EchoTool)]);
+    let result = agent.turn("normal usage").await;
+    assert!(
+        result.is_ok(),
+        "normal varied flow should complete: {:?}",
+        result.err()
+    );
+}


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

  - Problem: Agent tool loop relies solely on `max_tool_iterations=20` hard cutoff with no ability to detect unproductive cycles
   — wastes all iterations, tokens, and time on loops that will never converge
  - Why it matters: **This is a core reliability gap.** Every undetected loop = 20 wasted API round-trips + user blocked waiting
   + token budget burned. In unattended channel/gateway deployments, one loop can exhaust an entire session. Result-aware early
  intervention stops the agent at iteration 4 instead of 20, and gives the LLM one self-correction opportunity before
  terminating
  - What changed: New `LoopDetector` (3 detection strategies + 2-tier escalation), integrated into both tool loop paths, 3
  configurable thresholds
  - What did **not** change (scope boundary): Provider/Tool/Channel trait definitions, `max_tool_iterations` behavior,
  Cargo.toml dependencies, security/gateway modules


## Label Snapshot (required)

  - Risk label: `risk: low`
  - Size label: `size: M`
  - Scope labels: `agent`, `config`, `docs`, `tests`
  - Module labels: `agent: loop-detection`
  - Contributor tier label: (auto-managed)
  - If any auto-label is incorrect: N/A

## Change Metadata

  - Change type: `feature`
  - Primary scope: `agent`

## Linked Issue

- Closes #2152
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)
- Linear issue key(s) (required, e.g. `RMN-123`):
- Linear issue URL(s):

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

```bash
  cargo fmt --all -- --check                    # ✅ pass
  cargo clippy (own files only)                 # ✅ 0 warnings
  cargo test --lib agent::loop_::detection      # ✅ 10/10 passed
  cargo test --test agent_loop_robustness       # ✅ 17/17 passed (12 existing + 5 new)

  - Evidence provided: 10 unit tests (threshold boundaries, false-positive guards, warning→hard-stop escalation,
  disable-via-zero), 5 integration tests (no-progress stop, different-output no false positive, ping-pong stop, failure streak
  stop, normal flow no false positive), MockProvider simulation demo
  - If any command is intentionally skipped: cargo clippy --all-targets -- -D warnings has 64 pre-existing errors (not
  introduced by this PR); files changed in this PR have 0 clippy warnings

## Security Impact (required)

  - New permissions/capabilities? No
  - New external network calls? No
  - Secrets/tokens handling changed? No
  - File system access scope changed? No


## Privacy and Data Hygiene (required)

 - Data-hygiene status: pass
  - Redaction/anonymization notes: Tests use neutral placeholders (echo, tool_a, tool_b, shell)
  - Neutral wording confirmation: Yes

## Compatibility / Migration

  - Backward compatible? Yes — #[serde(default)] ensures existing configs work without changes
  - Config/env changes? Yes — 3 new optional fields, all with sensible defaults
  - Migration needed? No
  - Upgrade steps: None required; new fields take effect automatically. To customise: set loop_detection_* values under [agent];
   set to 0 to disable

## i18n Follow-Through (required when docs or user-facing wording changes)

  - i18n follow-through triggered? No (only config-reference.md technical table, not user-facing wording)

## Human Verification (required)

What was personally validated beyond CI:

  - Verified scenarios: MockProvider simulating a stuck LLM → agent stops at iteration 4 (not 20); repeated calls with varying
  output complete normally
  - Edge cases checked: all thresholds set to 0 disables detection; failure streak resets on success; ping-pong with progress
  does not trigger; mixed tools produce no false positives
  - What was not verified: Real LLM loop scenario (qwen2.5 models are smart enough to not loop, but MockProvider demo fully
  validates the mechanism)

## Side Effects / Blast Radius (required)

  - Affected subsystems: src/agent/ only (loop_.rs, agent.rs) + config schema
  - Potential unintended effects: Overly low thresholds could interrupt legitimate long tool chains — mitigated by
  result-awareness + configurable thresholds + disable-via-zero
  - Guardrails/monitoring: 2 runtime_trace events (loop_detected_warning, loop_detected_hard_stop) observable through existing
  observability pipeline

## Agent Collaboration Notes (recommended)

  - Agent tools used: Claude Code
  - Workflow/plan summary: Plan mode → explore architecture → implement detection module → integrate into both loop paths → unit
   + integration tests → rebase on latest main
  - Verification focus: False-positive prevention (result-awareness is the core design decision)
  - Confirmation: naming + architecture boundaries followed (CLAUDE.md + CONTRIBUTING.md)
  
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Rollback Plan (required)

  - Fast rollback command/path: git revert <commit> — single commit, under 1 minute
  - Feature flags or config toggles: All 3 thresholds can be set to 0 to disable without code revert
  - Observable failure symptoms: loop_detected_warning / loop_detected_hard_stop events in logs; CLI shows "Loop pattern
  detected" message

## Risks and Mitigations

  - Risk: False positives (legitimate repeated calls wrongly flagged as loop)
    - Mitigation: Result-aware detection (both input AND output must be identical to count as no-progress) + configurable
  thresholds + set-to-zero disable + warning gives LLM one correction chance before hard stop


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loop detection mechanism to prevent agent infinite loops. Detects and can halt three patterns: repeated tool calls with no progress, alternating tool calls, and consecutive tool failures. All thresholds are configurable via agent settings.

* **Documentation**
  * Added loop detection configuration reference with three new settings.

* **Tests**
  * Added test suite covering loop detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->