### PR TITLE
feat(gateway): add path-scoped webhook transforms

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -5071,6 +5071,89 @@ pub struct WebhookConfig {
     pub port: u16,
     /// Optional shared secret for webhook signature verification.
     pub secret: Option<String>,
+    /// Path-scoped payload transforms for generic webhook senders.
+    ///
+    /// Each transform route is matched by exact normalized path and executes
+    /// one command with the raw request body piped to stdin.
+    #[serde(default)]
+    pub transforms: Vec<WebhookTransformConfig>,
+}
+
+/// One inbound webhook transform route.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct WebhookTransformConfig {
+    /// Exact path to match (for example `/hooks/github`).
+    pub path: String,
+    /// Command argv to execute; first element is executable path.
+    pub command: Vec<String>,
+    /// Max transform runtime in milliseconds.
+    #[serde(default = "default_webhook_transform_timeout_ms")]
+    pub timeout_ms: u64,
+    /// Max stdout bytes accepted from transform output.
+    #[serde(default = "default_webhook_transform_max_output_bytes")]
+    pub max_output_bytes: usize,
+}
+
+fn default_webhook_transform_timeout_ms() -> u64 {
+    5_000
+}
+
+fn default_webhook_transform_max_output_bytes() -> usize {
+    65_536
+}
+
+pub(crate) fn normalize_webhook_transform_path(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut normalized = if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
+    };
+
+    while normalized.contains("//") {
+        normalized = normalized.replace("//", "/");
+    }
+
+    if normalized.len() > 1 && normalized.ends_with('/') {
+        normalized.pop();
+    }
+
+    if normalized.is_empty()
+        || !normalized.starts_with('/')
+        || normalized
+            .chars()
+            .any(|ch| ch.is_control() || ch == '?' || ch == '#')
+    {
+        return None;
+    }
+
+    Some(normalized)
+}
+
+fn is_reserved_gateway_path(path: &str) -> bool {
+    matches!(
+        path,
+        "/health"
+            | "/metrics"
+            | "/pair"
+            | "/webhook"
+            | "/whatsapp"
+            | "/linq"
+            | "/github"
+            | "/bluebubbles"
+            | "/wati"
+            | "/nextcloud-talk"
+            | "/qq"
+            | "/api/chat"
+            | "/v1/models"
+            | "/v1/chat/completions"
+            | "/ws/chat"
+    ) || path.starts_with("/api/")
+        || path.starts_with("/_app/")
 }
 
 impl ChannelConfig for WebhookConfig {
@@ -7880,6 +7963,55 @@ impl Config {
         // Gateway
         if self.gateway.host.trim().is_empty() {
             anyhow::bail!("gateway.host must not be empty");
+        }
+        if let Some(webhook) = &self.channels_config.webhook {
+            let mut seen_paths = std::collections::HashSet::new();
+            for (i, transform) in webhook.transforms.iter().enumerate() {
+                let Some(normalized_path) = normalize_webhook_transform_path(&transform.path)
+                else {
+                    anyhow::bail!(
+                        "channels_config.webhook.transforms[{i}].path is invalid; expected an absolute URL path without query/fragment"
+                    );
+                };
+                if is_reserved_gateway_path(&normalized_path) {
+                    anyhow::bail!(
+                        "channels_config.webhook.transforms[{i}].path conflicts with a reserved gateway route: {normalized_path}"
+                    );
+                }
+                if !seen_paths.insert(normalized_path.clone()) {
+                    anyhow::bail!(
+                        "channels_config.webhook.transforms contains duplicate path after normalization: {normalized_path}"
+                    );
+                }
+                if transform.command.is_empty() {
+                    anyhow::bail!(
+                        "channels_config.webhook.transforms[{i}].command must include at least one argv element"
+                    );
+                }
+                for (j, arg) in transform.command.iter().enumerate() {
+                    let trimmed = arg.trim();
+                    if trimmed.is_empty() {
+                        anyhow::bail!(
+                            "channels_config.webhook.transforms[{i}].command[{j}] must not be empty"
+                        );
+                    }
+                    if trimmed.contains('\0') {
+                        anyhow::bail!(
+                            "channels_config.webhook.transforms[{i}].command[{j}] must not contain null bytes"
+                        );
+                    }
+                }
+                if transform.timeout_ms == 0 || transform.timeout_ms > 300_000 {
+                    anyhow::bail!(
+                        "channels_config.webhook.transforms[{i}].timeout_ms must be between 1 and 300000"
+                    );
+                }
+                if transform.max_output_bytes == 0 || transform.max_output_bytes > 1_048_576 {
+                    anyhow::bail!(
+                        "channels_config.webhook.transforms[{i}].max_output_bytes must be between 1 and 1048576"
+                    );
+                }
+            }
         }
 
         // Autonomy
@@ -11276,6 +11408,7 @@ channel_id = "C123"
         let json = r#"{"port":8080,"secret":"my-secret-key"}"#;
         let parsed: WebhookConfig = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.secret.as_deref(), Some("my-secret-key"));
+        assert!(parsed.transforms.is_empty());
     }
 
     #[test]
@@ -11284,6 +11417,104 @@ channel_id = "C123"
         let parsed: WebhookConfig = serde_json::from_str(json).unwrap();
         assert!(parsed.secret.is_none());
         assert_eq!(parsed.port, 8080);
+        assert!(parsed.transforms.is_empty());
+    }
+
+    #[test]
+    async fn webhook_config_with_transform_routes() {
+        let json = r#"{
+            "port":8080,
+            "secret":"my-secret-key",
+            "transforms":[
+                {"path":"hooks/github","command":["sh","-c","cat"],"timeout_ms":3000,"max_output_bytes":1024}
+            ]
+        }"#;
+        let parsed: WebhookConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.transforms.len(), 1);
+        assert_eq!(parsed.transforms[0].path, "hooks/github");
+        assert_eq!(parsed.transforms[0].command[0], "sh");
+        assert_eq!(parsed.transforms[0].timeout_ms, 3000);
+    }
+
+    #[test]
+    async fn normalize_webhook_transform_path_handles_common_inputs() {
+        assert_eq!(
+            normalize_webhook_transform_path("/hooks/github/"),
+            Some("/hooks/github".to_string())
+        );
+        assert_eq!(
+            normalize_webhook_transform_path("hooks//github"),
+            Some("/hooks/github".to_string())
+        );
+        assert_eq!(normalize_webhook_transform_path(""), None);
+        assert_eq!(normalize_webhook_transform_path("/hooks/github?x=1"), None);
+    }
+
+    #[test]
+    async fn config_validate_rejects_duplicate_webhook_transform_paths() {
+        let mut config = Config::default();
+        config.channels_config.webhook = Some(WebhookConfig {
+            port: 8080,
+            secret: None,
+            transforms: vec![
+                WebhookTransformConfig {
+                    path: "/hooks/github".to_string(),
+                    command: vec!["sh".to_string(), "-c".to_string(), "cat".to_string()],
+                    timeout_ms: 1000,
+                    max_output_bytes: 1024,
+                },
+                WebhookTransformConfig {
+                    path: "hooks//github".to_string(),
+                    command: vec!["sh".to_string(), "-c".to_string(), "cat".to_string()],
+                    timeout_ms: 1000,
+                    max_output_bytes: 1024,
+                },
+            ],
+        });
+
+        let err = config
+            .validate()
+            .expect_err("expected duplicate webhook transform path validation failure");
+        assert!(err.to_string().contains("duplicate path"));
+    }
+
+    #[test]
+    async fn config_validate_rejects_reserved_webhook_transform_path() {
+        let mut config = Config::default();
+        config.channels_config.webhook = Some(WebhookConfig {
+            port: 8080,
+            secret: None,
+            transforms: vec![WebhookTransformConfig {
+                path: "/api/chat".to_string(),
+                command: vec!["sh".to_string(), "-c".to_string(), "cat".to_string()],
+                timeout_ms: 1000,
+                max_output_bytes: 1024,
+            }],
+        });
+
+        let err = config
+            .validate()
+            .expect_err("expected reserved webhook transform path failure");
+        assert!(err.to_string().contains("reserved gateway route"));
+    }
+
+    #[test]
+    async fn config_validate_accepts_valid_webhook_transform_path() {
+        let mut config = Config::default();
+        config.channels_config.webhook = Some(WebhookConfig {
+            port: 8080,
+            secret: None,
+            transforms: vec![WebhookTransformConfig {
+                path: "/hooks/github".to_string(),
+                command: vec!["sh".to_string(), "-c".to_string(), "cat".to_string()],
+                timeout_ms: 1000,
+                max_output_bytes: 1024,
+            }],
+        });
+
+        config
+            .validate()
+            .expect("valid webhook transform config should pass");
     }
 
     // ── WhatsApp config ──────────────────────────────────────

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -31,7 +31,7 @@ use crate::util::truncate_with_ellipsis;
 use anyhow::{Context, Result};
 use axum::{
     body::{Body, Bytes},
-    extract::{ConnectInfo, Query, State},
+    extract::{ConnectInfo, Path, Query, State},
     http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Json, Response},
     routing::{delete, get, post, put},
@@ -43,6 +43,8 @@ use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::timeout::TimeoutLayer;
 use uuid::Uuid;
@@ -870,6 +872,10 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         .route("/ws/chat", get(ws::handle_ws_chat))
         // ── Static assets (web dashboard) ──
         .route("/_app/{*path}", get(static_files::handle_static))
+        // ── Optional path-scoped webhook transforms ──
+        // Catch-all POST route for custom webhook transform paths configured under
+        // [channels_config.webhook.transforms]. Explicit routes above still take precedence.
+        .route("/{*path}", post(handle_webhook_transform_path))
         // ── Config PUT with larger body limit ──
         .merge(config_put_router)
         .with_state(state)
@@ -1578,28 +1584,44 @@ fn handle_webhook_streaming(
         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
 }
 
-/// POST /webhook — main webhook endpoint
-async fn handle_webhook(
-    State(state): State<AppState>,
-    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
-    headers: HeaderMap,
-    body: Result<Json<WebhookBody>, axum::extract::rejection::JsonRejection>,
-) -> Response {
-    let rate_key =
-        client_key_from_request(Some(peer_addr), &headers, state.trust_forwarded_headers);
+fn resolve_webhook_transform_for_path(
+    config: &Config,
+    request_path: &str,
+) -> Option<crate::config::schema::WebhookTransformConfig> {
+    let normalized_request = crate::config::schema::normalize_webhook_transform_path(request_path)?;
+    let webhook = config.channels_config.webhook.as_ref()?;
+
+    webhook.transforms.iter().find_map(|transform| {
+        let normalized_candidate =
+            crate::config::schema::normalize_webhook_transform_path(&transform.path)?;
+        if normalized_candidate == normalized_request {
+            Some(transform.clone())
+        } else {
+            None
+        }
+    })
+}
+
+fn enforce_webhook_request_guards(
+    state: &AppState,
+    peer_addr: SocketAddr,
+    headers: &HeaderMap,
+    request_path: &str,
+) -> Option<Response> {
+    let rate_key = client_key_from_request(Some(peer_addr), headers, state.trust_forwarded_headers);
     if !state.rate_limiter.allow_webhook(&rate_key) {
-        tracing::warn!("/webhook rate limit exceeded");
+        tracing::warn!("{request_path} rate limit exceeded");
         let err = serde_json::json!({
             "error": "Too many webhook requests. Please retry later.",
             "retry_after": RATE_LIMIT_WINDOW_SECS,
         });
-        return (StatusCode::TOO_MANY_REQUESTS, Json(err)).into_response();
+        return Some((StatusCode::TOO_MANY_REQUESTS, Json(err)).into_response());
     }
 
     // Require at least one auth layer for non-loopback traffic.
     if !state.pairing.require_pairing()
         && state.webhook_secret_hash.is_none()
-        && !is_loopback_request(Some(peer_addr), &headers, state.trust_forwarded_headers)
+        && !is_loopback_request(Some(peer_addr), headers, state.trust_forwarded_headers)
     {
         tracing::warn!(
             "Webhook: rejected unauthenticated non-loopback request (pairing disabled and no webhook secret configured)"
@@ -1607,7 +1629,7 @@ async fn handle_webhook(
         let err = serde_json::json!({
             "error": "Unauthorized — configure pairing or X-Webhook-Secret for non-local webhook access"
         });
-        return (StatusCode::UNAUTHORIZED, Json(err)).into_response();
+        return Some((StatusCode::UNAUTHORIZED, Json(err)).into_response());
     }
 
     // ── Bearer token auth (pairing) ──
@@ -1622,7 +1644,7 @@ async fn handle_webhook(
             let err = serde_json::json!({
                 "error": "Unauthorized — pair first via POST /pair, then send Authorization: Bearer <token>"
             });
-            return (StatusCode::UNAUTHORIZED, Json(err)).into_response();
+            return Some((StatusCode::UNAUTHORIZED, Json(err)).into_response());
         }
     }
 
@@ -1639,24 +1661,15 @@ async fn handle_webhook(
             _ => {
                 tracing::warn!("Webhook: rejected request — invalid or missing X-Webhook-Secret");
                 let err = serde_json::json!({"error": "Unauthorized — invalid or missing X-Webhook-Secret header"});
-                return (StatusCode::UNAUTHORIZED, Json(err)).into_response();
+                return Some((StatusCode::UNAUTHORIZED, Json(err)).into_response());
             }
         }
     }
 
-    // ── Parse body ──
-    let Json(webhook_body) = match body {
-        Ok(b) => b,
-        Err(e) => {
-            tracing::warn!("Webhook JSON parse error: {e}");
-            let err = serde_json::json!({
-                "error": "Invalid JSON body. Expected: {\"message\": \"...\"}"
-            });
-            return (StatusCode::BAD_REQUEST, Json(err)).into_response();
-        }
-    };
+    None
+}
 
-    // ── Idempotency (optional) ──
+fn enforce_webhook_idempotency(state: &AppState, headers: &HeaderMap) -> Option<Response> {
     if let Some(idempotency_key) = headers
         .get("X-Idempotency-Key")
         .and_then(|v| v.to_str().ok())
@@ -1670,10 +1683,90 @@ async fn handle_webhook(
                 "idempotent": true,
                 "message": "Request already processed for this idempotency key"
             });
-            return (StatusCode::OK, Json(body)).into_response();
+            return Some((StatusCode::OK, Json(body)).into_response());
         }
     }
+    None
+}
 
+async fn run_webhook_transform(
+    transform: &crate::config::schema::WebhookTransformConfig,
+    payload: &[u8],
+) -> anyhow::Result<Option<WebhookBody>> {
+    let mut command = Command::new(&transform.command[0]);
+    if transform.command.len() > 1 {
+        command.args(&transform.command[1..]);
+    }
+    command
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = command.spawn().with_context(|| {
+        format!(
+            "failed to spawn webhook transform command '{}'",
+            transform.command[0]
+        )
+    })?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(payload)
+            .await
+            .context("failed to write webhook payload to transform stdin")?;
+    }
+
+    let output = tokio::time::timeout(
+        Duration::from_millis(transform.timeout_ms),
+        child.wait_with_output(),
+    )
+    .await
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "webhook transform timed out after {} ms",
+            transform.timeout_ms
+        )
+    })?
+    .context("failed waiting for webhook transform output")?;
+
+    if output.stdout.len() > transform.max_output_bytes {
+        anyhow::bail!(
+            "webhook transform output exceeded max_output_bytes ({} > {})",
+            output.stdout.len(),
+            transform.max_output_bytes
+        );
+    }
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "webhook transform exited with status {}: {}",
+            output.status.code().unwrap_or(-1),
+            truncate_with_ellipsis(stderr.trim(), 240)
+        );
+    }
+
+    let stdout =
+        String::from_utf8(output.stdout).context("webhook transform stdout is not valid UTF-8")?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("webhook transform output is empty");
+    }
+
+    let transformed_value: serde_json::Value =
+        serde_json::from_str(trimmed).context("webhook transform output must be valid JSON")?;
+    if transformed_value.is_null() {
+        return Ok(None);
+    }
+
+    let webhook_body: WebhookBody = serde_json::from_value(transformed_value).context(
+        "webhook transform output must match webhook schema ({\"message\":\"...\", \"stream\"?, \"session_id\"?})",
+    )?;
+    Ok(Some(webhook_body))
+}
+
+async fn process_webhook_body(state: AppState, webhook_body: WebhookBody) -> Response {
     let message = webhook_body.message.trim();
     let webhook_session_id = webhook_body
         .session_id
@@ -1848,6 +1941,94 @@ async fn handle_webhook(
             let err = serde_json::json!({"error": "LLM request failed"});
             (StatusCode::INTERNAL_SERVER_ERROR, Json(err)).into_response()
         }
+    }
+}
+
+/// POST /webhook — main webhook endpoint
+async fn handle_webhook(
+    State(state): State<AppState>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    body: Result<Json<WebhookBody>, axum::extract::rejection::JsonRejection>,
+) -> Response {
+    if let Some(response) = enforce_webhook_request_guards(&state, peer_addr, &headers, "/webhook")
+    {
+        return response;
+    }
+
+    let Json(webhook_body) = match body {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            tracing::warn!("Webhook JSON parse error: {e}");
+            let err = serde_json::json!({
+                "error": "Invalid JSON body. Expected: {\"message\": \"...\"}"
+            });
+            return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+        }
+    };
+
+    if let Some(response) = enforce_webhook_idempotency(&state, &headers) {
+        return response;
+    }
+
+    process_webhook_body(state, webhook_body).await
+}
+
+/// POST /<custom-path> — path-scoped webhook transform endpoint.
+async fn handle_webhook_transform_path(
+    State(state): State<AppState>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    Path(path): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let request_path = format!("/{}", path.trim_start_matches('/'));
+
+    let Some(transform) = ({
+        let cfg = state.config.lock();
+        resolve_webhook_transform_for_path(&cfg, &request_path)
+    }) else {
+        let err = serde_json::json!({"error": "Not found"});
+        return (StatusCode::NOT_FOUND, Json(err)).into_response();
+    };
+
+    if let Some(response) =
+        enforce_webhook_request_guards(&state, peer_addr, &headers, &request_path)
+    {
+        return response;
+    }
+
+    if let Some(response) = enforce_webhook_idempotency(&state, &headers) {
+        return response;
+    }
+
+    let transformed_body = match run_webhook_transform(&transform, &body).await {
+        Ok(body) => body,
+        Err(err) => {
+            let sanitized = providers::sanitize_api_error(&err.to_string());
+            tracing::warn!(
+                "Webhook transform failed for path '{}': {}",
+                request_path,
+                sanitized
+            );
+            let err = serde_json::json!({
+                "error": "Webhook transform failed",
+                "path": request_path,
+            });
+            return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+        }
+    };
+
+    match transformed_body {
+        None => {
+            let body = serde_json::json!({
+                "status": "discarded",
+                "transformed": true,
+                "path": request_path
+            });
+            (StatusCode::OK, Json(body)).into_response()
+        }
+        Some(webhook_body) => process_webhook_body(state, webhook_body).await,
     }
 }
 
@@ -2928,6 +3109,90 @@ mod tests {
         assert_eq!(parsed["method"], "POST");
         assert_eq!(parsed["path"], "/webhook");
         assert_eq!(parsed["example"]["message"], "Hello from webhook");
+    }
+
+    #[test]
+    fn resolve_webhook_transform_for_path_matches_normalized_path() {
+        let mut config = Config::default();
+        config.channels_config.webhook = Some(crate::config::schema::WebhookConfig {
+            port: 8080,
+            secret: None,
+            transforms: vec![crate::config::schema::WebhookTransformConfig {
+                path: "hooks/github".to_string(),
+                command: vec!["sh".to_string(), "-c".to_string(), "cat".to_string()],
+                timeout_ms: 1000,
+                max_output_bytes: 1024,
+            }],
+        });
+
+        let found = resolve_webhook_transform_for_path(&config, "/hooks/github");
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().path, "hooks/github");
+
+        let missing = resolve_webhook_transform_for_path(&config, "/hooks/unknown");
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn run_webhook_transform_supports_discard_via_null_output() {
+        let transform = crate::config::schema::WebhookTransformConfig {
+            path: "/hooks/discard".to_string(),
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "cat >/dev/null; printf null".to_string(),
+            ],
+            timeout_ms: 2000,
+            max_output_bytes: 1024,
+        };
+
+        let output = run_webhook_transform(&transform, br#"{"event":"x"}"#)
+            .await
+            .unwrap();
+        assert!(output.is_none());
+    }
+
+    #[tokio::test]
+    async fn run_webhook_transform_converts_payload_to_webhook_body() {
+        let transform = crate::config::schema::WebhookTransformConfig {
+            path: "/hooks/convert".to_string(),
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "cat >/dev/null; printf '{\"message\":\"from transform\",\"session_id\":\"s1\"}'"
+                    .to_string(),
+            ],
+            timeout_ms: 2000,
+            max_output_bytes: 1024,
+        };
+
+        let output = run_webhook_transform(&transform, br#"{"event":"x"}"#)
+            .await
+            .unwrap()
+            .expect("expected transformed webhook body");
+        assert_eq!(output.message, "from transform");
+        assert_eq!(output.session_id.as_deref(), Some("s1"));
+        assert_eq!(output.stream, None);
+    }
+
+    #[tokio::test]
+    async fn run_webhook_transform_rejects_non_zero_exit() {
+        let transform = crate::config::schema::WebhookTransformConfig {
+            path: "/hooks/error".to_string(),
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "cat >/dev/null; echo boom >&2; exit 7".to_string(),
+            ],
+            timeout_ms: 2000,
+            max_output_bytes: 1024,
+        };
+
+        let err = match run_webhook_transform(&transform, br#"{"event":"x"}"#).await {
+            Ok(_) => panic!("expected transform failure"),
+            Err(err) => err,
+        };
+        assert!(err.to_string().contains("exited with status"));
     }
 
     #[test]

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -5472,6 +5472,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     } else {
                         Some(secret)
                     },
+                    transforms: Vec::new(),
                 });
                 println!(
                     "  {} Webhook on port {}",


### PR DESCRIPTION
Closes #2467

## Summary
- add configurable webhook transform routes with strict path normalization/validation
- add gateway catch-all transform handler that applies existing auth/rate-limit/idempotency guards
- run command-based payload transforms and map output back into `WebhookBody` with discard support

## Validation
- cargo fmt --all -- --check
- cargo test --lib config::schema::tests::webhook_config_with_transform_routes -- --nocapture
- cargo test --lib config::schema::tests::normalize_webhook_transform_path_handles_common_inputs -- --nocapture
- cargo test --lib config::schema::tests::config_validate_rejects_duplicate_webhook_transform_paths -- --nocapture
- cargo test --lib config::schema::tests::config_validate_rejects_reserved_webhook_transform_path -- --nocapture
- cargo test --lib config::schema::tests::config_validate_accepts_valid_webhook_transform_path -- --nocapture
- cargo test --lib gateway::tests::resolve_webhook_transform_for_path_matches_normalized_path -- --nocapture
- cargo test --lib gateway::tests::run_webhook_transform_supports_discard_via_null_output -- --nocapture
- cargo test --lib gateway::tests::run_webhook_transform_converts_payload_to_webhook_body -- --nocapture
- cargo test --lib gateway::tests::run_webhook_transform_rejects_non_zero_exit -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Webhook payload transformations - incoming webhooks can now be transformed through configurable external commands before ingestion, with controllable execution timeouts and output size limits to protect system resources.
  * Path-scoped webhook transforms - apply different transformation and processing rules to specific webhook request paths, enabling fine-grained control over webhook handling based on routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->