### PR TITLE
[CDV-2352] Fix duplicate workflow runs when creating issue with labels

### DIFF
--- a/.github/workflows/pr-auto-response.yml
+++ b/.github/workflows/pr-auto-response.yml
@@ -23,7 +23,9 @@ jobs:
   contributor-tier-issues:
     if: >-
       (github.event_name == 'issues' &&
-      (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'labeled' || github.event.action == 'unlabeled')) ||
+      (github.event.action == 'opened' || github.event.action == 'reopened' || 
+       (github.event.action == 'labeled' && github.event.issue.created_at != github.event.issue.updated_at) ||
+       github.event.action == 'unlabeled')) ||
       (github.event_name == 'pull_request_target' &&
       (github.event.action == 'labeled' || github.event.action == 'unlabeled'))
     runs-on: ubuntu-22.04
@@ -75,7 +77,7 @@ jobs:
             See `CONTRIBUTING.md` and `docs/pr-workflow.md` for full collaboration rules.
 
   labeled-routes:
-    if: github.event.action == 'labeled'
+    if: github.event.action == 'labeled' && (github.event_name == 'pull_request_target' || github.event.issue.created_at != github.event.issue.updated_at)
     runs-on: ubuntu-22.04
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

Issue #2352 reported duplicate workflow runs when creating an issue with labels. The `pr-auto-response.yml` workflow was triggering twice:
1. Once for the `opened` event 
2. Again for the `labeled` event (when labels are applied during creation)

## Solution  

Modified the workflow conditions to prevent duplicate execution:

- **contributor-tier-issues job**: Added condition `github.event.issue.created_at != github.event.issue.updated_at` to labeled events, ensuring it only runs when labels are added after issue creation
- **labeled-routes job**: Added same condition while maintaining `pull_request_target` exception for PR functionality

## Testing

The fix uses GitHub's native event context to distinguish between:
- Labels added during issue creation (`created_at == updated_at`)  
- Labels added after creation (`created_at != updated_at`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Changes generate no new warnings
- [x] Added tests (N/A - workflow logic change)
- [x] Documentation updated (N/A)

## Related Issues

Fixes #2352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined automated issue response conditions to trigger only on substantive updates after initial creation, excluding initial labeling events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->