### PR TITLE
fix(ci): route Rust-heavy jobs to Hetzner runners

### DIFF
--- a/.github/workflows/ci-reproducible-build.yml
+++ b/.github/workflows/ci-reproducible-build.yml
@@ -58,7 +58,7 @@ env:
 jobs:
     reproducibility:
         name: Reproducible Build Probe
-        runs-on: ubuntu-22.04
+        runs-on: [self-hosted, hetzner]
         timeout-minutes: 75
         env:
             CARGO_HOME: ${{ github.workspace }}/.ci-rust/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}/cargo

--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -50,7 +50,7 @@ jobs:
         name: Lint Gate (Format + Clippy + Strict Delta)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: ubuntu-22.04
+        runs-on: [self-hosted, hetzner]
         timeout-minutes: 75
         env:
             CARGO_HOME: ${{ github.workspace }}/.ci-rust/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}/cargo
@@ -136,7 +136,7 @@ jobs:
         name: Test
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: ubuntu-22.04
+        runs-on: [self-hosted, hetzner]
         timeout-minutes: 120
         env:
             CARGO_HOME: ${{ github.workspace }}/.ci-rust/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}/cargo
@@ -215,7 +215,7 @@ jobs:
         name: Build (Smoke)
         needs: [changes]
         if: needs.changes.outputs.rust_changed == 'true'
-        runs-on: ubuntu-22.04
+        runs-on: [self-hosted, hetzner]
         timeout-minutes: 90
         env:
             CARGO_HOME: ${{ github.workspace }}/.ci-rust/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}/cargo

--- a/.github/workflows/sec-audit.yml
+++ b/.github/workflows/sec-audit.yml
@@ -72,7 +72,7 @@ env:
 jobs:
     audit:
         name: Security Audit
-        runs-on: ubuntu-22.04
+        runs-on: [self-hosted, hetzner]
         timeout-minutes: 45
         env:
             CARGO_HOME: ${{ github.workspace }}/.ci-rust/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}/cargo
@@ -107,7 +107,7 @@ jobs:
 
     deny:
         name: License & Supply Chain
-        runs-on: ubuntu-22.04
+        runs-on: [self-hosted, hetzner]
         timeout-minutes: 20
         env:
             CARGO_HOME: ${{ github.workspace }}/.ci-rust/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}/cargo
@@ -216,7 +216,7 @@ jobs:
 
     security-regressions:
         name: Security Regression Tests
-        runs-on: ubuntu-22.04
+        runs-on: [self-hosted, hetzner]
         timeout-minutes: 30
         env:
             CARGO_HOME: ${{ github.workspace }}/.ci-rust/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}/cargo

--- a/.github/workflows/sec-codeql.yml
+++ b/.github/workflows/sec-codeql.yml
@@ -51,7 +51,7 @@ env:
 jobs:
     codeql:
         name: CodeQL Analysis
-        runs-on: ubuntu-22.04
+        runs-on: [self-hosted, hetzner]
         timeout-minutes: 120
         env:
             CARGO_HOME: ${{ github.workspace }}/.ci-rust/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}/cargo


### PR DESCRIPTION
## Summary
- Routes 8 Rust-heavy CI jobs to `[self-hosted, hetzner]` instead of `ubuntu-22.04`
- Hetzner fleet (25 runners) handles compile-intensive work
- AWS India Lightsail (2 vCPU) stays on lighter auxiliary jobs
- Reverts fd3944ea from the 2026-03-01 runner outage

## Jobs moved to `[self-hosted, hetzner]`
- **ci-run.yml**: Lint Gate, Test, Build (Smoke)
- **sec-audit.yml**: Security Audit, License & Supply Chain, Security Regression Tests
- **sec-codeql.yml**: CodeQL Analysis
- **ci-reproducible-build.yml**: Reproducible Build Probe

## Test plan
- [ ] Verify Rust jobs land on hetzner-* runners after merge
- [ ] Confirm build/test/lint pass on Hetzner fleet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and deployment infrastructure by migrating multiple workflow runners to self-hosted environments for enhanced performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->