### PR TITLE
ci: bind sec codeql to dedicated hetzner lane

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -6,5 +6,6 @@ self-hosted-runner:
         - aws-india
         - light
         - cpu40
+        - codeql
         - blacksmith-2vcpu-ubuntu-2404
         - hetzner

--- a/.github/workflows/sec-codeql.yml
+++ b/.github/workflows/sec-codeql.yml
@@ -51,7 +51,7 @@ env:
 jobs:
     codeql:
         name: CodeQL Analysis
-        runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+        runs-on: [self-hosted, Linux, X64, hetzner, codeql]
         timeout-minutes: 120
         env:
             CARGO_HOME: ${{ github.workspace }}/.ci-rust/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}/cargo
@@ -88,6 +88,12 @@ jobs:
             - name: Ensure cargo component
               shell: bash
               run: bash ./scripts/ci/ensure_cargo_component.sh 1.92.0
+
+            - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
+              with:
+                  prefix-key: sec-codeql-build
+                  cache-targets: true
+                  cache-bin: false
 
             - name: Build
               run: cargo build --workspace --all-targets --locked


### PR DESCRIPTION
## Summary
- bind Sec CodeQL to dedicated Hetzner lane via runs-on: [self-hosted, Linux, X64, hetzner, codeql]
- add Rust dependency/target caching in CodeQL workflow to reduce rebuild time
- whitelist codeql custom label in actionlint config

## Runtime Ops Applied
- labeled dedicated runners: hetzner-41..45 with codeql
- removed aws-india and blacksmith-2vcpu-ubuntu-2404 labels from those runners to avoid heavy-job contention

## Goal
- reduce CodeQL queue wait by isolating it from generic heavy lane contention


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure configurations to optimize build performance and security scanning processes.
  * Enhanced caching mechanisms for improved build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->