### PR TITLE
feat(cli): build-time short SHA in version output (issue #2347)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 name = "zeroclaw"
 version = "0.1.7"
 edition = "2021"
+build = "build.rs"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"
 description = "Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant."

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,80 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn git_short_sha(manifest_dir: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(manifest_dir)
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let short_sha = String::from_utf8(output.stdout).ok()?;
+    let trimmed = short_sha.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn emit_git_rerun_hints(manifest_dir: &str) {
+    let output = Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .current_dir(manifest_dir)
+        .output();
+
+    let Ok(output) = output else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+
+    let Ok(git_dir_raw) = String::from_utf8(output.stdout) else {
+        return;
+    };
+    let git_dir_raw = git_dir_raw.trim();
+    if git_dir_raw.is_empty() {
+        return;
+    }
+
+    let git_dir = if PathBuf::from(git_dir_raw).is_absolute() {
+        PathBuf::from(git_dir_raw)
+    } else {
+        PathBuf::from(manifest_dir).join(git_dir_raw)
+    };
+
+    println!("cargo:rerun-if-changed={}", git_dir.join("HEAD").display());
+    println!("cargo:rerun-if-changed={}", git_dir.join("refs").display());
+}
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=ZEROCLAW_GIT_SHORT_SHA");
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    emit_git_rerun_hints(&manifest_dir);
+
+    let package_version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "0.0.0".to_string());
+    let short_sha = env::var("ZEROCLAW_GIT_SHORT_SHA")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| git_short_sha(&manifest_dir));
+
+    let build_version = if let Some(sha) = short_sha.as_deref() {
+        format!("{package_version} ({sha})")
+    } else {
+        package_version
+    };
+
+    println!("cargo:rustc-env=ZEROCLAW_BUILD_VERSION={build_version}");
+    println!(
+        "cargo:rustc-env=ZEROCLAW_GIT_SHORT_SHA={}",
+        short_sha.unwrap_or_default()
+    );
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ use tracing::{info, warn};
 use tracing_subscriber::{fmt, EnvFilter};
 
 const PROFILE_MISMATCH_PREFIX: &str = "Pending login profile mismatch:";
+const ZEROCLAW_BUILD_VERSION: &str = env!("ZEROCLAW_BUILD_VERSION");
 
 #[derive(Debug, Clone, ValueEnum)]
 enum QuotaFormat {
@@ -132,7 +133,7 @@ enum EstopLevelArg {
 #[derive(Parser, Debug)]
 #[command(name = "zeroclaw")]
 #[command(author = "theonlyhennygod")]
-#[command(version)]
+#[command(version = ZEROCLAW_BUILD_VERSION)]
 #[command(about = "The fastest, smallest AI assistant.", long_about = None)]
 struct Cli {
     #[arg(long, global = true)]
@@ -1021,7 +1022,7 @@ async fn main() -> Result<()> {
         Commands::Status => {
             println!("🦀 ZeroClaw Status");
             println!();
-            println!("Version:     {}", env!("CARGO_PKG_VERSION"));
+            println!("Version:     {}", ZEROCLAW_BUILD_VERSION);
             println!("Workspace:   {}", config.workspace_dir.display());
             println!("Config:      {}", config.config_path.display());
             println!();


### PR DESCRIPTION
## Summary
Implements issue #2347 by embedding git short SHA at build time and exposing it in CLI version output.

## Scope
- Files:
  - `Cargo.toml`
  - `build.rs` (new)
  - `src/main.rs`
- No runtime git calls
- Backward-compatible output fallback when git metadata is unavailable

## Behavior
1. Build-time metadata:
- compose `ZEROCLAW_BUILD_VERSION` as `<semver> (<short-sha>)` when SHA is available
- fallback to `<semver>` otherwise

2. CLI output updates:
- `zeroclaw --version` uses build-time composed version string
- `zeroclaw status` version line aligned to the same value

## Validation
- `cargo check --bin zeroclaw` ✅
- `cargo run --bin zeroclaw -- --version` ✅
  - observed: `zeroclaw 0.1.7 (528aed53)`
- `cargo run --release --bin zeroclaw -- --version` ✅
  - observed: `zeroclaw 0.1.7 (528aed53)`

## Risk / Rollback
- Risk: low (version string/build metadata path)
- Rollback: revert commit `a13782f0`

## Links
- Closes #2347
