### PR TITLE
fix(channels): improve feishu startup diagnostics and feature-gate guidance

### DIFF
--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -99,6 +99,20 @@ impl LarkPlatform {
             Self::Feishu => "feishu",
         }
     }
+
+    fn display_name(self) -> &'static str {
+        match self {
+            Self::Lark => "Lark",
+            Self::Feishu => "Feishu",
+        }
+    }
+
+    fn config_table(self) -> &'static str {
+        match self {
+            Self::Lark => "[channels_config.lark]",
+            Self::Feishu => "[channels_config.feishu]",
+        }
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1958,6 +1972,14 @@ impl LarkChannel {
         &self,
         tx: tokio::sync::mpsc::Sender<ChannelMessage>,
     ) -> anyhow::Result<()> {
+        let port = self.port.ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} webhook mode requires `port` to be set in {}",
+                self.platform.display_name(),
+                self.platform.config_table()
+            )
+        })?;
+
         self.ensure_bot_open_id().await;
         use axum::{extract::State, routing::post, Json, Router};
 
@@ -2053,10 +2075,6 @@ impl LarkChannel {
             (StatusCode::OK, "ok").into_response()
         }
 
-        let port = self.port.ok_or_else(|| {
-            anyhow::anyhow!("Lark webhook mode requires `port` to be set in [channels_config.lark]")
-        })?;
-
         let state = AppState {
             verification_token: self.verification_token.clone(),
             channel: Arc::new(self.clone()),
@@ -2068,7 +2086,10 @@ impl LarkChannel {
             .with_state(state);
 
         let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
-        tracing::info!("Lark event callback server listening on {addr}");
+        tracing::info!(
+            "{} event callback server listening on {addr}",
+            self.platform.display_name()
+        );
 
         let listener = tokio::net::TcpListener::bind(addr).await?;
         axum::serve(listener, app).await?;
@@ -3248,6 +3269,56 @@ mod tests {
         assert_eq!(ch.api_base(), FEISHU_BASE_URL);
         assert_eq!(ch.ws_base(), FEISHU_WS_BASE_URL);
         assert_eq!(ch.name(), "feishu");
+    }
+
+    #[tokio::test]
+    async fn listen_http_missing_port_reports_lark_config_path() {
+        let channel = LarkChannel::new(
+            "cli_app123".into(),
+            "secret456".into(),
+            "vtoken789".into(),
+            None,
+            vec!["*".into()],
+            false,
+        );
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+
+        let err = channel
+            .listen_http(tx)
+            .await
+            .expect_err("listen_http should fail when webhook port is missing");
+
+        assert!(err
+            .to_string()
+            .contains("Lark webhook mode requires `port` to be set in [channels_config.lark]"));
+    }
+
+    #[tokio::test]
+    async fn listen_http_missing_port_reports_feishu_config_path() {
+        use crate::config::schema::{FeishuConfig, LarkReceiveMode};
+
+        let channel = LarkChannel::from_feishu_config(&FeishuConfig {
+            app_id: "cli_feishu_app123".into(),
+            app_secret: "secret456".into(),
+            encrypt_key: None,
+            verification_token: Some("vtoken789".into()),
+            allowed_users: vec!["*".into()],
+            group_reply: None,
+            receive_mode: LarkReceiveMode::Webhook,
+            port: None,
+            draft_update_interval_ms: 3_000,
+            max_draft_edits: 20,
+        });
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+
+        let err = channel
+            .listen_http(tx)
+            .await
+            .expect_err("listen_http should fail when webhook port is missing");
+
+        assert!(err
+            .to_string()
+            .contains("Feishu webhook mode requires `port` to be set in [channels_config.feishu]"));
     }
 
     #[test]

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -5287,10 +5287,35 @@ async fn append_nostr_channel_if_available(
     }
 }
 
+fn feature_gated_channel_notices(config: &Config) -> Vec<String> {
+    let mut notices = Vec::new();
+
+    #[cfg(not(feature = "channel-lark"))]
+    if config.channels_config.lark.is_some() || config.channels_config.feishu.is_some() {
+        notices.push(
+            "Lark/Feishu is configured but this binary was built without `channel-lark`; \
+             rebuild with `--features channel-lark` or use a release artifact that includes it."
+                .to_string(),
+        );
+    }
+
+    #[cfg(not(feature = "channel-matrix"))]
+    if config.channels_config.matrix.is_some() {
+        notices.push(
+            "Matrix is configured but this binary was built without `channel-matrix`; \
+             rebuild with `--features channel-matrix` or use a release artifact that includes it."
+                .to_string(),
+        );
+    }
+
+    notices
+}
+
 /// Run health checks for configured channels.
 pub async fn doctor_channels(config: Config) -> Result<()> {
     let mut channels = collect_configured_channels(&config, "health check");
     let mut init_failures = Vec::new();
+    let gated_notices = feature_gated_channel_notices(&config);
 
     if let Some(reason) =
         append_nostr_channel_if_available(&config, &mut channels, "health check").await
@@ -5299,12 +5324,26 @@ pub async fn doctor_channels(config: Config) -> Result<()> {
     }
 
     if channels.is_empty() && init_failures.is_empty() {
+        if !gated_notices.is_empty() {
+            println!("Configured channels are unavailable in this build:");
+            for notice in gated_notices {
+                println!("  ⚠️  {notice}");
+            }
+            return Ok(());
+        }
         println!("No real-time channels configured. Run `zeroclaw onboard` first.");
         return Ok(());
     }
 
     println!("🩺 ZeroClaw Channel Doctor");
     println!();
+
+    if !gated_notices.is_empty() {
+        for notice in &gated_notices {
+            println!("  ⚠️  {notice}");
+        }
+        println!();
+    }
 
     let mut healthy = 0_u32;
     let mut unhealthy = u32::try_from(init_failures.len()).unwrap_or(u32::MAX);
@@ -5611,6 +5650,7 @@ pub async fn start_channels(config: Config) -> Result<()> {
     // Collect active channels from a shared builder to keep startup and doctor parity.
     let mut configured_channels = collect_configured_channels(&config, "runtime startup");
     let mut init_failures = Vec::new();
+    let gated_notices = feature_gated_channel_notices(&config);
     if let Some(reason) =
         append_nostr_channel_if_available(&config, &mut configured_channels, "runtime startup")
             .await
@@ -5619,6 +5659,13 @@ pub async fn start_channels(config: Config) -> Result<()> {
     }
 
     if configured_channels.is_empty() && init_failures.is_empty() {
+        if !gated_notices.is_empty() {
+            println!("Configured channels are unavailable in this build:");
+            for notice in gated_notices {
+                println!("  ⚠️  {notice}");
+            }
+            anyhow::bail!("No runnable channels in this build.");
+        }
         println!("No channels configured. Run `zeroclaw onboard` to set up channels.");
         return Ok(());
     }
@@ -5633,6 +5680,13 @@ pub async fn start_channels(config: Config) -> Result<()> {
     if !init_failures.is_empty() {
         for failure in &init_failures {
             println!("  ⚠️  {failure}");
+        }
+        println!();
+    }
+
+    if !gated_notices.is_empty() {
+        for notice in &gated_notices {
+            println!("  ⚠️  {notice}");
         }
         println!();
     }
@@ -12069,6 +12123,52 @@ BTC is currently around $65,000 based on latest tool output."#;
         assert!(channels
             .iter()
             .any(|entry| entry.channel.name() == "dingtalk"));
+    }
+
+    #[cfg(not(feature = "channel-lark"))]
+    #[test]
+    fn feature_gated_channel_notices_reports_lark_and_feishu() {
+        let mut config = Config::default();
+        config.channels_config.feishu = Some(crate::config::FeishuConfig {
+            app_id: "feishu-app".to_string(),
+            app_secret: "feishu-secret".to_string(),
+            encrypt_key: None,
+            verification_token: None,
+            allowed_users: vec!["*".to_string()],
+            group_reply: None,
+            receive_mode: crate::config::schema::LarkReceiveMode::Websocket,
+            port: None,
+            draft_update_interval_ms: 3_000,
+            max_draft_edits: 20,
+        });
+
+        let notices = feature_gated_channel_notices(&config);
+        assert_eq!(notices.len(), 1);
+        assert!(notices[0].contains("channel-lark"));
+        assert!(notices[0].contains("Lark/Feishu"));
+    }
+
+    #[cfg(not(feature = "channel-matrix"))]
+    #[test]
+    fn feature_gated_channel_notices_reports_matrix() {
+        let mut config = Config::default();
+        config.channels_config.matrix = Some(crate::config::MatrixConfig {
+            homeserver: "https://matrix.example.com".to_string(),
+            access_token: "matrix-token".to_string(),
+            user_id: Some("@bot:matrix.example.com".to_string()),
+            device_id: None,
+            room_id: "!room:example.com".to_string(),
+            allowed_users: vec!["*".to_string()],
+            mention_only: false,
+        });
+
+        let notices = feature_gated_channel_notices(&config);
+        assert!(
+            notices
+                .iter()
+                .any(|notice| notice.contains("channel-matrix")),
+            "matrix notice should mention channel-matrix feature gate"
+        );
     }
 
     struct AlwaysFailChannel {


### PR DESCRIPTION
## Summary
- improve Feishu/Lark webhook startup diagnostics with platform-specific config hints
- surface feature-gate notices in `channel start` / `channel doctor` when channels are configured but unavailable in the current build
- add tests for Feishu/Lark missing-port errors and feature-gated notices

## Root Cause
Two operator-facing gaps caused confusing startup behavior:
1. Feishu webhook missing-port errors were reported as Lark-only config guidance.
2. When channels were configured but compiled-out by feature flags, startup could look like "no channels configured" instead of clearly reporting feature-gate unavailability.

## Changes
- added `display_name()` and `config_table()` on `LarkPlatform`
- moved webhook `port` validation to the start of `listen_http()` and made error text platform-aware:
  - Lark -> `[channels_config.lark]`
  - Feishu -> `[channels_config.feishu]`
- updated webhook startup log line to use platform display name
- introduced `feature_gated_channel_notices()` in `channels/mod.rs`
- wired notices into both `doctor_channels()` and `start_channels()` output paths

## Validation
- `cargo test feature_gated_channel_notices -- --nocapture`
- `cargo test --features channel-lark listen_http_missing_port_reports -- --nocapture`
- `cargo fmt --all -- --check`

Closes #2494
