### PR TITLE
feat(channel): add github webhook channel support

### DIFF
--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -143,6 +143,7 @@ If `[channels_config.matrix]`, `[channels_config.lark]`, or `[channels_config.fe
 | Feishu | websocket (default) or webhook | Webhook mode only |
 | DingTalk | stream mode | No |
 | QQ | bot gateway | No |
+| GitHub | webhook (`/github`) | Yes (public HTTPS callback) |
 | Napcat | websocket receive + HTTP send (OneBot) | No (typically local/LAN) |
 | Linq | webhook (`/linq`) | Yes (public HTTPS callback) |
 | iMessage | local integration | No |
@@ -164,6 +165,7 @@ Field names differ by channel:
 - `allowed_from` (Signal)
 - `allowed_numbers` (WhatsApp)
 - `allowed_senders` (Email/Linq)
+- `allowed_repos` (GitHub)
 - `allowed_contacts` (iMessage)
 - `allowed_pubkeys` (Nostr)
 
@@ -477,7 +479,28 @@ Notes:
 - `X-Bot-Appid` is checked when present and must match `app_id`.
 - Set `receive_mode = "websocket"` to keep the legacy gateway WS receive path.
 
-### 4.16 Napcat (QQ via OneBot)
+### 4.16 GitHub
+
+```toml
+[channels_config.github]
+api_token = "ghp_xxx"
+api_base_url = "https://api.github.com"      # optional
+webhook_secret = "optional-webhook-secret"   # optional but recommended
+allowed_repos = ["zeroclaw-labs/zeroclaw"]   # [] denies all, "*" allows all
+allowed_users = ["*"]                        # [] denies all, "*" allows all
+bot_login = "zeroclaw-bot"                   # optional; ignores self-authored comments
+```
+
+Notes:
+
+- Inbound webhook endpoint: `POST /github`.
+- Supported inbound events: `issue_comment` and `pull_request_review_comment` (`action=created`).
+- Outbound replies are posted to the corresponding issue/PR thread.
+- Signature verification uses `X-Hub-Signature-256` when `webhook_secret` is set.
+- `ZEROCLAW_GITHUB_API_TOKEN` and `ZEROCLAW_GITHUB_WEBHOOK_SECRET` override config values.
+- `X-GitHub-Delivery` is used as idempotency key when present.
+
+### 4.17 Napcat (QQ via OneBot)
 
 ```toml
 [channels_config.napcat]
@@ -496,7 +519,7 @@ Notes:
   - `group:<qq_group_id>` for group messages
 - Outbound reply chaining uses incoming message ids via CQ reply tags.
 
-### 4.17 Nextcloud Talk
+### 4.18 Nextcloud Talk
 
 ```toml
 [channels_config.nextcloud_talk]
@@ -514,7 +537,7 @@ Notes:
 - `ZEROCLAW_NEXTCLOUD_TALK_WEBHOOK_SECRET` overrides config secret.
 - See [nextcloud-talk-setup.md](./nextcloud-talk-setup.md) for a full runbook.
 
-### 4.18 Linq
+### 4.19 Linq
 
 ```toml
 [channels_config.linq]
@@ -533,7 +556,7 @@ Notes:
 - `ZEROCLAW_LINQ_SIGNING_SECRET` overrides config secret.
 - `allowed_senders` uses E.164 phone number format (e.g. `+1234567890`).
 
-### 4.19 iMessage
+### 4.20 iMessage
 
 ```toml
 [channels_config.imessage]
@@ -608,6 +631,7 @@ rg -n "Matrix|Telegram|Discord|Slack|Mattermost|Signal|WhatsApp|Email|IRC|Lark|D
 | Lark / Feishu | `Lark: WS connected` / `Lark event callback server listening on` | `Lark WS: ignoring ... (not in allowed_users)` / `Lark: ignoring message from unauthorized user:` | `Lark: ping failed, reconnecting` / `Lark: heartbeat timeout, reconnecting` / `Lark: WS read error:` |
 | DingTalk | `DingTalk: connected and listening for messages...` | `DingTalk: ignoring message from unauthorized user:` | `DingTalk WebSocket error:` / `DingTalk: message channel closed` |
 | QQ | `QQ: connected and identified` | `QQ: ignoring C2C message from unauthorized user:` / `QQ: ignoring group message from unauthorized user:` | `QQ: received Reconnect (op 7)` / `QQ: received Invalid Session (op 9)` / `QQ: message channel closed` |
+| GitHub (gateway) | `POST /github — GitHub webhook (issues + PR comments)` | `GitHub webhook signature verification failed` / `GitHub: ignoring webhook from unauthorized repository:` / `GitHub: ignoring webhook from unauthorized sender:` | `Failed to send GitHub reply:` / `LLM error for GitHub webhook message:` |
 | Nextcloud Talk (gateway) | `POST /nextcloud-talk — Nextcloud Talk bot webhook` | `Nextcloud Talk webhook signature verification failed` / `Nextcloud Talk: ignoring message from unauthorized actor:` | `Nextcloud Talk send failed:` / `LLM error for Nextcloud Talk message:` |
 | iMessage | `iMessage channel listening (AppleScript bridge)...` | (contact allowlist enforced by `allowed_contacts`) | `iMessage poll error:` |
 | Nostr | `Nostr channel listening as npub1...` | `Nostr: ignoring NIP-04 message from unauthorized pubkey:` / `Nostr: ignoring NIP-17 message from unauthorized pubkey:` | `Failed to decrypt NIP-04 message:` / `Failed to unwrap NIP-17 gift wrap:` / `Nostr relay pool shut down` |

--- a/src/channels/github.rs
+++ b/src/channels/github.rs
@@ -1,0 +1,480 @@
+use super::traits::{Channel, ChannelMessage, SendMessage};
+use async_trait::async_trait;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use uuid::Uuid;
+
+const GITHUB_API_BASE: &str = "https://api.github.com";
+const GITHUB_USER_AGENT: &str = "zeroclaw-github-channel";
+
+/// GitHub channel in webhook mode.
+///
+/// Incoming messages are received by gateway endpoint `/github`.
+/// Outbound replies are sent as issue/PR comments via GitHub REST API.
+pub struct GitHubChannel {
+    api_token: String,
+    api_base_url: String,
+    webhook_secret: Option<String>,
+    allowed_repos: Vec<String>,
+    allowed_users: Vec<String>,
+    bot_login: Option<String>,
+    client: reqwest::Client,
+}
+
+impl GitHubChannel {
+    pub fn new(
+        api_token: String,
+        api_base_url: String,
+        webhook_secret: Option<String>,
+        allowed_repos: Vec<String>,
+        allowed_users: Vec<String>,
+        bot_login: Option<String>,
+    ) -> Self {
+        Self {
+            api_token: api_token.trim().to_string(),
+            api_base_url: api_base_url.trim_end_matches('/').to_string(),
+            webhook_secret: webhook_secret.map(|value| value.trim().to_string()),
+            allowed_repos,
+            allowed_users,
+            bot_login: bot_login.map(|value| value.trim().to_string()),
+            client: crate::config::build_runtime_proxy_client("channel.github"),
+        }
+    }
+
+    pub fn webhook_secret(&self) -> Option<&str> {
+        self.webhook_secret
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+    }
+
+    fn api_base_url(&self) -> &str {
+        if self.api_base_url.trim().is_empty() {
+            GITHUB_API_BASE
+        } else {
+            self.api_base_url.as_str()
+        }
+    }
+
+    fn allowlist_matches(allowlist: &[String], value: &str) -> bool {
+        if allowlist.is_empty() {
+            return false;
+        }
+
+        allowlist.iter().any(|entry| {
+            let entry = entry.trim();
+            !entry.is_empty() && (entry == "*" || entry.eq_ignore_ascii_case(value))
+        })
+    }
+
+    fn is_repo_allowed(&self, repo: &str) -> bool {
+        Self::allowlist_matches(&self.allowed_repos, repo)
+    }
+
+    fn is_user_allowed(&self, login: &str) -> bool {
+        Self::allowlist_matches(&self.allowed_users, login)
+    }
+
+    fn is_self_message(&self, login: &str) -> bool {
+        self.bot_login
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|bot| !bot.is_empty() && bot.eq_ignore_ascii_case(login))
+    }
+
+    fn now_unix_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    fn parse_timestamp_secs(value: Option<&serde_json::Value>) -> u64 {
+        let Some(raw) = value.and_then(|v| v.as_str()) else {
+            return Self::now_unix_secs();
+        };
+
+        chrono::DateTime::parse_from_rfc3339(raw)
+            .ok()
+            .map(|dt| dt.timestamp().unsigned_abs())
+            .unwrap_or_else(Self::now_unix_secs)
+    }
+
+    fn build_message(
+        &self,
+        channel: &str,
+        repo: &str,
+        issue_or_pr_number: u64,
+        sender: &str,
+        content: &str,
+        comment_id: Option<u64>,
+        created_at: Option<&serde_json::Value>,
+    ) -> Option<ChannelMessage> {
+        let trimmed_content = content.trim();
+        if trimmed_content.is_empty() {
+            return None;
+        }
+
+        if !self.is_repo_allowed(repo) {
+            tracing::warn!(
+                "GitHub: ignoring webhook from unauthorized repository: {repo}. \
+                Add to channels.github.allowed_repos in config.toml, or use \"*\" for all."
+            );
+            return None;
+        }
+
+        if !self.is_user_allowed(sender) {
+            tracing::warn!(
+                "GitHub: ignoring webhook from unauthorized sender: {sender}. \
+                Add to channels.github.allowed_users in config.toml, or use \"*\" for all."
+            );
+            return None;
+        }
+
+        if self.is_self_message(sender) {
+            tracing::debug!("GitHub: skipping self-authored comment from {sender}");
+            return None;
+        }
+
+        let comment_id = comment_id
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| Uuid::new_v4().to_string());
+        let reply_target = format!("{repo}#{issue_or_pr_number}");
+
+        Some(ChannelMessage {
+            id: comment_id.clone(),
+            sender: sender.to_string(),
+            reply_target,
+            content: trimmed_content.to_string(),
+            channel: channel.to_string(),
+            timestamp: Self::parse_timestamp_secs(created_at),
+            thread_ts: Some(comment_id),
+        })
+    }
+
+    fn parse_issue_comment(&self, payload: &serde_json::Value) -> Option<ChannelMessage> {
+        let action = payload.get("action").and_then(|v| v.as_str()).unwrap_or("");
+        if action != "created" {
+            return None;
+        }
+
+        let repo = payload
+            .get("repository")
+            .and_then(|repo| repo.get("full_name"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())?;
+        let issue_number = payload
+            .get("issue")
+            .and_then(|issue| issue.get("number"))
+            .and_then(|v| v.as_u64())?;
+        let sender = payload
+            .get("comment")
+            .and_then(|comment| comment.get("user"))
+            .and_then(|user| user.get("login"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())?;
+        let body = payload
+            .get("comment")
+            .and_then(|comment| comment.get("body"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let comment_id = payload
+            .get("comment")
+            .and_then(|comment| comment.get("id"))
+            .and_then(|v| v.as_u64());
+        let created_at = payload
+            .get("comment")
+            .and_then(|comment| comment.get("created_at"));
+
+        self.build_message(
+            "github",
+            repo,
+            issue_number,
+            sender,
+            body,
+            comment_id,
+            created_at,
+        )
+    }
+
+    fn parse_review_comment(&self, payload: &serde_json::Value) -> Option<ChannelMessage> {
+        let action = payload.get("action").and_then(|v| v.as_str()).unwrap_or("");
+        if action != "created" {
+            return None;
+        }
+
+        let repo = payload
+            .get("repository")
+            .and_then(|repo| repo.get("full_name"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())?;
+        let pr_number = payload
+            .get("pull_request")
+            .and_then(|pr| pr.get("number"))
+            .and_then(|v| v.as_u64())?;
+        let sender = payload
+            .get("comment")
+            .and_then(|comment| comment.get("user"))
+            .and_then(|user| user.get("login"))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|v| !v.is_empty())?;
+        let body = payload
+            .get("comment")
+            .and_then(|comment| comment.get("body"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let comment_id = payload
+            .get("comment")
+            .and_then(|comment| comment.get("id"))
+            .and_then(|v| v.as_u64());
+        let created_at = payload
+            .get("comment")
+            .and_then(|comment| comment.get("created_at"));
+
+        self.build_message(
+            "github", repo, pr_number, sender, body, comment_id, created_at,
+        )
+    }
+
+    pub fn parse_webhook_payload(
+        &self,
+        event: &str,
+        payload: &serde_json::Value,
+    ) -> Vec<ChannelMessage> {
+        let mut messages = Vec::new();
+
+        let parsed = match event {
+            "issue_comment" => self.parse_issue_comment(payload),
+            "pull_request_review_comment" => self.parse_review_comment(payload),
+            _ => None,
+        };
+
+        if let Some(message) = parsed {
+            messages.push(message);
+        }
+
+        messages
+    }
+
+    fn parse_reply_target(reply_target: &str) -> Option<(&str, u64)> {
+        let (repo, issue_or_pr) = reply_target.rsplit_once('#')?;
+        let repo = repo.trim();
+        if repo.is_empty() {
+            return None;
+        }
+        let issue_or_pr = issue_or_pr.trim().parse::<u64>().ok()?;
+        Some((repo, issue_or_pr))
+    }
+}
+
+#[async_trait]
+impl Channel for GitHubChannel {
+    fn name(&self) -> &str {
+        "github"
+    }
+
+    async fn send(&self, message: &SendMessage) -> anyhow::Result<()> {
+        let Some((repo, issue_or_pr_number)) = Self::parse_reply_target(&message.recipient) else {
+            anyhow::bail!(
+                "GitHub send target is invalid: expected owner/repo#<issue_or_pr_number>, got {}",
+                message.recipient
+            );
+        };
+
+        let url = format!(
+            "{}/repos/{repo}/issues/{issue_or_pr_number}/comments",
+            self.api_base_url()
+        );
+
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.api_token)
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", GITHUB_USER_AGENT)
+            .json(&serde_json::json!({ "body": message.content }))
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            return Ok(());
+        }
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        let sanitized = crate::providers::sanitize_api_error(&body);
+        tracing::error!("GitHub send failed: {status} — {sanitized}");
+        anyhow::bail!("GitHub API error: {status}");
+    }
+
+    async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> anyhow::Result<()> {
+        tracing::info!(
+            "GitHub channel active (webhook mode). \
+            Configure GitHub webhook to POST to your gateway's /github endpoint."
+        );
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+        }
+    }
+
+    async fn health_check(&self) -> bool {
+        let url = format!("{}/rate_limit", self.api_base_url());
+        self.client
+            .get(url)
+            .bearer_auth(&self.api_token)
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", GITHUB_USER_AGENT)
+            .send()
+            .await
+            .map(|response| response.status().is_success())
+            .unwrap_or(false)
+    }
+}
+
+/// Verify `X-Hub-Signature-256` for GitHub webhooks.
+///
+/// Signature format: `sha256=<hex(hmac_sha256(secret, raw_body_bytes))>`.
+pub fn verify_github_signature(secret: &str, body: &[u8], signature_header: &str) -> bool {
+    let signature = signature_header
+        .trim()
+        .strip_prefix("sha256=")
+        .unwrap_or(signature_header)
+        .trim();
+    let Ok(provided) = hex::decode(signature) else {
+        tracing::warn!("GitHub: invalid webhook signature format");
+        return false;
+    };
+
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(secret.as_bytes()) else {
+        return false;
+    };
+    mac.update(body);
+    mac.verify_slice(&provided).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_channel() -> GitHubChannel {
+        GitHubChannel::new(
+            "token".into(),
+            GITHUB_API_BASE.into(),
+            Some("secret".into()),
+            vec!["zeroclaw-labs/zeroclaw".into()],
+            vec!["theonlyhennygod".into()],
+            Some("zeroclaw-bot".into()),
+        )
+    }
+
+    #[test]
+    fn github_channel_name() {
+        let channel = make_channel();
+        assert_eq!(channel.name(), "github");
+    }
+
+    #[test]
+    fn parse_issue_comment_created_event() {
+        let channel = make_channel();
+        let payload = serde_json::json!({
+            "action": "created",
+            "repository": {"full_name": "zeroclaw-labs/zeroclaw"},
+            "issue": {"number": 2079},
+            "comment": {
+                "id": 12345,
+                "body": "please add this",
+                "created_at": "2026-02-27T12:00:00Z",
+                "user": {"login": "theonlyhennygod"}
+            }
+        });
+
+        let messages = channel.parse_webhook_payload("issue_comment", &payload);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].reply_target, "zeroclaw-labs/zeroclaw#2079");
+        assert_eq!(messages[0].sender, "theonlyhennygod");
+        assert_eq!(messages[0].content, "please add this");
+        assert_eq!(messages[0].id, "12345");
+        assert_eq!(messages[0].channel, "github");
+    }
+
+    #[test]
+    fn parse_review_comment_created_event() {
+        let channel = make_channel();
+        let payload = serde_json::json!({
+            "action": "created",
+            "repository": {"full_name": "zeroclaw-labs/zeroclaw"},
+            "pull_request": {"number": 2195},
+            "comment": {
+                "id": 999,
+                "body": "nit: rename this",
+                "created_at": "2026-02-27T12:00:00Z",
+                "user": {"login": "theonlyhennygod"}
+            }
+        });
+
+        let messages = channel.parse_webhook_payload("pull_request_review_comment", &payload);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].reply_target, "zeroclaw-labs/zeroclaw#2195");
+        assert_eq!(messages[0].channel, "github");
+    }
+
+    #[test]
+    fn parse_webhook_ignores_unauthorized_or_self_sender() {
+        let channel = make_channel();
+
+        let unauthorized_user = serde_json::json!({
+            "action": "created",
+            "repository": {"full_name": "zeroclaw-labs/zeroclaw"},
+            "issue": {"number": 1},
+            "comment": {"id": 1, "body": "hello", "user": {"login": "someone-else"}}
+        });
+        assert!(channel
+            .parse_webhook_payload("issue_comment", &unauthorized_user)
+            .is_empty());
+
+        let self_sender = serde_json::json!({
+            "action": "created",
+            "repository": {"full_name": "zeroclaw-labs/zeroclaw"},
+            "issue": {"number": 1},
+            "comment": {"id": 1, "body": "hello", "user": {"login": "zeroclaw-bot"}}
+        });
+        assert!(channel
+            .parse_webhook_payload("issue_comment", &self_sender)
+            .is_empty());
+    }
+
+    #[test]
+    fn verify_signature_accepts_valid_signature() {
+        let secret = "github-webhook-secret";
+        let body = br#"{"action":"created"}"#;
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        let signature = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+
+        assert!(verify_github_signature(secret, body, &signature));
+    }
+
+    #[test]
+    fn verify_signature_rejects_invalid_signature() {
+        assert!(!verify_github_signature(
+            "github-webhook-secret",
+            br#"{"action":"created"}"#,
+            "sha256=deadbeef"
+        ));
+    }
+
+    #[test]
+    fn parse_reply_target_requires_owner_repo_hash_number() {
+        assert_eq!(
+            GitHubChannel::parse_reply_target("zeroclaw-labs/zeroclaw#42"),
+            Some(("zeroclaw-labs/zeroclaw", 42))
+        );
+        assert!(GitHubChannel::parse_reply_target("zeroclaw-labs/zeroclaw").is_none());
+        assert!(GitHubChannel::parse_reply_target("zeroclaw-labs/zeroclaw#x").is_none());
+    }
+}

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -19,6 +19,7 @@ pub mod cli;
 pub mod dingtalk;
 pub mod discord;
 pub mod email_channel;
+pub mod github;
 pub mod imessage;
 pub mod irc;
 #[cfg(feature = "channel-lark")]
@@ -48,6 +49,7 @@ pub use cli::CliChannel;
 pub use dingtalk::DingTalkChannel;
 pub use discord::DiscordChannel;
 pub use email_channel::EmailChannel;
+pub use github::GitHubChannel;
 pub use imessage::IMessageChannel;
 pub use irc::IrcChannel;
 #[cfg(feature = "channel-lark")]
@@ -4731,6 +4733,20 @@ fn collect_configured_channels(
                 wati_cfg.api_url.clone(),
                 wati_cfg.tenant_id.clone(),
                 wati_cfg.allowed_numbers.clone(),
+            )),
+        });
+    }
+
+    if let Some(ref github_cfg) = config.channels_config.github {
+        channels.push(ConfiguredChannel {
+            display_name: "GitHub",
+            channel: Arc::new(GitHubChannel::new(
+                github_cfg.api_token.clone(),
+                github_cfg.api_base_url.clone(),
+                github_cfg.webhook_secret.clone(),
+                github_cfg.allowed_repos.clone(),
+                github_cfg.allowed_users.clone(),
+                github_cfg.bot_login.clone(),
             )),
         });
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -10,7 +10,7 @@ pub use schema::{
     CoordinationConfig, CostConfig, CronConfig, DelegateAgentConfig, DiscordConfig,
     DockerRuntimeConfig, EconomicConfig, EconomicTokenPricing, EmbeddingRouteConfig, EstopConfig,
     FeishuConfig, GatewayConfig, GroupReplyConfig, GroupReplyMode, HardwareConfig,
-    HardwareTransport, HeartbeatConfig, HooksConfig, HttpRequestConfig,
+    GitHubConfig, HardwareTransport, HeartbeatConfig, HooksConfig, HttpRequestConfig,
     HttpRequestCredentialProfile, IMessageConfig, IdentityConfig, LarkConfig, MatrixConfig,
     MemoryConfig, ModelRouteConfig, MultimodalConfig, NextcloudTalkConfig,
     NonCliNaturalLanguageApprovalMode, ObservabilityConfig, OtpChallengeDelivery, OtpConfig,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -26,6 +26,7 @@ const SUPPORTED_PROXY_SERVICE_KEYS: &[&str] = &[
     "channel.dingtalk",
     "channel.discord",
     "channel.feishu",
+    "channel.github",
     "channel.lark",
     "channel.matrix",
     "channel.mattermost",
@@ -404,6 +405,7 @@ impl std::fmt::Debug for Config {
             self.channels_config.whatsapp.is_some(),
             self.channels_config.linq.is_some(),
             self.channels_config.wati.is_some(),
+            self.channels_config.github.is_some(),
             self.channels_config.nextcloud_talk.is_some(),
             self.channels_config.email.is_some(),
             self.channels_config.irc.is_some(),
@@ -3892,6 +3894,8 @@ pub struct ChannelsConfig {
     pub linq: Option<LinqConfig>,
     /// WATI WhatsApp Business API channel configuration.
     pub wati: Option<WatiConfig>,
+    /// GitHub Issues/PR comments channel configuration.
+    pub github: Option<GitHubConfig>,
     /// Nextcloud Talk bot channel configuration.
     pub nextcloud_talk: Option<NextcloudTalkConfig>,
     /// Email channel configuration.
@@ -3964,6 +3968,10 @@ impl ChannelsConfig {
             (
                 Box::new(ConfigWrapper::new(self.wati.as_ref())),
                 self.wati.is_some(),
+            ),
+            (
+                Box::new(ConfigWrapper::new(self.github.as_ref())),
+                self.github.is_some(),
             ),
             (
                 Box::new(ConfigWrapper::new(self.nextcloud_talk.as_ref())),
@@ -4039,6 +4047,7 @@ impl Default for ChannelsConfig {
             whatsapp: None,
             linq: None,
             wati: None,
+            github: None,
             nextcloud_talk: None,
             email: None,
             irc: None,
@@ -4520,6 +4529,51 @@ impl ChannelConfig for WatiConfig {
     }
     fn desc() -> &'static str {
         "WhatsApp via WATI Business API"
+    }
+}
+
+fn default_github_api_base_url() -> String {
+    "https://api.github.com".to_string()
+}
+
+/// GitHub channel configuration (webhook receive + REST send API).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GitHubConfig {
+    /// GitHub token used for outbound comment replies.
+    ///
+    /// Can also be set via `ZEROCLAW_GITHUB_API_TOKEN`.
+    pub api_token: String,
+    /// GitHub REST API base URL.
+    ///
+    /// Defaults to `https://api.github.com`. Override for GitHub Enterprise.
+    #[serde(default = "default_github_api_base_url")]
+    pub api_base_url: String,
+    /// Shared webhook secret used to validate `X-Hub-Signature-256`.
+    ///
+    /// Can also be set via `ZEROCLAW_GITHUB_WEBHOOK_SECRET`.
+    #[serde(default)]
+    pub webhook_secret: Option<String>,
+    /// Allowed repositories (`owner/repo`).
+    ///
+    /// `[]` means deny all, `"*"` allows all repositories.
+    #[serde(default)]
+    pub allowed_repos: Vec<String>,
+    /// Allowed GitHub usernames for inbound comments.
+    ///
+    /// `[]` means deny all, `"*"` allows all users.
+    #[serde(default)]
+    pub allowed_users: Vec<String>,
+    /// Optional bot login. If set, comments authored by this login are ignored.
+    #[serde(default)]
+    pub bot_login: Option<String>,
+}
+
+impl ChannelConfig for GitHubConfig {
+    fn name() -> &'static str {
+        "GitHub"
+    }
+    fn desc() -> &'static str {
+        "Issues and PR comments via GitHub webhooks"
     }
 }
 
@@ -6033,6 +6087,18 @@ fn decrypt_channel_secrets(
             "config.channels_config.linq.signing_secret",
         )?;
     }
+    if let Some(ref mut github) = channels.github {
+        decrypt_secret(
+            store,
+            &mut github.api_token,
+            "config.channels_config.github.api_token",
+        )?;
+        decrypt_optional_secret(
+            store,
+            &mut github.webhook_secret,
+            "config.channels_config.github.webhook_secret",
+        )?;
+    }
     if let Some(ref mut nextcloud) = channels.nextcloud_talk {
         decrypt_secret(
             store,
@@ -6200,6 +6266,18 @@ fn encrypt_channel_secrets(
             store,
             &mut linq.signing_secret,
             "config.channels_config.linq.signing_secret",
+        )?;
+    }
+    if let Some(ref mut github) = channels.github {
+        encrypt_secret(
+            store,
+            &mut github.api_token,
+            "config.channels_config.github.api_token",
+        )?;
+        encrypt_optional_secret(
+            store,
+            &mut github.webhook_secret,
+            "config.channels_config.github.webhook_secret",
         )?;
     }
     if let Some(ref mut nextcloud) = channels.nextcloud_talk {
@@ -8669,6 +8747,7 @@ default_temperature = 0.7
                 whatsapp: None,
                 linq: None,
                 wati: None,
+                github: None,
                 nextcloud_talk: None,
                 email: None,
                 irc: None,
@@ -9598,6 +9677,7 @@ allowed_users = ["@ops:matrix.org"]
             whatsapp: None,
             linq: None,
             wati: None,
+            github: None,
             nextcloud_talk: None,
             email: None,
             irc: None,
@@ -9877,6 +9957,7 @@ channel_id = "C123"
             }),
             linq: None,
             wati: None,
+            github: None,
             nextcloud_talk: None,
             email: None,
             irc: None,
@@ -11995,6 +12076,38 @@ default_model = "legacy-model"
             .find_map(|(handle, enabled)| (handle.name() == "DingTalk").then_some(*enabled));
 
         assert_eq!(dingtalk_state, Some(true));
+    }
+
+    #[test]
+    async fn github_config_serde() {
+        let gh = GitHubConfig {
+            api_token: "ghp_token".into(),
+            api_base_url: "https://api.github.com".into(),
+            webhook_secret: Some("hook-secret".into()),
+            allowed_repos: vec!["zeroclaw-labs/zeroclaw".into()],
+            allowed_users: vec!["theonlyhennygod".into()],
+            bot_login: Some("zeroclaw-bot".into()),
+        };
+
+        let json = serde_json::to_string(&gh).unwrap();
+        let parsed: GitHubConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.api_token, "ghp_token");
+        assert_eq!(parsed.api_base_url, "https://api.github.com");
+        assert_eq!(parsed.webhook_secret.as_deref(), Some("hook-secret"));
+        assert_eq!(parsed.allowed_repos, vec!["zeroclaw-labs/zeroclaw"]);
+        assert_eq!(parsed.allowed_users, vec!["theonlyhennygod"]);
+        assert_eq!(parsed.bot_login.as_deref(), Some("zeroclaw-bot"));
+    }
+
+    #[test]
+    async fn github_config_defaults_optional_fields() {
+        let json = r#"{"api_token":"ghp_token"}"#;
+        let parsed: GitHubConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.api_base_url, "https://api.github.com");
+        assert!(parsed.webhook_secret.is_none());
+        assert!(parsed.allowed_repos.is_empty());
+        assert!(parsed.allowed_users.is_empty());
+        assert!(parsed.bot_login.is_none());
     }
 
     #[test]

--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -700,6 +700,10 @@ fn mask_sensitive_fields(config: &crate::config::Config) -> crate::config::Confi
     if let Some(wati) = masked.channels_config.wati.as_mut() {
         mask_required_secret(&mut wati.api_token);
     }
+    if let Some(github) = masked.channels_config.github.as_mut() {
+        mask_required_secret(&mut github.api_token);
+        mask_optional_secret(&mut github.webhook_secret);
+    }
     if let Some(nextcloud) = masked.channels_config.nextcloud_talk.as_mut() {
         mask_required_secret(&mut nextcloud.app_token);
         mask_optional_secret(&mut nextcloud.webhook_secret);
@@ -863,6 +867,13 @@ fn restore_masked_sensitive_fields(
         current.channels_config.wati.as_ref(),
     ) {
         restore_required_secret(&mut incoming_ch.api_token, &current_ch.api_token);
+    }
+    if let (Some(incoming_ch), Some(current_ch)) = (
+        incoming.channels_config.github.as_mut(),
+        current.channels_config.github.as_ref(),
+    ) {
+        restore_required_secret(&mut incoming_ch.api_token, &current_ch.api_token);
+        restore_optional_secret(&mut incoming_ch.webhook_secret, &current_ch.webhook_secret);
     }
     if let (Some(incoming_ch), Some(current_ch)) = (
         incoming.channels_config.nextcloud_talk.as_mut(),
@@ -1035,7 +1046,7 @@ mod tests {
     }
 
     #[test]
-    fn mask_sensitive_fields_covers_wati_email_and_feishu_secrets() {
+    fn mask_sensitive_fields_covers_wati_github_email_and_feishu_secrets() {
         let mut cfg = crate::config::Config::default();
         cfg.proxy.http_proxy = Some("http://user:pass@proxy.internal:8080".to_string());
         cfg.proxy.https_proxy = Some("https://user:pass@proxy.internal:8443".to_string());
@@ -1058,6 +1069,14 @@ mod tests {
             api_url: "https://live-mt-server.wati.io".to_string(),
             tenant_id: Some("tenant-1".to_string()),
             allowed_numbers: vec!["*".to_string()],
+        });
+        cfg.channels_config.github = Some(crate::config::GitHubConfig {
+            api_token: "ghp-real-token".to_string(),
+            api_base_url: "https://api.github.com".to_string(),
+            webhook_secret: Some("github-webhook-secret".to_string()),
+            allowed_repos: vec!["zeroclaw-labs/zeroclaw".to_string()],
+            allowed_users: vec!["*".to_string()],
+            bot_login: Some("zeroclaw-bot".to_string()),
         });
         let mut email = crate::channels::email_channel::EmailConfig::default();
         email.password = "email-real-password".to_string();
@@ -1125,6 +1144,22 @@ mod tests {
         assert_eq!(
             masked
                 .channels_config
+                .github
+                .as_ref()
+                .map(|value| value.api_token.as_str()),
+            Some(MASKED_SECRET)
+        );
+        assert_eq!(
+            masked
+                .channels_config
+                .github
+                .as_ref()
+                .and_then(|value| value.webhook_secret.as_deref()),
+            Some(MASKED_SECRET)
+        );
+        assert_eq!(
+            masked
+                .channels_config
                 .email
                 .as_ref()
                 .map(|value| value.password.as_str()),
@@ -1144,7 +1179,7 @@ mod tests {
     }
 
     #[test]
-    fn hydrate_config_for_save_restores_wati_email_and_feishu_secrets() {
+    fn hydrate_config_for_save_restores_wati_github_email_and_feishu_secrets() {
         let mut current = crate::config::Config::default();
         current.proxy.http_proxy = Some("http://user:pass@proxy.internal:8080".to_string());
         current.proxy.https_proxy = Some("https://user:pass@proxy.internal:8443".to_string());
@@ -1166,6 +1201,14 @@ mod tests {
             api_url: "https://live-mt-server.wati.io".to_string(),
             tenant_id: Some("tenant-1".to_string()),
             allowed_numbers: vec!["*".to_string()],
+        });
+        current.channels_config.github = Some(crate::config::GitHubConfig {
+            api_token: "ghp-real-token".to_string(),
+            api_base_url: "https://api.github.com".to_string(),
+            webhook_secret: Some("github-webhook-secret".to_string()),
+            allowed_repos: vec!["zeroclaw-labs/zeroclaw".to_string()],
+            allowed_users: vec!["*".to_string()],
+            bot_login: Some("zeroclaw-bot".to_string()),
         });
         let mut email = crate::channels::email_channel::EmailConfig::default();
         email.password = "email-real-password".to_string();
@@ -1242,6 +1285,22 @@ mod tests {
                 .as_ref()
                 .map(|value| value.api_token.as_str()),
             Some("wati-real-token")
+        );
+        assert_eq!(
+            restored
+                .channels_config
+                .github
+                .as_ref()
+                .map(|value| value.api_token.as_str()),
+            Some("ghp-real-token")
+        );
+        assert_eq!(
+            restored
+                .channels_config
+                .github
+                .as_ref()
+                .and_then(|value| value.webhook_secret.as_deref()),
+            Some("github-webhook-secret")
         );
         assert_eq!(
             restored

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -15,7 +15,7 @@ pub mod static_files;
 pub mod ws;
 
 use crate::channels::{
-    Channel, LinqChannel, NextcloudTalkChannel, QQChannel, SendMessage, WatiChannel,
+    Channel, GitHubChannel, LinqChannel, NextcloudTalkChannel, QQChannel, SendMessage, WatiChannel,
     WhatsAppChannel,
 };
 use crate::config::Config;
@@ -82,11 +82,44 @@ fn qq_memory_key(msg: &crate::channels::traits::ChannelMessage) -> String {
     format!("qq_{}_{}", msg.sender, msg.id)
 }
 
+fn github_memory_key(msg: &crate::channels::traits::ChannelMessage) -> String {
+    format!("github_{}_{}", msg.sender, msg.id)
+}
+
 fn hash_webhook_secret(value: &str) -> String {
     use sha2::{Digest, Sha256};
 
     let digest = Sha256::digest(value.as_bytes());
     hex::encode(digest)
+}
+
+fn build_github_channel(config: &Config) -> Option<GitHubChannel> {
+    let github_cfg = config.channels_config.github.as_ref()?;
+
+    let api_token = std::env::var("ZEROCLAW_GITHUB_API_TOKEN")
+        .ok()
+        .and_then(|value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+        .unwrap_or_else(|| github_cfg.api_token.clone());
+
+    let webhook_secret = std::env::var("ZEROCLAW_GITHUB_WEBHOOK_SECRET")
+        .ok()
+        .and_then(|value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+        .or_else(|| github_cfg.webhook_secret.clone());
+
+    Some(GitHubChannel::new(
+        api_token,
+        github_cfg.api_base_url.clone(),
+        webhook_secret,
+        github_cfg.allowed_repos.clone(),
+        github_cfg.allowed_users.clone(),
+        github_cfg.bot_login.clone(),
+    ))
 }
 
 /// How often the rate limiter sweeps stale IP entries from its map.
@@ -632,6 +665,9 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
     if qq_webhook_enabled {
         println!("  POST /qq        — QQ Bot webhook (validation + events)");
     }
+    if config.channels_config.github.is_some() {
+        println!("  POST /github    — GitHub webhook (issues + PR comments)");
+    }
     if config.gateway.node_control.enabled {
         println!("  POST /api/node-control — experimental node-control RPC scaffold");
     }
@@ -738,6 +774,7 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         .route("/wati", post(handle_wati_webhook))
         .route("/nextcloud-talk", post(handle_nextcloud_talk_webhook))
         .route("/qq", post(handle_qq_webhook))
+        .route("/github", post(handle_github_webhook))
         // ── OpenClaw migration: tools-enabled chat endpoint ──
         .route("/api/chat", post(openclaw_compat::handle_api_chat))
         // ── OpenAI-compatible endpoints ──
@@ -2302,6 +2339,148 @@ async fn handle_qq_webhook(
     (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
 }
 
+/// POST /github — incoming GitHub webhook (issue_comment + pull_request_review_comment)
+async fn handle_github_webhook(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    let github = {
+        let config = state.config.lock();
+        build_github_channel(&config)
+    };
+    let Some(github) = github else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "GitHub channel not configured"})),
+        );
+    };
+
+    let event = headers
+        .get("X-GitHub-Event")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .unwrap_or("");
+    if event.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Missing X-GitHub-Event header"})),
+        );
+    }
+
+    if let Some(secret) = github.webhook_secret() {
+        let signature = headers
+            .get("X-Hub-Signature-256")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or("");
+        if !crate::channels::github::verify_github_signature(secret, body.as_ref(), signature) {
+            tracing::warn!(
+                "GitHub webhook signature verification failed (signature: {})",
+                if signature.is_empty() {
+                    "missing"
+                } else {
+                    "invalid"
+                }
+            );
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({"error": "Invalid signature"})),
+            );
+        }
+    }
+
+    if let Some(delivery_id) = headers
+        .get("X-GitHub-Delivery")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let idempotency_key = format!("github:{delivery_id}");
+        if !state.idempotency_store.record_if_new(&idempotency_key) {
+            tracing::info!("GitHub duplicate ignored (delivery id: {delivery_id})");
+            return (
+                StatusCode::OK,
+                Json(serde_json::json!({"status": "duplicate", "event": event})),
+            );
+        }
+    }
+
+    if event == "ping" {
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({"status": "ok", "event": "ping"})),
+        );
+    }
+
+    let Ok(payload) = serde_json::from_slice::<serde_json::Value>(&body) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Invalid JSON payload"})),
+        );
+    };
+
+    let messages = github.parse_webhook_payload(event, &payload);
+    if messages.is_empty() {
+        return (
+            StatusCode::OK,
+            Json(serde_json::json!({"status": "ignored", "event": event})),
+        );
+    }
+
+    for msg in &messages {
+        tracing::info!(
+            "GitHub webhook message from {}: {}",
+            msg.sender,
+            truncate_with_ellipsis(&msg.content, 80)
+        );
+
+        if state.auto_save {
+            let key = github_memory_key(msg);
+            let _ = state
+                .mem
+                .store(&key, &msg.content, MemoryCategory::Conversation, None)
+                .await;
+        }
+
+        match run_gateway_chat_with_tools(&state, &msg.content).await {
+            Ok(response) => {
+                let leak_guard_cfg = gateway_outbound_leak_guard_snapshot(&state);
+                let safe_response = sanitize_gateway_response(
+                    &response,
+                    state.tools_registry_exec.as_ref(),
+                    &leak_guard_cfg,
+                );
+                if let Err(error) = github
+                    .send(
+                        &SendMessage::new(safe_response, &msg.reply_target)
+                            .in_thread(msg.thread_ts.clone()),
+                    )
+                    .await
+                {
+                    tracing::error!("Failed to send GitHub reply: {error}");
+                }
+            }
+            Err(error) => {
+                tracing::error!("LLM error for GitHub webhook message: {error:#}");
+                let _ = github
+                    .send(
+                        &SendMessage::new(
+                            "Sorry, I couldn't process your message right now.",
+                            &msg.reply_target,
+                        )
+                        .in_thread(msg.thread_ts.clone()),
+                    )
+                    .await;
+            }
+        }
+    }
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({"status": "ok", "event": event})),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3837,6 +4016,114 @@ Reminder set successfully."#;
             parsed["signature"],
             "87befc99c42c651b3aac0278e71ada338433ae26fcb24307bdc5ad38c1adc2d01bcfcadc0842edac85e85205028a1132afe09280305f13aa6909ffc2d652c706"
         );
+        assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn github_webhook_returns_not_found_when_not_configured() {
+        let provider: Arc<dyn Provider> = Arc::new(MockProvider::default());
+        let memory: Arc<dyn Memory> = Arc::new(MockMemory);
+        let state = AppState {
+            config: Arc::new(Mutex::new(Config::default())),
+            provider,
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: memory,
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            linq: None,
+            linq_signing_secret: None,
+            nextcloud_talk: None,
+            nextcloud_talk_webhook_secret: None,
+            wati: None,
+            qq: None,
+            qq_webhook_enabled: false,
+            observer: Arc::new(crate::observability::NoopObserver),
+            tools_registry: Arc::new(Vec::new()),
+            tools_registry_exec: Arc::new(Vec::new()),
+            multimodal: crate::config::MultimodalConfig::default(),
+            max_tool_iterations: 10,
+            cost_tracker: None,
+            event_tx: tokio::sync::broadcast::channel(16).0,
+        };
+
+        let mut headers = HeaderMap::new();
+        headers.insert("X-GitHub-Event", HeaderValue::from_static("issue_comment"));
+        let response = handle_github_webhook(
+            State(state),
+            headers,
+            Bytes::from_static(br#"{"action":"created"}"#),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn github_webhook_rejects_invalid_signature() {
+        let provider_impl = Arc::new(MockProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+        let memory: Arc<dyn Memory> = Arc::new(MockMemory);
+        let mut config = Config::default();
+        config.channels_config.github = Some(crate::config::GitHubConfig {
+            api_token: "ghp_test_token".into(),
+            api_base_url: "https://api.github.com".into(),
+            webhook_secret: Some("github-secret".into()),
+            allowed_repos: vec!["zeroclaw-labs/zeroclaw".into()],
+            allowed_users: vec!["*".into()],
+            bot_login: None,
+        });
+
+        let state = AppState {
+            config: Arc::new(Mutex::new(config)),
+            provider,
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: memory,
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            linq: None,
+            linq_signing_secret: None,
+            nextcloud_talk: None,
+            nextcloud_talk_webhook_secret: None,
+            wati: None,
+            qq: None,
+            qq_webhook_enabled: false,
+            observer: Arc::new(crate::observability::NoopObserver),
+            tools_registry: Arc::new(Vec::new()),
+            tools_registry_exec: Arc::new(Vec::new()),
+            multimodal: crate::config::MultimodalConfig::default(),
+            max_tool_iterations: 10,
+            cost_tracker: None,
+            event_tx: tokio::sync::broadcast::channel(16).0,
+        };
+
+        let mut headers = HeaderMap::new();
+        headers.insert("X-GitHub-Event", HeaderValue::from_static("issue_comment"));
+        headers.insert(
+            "X-Hub-Signature-256",
+            HeaderValue::from_static("sha256=deadbeef"),
+        );
+        let response = handle_github_webhook(
+            State(state),
+            headers,
+            Bytes::from_static(br#"{"action":"created"}"#),
+        )
+        .await
+        .into_response();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 0);
     }
 


### PR DESCRIPTION
## Summary
- add native GitHub channel (`channels_config.github`) with webhook-mode support
- support inbound `issue_comment` and `pull_request_review_comment` events via `POST /github`
- add outbound issue/PR thread replies using GitHub REST API comment endpoints
- add optional HMAC verification (`X-Hub-Signature-256`), delivery idempotency (`X-GitHub-Delivery`), and sender/repo allowlists
- wire config secret encryption/decryption + dashboard masking/restoration for GitHub token/webhook secret
- document GitHub channel setup and troubleshooting in channels reference

## Validation
- `CARGO_TARGET_DIR=/tmp/zc-batch-target cargo test --lib channels::github::tests:: -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/zc-batch-target cargo test --lib github_webhook_ -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/zc-batch-target cargo test --lib github_config_ -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/zc-batch-target cargo test --lib wati_github_email_and_feishu -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/zc-batch-target cargo check`

Closes #2079