### PR TITLE
CI: move maintenance workflows to hosted runners

### DIFF
--- a/.github/workflows/pr-check-stale.yml
+++ b/.github/workflows/pr-check-stale.yml
@@ -17,7 +17,8 @@ jobs:
         permissions:
             issues: write
             pull-requests: write
-        runs-on: [self-hosted, aws-india]
+        runs-on: ubuntu-22.04
+        timeout-minutes: 10
         steps:
             - name: Mark stale issues and pull requests
               uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0

--- a/.github/workflows/pr-check-status.yml
+++ b/.github/workflows/pr-check-status.yml
@@ -18,7 +18,8 @@ env:
 
 jobs:
   nudge-stale-prs:
-    runs-on: [self-hosted, aws-india]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/sync-contributors.yml
+++ b/.github/workflows/sync-contributors.yml
@@ -17,7 +17,8 @@ permissions:
 jobs:
   update-notice:
     name: Update NOTICE with new contributors
-    runs-on: [self-hosted, aws-india]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- Problem: Low-cost maintenance workflows still consumed `self-hosted/aws-india` capacity and could queue behind heavier CI jobs.
- Why it matters: Routine hygiene automation should not compete with Rust/security pipelines for the same runner pool.
- What changed: RMN-2138; moved `pr-check-status`, `pr-check-stale`, and `sync-contributors` jobs to `ubuntu-22.04` and added bounded timeouts.

## Validation Evidence (required)
Commands and result summary:
```bash
python3 -m unittest discover -s scripts/ci/tests -p 'test_*.py' -v
# Ran 57 tests, OK
```

## Security Impact (required)
- New permissions/capabilities? (`Yes/No`): No
- If yes, minimal scope and justification: N/A
- Abuse/misuse case considered: workflow permissions stay unchanged; only runner placement and timeout bounds changed.

## Privacy and Data Hygiene (required)
- Data-hygiene status (`pass|needs-follow-up`): pass
- New data collected/processed? (`Yes/No`): No
- Secrets handling changes? (`Yes/No`): No

## Rollback Plan (required)
- Fast rollback command/path: Revert this PR merge commit on `main`.
- Blast radius: Scheduled maintenance workflows only.
- Verification after rollback: these jobs return to `self-hosted/aws-india` runner labels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration infrastructure by transitioning to Ubuntu 22.04 runners and implementing job-level timeouts to enhance build reliability and prevent workflow hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->