### PR TITLE
feat(slack): support listening on multiple channel IDs

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4587,6 +4587,7 @@ fn collect_configured_channels(
                     sl.bot_token.clone(),
                     sl.app_token.clone(),
                     sl.channel_id.clone(),
+                    sl.channel_ids.clone(),
                     sl.allowed_users.clone(),
                 )
                 .with_group_reply_policy(

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4362,7 +4362,12 @@ pub struct SlackConfig {
     pub app_token: Option<String>,
     /// Optional channel ID to restrict the bot to a single channel.
     /// Omit (or set `"*"`) to listen across all accessible channels.
+    /// Ignored when `channel_ids` is non-empty.
     pub channel_id: Option<String>,
+    /// Explicit list of channel/DM IDs to listen on simultaneously.
+    /// Takes precedence over `channel_id`. Empty = fall back to `channel_id`.
+    #[serde(default)]
+    pub channel_ids: Vec<String>,
     /// Allowed Slack user IDs. Empty = deny all.
     #[serde(default)]
     pub allowed_users: Vec<String>,
@@ -9922,6 +9927,7 @@ allowed_users = ["@ops:matrix.org"]
     async fn slack_config_deserializes_without_allowed_users() {
         let json = r#"{"bot_token":"xoxb-tok"}"#;
         let parsed: SlackConfig = serde_json::from_str(json).unwrap();
+        assert!(parsed.channel_ids.is_empty());
         assert!(parsed.allowed_users.is_empty());
         assert_eq!(
             parsed.effective_group_reply_mode(),
@@ -9933,6 +9939,7 @@ allowed_users = ["@ops:matrix.org"]
     async fn slack_config_deserializes_with_allowed_users() {
         let json = r#"{"bot_token":"xoxb-tok","allowed_users":["U111"]}"#;
         let parsed: SlackConfig = serde_json::from_str(json).unwrap();
+        assert!(parsed.channel_ids.is_empty());
         assert_eq!(parsed.allowed_users, vec!["U111"]);
     }
 
@@ -9954,6 +9961,7 @@ bot_token = "xoxb-tok"
 channel_id = "C123"
 "#;
         let parsed: SlackConfig = toml::from_str(toml_str).unwrap();
+        assert!(parsed.channel_ids.is_empty());
         assert!(parsed.allowed_users.is_empty());
         assert_eq!(parsed.channel_id.as_deref(), Some("C123"));
         assert_eq!(

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -364,6 +364,7 @@ pub(crate) async fn deliver_announcement(
                 sl.bot_token.clone(),
                 sl.app_token.clone(),
                 sl.channel_id.clone(),
+                sl.channel_ids.clone(),
                 sl.allowed_users.clone(),
             );
             channel.send(&SendMessage::new(output, target)).await?;

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -4479,6 +4479,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     } else {
                         Some(channel)
                     },
+                    channel_ids: vec![],
                     allowed_users,
                     group_reply: None,
                 });


### PR DESCRIPTION
## Summary

- Problem: Slack listener config only supports one `channel_id` or wildcard discovery, which prevents targeted multi-channel monitoring for shared workspaces.
- Why it matters: Multi-instance operators need a deterministic allowlist of channels/DMs without polling every accessible channel.
- What changed:
  - Added `channels_config.slack.channel_ids: Vec<String>` (defaults empty, backward-compatible).
  - Added `SlackChannel::scoped_channel_ids()` precedence: `channel_ids` -> `channel_id` -> wildcard discovery.
  - Applied scoped filtering in both Web API polling and Socket Mode paths.
  - Wired `channel_ids` through channel bootstrap, cron scheduler Slack delivery path, and onboarding config creation.
  - Added/updated unit tests for scope resolution and backward-compatible config deserialization.
- What did not change: Existing `channel_id` behavior remains intact when `channel_ids` is unset/empty.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `channel`, `config: core`
- Module labels: `channel: slack`, `cron: scheduler`

## Change Metadata

- Change type: `feature`
- Primary scope: `slack`

## Linked Issue

- Supersedes: #2046
- Resolves RMN-255
- Linear issue URL: https://linear.app/zeroclawlabs/issue/RMN-255/feature-slack-multi-channel-listener-support-supersede-2046

## Validation Evidence (required)

```bash
rustfmt src/channels/mod.rs src/channels/slack.rs src/config/schema.rs src/cron/scheduler.rs src/onboard/wizard.rs
cargo test scoped_channel_ids_prefers_explicit_list -- --nocapture
cargo test slack_config_toml_backward_compat -- --nocapture
cargo check -q
```

Result summary:
- New Slack multi-channel scope resolution tests pass.
- Slack config backward-compat TOML parsing remains green.
- Full crate type-check passes with updated constructor wiring.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- Notes: Change narrows listener scope when configured and keeps existing allowlist checks.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A (no new data classes)
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): Yes (optional additive field)
- Migration needed? (`Yes/No`): No
- Optional usage:

```toml
[channels_config.slack]
bot_token = "xoxb-..."
channel_ids = ["C123", "D456"]
allowed_users = ["U123"]
```

## Human Verification (required)

- Verified scenarios:
  - explicit `channel_ids` list is used when present
  - fallback to `channel_id` still works
  - wildcard mode preserved when neither is configured
  - scheduler Slack initialization compiles with updated constructor signature
- What was not verified: live Slack workspace integration in this run

## Rollback Plan (required)

- Fast rollback: `git revert c711eb6e`
- Safety toggle: remove/empty `channel_ids` to revert runtime behavior to existing `channel_id`/wildcard path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and listening to multiple Slack channels simultaneously. The configuration now accepts a list of channel/DM IDs that takes precedence over single-channel configuration, enabling broader message monitoring across multiple channels at once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->