### PR TITLE
feat(file_edit): whitespace-flexible fallback matching (issue #2348)

### DIFF
--- a/src/tools/file_edit.rs
+++ b/src/tools/file_edit.rs
@@ -9,10 +9,12 @@ use std::sync::Arc;
 
 /// Edit a file by replacing an exact string match with new content.
 ///
-/// Uses `old_string` → `new_string` precise replacement within the workspace.
-/// The `old_string` must appear exactly once in the file (zero matches = not
-/// found, multiple matches = ambiguous). `new_string` may be empty to delete
-/// the matched text. Security checks mirror [`super::file_write::FileWriteTool`].
+/// Uses `old_string` → `new_string` replacement within the workspace.
+/// Exact matching is preferred and unchanged. When exact matching finds zero
+/// matches, the tool falls back to whitespace-flexible line matching.
+/// The final match must still be unique (zero matches = not found, multiple
+/// matches = ambiguous). `new_string` may be empty to delete the matched text.
+/// Security checks mirror [`super::file_write::FileWriteTool`].
 pub struct FileEditTool {
     security: Arc<SecurityPolicy>,
 }
@@ -38,6 +40,169 @@ fn hard_link_edit_block_message(path: &Path) -> String {
     )
 }
 
+#[derive(Debug, Clone, Copy)]
+struct LineSpan {
+    start: usize,
+    content_end: usize,
+    end: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MatchOutcome {
+    start: usize,
+    end: usize,
+    used_whitespace_flex: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FlexibleLineMatch {
+    NoMatch,
+    Unique { start: usize, end: usize },
+    Ambiguous { count: usize },
+}
+
+fn normalize_line(line: &str) -> String {
+    let trimmed = line.trim_end_matches([' ', '\t']);
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut in_whitespace_run = false;
+
+    for ch in trimmed.chars() {
+        if ch == ' ' || ch == '\t' {
+            if !in_whitespace_run {
+                normalized.push(' ');
+                in_whitespace_run = true;
+            }
+        } else {
+            normalized.push(ch);
+            in_whitespace_run = false;
+        }
+    }
+
+    normalized
+}
+
+fn compute_line_spans(content: &str) -> Vec<LineSpan> {
+    let mut spans = Vec::new();
+    let bytes = content.as_bytes();
+    let mut line_start = 0usize;
+
+    for (idx, byte) in bytes.iter().enumerate() {
+        if *byte == b'\n' {
+            let mut content_end = idx;
+            if content_end > line_start && bytes[content_end - 1] == b'\r' {
+                content_end -= 1;
+            }
+            spans.push(LineSpan {
+                start: line_start,
+                content_end,
+                end: idx + 1,
+            });
+            line_start = idx + 1;
+        }
+    }
+
+    if line_start < content.len() {
+        spans.push(LineSpan {
+            start: line_start,
+            content_end: content.len(),
+            end: content.len(),
+        });
+    }
+
+    spans
+}
+
+fn try_flexible_line_match(content: &str, old_string: &str) -> FlexibleLineMatch {
+    let content_spans = compute_line_spans(content);
+    let old_spans = compute_line_spans(old_string);
+
+    if old_spans.is_empty() || content_spans.len() < old_spans.len() {
+        return FlexibleLineMatch::NoMatch;
+    }
+
+    let normalized_old_lines: Vec<String> = old_spans
+        .iter()
+        .map(|span| normalize_line(&old_string[span.start..span.content_end]))
+        .collect();
+    let normalized_content_lines: Vec<String> = content_spans
+        .iter()
+        .map(|span| normalize_line(&content[span.start..span.content_end]))
+        .collect();
+
+    let mut match_count = 0usize;
+    let mut matched_start_line = 0usize;
+    let window_size = old_spans.len();
+
+    for start_line in 0..=(content_spans.len() - window_size) {
+        let mut window_matches = true;
+        for line_offset in 0..window_size {
+            if normalized_content_lines[start_line + line_offset]
+                != normalized_old_lines[line_offset]
+            {
+                window_matches = false;
+                break;
+            }
+        }
+
+        if window_matches {
+            match_count += 1;
+            if match_count == 1 {
+                matched_start_line = start_line;
+            }
+        }
+    }
+
+    if match_count == 0 {
+        return FlexibleLineMatch::NoMatch;
+    }
+
+    if match_count > 1 {
+        return FlexibleLineMatch::Ambiguous { count: match_count };
+    }
+
+    let first_span = content_spans[matched_start_line];
+    let last_span = content_spans[matched_start_line + window_size - 1];
+    let end = if old_string.ends_with('\n') {
+        last_span.end
+    } else {
+        last_span.content_end
+    };
+
+    FlexibleLineMatch::Unique {
+        start: first_span.start,
+        end,
+    }
+}
+
+fn resolve_match(content: &str, old_string: &str) -> Result<MatchOutcome, String> {
+    let mut exact_matches = content.match_indices(old_string);
+    if let Some((start, _)) = exact_matches.next() {
+        if exact_matches.next().is_some() {
+            let match_count = 2 + exact_matches.count();
+            return Err(format!(
+                "old_string matches {match_count} times; must match exactly once"
+            ));
+        }
+        return Ok(MatchOutcome {
+            start,
+            end: start + old_string.len(),
+            used_whitespace_flex: false,
+        });
+    }
+
+    match try_flexible_line_match(content, old_string) {
+        FlexibleLineMatch::NoMatch => Err("old_string not found in file".into()),
+        FlexibleLineMatch::Ambiguous { count } => Err(format!(
+            "old_string matches {count} times with whitespace flexibility; must match exactly once"
+        )),
+        FlexibleLineMatch::Unique { start, end } => Ok(MatchOutcome {
+            start,
+            end,
+            used_whitespace_flex: true,
+        }),
+    }
+}
+
 #[async_trait]
 impl Tool for FileEditTool {
     fn name(&self) -> &str {
@@ -45,7 +210,7 @@ impl Tool for FileEditTool {
     }
 
     fn description(&self) -> &str {
-        "Edit a file by replacing an exact string match with new content. Sensitive files (for example .env and key material) are blocked by default."
+        "Edit a file by replacing text in a file. Exact matching is preferred; if exact matching fails, whitespace-flexible line matching is used. Sensitive files (for example .env and key material) are blocked by default."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -58,7 +223,7 @@ impl Tool for FileEditTool {
                 },
                 "old_string": {
                     "type": "string",
-                    "description": "The exact text to find and replace (must appear exactly once in the file)"
+                    "description": "The text to find and replace. Exact matching is attempted first; if no exact match is found, whitespace-flexible line matching is attempted."
                 },
                 "new_string": {
                     "type": "string",
@@ -226,34 +391,43 @@ impl Tool for FileEditTool {
             }
         };
 
-        let match_count = content.matches(old_string).count();
+        let match_outcome = match resolve_match(&content, old_string) {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(error),
+                });
+            }
+        };
 
-        if match_count == 0 {
+        if match_outcome.end < match_outcome.start || match_outcome.end > content.len() {
             return Ok(ToolResult {
                 success: false,
                 output: String::new(),
-                error: Some("old_string not found in file".into()),
+                error: Some("Internal matching error: invalid replacement range".into()),
             });
         }
 
-        if match_count > 1 {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some(format!(
-                    "old_string matches {match_count} times; must match exactly once"
-                )),
-            });
-        }
-
-        let new_content = content.replacen(old_string, new_string, 1);
+        let mut new_content = String::with_capacity(
+            content.len() - (match_outcome.end - match_outcome.start) + new_string.len(),
+        );
+        new_content.push_str(&content[..match_outcome.start]);
+        new_content.push_str(new_string);
+        new_content.push_str(&content[match_outcome.end..]);
 
         match tokio::fs::write(&resolved_target, &new_content).await {
             Ok(()) => Ok(ToolResult {
                 success: true,
                 output: format!(
-                    "Edited {path}: replaced 1 occurrence ({} bytes)",
-                    new_content.len()
+                    "Edited {path}: replaced 1 occurrence ({} bytes){}",
+                    new_content.len(),
+                    if match_outcome.used_whitespace_flex {
+                        " (matched with whitespace flexibility)"
+                    } else {
+                        ""
+                    }
                 ),
                 error: None,
             }),
@@ -380,6 +554,272 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(content, "hello world");
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_edit_flexible_match_indentation_difference() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_edit_flex_indent");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(
+            dir.join("test.txt"),
+            "fn main() {\n    println!(\"hi\");\n}\n",
+        )
+        .await
+        .unwrap();
+
+        let tool = FileEditTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({
+                "path": "test.txt",
+                "old_string": "fn main() {\n  println!(\"hi\");\n}\n",
+                "new_string": "fn main() {\n    println!(\"hello\");\n}\n"
+            }))
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "flexible indentation match should succeed: {:?}",
+            result.error
+        );
+        assert!(result.output.contains("whitespace flexibility"));
+
+        let content = tokio::fs::read_to_string(dir.join("test.txt"))
+            .await
+            .unwrap();
+        assert_eq!(content, "fn main() {\n    println!(\"hello\");\n}\n");
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_edit_flexible_match_tab_space_difference() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_edit_flex_tabs");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("test.txt"), "alpha\n\tbeta\ngamma\n")
+            .await
+            .unwrap();
+
+        let tool = FileEditTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({
+                "path": "test.txt",
+                "old_string": "alpha\n  beta\ngamma\n",
+                "new_string": "alpha\n\tdelta\ngamma\n"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "tab/space flex match should succeed");
+        assert!(result.output.contains("whitespace flexibility"));
+
+        let content = tokio::fs::read_to_string(dir.join("test.txt"))
+            .await
+            .unwrap();
+        assert_eq!(content, "alpha\n\tdelta\ngamma\n");
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_edit_flexible_match_trailing_whitespace_difference() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_edit_flex_trailing");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("test.txt"), "line one   \nline two\t\t\n")
+            .await
+            .unwrap();
+
+        let tool = FileEditTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({
+                "path": "test.txt",
+                "old_string": "line one\nline two\n",
+                "new_string": "line one\nline 2\n"
+            }))
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "trailing whitespace flex match should succeed"
+        );
+        assert!(result.output.contains("whitespace flexibility"));
+
+        let content = tokio::fs::read_to_string(dir.join("test.txt"))
+            .await
+            .unwrap();
+        assert_eq!(content, "line one\nline 2\n");
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_edit_flexible_match_collapsed_spaces() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_edit_flex_spaces");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("test.txt"), "let value    =    42;\n")
+            .await
+            .unwrap();
+
+        let tool = FileEditTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({
+                "path": "test.txt",
+                "old_string": "let value = 42;\n",
+                "new_string": "let value = 7;\n"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "collapsed-space flex match should succeed");
+        assert!(result.output.contains("whitespace flexibility"));
+
+        let content = tokio::fs::read_to_string(dir.join("test.txt"))
+            .await
+            .unwrap();
+        assert_eq!(content, "let value = 7;\n");
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_edit_flexible_match_ambiguous_errors() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_edit_flex_ambiguous");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(
+            dir.join("test.txt"),
+            "if cond {\n    work();\n}\n\nif cond {\n\twork();\n}\n",
+        )
+        .await
+        .unwrap();
+
+        let tool = FileEditTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({
+                "path": "test.txt",
+                "old_string": "if cond {\n  work();\n}\n",
+                "new_string": "if cond {\n  done();\n}\n"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success, "ambiguous flex match must fail");
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("whitespace flexibility"));
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("matches 2 times"));
+
+        let content = tokio::fs::read_to_string(dir.join("test.txt"))
+            .await
+            .unwrap();
+        assert_eq!(
+            content,
+            "if cond {\n    work();\n}\n\nif cond {\n\twork();\n}\n"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_edit_flexible_match_not_found_when_no_line_match() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_edit_flex_not_found");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("test.txt"), "alpha\nbeta\n")
+            .await
+            .unwrap();
+
+        let tool = FileEditTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({
+                "path": "test.txt",
+                "old_string": "gamma\n",
+                "new_string": "delta\n"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success, "non-matching flex case should fail");
+        assert!(result.error.as_deref().unwrap_or("").contains("not found"));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_edit_prefers_exact_match_over_flexible() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_edit_exact_preference");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(
+            dir.join("test.txt"),
+            "let value = 1;\nlet value    =    1;\n",
+        )
+        .await
+        .unwrap();
+
+        let tool = FileEditTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({
+                "path": "test.txt",
+                "old_string": "let value = 1;",
+                "new_string": "let value = 2;"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "exact match should succeed");
+        assert!(!result.output.contains("whitespace flexibility"));
+
+        let content = tokio::fs::read_to_string(dir.join("test.txt"))
+            .await
+            .unwrap();
+        assert_eq!(content, "let value = 2;\nlet value    =    1;\n");
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_edit_flexible_match_preserves_trailing_newline_when_old_string_has_none() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_edit_flex_no_trailing_nl");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        tokio::fs::write(dir.join("test.txt"), "line one\n    line two\nline three\n")
+            .await
+            .unwrap();
+
+        let tool = FileEditTool::new(test_security(dir.clone()));
+        let result = tool
+            .execute(json!({
+                "path": "test.txt",
+                "old_string": "line one\n  line two\nline three",
+                "new_string": "updated block"
+            }))
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "flex match without trailing newline should succeed"
+        );
+        assert!(result.output.contains("whitespace flexibility"));
+
+        let content = tokio::fs::read_to_string(dir.join("test.txt"))
+            .await
+            .unwrap();
+        assert_eq!(content, "updated block\n");
 
         let _ = tokio::fs::remove_dir_all(&dir).await;
     }


### PR DESCRIPTION
## Summary
Implements issue #2348 by adding a safe whitespace-flexible fallback for `file_edit` while preserving exact-match behavior.

## Scope
- File: `src/tools/file_edit.rs` only
- No dependency changes
- No security policy boundary changes

## Behavior
1. Matching strategy:
- Tier 1: exact substring match (unchanged, preferred)
- Tier 2: whitespace-flexible line-window match (only if tier 1 finds zero matches)

2. Safety invariants preserved:
- zero matches -> error
- multiple matches -> error
- never silently selects among ambiguous matches

3. Output observability:
- successful fallback edits append `(matched with whitespace flexibility)`

## Test Coverage
Added focused tests for:
- indentation differences
- tab vs space differences
- trailing whitespace differences
- collapsed spaces
- ambiguity rejection
- no-match rejection
- exact-match precedence
- trailing-newline boundary behavior

## Validation
- `rustfmt src/tools/file_edit.rs` ✅
- `cargo check --lib` ✅
- `cargo test --lib tools::file_edit -- --nocapture` ⚠️ blocked by unrelated upstream `lib test` compile error in `src/gateway/mod.rs` (`AppState` test initializer missing `bluebubbles` fields)
- `cargo clippy --lib -- -D warnings` ⚠️ blocked by pre-existing repo-wide clippy failures unrelated to this PR

## Risk / Rollback
- Risk: medium-high (tool matching path), mitigated by exact-first strategy and strict ambiguity handling
- Rollback: revert commit `b2c019d5`

## Links
- Closes #2348
