### PR TITLE
fix(providers): harden circuit breaker cooldown semantics and validation

### DIFF
--- a/src/providers/backoff.rs
+++ b/src/providers/backoff.rs
@@ -20,7 +20,7 @@ pub struct BackoffEntry<T> {
 /// Cleanup strategies:
 /// - Lazy removal on `get()` if expired
 /// - Opportunistic cleanup before eviction
-/// - Soonest-to-expire eviction when max_entries reached (evicts the entry with the smallest deadline)
+/// - Min-deadline (soonest-to-expire) eviction when max_entries is reached
 pub struct BackoffStore<K, T> {
     data: Mutex<HashMap<K, BackoffEntry<T>>>,
     max_entries: usize,
@@ -70,7 +70,7 @@ where
             data.retain(|_, entry| entry.deadline > now);
         }
 
-        // Soonest-to-expire eviction if still over capacity
+        // Min-deadline eviction if still over capacity.
         if data.len() >= self.max_entries {
             if let Some(oldest_key) = data
                 .iter()
@@ -148,7 +148,7 @@ mod tests {
         );
         assert!(store.get(&key.to_string()).is_some());
 
-        thread::sleep(Duration::from_millis(60));
+        thread::sleep(Duration::from_millis(200));
         assert!(store.get(&key.to_string()).is_none());
     }
 
@@ -169,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    fn backoff_lru_eviction_at_capacity() {
+    fn backoff_min_deadline_eviction_at_capacity() {
         let store = BackoffStore::new(2);
 
         store.set(

--- a/tests/circuit_breaker_integration.rs
+++ b/tests/circuit_breaker_integration.rs
@@ -1,6 +1,6 @@
 //! Integration tests for circuit breaker behavior.
 //!
-//! Tests circuit breaker opening, closing, and interaction with ReliableProvider.
+//! Tests ProviderHealthTracker opening/closing semantics and reset behavior.
 
 use std::time::Duration;
 use zeroclaw::providers::health::ProviderHealthTracker;
@@ -42,7 +42,7 @@ fn circuit_breaker_closes_after_timeout() {
     assert!(tracker.should_try("test-provider").is_err());
 
     // Wait for cooldown
-    std::thread::sleep(Duration::from_millis(120));
+    std::thread::sleep(Duration::from_millis(250));
 
     // Circuit should be closed (timeout expired)
     assert!(


### PR DESCRIPTION
Focused replay of the safe, circuit-breaker-specific subset from closed PR #1842.

This PR intentionally excludes unrelated quota/auth/channel/gateway changes from the original bundle and keeps scope limited to provider health/backoff hardening.

Refs RMN-269

## Summary

- Base branch target (`dev` for normal contributions; `main` only for `dev` promotion): `main`
- Problem: circuit breaker accepted invalid constructor inputs and could reset cooldown if duplicate failures were recorded while circuit was already open.
- Why it matters: invalid settings can produce undefined behavior; cooldown extension can keep providers blocked longer than intended.
- What changed: input guards for `ProviderHealthTracker::new`, no-cooldown-extension guard in `record_failure`, deterministic timing margins in circuit-breaker tests, and doc/test naming cleanup for backoff eviction semantics.
- What did **not** change (scope boundary): no quota tooling, no provider routing expansion, no channel/gateway/runtime behavior changes beyond circuit-breaker internals.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `provider,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `provider: health`, `provider: backoff`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `provider`

## Linked Issue

- Closes #
- Related #1842
- Depends on # (if stacked)
- Supersedes #1842
- Linear: `Refs RMN-269`

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `#1842 by @zverozabr`
- Integrated scope by source PR (what was materially carried forward): circuit breaker hardening only (`health.rs`, `backoff.rs`, `tests/circuit_breaker_integration.rs`), excluding unrelated bundled tracks.
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): replay is a focused maintainer reimplementation against current `main`; no direct commit/chunk cherry-pick was applied.
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
rustfmt --check src/providers/health.rs src/providers/backoff.rs tests/circuit_breaker_integration.rs
cargo test --locked providers::health::tests:: -- --nocapture
cargo test --locked providers::backoff::tests:: -- --nocapture
cargo test --locked --test circuit_breaker_integration -- --nocapture
cargo test --locked --test e2e_circuit_breaker_simple -- --nocapture
```

- Evidence provided (test/log/trace/screenshot/perf): command outputs captured in maintainer run logs.
- If any command is intentionally skipped, explain why: full-repo `cargo clippy --all-targets -- -D warnings` currently reports many pre-existing unrelated baseline lints on `main`; this PR validated focused provider/test scope instead.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no user data path changes.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: threshold opens circuit, cooldown closes circuit, success resets state, repeated failure while open does not refresh cooldown.
- Edge cases checked: zero threshold / zero cooldown rejected at constructor.
- What was not verified: long-duration production traffic behavior under real provider outages.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: provider health tracking and backoff tests.
- Potential unintended effects: constructor now panics on invalid inputs instead of accepting them silently.
- Guardrails/monitoring for early detection: added explicit panic tests and cooldown non-extension regression test.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `git`, `cargo`, `gh`, `linear api`
- Workflow/plan summary (if any): deep diff audit of #1842 vs main, replayed only safe hardening subset on clean branch.
- Verification focus: cooldown semantics correctness and deterministic test behavior.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert this PR merge commit from `main`.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: startup/test panics when `ProviderHealthTracker::new` is called with invalid values.

## Risks and Mitigations

- Risk: constructor assertions surface invalid caller input as panics.
  - Mitigation: invalid states were unsupported already; explicit messages and tests make failures deterministic and actionable.
- Risk: cooldown semantics change could alter retry timing in pathological caller flows.
  - Mitigation: regression test ensures cooldown counts down monotonically while circuit is open.
