### PR TITLE
build(deps): bump debian from f6e2cfa to 1d3c811

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ allow_public_bind = false
 EOF
 
 # ── Stage 2: Development Runtime (Debian) ────────────────────
-FROM debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba AS dev
+FROM debian:trixie-slim@sha256:1d3c811171a08a5adaa4a163fbafd96b61b87aa871bbc7aa15431ac275d3d430 AS dev
 
 # Install essential runtime dependencies only (use docker-compose.override.yml for dev tools)
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary

- Base branch target (`main` or `dev`; direct `main` PRs are allowed): `main`
- Problem: PR #1937 is heavily diverged and carries unrelated stale history, making direct merge unsafe.
- Why it matters: Debian runtime base image digest bump is still needed for security hygiene.
- What changed: one-line Dockerfile digest bump for the `dev` stage from `f6e2cfa...` to `1d3c811...`.
- What did **not** change (scope boundary): no CI/workflow/source-code/docs changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `dependencies, security`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `runtime: docker`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `chore`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `security`

## Linked Issue

- Closes #1937
- Related #
- Depends on # (if stacked): none
- Supersedes # (if replacing older PR): #1937
- Linear issue key(s) (required, e.g. `RMN-123`): `RMN-1937`
- Linear issue URL(s): N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `#1937 by @app/dependabot`
- Integrated scope by source PR (what was materially carried forward): Debian digest bump in `Dockerfile` dev stage.
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): exact single-line replay from upstream dependabot intent.
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
# diff inspection only (single-line digest update)
```

- Evidence provided (test/log/trace/screenshot/perf): verified only `Dockerfile` digest line changed.
- If any command is intentionally skipped, explain why: no code-path/runtime logic changes beyond base image pin update.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no data handling changes.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: not applicable.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Dockerfile `dev` stage pin updated to expected digest.
- Edge cases checked: none (single deterministic pin change).
- What was not verified: full image build in local environment.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Docker dev image base layer.
- Potential unintended effects: package set differences from updated Debian digest.
- Guardrails/monitoring for early detection: existing CI Docker smoke/build checks.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `gh` CLI + isolated `/tmp` branch.
- Workflow/plan summary (if any): detect divergence -> clean one-line replay -> supersede PR.
- Verification focus: scope isolation.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge_commit_sha>`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: Docker dev stage pull/build issues related to new digest.

## Risks and Mitigations

- Risk: upstream base image changes can alter runtime package state.
  - Mitigation: pinned digest + CI docker smoke/build coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development Docker base image to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->