### PR TITLE
fix(ci): avoid rollback guard false-fail on scheduled runs

### DIFF
--- a/.github/workflows/ci-rollback.yml
+++ b/.github/workflows/ci-rollback.yml
@@ -48,7 +48,7 @@ on:
         - cron: "15 7 * * 1" # Weekly Monday 07:15 UTC
 
 concurrency:
-    group: ci-rollback-${{ github.event.inputs.branch || 'dev' }}
+    group: ci-rollback-${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.branch || 'dev') || github.ref_name }}
     cancel-in-progress: false
 
 permissions:
@@ -77,7 +77,7 @@ jobs:
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               with:
                   fetch-depth: 0
-                  ref: ${{ github.event.inputs.branch || 'dev' }}
+                  ref: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.branch || 'dev') || github.ref_name }}
 
             - name: Build rollback plan
               id: plan
@@ -86,7 +86,7 @@ jobs:
                   set -euo pipefail
                   mkdir -p artifacts
 
-                  branch_input="dev"
+                  branch_input="${GITHUB_REF_NAME}"
                   mode_input="dry-run"
                   target_ref_input=""
                   allow_non_ancestor="false"


### PR DESCRIPTION
## Summary
- fix `CI Rollback Guard` defaults for non-manual triggers to use the triggering ref (`github.ref_name`) instead of hard-coded `dev`
- keep `workflow_dispatch` behavior unchanged (still supports explicit branch input)
- apply the same defaulting rule to `concurrency.group`, checkout `ref`, and `branch_input`

## Root cause
Scheduled runs execute on `main`, but the workflow defaulted branch selection to `dev` for non-dispatch events. That can produce false guard violations when latest release tags are not ancestors of current `dev` head.

## Validation
- YAML parse check succeeded for `.github/workflows/ci-rollback.yml`
- local rollback guard dry-run with current default branch context succeeded

## Related failure
- https://github.com/zeroclaw-labs/zeroclaw/actions/runs/22566583169/job/65363943916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD rollback workflow to correctly handle branch references based on trigger type. Workflow now dynamically determines branch context for workflow dispatch events versus standard triggers, improving rollback process accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->