### PR TITLE
refactor(plugins): add validation profiles with strict runtime defaults

### DIFF
--- a/src/plugins/manifest.rs
+++ b/src/plugins/manifest.rs
@@ -378,11 +378,10 @@ id = "  "
             tools: vec![],
             providers: vec![],
         };
-        assert!(validate_manifest_with_profile(
-            &manifest,
-            ManifestValidationProfile::SchemaOnly
-        )
-        .is_ok());
+        assert!(
+            validate_manifest_with_profile(&manifest, ManifestValidationProfile::SchemaOnly)
+                .is_ok()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `ManifestValidationProfile` with `RuntimeWasm` (strict) and `SchemaOnly` modes
- keep `validate_manifest()` runtime-strict (module_path required) to preserve current WASM execution contract
- add explicit profile-based validator entrypoint for future non-WASM extension without changing runtime behavior
- add regression tests for schema-only empty `module_path` and missing providers WIT package

## Why
- keeps today’s runtime invariant (option 1)
- avoids painting future plugin models into a corner by separating validation intent

## Verification
- `cargo test plugins::manifest::tests::`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Plugin manifests now support flexible validation modes: runtime and schema-only validation.
  * WASM module path requirements dynamically adjust based on the validation mode used.

* **Documentation**
  * Updated module_path field documentation to clarify runtime versus schema validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->