### PR TITLE
feat(memory): boost Core memories in context retrieval

### DIFF
--- a/src/agent/loop_/context.rs
+++ b/src/agent/loop_/context.rs
@@ -1,13 +1,29 @@
-use crate::memory::{self, decay, Memory};
+use crate::memory::{self, decay, Memory, MemoryCategory};
 use std::fmt::Write;
 
 /// Default half-life (days) for time decay in context building.
 const CONTEXT_DECAY_HALF_LIFE_DAYS: f64 = 7.0;
 
+/// Score boost applied to `Core` category memories so durable facts and
+/// preferences surface even when keyword/semantic similarity is moderate.
+const CORE_CATEGORY_SCORE_BOOST: f64 = 0.3;
+
+/// Maximum number of memory entries included in the context preamble.
+const CONTEXT_ENTRY_LIMIT: usize = 5;
+
+/// Over-fetch factor: retrieve more candidates than the output limit so
+/// that Core boost and re-ranking can select the best subset.
+const RECALL_OVER_FETCH_FACTOR: usize = 2;
+
 /// Build context preamble by searching memory for relevant entries.
 /// Entries with a hybrid score below `min_relevance_score` are dropped to
 /// prevent unrelated memories from bleeding into the conversation.
+///
 /// Core memories are exempt from time decay (evergreen).
+///
+/// `Core` category memories receive a score boost so that durable facts,
+/// preferences, and project rules are more likely to appear in context
+/// even when semantic similarity to the current message is moderate.
 pub(super) async fn build_context(
     mem: &dyn Memory,
     user_msg: &str,
@@ -16,32 +32,41 @@ pub(super) async fn build_context(
 ) -> String {
     let mut context = String::new();
 
-    // Pull relevant memories for this message
-    if let Ok(mut entries) = mem.recall(user_msg, 5, session_id).await {
-        // Apply time decay: older non-Core memories score lower
+    // Over-fetch so Core-boosted entries can compete fairly after re-ranking.
+    let fetch_limit = CONTEXT_ENTRY_LIMIT * RECALL_OVER_FETCH_FACTOR;
+    if let Ok(mut entries) = mem.recall(user_msg, fetch_limit, session_id).await {
+        // Apply time decay: older non-Core memories score lower.
         decay::apply_time_decay(&mut entries, CONTEXT_DECAY_HALF_LIFE_DAYS);
 
-        let relevant: Vec<_> = entries
+        // Apply Core category boost and filter by minimum relevance.
+        let mut scored: Vec<_> = entries
             .iter()
-            .filter(|e| match e.score {
-                Some(score) => score >= min_relevance_score,
-                None => true,
+            .filter(|e| !memory::is_assistant_autosave_key(&e.key))
+            .filter_map(|e| {
+                let base = e.score.unwrap_or(min_relevance_score);
+                let boosted = if e.category == MemoryCategory::Core {
+                    (base + CORE_CATEGORY_SCORE_BOOST).min(1.0)
+                } else {
+                    base
+                };
+                if boosted >= min_relevance_score {
+                    Some((e, boosted))
+                } else {
+                    None
+                }
             })
             .collect();
 
-        if !relevant.is_empty() {
+        // Sort by boosted score descending, then truncate to output limit.
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(CONTEXT_ENTRY_LIMIT);
+
+        if !scored.is_empty() {
             context.push_str("[Memory context]\n");
-            for entry in &relevant {
-                if memory::is_assistant_autosave_key(&entry.key) {
-                    continue;
-                }
+            for (entry, _) in &scored {
                 let _ = writeln!(context, "- {}: {}", entry.key, entry.content);
             }
-            if context == "[Memory context]\n" {
-                context.clear();
-            } else {
-                context.push('\n');
-            }
+            context.push('\n');
         }
     }
 
@@ -86,4 +111,136 @@ pub(super) fn build_hardware_context(
     }
     context.push('\n');
     context
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::{Memory, MemoryCategory, MemoryEntry};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct MockMemory {
+        entries: Arc<Vec<MemoryEntry>>,
+    }
+
+    #[async_trait]
+    impl Memory for MockMemory {
+        async fn store(
+            &self,
+            _key: &str,
+            _content: &str,
+            _category: MemoryCategory,
+            _session_id: Option<&str>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn recall(
+            &self,
+            _query: &str,
+            _limit: usize,
+            _session_id: Option<&str>,
+        ) -> anyhow::Result<Vec<MemoryEntry>> {
+            Ok(self.entries.as_ref().clone())
+        }
+
+        async fn get(&self, _key: &str) -> anyhow::Result<Option<MemoryEntry>> {
+            Ok(None)
+        }
+
+        async fn list(
+            &self,
+            _category: Option<&MemoryCategory>,
+            _session_id: Option<&str>,
+        ) -> anyhow::Result<Vec<MemoryEntry>> {
+            Ok(vec![])
+        }
+
+        async fn forget(&self, _key: &str) -> anyhow::Result<bool> {
+            Ok(true)
+        }
+
+        async fn count(&self) -> anyhow::Result<usize> {
+            Ok(self.entries.len())
+        }
+
+        async fn health_check(&self) -> bool {
+            true
+        }
+
+        fn name(&self) -> &str {
+            "mock-memory"
+        }
+    }
+
+    #[tokio::test]
+    async fn build_context_promotes_core_entries_with_score_boost() {
+        let memory = MockMemory {
+            entries: Arc::new(vec![
+                MemoryEntry {
+                    id: "1".into(),
+                    key: "conv_note".into(),
+                    content: "small talk".into(),
+                    category: MemoryCategory::Conversation,
+                    timestamp: "now".into(),
+                    session_id: None,
+                    score: Some(0.6),
+                },
+                MemoryEntry {
+                    id: "2".into(),
+                    key: "core_rule".into(),
+                    content: "always provide tests".into(),
+                    category: MemoryCategory::Core,
+                    timestamp: "now".into(),
+                    session_id: None,
+                    score: Some(0.2),
+                },
+                MemoryEntry {
+                    id: "3".into(),
+                    key: "conv_low".into(),
+                    content: "irrelevant".into(),
+                    category: MemoryCategory::Conversation,
+                    timestamp: "now".into(),
+                    session_id: None,
+                    score: Some(0.1),
+                },
+            ]),
+        };
+
+        let context = build_context(&memory, "test query", 0.4, None).await;
+        assert!(
+            context.contains("core_rule"),
+            "expected core boost to include core_rule"
+        );
+        assert!(
+            !context.contains("conv_low"),
+            "low-score non-core should be filtered"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_context_keeps_output_limit_at_five_entries() {
+        let entries = (0..8)
+            .map(|idx| MemoryEntry {
+                id: idx.to_string(),
+                key: format!("k{idx}"),
+                content: format!("v{idx}"),
+                category: MemoryCategory::Conversation,
+                timestamp: "now".into(),
+                session_id: None,
+                score: Some(0.9 - (idx as f64 * 0.01)),
+            })
+            .collect::<Vec<_>>();
+        let memory = MockMemory {
+            entries: Arc::new(entries),
+        };
+
+        let context = build_context(&memory, "limit", 0.0, None).await;
+        let listed = context
+            .lines()
+            .filter(|line| line.starts_with("- "))
+            .count();
+        assert_eq!(listed, 5, "context output limit should remain 5 entries");
+    }
 }

--- a/src/agent/memory_loader.rs
+++ b/src/agent/memory_loader.rs
@@ -1,9 +1,17 @@
-use crate::memory::{self, decay, Memory};
+use crate::memory::{self, decay, Memory, MemoryCategory};
 use async_trait::async_trait;
 use std::fmt::Write;
 
 /// Default half-life (days) for time decay in memory loading.
 const LOADER_DECAY_HALF_LIFE_DAYS: f64 = 7.0;
+
+/// Score boost applied to `Core` category memories so durable facts and
+/// preferences surface even when keyword/semantic similarity is moderate.
+const CORE_CATEGORY_SCORE_BOOST: f64 = 0.3;
+
+/// Over-fetch factor: retrieve more candidates than the output limit so
+/// that Core boost and re-ranking can select the best subset.
+const RECALL_OVER_FETCH_FACTOR: usize = 2;
 
 #[async_trait]
 pub trait MemoryLoader: Send + Sync {
@@ -41,32 +49,47 @@ impl MemoryLoader for DefaultMemoryLoader {
         memory: &dyn Memory,
         user_message: &str,
     ) -> anyhow::Result<String> {
-        let mut entries = memory.recall(user_message, self.limit, None).await?;
+        // Over-fetch so Core-boosted entries can compete fairly after re-ranking.
+        let fetch_limit = self.limit * RECALL_OVER_FETCH_FACTOR;
+        let mut entries = memory.recall(user_message, fetch_limit, None).await?;
         if entries.is_empty() {
             return Ok(String::new());
         }
 
-        // Apply time decay: older non-Core memories score lower
+        // Apply time decay: older non-Core memories score lower.
         decay::apply_time_decay(&mut entries, LOADER_DECAY_HALF_LIFE_DAYS);
 
-        let mut context = String::from("[Memory context]\n");
-        for entry in entries {
-            if memory::is_assistant_autosave_key(&entry.key) {
-                continue;
-            }
-            if let Some(score) = entry.score {
-                if score < self.min_relevance_score {
-                    continue;
+        // Apply Core category boost and filter by minimum relevance.
+        let mut scored: Vec<_> = entries
+            .iter()
+            .filter(|e| !memory::is_assistant_autosave_key(&e.key))
+            .filter_map(|e| {
+                let base = e.score.unwrap_or(self.min_relevance_score);
+                let boosted = if e.category == MemoryCategory::Core {
+                    (base + CORE_CATEGORY_SCORE_BOOST).min(1.0)
+                } else {
+                    base
+                };
+                if boosted >= self.min_relevance_score {
+                    Some((e, boosted))
+                } else {
+                    None
                 }
-            }
-            let _ = writeln!(context, "- {}: {}", entry.key, entry.content);
-        }
+            })
+            .collect();
 
-        // If all entries were below threshold, return empty
-        if context == "[Memory context]\n" {
+        // Sort by boosted score descending, then truncate to output limit.
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(self.limit);
+
+        if scored.is_empty() {
             return Ok(String::new());
         }
 
+        let mut context = String::from("[Memory context]\n");
+        for (entry, _) in &scored {
+            let _ = writeln!(context, "- {}: {}", entry.key, entry.content);
+        }
         context.push('\n');
         Ok(context)
     }
@@ -232,5 +255,94 @@ mod tests {
         assert!(context.contains("user_fact"));
         assert!(!context.contains("assistant_resp_legacy"));
         assert!(!context.contains("fabricated detail"));
+    }
+
+    #[tokio::test]
+    async fn core_category_boost_promotes_low_score_core_entry() {
+        let loader = DefaultMemoryLoader::new(2, 0.4);
+        let memory = MockMemoryWithEntries {
+            entries: Arc::new(vec![
+                MemoryEntry {
+                    id: "1".into(),
+                    key: "chat_detail".into(),
+                    content: "talked about weather".into(),
+                    category: MemoryCategory::Conversation,
+                    timestamp: "now".into(),
+                    session_id: None,
+                    score: Some(0.6),
+                },
+                MemoryEntry {
+                    id: "2".into(),
+                    key: "project_rule".into(),
+                    content: "always use async/await".into(),
+                    category: MemoryCategory::Core,
+                    timestamp: "now".into(),
+                    session_id: None,
+                    // Below threshold without boost (0.25 < 0.4),
+                    // but above with +0.3 boost (0.55 >= 0.4).
+                    score: Some(0.25),
+                },
+                MemoryEntry {
+                    id: "3".into(),
+                    key: "low_conv".into(),
+                    content: "irrelevant chatter".into(),
+                    category: MemoryCategory::Conversation,
+                    timestamp: "now".into(),
+                    session_id: None,
+                    score: Some(0.2),
+                },
+            ]),
+        };
+
+        let context = loader.load_context(&memory, "code style").await.unwrap();
+        // Core entry should survive thanks to boost
+        assert!(
+            context.contains("project_rule"),
+            "Core entry should be promoted by boost: {context}"
+        );
+        // Low-score Conversation entry should be filtered out
+        assert!(
+            !context.contains("low_conv"),
+            "Low-score non-Core entry should be filtered: {context}"
+        );
+    }
+
+    #[tokio::test]
+    async fn core_boost_reranks_above_conversation() {
+        let loader = DefaultMemoryLoader::new(1, 0.0);
+        let memory = MockMemoryWithEntries {
+            entries: Arc::new(vec![
+                MemoryEntry {
+                    id: "1".into(),
+                    key: "conv_high".into(),
+                    content: "recent conversation".into(),
+                    category: MemoryCategory::Conversation,
+                    timestamp: "now".into(),
+                    session_id: None,
+                    score: Some(0.6),
+                },
+                MemoryEntry {
+                    id: "2".into(),
+                    key: "core_pref".into(),
+                    content: "user prefers Rust".into(),
+                    category: MemoryCategory::Core,
+                    timestamp: "now".into(),
+                    session_id: None,
+                    // 0.5 + 0.3 boost = 0.8 > 0.6
+                    score: Some(0.5),
+                },
+            ]),
+        };
+
+        let context = loader.load_context(&memory, "language").await.unwrap();
+        // With limit=1 and Core boost, Core entry (0.8) should win over Conversation (0.6)
+        assert!(
+            context.contains("core_pref"),
+            "Boosted Core should rank above Conversation: {context}"
+        );
+        assert!(
+            !context.contains("conv_high"),
+            "Conversation should be truncated when limit=1: {context}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Apply `+0.3` score boost to `Core` memories in retrieval ranking.
- Over-fetch candidates (2x), re-rank after boost, and keep output size capped at 5.
- Apply the same behavior in both `build_context()` and `DefaultMemoryLoader`.
- Add explicit tests for `build_context()` boost promotion and output-limit preservation.

## Validation
- `cargo test --lib core_category_boost_promotes_low_score_core_entry -- --nocapture`
- `cargo test --lib core_boost_reranks_above_conversation -- --nocapture`
- `cargo test --lib build_context_promotes_core_entries_with_score_boost -- --nocapture`
- `cargo test --lib build_context_keeps_output_limit_at_five_entries -- --nocapture`

Closes #2378
