### PR TITLE
fix(agent): avoid orphan tool messages after compaction

### DIFF
--- a/src/agent/loop_/history.rs
+++ b/src/agent/loop_/history.rs
@@ -28,8 +28,13 @@ pub(super) fn trim_history(history: &mut Vec<ChatMessage>, max_history: usize) {
     }
 
     let start = if has_system { 1 } else { 0 };
-    let to_remove = non_system_count - max_history;
-    history.drain(start..start + to_remove);
+    let mut trim_end = start + (non_system_count - max_history);
+    // Never keep a leading `role=tool` at the trim boundary. Tool-message runs
+    // must remain attached to their preceding assistant(tool_calls) message.
+    while trim_end < history.len() && history[trim_end].role == "tool" {
+        trim_end += 1;
+    }
+    history.drain(start..trim_end);
 }
 
 pub(super) fn build_compaction_transcript(messages: &[ChatMessage]) -> String {
@@ -80,7 +85,11 @@ pub(super) async fn auto_compact_history(
         return Ok(false);
     }
 
-    let compact_end = start + compact_count;
+    let mut compact_end = start + compact_count;
+    // Do not split assistant(tool_calls) -> tool runs across compaction boundary.
+    while compact_end < history.len() && history[compact_end].role == "tool" {
+        compact_end += 1;
+    }
     let to_compact: Vec<ChatMessage> = history[start..compact_end].to_vec();
     let transcript = build_compaction_transcript(&to_compact);
 
@@ -103,4 +112,98 @@ pub(super) async fn auto_compact_history(
     apply_compaction_summary(history, start, compact_end, &summary);
 
     Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::{ChatRequest, ChatResponse, Provider};
+    use async_trait::async_trait;
+
+    struct StaticSummaryProvider;
+
+    #[async_trait]
+    impl Provider for StaticSummaryProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            Ok("- summarized context".to_string())
+        }
+
+        async fn chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<ChatResponse> {
+            Ok(ChatResponse {
+                text: Some("- summarized context".to_string()),
+                tool_calls: Vec::new(),
+                usage: None,
+                reasoning_content: None,
+                quota_metadata: None,
+            })
+        }
+    }
+
+    fn assistant_with_tool_call(id: &str) -> ChatMessage {
+        ChatMessage::assistant(format!(
+            "{{\"content\":\"\",\"tool_calls\":[{{\"id\":\"{id}\",\"name\":\"shell\",\"arguments\":\"{{}}\"}}]}}"
+        ))
+    }
+
+    fn tool_result(id: &str) -> ChatMessage {
+        ChatMessage::tool(format!("{{\"tool_call_id\":\"{id}\",\"content\":\"ok\"}}"))
+    }
+
+    #[test]
+    fn trim_history_avoids_orphan_tool_at_boundary() {
+        let mut history = vec![
+            ChatMessage::user("old"),
+            assistant_with_tool_call("call_1"),
+            tool_result("call_1"),
+            ChatMessage::user("recent"),
+        ];
+
+        trim_history(&mut history, 2);
+
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].role, "user");
+        assert_eq!(history[0].content, "recent");
+    }
+
+    #[tokio::test]
+    async fn auto_compact_history_does_not_split_tool_run_boundary() {
+        let mut history = vec![
+            ChatMessage::user("oldest"),
+            assistant_with_tool_call("call_2"),
+            tool_result("call_2"),
+        ];
+        for idx in 0..19 {
+            history.push(ChatMessage::user(format!("recent-{idx}")));
+        }
+        // 22 non-system messages => compaction with max_history=21 would
+        // previously cut right before the tool result (index 2).
+        assert_eq!(history.len(), 22);
+
+        let compacted =
+            auto_compact_history(&mut history, &StaticSummaryProvider, "test-model", 21)
+                .await
+                .expect("compaction should succeed");
+
+        assert!(compacted);
+        assert_eq!(history[0].role, "assistant");
+        assert!(
+            history[0].content.contains("[Compaction summary]"),
+            "summary message should replace compacted range"
+        );
+        assert_ne!(
+            history[1].role, "tool",
+            "first retained message must not be an orphan tool result"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`main` or `dev`; direct `main` PRs are allowed): `main`
- Problem: Auto-compaction/history trimming could retain a leading `role=tool` message without its preceding `assistant.tool_calls` message.
- Why it matters: DeepSeek rejects this malformed sequence with HTTP 400 (`orphan role=tool message without preceding assistant.tool_calls`).
- What changed: Guarded both trim boundaries (`trim_history` and `auto_compact_history`) to advance past tool-only leading segments, and added regression tests for both boundary paths.
- What did **not** change (scope boundary): No provider API contract changes, no prompt/model logic changes, and no channel routing behavior changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `agent,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `agent: history`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `distinguished contributor`
- If any auto-label is incorrect, note requested correction: `N/A`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `runtime`

## Linked Issue

- Closes #2232
- Related #N/A
- Depends on #N/A (if stacked)
- Supersedes #N/A (if replacing older PR)
- Linear issue key(s) (required, e.g. `RMN-123`): `RMN-241`
- Linear issue URL(s): `https://linear.app/zeroclawlabs/issue/RMN-241/bug-deepseek-400-after-auto-compaction-leaves-orphan-tool-message`

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Integrated scope by source PR (what was materially carried forward): `N/A`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): `No superseded PR/code carry-over.`
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo test --no-default-features history::tests:: -- --nocapture
cargo fmt --all -- --check
```

- Evidence provided (test/log/trace/screenshot/perf): Added regressions `trim_history_avoids_orphan_tool_at_boundary` and `auto_compact_history_does_not_split_tool_run_boundary`; focused history test command passed before rebase (`2 passed`).
- If any command is intentionally skipped, explain why: Full-workspace `cargo fmt --all -- --check` currently reports unrelated baseline formatting deltas in untouched files (`src/tools/auth_profile.rs`, `src/tools/quota_tools.rs`) on the latest rebased base; no formatting changes were introduced in this PR.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: No user data surfaces changed; logic is internal conversation-history boundary handling.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N.A.
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N.A.
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: Not applicable (no user-facing wording/docs changes).

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: History trim boundary and auto-compaction boundary around assistant-tool call runs.
- Edge cases checked: Boundary lands exactly on first tool message; multi-tool contiguous run boundary.
- What was not verified: End-to-end DeepSeek live API call in this local environment.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Agent loop conversation-history trimming and compaction.
- Potential unintended effects: Slightly fewer retained messages at boundaries when leading retained block starts with tool-only messages.
- Guardrails/monitoring for early detection: Regression tests in `src/agent/loop_/history.rs` and runtime provider 400 error telemetry.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Local codex shell + git + cargo.
- Workflow/plan summary (if any): Root-cause -> boundary fix in two paths -> regression tests -> issue/Linear sync.
- Verification focus: Preventing orphan tool messages after trimming/compaction.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Confirmed.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 234e7d22`
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Any regression would show as context-history behavior drift or provider prompt-sequence errors.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: Boundary advancement could drop more historical tool messages than expected at trim edges.
- Mitigation: Added explicit boundary regression tests covering both trim and compaction paths.
