### PR TITLE
fix(bootstrap): handle unreadable /dev/stdin in guided installer

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -423,8 +423,15 @@ string_to_bool() {
 }
 
 guided_input_stream() {
-  if [[ -t 0 ]]; then
+  # Some constrained Linux containers report interactive stdin but deny opening
+  # /dev/stdin directly. Probe readability before selecting it.
+  if [[ -t 0 ]] && (: </dev/stdin) 2>/dev/null; then
     echo "/dev/stdin"
+    return 0
+  fi
+
+  if [[ -t 0 ]] && (: </proc/self/fd/0) 2>/dev/null; then
+    echo "/proc/self/fd/0"
     return 0
   fi
 


### PR DESCRIPTION
## Summary

- Base branch target (`main` or `dev`; direct `main` PRs are allowed): `main`
- Problem: guided bootstrap input selected `/dev/stdin` whenever stdin looked interactive, which can fail in constrained containers (Debian 13 Proxmox LXC) with `Permission denied`.
- Why it matters: installer flow aborts before users can complete onboarding, blocking first-time setup.
- What changed: hardened `guided_input_stream` in `scripts/bootstrap.sh` to probe readability before selecting `/dev/stdin`, added fallback to `/proc/self/fd/0`, and retained `/dev/tty` fallback.
- What did **not** change (scope boundary): no package/dependency install behavior changes, no onboarding logic changes beyond input-source selection.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `scripts`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `scripts: bootstrap`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `distinguished contributor`
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #2301
- Related #N/A
- Depends on #N/A
- Supersedes #N/A
- Linear issue key(s) (required, e.g. `RMN-123`): `Resolves RMN-272`
- Linear issue URL(s): https://linear.app/zeroclawlabs/issue/RMN-272/bug-bootstrap-guided-installer-fails-on-debian-13-proxmox-lxc-devstdin

## Validation Evidence (required)

Commands and result summary:

```bash
bash -n scripts/bootstrap.sh
bash -n bootstrap.sh
```

- Evidence provided (test/log/trace/screenshot/perf): syntax validation passed for installer entrypoints.
- If any command is intentionally skipped, explain why: Rust/Cargo checks skipped because this change only touches shell installer script behavior.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: no sensitive/user data added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: script parsing validity for both wrapper and installer entrypoint.
- Edge cases checked: fallback probing order now handles unreadable `/dev/stdin` before failing.
- What was not verified: live interactive run on Debian 13 Proxmox LXC environment.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: guided installer prompt input source selection.
- Potential unintended effects: minimal; one additional candidate path (`/proc/self/fd/0`) in constrained Linux envs.
- Guardrails/monitoring for early detection: installer CI + user-reported guided install behavior.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `gh`, local shell diagnostics, targeted script validation.
- Workflow/plan summary (if any): issue-scoped worktree, root-cause patch, syntax validation, linked Linear issue.
- Verification focus: prevent guided input aborts when `/dev/stdin` exists but is unreadable.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: `git revert fae7b40c`
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: guided installer reverts to prior `/dev/stdin` permission failure pattern in constrained containers.

## Risks and Mitigations

- Risk: alternate stdin probe path behaves differently across shells/containers.
- Mitigation: probes are non-fatal and preserve existing `/dev/tty` fallback; no behavior change for normal interactive terminals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interactive input stream detection to support additional terminal configurations. The bootstrap script now checks multiple input sources to ensure compatibility across different system setups, with a fallback mechanism to maintain existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->