### PR TITLE
fix: harden tool follow-through and workspace path resolution

### DIFF
--- a/src/tools/docx_read.rs
+++ b/src/tools/docx_read.rs
@@ -143,7 +143,7 @@ impl Tool for DocxReadTool {
             });
         }
 
-        let full_path = self.security.workspace_dir.join(path);
+        let full_path = self.security.resolve_user_supplied_path(path);
 
         let resolved_path = match tokio::fs::canonicalize(&full_path).await {
             Ok(p) => p,

--- a/src/tools/file_edit.rs
+++ b/src/tools/file_edit.rs
@@ -294,7 +294,7 @@ impl Tool for FileEditTool {
             });
         }
 
-        let full_path = self.security.workspace_dir.join(path);
+        let full_path = self.security.resolve_user_supplied_path(path);
 
         // ── 5. Canonicalize parent ─────────────────────────────────
         let Some(parent) = full_path.parent() else {
@@ -474,6 +474,18 @@ mod tests {
             autonomy: AutonomyLevel::Supervised,
             workspace_dir: workspace,
             allow_sensitive_file_writes,
+            ..SecurityPolicy::default()
+        })
+    }
+
+    fn test_security_allows_outside_workspace(
+        workspace: std::path::PathBuf,
+    ) -> Arc<SecurityPolicy> {
+        Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Supervised,
+            workspace_dir: workspace,
+            workspace_only: false,
+            forbidden_paths: vec![],
             ..SecurityPolicy::default()
         })
     }
@@ -1052,6 +1064,44 @@ mod tests {
 
         assert!(!result.success);
         assert!(result.error.as_ref().unwrap().contains("not allowed"));
+    }
+
+    #[tokio::test]
+    async fn file_edit_expands_tilde_path_consistently_with_policy() {
+        let home = std::env::var_os("HOME")
+            .map(std::path::PathBuf::from)
+            .expect("HOME should be available for tilde expansion tests");
+        let target_rel = format!("zeroclaw_tilde_edit_{}.txt", uuid::Uuid::new_v4());
+        let target_path = home.join(&target_rel);
+        let _ = tokio::fs::remove_file(&target_path).await;
+        tokio::fs::write(&target_path, "alpha beta gamma")
+            .await
+            .unwrap();
+
+        let workspace = std::env::temp_dir().join("zeroclaw_test_file_edit_tilde_workspace");
+        let _ = tokio::fs::remove_dir_all(&workspace).await;
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+
+        let tool = FileEditTool::new(test_security_allows_outside_workspace(workspace.clone()));
+        let result = tool
+            .execute(json!({
+                "path": format!("~/{}", target_rel),
+                "old_string": "beta",
+                "new_string": "delta"
+            }))
+            .await
+            .unwrap();
+        assert!(
+            result.success,
+            "tilde path edit should succeed when policy allows outside workspace: {:?}",
+            result.error
+        );
+
+        let content = tokio::fs::read_to_string(&target_path).await.unwrap();
+        assert_eq!(content, "alpha delta gamma");
+
+        let _ = tokio::fs::remove_file(&target_path).await;
+        let _ = tokio::fs::remove_dir_all(&workspace).await;
     }
 
     #[cfg(unix)]

--- a/src/tools/pdf_read.rs
+++ b/src/tools/pdf_read.rs
@@ -100,7 +100,7 @@ impl Tool for PdfReadTool {
             });
         }
 
-        let full_path = self.security.workspace_dir.join(path);
+        let full_path = self.security.resolve_user_supplied_path(path);
 
         let resolved_path = match tokio::fs::canonicalize(&full_path).await {
             Ok(p) => p,

--- a/src/tools/pptx_read.rs
+++ b/src/tools/pptx_read.rs
@@ -375,7 +375,7 @@ impl Tool for PptxReadTool {
             });
         }
 
-        let full_path = self.security.workspace_dir.join(path);
+        let full_path = self.security.resolve_user_supplied_path(path);
 
         let resolved_path = match tokio::fs::canonicalize(&full_path).await {
             Ok(p) => p,

--- a/src/tools/xlsx_read.rs
+++ b/src/tools/xlsx_read.rs
@@ -560,7 +560,7 @@ impl Tool for XlsxReadTool {
             });
         }
 
-        let full_path = self.security.workspace_dir.join(path);
+        let full_path = self.security.resolve_user_supplied_path(path);
 
         let resolved_path = match tokio::fs::canonicalize(&full_path).await {
             Ok(p) => p,


### PR DESCRIPTION
## Summary
- harden `active_workspace.toml` marker loading to ignore stale/invalid/temp-hijacked config dirs
- unify user path resolution (`~`, absolute, workspace-relative) via `SecurityPolicy::resolve_user_supplied_path`
- apply unified path resolver across file/doc tools (`file_read`, `file_write`, `file_edit`, `pdf_read`, `docx_read`, `pptx_read`, `xlsx_read`)
- enforce explicit failure in tool loop when deferred-action text repeats without any emitted tool call after retry
- add regression tests for marker fallback, deferred-action hard-fail, and tilde path consistency

## Why
This closes several high-impact causes of “只说不做” / false-completion behavior:
- stale active workspace markers silently redirect runtime config
- path-policy check and runtime write/read path semantics diverge for `~` paths
- retry-once fallback previously allowed a second deferred no-tool response to be treated as successful completion

## Validation
- `cargo fmt`
- `cargo test --lib tilde_path_consistently_with_policy -- --nocapture`
- `cargo test --lib resolve_user_supplied_path_ -- --nocapture`
- `cargo test --lib resolve_runtime_config_dirs_ -- --nocapture`
- `cargo test --lib run_tool_call_loop_errors_when_deferred_action_repeats_without_tool_call -- --nocapture`
- `cargo test --lib run_tool_call_loop_retries_once_when_response_defers_action_without_tool_call -- --nocapture`
- `cargo test --lib agent::loop_::tests::run_tool_call_loop_ -- --nocapture`
- `cargo test --lib tools::file_write::tests:: -- --nocapture`
- `cargo test --lib tools::file_read::tests:: -- --nocapture`
- `cargo test --lib tools::file_edit::tests:: -- --nocapture`
- `cargo test --lib tools::pdf_read::tests:: -- --nocapture`
- `cargo test --lib tools::docx_read::tests:: -- --nocapture`
- `cargo test --lib tools::pptx_read::tests:: -- --nocapture`
- `cargo test --lib tools::xlsx_read::tests:: -- --nocapture`
- `cargo test --lib load_or_init_uses_persisted_active_workspace_marker -- --nocapture`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for tilde (~) expansion in file paths to reference home directories.

* **Bug Fixes**
  * Improved detection and error handling when tool execution responses are incomplete or deferred.
  * Enhanced workspace configuration validation to ignore stale or invalid settings.
  * Improved path resolution consistency across all file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->