### PR TITLE
feat(provider): add LiteLLM as registered OpenAI-compatible provider alias(#2602)

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -992,6 +992,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "llamacpp" | "llama.cpp" => vec!["LLAMACPP_API_KEY"],
         "sglang" => vec!["SGLANG_API_KEY"],
         "vllm" => vec!["VLLM_API_KEY"],
+        "litellm" => vec!["LITELLM_API_KEY"],
         "osaurus" => vec!["OSAURUS_API_KEY"],
         "telnyx" => vec!["TELNYX_API_KEY"],
         _ => vec![],
@@ -1433,6 +1434,18 @@ fn create_provider_with_url_and_options(
                 .unwrap_or("http://localhost:8000/v1");
             Ok(Box::new(OpenAiCompatibleProvider::new(
                 "vLLM",
+                base_url,
+                key,
+                AuthStyle::Bearer,
+            )))
+        }
+        "litellm" => {
+            let base_url = api_url
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or("http://localhost:4000/v1");
+            Ok(Box::new(OpenAiCompatibleProvider::new(
+                "LiteLLM",
                 base_url,
                 key,
                 AuthStyle::Bearer,
@@ -2058,6 +2071,12 @@ pub fn list_providers() -> Vec<ProviderInfo> {
             local: true,
         },
         ProviderInfo {
+            name: "litellm",
+            display_name: "LiteLLM",
+            aliases: &[],
+            local: false,
+        },
+        ProviderInfo {
             name: "osaurus",
             display_name: "Osaurus",
             aliases: &[],
@@ -2679,6 +2698,12 @@ mod tests {
     }
 
     #[test]
+    fn factory_litellm() {
+        assert!(create_provider("litellm", None).is_ok());
+        assert!(create_provider("litellm", Some("key")).is_ok());
+    }
+
+    #[test]
     fn factory_osaurus() {
         // Osaurus works without an explicit key (defaults to "osaurus").
         assert!(create_provider("osaurus", None).is_ok());
@@ -3135,6 +3160,7 @@ providers = ["demo-plugin-provider"]
             "llamacpp",
             "sglang",
             "vllm",
+            "litellm",
             "osaurus",
             "telnyx",
             "groq",


### PR DESCRIPTION
- Base branch target: main
  - Problem: LiteLLM is a widely adopted AI gateway proxy, but users must manually configure provider = "openai" + api_url to
  use it, which is non-discoverable and inconsistent with how vLLM/SGLang/LM Studio are handled
  - Why it matters: LiteLLM is arguably the most popular open-source LLM gateway (8ms P95 latency at 1k RPS, 100+ provider
  support, cost tracking). Every comparable local/gateway server already has a named alias in ZeroClaw — LiteLLM is the notable
  gap. Adding it enables provider = "litellm" with zero friction and makes LiteLLM discoverable via zeroclaw providers list
  - What changed: Registered "litellm" provider key using OpenAiCompatibleProvider with default endpoint
  http://localhost:4000/v1, added env var resolution, provider list entry, and factory test
  - What did not change: No new files, no new dependencies, no config schema changes, no security boundary changes, no
  documentation changes (follow-up)

  Label Snapshot (required)

  - Risk label: risk: low
  - Size label: size: XS
  - Scope labels: provider
  - Module labels: provider: litellm
  - Contributor tier label: (auto-managed)
  - If any auto-label is incorrect, note requested correction: N/A

  Change Metadata

  - Change type: feature
  - Primary scope: provider

  Linked Issue

  - Closes #2602
  - Related: N/A
  - Depends on: N/A
  - Supersedes: N/A
  - Linear issue key(s): (to be assigned)
  - Linear issue URL(s): (to be assigned)

  Supersede Attribution (required when Supersedes # is used)

  N/A — this is a new feature, not a supersede.

  Validation Evidence (required)

  cargo fmt --all -- --check          # ✅ passed
  cargo clippy -p zeroclaw --lib      # ✅ no new warnings (pre-existing 95 errors unrelated)
  cargo test --lib factory_litellm    # ✅ 1 passed
  cargo test --lib factory_all_providers  # ✅ 1 passed
  cargo test --lib factory_           # ✅ 109 passed, 0 failed

  - Evidence provided: CLI test output
  - If any command is intentionally skipped: full cargo clippy --all-targets -- -D warnings exits non-zero due to 95
  pre-existing errors in other modules; confirmed zero warnings in src/providers/mod.rs

  Security Impact (required)

  - New permissions/capabilities? No
  - New external network calls? No (OpenAI-compatible wrapper; same HTTP path as existing providers)
  - Secrets/tokens handling changed? No (uses existing LITELLM_API_KEY env var resolution and AuthStyle::Bearer — identical to
  vLLM/SGLang pattern)
  - File system access scope changed? No

  Privacy and Data Hygiene (required)

  - Data-hygiene status: pass
  - Redaction/anonymization notes: No user data involved. Provider key and endpoint are infrastructure configuration only.
  - Neutral wording confirmation: All labels use project-scoped naming ("LiteLLM", "litellm")

  Compatibility / Migration

  - Backward compatible? Yes — purely additive registration; no existing behavior affected
  - Config/env changes? Yes — new optional LITELLM_API_KEY env var lookup (no-op if unset)
  - Migration needed? No

  i18n Follow-Through (required when docs or user-facing wording changes)

  - i18n follow-through triggered? No — no docs or user-facing wording changes in this PR

  Human Verification (required)

  - Verified scenarios:
    - create_provider("litellm", None) succeeds (key-less local usage)
    - create_provider("litellm", Some("key")) succeeds (explicit key)
    - factory_all_providers_create_successfully includes "litellm" and passes
    - Provider appears with correct display_name: "LiteLLM" and local: false in list
  - Edge cases checked:
    - No key provided → works (same as vLLM pattern, key is optional for local proxy)
    - Custom api_url override → works (for remote LiteLLM deployments)
  - What was not verified: End-to-end chat against a live LiteLLM proxy (requires running LiteLLM instance)

  Side Effects / Blast Radius (required)

  - Affected subsystems/workflows: Provider factory only; no runtime, channel, gateway, or tool changes
  - Potential unintended effects: None — additive registration, isolated to factory match arm
  - Guardrails/monitoring for early detection: Factory test covers creation; existing ReliableProvider wrapper handles runtime
  errors


  Rollback Plan (required)

  - Fast rollback command/path: git revert <commit-sha>
  - Feature flags or config toggles: N/A (users simply switch back to provider = "openai" + api_url)
  - Observable failure symptoms: provider = "litellm" returns unknown provider error after revert

  Risks and Mitigations

  - Risk: None — this is the 5th identical OpenAiCompatibleProvider alias registration following an established, battle-tested
  pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LiteLLM provider support has been added to the platform. Users can now select and use LiteLLM as an alternative AI provider option within their workflows. The integration provides automatic API key credential resolution, supports OpenAI-compatible API requests, includes pre-configured default endpoint settings for local deployment, and maintains consistency with existing provider workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->