### PR TITLE
feat(agent): expose tool_specs and public run_tool_call_loop

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -243,6 +243,10 @@ impl Agent {
         AgentBuilder::new()
     }
 
+    pub fn tool_specs(&self) -> &[ToolSpec] {
+        &self.tool_specs
+    }
+
     pub fn history(&self) -> &[ConversationMessage] {
         &self.history
     }

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -983,7 +983,7 @@ pub(crate) async fn run_tool_call_loop_with_non_cli_approval_context(
 /// Execute a single turn of the agent loop: send messages, parse tool calls,
 /// execute tools, and loop until the LLM produces a final text response.
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn run_tool_call_loop(
+pub async fn run_tool_call_loop(
     provider: &dyn Provider,
     history: &mut Vec<ChatMessage>,
     tools_registry: &[Box<dyn Tool>],

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -16,4 +16,4 @@ mod tests;
 #[allow(unused_imports)]
 pub use agent::{Agent, AgentBuilder};
 #[allow(unused_imports)]
-pub use loop_::{process_message, process_message_with_session, run};
+pub use loop_::{process_message, process_message_with_session, run, run_tool_call_loop};

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -736,6 +736,20 @@ async fn native_dispatcher_sends_tool_specs() {
     assert!(dispatcher.should_send_tool_specs());
 }
 
+#[test]
+fn agent_tool_specs_accessor_exposes_registered_tools() {
+    let provider = Box::new(ScriptedProvider::new(vec![text_response("ok")]));
+    let agent = build_agent_with(
+        provider,
+        vec![Box::new(EchoTool)],
+        Box::new(NativeToolDispatcher),
+    );
+
+    let specs = agent.tool_specs();
+    assert_eq!(specs.len(), 1);
+    assert_eq!(specs[0].name, "echo");
+}
+
 #[tokio::test]
 async fn xml_dispatcher_does_not_send_tool_specs() {
     let dispatcher = XmlToolDispatcher;


### PR DESCRIPTION
## Summary
- add `Agent::tool_specs(&self) -> &[ToolSpec]` as a zero-copy read-only accessor for registered tool specs
- widen `run_tool_call_loop` visibility from `pub(crate)` to `pub`
- re-export `run_tool_call_loop` from `src/agent/mod.rs`
- add a test ensuring `tool_specs()` exposes registered tools

## Why
Library consumers need public access to:
- tool specs for runtime inspection / UI wiring
- the existing tool call loop for custom execution frontends

This change widens API visibility only and does not alter loop behavior.

## Validation
- `cargo test agent_tool_specs_accessor_exposes_registered_tools -- --nocapture`
- `cargo test run_tool_call_loop_returns_structured_error_for_non_vision_provider -- --nocapture`

Closes #2384
