### PR TITLE
feat(channel): add napcat support for qq protocol

### DIFF
--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -143,6 +143,7 @@ If `[channels_config.matrix]`, `[channels_config.lark]`, or `[channels_config.fe
 | Feishu | websocket (default) or webhook | Webhook mode only |
 | DingTalk | stream mode | No |
 | QQ | bot gateway | No |
+| Napcat | websocket receive + HTTP send (OneBot) | No (typically local/LAN) |
 | Linq | webhook (`/linq`) | Yes (public HTTPS callback) |
 | iMessage | local integration | No |
 | Nostr | relay websocket (NIP-04 / NIP-17) | No |
@@ -159,7 +160,7 @@ For channels with inbound sender allowlists:
 
 Field names differ by channel:
 
-- `allowed_users` (Telegram/Discord/Slack/Mattermost/Matrix/IRC/Lark/Feishu/DingTalk/QQ/Nextcloud Talk)
+- `allowed_users` (Telegram/Discord/Slack/Mattermost/Matrix/IRC/Lark/Feishu/DingTalk/QQ/Napcat/Nextcloud Talk)
 - `allowed_from` (Signal)
 - `allowed_numbers` (WhatsApp)
 - `allowed_senders` (Email/Linq)
@@ -472,7 +473,26 @@ Notes:
 - `X-Bot-Appid` is checked when present and must match `app_id`.
 - Set `receive_mode = "websocket"` to keep the legacy gateway WS receive path.
 
-### 4.16 Nextcloud Talk
+### 4.16 Napcat (QQ via OneBot)
+
+```toml
+[channels_config.napcat]
+websocket_url = "ws://127.0.0.1:3001"
+api_base_url = "http://127.0.0.1:3001"  # optional; auto-derived when omitted
+access_token = ""                         # optional
+allowed_users = ["*"]
+```
+
+Notes:
+
+- Inbound messages are consumed from Napcat's WebSocket stream.
+- Outbound sends use OneBot-compatible HTTP endpoints (`send_private_msg` / `send_group_msg`).
+- Recipients:
+  - `user:<qq_user_id>` for private messages
+  - `group:<qq_group_id>` for group messages
+- Outbound reply chaining uses incoming message ids via CQ reply tags.
+
+### 4.17 Nextcloud Talk
 
 ```toml
 [channels_config.nextcloud_talk]
@@ -490,7 +510,7 @@ Notes:
 - `ZEROCLAW_NEXTCLOUD_TALK_WEBHOOK_SECRET` overrides config secret.
 - See [nextcloud-talk-setup.md](./nextcloud-talk-setup.md) for a full runbook.
 
-### 4.16 Linq
+### 4.18 Linq
 
 ```toml
 [channels_config.linq]
@@ -509,7 +529,7 @@ Notes:
 - `ZEROCLAW_LINQ_SIGNING_SECRET` overrides config secret.
 - `allowed_senders` uses E.164 phone number format (e.g. `+1234567890`).
 
-### 4.17 iMessage
+### 4.19 iMessage
 
 ```toml
 [channels_config.imessage]

--- a/src/channels/napcat.rs
+++ b/src/channels/napcat.rs
@@ -1,0 +1,523 @@
+use super::traits::{Channel, ChannelMessage, SendMessage};
+use crate::config::schema::NapcatConfig;
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use reqwest::Url;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::RwLock;
+use tokio::time::{sleep, Duration};
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::Message;
+use uuid::Uuid;
+
+const NAPCAT_SEND_PRIVATE: &str = "/send_private_msg";
+const NAPCAT_SEND_GROUP: &str = "/send_group_msg";
+const NAPCAT_STATUS: &str = "/get_status";
+const NAPCAT_DEDUP_CAPACITY: usize = 10_000;
+const NAPCAT_MAX_BACKOFF_SECS: u64 = 60;
+
+fn current_unix_timestamp_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn normalize_token(raw: &str) -> Option<String> {
+    let token = raw.trim();
+    (!token.is_empty()).then(|| token.to_string())
+}
+
+fn derive_api_base_from_websocket(websocket_url: &str) -> Option<String> {
+    let mut url = Url::parse(websocket_url).ok()?;
+    match url.scheme() {
+        "ws" => {
+            url.set_scheme("http").ok()?;
+        }
+        "wss" => {
+            url.set_scheme("https").ok()?;
+        }
+        _ => return None,
+    }
+    url.set_path("");
+    url.set_query(None);
+    url.set_fragment(None);
+    Some(url.to_string().trim_end_matches('/').to_string())
+}
+
+fn compose_onebot_content(content: &str, reply_message_id: Option<&str>) -> String {
+    let mut parts = Vec::new();
+    if let Some(reply_id) = reply_message_id {
+        let trimmed = reply_id.trim();
+        if !trimmed.is_empty() {
+            parts.push(format!("[CQ:reply,id={trimmed}]"));
+        }
+    }
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if let Some(marker) = trimmed
+            .strip_prefix("[IMAGE:")
+            .and_then(|v| v.strip_suffix(']'))
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+        {
+            parts.push(format!("[CQ:image,file={marker}]"));
+            continue;
+        }
+        parts.push(line.to_string());
+    }
+
+    parts.join("\n").trim().to_string()
+}
+
+fn parse_message_segments(message: &Value) -> String {
+    if let Some(text) = message.as_str() {
+        return text.trim().to_string();
+    }
+
+    let Some(segments) = message.as_array() else {
+        return String::new();
+    };
+
+    let mut parts = Vec::new();
+    for segment in segments {
+        let seg_type = segment
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .trim();
+        let data = segment.get("data");
+        match seg_type {
+            "text" => {
+                if let Some(text) = data
+                    .and_then(|d| d.get("text"))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|v| !v.is_empty())
+                {
+                    parts.push(text.to_string());
+                }
+            }
+            "image" => {
+                if let Some(url) = data
+                    .and_then(|d| d.get("url"))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|v| !v.is_empty())
+                {
+                    parts.push(format!("[IMAGE:{url}]"));
+                } else if let Some(file) = data
+                    .and_then(|d| d.get("file"))
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|v| !v.is_empty())
+                {
+                    parts.push(format!("[IMAGE:{file}]"));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    parts.join("\n").trim().to_string()
+}
+
+fn extract_message_id(event: &Value) -> String {
+    event
+        .get("message_id")
+        .and_then(Value::as_i64)
+        .map(|v| v.to_string())
+        .or_else(|| {
+            event
+                .get("message_id")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| Uuid::new_v4().to_string())
+}
+
+fn extract_timestamp(event: &Value) -> u64 {
+    event
+        .get("time")
+        .and_then(Value::as_i64)
+        .and_then(|v| u64::try_from(v).ok())
+        .unwrap_or_else(current_unix_timestamp_secs)
+}
+
+pub struct NapcatChannel {
+    websocket_url: String,
+    api_base_url: String,
+    access_token: Option<String>,
+    allowed_users: Vec<String>,
+    dedup: Arc<RwLock<HashSet<String>>>,
+}
+
+impl NapcatChannel {
+    pub fn from_config(config: NapcatConfig) -> Result<Self> {
+        let websocket_url = config.websocket_url.trim().to_string();
+        if websocket_url.is_empty() {
+            anyhow::bail!("napcat.websocket_url cannot be empty");
+        }
+
+        let api_base_url = if config.api_base_url.trim().is_empty() {
+            derive_api_base_from_websocket(&websocket_url).ok_or_else(|| {
+                anyhow!("napcat.api_base_url is required when websocket_url is not ws:// or wss://")
+            })?
+        } else {
+            config.api_base_url.trim().trim_end_matches('/').to_string()
+        };
+
+        Ok(Self {
+            websocket_url,
+            api_base_url,
+            access_token: normalize_token(config.access_token.as_deref().unwrap_or_default()),
+            allowed_users: config.allowed_users,
+            dedup: Arc::new(RwLock::new(HashSet::new())),
+        })
+    }
+
+    fn is_user_allowed(&self, user_id: &str) -> bool {
+        self.allowed_users.iter().any(|u| u == "*" || u == user_id)
+    }
+
+    async fn is_duplicate(&self, message_id: &str) -> bool {
+        if message_id.is_empty() {
+            return false;
+        }
+        let mut dedup = self.dedup.write().await;
+        if dedup.contains(message_id) {
+            return true;
+        }
+        if dedup.len() >= NAPCAT_DEDUP_CAPACITY {
+            let remove_n = dedup.len() / 2;
+            let to_remove: Vec<String> = dedup.iter().take(remove_n).cloned().collect();
+            for key in to_remove {
+                dedup.remove(&key);
+            }
+        }
+        dedup.insert(message_id.to_string());
+        false
+    }
+
+    fn http_client(&self) -> reqwest::Client {
+        crate::config::build_runtime_proxy_client("channel.napcat")
+    }
+
+    async fn post_onebot(&self, endpoint: &str, body: &Value) -> Result<()> {
+        let url = format!("{}{}", self.api_base_url, endpoint);
+        let mut request = self.http_client().post(&url).json(body);
+        if let Some(token) = &self.access_token {
+            request = request.bearer_auth(token);
+        }
+
+        let response = request.send().await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let err = response.text().await.unwrap_or_default();
+            let sanitized = crate::providers::sanitize_api_error(&err);
+            anyhow::bail!("Napcat HTTP request failed ({status}): {sanitized}");
+        }
+
+        let payload: Value = response.json().await.unwrap_or_else(|_| json!({}));
+        if payload
+            .get("retcode")
+            .and_then(Value::as_i64)
+            .is_some_and(|retcode| retcode != 0)
+        {
+            let msg = payload
+                .get("wording")
+                .and_then(Value::as_str)
+                .or_else(|| payload.get("msg").and_then(Value::as_str))
+                .unwrap_or("unknown error");
+            anyhow::bail!("Napcat returned retcode != 0: {msg}");
+        }
+
+        Ok(())
+    }
+
+    fn build_ws_request(&self) -> Result<tokio_tungstenite::tungstenite::http::Request<()>> {
+        let mut ws_url =
+            Url::parse(&self.websocket_url).with_context(|| "invalid napcat.websocket_url")?;
+        if let Some(token) = &self.access_token {
+            let has_access_token = ws_url.query_pairs().any(|(k, _)| k == "access_token");
+            if !has_access_token {
+                ws_url.query_pairs_mut().append_pair("access_token", token);
+            }
+        }
+
+        let mut request = ws_url.as_str().into_client_request()?;
+        if let Some(token) = &self.access_token {
+            let value = format!("Bearer {token}");
+            request.headers_mut().insert(
+                tokio_tungstenite::tungstenite::http::header::AUTHORIZATION,
+                value
+                    .parse()
+                    .context("invalid napcat access token header")?,
+            );
+        }
+        Ok(request)
+    }
+
+    async fn parse_message_event(&self, event: &Value) -> Option<ChannelMessage> {
+        if event.get("post_type").and_then(Value::as_str) != Some("message") {
+            return None;
+        }
+
+        let message_id = extract_message_id(event);
+        if self.is_duplicate(&message_id).await {
+            return None;
+        }
+
+        let message_type = event
+            .get("message_type")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let sender_id = event
+            .get("user_id")
+            .and_then(Value::as_i64)
+            .map(|v| v.to_string())
+            .or_else(|| {
+                event
+                    .get("sender")
+                    .and_then(|s| s.get("user_id"))
+                    .and_then(Value::as_i64)
+                    .map(|v| v.to_string())
+            })
+            .unwrap_or_else(|| "unknown".to_string());
+
+        if !self.is_user_allowed(&sender_id) {
+            tracing::warn!("Napcat: ignoring message from unauthorized user: {sender_id}");
+            return None;
+        }
+
+        let content = {
+            let parsed = parse_message_segments(event.get("message").unwrap_or(&Value::Null));
+            if parsed.is_empty() {
+                event
+                    .get("raw_message")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .unwrap_or("")
+                    .to_string()
+            } else {
+                parsed
+            }
+        };
+
+        if content.trim().is_empty() {
+            return None;
+        }
+
+        let reply_target = if message_type == "group" {
+            let group_id = event
+                .get("group_id")
+                .and_then(Value::as_i64)
+                .map(|v| v.to_string())
+                .unwrap_or_default();
+            format!("group:{group_id}")
+        } else {
+            format!("user:{sender_id}")
+        };
+
+        Some(ChannelMessage {
+            id: message_id.clone(),
+            sender: sender_id,
+            reply_target,
+            content,
+            channel: "napcat".to_string(),
+            timestamp: extract_timestamp(event),
+            // This is a message id for passive reply, not a thread id.
+            thread_ts: Some(message_id),
+        })
+    }
+
+    async fn listen_once(&self, tx: &tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+        let request = self.build_ws_request()?;
+        let (mut socket, _) = connect_async(request).await?;
+        tracing::info!("Napcat: connected to {}", self.websocket_url);
+
+        while let Some(frame) = socket.next().await {
+            match frame {
+                Ok(Message::Text(text)) => {
+                    let event: Value = match serde_json::from_str(&text) {
+                        Ok(v) => v,
+                        Err(err) => {
+                            tracing::warn!("Napcat: failed to parse event payload: {err}");
+                            continue;
+                        }
+                    };
+                    if let Some(msg) = self.parse_message_event(&event).await {
+                        if tx.send(msg).await.is_err() {
+                            return Ok(());
+                        }
+                    }
+                }
+                Ok(Message::Binary(_)) => {}
+                Ok(Message::Ping(payload)) => {
+                    socket.send(Message::Pong(payload)).await?;
+                }
+                Ok(Message::Pong(_)) => {}
+                Ok(Message::Close(frame)) => {
+                    return Err(anyhow!("Napcat websocket closed: {:?}", frame));
+                }
+                Ok(Message::Frame(_)) => {}
+                Err(err) => {
+                    return Err(anyhow!("Napcat websocket error: {err}"));
+                }
+            }
+        }
+
+        Err(anyhow!("Napcat websocket stream ended"))
+    }
+}
+
+#[async_trait]
+impl Channel for NapcatChannel {
+    fn name(&self) -> &str {
+        "napcat"
+    }
+
+    async fn send(&self, message: &SendMessage) -> Result<()> {
+        let payload = compose_onebot_content(&message.content, message.thread_ts.as_deref());
+        if payload.trim().is_empty() {
+            return Ok(());
+        }
+
+        if let Some(group_id) = message.recipient.strip_prefix("group:") {
+            let body = json!({
+                "group_id": group_id,
+                "message": payload,
+            });
+            self.post_onebot(NAPCAT_SEND_GROUP, &body).await?;
+            return Ok(());
+        }
+
+        let user_id = message
+            .recipient
+            .strip_prefix("user:")
+            .unwrap_or(&message.recipient)
+            .trim();
+        if user_id.is_empty() {
+            anyhow::bail!("Napcat recipient is empty");
+        }
+
+        let body = json!({
+            "user_id": user_id,
+            "message": payload,
+        });
+        self.post_onebot(NAPCAT_SEND_PRIVATE, &body).await
+    }
+
+    async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+        let mut backoff = Duration::from_secs(1);
+        loop {
+            match self.listen_once(&tx).await {
+                Ok(()) => return Ok(()),
+                Err(err) => {
+                    tracing::error!(
+                        "Napcat listener error: {err}. Reconnecting in {:?}...",
+                        backoff
+                    );
+                    sleep(backoff).await;
+                    backoff =
+                        std::cmp::min(backoff * 2, Duration::from_secs(NAPCAT_MAX_BACKOFF_SECS));
+                }
+            }
+        }
+    }
+
+    async fn health_check(&self) -> bool {
+        let url = format!("{}{}", self.api_base_url, NAPCAT_STATUS);
+        let mut request = self.http_client().get(url);
+        if let Some(token) = &self.access_token {
+            request = request.bearer_auth(token);
+        }
+        request
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .map(|resp| resp.status().is_success())
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derive_api_base_converts_ws_to_http() {
+        let base = derive_api_base_from_websocket("ws://127.0.0.1:3001/ws").unwrap();
+        assert_eq!(base, "http://127.0.0.1:3001");
+    }
+
+    #[test]
+    fn compose_onebot_content_includes_reply_and_image_markers() {
+        let content = "hello\n[IMAGE:https://example.com/cat.png]";
+        let parsed = compose_onebot_content(content, Some("123"));
+        assert!(parsed.contains("[CQ:reply,id=123]"));
+        assert!(parsed.contains("[CQ:image,file=https://example.com/cat.png]"));
+        assert!(parsed.contains("hello"));
+    }
+
+    #[tokio::test]
+    async fn parse_private_event_maps_to_channel_message() {
+        let cfg = NapcatConfig {
+            websocket_url: "ws://127.0.0.1:3001".into(),
+            api_base_url: "".into(),
+            access_token: None,
+            allowed_users: vec!["10001".into()],
+        };
+        let channel = NapcatChannel::from_config(cfg).unwrap();
+        let event = json!({
+            "post_type": "message",
+            "message_type": "private",
+            "message_id": 99,
+            "user_id": 10001,
+            "time": 1700000000,
+            "message": [{"type":"text","data":{"text":"hi"}}]
+        });
+
+        let msg = channel.parse_message_event(&event).await.unwrap();
+        assert_eq!(msg.channel, "napcat");
+        assert_eq!(msg.sender, "10001");
+        assert_eq!(msg.reply_target, "user:10001");
+        assert_eq!(msg.content, "hi");
+        assert_eq!(msg.thread_ts.as_deref(), Some("99"));
+    }
+
+    #[tokio::test]
+    async fn parse_group_event_with_image_segment() {
+        let cfg = NapcatConfig {
+            websocket_url: "ws://127.0.0.1:3001".into(),
+            api_base_url: "".into(),
+            access_token: None,
+            allowed_users: vec!["*".into()],
+        };
+        let channel = NapcatChannel::from_config(cfg).unwrap();
+        let event = json!({
+            "post_type": "message",
+            "message_type": "group",
+            "message_id": "abc-1",
+            "user_id": 20002,
+            "group_id": 30003,
+            "message": [
+                {"type":"text","data":{"text":"photo"}},
+                {"type":"image","data":{"url":"https://img.example.com/1.jpg"}}
+            ]
+        });
+
+        let msg = channel.parse_message_event(&event).await.unwrap();
+        assert_eq!(msg.reply_target, "group:30003");
+        assert!(msg.content.contains("photo"));
+        assert!(msg
+            .content
+            .contains("[IMAGE:https://img.example.com/1.jpg]"));
+    }
+}

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -3,8 +3,8 @@ use crate::channels::LarkChannel;
 #[cfg(feature = "channel-matrix")]
 use crate::channels::MatrixChannel;
 use crate::channels::{
-    Channel, DiscordChannel, EmailChannel, MattermostChannel, QQChannel, SendMessage, SlackChannel,
-    TelegramChannel, WhatsAppChannel,
+    Channel, DiscordChannel, EmailChannel, MattermostChannel, NapcatChannel, QQChannel,
+    SendMessage, SlackChannel, TelegramChannel, WhatsAppChannel,
 };
 use crate::config::Config;
 use crate::cron::{
@@ -396,6 +396,15 @@ pub(crate) async fn deliver_announcement(
                 qq.allowed_users.clone(),
                 qq.environment.clone(),
             );
+            channel.send(&SendMessage::new(output, target)).await?;
+        }
+        "napcat" => {
+            let napcat_cfg = config
+                .channels_config
+                .napcat
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("napcat channel not configured"))?;
+            let channel = NapcatChannel::from_config(napcat_cfg.clone())?;
             channel.send(&SendMessage::new(output, target)).await?;
         }
         "whatsapp_web" | "whatsapp" => {

--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -683,6 +683,9 @@ fn mask_sensitive_fields(config: &crate::config::Config) -> crate::config::Confi
     if let Some(dingtalk) = masked.channels_config.dingtalk.as_mut() {
         mask_required_secret(&mut dingtalk.client_secret);
     }
+    if let Some(napcat) = masked.channels_config.napcat.as_mut() {
+        mask_optional_secret(&mut napcat.access_token);
+    }
     if let Some(qq) = masked.channels_config.qq.as_mut() {
         mask_required_secret(&mut qq.app_secret);
     }
@@ -873,6 +876,12 @@ fn restore_masked_sensitive_fields(
         current.channels_config.dingtalk.as_ref(),
     ) {
         restore_required_secret(&mut incoming_ch.client_secret, &current_ch.client_secret);
+    }
+    if let (Some(incoming_ch), Some(current_ch)) = (
+        incoming.channels_config.napcat.as_mut(),
+        current.channels_config.napcat.as_ref(),
+    ) {
+        restore_optional_secret(&mut incoming_ch.access_token, &current_ch.access_token);
     }
     if let (Some(incoming_ch), Some(current_ch)) = (
         incoming.channels_config.qq.as_mut(),

--- a/src/integrations/registry.rs
+++ b/src/integrations/registry.rs
@@ -159,6 +159,18 @@ pub fn all_integrations() -> Vec<IntegrationEntry> {
                 }
             },
         },
+        IntegrationEntry {
+            name: "Napcat",
+            description: "QQ via Napcat (OneBot)",
+            category: IntegrationCategory::Chat,
+            status_fn: |c| {
+                if c.channels_config.napcat.is_some() {
+                    IntegrationStatus::Active
+                } else {
+                    IntegrationStatus::Available
+                }
+            },
+        },
         // ── AI Models ───────────────────────────────────────────
         IntegrationEntry {
             name: "OpenRouter",

--- a/src/tools/cron_add.rs
+++ b/src/tools/cron_add.rs
@@ -56,7 +56,7 @@ impl Tool for CronAddTool {
     fn description(&self) -> &str {
         "Create a scheduled cron job (shell or agent) with cron/at/every schedules. \
          Use job_type='agent' with a prompt to run the AI agent on schedule. \
-         To deliver output to a channel (Discord, Telegram, Slack, Mattermost, QQ, Lark, Feishu, Email), set \
+         To deliver output to a channel (Discord, Telegram, Slack, Mattermost, QQ, Napcat, Lark, Feishu, Email), set \
          delivery={\"mode\":\"announce\",\"channel\":\"discord\",\"to\":\"<channel_id_or_chat_id>\"}. \
          This is the preferred tool for sending scheduled/delayed messages to users via channels."
     }
@@ -80,7 +80,7 @@ impl Tool for CronAddTool {
                     "description": "Delivery config to send job output to a channel. Example: {\"mode\":\"announce\",\"channel\":\"discord\",\"to\":\"<channel_id>\"}",
                     "properties": {
                         "mode": { "type": "string", "enum": ["none", "announce"], "description": "Set to 'announce' to deliver output to a channel" },
-                        "channel": { "type": "string", "enum": ["telegram", "discord", "slack", "mattermost", "qq", "lark", "feishu", "email"], "description": "Channel type to deliver to" },
+                        "channel": { "type": "string", "enum": ["telegram", "discord", "slack", "mattermost", "qq", "napcat", "lark", "feishu", "email"], "description": "Channel type to deliver to" },
                         "to": { "type": "string", "description": "Target: Discord channel ID, Telegram chat ID, Slack channel, etc." },
                         "best_effort": { "type": "boolean", "description": "If true, delivery failure does not fail the job" }
                     }


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`main` or `dev`; direct `main` PRs are allowed): `main`
- Problem: ZeroClaw had QQ Official support only, but no Napcat/OneBot-compatible QQ channel.
- Why it matters: users running Napcat could not connect QQ inbound/outbound flows without the official QQ bot platform.
- What changed: added `channels_config.napcat`, implemented Napcat websocket receive + HTTP send channel, and wired schema/registry/scheduler/gateway secret handling + docs.
- What did **not** change (scope boundary): no changes to existing QQ Official protocol behavior.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto-managed
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel,config,cron,integration,docs,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `channel: napcat`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #2236
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)
- Linear issue key(s) (required, e.g. `RMN-123`): `RMN-222`
- Linear issue URL(s): https://linear.app/zeroclawlabs/issue/RMN-222/feature-add-napcat-channel-support-for-qq-protocol-gh-2236

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): no superseded PR in this change.
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
cargo test --lib napcat -- --nocapture
```

- Evidence provided (test/log/trace/screenshot/perf): local `cargo test --lib napcat -- --nocapture` passed (5 tests).
- If any command is intentionally skipped, explain why: full-repo checks were not rerun in this branch due workspace contention and run-time cost; focused Napcat/library validation executed.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `Yes`
- Secrets/tokens handling changed? (`Yes/No`): `Yes`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: Napcat HTTP/WS endpoints are configurable and optional; `access_token` is now masked/restored/encrypted via existing config secret pipeline.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no new sensitive user-data persistence paths added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `Yes`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: optionally add `[channels_config.napcat]` config; existing channels continue unchanged.

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `Yes`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `No`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `No`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `No`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: i18n sync will follow in a dedicated localization docs pass.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Napcat config parsing, outbound message composition (text/image/reply), inbound private/group event parsing.
- Edge cases checked: message deduplication behavior, optional token handling, auto-derived API base from websocket URL.
- What was not verified: live Napcat instance interoperability test in this environment.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: channels runtime, config schema, scheduler channel delivery enum, integrations registry, gateway secret masking, channel docs.
- Potential unintended effects: misconfigured Napcat endpoint/token can cause channel connection/send failures.
- Guardrails/monitoring for early detection: Napcat listener/send paths emit explicit error logs and health checks.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex CLI + git/gh/linear CLI.
- Workflow/plan summary (if any): issue triage -> isolated worktree from `origin/main` -> implementation -> focused validation -> rebase -> PR.
- Verification focus: Napcat channel parser/sender behavior and schema wiring.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert this PR merge commit from `main`.
- Feature flags or config toggles (if any): remove/disable `[channels_config.napcat]`.
- Observable failure symptoms: Napcat channel fails to connect/send; scheduler `napcat` delivery errors.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: Napcat/OneBot payload variants may differ by deployment.
  - Mitigation: parser supports both string and segment-array message forms and ignores unsupported payload shapes safely.
