### PR TITLE
docs(codex): add oauth quickstart and gpt-5.3 model

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -18,7 +18,7 @@ For first-time setup and quick orientation.
 | I want guided prompts | `zeroclaw onboard --interactive` |
 | Config exists, just fix channels | `zeroclaw onboard --channels-only` |
 | Config exists, I intentionally want full overwrite | `zeroclaw onboard --force` |
-| Using subscription auth | See [Subscription Auth](../../README.md#subscription-auth-openai-codex--claude-code) |
+| Using OpenAI Codex subscription auth | See [OpenAI Codex OAuth Quick Setup](#openai-codex-oauth-quick-setup) |
 
 ## Onboarding and Validation
 
@@ -27,6 +27,50 @@ For first-time setup and quick orientation.
 - Existing config protection: reruns require explicit confirmation (or `--force` in non-interactive flows)
 - Ollama cloud models (`:cloud`) require a remote `api_url` and API key (for example `api_url = "https://ollama.com"`).
 - Validate environment: `zeroclaw status` + `zeroclaw doctor`
+
+## OpenAI Codex OAuth Quick Setup
+
+Use this path when you want `openai-codex` with subscription OAuth credentials (no API key required).
+
+1. Authenticate:
+
+```bash
+zeroclaw auth login --provider openai-codex
+```
+
+2. Verify auth material is loaded:
+
+```bash
+zeroclaw auth status --provider openai-codex
+```
+
+3. Set provider/model defaults:
+
+```toml
+default_provider = "openai-codex"
+default_model = "gpt-5.3-codex"
+default_temperature = 0.2
+
+[provider]
+transport = "auto"
+reasoning_level = "high"
+```
+
+4. Optional stable fallback model (if your account/region does not currently expose `gpt-5.3-codex`):
+
+```toml
+default_model = "gpt-5.2-codex"
+```
+
+5. Start chat:
+
+```bash
+zeroclaw chat
+```
+
+Notes:
+- You do not need to define a custom `[model_providers."openai-codex"]` block for normal OAuth usage.
+- If you see raw `<tool_call>` tags in output, first verify you are on the built-in `openai-codex` provider path above and not a custom OpenAI-compatible provider override.
 
 ## Next
 

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -1075,6 +1075,10 @@ fn curated_models_for_provider(provider_name: &str) -> Vec<(String, String)> {
         ],
         "openai-codex" => vec![
             (
+                "gpt-5.3-codex".to_string(),
+                "GPT-5.3 Codex (latest codex generation)".to_string(),
+            ),
+            (
                 "gpt-5-codex".to_string(),
                 "GPT-5 Codex (recommended)".to_string(),
             ),
@@ -7960,6 +7964,7 @@ mod tests {
             .map(|(id, _)| id)
             .collect();
 
+        assert!(ids.contains(&"gpt-5.3-codex".to_string()));
         assert!(ids.contains(&"gpt-5-codex".to_string()));
         assert!(ids.contains(&"gpt-5.2-codex".to_string()));
     }


### PR DESCRIPTION
## Summary
- add `gpt-5.3-codex` to curated `openai-codex` model options in onboarding wizard
- fix broken Codex subscription-auth link in getting-started docs
- add explicit OAuth quickstart for `openai-codex` with minimal working config and verification commands
- include fallback guidance to `gpt-5.2-codex`

Closes #2474

## Root Cause
The docs lacked a practical, end-to-end OAuth setup path for OpenAI Codex and referenced a broken subscription-auth target. The onboarding curated model list also did not include the newer `gpt-5.3-codex`, creating avoidable setup friction.

## Validation Evidence
- `cargo test curated_models_for_openai_codex_include_codex_family -- --nocapture`
- `cargo fmt --all -- --check`

## Security Impact
- documentation and curated model metadata only; no auth-flow privilege changes.

## Privacy and Data Hygiene
- no secrets, credentials, or user data added.

## Rollback Plan
- revert this commit to restore previous docs/model list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPT-5.3 Codex (latest codex generation) is now available as a selectable model option.

* **Documentation**
  * Added comprehensive OpenAI Codex OAuth Quick Setup guide including step-by-step authentication, default configuration, and usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->