### PR TITLE
fix(telegram): deduplicate attachment markers in single reply

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -432,7 +432,13 @@ fn parse_attachment_markers(message: &str) -> (String, Vec<TelegramAttachment>) 
         });
 
         if let Some(attachment) = parsed {
-            attachments.push(attachment);
+            // Skip duplicate targets — LLMs sometimes emit repeated markers in one reply.
+            if !attachments
+                .iter()
+                .any(|a: &TelegramAttachment| a.target == attachment.target)
+            {
+                attachments.push(attachment);
+            }
         } else {
             cleaned.push_str(&message[open..=close]);
         }
@@ -3766,6 +3772,17 @@ mod tests {
         assert_eq!(attachments[0].target, "/tmp/a.png");
         assert_eq!(attachments[1].kind, TelegramAttachmentKind::Document);
         assert_eq!(attachments[1].target, "https://example.com/a.pdf");
+    }
+
+    #[test]
+    fn parse_attachment_markers_deduplicates_duplicate_targets() {
+        let message = "twice [IMAGE:/tmp/a.png] then again [IMAGE:/tmp/a.png] end";
+        let (cleaned, attachments) = parse_attachment_markers(message);
+
+        assert_eq!(cleaned, "twice  then again  end");
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(attachments[0].kind, TelegramAttachmentKind::Image);
+        assert_eq!(attachments[0].target, "/tmp/a.png");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- deduplicate repeated attachment markers in `parse_attachment_markers` so identical targets are sent once
- add regression coverage for duplicate `[IMAGE:/path]` marker handling

## Notes
- Supersedes #1841 due fork push identity-guard restrictions that prevented safe head refresh.
- Local test execution in this environment hit disk exhaustion (`No space left on device` in `/tmp`), so CI should be treated as source of truth for full validation.
