### PR TITLE
fix(ci): prevent scheduled canary dry-run false failures

### DIFF
--- a/.github/workflows/ci-canary-gate.yml
+++ b/.github/workflows/ci-canary-gate.yml
@@ -122,7 +122,8 @@ jobs:
                   trigger_rollback_on_abort="true"
                   rollback_branch="dev"
                   rollback_target_ref=""
-                  fail_on_violation="true"
+                  # Scheduled audits may not have live canary telemetry; report violations without failing by default.
+                  fail_on_violation="false"
 
                   if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
                     mode="${{ github.event.inputs.mode || 'dry-run' }}"


### PR DESCRIPTION
## Summary
- make scheduled `CI Canary Gate` audits non-blocking by default when no live telemetry is provided
- keep manual `workflow_dispatch` behavior unchanged (it can still set `fail_on_violation=true` and enforce strict failure)

## Root cause
The scheduled canary run uses default telemetry values (`sample_size=0`) and also defaulted `fail_on_violation=true`, which deterministically failed with:
- `Insufficient sample size for canary decision: 0 < required 500.`

That caused `main` head CI to stay red even though product code was healthy.

## Validation
- YAML parse check passed for `.github/workflows/ci-canary-gate.yml`
- local canary guard dry-run with zero sample and no fail flag succeeded

## Related failure
- https://github.com/zeroclaw-labs/zeroclaw/actions/runs/22566927382/job/65365001769


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to adjust the default behavior for policy violation handling. When workflows are triggered manually, violations are now reported independently without automatically causing workflow failure, providing greater flexibility for audit and compliance processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->