### PR TITLE
fix(channels): import ApprovalResponse in runtime command handler

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -72,7 +72,7 @@ use crate::agent::loop_::{
     run_tool_call_loop_with_non_cli_approval_context, scrub_credentials, NonCliApprovalContext,
     SafetyHeartbeatConfig,
 };
-use crate::approval::{ApprovalManager, PendingApprovalError};
+use crate::approval::{ApprovalManager, ApprovalResponse, PendingApprovalError};
 use crate::config::{Config, NonCliNaturalLanguageApprovalMode};
 use crate::identity;
 use crate::memory::{self, Memory};


### PR DESCRIPTION
Follow-up fix after #1961 merge.

## What
- add missing  import in 

## Why
-  failed with  due unresolved  used in runtime approval handling.

## Validation
- cargo check --locked