### PR TITLE
fix(observability): propagate metric registration errors in Prometheus observer

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -2670,7 +2670,10 @@ mod tests {
 
     #[tokio::test]
     async fn metrics_endpoint_renders_prometheus_output() {
-        let prom = Arc::new(crate::observability::PrometheusObserver::new());
+        let prom = Arc::new(
+            crate::observability::PrometheusObserver::new()
+                .expect("prometheus observer should initialize in tests"),
+        );
         crate::observability::Observer::record_event(
             prom.as_ref(),
             &crate::observability::ObserverEvent::HeartbeatTick,

--- a/src/observability/prometheus.rs
+++ b/src/observability/prometheus.rs
@@ -1,4 +1,5 @@
 use super::traits::{Observer, ObserverEvent, ObserverMetric};
+use anyhow::Context as _;
 use prometheus::{
     Encoder, GaugeVec, Histogram, HistogramOpts, HistogramVec, IntCounterVec, Registry, TextEncoder,
 };
@@ -29,26 +30,26 @@ pub struct PrometheusObserver {
 }
 
 impl PrometheusObserver {
-    pub fn new() -> Self {
+    pub fn new() -> anyhow::Result<Self> {
         let registry = Registry::new();
 
         let agent_starts = IntCounterVec::new(
             prometheus::Opts::new("zeroclaw_agent_starts_total", "Total agent invocations"),
             &["provider", "model"],
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_agent_starts_total counter")?;
 
         let llm_requests = IntCounterVec::new(
             prometheus::Opts::new("zeroclaw_llm_requests_total", "Total LLM provider requests"),
             &["provider", "model", "success"],
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_llm_requests_total counter")?;
 
         let tokens_input_total = IntCounterVec::new(
             prometheus::Opts::new("zeroclaw_tokens_input_total", "Total input tokens consumed"),
             &["provider", "model"],
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_tokens_input_total counter")?;
 
         let tokens_output_total = IntCounterVec::new(
             prometheus::Opts::new(
@@ -57,29 +58,29 @@ impl PrometheusObserver {
             ),
             &["provider", "model"],
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_tokens_output_total counter")?;
 
         let tool_calls = IntCounterVec::new(
             prometheus::Opts::new("zeroclaw_tool_calls_total", "Total tool calls"),
             &["tool", "success"],
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_tool_calls_total counter")?;
 
         let channel_messages = IntCounterVec::new(
             prometheus::Opts::new("zeroclaw_channel_messages_total", "Total channel messages"),
             &["channel", "direction"],
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_channel_messages_total counter")?;
 
         let heartbeat_ticks =
             prometheus::IntCounter::new("zeroclaw_heartbeat_ticks_total", "Total heartbeat ticks")
-                .expect("valid metric");
+                .context("failed to create zeroclaw_heartbeat_ticks_total counter")?;
 
         let errors = IntCounterVec::new(
             prometheus::Opts::new("zeroclaw_errors_total", "Total errors by component"),
             &["component"],
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_errors_total counter")?;
 
         let agent_duration = HistogramVec::new(
             HistogramOpts::new(
@@ -89,7 +90,7 @@ impl PrometheusObserver {
             .buckets(vec![0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0]),
             &["provider", "model"],
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_agent_duration_seconds histogram")?;
 
         let tool_duration = HistogramVec::new(
             HistogramOpts::new(
@@ -99,7 +100,7 @@ impl PrometheusObserver {
             .buckets(vec![0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0]),
             &["tool"],
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_tool_duration_seconds histogram")?;
 
         let request_latency = Histogram::with_opts(
             HistogramOpts::new(
@@ -108,45 +109,71 @@ impl PrometheusObserver {
             )
             .buckets(vec![0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]),
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_request_latency_seconds histogram")?;
 
         let tokens_used = prometheus::IntGauge::new(
             "zeroclaw_tokens_used_last",
             "Tokens used in the last request",
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_tokens_used_last gauge")?;
 
         let active_sessions = GaugeVec::new(
             prometheus::Opts::new("zeroclaw_active_sessions", "Number of active sessions"),
             &[],
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_active_sessions gauge")?;
 
         let queue_depth = GaugeVec::new(
             prometheus::Opts::new("zeroclaw_queue_depth", "Message queue depth"),
             &[],
         )
-        .expect("valid metric");
+        .context("failed to create zeroclaw_queue_depth gauge")?;
 
         // Register all metrics
-        registry.register(Box::new(agent_starts.clone())).ok();
-        registry.register(Box::new(llm_requests.clone())).ok();
-        registry.register(Box::new(tokens_input_total.clone())).ok();
+        registry
+            .register(Box::new(agent_starts.clone()))
+            .context("failed to register zeroclaw_agent_starts_total counter")?;
+        registry
+            .register(Box::new(llm_requests.clone()))
+            .context("failed to register zeroclaw_llm_requests_total counter")?;
+        registry
+            .register(Box::new(tokens_input_total.clone()))
+            .context("failed to register zeroclaw_tokens_input_total counter")?;
         registry
             .register(Box::new(tokens_output_total.clone()))
-            .ok();
-        registry.register(Box::new(tool_calls.clone())).ok();
-        registry.register(Box::new(channel_messages.clone())).ok();
-        registry.register(Box::new(heartbeat_ticks.clone())).ok();
-        registry.register(Box::new(errors.clone())).ok();
-        registry.register(Box::new(agent_duration.clone())).ok();
-        registry.register(Box::new(tool_duration.clone())).ok();
-        registry.register(Box::new(request_latency.clone())).ok();
-        registry.register(Box::new(tokens_used.clone())).ok();
-        registry.register(Box::new(active_sessions.clone())).ok();
-        registry.register(Box::new(queue_depth.clone())).ok();
+            .context("failed to register zeroclaw_tokens_output_total counter")?;
+        registry
+            .register(Box::new(tool_calls.clone()))
+            .context("failed to register zeroclaw_tool_calls_total counter")?;
+        registry
+            .register(Box::new(channel_messages.clone()))
+            .context("failed to register zeroclaw_channel_messages_total counter")?;
+        registry
+            .register(Box::new(heartbeat_ticks.clone()))
+            .context("failed to register zeroclaw_heartbeat_ticks_total counter")?;
+        registry
+            .register(Box::new(errors.clone()))
+            .context("failed to register zeroclaw_errors_total counter")?;
+        registry
+            .register(Box::new(agent_duration.clone()))
+            .context("failed to register zeroclaw_agent_duration_seconds histogram")?;
+        registry
+            .register(Box::new(tool_duration.clone()))
+            .context("failed to register zeroclaw_tool_duration_seconds histogram")?;
+        registry
+            .register(Box::new(request_latency.clone()))
+            .context("failed to register zeroclaw_request_latency_seconds histogram")?;
+        registry
+            .register(Box::new(tokens_used.clone()))
+            .context("failed to register zeroclaw_tokens_used_last gauge")?;
+        registry
+            .register(Box::new(active_sessions.clone()))
+            .context("failed to register zeroclaw_active_sessions gauge")?;
+        registry
+            .register(Box::new(queue_depth.clone()))
+            .context("failed to register zeroclaw_queue_depth gauge")?;
 
-        Self {
+        Ok(Self {
             registry,
             agent_starts,
             llm_requests,
@@ -162,7 +189,7 @@ impl PrometheusObserver {
             tokens_used,
             active_sessions,
             queue_depth,
-        }
+        })
     }
 
     /// Encode all registered metrics into Prometheus text exposition format.
@@ -289,14 +316,18 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
+    fn test_observer() -> PrometheusObserver {
+        PrometheusObserver::new().expect("prometheus observer should initialize in tests")
+    }
+
     #[test]
     fn prometheus_observer_name() {
-        assert_eq!(PrometheusObserver::new().name(), "prometheus");
+        assert_eq!(test_observer().name(), "prometheus");
     }
 
     #[test]
     fn records_all_events_without_panic() {
-        let obs = PrometheusObserver::new();
+        let obs = test_observer();
         obs.record_event(&ObserverEvent::AgentStart {
             provider: "openrouter".into(),
             model: "claude-sonnet".into(),
@@ -338,7 +369,7 @@ mod tests {
 
     #[test]
     fn records_all_metrics_without_panic() {
-        let obs = PrometheusObserver::new();
+        let obs = test_observer();
         obs.record_metric(&ObserverMetric::RequestLatency(Duration::from_secs(2)));
         obs.record_metric(&ObserverMetric::TokensUsed(500));
         obs.record_metric(&ObserverMetric::TokensUsed(0));
@@ -348,7 +379,7 @@ mod tests {
 
     #[test]
     fn encode_produces_prometheus_text_format() {
-        let obs = PrometheusObserver::new();
+        let obs = test_observer();
         obs.record_event(&ObserverEvent::AgentStart {
             provider: "openrouter".into(),
             model: "claude-sonnet".into(),
@@ -370,7 +401,7 @@ mod tests {
 
     #[test]
     fn counters_increment_correctly() {
-        let obs = PrometheusObserver::new();
+        let obs = test_observer();
 
         for _ in 0..3 {
             obs.record_event(&ObserverEvent::HeartbeatTick);
@@ -382,7 +413,7 @@ mod tests {
 
     #[test]
     fn tool_calls_track_success_and_failure_separately() {
-        let obs = PrometheusObserver::new();
+        let obs = test_observer();
 
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
@@ -407,7 +438,7 @@ mod tests {
 
     #[test]
     fn errors_track_by_component() {
-        let obs = PrometheusObserver::new();
+        let obs = test_observer();
         obs.record_event(&ObserverEvent::Error {
             component: "provider".into(),
             message: "timeout".into(),
@@ -428,7 +459,7 @@ mod tests {
 
     #[test]
     fn gauge_reflects_latest_value() {
-        let obs = PrometheusObserver::new();
+        let obs = test_observer();
         obs.record_metric(&ObserverMetric::TokensUsed(100));
         obs.record_metric(&ObserverMetric::TokensUsed(200));
 
@@ -438,7 +469,7 @@ mod tests {
 
     #[test]
     fn llm_response_tracks_request_count_and_tokens() {
-        let obs = PrometheusObserver::new();
+        let obs = test_observer();
 
         obs.record_event(&ObserverEvent::LlmResponse {
             provider: "openrouter".into(),
@@ -473,7 +504,7 @@ mod tests {
 
     #[test]
     fn llm_response_without_tokens_increments_request_only() {
-        let obs = PrometheusObserver::new();
+        let obs = test_observer();
 
         obs.record_event(&ObserverEvent::LlmResponse {
             provider: "ollama".into(),


### PR DESCRIPTION
## Summary
- make `PrometheusObserver::new()` return `anyhow::Result<Self>` and propagate metric construction failures with context
- propagate all `Registry::register` failures instead of swallowing them with `.ok()`
- update observability factory to fall back to `NoopObserver` when Prometheus initialization fails, with explicit logging
- update gateway and Prometheus tests for the new `Result` constructor

## Validation
- `cargo test prometheus_observer_name`
- `cargo test metrics_endpoint_renders_prometheus_output`

Supersedes #1849 (stale/conflicting branch after retarget to `main`).
