### PR TITLE
ci: offload lightweight workflows from hetzner lane

### DIFF
--- a/.github/workflows/ci-queue-hygiene.yml
+++ b/.github/workflows/ci-queue-hygiene.yml
@@ -42,7 +42,7 @@ env:
 jobs:
     hygiene:
         name: Queue Hygiene
-        runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+        runs-on: [self-hosted, Linux, X64, aws-india]
         timeout-minutes: 15
         steps:
             - name: Checkout

--- a/.github/workflows/pr-auto-response.yml
+++ b/.github/workflows/pr-auto-response.yml
@@ -27,7 +27,7 @@ jobs:
     if: >-
       (github.event_name == 'issues' &&
       (github.event.action == 'opened' || github.event.action == 'reopened'))
-    runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+    runs-on: [self-hosted, Linux, X64, aws-india]
     permissions:
       contents: read
       issues: write
@@ -46,7 +46,7 @@ jobs:
             await script({ github, context, core });
   first-interaction:
     if: github.event.action == 'opened'
-    runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+    runs-on: [self-hosted, Linux, X64, aws-india]
     permissions:
       issues: write
       pull-requests: write
@@ -77,7 +77,7 @@ jobs:
 
   labeled-routes:
     if: github.event.action == 'labeled'
-    runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+    runs-on: [self-hosted, Linux, X64, aws-india]
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/pr-check-stale.yml
+++ b/.github/workflows/pr-check-stale.yml
@@ -17,7 +17,7 @@ jobs:
         permissions:
             issues: write
             pull-requests: write
-        runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+        runs-on: [self-hosted, Linux, X64, aws-india]
         timeout-minutes: 10
         steps:
             - name: Mark stale issues and pull requests

--- a/.github/workflows/pr-check-status.yml
+++ b/.github/workflows/pr-check-status.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   nudge-stale-prs:
-    runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+    runs-on: [self-hosted, Linux, X64, aws-india]
     timeout-minutes: 10
     permissions:
       contents: read

--- a/.github/workflows/pr-intake-checks.yml
+++ b/.github/workflows/pr-intake-checks.yml
@@ -23,7 +23,7 @@ env:
 jobs:
     intake:
         name: Intake Checks
-        runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+        runs-on: [self-hosted, Linux, X64, aws-india]
         timeout-minutes: 10
         steps:
             - name: Checkout repository

--- a/.github/workflows/pr-label-policy-check.yml
+++ b/.github/workflows/pr-label-policy-check.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
     contributor-tier-consistency:
-        runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+        runs-on: [self-hosted, Linux, X64, aws-india]
         timeout-minutes: 10
         steps:
             - name: Checkout

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
     label:
-        runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+        runs-on: [self-hosted, Linux, X64, aws-india]
         steps:
             - name: Checkout repository
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/sync-contributors.yml
+++ b/.github/workflows/sync-contributors.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   update-notice:
     name: Update NOTICE with new contributors
-    runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+    runs-on: [self-hosted, Linux, X64, aws-india]
     timeout-minutes: 20
     steps:
       - name: Checkout repository

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
     no-tabs:
-        runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+        runs-on: [self-hosted, Linux, X64, aws-india]
         timeout-minutes: 10
         steps:
             - name: Normalize git global hooks config
@@ -67,7 +67,7 @@ jobs:
                   PY
 
     actionlint:
-        runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+        runs-on: [self-hosted, Linux, X64, aws-india]
         timeout-minutes: 10
         steps:
             - name: Normalize git global hooks config


### PR DESCRIPTION
## Summary
- Route lightweight GitHub workflows to the broader self-hosted lane (`self-hosted, Linux, X64, aws-india`)
- Keep heavy CI workflows on the dedicated Hetzner lane (`self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner`)

## Why
- Queue pressure was caused by lightweight PR metadata workflows contending with heavy compile/test workloads for the same Hetzner-only label set
- This change frees Hetzner capacity for heavy jobs while keeping all execution self-hosted

## Validation
- YAML parsing succeeded for all modified workflows (Ruby YAML loader)
- Runner labels confirmed: Hetzner runners remain dedicated to heavy lane; `gcp-us` runners can absorb lightweight jobs

## Host-side Ops Applied (already live)
- `henny-2` / `henny-3`: runner CPU affinity defaults updated to `0-6` (~90% target) in `start-runners.sh` and `enforce-cpuset.sh`
- `henny-1`: existing `github-runners.slice` quota verified at `CPUQuotaPerSecUSec=7.200000s` (90% of 8 vCPU)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration infrastructure by consolidating runner configurations across multiple workflows, resulting in simplified and more streamlined build processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->