### PR TITLE
fix(docs): correct Feishu/Lark channel build feature documentation [CDV-2325]

### DIFF
--- a/docs/channels-reference.md
+++ b/docs/channels-reference.md
@@ -100,11 +100,17 @@ Operational notes:
 
 Matrix and Lark support are controlled at compile time.
 
-- Default builds include Lark/Feishu (`default = ["channel-lark"]`), while Matrix remains opt-in.
-- For a lean local build without Matrix/Lark:
+- Default builds are minimal for compatibility (`default = []`). Both Lark/Feishu and Matrix are opt-in features.
+- For a minimal build with only hardware features (default behavior):
 
 ```bash
 cargo check --no-default-features --features hardware
+```
+
+- To build with Lark/Feishu support enabled:
+
+```bash
+cargo check --features hardware,channel-lark
 ```
 
 - Enable Matrix explicitly in a custom feature set:

--- a/docs/i18n/vi/channels-reference.md
+++ b/docs/i18n/vi/channels-reference.md
@@ -73,11 +73,17 @@ Lưu ý vận hành:
 
 Hỗ trợ Matrix và Lark/Feishu được kiểm soát tại thời điểm biên dịch bằng Cargo features.
 
-- Bản build mặc định bao gồm Lark/Feishu (`default = ["channel-lark"]`), còn Matrix là opt-in.
-- Để lặp lại nhanh hơn khi không cần Matrix/Lark:
+- Bản build mặc định tối giản cho tương thích (`default = []`). Cả Lark/Feishu và Matrix đều là opt-in features.
+- Để build tối giản với chỉ hardware features (hành vi mặc định):
 
 ```bash
 cargo check --no-default-features --features hardware
+```
+
+- Để build với hỗ trợ Lark/Feishu được bật:
+
+```bash
+cargo check --features hardware,channel-lark
 ```
 
 - Để bật tường minh hỗ trợ Matrix trong feature set tùy chỉnh:


### PR DESCRIPTION
## Summary

Fixes issue #2325 where users get "Lark/Feishu channel is configured but this build was compiled without `channel-lark`" error.

### Problem
Documentation incorrectly stated that Lark/Feishu channels are included by default (`default = ["channel-lark"]`), but actual `Cargo.toml` has `default = []` for minimal host compatibility.

### Solution
Updated documentation to accurately reflect:
- Default builds are minimal (no Lark/Feishu)
- Both Lark/Feishu and Matrix are opt-in features
- Clear build instructions: `cargo build --features channel-lark`

## Changed Files
| File | Changes |
|------|---------|
| `docs/channels-reference.md` | Fixed default feature claims, added build instructions |
| `docs/i18n/vi/channels-reference.md` | Vietnamese translation consistency |

## Validation Evidence
- Documentation now matches actual `Cargo.toml` configuration
- Both language versions are consistent
- Clear user-facing instructions provided

## Security Impact
**Risk Level:** None (documentation only)

## Privacy and Data Hygiene
**Status:** No impact (documentation only)

## Rollback Plan
1. Revert this PR via GitHub UI

## Related
- Fixes #2325

---
*Contributor: Oystra (@Preventnetworkhacking)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated channel features build guidance: Lark/Feishu and Matrix now require explicit opt-in instead of being included by default
  * Added instructions for minimal hardware-only builds and explicit commands for enabling specific channel support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->