### PR TITLE
fix(ci): avoid canceled duplicate issue auto-response runs

### DIFF
--- a/.github/workflows/pr-auto-response.yml
+++ b/.github/workflows/pr-auto-response.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: pr-auto-response-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions: {}
 
@@ -23,7 +23,7 @@ jobs:
   contributor-tier-issues:
     if: >-
       (github.event_name == 'issues' &&
-      (github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'labeled' || github.event.action == 'unlabeled')) ||
+      (github.event.action == 'opened' || github.event.action == 'reopened')) ||
       (github.event_name == 'pull_request_target' &&
       (github.event.action == 'labeled' || github.event.action == 'unlabeled'))
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
- adjust `pr-auto-response` workflow concurrency so issue `opened` and `labeled` events no longer cancel each other
- scope contributor-tier issue processing to `opened`/`reopened` events only (label changes on issues no longer trigger that extra tier job)

## Why
Creating an issue with template/default labels emits both `issues.opened` and `issues.labeled`. Previously, shared concurrency with `cancel-in-progress: true` caused the second run to show as canceled, which looked like a workflow failure.

## Validation
- Parsed workflow YAML successfully:
  - `ruby -ryaml -e "YAML.load_file('.github/workflows/pr-auto-response.yml')"`

Closes #2352
