### PR TITLE
fix(docs): reference canonical install docs from README/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Built by students and members of the Harvard, MIT, and Sundai.Club communities.
 
 <p align="center">
   <a href="#quick-start">Getting Started</a> |
-  <a href="bootstrap.sh">One-Click Setup</a> |
+  <a href="docs/one-click-bootstrap.md">One-Click Setup</a> |
   <a href="docs/README.md">Docs Hub</a> |
   <a href="docs/SUMMARY.md">Docs TOC</a>
 </p>
@@ -119,6 +119,16 @@ zeroclaw chat "Hello!"
 ```
 
 For detailed setup options, see [docs/one-click-bootstrap.md](docs/one-click-bootstrap.md).
+
+### Installation Docs (Canonical Source)
+
+Use repository docs as the source of truth for install/setup instructions:
+
+- [README Quick Start](#quick-start)
+- [docs/one-click-bootstrap.md](docs/one-click-bootstrap.md)
+- [docs/getting-started/README.md](docs/getting-started/README.md)
+
+Issue comments can provide context, but they are not canonical installation documentation.
 
 ## Benchmark Snapshot (ZeroClaw vs OpenClaw, Reproducible)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,8 @@ Localized hubs: [简体中文](i18n/zh-CN/README.md) · [日本語](i18n/ja/READ
 | See project PR/issue docs snapshot | [project-triage-snapshot-2026-02-18.md](project-triage-snapshot-2026-02-18.md) |
 | Perform i18n completion for docs changes | [i18n-guide.md](i18n-guide.md) |
 
+Installation source-of-truth: keep install/run instructions in repository docs and README pages; issue comments are supplemental context only.
+
 ## Quick Decision Tree (10 seconds)
 
 - Need first-time setup or install? → [getting-started/README.md](getting-started/README.md)


### PR DESCRIPTION
## Summary
- Problem: The root README routed "One-Click Setup" to the raw `bootstrap.sh` path, and install-source-of-truth expectations were not explicit across README/docs hub.
- Why it matters: New users should land on canonical install documentation in-repo, not rely on issue comments or script source files for onboarding guidance.
- What changed: Repointed the README top-route link to `docs/one-click-bootstrap.md`, added a canonical install-docs section in root README, and added a matching source-of-truth statement in `docs/README.md`.
- Linear: RMN-277

## Validation Evidence (required)
Commands and result summary:
```bash
DOCS_FILES=$'README.md\ndocs/README.md' BASE_SHA=$(git merge-base origin/main HEAD) ./scripts/ci/docs_quality_gate.sh
python3 scripts/ci/collect_changed_links.py --base $(git merge-base origin/main HEAD) --docs-files $'README.md\ndocs/README.md' --output /tmp/issue2283_changed_links.txt
```
Result: docs quality gate passed for changed lines; changed-link collector found 0 new external links.

## Security Impact (required)
- New permissions/capabilities? (`Yes/No`): No
- Risk level: Low (docs/link routing only).
- Mitigation: Changes are documentation-only and preserve existing install command paths.

## Privacy and Data Hygiene (required)
- Data-hygiene status (`pass|needs-follow-up`): pass
- Notes: No data collection, no secret handling, no new external endpoints.

## Rollback Plan (required)
- Fast rollback command/path: revert commit `d52d1e93` to restore prior README/docs wording.
- Operational rollback: none required beyond normal doc rollback.

Closes #2283
