### PR TITLE
feat(channel): add native Discord approval buttons via Components API

### DIFF
--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -12,6 +12,10 @@ use std::path::{Path, PathBuf};
 use tokio_tungstenite::tungstenite::Message;
 use uuid::Uuid;
 
+/// Discord approval button custom_id prefixes (mirrors Telegram callback_data format)
+const DISCORD_APPROVAL_APPROVE_PREFIX: &str = "zcapr:yes:";
+const DISCORD_APPROVAL_DENY_PREFIX: &str = "zcapr:no:";
+
 /// Discord channel — connects via Gateway WebSocket for real-time messages
 pub struct DiscordChannel {
     bot_token: String,
@@ -814,8 +818,45 @@ impl Channel for DiscordChannel {
                         _ => {}
                     }
 
-                    // Only handle MESSAGE_CREATE (opcode 0, type "MESSAGE_CREATE")
                     let event_type = event.get("t").and_then(|t| t.as_str()).unwrap_or("");
+
+                    // Handle approval button interactions
+                    if event_type == "INTERACTION_CREATE" {
+                        if let Some(d) = event.get("d") {
+                            if let Some((channel_msg, iid, itoken)) =
+                                try_parse_approval_interaction(d)
+                            {
+                                // Validate the interaction user is authorized
+                                if !self.is_user_allowed(&channel_msg.sender) {
+                                    tracing::warn!(
+                                        "Discord: ignoring approval interaction from unauthorized user: {}",
+                                        channel_msg.sender
+                                    );
+                                    // Still acknowledge to avoid Discord showing "interaction failed"
+                                    acknowledge_interaction_nonblocking(
+                                        self.http_client(),
+                                        iid,
+                                        itoken,
+                                        false,
+                                    );
+                                    continue;
+                                }
+                                let approved =
+                                    channel_msg.content.contains("/approve-allow");
+                                acknowledge_interaction_nonblocking(
+                                    self.http_client(),
+                                    iid,
+                                    itoken,
+                                    approved,
+                                );
+                                if tx.send(channel_msg).await.is_err() {
+                                    break;
+                                }
+                            }
+                        }
+                        continue;
+                    }
+
                     if event_type != "MESSAGE_CREATE" {
                         continue;
                     }
@@ -959,6 +1000,63 @@ impl Channel for DiscordChannel {
         Ok(())
     }
 
+    async fn send_approval_prompt(
+        &self,
+        recipient: &str,
+        request_id: &str,
+        tool_name: &str,
+        arguments: &serde_json::Value,
+        _thread_ts: Option<String>,
+    ) -> anyhow::Result<()> {
+        let raw_args = arguments.to_string();
+        let args_preview = if raw_args.chars().count() > 260 {
+            crate::util::truncate_with_ellipsis(&raw_args, 260)
+        } else {
+            raw_args
+        };
+
+        let url = format!("https://discord.com/api/v10/channels/{recipient}/messages");
+        let body = json!({
+            "content": format!(
+                "**Approval required** for tool `{tool_name}`.\nRequest ID: `{request_id}`\nArgs: `{args_preview}`"
+            ),
+            "components": [{
+                "type": 1,
+                "components": [
+                    {
+                        "type": 2,
+                        "style": 3,
+                        "label": "Approve",
+                        "custom_id": format!("{DISCORD_APPROVAL_APPROVE_PREFIX}{request_id}")
+                    },
+                    {
+                        "type": 2,
+                        "style": 4,
+                        "label": "Deny",
+                        "custom_id": format!("{DISCORD_APPROVAL_DENY_PREFIX}{request_id}")
+                    }
+                ]
+            }]
+        });
+
+        let resp = self
+            .http_client()
+            .post(&url)
+            .header("Authorization", format!("Bot {}", self.bot_token))
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let err = resp.text().await.unwrap_or_default();
+            let sanitized = crate::providers::sanitize_api_error(&err);
+            anyhow::bail!("Discord approval prompt failed ({status}): {sanitized}");
+        }
+
+        Ok(())
+    }
+
     async fn health_check(&self) -> bool {
         self.http_client()
             .get("https://discord.com/api/v10/users/@me")
@@ -1058,6 +1156,100 @@ impl Channel for DiscordChannel {
 
         Ok(())
     }
+}
+
+/// Parse a Discord INTERACTION_CREATE (MessageComponent) event into a [`ChannelMessage`]
+/// containing the equivalent approval slash command, or `None` if not an approval interaction.
+fn try_parse_approval_interaction(
+    d: &serde_json::Value,
+) -> Option<(ChannelMessage, String, String)> {
+    // type=3 means MessageComponent
+    let interaction_type = d.get("type").and_then(serde_json::Value::as_u64)?;
+    if interaction_type != 3 {
+        return None;
+    }
+
+    let interaction_id = d.get("id").and_then(serde_json::Value::as_str)?.to_string();
+    let interaction_token = d
+        .get("token")
+        .and_then(serde_json::Value::as_str)?
+        .to_string();
+
+    let data = d.get("data")?;
+    let custom_id = data.get("custom_id").and_then(serde_json::Value::as_str)?;
+
+    let content = if let Some(request_id) = custom_id.strip_prefix(DISCORD_APPROVAL_APPROVE_PREFIX)
+    {
+        if request_id.trim().is_empty() {
+            return None;
+        }
+        format!("/approve-allow {}", request_id.trim())
+    } else if let Some(request_id) = custom_id.strip_prefix(DISCORD_APPROVAL_DENY_PREFIX) {
+        if request_id.trim().is_empty() {
+            return None;
+        }
+        format!("/approve-deny {}", request_id.trim())
+    } else {
+        return None;
+    };
+
+    // Extract user info — Discord interactions put user info in "member.user" (guild) or "user" (DM)
+    let user = d
+        .get("member")
+        .and_then(|m| m.get("user"))
+        .or_else(|| d.get("user"))?;
+    let user_id = user
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("unknown");
+
+    let channel_id = d
+        .get("channel_id")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+
+    let msg = ChannelMessage {
+        id: format!("discord_interaction_{interaction_id}"),
+        sender: user_id.to_string(),
+        reply_target: if channel_id.is_empty() {
+            user_id.to_string()
+        } else {
+            channel_id.to_string()
+        },
+        content,
+        channel: "discord".to_string(),
+        timestamp: std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs(),
+        thread_ts: None,
+    };
+
+    Some((msg, interaction_id, interaction_token))
+}
+
+/// Acknowledge a Discord interaction by updating the original message (remove buttons, show decision).
+fn acknowledge_interaction_nonblocking(
+    client: reqwest::Client,
+    interaction_id: String,
+    interaction_token: String,
+    approved: bool,
+) {
+    let decision_text = if approved { "Approved" } else { "Denied" };
+    let emoji = if approved { "\u{2705}" } else { "\u{274c}" };
+    tokio::spawn(async move {
+        let url = format!(
+            "https://discord.com/api/v10/interactions/{interaction_id}/{interaction_token}/callback"
+        );
+        let body = json!({
+            "type": 7,
+            "data": {
+                "content": format!("{emoji} {decision_text}."),
+                "components": []
+            }
+        });
+        let _ = client.post(&url).json(&body).send().await;
+    });
 }
 
 #[cfg(test)]
@@ -1799,5 +1991,71 @@ mod tests {
 
         let escaped = channel.resolve_local_attachment_path(outside.to_string_lossy().as_ref());
         assert!(escaped.is_err(), "path outside workspace must be rejected");
+    }
+
+    // ── Approval interaction parsing ─────────────────────────────
+
+    #[test]
+    fn discord_parse_approval_interaction_approve() {
+        let event = json!({
+            "type": 3,
+            "id": "111222333",
+            "token": "fake_token",
+            "data": { "custom_id": "zcapr:yes:req-42" },
+            "member": { "user": { "id": "user_1" } },
+            "channel_id": "chan_99"
+        });
+        let (msg, iid, itoken) = try_parse_approval_interaction(&event).unwrap();
+        assert_eq!(msg.content, "/approve-allow req-42");
+        assert_eq!(msg.sender, "user_1");
+        assert_eq!(msg.reply_target, "chan_99");
+        assert_eq!(msg.channel, "discord");
+        assert!(msg.id.contains("111222333"));
+        assert_eq!(iid, "111222333");
+        assert_eq!(itoken, "fake_token");
+    }
+
+    #[test]
+    fn discord_parse_approval_interaction_deny() {
+        let event = json!({
+            "type": 3,
+            "id": "444555666",
+            "token": "tok",
+            "data": { "custom_id": "zcapr:no:req-99" },
+            "user": { "id": "dm_user" },
+            "channel_id": ""
+        });
+        let (msg, _, _) = try_parse_approval_interaction(&event).unwrap();
+        assert_eq!(msg.content, "/approve-deny req-99");
+        assert_eq!(msg.sender, "dm_user");
+        // Empty channel_id falls back to user_id
+        assert_eq!(msg.reply_target, "dm_user");
+    }
+
+    #[test]
+    fn discord_parse_approval_interaction_ignores_non_approval() {
+        let event = json!({
+            "type": 3,
+            "id": "777",
+            "token": "tok",
+            "data": { "custom_id": "some_other_button" },
+            "member": { "user": { "id": "user_1" } },
+            "channel_id": "chan_1"
+        });
+        assert!(try_parse_approval_interaction(&event).is_none());
+    }
+
+    #[test]
+    fn discord_parse_approval_interaction_ignores_non_component() {
+        // type=2 is ApplicationCommand, not MessageComponent
+        let event = json!({
+            "type": 2,
+            "id": "888",
+            "token": "tok",
+            "data": { "custom_id": "zcapr:yes:req-1" },
+            "member": { "user": { "id": "user_1" } },
+            "channel_id": "chan_1"
+        });
+        assert!(try_parse_approval_interaction(&event).is_none());
     }
 }


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

  - Problem: Discord tool approval relies on manual text commands (/approve-allow <id>), which is error-prone and inconsistent
  with Telegram's native button experience.
  - Why it matters: One-click approval reduces friction, eliminates request-ID typos, and brings Discord channel to parity with
  Telegram's existing InlineKeyboard flow.
  - What changed: src/channels/discord.rs — added send_approval_prompt() override with Discord Button components,
  INTERACTION_CREATE handling in listen(), interaction parsing and acknowledgment helpers, user authorization check, and 4 unit
  tests.
  - What did not change (scope boundary): Channel trait, mod.rs, loop_.rs, approval/mod.rs, Cargo.toml, Gateway intents,
  approval manager, command routing, polling mechanism.

## Label Snapshot (required)

  - Risk label: risk: low
  - Size label: size: S
  - Scope labels: channel
  - Module labels: channel: discord
  - Contributor tier label: (auto-managed)
  - If any auto-label is incorrect: N/A

## Change Metadata

  - Change type: feature
  - Primary scope: channel

## Linked Issue

- Closes #2365
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)
- Linear issue key(s) (required, e.g. `RMN-123`):
- Linear issue URL(s):

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

  cargo fmt --all -- --check     # pass (discord.rs clean)
  cargo clippy --all-targets -- -D warnings  # no warnings in discord.rs (pre-existing warnings in other files)
  cargo test --lib channels::discord  # 74 passed, 0 failed

  - Evidence provided: all 74 Discord channel tests pass, including 4 new approval interaction parsing tests.
  - If any command is intentionally skipped: cargo clippy has pre-existing warnings in unrelated files (hooks/runner.rs,
  tools/pptx_read.rs, channels/napcat.rs, config/schema.rs); none from this change.

## Security Impact (required)

  - New permissions/capabilities? No
  - New external network calls? No (uses existing Discord REST API and Gateway WebSocket already in use)
  - Secrets/tokens handling changed? No (interaction responses use interaction_token, not bot token — this is Discord's standard
   pattern)
  - File system access scope changed? No
  - If any Yes: N/A

## Privacy and Data Hygiene (required)

  - Data-hygiene status: pass
  - Redaction/anonymization notes: Error responses sanitized via existing sanitize_api_error(). No secrets logged.
  - Neutral wording confirmation: All test data uses neutral placeholders (user_1, chan_99, fake_token). No personal
  identifiers.

## Compatibility / Migration

  - Backward compatible? Yes — text-based /approve-allow and /approve-deny commands continue to work unchanged as fallback.
  - Config/env changes? No
  - Migration needed? No
  - 
## i18n Follow-Through (required when docs or user-facing wording changes)

  - i18n follow-through triggered? No (no docs or user-facing wording changes outside runtime Discord messages)

## Human Verification (required)

  - Verified scenarios: Unit tests for all 4 interaction parsing paths (approve, deny, non-approval custom_id, non-component
  type). Full existing test suite (74 tests) passes.
  - Edge cases checked: Empty request_id in custom_id returns None. Missing user/member fields returns None. Empty channel_id
  falls back to user_id for reply_target. Unauthorized user clicks are rejected but still acknowledged to Discord.
  - What was not verified: End-to-end with a live Discord bot (requires bot token + guild setup). Button rendering verified by
  reviewing Discord Components API v10 spec.

## Side Effects / Blast Radius (required)

  - Affected subsystems/workflows: Discord channel only. Approval pipeline receives identical ChannelMessage regardless of
  button vs text input.
  - Potential unintended effects: None — INTERACTION_CREATE events for non-approval buttons (if any future buttons exist) are
  silently ignored via prefix mismatch.
  - Guardrails/monitoring for early detection: tracing::warn on unauthorized interaction attempts. Discord shows "interaction
  failed" only if bot is offline (not a regression).

## Agent Collaboration Notes (recommended)

  - Agent tools used: Claude Code (Opus 4.6)
  - Workflow/plan summary: Plan designed referencing Telegram's existing InlineKeyboard implementation as pattern. Single-file
  change, trait reuse, no new abstractions.
  - Verification focus: Interaction parsing correctness, user authorization enforcement, backward compatibility with text
  commands.
  - Confirmation: naming + architecture boundaries followed (CLAUDE.md + CONTRIBUTING.md): Yes — trait extension via override,
  no cross-module coupling, snake_case functions, domain-specific naming.

## Rollback Plan (required)

  - Fast rollback command/path: git revert <commit-sha> — approval automatically falls back to Channel trait's default
  text-based send_approval_prompt().
  - Feature flags or config toggles: None needed — revert restores previous behavior with zero config changes.
  - Observable failure symptoms: If buttons fail to render, Discord shows plain text (graceful degradation). If
  INTERACTION_CREATE parsing fails, buttons show "interaction failed" in Discord UI — no impact on agent loop.

## Risks and Mitigations

List real risks in this PR (or write `None`).

  - Risk: Discord API v10 button payload format could change.
    - Mitigation: Uses stable, well-documented Components API types (ActionRow=1, Button=2, styles 3/4). Format has been stable
  since 2021. Failure mode is graceful (API error logged, no crash).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord approval prompts now include interactive Approve and Deny buttons for streamlined request handling.
  * Users can respond to approval requests directly through Discord button interactions, with automatic acknowledgment to prevent interaction failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->