### PR TITLE
feat(channel): use DingTalk Open API for sending messages

### DIFF
--- a/src/channels/dingtalk.rs
+++ b/src/channels/dingtalk.rs
@@ -3,14 +3,22 @@ use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use tokio_tungstenite::tungstenite::Message;
 use uuid::Uuid;
 
 const DINGTALK_BOT_CALLBACK_TOPIC: &str = "/v1.0/im/bot/messages/get";
 
+/// Cached access token with expiry time
+#[derive(Clone)]
+struct AccessToken {
+    token: String,
+    expires_at: Instant,
+}
+
 /// DingTalk channel — connects via Stream Mode WebSocket for real-time messages.
-/// Replies are sent through per-message session webhook URLs.
+/// Replies are sent through DingTalk Open API (no session webhook required).
 pub struct DingTalkChannel {
     client_id: String,
     client_secret: String,
@@ -18,6 +26,8 @@ pub struct DingTalkChannel {
     /// Per-chat session webhooks for sending replies (chatID -> webhook URL).
     /// DingTalk provides a unique webhook URL with each incoming message.
     session_webhooks: Arc<RwLock<HashMap<String, String>>>,
+    /// Cached access token for Open API calls
+    access_token: Arc<RwLock<Option<AccessToken>>>,
 }
 
 /// Response from DingTalk gateway connection registration.
@@ -34,7 +44,65 @@ impl DingTalkChannel {
             client_secret,
             allowed_users,
             session_webhooks: Arc::new(RwLock::new(HashMap::new())),
+            access_token: Arc::new(RwLock::new(None)),
         }
+    }
+
+    /// Get or refresh access token using OAuth2
+    async fn get_access_token(&self) -> anyhow::Result<String> {
+        {
+            let cached = self.access_token.read().await;
+            if let Some(ref at) = *cached {
+                if at.expires_at > Instant::now() {
+                    return Ok(at.token.clone());
+                }
+            }
+        }
+
+        // Re-check under write lock to avoid duplicate token fetches under contention.
+        let mut cached = self.access_token.write().await;
+        if let Some(ref at) = *cached {
+            if at.expires_at > Instant::now() {
+                return Ok(at.token.clone());
+            }
+        }
+
+        let url = "https://api.dingtalk.com/v1.0/oauth2/accessToken";
+        let body = serde_json::json!({
+            "appKey": self.client_id,
+            "appSecret": self.client_secret,
+        });
+
+        let resp = self.http_client().post(url).json(&body).send().await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let err = resp.text().await.unwrap_or_default();
+            anyhow::bail!("DingTalk access token request failed ({status}): {err}");
+        }
+
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct TokenResponse {
+            access_token: String,
+            expire_in: u64,
+        }
+
+        let token_resp: TokenResponse = resp.json().await?;
+        let expires_in = Duration::from_secs(token_resp.expire_in.saturating_sub(60));
+        let token = token_resp.access_token;
+
+        *cached = Some(AccessToken {
+            token: token.clone(),
+            expires_at: Instant::now() + expires_in,
+        });
+
+        Ok(token)
+    }
+
+    fn is_group_recipient(recipient: &str) -> bool {
+        // DingTalk group conversation IDs are typically prefixed with `cid`.
+        recipient.starts_with("cid")
     }
 
     fn http_client(&self) -> reqwest::Client {
@@ -113,36 +181,67 @@ impl Channel for DingTalkChannel {
     }
 
     async fn send(&self, message: &SendMessage) -> anyhow::Result<()> {
-        let webhooks = self.session_webhooks.read().await;
-        let webhook_url = webhooks.get(&message.recipient).ok_or_else(|| {
-            anyhow::anyhow!(
-                "No session webhook found for chat {}. \
-                 The user must send a message first to establish a session.",
-                message.recipient
-            )
-        })?;
+        let token = self.get_access_token().await?;
 
         let title = message.subject.as_deref().unwrap_or("ZeroClaw");
-        let body = serde_json::json!({
-            "msgtype": "markdown",
-            "markdown": {
-                "title": title,
-                "text": message.content,
-            }
+
+        let msg_param = serde_json::json!({
+            "text": message.content,
+            "title": title,
         });
+
+        let (url, body) = if Self::is_group_recipient(&message.recipient) {
+            (
+                "https://api.dingtalk.com/v1.0/robot/groupMessages/send",
+                serde_json::json!({
+                    "robotCode": self.client_id,
+                    "openConversationId": message.recipient,
+                    "msgKey": "sampleMarkdown",
+                    "msgParam": msg_param.to_string(),
+                }),
+            )
+        } else {
+            (
+                "https://api.dingtalk.com/v1.0/robot/oToMessages/batchSend",
+                serde_json::json!({
+                    "robotCode": self.client_id,
+                    "userIds": [&message.recipient],
+                    "msgKey": "sampleMarkdown",
+                    "msgParam": msg_param.to_string(),
+                }),
+            )
+        };
 
         let resp = self
             .http_client()
-            .post(webhook_url)
+            .post(url)
+            .header("x-acs-dingtalk-access-token", &token)
             .json(&body)
             .send()
             .await?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let err = resp.text().await.unwrap_or_default();
-            let sanitized = crate::providers::sanitize_api_error(&err);
-            anyhow::bail!("DingTalk webhook reply failed ({status}): {sanitized}");
+        let status = resp.status();
+        let resp_text = resp.text().await.unwrap_or_default();
+
+        if !status.is_success() {
+            let sanitized = crate::providers::sanitize_api_error(&resp_text);
+            anyhow::bail!("DingTalk API send failed ({status}): {sanitized}");
+        }
+
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&resp_text) {
+            let app_code = json
+                .get("errcode")
+                .and_then(|v| v.as_i64())
+                .or_else(|| json.get("code").and_then(|v| v.as_i64()))
+                .unwrap_or(0);
+            if app_code != 0 {
+                let app_msg = json
+                    .get("errmsg")
+                    .and_then(|v| v.as_str())
+                    .or_else(|| json.get("message").and_then(|v| v.as_str()))
+                    .unwrap_or("unknown error");
+                anyhow::bail!("DingTalk API send rejected (code={app_code}): {app_msg}");
+            }
         }
 
         Ok(())

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -3,8 +3,8 @@ use crate::channels::LarkChannel;
 #[cfg(feature = "channel-matrix")]
 use crate::channels::MatrixChannel;
 use crate::channels::{
-    Channel, DiscordChannel, EmailChannel, MattermostChannel, NapcatChannel, QQChannel,
-    SendMessage, SlackChannel, TelegramChannel, WhatsAppChannel,
+    Channel, DingTalkChannel, DiscordChannel, EmailChannel, MattermostChannel, NapcatChannel,
+    QQChannel, SendMessage, SlackChannel, TelegramChannel, WhatsAppChannel,
 };
 use crate::config::Config;
 use crate::cron::{
@@ -386,6 +386,19 @@ pub(crate) async fn deliver_announcement(
                 mm.allowed_users.clone(),
                 mm.thread_replies.unwrap_or(true),
                 mm.mention_only.unwrap_or(false),
+            );
+            channel.send(&SendMessage::new(output, target)).await?;
+        }
+        "dingtalk" => {
+            let dt = config
+                .channels_config
+                .dingtalk
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("dingtalk channel not configured"))?;
+            let channel = DingTalkChannel::new(
+                dt.client_id.clone(),
+                dt.client_secret.clone(),
+                dt.allowed_users.clone(),
             );
             channel.send(&SendMessage::new(output, target)).await?;
         }


### PR DESCRIPTION
## Summary
- Problem: PR #1797 is merge-conflicted against current `main` and blocked from update-branch, so CI and policy checks cannot converge.
- Why it matters: DingTalk cron announcements require proactive Open API delivery (OAuth token + send endpoint), which is currently blocked from landing.
- What changed: Replayed the DingTalk Open API delivery change on top of latest `main`, resolved scheduler/import conflicts, and hardened send-path behavior for group routing and API-level error reporting.

Refs RMN-1797
Supersedes #1797

## Validation Evidence (required)
Commands and result summary:
```bash
cargo check --lib
```
- Result: pass on branch `pr-1797-clean-replay`.
- Scope check: only `src/channels/dingtalk.rs` and `src/cron/scheduler.rs` changed.

## Security Impact (required)
- New permissions/capabilities? (`Yes/No`): Yes
- Risk assessment: Enables outbound DingTalk API delivery via OAuth token and robot send APIs.
- Mitigation/controls: token is cached in-memory only; HTTPS APIs; non-2xx and application-level API errors return explicit failures; group/user recipient paths are explicit.

## Privacy and Data Hygiene (required)
- Data-hygiene status (`pass|needs-follow-up`): pass
- Notes: no new persistence or telemetry; only configured DingTalk targets receive announcements.

## Rollback Plan (required)
- Fast rollback command/path: `git revert <merge_commit_sha>`
- Operational rollback: remove `dingtalk` from cron delivery channel usage in config.
