### PR TITLE
fix(security): deny approval-required tools on non-CLI channels

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1308,6 +1308,8 @@ pub(crate) async fn run_tool_call_loop(
                         arguments: tool_args.clone(),
                     };
 
+                    // Only prompt interactively on CLI; deny on other channels
+                    // (remote channels cannot provide interactive approval).
                     let decision = if channel_name == "cli" {
                         mgr.prompt_cli(&request)
                     } else if let Some(ctx) = non_cli_approval_context.as_ref() {
@@ -1338,13 +1340,26 @@ pub(crate) async fn run_tool_call_loop(
                         )
                         .await
                     } else {
+                        tracing::warn!(
+                            tool = %tool_name,
+                            channel = %channel_name,
+                            "Tool requires approval but channel cannot prompt — denied"
+                        );
                         ApprovalResponse::No
                     };
 
                     mgr.record_decision(&tool_name, &tool_args, decision, channel_name);
 
                     if decision == ApprovalResponse::No {
-                        let denied = "Denied by user.".to_string();
+                        let denied = if channel_name == "cli" {
+                            "Denied by user.".to_string()
+                        } else {
+                            format!(
+                                "Tool '{}' requires approval but channel '{}' cannot prompt interactively. \
+                                 Configure auto_approve or set autonomy level to Full to allow.",
+                                tool_name, channel_name
+                            )
+                        };
                         runtime_trace::record_event(
                             "tool_call_result",
                             Some(channel_name),

--- a/src/approval/mod.rs
+++ b/src/approval/mod.rs
@@ -581,8 +581,9 @@ impl ApprovalManager {
 
     /// Prompt the user on the CLI and return their decision.
     ///
-    /// For non-CLI channels, returns `Yes` automatically (interactive
-    /// approval is only supported on CLI for now).
+    /// Only valid for the CLI channel. Non-CLI channels should not call
+    /// this method; the caller in `run_tool_call_loop` denies by default
+    /// when the channel cannot provide interactive approval.
     pub fn prompt_cli(&self, request: &ApprovalRequest) -> ApprovalResponse {
         prompt_cli_interactive(request)
     }


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`main` or `dev`; direct `main` PRs are allowed): `main`
- Problem: supervised tool calls on non-CLI channels could still execute without an actionable interactive approval path.
- Why it matters: this is a security boundary break for remote channel execution.
- What changed: deny-by-default non-CLI approval fallback now logs a warning and returns a descriptive denial message; updated prompt-cli doc comment to match behavior.
- What did **not** change (scope boundary): no change to CLI interactive approval flow, no policy broadening for auto-approve/full autonomy.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `security, agent`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `agent: loop`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `security`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `security`

## Linked Issue

- Closes #
- Related #2049
- Depends on # (if stacked)
- Supersedes #2049 (draft track replacement to isolate scope on main)
- Linear issue key(s) (required, e.g. `RMN-123`): `CDV-19`
- Linear issue URL(s): https://linear.app/zeroclawlabs/issue/CDV-19

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `#2049 by @gh-xj`
- Integrated scope by source PR (what was materially carried forward): single security fix commit for non-CLI approval denial behavior in `src/agent/loop_.rs` and doc-comment alignment in `src/approval/mod.rs`.
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): Yes
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): Pass

## Validation Evidence (required)

Commands and result summary:

```bash
cargo check --workspace --locked
./scripts/ci/rust_strict_delta_gate.sh
```

- Evidence provided (test/log/trace/screenshot/perf): local compile + strict-delta gate logs.
- If any command is intentionally skipped, explain why: full global `clippy -D warnings` and full test matrix currently contain known repository baseline failures outside changed lines; strict-delta gate used as enforcement for this scoped fix.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: no personal/sensitive payloads introduced.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: non-CLI fallback path remains deny-by-default and now emits explicit security rationale.
- Edge cases checked: CLI denial message remains unchanged (`Denied by user.`) to preserve interactive UX semantics.
- What was not verified: end-to-end remote channel runtime prompt flow in live integrations.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: agent tool approval branch for non-CLI channels; approval module doc comments.
- Potential unintended effects: remote users see a more explicit denial message when approvals are required but unavailable.
- Guardrails/monitoring for early detection: existing CI security/agent lanes and runtime trace events for denied tool calls.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex CLI with isolated worktree replay/cherry-pick.
- Workflow/plan summary (if any): extracted intended security delta from draft branch onto clean `main`, validated, and opened replacement PR.
- Verification focus: approval boundary integrity and changed-line lint discipline.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge_sha>`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: unexpected denial text changes or non-CLI tool calls blocked/allowed contrary to supervision policy.

## Risks and Mitigations

- Risk:
  - Non-CLI workflows expecting generic denial text may need update.
- Mitigation:
  - Kept logic-compatible deny path; only non-CLI denial text clarified and traced.

Refs #2049
Refs CDV-19


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interactive tool-approval prompts now enforce CLI-only restrictions. Non-CLI channels now receive explicit denial messages with instructions to configure auto-approval or set autonomy settings.

* **Documentation**
  * Updated documentation to clarify that approval prompts are valid only for CLI channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->