### PR TITLE
chore: add self-hosted runners skill and CI gotchas

### DIFF
--- a/.claude/skills/zeroclaw-runners/SKILL.md
+++ b/.claude/skills/zeroclaw-runners/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: zeroclaw-runners
+description: Manage self-hosted GitHub Actions runners for zeroclaw-labs/zeroclaw. Use when setting up runners, scaling capacity, troubleshooting CI job routing, checking runner status, or managing labels. Triggers on "runner setup", "add runners", "runner status", "CI not picking up jobs", "scale runners".
+version: 0.1
+last_updated: 2026-03-01
+---
+
+# ZeroClaw Self-Hosted Runners
+
+Manage self-hosted GitHub Actions runners for the zeroclaw repo.
+
+## Quick Reference
+
+| Item | Value |
+|------|-------|
+| Repo | `zeroclaw-labs/zeroclaw` |
+| Runner Taskfile | `~/actions-runner/Taskfile.yml` |
+| Runner tarball | `~/actions-runner/actions-runner-osx-x64-2.332.0.tar.gz` |
+| Required labels (Linux CI) | `[self-hosted, aws-india]` |
+| macOS-only labels | `[self-hosted, macOS, X64]` |
+
+## Runner Fleet
+
+| Group | Purpose | Labels |
+|-------|---------|--------|
+| aws-india-* | Linux CI (build, test, lint) | `self-hosted, aws-india` |
+| hetzner-* | Linux CI (overflow) | `self-hosted, aws-india` |
+| mMacBook-* | macOS builds (future) | `self-hosted, macOS, X64` |
+
+## Workflows
+
+### Check Status
+
+```bash
+# All runners
+gh api "repos/zeroclaw-labs/zeroclaw/actions/runners?per_page=100" \
+  --jq '.runners[] | "\(.name)\t\(.status)\t\(.busy)"'
+
+# Mac runners only
+gh api "repos/zeroclaw-labs/zeroclaw/actions/runners?per_page=100" \
+  --jq '.runners[] | select(.name | startswith("mMacBook")) | "\(.name)\t\(.status)\t\(.busy)"'
+
+# Job queue
+echo "Queued: $(gh run list -R zeroclaw-labs/zeroclaw --status queued --json name --jq 'length')"
+echo "In Progress: $(gh run list -R zeroclaw-labs/zeroclaw --status in_progress --json name --jq 'length')"
+```
+
+### Add Runners (macOS)
+
+1. Get registration token from GitHub Settings > Actions > Runners > Add runner
+2. Run via Taskfile:
+```bash
+cd ~/actions-runner
+task run-multi TOKEN=<token> RUNNER_COUNT=2
+```
+
+### Scale Down
+
+```bash
+# Stop and uninstall service
+cd ~/actions-runner-N && ./svc.sh stop && ./svc.sh uninstall
+
+# Remove from GitHub (get ID first)
+gh api "repos/zeroclaw-labs/zeroclaw/actions/runners?per_page=100" \
+  --jq '.runners[] | select(.name=="mMacBook-N") | .id'
+gh api -X DELETE repos/zeroclaw-labs/zeroclaw/actions/runners/<ID>
+
+# Clean up local directory
+rm -rf ~/actions-runner-N
+```
+
+### Add/Remove Labels
+
+```bash
+# Add label
+gh api -X POST repos/zeroclaw-labs/zeroclaw/actions/runners/<ID>/labels \
+  --input - <<< '{"labels":["aws-india"]}'
+
+# Remove label
+gh api -X DELETE repos/zeroclaw-labs/zeroclaw/actions/runners/<ID>/labels/aws-india
+
+# IMPORTANT: Restart runner after label change
+cd ~/actions-runner-N && ./svc.sh stop && ./svc.sh start
+```
+
+### Restart All Runners
+
+```bash
+cd ~/actions-runner && task start-all
+```
+
+## Gotchas
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| Jobs queued but runners idle | Label mismatch | Check workflow `runs-on` vs runner labels |
+| Label change not working | Runner cache | Restart runner service after API label change |
+| Container action fails on macOS | Platform limitation | Container actions only work on Linux |
+| "Runner is busy" on delete | Active job | Wait for job to complete, then delete |
+
+## Taskfile Commands
+
+| Command | Description |
+|---------|-------------|
+| `task run-multi TOKEN=x` | Set up N new runners |
+| `task status` | Check all runner services |
+| `task start-all` | Start all runner services |
+| `task stop-all` | Stop all runner services |
+| `task uninstall-all` | Stop and uninstall all services |
+| `task logs` | Tail logs from all runners |
+| `task cpu-info` | Show CPU info for scaling decisions |
+| `task new-token-url` | Open browser to get registration token |
+
+## Monitoring
+
+```bash
+# System resources while runners active
+top -l 1 -n 0 | grep -E "CPU usage|PhysMem|Load Avg"
+
+# Check what jobs each runner is processing
+for dir in ~/actions-runner ~/actions-runner-{2,3,4}; do
+  [ -d "$dir" ] && tail -5 "$dir/_diag/Worker_*.log" 2>/dev/null
+done
+```
+
+## Gaps
+
+> v0.1 - Based on 1 session. Needs validation:
+
+- [ ] Linux runner setup (AWS/Hetzner) - only macOS documented
+- [ ] Runner auto-scaling policies
+- [ ] Cost/resource thresholds for scaling decisions
+- [ ] Monitoring/alerting for offline runners
+- [ ] Runner version upgrade workflow
+
+## Out of Scope
+
+- PR workflow -> use `zeroclaw-pr` skill
+- CI pipeline configuration -> see `zeroclaw-pr/references/ci-and-github.md`
+- Workflow YAML editing -> modify `.github/workflows/` directly

--- a/.claude/skills/zeroclaw-runners/references/taskfile.md
+++ b/.claude/skills/zeroclaw-runners/references/taskfile.md
@@ -1,0 +1,137 @@
+# Runner Taskfile Reference
+
+Location: `~/actions-runner/Taskfile.yml`
+
+## Variables
+
+| Var | Default | Description |
+|-----|---------|-------------|
+| `RUNNER_COUNT` | 3 | Number of new runners to create |
+| `TOKEN` | (required) | GitHub registration token |
+| `REPO_URL` | zeroclaw-labs/zeroclaw | Target repository |
+| `BASE_NAME` | mMacBook | Runner name prefix |
+| `LABELS` | self-hosted,macOS,x64 | Initial labels |
+| `TARBALL` | ~/actions-runner/actions-runner-osx-x64-2.332.0.tar.gz | Runner package |
+
+## Full Taskfile
+
+```yaml
+version: "3"
+
+vars:
+  RUNNER_COUNT: "3"
+  TOKEN: ""
+  REPO_URL: "https://github.com/zeroclaw-labs/zeroclaw"
+  BASE_NAME: "mMacBook"
+  LABELS: "self-hosted,macOS,x64"
+  TARBALL: "~/actions-runner/actions-runner-osx-x64-2.332.0.tar.gz"
+
+tasks:
+  run-multi:
+    desc: Set up multiple GitHub Actions runners
+    requires:
+      vars: [TOKEN]
+    cmds:
+      - |
+        for i in $(seq 2 $(({{.RUNNER_COUNT}} + 1))); do
+          DIR=~/actions-runner-$i
+          mkdir -p $DIR && cd $DIR
+          tar xzf {{.TARBALL}}
+          ./config.sh \
+            --url {{.REPO_URL}} \
+            --token {{.TOKEN}} \
+            --name "{{.BASE_NAME}}-$i" \
+            --labels "{{.LABELS}}" \
+            --unattended
+          ./svc.sh install
+          ./svc.sh start
+          echo "Runner {{.BASE_NAME}}-$i started"
+        done
+
+  status:
+    desc: Check status of all runners
+    cmds:
+      - |
+        for dir in ~/actions-runner-*/; do
+          if [ -f "$dir/.service" ]; then
+            echo "=== $(basename $dir) ==="
+            cd "$dir" && ./svc.sh status 2>/dev/null || echo "Not installed as service"
+          fi
+        done
+
+  stop-all:
+    desc: Stop all runner services
+    cmds:
+      - |
+        for dir in ~/actions-runner-*/; do
+          if [ -f "$dir/.service" ]; then
+            echo "Stopping $(basename $dir)..."
+            cd "$dir" && ./svc.sh stop 2>/dev/null || true
+          fi
+        done
+
+  uninstall-all:
+    desc: Stop and uninstall all runner services
+    cmds:
+      - |
+        for dir in ~/actions-runner-*/; do
+          if [ -f "$dir/.service" ]; then
+            echo "Uninstalling $(basename $dir)..."
+            cd "$dir" && ./svc.sh stop 2>/dev/null || true
+            cd "$dir" && ./svc.sh uninstall 2>/dev/null || true
+          fi
+        done
+
+  start-all:
+    desc: Start all runner services
+    cmds:
+      - |
+        for dir in ~/actions-runner ~/actions-runner-*/; do
+          if [ -f "$dir/.service" ]; then
+            echo "Starting $(basename $dir)..."
+            cd "$dir" && ./svc.sh start 2>/dev/null || true
+          fi
+        done
+
+  logs:
+    desc: View live logs from all runners
+    cmds:
+      - tail -f ~/Library/Logs/actions.runner.*/Runner_*.log
+
+  remove:
+    desc: Unregister a runner from GitHub
+    requires:
+      vars: [TOKEN, DIR]
+    cmds:
+      - cd {{.DIR}} && ./config.sh remove --token {{.TOKEN}}
+
+  cpu-info:
+    desc: Show CPU info for scaling decisions
+    cmds:
+      - |
+        LOGICAL=$(sysctl -n hw.logicalcpu)
+        echo "Logical CPUs: $LOGICAL"
+        echo "Recommended runners: $((LOGICAL / 2))"
+
+  new-token-url:
+    desc: Open browser to get a new registration token
+    cmds:
+      - open "https://github.com/zeroclaw-labs/zeroclaw/settings/actions/runners/new?arch=x64&os=osx"
+```
+
+## Usage Examples
+
+```bash
+# Add 2 runners
+task run-multi TOKEN=ABCD1234 RUNNER_COUNT=2
+
+# Check all services
+task status
+
+# View logs
+task logs
+
+# Scale down
+task stop-all
+task uninstall-all
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,3 +533,9 @@ When working in fast iterative mode:
 - Prefer deterministic behavior over clever shortcuts.
 - Do not “ship and hope” on security-sensitive paths.
 - If uncertain, leave a concrete TODO with verification context, not a hidden guess.
+
+## 13) CI / Self-Hosted Runner Gotchas
+
+- **Label changes via GitHub API require runner restart.** Adding/removing labels via `gh api repos/.../actions/runners/{id}/labels` does not take effect until the runner service is restarted (`./svc.sh stop && ./svc.sh start`). Jobs will remain queued despite matching labels if the runner hasn't been restarted.
+- Self-hosted runners for this repo require `[self-hosted, aws-india]` labels to pick up CI jobs (see `ci-run.yml`).
+- **Container actions only work on Linux.** macOS runners cannot execute container-based GitHub Actions (e.g., `cargo-deny-action`). Route container jobs to Linux runners only.


### PR DESCRIPTION
## Summary

- Add project-level Claude skill for self-hosted runner management (`zeroclaw-runners`)
- Document CI runner gotchas in CLAUDE.md section 13
- Include Taskfile reference for runner operations

## What's Added

### `.claude/skills/zeroclaw-runners/`
- `SKILL.md` - Runner management workflows, status checks, scaling, label management
- `references/taskfile.md` - Full Taskfile.yml for macOS runner operations

### CLAUDE.md Section 13
- Label changes require runner restart
- `[self-hosted, aws-india]` labels required for CI jobs
- Container actions only work on Linux

## Motivation

Learned from setting up macOS self-hosted runners:
1. Label changes via API don't take effect until runner restart
2. Container-based actions fail on macOS (Linux only)
3. Need consistent Taskfile for runner ops

## Test Plan

- [x] Skill structure follows skill-builder conventions
- [x] Gotchas verified during actual runner setup session
- [ ] Skill triggers correctly on runner-related queries

## Risk

Low - docs/skill only, no code changes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added complete guide for managing self-hosted GitHub Actions runners including deployment, configuration, monitoring, troubleshooting, and operational best practices.
  * Added runner fleet management reference documentation with automation tasks, scaling procedures, and common operational examples.
  * Added troubleshooting tips covering configuration changes, runner labels, and container action compatibility across different runner environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->