### PR TITLE
fix(build): resolve compile errors, clippy violations, and fmt on main

### DIFF
--- a/src/tools/auth_profile.rs
+++ b/src/tools/auth_profile.rs
@@ -37,8 +37,7 @@ impl ManageAuthProfileTool {
         let mut count = 0u32;
         for (id, profile) in &data.profiles {
             if let Some(filter) = provider_filter {
-                let normalized =
-                    normalize_provider(filter).unwrap_or_else(|_| filter.to_string());
+                let normalized = normalize_provider(filter).unwrap_or_else(|_| filter.to_string());
                 if profile.provider != normalized {
                     continue;
                 }

--- a/src/tools/quota_tools.rs
+++ b/src/tools/quota_tools.rs
@@ -112,16 +112,23 @@ impl Tool for CheckProviderQuotaTool {
             let _ = writeln!(output, "Available providers: {}", available.join(", "));
         }
         if !rate_limited.is_empty() {
-            let _ = writeln!(output, "Rate-limited providers: {}", rate_limited.join(", "));
+            let _ = writeln!(
+                output,
+                "Rate-limited providers: {}",
+                rate_limited.join(", ")
+            );
         }
         if !circuit_open.is_empty() {
-            let _ = writeln!(output, "Circuit-open providers: {}", circuit_open.join(", "));
+            let _ = writeln!(
+                output,
+                "Circuit-open providers: {}",
+                circuit_open.join(", ")
+            );
         }
 
         if available.is_empty() && rate_limited.is_empty() && circuit_open.is_empty() {
-            output.push_str(
-                "No quota information available. Quota is populated after API calls.\n",
-            );
+            output
+                .push_str("No quota information available. Quota is populated after API calls.\n");
         }
 
         // Always show per-provider and per-profile details


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: Main branch fails to compile (E0061, E0063) and has formatting/clippy violations
- Why it matters: Blocks all contributors from building; CI fmt/clippy gates fail
- What changed:
  - `src/gateway/mod.rs`: pass missing `session_id` argument to `run_gateway_chat_with_tools`
  - `src/providers/cursor.rs`: add missing `quota_metadata` field to `ChatResponse`
  - `src/onboard/wizard.rs`: remove redundant else block (clippy::redundant_else)
  - `src/tools/pptx_read.rs`: nest or-patterns (clippy::unnested_or_patterns)
  - `src/channels/napcat.rs`: add digit separators to literal (clippy::unreadable_literal)
  - `src/tools/auth_profile.rs`: formatting fix
  - `src/tools/quota_tools.rs`: formatting fix
- What did **not** change: No behavior changes beyond fixing broken code

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `gateway`, `provider`, `channel`, `tool`, `onboard`
- Module labels: `provider: cursor`, `channel: napcat`
- Contributor tier label: auto-managed

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #2279
- Related #2280
- Linear issue key(s): `RMN-1`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check          # PASS
cargo clippy --all-targets -- -D clippy::correctness  # PASS
cargo check                         # PASS (compiles clean)
cargo test                          # PASS (all tests pass)
```

- Evidence provided: All four commands pass locally
- If any command is intentionally skipped: `cargo clippy -- -D warnings` has 130 pre-existing warnings unrelated to this PR (large_futures, await_holding_lock, etc.)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: N/A — compile fix only

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Full compilation, all tests, fmt check, clippy correctness
- Edge cases checked: Verified `run_gateway_chat_with_tools` callers all pass `session_id`
- What was not verified: Full `-D warnings` clippy (pre-existing issues)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: gateway (GitHub channel handler), cursor provider, onboard wizard, pptx reader, napcat channel
- Potential unintended effects: None — fixes missing args/fields and cosmetic lint
- Guardrails/monitoring: CI compile + test gates

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None
- Observable failure symptoms: Compilation failure

## Risks and Mitigations

- Risk: `None` passed for `session_id` in GitHub channel handler may miss session tracking
  - Mitigation: This matches the pattern used by other channel handlers (WhatsApp, Linq, Nextcloud) that also pass `None`