### PR TITLE
fix(utf8): prevent panic on CJK text truncation [CDV-27]

### DIFF
--- a/src/agent/loop_/detection.rs
+++ b/src/agent/loop_/detection.rs
@@ -220,7 +220,9 @@ impl LoopDetector {
 
 fn hash_output(output: &str) -> u64 {
     let prefix = if output.len() > OUTPUT_HASH_PREFIX_BYTES {
-        &output[..OUTPUT_HASH_PREFIX_BYTES]
+        // Use floor_utf8_char_boundary to avoid panic on multi-byte UTF-8 characters
+        let boundary = crate::util::floor_utf8_char_boundary(output, OUTPUT_HASH_PREFIX_BYTES);
+        &output[..boundary]
     } else {
         output
     };
@@ -385,5 +387,27 @@ mod tests {
         det.record_call("file_read", r#"{"path":"b.rs"}"#, "content_b", true);
         det.record_call("shell", r#"{"cmd":"cargo test"}"#, "ok", true);
         assert_eq!(det.check(), DetectionVerdict::Continue);
+    }
+
+    // 11. UTF-8 boundary safety: hash_output must not panic on CJK text
+    #[test]
+    fn hash_output_utf8_boundary_safe() {
+        // Create a string where byte 4096 lands inside a multi-byte char
+        // Chinese chars are 3 bytes each, so 1366 chars = 4098 bytes
+        let cjk_text: String = "文".repeat(1366); // 4098 bytes
+        assert!(cjk_text.len() > super::OUTPUT_HASH_PREFIX_BYTES);
+        
+        // This should NOT panic
+        let hash1 = super::hash_output(&cjk_text);
+        
+        // Different content should produce different hash
+        let cjk_text2: String = "字".repeat(1366);
+        let hash2 = super::hash_output(&cjk_text2);
+        assert_ne!(hash1, hash2);
+        
+        // Mixed ASCII + CJK at boundary
+        let mixed = "a".repeat(4094) + "文文"; // 4094 + 6 = 4100 bytes, boundary at 4096
+        let hash3 = super::hash_output(&mixed);
+        assert!(hash3 != 0); // Just verify it runs
     }
 }

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -3109,8 +3109,8 @@ impl Channel for TelegramChannel {
         let thread_id = parsed_thread_id.or(thread_ts);
 
         let raw_args = arguments.to_string();
-        let args_preview = if raw_args.len() > 260 {
-            format!("{}...", &raw_args[..260])
+        let args_preview = if raw_args.chars().count() > 260 {
+            crate::util::truncate_with_ellipsis(&raw_args, 260)
         } else {
             raw_args
         };


### PR DESCRIPTION
## Summary

Fix UTF-8 boundary panics in two locations not covered by PR #2154:

### Problem
The daemon panics with `byte index is not a char boundary` when processing messages containing multi-byte UTF-8 characters (Chinese, Japanese, Korean) that land near truncation boundaries.

### Why It Matters
- S1 severity: workflow blocked for CJK users
- Tokio worker thread panics, message dropped, user gets no response
- Affects any user whose messages/memory/tool args contain CJK characters

### What Changed
1. **`src/channels/telegram.rs:3112`** — OTP/approval message preview
   - Changed from byte-based `&raw_args[..260]` to char-based truncation
   - Uses existing `truncate_with_ellipsis` utility

2. **`src/agent/loop_/detection.rs:222`** — Tool output hash prefix  
   - Changed from `&output[..4096]` to UTF-8-safe boundary
   - Uses existing `floor_utf8_char_boundary` utility

3. **Added test:** `hash_output_utf8_boundary_safe()` verifies no panic on CJK text

## Changed Files
| File | Changes |
|------|---------|
| `src/channels/telegram.rs` | 2 lines - use char-based truncation |
| `src/agent/loop_/detection.rs` | 25 lines - UTF-8 safe boundary + test |

## Validation Evidence
```bash
# Verify UTF-8 safe utilities exist and are used
grep -n "truncate_with_ellipsis\|floor_utf8_char_boundary" src/channels/telegram.rs src/agent/loop_/detection.rs
# src/channels/telegram.rs:3113: crate::util::truncate_with_ellipsis(&raw_args, 260)
# src/agent/loop_/detection.rs:224: crate::util::floor_utf8_char_boundary(output, OUTPUT_HASH_PREFIX_BYTES)

# Test added to verify no panic (test file included)
# cargo test hash_output_utf8_boundary_safe
```

## Security Impact
**Risk Level:** None

**Analysis:** This is a defensive fix that prevents panics. No new code paths, no changes to authentication/encryption/data handling. Uses existing utility functions already reviewed in PR #2154.

## Privacy and Data Hygiene
**Status:** No privacy impact

No changes to data collection, logging, or storage behavior.

## Rollback Plan
1. Revert this PR via GitHub UI
2. No database/state changes to undo
3. CJK users would continue experiencing panics (known issue)

## Related
- Fixes #2276
- Extends pattern from PR #2154 to remaining locations

---
*Contributor: Oystra (@Preventnetworkhacking)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hashing logic to safely handle multi-byte UTF-8 characters, preventing crashes with international text
  * Improved approval prompt text display with correct character-aware truncation for international language support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->