### PR TITLE
fix(cli): handle empty invocation before clap parse

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,30 @@ fn parse_temperature(s: &str) -> std::result::Result<f64, String> {
     Ok(t)
 }
 
+fn print_no_command_help() -> Result<()> {
+    println!("No command provided.");
+    println!("Try `zeroclaw onboard --interactive` to initialize your workspace.");
+    println!();
+
+    let mut cmd = Cli::command();
+    cmd.print_help()?;
+    println!();
+
+    #[cfg(windows)]
+    pause_after_no_command_help();
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn pause_after_no_command_help() {
+    println!();
+    print!("Press Enter to exit...");
+    let _ = std::io::stdout().flush();
+    let mut line = String::new();
+    let _ = std::io::stdin().read_line(&mut line);
+}
+
 mod agent;
 mod approval;
 mod auth;
@@ -800,6 +824,10 @@ async fn main() -> Result<()> {
     // when both aws-lc-rs and ring features are available (or neither is explicitly selected).
     if let Err(e) = rustls::crypto::ring::default_provider().install_default() {
         eprintln!("Warning: Failed to install default crypto provider: {e:?}");
+    }
+
+    if std::env::args_os().len() <= 1 {
+        return print_no_command_help();
     }
 
     let cli = Cli::parse();


### PR DESCRIPTION
## Summary
- handle empty invocation (`zeroclaw` with no command) before Clap parse
- print actionable startup guidance and command help instead of immediate parse-exit
- on Windows, pause for Enter after help so double-click launch does not flash-close immediately

## Why
Issue #2499 reports Win11 users double-clicking `zeroclaw.exe` and seeing immediate exit (“flash crash”).

## Validation
- `cargo test --bin zeroclaw cli_definition_has_no_flag_conflicts`
- `cargo test --bin zeroclaw completion_generation_mentions_binary_name`
- `cargo test --bin zeroclaw config_cli_parses_show_get_set_subcommands`
- `cargo run --quiet --bin zeroclaw --` (verified no-command path now prints help and exits cleanly)
- `cargo fmt --all -- --check`

Closes #2499
