### PR TITLE
fix(feishu): improve legacy config compatibility and startup guidance

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -5117,8 +5117,14 @@ fn collect_configured_channels(
 
     #[cfg(not(feature = "channel-lark"))]
     if config.channels_config.lark.is_some() || config.channels_config.feishu.is_some() {
+        let executable = std::env::current_exe()
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|_| "<unknown>".to_string());
         tracing::warn!(
-            "Lark/Feishu channel is configured but this build was compiled without `channel-lark`; skipping Lark/Feishu health check."
+            "Lark/Feishu channel is configured but this binary was compiled without `channel-lark`; skipping Lark/Feishu startup. \
+             binary={executable}. \
+             If you built from source, run the built artifact directly (for example `./target/release/zeroclaw daemon`) \
+             or run `cargo run --features channel-lark -- daemon`."
         );
     }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -7031,6 +7031,73 @@ fn validate_mcp_config(config: &McpConfig) -> Result<()> {
     Ok(())
 }
 
+fn legacy_feishu_table(raw_toml: &toml::Value) -> Option<&toml::map::Map<String, toml::Value>> {
+    raw_toml
+        .get("channels_config")?
+        .as_table()?
+        .get("feishu")?
+        .as_table()
+}
+
+fn extract_legacy_feishu_mention_only(raw_toml: &toml::Value) -> Option<bool> {
+    legacy_feishu_table(raw_toml)?
+        .get("mention_only")
+        .and_then(toml::Value::as_bool)
+}
+
+fn has_legacy_feishu_use_feishu(raw_toml: &toml::Value) -> bool {
+    legacy_feishu_table(raw_toml)
+        .and_then(|table| table.get("use_feishu"))
+        .is_some()
+}
+
+fn is_legacy_feishu_unknown_path(path: &str, key: &str) -> bool {
+    path.contains("channels_config.feishu") && path.ends_with(key)
+}
+
+fn apply_feishu_legacy_compat(
+    config: &mut Config,
+    legacy_feishu_mention_only: Option<bool>,
+    legacy_feishu_use_feishu_present: bool,
+    saw_legacy_feishu_mention_only_path: bool,
+    saw_legacy_feishu_use_feishu_path: bool,
+) {
+    // Backward compatibility: users sometimes migrate config snippets from
+    // [channels_config.lark] to [channels_config.feishu] and keep old keys.
+    if let Some(feishu_cfg) = config.channels_config.feishu.as_mut() {
+        if let Some(legacy_mention_only) = legacy_feishu_mention_only {
+            if feishu_cfg.group_reply.is_none() {
+                let mapped_mode = if legacy_mention_only {
+                    GroupReplyMode::MentionOnly
+                } else {
+                    GroupReplyMode::AllMessages
+                };
+                feishu_cfg.group_reply = Some(GroupReplyConfig {
+                    mode: Some(mapped_mode),
+                    allowed_sender_ids: Vec::new(),
+                });
+                tracing::warn!(
+                    "Legacy key [channels_config.feishu].mention_only is deprecated; mapped to [channels_config.feishu.group_reply].mode."
+                );
+            } else if saw_legacy_feishu_mention_only_path {
+                tracing::warn!(
+                    "Legacy key [channels_config.feishu].mention_only is ignored because [channels_config.feishu.group_reply] is already set."
+                );
+            }
+        } else if saw_legacy_feishu_mention_only_path {
+            tracing::warn!(
+                "Legacy key [channels_config.feishu].mention_only is invalid; expected boolean."
+            );
+        }
+
+        if legacy_feishu_use_feishu_present || saw_legacy_feishu_use_feishu_path {
+            tracing::warn!(
+                "Legacy key [channels_config.feishu].use_feishu is redundant and ignored; [channels_config.feishu] always uses Feishu endpoints."
+            );
+        }
+    }
+}
+
 impl Config {
     pub async fn load_or_init() -> Result<Self> {
         let (default_zeroclaw_dir, default_workspace_dir) = default_config_and_workspace_dirs()?;
@@ -7069,6 +7136,13 @@ impl Config {
                 .await
                 .context("Failed to read config file")?;
 
+            // Parse raw TOML first so legacy compatibility rewrites can be applied after
+            // deserialization while still preserving unknown-key detection.
+            let raw_toml: toml::Value =
+                toml::from_str(&contents).context("Failed to parse config file")?;
+            let legacy_feishu_mention_only = extract_legacy_feishu_mention_only(&raw_toml);
+            let legacy_feishu_use_feishu_present = has_legacy_feishu_use_feishu(&raw_toml);
+
             // Track ignored/unknown config keys to warn users about silent misconfigurations
             // (e.g., using [providers.ollama] which doesn't exist instead of top-level api_url)
             let mut ignored_paths: Vec<String> = Vec::new();
@@ -7080,13 +7154,31 @@ impl Config {
             )
             .context("Failed to deserialize config file")?;
 
+            let mut saw_legacy_feishu_mention_only_path = false;
+            let mut saw_legacy_feishu_use_feishu_path = false;
             // Warn about each unknown config key
             for path in ignored_paths {
+                if is_legacy_feishu_unknown_path(&path, ".mention_only") {
+                    saw_legacy_feishu_mention_only_path = true;
+                    continue;
+                }
+                if is_legacy_feishu_unknown_path(&path, ".use_feishu") {
+                    saw_legacy_feishu_use_feishu_path = true;
+                    continue;
+                }
                 tracing::warn!(
                     "Unknown config key ignored: \"{}\". Check config.toml for typos or deprecated options.",
                     path
                 );
             }
+
+            apply_feishu_legacy_compat(
+                &mut config,
+                legacy_feishu_mention_only,
+                legacy_feishu_use_feishu_present,
+                saw_legacy_feishu_mention_only_path,
+                saw_legacy_feishu_use_feishu_path,
+            );
             // Set computed paths that are skipped during serialization
             config.config_path = config_path.clone();
             config.workspace_dir = workspace_dir;
@@ -13106,6 +13198,82 @@ default_model = "legacy-model"
         assert_eq!(
             parsed.group_reply_allowed_sender_ids(),
             vec!["ou_9".to_string()]
+        );
+    }
+
+    #[test]
+    async fn feishu_legacy_key_extractors_detect_compat_fields() {
+        let raw: toml::Value = toml::from_str(
+            r#"
+[channels_config.feishu]
+app_id = "cli_123"
+app_secret = "secret"
+mention_only = true
+use_feishu = true
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(extract_legacy_feishu_mention_only(&raw), Some(true));
+        assert!(has_legacy_feishu_use_feishu(&raw));
+    }
+
+    #[test]
+    async fn feishu_legacy_mention_only_maps_to_group_reply_mode() {
+        let mut parsed = Config::default();
+        parsed.channels_config.feishu = Some(FeishuConfig {
+            app_id: "cli_123".into(),
+            app_secret: "secret".into(),
+            encrypt_key: None,
+            verification_token: None,
+            allowed_users: vec![],
+            group_reply: None,
+            receive_mode: LarkReceiveMode::Websocket,
+            port: None,
+            draft_update_interval_ms: default_lark_draft_update_interval_ms(),
+            max_draft_edits: default_lark_max_draft_edits(),
+        });
+
+        apply_feishu_legacy_compat(&mut parsed, Some(true), true, true, true);
+
+        let feishu = parsed
+            .channels_config
+            .feishu
+            .expect("feishu config should exist");
+        assert_eq!(
+            feishu.effective_group_reply_mode(),
+            GroupReplyMode::MentionOnly
+        );
+    }
+
+    #[test]
+    async fn feishu_legacy_mention_only_does_not_override_group_reply() {
+        let mut parsed = Config::default();
+        parsed.channels_config.feishu = Some(FeishuConfig {
+            app_id: "cli_123".into(),
+            app_secret: "secret".into(),
+            encrypt_key: None,
+            verification_token: None,
+            allowed_users: vec![],
+            group_reply: Some(GroupReplyConfig {
+                mode: Some(GroupReplyMode::AllMessages),
+                allowed_sender_ids: vec![],
+            }),
+            receive_mode: LarkReceiveMode::Websocket,
+            port: None,
+            draft_update_interval_ms: default_lark_draft_update_interval_ms(),
+            max_draft_edits: default_lark_max_draft_edits(),
+        });
+
+        apply_feishu_legacy_compat(&mut parsed, Some(true), false, true, false);
+
+        let feishu = parsed
+            .channels_config
+            .feishu
+            .expect("feishu config should exist");
+        assert_eq!(
+            feishu.effective_group_reply_mode(),
+            GroupReplyMode::AllMessages
         );
     }
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`main` or `dev`; direct `main` PRs are allowed): `main`
- Problem: Feishu first-time setups can be blocked by confusing startup diagnostics when `channel-lark` is not present in the running binary, and legacy Feishu keys (`mention_only`, `use_feishu`) are treated as unknown/ignored.
- Why it matters: Operators cannot quickly determine whether Feishu is broken vs. running the wrong binary, and legacy config snippets trigger noisy warnings that hide actionable misconfigurations.
- What changed: Added Feishu legacy-key compatibility mapping in config load path (`mention_only -> group_reply.mode`), suppressed legacy-only unknown-key noise with targeted migration warnings, and improved non-`channel-lark` startup warning with executable path + exact run commands.
- What did **not** change (scope boundary): No protocol/API changes to Lark/Feishu transport logic, no CI/workflow modifications, and no changes to unrelated channels.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel, config, tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `channel: feishu, config: schema`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `distinguished contributor`
- If any auto-label is incorrect, note requested correction: `None`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #2325
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)
- Linear issue key(s) (required, e.g. `RMN-123`): `RMN-281`
- Linear issue URL(s): https://linear.app/zeroclawlabs/issue/RMN-281/bug-feishu-channel-startup-compatibility
- Resolves RMN-281

## Validation Evidence (required)

Commands and result summary:

```bash
cargo check --quiet --features channel-lark --lib
cargo test --quiet feishu_legacy_ -- --nocapture
```

- Evidence provided (test/log/trace/screenshot/perf): Added and executed new config-schema compatibility tests for Feishu legacy keys; compile gate passes with `channel-lark` feature enabled.
- If any command is intentionally skipped, explain why: Full workspace `cargo test` was not rerun due runtime/cost; targeted tests cover modified compatibility paths directly.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: `N/A`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: No user-data schema changes; this patch only adjusts config compatibility and diagnostic messaging.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No` (compatibility support added for legacy keys)
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N/A`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Legacy Feishu `mention_only` values are mapped into effective group-reply mode when `group_reply` is absent.
- Edge cases checked: Legacy `mention_only` does not override explicit `group_reply.mode`; legacy `use_feishu` presence is treated as redundant with explicit warning.
- What was not verified: End-to-end live Feishu websocket/webhook exchange against external Feishu tenant.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Config load compatibility path for Feishu channel and startup warning text in channel collection.
- Potential unintended effects: Operators relying on unknown-key warnings for Feishu legacy fields will now get migration-specific warnings instead.
- Guardrails/monitoring for early detection: Existing startup warnings retained with stronger actionable guidance; regression tests added for compatibility behavior.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex CLI + gh + linear CLI.
- Workflow/plan summary (if any): Deep triage from issue logs, root-cause narrowing, scoped compatibility + diagnostic patch, targeted compile/tests.
- Verification focus: Feishu config compatibility mapping + feature-disabled binary diagnostics.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `926d9a19` from `main`.
- Feature flags or config toggles (if any): `N/A`
- Observable failure symptoms: Feishu legacy key behavior unexpectedly changes (e.g., mention-only mapping not applied as expected) or startup warning regresses.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: Compatibility mapping may mask intentional strictness for deprecated Feishu keys in some operator workflows.
  - Mitigation: Mapping is narrow (only legacy Feishu fields), preserves explicit `group_reply` precedence, and emits deprecation warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Startup warning for Lark/Feishu configuration now displays the executable path and provides setup guidance.

* **Bug Fixes**
  * Added backward-compatibility support for legacy Feishu configuration keys. Legacy settings are automatically mapped to the current format with migration warnings to guide users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->