### PR TITLE
fix(ci): stabilize post-2142 local quality gates (COM-2142)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,7 +350,6 @@ Use these rules to keep the trait/factory architecture stable under growth.
 - Apply `docs/i18n-guide.md` completion checklist before merge and include i18n status in PR notes.
 - For docs snapshots, add new date-stamped files for new sprints rather than rewriting historical context.
 
-
 ## 8) Validation Matrix
 
 Default local checks for code changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Legacy values are still decrypted for backward compatibility but should be migrated.
 
 ### Fixed
+
 - **Gemini thinking model support** — Responses from thinking models (e.g. `gemini-3-pro-preview`)
   are now handled correctly. The provider skips internal reasoning parts (`thought: true`) and
   signature parts (`thoughtSignature`), extracting only the final answer text. Falls back to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,7 +350,6 @@ Use these rules to keep the trait/factory architecture stable under growth.
 - Apply `docs/i18n-guide.md` completion checklist before merge and include i18n status in PR notes.
 - For docs snapshots, add new date-stamped files for new sprints rather than rewriting historical context.
 
-
 ## 8) Validation Matrix
 
 Default local checks for code changes:

--- a/docs/android-setup.md
+++ b/docs/android-setup.md
@@ -89,12 +89,15 @@ cargo build --release --target aarch64-linux-android
 ## Troubleshooting
 
 ### "Permission denied"
+
 ```bash
 chmod +x zeroclaw
 ```
 
 ### "not found" or linker errors
+
 Make sure you downloaded the correct architecture for your device.
 
 ### Old Android (4.x)
+
 Use the `armv7-linux-androideabi` build with API level 16+.

--- a/scripts/ci/detect_change_scope.sh
+++ b/scripts/ci/detect_change_scope.sh
@@ -112,6 +112,8 @@ done <<< "$CHANGED"
   echo "workflow_changed=$workflow_changed"
   echo "base_sha=$DIFF_BASE"
   echo "docs_files<<EOF"
-  printf '%s\n' "${docs_files[@]}"
+  if [ "${#docs_files[@]}" -gt 0 ]; then
+    printf '%s\n' "${docs_files[@]}"
+  fi
   echo "EOF"
 } >> "$GITHUB_OUTPUT"

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -10293,8 +10293,12 @@ BTC is currently around $65,000 based on latest tool output."#;
 
         let channels = collect_configured_channels(&config, "test");
 
-        assert!(channels.iter().any(|entry| entry.display_name == "DingTalk"));
-        assert!(channels.iter().any(|entry| entry.channel.name() == "dingtalk"));
+        assert!(channels
+            .iter()
+            .any(|entry| entry.display_name == "DingTalk"));
+        assert!(channels
+            .iter()
+            .any(|entry| entry.channel.name() == "dingtalk"));
     }
 
     struct AlwaysFailChannel {


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`main` or `dev`; direct `main` PRs are allowed): `main`
- Problem: After the `#2142` policy shift, local quality-gate runs on rebased main exposed a shell `set -u` array edge case plus formatting/markdown blockers.
- Why it matters: These blockers reduce confidence when maintainers validate CI behavior locally before merge.
- What changed: Fixed `detect_change_scope.sh` empty-array handling, aligned rustfmt-sensitive assertions, and corrected markdown heading spacing in affected docs files.
- What did **not** change (scope boundary): No workflow policy/routing logic changes beyond quality gate stability fixes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS` (expected)
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `ci,docs,scripts,channel`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `scripts: ci`, `channel: core`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `ci`

## Linked Issue

- Closes # N/A
- Related #2142
- Depends on # N/A
- Supersedes # N/A
- Linear issue key(s) (required, e.g. `RMN-123`): `COM-2142`
- Linear issue URL(s): N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): No supersede action
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
./scripts/ci/rust_quality_gate.sh
BASE_SHA=$(git merge-base upstream/main HEAD) ./scripts/ci/rust_strict_delta_gate.sh
./scripts/ci/docs_quality_gate.sh
python3 -m unittest scripts/ci/tests/test_detect_change_scope.py
```

- Evidence provided (test/log/trace/screenshot/perf): local command output (all pass)
- If any command is intentionally skipped, explain why: None

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no personal/sensitive data added
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: local gate scripts and focused unit test pass after patch
- Edge cases checked: empty `docs_files` output path under `set -u`
- What was not verified: hosted `pull_request_target` automation specifics

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: CI scripts, docs lint inputs, channel test formatting only
- Potential unintended effects: low; docs formatting and output-file behavior only
- Guardrails/monitoring for early detection: CI required gate + docs quality gate + unit tests

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local shell checks, isolated worktree workflow
- Workflow/plan summary (if any): rebase on current `main`, repro failures, targeted minimal patch, rerun checks
- Verification focus: reproducible local CI subset matching reviewer workflow
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed

## Rollback Plan (required)

- Fast rollback command/path: revert this single commit/PR
- Feature flags or config toggles (if any): none
- Observable failure symptoms: CI scope output regression or docs lint regressions

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: Small chance of shell behavior difference in CI environment
  - Mitigation: unit tests + detect-scope script coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support documentation for Gemini thinking model responses.

* **Documentation**
  * Enhanced Android setup troubleshooting guidance with architecture selection and permission instructions.
  * Updated developer documentation standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->