### PR TITLE
feat(skills): add trusted symlink roots for workspace skills

### DIFF
--- a/docs/commands-reference.md
+++ b/docs/commands-reference.md
@@ -264,6 +264,11 @@ Registry packages are installed to `~/.zeroclaw/workspace/skills/<name>/`.
 
 Use `skills audit` to manually validate a candidate skill directory (or an installed skill by name) before sharing it.
 
+Workspace symlink policy:
+- Symlinked entries under `~/.zeroclaw/workspace/skills/` are blocked by default.
+- To allow shared local skill directories, set `[skills].trusted_skill_roots` in `config.toml`.
+- A symlinked skill is accepted only when its resolved canonical target is inside one of the trusted roots.
+
 Skill manifests (`SKILL.toml`) support `prompts` and `[[tools]]`; both are injected into the agent system prompt at runtime, so the model can follow skill instructions without manually reading skill files.
 
 ### `migrate`

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -536,6 +536,7 @@ Notes:
 |---|---|---|
 | `open_skills_enabled` | `false` | Opt-in loading/sync of community `open-skills` repository |
 | `open_skills_dir` | unset | Optional local path for `open-skills` (defaults to `$HOME/open-skills` when enabled) |
+| `trusted_skill_roots` | `[]` | Allowlist of directory roots for symlink targets in `workspace/skills/*` |
 | `prompt_injection_mode` | `full` | Skill prompt verbosity: `full` (inline instructions/tools) or `compact` (name/description/location only) |
 | `clawhub_token` | unset | Optional Bearer token for authenticated ClawhHub skill downloads |
 
@@ -548,7 +549,8 @@ Notes:
   - `ZEROCLAW_SKILLS_PROMPT_MODE` accepts `full` or `compact`.
 - Precedence for enable flag: `ZEROCLAW_OPEN_SKILLS_ENABLED` → `skills.open_skills_enabled` in `config.toml` → default `false`.
 - `prompt_injection_mode = "compact"` is recommended on low-context local models to reduce startup prompt size while keeping skill files available on demand.
-- Skill loading and `zeroclaw skills install` both apply a static security audit. Skills that contain symlinks, script-like files, high-risk shell payload snippets, or unsafe markdown link traversal are rejected.
+- Symlinked workspace skills are blocked by default. Set `trusted_skill_roots` to allow local shared-skill directories after explicit trust review.
+- `zeroclaw skills install` and `zeroclaw skills audit` apply a static security audit. Skills that contain script-like files, high-risk shell payload snippets, or unsafe markdown link traversal are rejected.
 - `clawhub_token` is sent as `Authorization: Bearer <token>` when downloading from ClawhHub. Obtain a token from [https://clawhub.ai](https://clawhub.ai) after signing in. Required if the API returns 429 (rate-limited) or 401 (unauthorized) for anonymous requests.
 
 **ClawhHub token example:**

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1026,6 +1026,11 @@ pub struct SkillsConfig {
     /// If unset, defaults to `$HOME/open-skills` when enabled.
     #[serde(default)]
     pub open_skills_dir: Option<String>,
+    /// Optional allowlist of canonical directory roots for workspace skill symlink targets.
+    /// Symlinked workspace skills are rejected unless their resolved targets are under one
+    /// of these roots. Accepts absolute paths and `~/` home-relative paths.
+    #[serde(default)]
+    pub trusted_skill_roots: Vec<String>,
     /// Allow script-like files in skills (`.sh`, `.bash`, `.ps1`, shebang shell files).
     /// Default: `false` (secure by default).
     #[serde(default)]

--- a/src/skills/symlink_tests.rs
+++ b/src/skills/symlink_tests.rs
@@ -1,6 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use crate::skills::skills_dir;
+    use crate::config::Config;
+    use crate::skills::{handle_command, load_skills_with_config, skills_dir};
+    use crate::SkillCommands;
     use std::path::Path;
     use tempfile::TempDir;
 
@@ -83,7 +85,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_skills_symlink_permissions_and_safety() {
+    async fn test_workspace_symlink_loading_requires_trusted_roots() {
         let tmp = TempDir::new().unwrap();
         let workspace_dir = tmp.path().join("workspace");
         tokio::fs::create_dir_all(&workspace_dir).await.unwrap();
@@ -93,7 +95,6 @@ mod tests {
 
         #[cfg(unix)]
         {
-            // Test case: Symlink outside workspace should be allowed (user responsibility)
             let outside_dir = tmp.path().join("outside_skill");
             tokio::fs::create_dir_all(&outside_dir).await.unwrap();
             tokio::fs::write(outside_dir.join("SKILL.md"), "# Outside Skill\nContent")
@@ -102,15 +103,74 @@ mod tests {
 
             let dest_link = skills_path.join("outside_skill");
             let result = std::os::unix::fs::symlink(&outside_dir, &dest_link);
+            assert!(result.is_ok(), "symlink creation should succeed on unix");
+
+            let mut config = Config::default();
+            config.workspace_dir = workspace_dir.clone();
+            config.config_path = workspace_dir.join("config.toml");
+
+            let blocked = load_skills_with_config(&workspace_dir, &config);
             assert!(
-                result.is_ok(),
-                "Should allow symlinking to directories outside workspace"
+                blocked.is_empty(),
+                "symlinked skill should be rejected when trusted_skill_roots is empty"
             );
 
-            // Should still be readable
-            let content = tokio::fs::read_to_string(dest_link.join("SKILL.md")).await;
-            assert!(content.is_ok());
-            assert!(content.unwrap().contains("Outside Skill"));
+            config.skills.trusted_skill_roots = vec![tmp.path().display().to_string()];
+            let allowed = load_skills_with_config(&workspace_dir, &config);
+            assert_eq!(
+                allowed.len(),
+                1,
+                "symlinked skill should load when target is inside trusted roots"
+            );
+            assert_eq!(allowed[0].name, "outside_skill");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_skills_audit_respects_trusted_symlink_roots() {
+        let tmp = TempDir::new().unwrap();
+        let workspace_dir = tmp.path().join("workspace");
+        tokio::fs::create_dir_all(&workspace_dir).await.unwrap();
+
+        let skills_path = skills_dir(&workspace_dir);
+        tokio::fs::create_dir_all(&skills_path).await.unwrap();
+
+        #[cfg(unix)]
+        {
+            let outside_dir = tmp.path().join("outside_skill");
+            tokio::fs::create_dir_all(&outside_dir).await.unwrap();
+            tokio::fs::write(outside_dir.join("SKILL.md"), "# Outside Skill\nContent")
+                .await
+                .unwrap();
+            let link_path = skills_path.join("outside_skill");
+            std::os::unix::fs::symlink(&outside_dir, &link_path).unwrap();
+
+            let mut config = Config::default();
+            config.workspace_dir = workspace_dir.clone();
+            config.config_path = workspace_dir.join("config.toml");
+
+            let blocked = handle_command(
+                SkillCommands::Audit {
+                    source: "outside_skill".to_string(),
+                },
+                &config,
+            );
+            assert!(
+                blocked.is_err(),
+                "audit should reject symlink target when trusted roots are not configured"
+            );
+
+            config.skills.trusted_skill_roots = vec![tmp.path().display().to_string()];
+            let allowed = handle_command(
+                SkillCommands::Audit {
+                    source: "outside_skill".to_string(),
+                },
+                &config,
+            );
+            assert!(
+                allowed.is_ok(),
+                "audit should pass when symlink target is inside a trusted root"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- Problem: Workspace skill symlink targets had no explicit trust-root allowlist, so shared-symlink use cases could not be enabled safely.
- Why it matters: Without policy-backed trust roots, symlinked workspace skills are either unsafe (if broadly allowed) or unusable (if broadly blocked).
- What changed: Added `[skills].trusted_skill_roots`, enforced default-deny trust checks for workspace symlinked skills and `skills audit`, added regression tests, and documented policy in reference docs.
- Linear: RMN-276

## Validation Evidence (required)
Commands and result summary:
```bash
cargo check -q -p zeroclaw --lib
cargo test -q -p zeroclaw test_workspace_symlink_loading_requires_trusted_roots -- --nocapture
cargo test -q -p zeroclaw test_skills_symlink_unix_edge_cases -- --nocapture
cargo test -q -p zeroclaw test_skills_audit_respects_trusted_symlink_roots -- --nocapture
```
All commands passed locally in the issue worktree.

## Security Impact (required)
- New permissions/capabilities? (`Yes/No`): No
- Risk level: Low-to-medium behavior change in workspace skill loading for symlink entries only.
- Mitigation: Default-deny policy; requires explicit trusted root configuration; canonical path boundary checks.

## Privacy and Data Hygiene (required)
- Data-hygiene status (`pass|needs-follow-up`): pass
- Notes: No new telemetry or external data sinks; change is local filesystem policy enforcement only.

## Rollback Plan (required)
- Fast rollback command/path: revert commit `635fb287` (or disable by reverting this PR) to restore previous symlink behavior.
- Operational rollback: remove `trusted_skill_roots` config usage and redeploy previous binary.

Closes #2285
