### PR TITLE
test(gateway): fix AppState BlueBubbles fixture fields

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -3837,6 +3837,8 @@ Reminder set successfully."#;
             whatsapp_app_secret: None,
             linq: None,
             linq_signing_secret: None,
+            bluebubbles: None,
+            bluebubbles_webhook_secret: None,
             nextcloud_talk: None,
             nextcloud_talk_webhook_secret: None,
             wati: None,


### PR DESCRIPTION
## Summary
- update gateway node-control AppState test fixture to include BlueBubbles fields
- restore clean test compilation after AppState field expansion

## Validation
- `cargo test --no-default-features connect_nonexistent_command_fails_cleanly -- --nocapture`
- `cargo test --no-default-features connect_all_nonfatal_on_single_failure -- --nocapture`
- `cargo test --no-default-features test_extract_json_from_sse_with_event_and_id -- --nocapture`
- `cargo test --no-default-features test_transport_default_is_stdio -- --nocapture`

Closes #1380