### PR TITLE
docs(readme): restore Quick Start section [CDV-26]

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,45 @@ Use this board for important notices (breaking changes, security advisories, mai
 - **Fully swappable:** core systems are traits (providers, channels, tools, memory, tunnels).
 - **No lock-in:** OpenAI-compatible provider support + pluggable custom endpoints.
 
+## Quick Start
+
+### Option 1: Homebrew (macOS/Linuxbrew)
+
+```bash
+brew install zeroclaw
+```
+
+### Option 2: Clone + Bootstrap
+
+```bash
+git clone https://github.com/zeroclaw-labs/zeroclaw.git
+cd zeroclaw
+./bootstrap.sh
+```
+
+> **Note:** Source builds require ~2GB RAM and ~6GB disk. For resource-constrained systems, use `./bootstrap.sh --prefer-prebuilt` to download a pre-built binary instead.
+
+### Option 3: Cargo Install
+
+```bash
+cargo install zeroclaw
+```
+
+### First Run
+
+```bash
+# Start the gateway daemon
+zeroclaw gateway start
+
+# Open the web UI
+zeroclaw dashboard
+
+# Or chat directly
+zeroclaw chat "Hello!"
+```
+
+For detailed setup options, see [docs/one-click-bootstrap.md](docs/one-click-bootstrap.md).
+
 ## Benchmark Snapshot (ZeroClaw vs OpenClaw, Reproducible)
 
 Local machine quick benchmark (macOS arm64, Feb 2026) normalized for 0.8GHz edge hardware.


### PR DESCRIPTION
## Summary
Restore the missing Quick Start section in README.md that was previously removed, leaving users unable to find installation instructions.

### Problem
The README.md links to `#quick-start` but no such section exists. Users landing on the main GitHub page have no visible installation instructions, forcing them to dig through docs/ subdirectories.

### Why It Matters
This is a **S1 - workflow blocked** issue. New users cannot easily install ZeroClaw from the main README. First impressions matter for OSS adoption.

### What Changed
Added a comprehensive Quick Start section with:
- Homebrew install (one command)
- Clone + bootstrap (recommended path)
- Cargo install (for Rust developers)
- First run commands (gateway, dashboard, chat)
- Link to detailed docs for advanced options

## Changed Files
| File | Changes |
|------|---------|
| `README.md` | +39 lines - Quick Start section |

## Validation Evidence
```bash
# Verified anchor link resolves
grep -n "## Quick Start" README.md
# Output: line 84

# Verified link in header points to valid anchor
grep "#quick-start" README.md
# Links now resolve correctly

# Manual review: section is visible and clear
```

## Security Impact
**Risk Level:** None

**Analysis:** Documentation-only change. No code, dependencies, or runtime behavior affected.

## Privacy and Data Hygiene
**Status:** No privacy impact

Documentation change only.

## Rollback Plan
1. Revert this PR via GitHub UI
2. No state or config changes to undo

## Related
Fixes #2275

---
*Contributor: Oystra (@Preventnetworkhacking)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Quick Start section with multiple installation options (Homebrew, Clone + Bootstrap, Cargo Install)
  * Documented First Run workflow for initial setup
  * Included resource requirements information for users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->