### PR TITLE
ci: fix queue hygiene apply-mode authentication

### DIFF
--- a/.github/workflows/ci-queue-hygiene.yml
+++ b/.github/workflows/ci-queue-hygiene.yml
@@ -51,6 +51,8 @@ jobs:
             - name: Run queue hygiene policy
               id: hygiene
               shell: bash
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   set -euo pipefail
                   mkdir -p artifacts

--- a/scripts/ci/queue_hygiene.py
+++ b/scripts/ci/queue_hygiene.py
@@ -321,6 +321,13 @@ def main() -> int:
 
     owner, repo = split_repo(args.repo)
     token = resolve_token(args.token)
+    if args.apply and not token:
+        print(
+            "queue_hygiene: apply mode requires authentication token "
+            "(set GH_TOKEN/GITHUB_TOKEN, pass --token, or configure gh auth).",
+            file=sys.stderr,
+        )
+        return 2
     api = GitHubApi(args.api_url, token)
 
     if args.runs_json:


### PR DESCRIPTION
## Summary
- pass `GH_TOKEN` to queue hygiene workflow step so apply-mode cancellation calls are authenticated
- add explicit apply-mode token guard in `scripts/ci/queue_hygiene.py` for clear failure semantics
- add regression test ensuring apply mode fails fast when token is absent

## Root Cause
`CI Queue Hygiene` run `22547744689` failed with HTTP `401 Requires authentication` while calling `POST /actions/runs/{id}/cancel`.
The workflow step did not export `GITHUB_TOKEN`/`GH_TOKEN` to the script process.

## Validation
- python3 -m unittest scripts/ci/tests/test_ci_scripts.py -k queue_hygiene
- python3 -m py_compile scripts/ci/queue_hygiene.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Queue hygiene process now enforces authentication token requirement in apply mode with explicit error handling

* **Tests**
  * Added test coverage to verify authentication token validation for queue hygiene operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->