### PR TITLE
fix(anthropic): handle empty text content blocks in non-streaming response

### DIFF
--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -410,6 +410,8 @@ impl AnthropicProvider {
             .into_iter()
             .find(|c| c.kind == "text")
             .and_then(|c| c.text)
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
             .ok_or_else(|| anyhow::anyhow!("No response from Anthropic"))
     }
 
@@ -1411,6 +1413,51 @@ mod tests {
         let resp: NativeChatResponse = serde_json::from_str(json).unwrap();
         let result = AnthropicProvider::parse_native_response(resp);
         assert!(result.usage.is_none());
+    }
+
+    #[test]
+    fn text_response_skips_empty_text_block() {
+        let json = r#"{"content": [{"type": "text", "text": ""}]}"#;
+        let resp: ChatResponse = serde_json::from_str(json).unwrap();
+        let result = AnthropicProvider::parse_text_response(resp);
+        assert!(result.is_err(), "Empty text block should produce an error");
+    }
+
+    #[test]
+    fn text_response_skips_whitespace_only_block() {
+        let json = r#"{"content": [{"type": "text", "text": "   \n  "}]}"#;
+        let resp: ChatResponse = serde_json::from_str(json).unwrap();
+        let result = AnthropicProvider::parse_text_response(resp);
+        assert!(
+            result.is_err(),
+            "Whitespace-only text block should produce an error"
+        );
+    }
+
+    #[test]
+    fn text_response_trims_valid_text() {
+        let json = r#"{"content": [{"type": "text", "text": "  Hello world  "}]}"#;
+        let resp: ChatResponse = serde_json::from_str(json).unwrap();
+        let result = AnthropicProvider::parse_text_response(resp).unwrap();
+        assert_eq!(result, "Hello world");
+    }
+
+    #[test]
+    fn native_response_skips_empty_text_with_tool_calls() {
+        let json = r#"{
+            "content": [
+                {"type": "text", "text": ""},
+                {"type": "tool_use", "id": "call_1", "name": "shell", "input": {"command": "ls"}}
+            ]
+        }"#;
+        let resp: NativeChatResponse = serde_json::from_str(json).unwrap();
+        let result = AnthropicProvider::parse_native_response(resp);
+        assert!(
+            result.text.is_none(),
+            "Empty text block should not produce text output"
+        );
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].name, "shell");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: `parse_text_response()` returns empty string when Anthropic API sends text content blocks with empty/whitespace-only text
- Why it matters: Downstream callers expect meaningful text; empty string causes silent failures
- What changed: Added `.map(|t| t.trim().to_string()).filter(|t| !t.is_empty())` to `parse_text_response()` + 4 new tests
- What did **not** change: `parse_native_response()` (already handles this correctly), no API behavior changes

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `provider`
- Module labels: `provider: anthropic`
- Contributor tier label: (first contribution)
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `provider`

## Linked Issue

- Closes #2411

## Validation Evidence (required)

```bash
# Format check (anthropic.rs only — wizard.rs has pre-existing fmt issue on main)
rustfmt --check src/providers/anthropic.rs  # ✅ clean

# Non-test compilation
cargo check  # ✅ clean

# Test compilation has pre-existing failure on main:
# error[E0063]: missing fields `bluebubbles` and `bluebubbles_webhook_secret`
# in src/gateway/mod.rs:3824 — NOT introduced by this PR
```

- Evidence provided: fmt check clean, cargo check clean
- Pre-existing issues on main: `cargo test --lib` fails due to missing `bluebubbles` fields in gateway test AppState constructors (unrelated to this change)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes, tests use project-scoped neutral wording

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Empty text block, whitespace-only text block, valid text with leading/trailing whitespace, empty text alongside tool_use blocks
- Edge cases checked: `""`, `"   \n  "`, `"  Hello world  "`, mixed text+tool_use content
- What was not verified: Full integration test (blocked by pre-existing test compilation issue on main)

## Side Effects / Blast Radius (required)

- Affected subsystems: `providers::anthropic::parse_text_response()` only
- Potential unintended effects: Callers that previously received empty strings will now get an error — this is the correct behavior
- Guardrails: Behavior now matches `parse_native_response()` which has been working correctly

## Rollback Plan (required)

- Fast rollback: Revert commit (single file, 2-line functional change)
- Feature flags: None needed
- Observable failure symptoms: "No response from Anthropic" error where empty string was previously returned

## Risks and Mitigations

- Risk: Code paths that tolerated empty string responses may now see errors
  - Mitigation: This aligns with the existing `parse_native_response()` behavior; empty responses from Anthropic are not useful to callers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Response parsing now ignores empty or whitespace-only text blocks and trims surrounding whitespace, yielding more consistent and reliable outputs when responses include incidental blank content.

* **Tests**
  * Added tests validating that empty or whitespace-only blocks are skipped and that valid text is correctly trimmed to prevent unexpected empty responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->