### PR TITLE
fix(ci): keep scheduled rollback audits non-blocking

### DIFF
--- a/.github/workflows/ci-rollback.yml
+++ b/.github/workflows/ci-rollback.yml
@@ -90,7 +90,8 @@ jobs:
                   mode_input="dry-run"
                   target_ref_input=""
                   allow_non_ancestor="false"
-                  fail_on_violation="true"
+                  # Scheduled audits can surface historical rollback violations; report without blocking by default.
+                  fail_on_violation="false"
 
                   if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
                     branch_input="${{ github.event.inputs.branch || 'dev' }}"


### PR DESCRIPTION
## Summary
- keep CI Rollback Guard scheduled audits report-only by default
- set default fail_on_violation=false for non-dispatch runs in rollback plan step
- keep manual workflow_dispatch behavior unchanged and still configurable (default strict)

## Why
Scheduled rollback audits can detect historical rollback-plan violations (for example non-ancestor tag targets) that should be surfaced but should not turn routine schedule runs red.

## Validation
- python3 -m pytest scripts/ci/tests/test_ci_scripts.py -k rollback_guard