### PR TITLE
fix(cron): support feishu announcement fallback to lark config

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -469,13 +469,25 @@ pub(crate) async fn deliver_announcement(
         "feishu" => {
             #[cfg(feature = "channel-lark")]
             {
-                let feishu = config
-                    .channels_config
-                    .feishu
-                    .as_ref()
-                    .ok_or_else(|| anyhow::anyhow!("feishu channel not configured"))?;
-                let channel = LarkChannel::from_feishu_config(feishu);
-                channel.send(&SendMessage::new(output, target)).await?;
+                // Try [channels_config.feishu] first, then fall back to [channels_config.lark] with use_feishu=true
+                if let Some(feishu_cfg) = &config.channels_config.feishu {
+                    let channel = LarkChannel::from_feishu_config(feishu_cfg);
+                    channel.send(&SendMessage::new(output, target)).await?;
+                } else if let Some(lark_cfg) = &config.channels_config.lark {
+                    if lark_cfg.use_feishu {
+                        let channel = LarkChannel::from_config(lark_cfg);
+                        channel.send(&SendMessage::new(output, target)).await?;
+                    } else {
+                        anyhow::bail!(
+                            "feishu channel not configured: [channels_config.feishu] is missing \
+                             and [channels_config.lark] exists but use_feishu=false"
+                        );
+                    }
+                } else {
+                    anyhow::bail!("feishu channel not configured: \
+                                   neither [channels_config.feishu] nor [channels_config.lark] \
+                                   with use_feishu=true is configured");
+                }
             }
             #[cfg(not(feature = "channel-lark"))]
             {


### PR DESCRIPTION
## Summary
- Fix feishu announcement delivery failing when channel is configured as Lark
- Add fallback logic: try `[channels_config.feishu]` first, then `[channels_config.lark]` with `use_feishu=true`
- Provide clearer error messages when configuration is missing

## Problem
When using feishu (飞书) with scheduled tasks, the system could not deliver announcements because:
- It only looked for `[channels_config.feishu]` configuration
- Users who configured under `[channels_config.lark]` with `use_feishu=true` were not supported
- This caused "feishu channel not configured" errors even when lark was properly configured

## Solution
- Try `[channels_config.feishu]` configuration first
- Fall back to `[channels_config.lark]` when:
  - `feishu` config is missing, AND
  - `lark` config exists with `use_feishu=true`
- Provide detailed error messages explaining which configurations are missing

## Test plan
- [x] Verify feishu announcements work with `[channels_config.feishu]` config
- [x] Verify feishu announcements work with `[channels_config.lark]` + `use_feishu=true`
- [x] Verify appropriate error messages when neither config is available

## Risk and Blast Radius
- Low risk: only affects feishu/lark announcement delivery path
- Backward compatible: existing `[channels_config.feishu]` configs continue to work
- Rollback: simple revert if issues arise

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Announcement delivery now preserves the original channel path when the primary channel configuration is present.
  * When the primary channel config is absent, delivery falls back to the alternate channel if explicitly enabled.
  * Error messages for missing or misconfigured channel options are clearer and more descriptive, improving troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->