### PR TITLE
refactor(tools): extract initialize request builder to helper method

### DIFF
--- a/src/tools/mcp_client.rs
+++ b/src/tools/mcp_client.rs
@@ -56,20 +56,7 @@ impl McpServer {
         })?;
 
         // Initialize handshake
-        let id = 1u64;
-        let init_req = JsonRpcRequest::new(
-            id,
-            "initialize",
-            json!({
-                "protocolVersion": MCP_PROTOCOL_VERSION,
-                "capabilities": {},
-                "clientInfo": {
-                    "name": "zeroclaw",
-                    "version": env!("CARGO_PKG_VERSION")
-                }
-            }),
-        );
-
+        let init_req = JsonRpcRequest::initialize();
         let init_resp = timeout(
             Duration::from_secs(RECV_TIMEOUT_SECS),
             transport.send_and_recv(&init_req),

--- a/src/tools/mcp_protocol.rs
+++ b/src/tools/mcp_protocol.rs
@@ -5,6 +5,7 @@
 //! and receives (Deserialize) JSON-RPC messages.
 
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 
 pub const JSONRPC_VERSION: &str = "2.0";
 pub const MCP_PROTOCOL_VERSION: &str = "2024-11-05";
@@ -37,6 +38,21 @@ impl JsonRpcRequest {
             method: method.into(),
             params: Some(params),
         }
+    }
+
+    pub fn initialize() -> Self {
+        Self::new(
+            1u64,
+            "initialize",
+            json!({
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "zeroclaw",
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            }),
+        )
     }
 
     /// Create a notification — no id, no response expected from server.


### PR DESCRIPTION
## Summary
- Extract the MCP initialize request creation logic into a dedicated `JsonRpcRequest::initialize()` helper method
- Reduces code duplication and improves maintainability in the MCP client initialization flow

## Changes
- Add `JsonRpcRequest::initialize()` method in `src/tools/mcp_protocol.rs`
- Use the new helper in `src/tools/mcp_client.rs` instead of inline request construction

## Non-goals
- No functional behavior changes
- No protocol or API changes

## Risk and Rollback
- Risk: Low - simple refactor with no behavioral changes
- Rollback: Revert commit if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal initialization logic reorganized into a reusable helper to simplify request construction.
  * No user-visible behavior changes; startup and communication flows remain unchanged.
  * Improvements reduce code duplication and make future maintenance easier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- intake-refresh: 2026-03-01T14:00:46Z -->
