### PR TITLE
fix(runtime): robust Windows shell fallback and doctor diagnostics

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,7 @@
 
 This guide focuses on common setup/runtime failures and fast resolution paths.
 
-Last verified: **February 20, 2026**.
+Last verified: **March 2, 2026**.
 
 ## Installation / Bootstrap
 
@@ -141,6 +141,54 @@ which zeroclaw
 Persist in your shell profile if needed.
 
 ## Runtime / Gateway
+
+### Windows: shell tool unavailable or repeated shell failures
+
+Symptoms:
+
+- agent repeatedly fails shell calls and stops early
+- shell-based actions fail even though ZeroClaw starts
+- `zeroclaw doctor` reports runtime shell capability unavailable
+
+Why this happens:
+
+- Native Windows shell availability differs by machine setup.
+- Some environments do not have `sh` in `PATH`.
+- If both Git Bash and PowerShell are missing/misconfigured, shell tool execution will fail.
+
+What changed in ZeroClaw:
+
+- Native runtime now resolves shell with Windows fallbacks in this order:
+  - `bash` -> `sh` -> `pwsh` -> `powershell` -> `cmd`/`COMSPEC`
+- `zeroclaw doctor` now reports:
+  - selected native shell (kind + resolved executable path)
+  - candidate shell availability on Windows
+  - explicit warning when fallback is only `cmd`
+- WSL2 is optional, not required.
+
+Checks (PowerShell):
+
+```powershell
+where.exe bash
+where.exe pwsh
+where.exe powershell
+echo $env:COMSPEC
+zeroclaw doctor
+```
+
+Fix:
+
+1. Install at least one preferred shell:
+   - Git Bash (recommended for Unix-like command compatibility), or
+   - PowerShell 7 (`pwsh`)
+2. Confirm the shell executable is available in `PATH`.
+3. Ensure `COMSPEC` is set (normally points to `cmd.exe` on Windows).
+4. Reopen terminal and rerun `zeroclaw doctor`.
+
+Notes:
+
+- Running with only `cmd` fallback can work, but compatibility is lower than Git Bash or PowerShell.
+- If you already use WSL2, it can help with Unix-style workflows, but it is not mandatory for ZeroClaw shell tooling.
 
 ### Gateway unreachable
 

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -2,7 +2,7 @@ use crate::config::Config;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const DAEMON_STALE_SECONDS: i64 = 30;
 const SCHEDULER_STALE_SECONDS: i64 = 120;
@@ -80,6 +80,7 @@ pub fn diagnose(config: &Config) -> Vec<DiagResult> {
     let mut items: Vec<DiagItem> = Vec::new();
 
     check_config_semantics(config, &mut items);
+    check_runtime_capabilities(config, &mut items);
     check_workspace(config, &mut items);
     check_daemon_state(config, &mut items);
     check_environment(&mut items);
@@ -655,6 +656,123 @@ fn embedding_provider_validation_error(name: &str) -> Option<String> {
 
 // ── Workspace integrity ──────────────────────────────────────────
 
+fn check_runtime_capabilities(config: &Config, items: &mut Vec<DiagItem>) {
+    let cat = "runtime";
+
+    let runtime = match crate::runtime::create_runtime(&config.runtime) {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            items.push(DiagItem::error(
+                cat,
+                format!(
+                    "failed to construct runtime '{}' from config: {}",
+                    config.runtime.kind,
+                    truncate_for_display(&err.to_string(), 180)
+                ),
+            ));
+            return;
+        }
+    };
+
+    items.push(DiagItem::ok(
+        cat,
+        format!("runtime adapter: {}", runtime.name()),
+    ));
+
+    if runtime.has_shell_access() {
+        items.push(DiagItem::ok(cat, "shell tool capability enabled"));
+    } else if runtime.name() == "native" {
+        items.push(DiagItem::error(
+            cat,
+            "native runtime shell capability unavailable — install Git Bash or PowerShell (WSL2 is optional)",
+        ));
+    } else {
+        items.push(DiagItem::warn(
+            cat,
+            format!(
+                "runtime '{}' does not expose shell capability",
+                runtime.name()
+            ),
+        ));
+    }
+
+    if runtime.has_filesystem_access() {
+        items.push(DiagItem::ok(cat, "filesystem capability enabled"));
+    } else {
+        items.push(DiagItem::warn(cat, "filesystem capability disabled"));
+    }
+
+    if runtime.supports_long_running() {
+        items.push(DiagItem::ok(cat, "long-running capability enabled"));
+    } else {
+        items.push(DiagItem::warn(cat, "long-running capability disabled"));
+    }
+
+    if let Some(native) = runtime
+        .as_any()
+        .downcast_ref::<crate::runtime::NativeRuntime>()
+    {
+        if let Some(kind) = native.selected_shell_kind() {
+            let shell_program = native
+                .selected_shell_program()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "unknown".to_string());
+            items.push(DiagItem::ok(
+                cat,
+                format!("native shell selected: {kind} ({shell_program})"),
+            ));
+
+            if cfg!(target_os = "windows") && kind == "cmd" {
+                items.push(DiagItem::warn(
+                    cat,
+                    "shell fallback is cmd; install Git Bash or PowerShell for best compatibility (WSL2 optional)",
+                ));
+            }
+        } else {
+            items.push(DiagItem::error(
+                cat,
+                "native runtime detected but no usable shell resolved from PATH/COMSPEC",
+            ));
+        }
+    }
+
+    if cfg!(target_os = "windows") {
+        let shell_checks = windows_shell_candidates();
+        let available: Vec<String> = shell_checks
+            .iter()
+            .filter_map(|(name, path)| path.as_ref().map(|p| format!("{name} ({})", p.display())))
+            .collect();
+
+        if available.is_empty() {
+            items.push(DiagItem::warn(
+                cat,
+                "Windows shell candidates not found in PATH (bash/pwsh/powershell/cmd)",
+            ));
+        } else {
+            items.push(DiagItem::ok(
+                cat,
+                format!("Windows shell candidates: {}", available.join(", ")),
+            ));
+        }
+    }
+}
+
+fn windows_shell_candidates() -> Vec<(&'static str, Option<PathBuf>)> {
+    let mut checks = vec![
+        ("bash", which::which("bash").ok()),
+        ("sh", which::which("sh").ok()),
+        ("pwsh", which::which("pwsh").ok()),
+        ("powershell", which::which("powershell").ok()),
+    ];
+
+    let cmd_path = which::which("cmd")
+        .ok()
+        .or_else(|| which::which("cmd.exe").ok())
+        .or_else(|| std::env::var_os("COMSPEC").map(PathBuf::from));
+    checks.push(("cmd", cmd_path));
+    checks
+}
+
 fn check_workspace(config: &Config, items: &mut Vec<DiagItem>) {
     let cat = "workspace";
     let ws = &config.workspace_dir;
@@ -908,12 +1026,24 @@ fn check_environment(items: &mut Vec<DiagItem>) {
     // git
     check_command_available("git", &["--version"], cat, items);
 
-    // Shell
-    let shell = std::env::var("SHELL").unwrap_or_default();
-    if shell.is_empty() {
-        items.push(DiagItem::warn(cat, "$SHELL not set"));
+    // Shell environment
+    if cfg!(target_os = "windows") {
+        match std::env::var("COMSPEC") {
+            Ok(comspec) if !comspec.trim().is_empty() => {
+                items.push(DiagItem::ok(cat, format!("COMSPEC: {comspec}")));
+            }
+            _ => items.push(DiagItem::warn(
+                cat,
+                "COMSPEC not set (Windows shell fallback may fail)",
+            )),
+        }
     } else {
-        items.push(DiagItem::ok(cat, format!("shell: {shell}")));
+        let shell = std::env::var("SHELL").unwrap_or_default();
+        if shell.is_empty() {
+            items.push(DiagItem::warn(cat, "$SHELL not set"));
+        } else {
+            items.push(DiagItem::ok(cat, format!("shell: {shell}")));
+        }
     }
 
     // HOME
@@ -1312,5 +1442,24 @@ mod tests {
         assert_eq!(agent_messages.len(), 2);
         assert!(agent_messages[0].contains("agent \"alpha\""));
         assert!(agent_messages[1].contains("agent \"zeta\""));
+    }
+
+    #[test]
+    fn runtime_check_reports_runtime_adapter() {
+        let config = Config::default();
+        let mut items = Vec::new();
+        check_runtime_capabilities(&config, &mut items);
+
+        let runtime_item = items.iter().find(|item| {
+            item.category == "runtime" && item.message.starts_with("runtime adapter:")
+        });
+        assert!(runtime_item.is_some());
+        assert_eq!(runtime_item.unwrap().severity, Severity::Ok);
+    }
+
+    #[test]
+    fn windows_shell_candidates_include_cmd_probe() {
+        let checks = windows_shell_candidates();
+        assert!(checks.iter().any(|(name, _)| *name == "cmd"));
     }
 }

--- a/src/runtime/native.rs
+++ b/src/runtime/native.rs
@@ -2,11 +2,139 @@ use super::traits::RuntimeAdapter;
 use std::path::{Path, PathBuf};
 
 /// Native runtime — full access, runs on Mac/Linux/Docker/Raspberry Pi
-pub struct NativeRuntime;
+pub struct NativeRuntime {
+    shell: Option<ShellProgram>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ShellProgram {
+    kind: ShellKind,
+    program: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShellKind {
+    Sh,
+    Bash,
+    Pwsh,
+    PowerShell,
+    Cmd,
+}
+
+impl ShellKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            ShellKind::Sh => "sh",
+            ShellKind::Bash => "bash",
+            ShellKind::Pwsh => "pwsh",
+            ShellKind::PowerShell => "powershell",
+            ShellKind::Cmd => "cmd",
+        }
+    }
+}
+
+impl ShellProgram {
+    fn add_shell_args(&self, process: &mut tokio::process::Command, command: &str) {
+        match self.kind {
+            ShellKind::Sh | ShellKind::Bash => {
+                process.arg("-c").arg(command);
+            }
+            ShellKind::Pwsh | ShellKind::PowerShell => {
+                process
+                    .arg("-NoLogo")
+                    .arg("-NoProfile")
+                    .arg("-NonInteractive")
+                    .arg("-Command")
+                    .arg(command);
+            }
+            ShellKind::Cmd => {
+                process.arg("/C").arg(command);
+            }
+        }
+    }
+}
+
+fn detect_native_shell() -> Option<ShellProgram> {
+    #[cfg(target_os = "windows")]
+    {
+        let comspec = std::env::var_os("COMSPEC").map(PathBuf::from);
+        detect_native_shell_with(true, |name| which::which(name).ok(), comspec)
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        detect_native_shell_with(false, |name| which::which(name).ok(), None)
+    }
+}
+
+fn detect_native_shell_with<F>(
+    is_windows: bool,
+    mut resolve: F,
+    comspec: Option<PathBuf>,
+) -> Option<ShellProgram>
+where
+    F: FnMut(&str) -> Option<PathBuf>,
+{
+    if is_windows {
+        for (name, kind) in [
+            ("bash", ShellKind::Bash),
+            ("sh", ShellKind::Sh),
+            ("pwsh", ShellKind::Pwsh),
+            ("powershell", ShellKind::PowerShell),
+            ("cmd", ShellKind::Cmd),
+            ("cmd.exe", ShellKind::Cmd),
+        ] {
+            if let Some(program) = resolve(name) {
+                return Some(ShellProgram { kind, program });
+            }
+        }
+        if let Some(program) = comspec {
+            return Some(ShellProgram {
+                kind: ShellKind::Cmd,
+                program,
+            });
+        }
+        return None;
+    }
+
+    for (name, kind) in [("sh", ShellKind::Sh), ("bash", ShellKind::Bash)] {
+        if let Some(program) = resolve(name) {
+            return Some(ShellProgram { kind, program });
+        }
+    }
+    None
+}
+
+fn missing_shell_error() -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        "Native runtime could not find a usable shell (tried: bash, sh, pwsh, powershell, cmd). \
+         Install Git Bash or PowerShell and ensure it is available on PATH."
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        "Native runtime could not find a usable shell (tried: sh, bash). \
+         Install a POSIX shell and ensure it is available on PATH."
+    }
+}
 
 impl NativeRuntime {
     pub fn new() -> Self {
-        Self
+        Self {
+            shell: detect_native_shell(),
+        }
+    }
+
+    pub(crate) fn selected_shell_kind(&self) -> Option<&'static str> {
+        self.shell.as_ref().map(|shell| shell.kind.as_str())
+    }
+
+    pub(crate) fn selected_shell_program(&self) -> Option<&Path> {
+        self.shell.as_ref().map(|shell| shell.program.as_path())
+    }
+
+    #[cfg(test)]
+    fn new_for_test(shell: Option<ShellProgram>) -> Self {
+        Self { shell }
     }
 }
 
@@ -20,7 +148,7 @@ impl RuntimeAdapter for NativeRuntime {
     }
 
     fn has_shell_access(&self) -> bool {
-        true
+        self.shell.is_some()
     }
 
     fn has_filesystem_access(&self) -> bool {
@@ -43,8 +171,14 @@ impl RuntimeAdapter for NativeRuntime {
         command: &str,
         workspace_dir: &Path,
     ) -> anyhow::Result<tokio::process::Command> {
-        let mut process = tokio::process::Command::new("sh");
-        process.arg("-c").arg(command).current_dir(workspace_dir);
+        let shell = self
+            .shell
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!(missing_shell_error()))?;
+
+        let mut process = tokio::process::Command::new(&shell.program);
+        shell.add_shell_args(&mut process, command);
+        process.current_dir(workspace_dir);
         Ok(process)
     }
 }
@@ -52,6 +186,7 @@ impl RuntimeAdapter for NativeRuntime {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn native_name() {
@@ -60,7 +195,10 @@ mod tests {
 
     #[test]
     fn native_has_shell_access() {
-        assert!(NativeRuntime::new().has_shell_access());
+        assert_eq!(
+            NativeRuntime::new().has_shell_access(),
+            detect_native_shell().is_some()
+        );
     }
 
     #[test]
@@ -85,11 +223,119 @@ mod tests {
     }
 
     #[test]
+    fn detect_shell_windows_prefers_git_bash() {
+        let mut map = HashMap::new();
+        map.insert("bash", r"C:\Program Files\Git\bin\bash.exe");
+        map.insert(
+            "powershell",
+            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+        );
+        map.insert("cmd", r"C:\Windows\System32\cmd.exe");
+
+        let shell = detect_native_shell_with(
+            true,
+            |name| map.get(name).map(PathBuf::from),
+            Some(PathBuf::from(r"C:\Windows\System32\cmd.exe")),
+        )
+        .expect("windows shell should be detected");
+
+        assert_eq!(shell.kind, ShellKind::Bash);
+    }
+
+    #[test]
+    fn detect_shell_windows_falls_back_to_powershell_then_cmd() {
+        let mut map = HashMap::new();
+        map.insert(
+            "powershell",
+            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+        );
+
+        let shell = detect_native_shell_with(
+            true,
+            |name| map.get(name).map(PathBuf::from),
+            Some(PathBuf::from(r"C:\Windows\System32\cmd.exe")),
+        )
+        .expect("windows shell should be detected");
+
+        assert_eq!(shell.kind, ShellKind::PowerShell);
+
+        let cmd_shell = detect_native_shell_with(
+            true,
+            |_name| None,
+            Some(PathBuf::from(r"C:\Windows\System32\cmd.exe")),
+        )
+        .expect("cmd fallback should be detected");
+        assert_eq!(cmd_shell.kind, ShellKind::Cmd);
+    }
+
+    #[test]
+    fn detect_shell_unix_prefers_sh() {
+        let mut map = HashMap::new();
+        map.insert("sh", "/bin/sh");
+        map.insert("bash", "/usr/bin/bash");
+
+        let shell = detect_native_shell_with(false, |name| map.get(name).map(PathBuf::from), None)
+            .expect("unix shell should be detected");
+
+        assert_eq!(shell.kind, ShellKind::Sh);
+    }
+
+    #[test]
+    fn native_without_shell_disables_shell_access() {
+        let runtime = NativeRuntime::new_for_test(None);
+        assert!(!runtime.has_shell_access());
+
+        let err = runtime
+            .build_shell_command("echo hello", Path::new("."))
+            .expect_err("build should fail without available shell")
+            .to_string();
+        assert!(err.contains("could not find a usable shell"));
+    }
+
+    #[test]
+    fn native_builds_powershell_command() {
+        let runtime = NativeRuntime::new_for_test(Some(ShellProgram {
+            kind: ShellKind::PowerShell,
+            program: PathBuf::from("powershell"),
+        }));
+
+        let command = runtime
+            .build_shell_command("Get-Location", Path::new("."))
+            .expect("powershell command should build");
+        let debug = format!("{command:?}");
+
+        assert!(debug.contains("powershell"));
+        assert!(debug.contains("-NoProfile"));
+        assert!(debug.contains("-Command"));
+        assert!(debug.contains("Get-Location"));
+    }
+
+    #[test]
+    fn native_builds_cmd_command() {
+        let runtime = NativeRuntime::new_for_test(Some(ShellProgram {
+            kind: ShellKind::Cmd,
+            program: PathBuf::from("cmd"),
+        }));
+
+        let command = runtime
+            .build_shell_command("echo hello", Path::new("."))
+            .expect("cmd command should build");
+        let debug = format!("{command:?}");
+
+        assert!(debug.contains("cmd"));
+        assert!(debug.contains("/C"));
+        assert!(debug.contains("echo hello"));
+    }
+
+    #[test]
     fn native_builds_shell_command() {
+        let runtime = NativeRuntime::new();
+        if !runtime.has_shell_access() {
+            return;
+        }
+
         let cwd = std::env::temp_dir();
-        let command = NativeRuntime::new()
-            .build_shell_command("echo hello", &cwd)
-            .unwrap();
+        let command = runtime.build_shell_command("echo hello", &cwd).unwrap();
         let debug = format!("{command:?}");
         assert!(debug.contains("echo hello"));
     }

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -15,7 +15,26 @@ const MAX_OUTPUT_BYTES: usize = 1_048_576;
 /// Environment variables safe to pass to shell commands.
 /// Only functional variables are included — never API keys or secrets.
 const SAFE_ENV_VARS: &[&str] = &[
-    "PATH", "HOME", "TERM", "LANG", "LC_ALL", "LC_CTYPE", "USER", "SHELL", "TMPDIR",
+    "PATH",
+    "HOME",
+    "TERM",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "USER",
+    "SHELL",
+    "TMPDIR",
+    // Windows runtime essentials when env is cleared before shell spawn.
+    "USERPROFILE",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "PROGRAMDATA",
+    "SYSTEMROOT",
+    "WINDIR",
+    "COMSPEC",
+    "TEMP",
+    "TMP",
+    "PATHEXT",
 ];
 
 fn truncate_utf8_to_max_bytes(text: &mut String, max_bytes: usize) {


### PR DESCRIPTION
## Summary
- fix native runtime shell resolution for Windows so `shell` tool no longer depends on `sh -c`
- add Windows-aware fallback chain: `bash -> sh -> pwsh -> powershell -> cmd/COMSPEC`
- make `has_shell_access()` reflect actual shell availability
- build shell command args by shell kind (`-c`, `-Command`, `/C`)
- preserve Windows runtime env essentials in shell tool after `env_clear`
- add runtime/shell diagnostics in `zeroclaw doctor`, including selected shell and candidate probes
- explicitly clarify in diagnostics/docs that **WSL2 is optional**, not required

## Root Cause
- Native runtime previously hardcoded POSIX shell invocation behavior, which is fragile on native Windows setups where `sh` may be absent.
- After environment clearing, missing Windows baseline vars caused shell subprocess instability.
- Lack of runtime diagnostics made this difficult for users to self-diagnose.

## Changes
- `src/runtime/native.rs`
  - runtime-level shell detection + fallback ordering
  - command construction by shell type
  - native shell diagnostics accessors
  - tests for fallback ordering, cmd/powershell command building, and no-shell behavior
- `src/tools/shell.rs`
  - extend safe passthrough env vars for Windows (`COMSPEC`, `SYSTEMROOT`, `PATHEXT`, `TEMP`, ...)
- `src/doctor/mod.rs`
  - add runtime capability checks
  - report selected native shell + Windows candidate availability
  - improve Windows shell environment checks (`COMSPEC`)
- `docs/troubleshooting.md`
  - add Windows shell troubleshooting section and WSL2 clarification

## Validation
Executed on latest `upstream/main` baseline:
- `cargo test runtime::native::tests -- --nocapture`
- `cargo test doctor::tests::runtime_check_reports_runtime_adapter -- --nocapture`
- `cargo test doctor::tests::windows_shell_candidates_include_cmd_probe -- --nocapture`
- `cargo test shell_safe_env_vars_includes_essentials -- --nocapture`
- `cargo fmt --all -- --check`

All passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved runtime shell detection and selection across Windows and Unix-like environments
  * Diagnostics now report the selected native shell and available shell candidates

* **Bug Fixes**
  * Clearer error messages and safer fallback when no suitable shell is found
  * More robust handling of Windows cmd/COMSPEC and PowerShell fallbacks

* **Documentation**
  * Added detailed Windows shell troubleshooting guide with diagnostics and step-by-step fixes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->