### PR TITLE
feat(email): add IMAP ID extension support for NetEase mailboxes

### DIFF
--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -352,7 +352,11 @@ password = "email-password"
 from_address = "bot@example.com"
 poll_interval_secs = 60
 allowed_senders = ["*"]
+imap_id = { enabled = true, name = "zeroclaw", version = "0.1.7", vendor = "zeroclaw-labs" }
 ```
+
+`imap_id` sends RFC 2971 client metadata right after IMAP login. This is required by some providers
+(for example NetEase `163.com` / `126.com`) before mailbox selection is allowed.
 
 ### 4.10 IRC
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`main` or `dev`; direct `main` PRs are allowed): `main`
- Problem: NetEase IMAP providers (`163.com`/`126.com`) can reject mailbox selection unless the client sends RFC 2971 `ID` metadata after login.
- Why it matters: Email channel users on NetEase cannot receive mail events when the server blocks pre-`SELECT` access.
- What changed: Added configurable email `imap_id` metadata and sent IMAP `ID` immediately after login, before mailbox `SELECT`; added tests and docs updates.
- What did **not** change (scope boundary): No transport/backend changes outside email channel; no CI/workflow changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto-managed
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel,config,docs,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `channel: email`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #2235
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)
- Linear issue key(s) (required, e.g. `RMN-123`): `RMN-219`
- Linear issue URL(s): https://linear.app/zeroclawlabs/issue/RMN-219/feature-email-channel-imap-id-extension-for-netease-gh-2235

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): No superseded PR in this change.
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
cargo test email_channel -- --nocapture
```

- Evidence provided (test/log/trace/screenshot/perf): local test output for `cargo test email_channel -- --nocapture` (all passing)
- If any command is intentionally skipped, explain why: `cargo fmt --all -- --check` currently reports baseline formatting diffs in untouched files from `origin/main`; this PR keeps scope limited to email channel + docs.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no new PII collection; existing email processing path unchanged.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `Yes`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: Optional new config key `channels_config.email.imap_id` can be provided; defaults are auto-applied.

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `Yes`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `No`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `No`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `No`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: This PR focuses on functional channel support and primary English docs; localization sync will follow in a dedicated docs pass.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Email config serialization defaults; custom `imap_id` settings; email channel unit test suite.
- Edge cases checked: Disabled `imap_id`; omitted `imap_id`; custom metadata values; unsupported ID command path remains non-fatal.
- What was not verified: live NetEase mailbox integration in this local environment.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `src/channels/email_channel.rs` config + IMAP login flow; email docs.
- Potential unintended effects: providers with strict IMAP servers may reject `ID`; this is mitigated by non-fatal handling and configurable disable.
- Guardrails/monitoring for early detection: existing channel error logs include IMAP session error context.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex CLI + git/gh/linear CLI.
- Workflow/plan summary (if any): issue intake -> isolated worktree from `origin/main` -> implement/test -> PR.
- Verification focus: email channel serialization and IMAP session behavior.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert PR #2240 from `main`.
- Feature flags or config toggles (if any): set `channels_config.email.imap_id.enabled = false` to disable IMAP ID behavior without rollback.
- Observable failure symptoms: IMAP login/select flow regressions or repeated IMAP ID warnings in logs.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: Some IMAP servers may not support RFC 2971 `ID`.
  - Mitigation: `ID` errors are explicitly non-fatal and behavior can be disabled via config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added IMAP ID extension support for the Email channel, enabling RFC 2971 client metadata transmission during IMAP authentication. This supports email providers that require this metadata before mailbox selection.

* **Documentation**
  * Added configuration reference documentation for the new IMAP ID settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->