### PR TITLE
feat(onboard): add hybrid sqlite+qdrant option to interactive memory setup

### DIFF
--- a/src/memory/backend.rs
+++ b/src/memory/backend.rs
@@ -103,8 +103,9 @@ const CUSTOM_PROFILE: MemoryBackendProfile = MemoryBackendProfile {
     optional_dependency: false,
 };
 
-const SELECTABLE_MEMORY_BACKENDS: [MemoryBackendProfile; 5] = [
+const SELECTABLE_MEMORY_BACKENDS: [MemoryBackendProfile; 6] = [
     SQLITE_PROFILE,
+    SQLITE_QDRANT_HYBRID_PROFILE,
     LUCID_PROFILE,
     CORTEX_MEM_PROFILE,
     MARKDOWN_PROFILE,
@@ -194,12 +195,13 @@ mod tests {
     #[test]
     fn selectable_backends_are_ordered_for_onboarding() {
         let backends = selectable_memory_backends();
-        assert_eq!(backends.len(), 5);
+        assert_eq!(backends.len(), 6);
         assert_eq!(backends[0].key, "sqlite");
-        assert_eq!(backends[1].key, "lucid");
-        assert_eq!(backends[2].key, "cortex-mem");
-        assert_eq!(backends[3].key, "markdown");
-        assert_eq!(backends[4].key, "none");
+        assert_eq!(backends[1].key, "sqlite_qdrant_hybrid");
+        assert_eq!(backends[2].key, "lucid");
+        assert_eq!(backends[3].key, "cortex-mem");
+        assert_eq!(backends[4].key, "markdown");
+        assert_eq!(backends[5].key, "none");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target (`main` or `dev`; direct `main` PRs are allowed): `main`
- Problem: interactive onboarding did not expose the `sqlite_qdrant_hybrid` memory backend, forcing manual config edits.
- Why it matters: hybrid memory is a supported backend and manual post-onboarding edits increase setup friction and config mistakes.
- What changed: added hybrid backend to selectable onboarding memory options and introduced conditional Qdrant prompts (URL required, collection optional/defaulted, API key optional) when hybrid is chosen.
- What did **not** change (scope boundary): no runtime memory engine changes, no active Qdrant network validation during onboarding, no migration tooling changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `onboard,memory,config,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `onboard: wizard`, `memory: backend`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `distinguished contributor`
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `memory`

## Linked Issue

- Closes #2314
- Related #N/A
- Depends on #N/A
- Supersedes #N/A
- Linear issue key(s) (required, e.g. `RMN-123`): `Resolves RMN-273`
- Linear issue URL(s): https://linear.app/zeroclawlabs/issue/RMN-273/feature-expose-sqlite-qdrant-hybrid-in-interactive-onboarding-wizard

## Validation Evidence (required)

Commands and result summary:

```bash
cargo test --lib selectable_backends_are_ordered_for_onboarding -- --nocapture
cargo test --lib backend_key_from_choice_maps_supported_backends -- --nocapture
cargo test --lib memory_config_defaults_for_hybrid_enable_sqlite_hygiene -- --nocapture
```

- Evidence provided (test/log/trace/screenshot/perf): all three targeted tests passed.
- If any command is intentionally skipped, explain why: full repo `cargo fmt --check` is currently noisy from unrelated pre-existing formatting drift in untouched files; this PR was rustfmt'd on changed files and validated with focused tests.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: no user data, secrets, or telemetry payload changes.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: hybrid backend now appears in onboarding memory menu and maps to `sqlite_qdrant_hybrid`; defaults retain SQLite hygiene settings; Qdrant defaults remain consistent.
- Edge cases checked: fallback choice mapping still defaults to sqlite for out-of-range selection.
- What was not verified: full interactive terminal e2e run with manual prompt entry.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: onboarding memory selection and generated memory config for hybrid setup.
- Potential unintended effects: minimal prompt UX changes only when selecting hybrid backend.
- Guardrails/monitoring for early detection: onboarding unit tests for backend ordering/mapping/defaults.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `gh`, local Rust test runs, issue-scoped worktree flow.
- Workflow/plan summary (if any): issue isolation, backend list update, conditional prompt implementation, targeted tests, linked Linear tracking.
- Verification focus: ensure hybrid backend is selectable and onboarding collects required Qdrant config safely.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 5463a7e9`
- Feature flags or config toggles (if any): choose another memory backend in onboarding or set `[memory].backend` manually.
- Observable failure symptoms: hybrid option absent again from onboarding memory backend menu.

## Risks and Mitigations

- Risk: onboarding menu index shifts could break selection mapping.
- Mitigation: added/updated backend mapping tests and selectable-backend order test coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new SQLite-Qdrant hybrid memory backend option, expanding available memory storage configurations.
  * During memory setup, users can now configure Qdrant-specific parameters including the connection URL, collection name, and optional authentication API key when selecting the hybrid backend option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->