### PR TITLE
fix(ci): broaden runner labels to unblock CI queue

### DIFF
--- a/.github/workflows/ci-canary-gate.yml
+++ b/.github/workflows/ci-canary-gate.yml
@@ -89,7 +89,7 @@ env:
 jobs:
     canary-plan:
         name: Canary Plan
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         outputs:
             mode: ${{ steps.inputs.outputs.mode }}
@@ -237,7 +237,7 @@ jobs:
         name: Canary Execute
         needs: [canary-plan]
         if: github.event_name == 'workflow_dispatch' && needs.canary-plan.outputs.mode == 'execute' && needs.canary-plan.outputs.ready_to_execute == 'true'
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 10
         permissions:
             contents: write

--- a/.github/workflows/ci-provider-connectivity.yml
+++ b/.github/workflows/ci-provider-connectivity.yml
@@ -39,7 +39,7 @@ env:
 jobs:
     probe:
         name: Provider Connectivity Probe
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - name: Checkout

--- a/.github/workflows/ci-reproducible-build.yml
+++ b/.github/workflows/ci-reproducible-build.yml
@@ -50,7 +50,7 @@ env:
 jobs:
     reproducibility:
         name: Reproducible Build Probe
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 45
         steps:
             - name: Checkout

--- a/.github/workflows/ci-rollback.yml
+++ b/.github/workflows/ci-rollback.yml
@@ -64,7 +64,7 @@ env:
 jobs:
     rollback-plan:
         name: Rollback Guard Plan
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         outputs:
             branch: ${{ steps.plan.outputs.branch }}
@@ -188,7 +188,7 @@ jobs:
         name: Rollback Execute Actions
         needs: [rollback-plan]
         if: github.event_name == 'workflow_dispatch' && needs.rollback-plan.outputs.mode == 'execute' && needs.rollback-plan.outputs.ready_to_execute == 'true'
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 15
         permissions:
             contents: write

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -50,7 +50,7 @@ jobs:
         name: Lint Gate (Format + Clippy + Strict Delta)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 40
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -74,7 +74,7 @@ jobs:
         name: Test
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 60
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -137,7 +137,7 @@ jobs:
         name: Build (Smoke)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 35
 
         steps:

--- a/.github/workflows/ci-supply-chain-provenance.yml
+++ b/.github/workflows/ci-supply-chain-provenance.yml
@@ -31,7 +31,7 @@ env:
 jobs:
     provenance:
         name: Build + Provenance Bundle
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 60
         steps:
             - name: Checkout

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -56,7 +56,7 @@ env:
 jobs:
     docs-quality:
         name: Docs Quality Gate
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         outputs:
             docs_files: ${{ steps.scope.outputs.docs_files }}
@@ -203,7 +203,7 @@ jobs:
         name: Docs Preview Artifact
         needs: [docs-quality]
         if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'preview')
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 15
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -237,7 +237,7 @@ jobs:
         name: Deploy Docs to GitHub Pages
         needs: [docs-quality]
         if: needs.docs-quality.outputs.deploy_target == 'production' && needs.docs-quality.outputs.ready_to_deploy == 'true'
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         permissions:
             contents: read

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -51,7 +51,7 @@ env:
 jobs:
     resolve-profile:
         name: Resolve Matrix Profile
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         outputs:
             profile: ${{ steps.resolve.outputs.profile }}
             lane_job_prefix: ${{ steps.resolve.outputs.lane_job_prefix }}
@@ -127,7 +127,7 @@ jobs:
             github.event_name != 'pull_request' ||
             contains(github.event.pull_request.labels.*.name, 'ci:full') ||
             contains(github.event.pull_request.labels.*.name, 'ci:feature-matrix')
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: ${{ fromJSON(needs.resolve-profile.outputs.lane_timeout_minutes) }}
         strategy:
             fail-fast: false
@@ -278,7 +278,7 @@ jobs:
         name: ${{ needs.resolve-profile.outputs.summary_job_name }}
         needs: [resolve-profile, feature-check]
         if: always()
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/nightly-all-features.yml
+++ b/.github/workflows/nightly-all-features.yml
@@ -27,7 +27,7 @@ env:
 jobs:
     nightly-lanes:
         name: Nightly Lane (${{ matrix.name }})
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 70
         strategy:
             fail-fast: false
@@ -137,7 +137,7 @@ jobs:
         name: Nightly Summary & Routing
         needs: [nightly-lanes]
         if: always()
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/pub-docker-img.yml
+++ b/.github/workflows/pub-docker-img.yml
@@ -33,7 +33,7 @@ jobs:
     pr-smoke:
         name: PR Docker Smoke
         if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 25
         permissions:
             contents: read
@@ -73,7 +73,7 @@ jobs:
     publish:
         name: Build and Push Docker Image
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'zeroclaw-labs/zeroclaw'
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 45
         permissions:
             contents: read

--- a/.github/workflows/pub-prerelease.yml
+++ b/.github/workflows/pub-prerelease.yml
@@ -43,7 +43,7 @@ env:
 jobs:
     prerelease-guard:
         name: Pre-release Guard
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         outputs:
             release_tag: ${{ steps.vars.outputs.release_tag }}
@@ -239,7 +239,7 @@ jobs:
         name: Publish GitHub Pre-release
         needs: [prerelease-guard, build-prerelease]
         if: needs.prerelease-guard.outputs.ready_to_publish == 'true'
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 15
         steps:
             - name: Download prerelease artifacts

--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -47,7 +47,7 @@ env:
 jobs:
     prepare:
         name: Prepare Release Context
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         outputs:
             release_ref: ${{ steps.vars.outputs.release_ref }}
             release_tag: ${{ steps.vars.outputs.release_tag }}
@@ -386,7 +386,7 @@ jobs:
     verify-artifacts:
         name: Verify Artifact Set
         needs: [prepare, build-release]
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               with:
@@ -447,7 +447,7 @@ jobs:
         name: Publish Release
         if: needs.prepare.outputs.publish_release == 'true'
         needs: [prepare, verify-artifacts]
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 45
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/sec-audit.yml
+++ b/.github/workflows/sec-audit.yml
@@ -86,7 +86,7 @@ env:
 jobs:
     audit:
         name: Security Audit
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -101,7 +101,7 @@ jobs:
 
     deny:
         name: License & Supply Chain
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -156,7 +156,7 @@ jobs:
 
     security-regressions:
         name: Security Regression Tests
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -172,7 +172,7 @@ jobs:
 
     secrets:
         name: Secrets Governance (Gitleaks)
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -367,7 +367,7 @@ jobs:
 
     sbom:
         name: SBOM Snapshot
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -432,7 +432,7 @@ jobs:
 
     unsafe-debt:
         name: Unsafe Debt Audit
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -571,7 +571,7 @@ jobs:
         name: Security Required Gate
         if: always() && (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
         needs: [audit, deny, security-regressions, secrets, sbom, unsafe-debt]
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         steps:
             - name: Enforce security gate
               shell: bash

--- a/.github/workflows/sec-codeql.yml
+++ b/.github/workflows/sec-codeql.yml
@@ -43,7 +43,7 @@ env:
 jobs:
     codeql:
         name: CodeQL Analysis
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 60
         steps:
             - name: Checkout repository

--- a/.github/workflows/sec-vorpal-reviewdog.yml
+++ b/.github/workflows/sec-vorpal-reviewdog.yml
@@ -91,7 +91,7 @@ env:
 jobs:
     vorpal:
         name: Vorpal Reviewdog Scan
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 20
         steps:
             - name: Checkout

--- a/.github/workflows/test-benchmarks.yml
+++ b/.github/workflows/test-benchmarks.yml
@@ -22,7 +22,7 @@ env:
 jobs:
     benchmarks:
         name: Criterion Benchmarks
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -29,7 +29,7 @@ env:
 jobs:
     integration-tests:
         name: Integration / E2E Tests
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 30
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/test-fuzz.yml
+++ b/.github/workflows/test-fuzz.yml
@@ -27,7 +27,7 @@ env:
 jobs:
     fuzz:
         name: Fuzz (${{ matrix.target }})
-        runs-on: [self-hosted, aws-india]
+        runs-on: [self-hosted, Linux, X64]
         timeout-minutes: 60
         strategy:
             fail-fast: false


### PR DESCRIPTION
## Summary
- Replace `runs-on: [self-hosted, aws-india]` with `runs-on: [self-hosted, Linux, X64]` across 18 workflow files
- Unblocks 420+ queued workflow runs stuck for ~2 days due to AWS account suspension (non-payment)
- New GCP us-east1 runners (`zc-runner-01..03`, 8 vCPU / 32 GB each) are online with `gcp-us` label
- Broader selector matches both new GCP runners and any restored AWS runners

## Root Cause
AWS Lightsail account (ap-south-1) suspended due to non-payment → 25/26 `aws-india` runners offline since Feb 27.

## Affected Workflows (18 files, 36 `runs-on` lines)
CI Run, CI Reproducible Build, Sec Audit, Sec CodeQL, Docs Deploy, CI Provider Connectivity, CI Canary Gate, CI Rollback, CI Supply Chain, Feature Matrix, Nightly All Features, Pub Docker/Prerelease/Release, Sec Vorpal, Test Benchmarks/E2E/Fuzz

## Risk
- **Low**: Only changes `runs-on` labels, no logic changes
- **Rollback**: Revert commit to restore `aws-india` labels

## Test plan
- [ ] Verify new GCP runners pick up queued jobs after merge
- [ ] Confirm CI Run, Sec Audit, Sec CodeQL complete successfully
- [ ] Monitor queue drain progress

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow runner specifications across multiple pipeline jobs to use generic Linux x64 self-hosted runners instead of region-specific runner labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->