### PR TITLE
fix(channels): restore Feishu usability in default Docker builds [CDV-2325]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM rust:1.93-slim@sha256:7e6fa79cf81be23fd45d857f75f583d80cfdbb11c91fa06180fd7
 
 WORKDIR /app
 ARG ZEROCLAW_CARGO_FEATURES=""
+ARG ZEROCLAW_DEFAULT_CARGO_FEATURES="channel-lark"
 
 # Install build dependencies
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -24,8 +25,12 @@ RUN mkdir -p src benches crates/robot-kit/src \
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
-    if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
-      cargo build --release --features "$ZEROCLAW_CARGO_FEATURES"; \
+    FEATURES="$ZEROCLAW_CARGO_FEATURES"; \
+    if [ -z "$FEATURES" ]; then \
+      FEATURES="$ZEROCLAW_DEFAULT_CARGO_FEATURES"; \
+    fi; \
+    if [ -n "$FEATURES" ]; then \
+      cargo build --release --locked --features "$FEATURES"; \
     else \
       cargo build --release --locked; \
     fi
@@ -58,8 +63,12 @@ RUN mkdir -p web/dist && \
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
-    if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
-      cargo build --release --features "$ZEROCLAW_CARGO_FEATURES"; \
+    FEATURES="$ZEROCLAW_CARGO_FEATURES"; \
+    if [ -z "$FEATURES" ]; then \
+      FEATURES="$ZEROCLAW_DEFAULT_CARGO_FEATURES"; \
+    fi; \
+    if [ -n "$FEATURES" ]; then \
+      cargo build --release --locked --features "$FEATURES"; \
     else \
       cargo build --release --locked; \
     fi && \

--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -100,7 +100,8 @@ Operational notes:
 
 Matrix and Lark support are controlled at compile time.
 
-- Default builds include Lark/Feishu (`default = ["channel-lark"]`), while Matrix remains opt-in.
+- Source builds default to a minimal feature set (`default = []`).
+- Official Docker images enable Lark/Feishu by default (`channel-lark`), while Matrix remains opt-in.
 - For a lean local build without Matrix/Lark:
 
 ```bash

--- a/docs/i18n/vi/channels-reference.md
+++ b/docs/i18n/vi/channels-reference.md
@@ -73,7 +73,8 @@ Lưu ý vận hành:
 
 Hỗ trợ Matrix và Lark/Feishu được kiểm soát tại thời điểm biên dịch bằng Cargo features.
 
-- Bản build mặc định bao gồm Lark/Feishu (`default = ["channel-lark"]`), còn Matrix là opt-in.
+- Bản build từ mã nguồn mặc định dùng feature tối thiểu (`default = []`).
+- Docker image chính thức bật Lark/Feishu mặc định (`channel-lark`), còn Matrix là opt-in.
 - Để lặp lại nhanh hơn khi không cần Matrix/Lark:
 
 ```bash

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -7031,6 +7031,27 @@ fn validate_mcp_config(config: &McpConfig) -> Result<()> {
     Ok(())
 }
 
+fn warn_or_explain_ignored_config_key(path: &str) {
+    match path {
+        "channels_config.feishu.mention_only" => {
+            tracing::warn!(
+                "Config key \"{path}\" is legacy for Feishu and ignored. Use [channels_config.feishu.group_reply].mode = \"mention_only\" when mention gating is needed."
+            );
+        }
+        "channels_config.feishu.use_feishu" => {
+            tracing::warn!(
+                "Config key \"{path}\" is ignored in [channels_config.feishu] (Feishu mode is implied). Remove this legacy key."
+            );
+        }
+        _ => {
+            tracing::warn!(
+                "Unknown config key ignored: \"{}\". Check config.toml for typos or deprecated options.",
+                path
+            );
+        }
+    }
+}
+
 impl Config {
     pub async fn load_or_init() -> Result<Self> {
         let (default_zeroclaw_dir, default_workspace_dir) = default_config_and_workspace_dirs()?;
@@ -7082,10 +7103,7 @@ impl Config {
 
             // Warn about each unknown config key
             for path in ignored_paths {
-                tracing::warn!(
-                    "Unknown config key ignored: \"{}\". Check config.toml for typos or deprecated options.",
-                    path
-                );
+                warn_or_explain_ignored_config_key(&path);
             }
             // Set computed paths that are skipped during serialization
             config.config_path = config_path.clone();
@@ -13107,6 +13125,16 @@ default_model = "legacy-model"
             parsed.group_reply_allowed_sender_ids(),
             vec!["ou_9".to_string()]
         );
+    }
+
+    #[test]
+    async fn ignored_key_warning_uses_feishu_legacy_explanation_for_mention_only() {
+        warn_or_explain_ignored_config_key("channels_config.feishu.mention_only");
+    }
+
+    #[test]
+    async fn ignored_key_warning_uses_feishu_legacy_explanation_for_use_feishu() {
+        warn_or_explain_ignored_config_key("channels_config.feishu.use_feishu");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- default Docker builds now enable `channel-lark` when no explicit feature override is provided
- keep explicit override support via `ZEROCLAW_CARGO_FEATURES` (and add `ZEROCLAW_DEFAULT_CARGO_FEATURES` for controlled defaults)
- improve config key diagnostics for legacy Feishu keys (`channels_config.feishu.mention_only` / `channels_config.feishu.use_feishu`)
- align channel feature documentation with actual source-build defaults and Docker behavior

## Validation
- `cargo fmt --all`
- `CARGO_TARGET_DIR=/tmp/zc-target-2325 cargo test -p zeroclaw "config::schema::tests::ignored_key_warning_uses_feishu_legacy_explanation_for_" -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/zc-target-2325 cargo test -p zeroclaw "config::schema::tests::feishu_group_reply_mode_supports_mention_only" -- --exact --nocapture`

Closes #2325
