### PR TITLE
fix(channels): use routed provider for channel startup

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -9989,15 +9989,15 @@ BTC is currently around $65,000 based on latest tool output."#
 
         let config_path = cfg.config_path.clone();
         let result = start_channels(cfg).await;
-        assert!(
-            result.is_ok(),
-            "start_channels should support routed providers without global credentials: {result:?}"
-        );
-
         let mut store = runtime_config_store()
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         store.remove(&config_path);
+
+        assert!(
+            result.is_ok(),
+            "start_channels should support routed providers without global credentials: {result:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Route `start_channels` provider initialization through model routing so `model_routes` and hint defaults are honored consistently with agent execution.

Closes #2537

## Root Cause
`start_channels()` initialized providers via `create_resilient_provider_nonblocking()` (non-routed path), so route-specific credentials and `default_model = "hint:*"` behavior were bypassed unless global provider credentials were present.

## What Changed
- Added `create_routed_provider_nonblocking()` wrapper using `create_routed_provider_with_options`.
- Updated `start_channels()` to initialize provider via routed path.
- Passed `config.model_routes` and resolved default model into channel provider initialization.
- Added regression test:
  - no global `default_provider`
  - no global `api_key`
  - `default_model = "hint:fast"`
  - per-route provider/model/api_key configured
  - verifies `start_channels()` succeeds.

## Why This Resolves It
Channel startup now uses the same routing semantics as agent flow, including route-level API keys and hint-based fallback behavior.

## Validation
- `cargo test start_channels_uses_model_routes_when_global_provider_key_is_missing -- --nocapture`
- Result: 1 passed, 0 failed
- `cargo fmt --all -- --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-blocking routed provider initialization added, enabling per-route model routing and passing resolved default models into provider creation.
  * Providers can use route-specific models even when no global provider key is configured, improving flexibility and startup behavior.

* **Tests**
  * Added end-to-end test coverage validating routed provider behavior when global provider configuration is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->