### PR TITLE
feat(memory): add time-decay scoring with Core evergreen exemption

### DIFF
--- a/src/memory/decay.rs
+++ b/src/memory/decay.rs
@@ -1,0 +1,152 @@
+use super::traits::{MemoryCategory, MemoryEntry};
+use chrono::{DateTime, Utc};
+
+/// Default half-life in days for time-decay scoring.
+/// After this many days, a non-Core memory's score drops to 50%.
+const DEFAULT_HALF_LIFE_DAYS: f64 = 7.0;
+
+/// Apply exponential time decay to memory entry scores.
+///
+/// - `Core` memories are exempt ("evergreen") — their scores are never decayed.
+/// - Entries without a parseable RFC3339 timestamp are left unchanged.
+/// - Entries without a score (`None`) are left unchanged.
+///
+/// Decay formula: `score * 2^(-age_days / half_life_days)`
+pub fn apply_time_decay(entries: &mut [MemoryEntry], half_life_days: f64) {
+    let half_life = if half_life_days <= 0.0 {
+        DEFAULT_HALF_LIFE_DAYS
+    } else {
+        half_life_days
+    };
+
+    let now = Utc::now();
+
+    for entry in entries.iter_mut() {
+        // Core memories are evergreen — never decay
+        if entry.category == MemoryCategory::Core {
+            continue;
+        }
+
+        let score = match entry.score {
+            Some(s) => s,
+            None => continue,
+        };
+
+        let ts = match DateTime::parse_from_rfc3339(&entry.timestamp) {
+            Ok(dt) => dt.with_timezone(&Utc),
+            Err(_) => continue,
+        };
+
+        let age_days = now
+            .signed_duration_since(ts)
+            .num_seconds()
+            .max(0) as f64
+            / 86_400.0;
+
+        let decay_factor = (-age_days / half_life * std::f64::consts::LN_2).exp();
+        entry.score = Some(score * decay_factor);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_entry(category: MemoryCategory, score: Option<f64>, timestamp: &str) -> MemoryEntry {
+        MemoryEntry {
+            id: "1".into(),
+            key: "test".into(),
+            content: "value".into(),
+            category,
+            timestamp: timestamp.into(),
+            session_id: None,
+            score,
+        }
+    }
+
+    fn recent_rfc3339() -> String {
+        Utc::now().to_rfc3339()
+    }
+
+    fn days_ago_rfc3339(days: i64) -> String {
+        (Utc::now() - chrono::Duration::days(days)).to_rfc3339()
+    }
+
+    #[test]
+    fn core_memories_are_never_decayed() {
+        let mut entries = vec![make_entry(
+            MemoryCategory::Core,
+            Some(0.9),
+            &days_ago_rfc3339(30),
+        )];
+        apply_time_decay(&mut entries, 7.0);
+        assert_eq!(entries[0].score, Some(0.9));
+    }
+
+    #[test]
+    fn recent_entry_score_barely_changes() {
+        let mut entries = vec![make_entry(
+            MemoryCategory::Conversation,
+            Some(0.8),
+            &recent_rfc3339(),
+        )];
+        apply_time_decay(&mut entries, 7.0);
+        let decayed = entries[0].score.unwrap();
+        assert!(
+            (decayed - 0.8).abs() < 0.01,
+            "recent entry should barely decay, got {decayed}"
+        );
+    }
+
+    #[test]
+    fn one_half_life_halves_score() {
+        let mut entries = vec![make_entry(
+            MemoryCategory::Conversation,
+            Some(1.0),
+            &days_ago_rfc3339(7),
+        )];
+        apply_time_decay(&mut entries, 7.0);
+        let decayed = entries[0].score.unwrap();
+        assert!(
+            (decayed - 0.5).abs() < 0.05,
+            "score after one half-life should be ~0.5, got {decayed}"
+        );
+    }
+
+    #[test]
+    fn two_half_lives_quarters_score() {
+        let mut entries = vec![make_entry(
+            MemoryCategory::Conversation,
+            Some(1.0),
+            &days_ago_rfc3339(14),
+        )];
+        apply_time_decay(&mut entries, 7.0);
+        let decayed = entries[0].score.unwrap();
+        assert!(
+            (decayed - 0.25).abs() < 0.05,
+            "score after two half-lives should be ~0.25, got {decayed}"
+        );
+    }
+
+    #[test]
+    fn no_score_entry_is_unchanged() {
+        let mut entries = vec![make_entry(
+            MemoryCategory::Conversation,
+            None,
+            &days_ago_rfc3339(30),
+        )];
+        apply_time_decay(&mut entries, 7.0);
+        assert_eq!(entries[0].score, None);
+    }
+
+    #[test]
+    fn unparseable_timestamp_is_unchanged() {
+        let mut entries = vec![make_entry(
+            MemoryCategory::Conversation,
+            Some(0.9),
+            "not-a-date",
+        )];
+        apply_time_decay(&mut entries, 7.0);
+        assert_eq!(entries[0].score, Some(0.9));
+    }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2,6 +2,7 @@ pub mod backend;
 pub mod chunker;
 pub mod cli;
 pub mod cortex;
+pub mod decay;
 pub mod embeddings;
 pub mod hybrid;
 pub mod hygiene;


### PR DESCRIPTION
 Summary

  - Base branch target: main
  - Problem: Memory retrieval ranks purely by relevance with no recency signal, causing stale entries to compete equally with
  recent ones and leading to outdated context in long-lived sessions
  - Why it matters: Users' preferences and decisions evolve over time; the agent should naturally favor recent context while
  preserving important long-term facts
  - What changed: Added src/memory/decay.rs with apply_time_decay() (exponential decay, Core exempt), applied in both memory
  retrieval paths
  - What did not change: Memory storage, backend recall() implementations, config schema, compaction logic

  Label Snapshot (required)

  - Risk label: risk: low
  - Size label: size: S
  - Scope labels: memory, agent
  - Module labels: memory: decay, agent: context
  - Contributor tier label: (auto-managed)
  - If any auto-label is incorrect: N/A

  Change Metadata

  - Change type: feature
  - Primary scope: memory

  Linked Issue

  - Closes #2386

  Supersede Attribution (required when Supersedes # is used)

  N/A

  Validation Evidence (required)

  cargo check                    # ✅ compiles (pre-existing warnings only, none in modified files)
  cargo test "decay"             # ✅ 6/6 passed
  cargo test "default_loader"    # ✅ 2/2 passed
  cargo test "build_context_ignores"  # ✅ 1/1 passed
  cargo clippy -- -D warnings | grep -E "decay|context\.rs|memory_loader"  # ✅ no output

  - Evidence provided: test output (9 total tests passed across 3 test groups)
  - If any command is intentionally skipped: Full cargo clippy has pre-existing warnings in unrelated modules; confirmed zero
  warnings in all modified/new files

  Security Impact (required)

  - New permissions/capabilities? No
  - New external network calls? No
  - Secrets/tokens handling changed? No
  - File system access scope changed? No

  Privacy and Data Hygiene (required)

  - Data-hygiene status: pass
  - Redaction/anonymization notes: No user data involved; decay operates on ephemeral scores at retrieval time
  - Neutral wording confirmation: All test fixtures use impersonal identifiers ("test", "value")

  Compatibility / Migration

  - Backward compatible? Yes (no storage changes, no config changes, no API changes)
  - Config/env changes? No
  - Migration needed? No

  i18n Follow-Through

  - i18n follow-through triggered? No (no docs or user-facing wording changes)

  Human Verification (required)

  - Verified scenarios: Decay math correctness at 0/7/14 days, Core exemption, no-score passthrough, bad-timestamp passthrough
  - Edge cases checked: Negative duration (future timestamps clamped to 0), zero/negative half-life (falls back to default),
  empty entry list
  - What was not verified: Live integration with real memory backends (unit tests use in-memory entries)

  Side Effects / Blast Radius (required)

  - Affected subsystems/workflows: Memory retrieval scoring in both build_context (interactive loop) and DefaultMemoryLoader
  (Agent struct) paths
  - Potential unintended effects: Older Conversation/Daily memories with marginal relevance scores may now fall below
  min_relevance_score threshold and be excluded from context. This is the intended behavior.
  - Guardrails/monitoring: Core memories are exempt; half-life constant is easy to tune; decay is purely ephemeral (no stored
  data modified)

  Rollback Plan (required)

  - Fast rollback command/path: Remove apply_time_decay() calls in context.rs and memory_loader.rs (2 lines total); module
  remains inert
  - Feature flags or config toggles: None (can be added later by making half-life configurable with 0.0 = disabled)
  - Observable failure symptoms: None expected; if decay is too aggressive, users would notice the agent "forgetting"
  recent-but-not-today context — resolved by increasing half-life constant

  Risks and Mitigations

  - Risk: 7-day half-life may be too aggressive for some usage patterns (e.g., weekly check-in users)
    - Mitigation: Core memories are exempt (long-term facts preserved); half-life can be made configurable via config schema in
  a follow-up PR
  - Risk: None (zero latency cost, zero storage mutation, zero external calls)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented time-decay processing for memory entries to prioritize recent information. Memories gradually lose relevance over time using exponential decay with a configurable half-life period. Core memories remain exempt from decay and retain full relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- intake-refresh: 2026-03-01T14:00:46Z -->
