### PR TITLE
fix(gateway): clarify public-bind warning wording

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -384,7 +384,9 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
     if is_public_bind(host) && config.tunnel.provider == "none" && !config.gateway.allow_public_bind
     {
         anyhow::bail!(
-            "🛑 Refusing to bind to {host} — gateway would be exposed to the internet.\n\
+            "🛑 Refusing to bind to {host} — gateway would be reachable outside localhost\n\
+             (for example from your local network, and potentially the internet\n\
+             depending on your router/firewall setup).\n\
              Fix: use --host 127.0.0.1 (default), configure a tunnel, or set\n\
              [gateway] allow_public_bind = true in config.toml (NOT recommended)."
         );


### PR DESCRIPTION
## Summary
- clarify the public-bind refusal message to avoid implying every non-localhost bind is internet-exposed
- explain that non-localhost binds are reachable outside localhost (local network first, internet only if router/firewall expose it)
- preserve existing mitigation guidance (`--host 127.0.0.1`, tunnel, or `allow_public_bind`)

## Validation
- cargo test is_public_bind -- --nocapture
- cargo fmt --all -- --check

Closes #2465


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved security warning message when refusing to bind to public addresses, providing clearer details about local network exposure and router/firewall configuration considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->