### PR TITLE
ci: increase supply-chain provenance timeout to 60m

### DIFF
--- a/.github/workflows/ci-supply-chain-provenance.yml
+++ b/.github/workflows/ci-supply-chain-provenance.yml
@@ -32,7 +32,7 @@ jobs:
     provenance:
         name: Build + Provenance Bundle
         runs-on: [self-hosted, aws-india]
-        timeout-minutes: 35
+        timeout-minutes: 60
         steps:
             - name: Checkout
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- increase `CI Supply Chain Provenance` job timeout from 35 minutes to 60 minutes
- addresses timeout cancellation seen on main commit `4fb784e7` in step `Build release-fast artifact`

## Why
- the workflow run exceeded 35 minutes and was cancelled before provenance generation/signing
- this leaves main CI in prolonged pending state and blocks clean green status convergence

## Scope
- workflow timeout only; no product/runtime behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow timeout configuration to improve build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->