### PR TITLE
fix(ci): reduce Actions queue saturation on self-hosted lanes

### DIFF
--- a/.github/workflows/ci-queue-hygiene.yml
+++ b/.github/workflows/ci-queue-hygiene.yml
@@ -8,7 +8,7 @@ on:
             apply:
                 description: "Cancel selected queued runs (false = dry-run report only)"
                 required: true
-                default: true
+                default: false
                 type: boolean
             status:
                 description: "Queued-run status scope"
@@ -57,22 +57,27 @@ jobs:
 
                   status_scope="queued"
                   max_cancel="120"
-                  apply_mode="true"
+                  apply_mode="false"
                   if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
                     status_scope="${{ github.event.inputs.status || 'queued' }}"
                     max_cancel="${{ github.event.inputs.max_cancel || '120' }}"
-                    apply_mode="${{ github.event.inputs.apply || 'true' }}"
+                    apply_mode="${{ github.event.inputs.apply || 'false' }}"
                   fi
 
                   cmd=(python3 scripts/ci/queue_hygiene.py
                     --repo "${{ github.repository }}"
                     --status "${status_scope}"
                     --max-cancel "${max_cancel}"
+                    --dedupe-workflow "CI Run"
+                    --dedupe-workflow "Test E2E"
+                    --dedupe-workflow "Docs Deploy"
                     --dedupe-workflow "PR Intake Checks"
                     --dedupe-workflow "PR Labeler"
                     --dedupe-workflow "PR Auto Responder"
                     --dedupe-workflow "Workflow Sanity"
                     --dedupe-workflow "PR Label Policy Check"
+                    --dedupe-include-non-pr
+                    --non-pr-key branch
                     --output-json artifacts/queue-hygiene-report.json
                     --verbose)
 

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -9,7 +9,7 @@ on:
         branches: [dev, main]
 
 concurrency:
-    group: ci-${{ github.event.pull_request.number || github.sha }}
+    group: ci-run-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name || github.sha }}
     cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -41,7 +41,7 @@ on:
                 default: ""
 
 concurrency:
-    group: docs-deploy-${{ github.event.pull_request.number || github.sha }}
+    group: docs-deploy-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name || github.sha }}
     cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -14,7 +14,7 @@ on:
     workflow_dispatch:
 
 concurrency:
-    group: e2e-${{ github.event.pull_request.number || github.sha }}
+    group: test-e2e-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name || github.sha }}
     cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Closes #2299
Refs RMN-268

## Summary
Phase-0 queue pressure reduction for heavy lanes plus safer queue-hygiene defaults.

## Root Cause
- Heavy workflows (`CI Run`, `Test E2E`, `Docs Deploy`) used concurrency groups keyed to `github.sha` on push lanes, so each new commit created an independent in-flight run instead of superseding stale branch runs.
- `CI Queue Hygiene` schedule path defaulted to apply-mode cancellations, and policy focus was mostly lightweight PR workflows.
- Queue hygiene supported non-PR dedupe, but there was no branch-level policy control to supersede stale non-PR runs safely.

## Changes
- Updated concurrency groups to branch/event-scoped supersedence for heavy workflows:
  - `.github/workflows/ci-run.yml`
  - `.github/workflows/test-e2e.yml`
  - `.github/workflows/docs-deploy.yml`
- Hardened queue hygiene workflow defaults:
  - `.github/workflows/ci-queue-hygiene.yml`
  - schedule now defaults to dry-run (`apply_mode=false`)
  - manual dispatch remains able to opt into `--apply`
  - added heavy-lane dedupe targets: `CI Run`, `Test E2E`, `Docs Deploy`
  - enabled non-PR dedupe with branch-level keying
- Extended queue hygiene script policy controls:
  - `scripts/ci/queue_hygiene.py`
  - new `--non-pr-key {sha,branch}` (default `sha`)
  - branch-level supersedence available when `--dedupe-include-non-pr` is used
- Added regression tests for non-PR dedupe modes:
  - `scripts/ci/tests/test_ci_scripts.py`

## Validation
- `python3 -m unittest -v scripts.ci.tests.test_ci_scripts.CiScriptsBehaviorTest.test_queue_hygiene_dry_run_selects_obsolete_and_superseded_runs scripts.ci.tests.test_ci_scripts.CiScriptsBehaviorTest.test_queue_hygiene_respects_max_cancel_cap scripts.ci.tests.test_ci_scripts.CiScriptsBehaviorTest.test_queue_hygiene_non_pr_branch_mode_dedupes_push_runs scripts.ci.tests.test_ci_scripts.CiScriptsBehaviorTest.test_queue_hygiene_non_pr_sha_mode_keeps_distinct_push_commits`
- Parsed modified workflow YAML files via `python3` + `yaml.safe_load` to ensure syntax validity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub Actions workflow concurrency handling to better manage concurrent runs across different event types and branches.
  * Enhanced CI queue deduplication with flexible options for handling non-PR runs, supporting both commit-based and branch-based deduplication strategies.

* **Tests**
  * Added tests for non-PR run deduplication behavior under different configuration modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->