### PR TITLE
fix(config): report initialized state correctly on load

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -7624,7 +7624,8 @@ impl Config {
                 path = %config.config_path.display(),
                 workspace = %config.workspace_dir.display(),
                 source = resolution_source.as_str(),
-                initialized = false,
+                initialized = true,
+                created = false,
                 "Config loaded"
             );
             Ok(config)
@@ -7648,6 +7649,7 @@ impl Config {
                 workspace = %config.workspace_dir.display(),
                 source = resolution_source.as_str(),
                 initialized = true,
+                created = true,
                 "Config loaded"
             );
             Ok(config)


### PR DESCRIPTION
## Summary
- fix config-load telemetry to report `initialized=true` for existing valid `config.toml`
- add explicit `created` flag to distinguish first-time config creation from normal loads

## Why
Issue #2510 reports startup showing `initialized=false` after onboarding, which is misleading and can trigger activation confusion.

## Validation
- `cargo test --lib config::schema::tests::load_or_init_workspace_override_uses_workspace_root_for_config`
- `cargo test --lib config::schema::tests::load_or_init_uses_persisted_active_workspace_marker`
- `cargo test --lib config::schema::tests::load_or_init_env_workspace_override_takes_priority_over_marker`
- `cargo fmt --all -- --check`

Closes #2510
