### PR TITLE
fix(ci): restore GitHub-hosted runner labels for macOS/Windows release builds

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -233,21 +233,21 @@ jobs:
                       linker_env: ""
                       linker: ""
                       use_cross: true
-                    - os: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+                    - os: macos-15-intel
                       target: x86_64-apple-darwin
                       artifact: zeroclaw
                       archive_ext: tar.gz
                       cross_compiler: ""
                       linker_env: ""
                       linker: ""
-                    - os: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+                    - os: macos-14
                       target: aarch64-apple-darwin
                       artifact: zeroclaw
                       archive_ext: tar.gz
                       cross_compiler: ""
                       linker_env: ""
                       linker: ""
-                    - os: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+                    - os: windows-latest
                       target: x86_64-pc-windows-msvc
                       artifact: zeroclaw.exe
                       archive_ext: zip


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: The release safety gates branch (#2604, #2610) inadvertently replaced **all** matrix `os:` labels with self-hosted Linux runner arrays — including macOS and Windows targets that require GitHub-hosted runners
- Why it matters: All 5 Pub Release runs since Mar 2 failed — macOS builds hit GNU `cc` errors (`-arch` flag unrecognized), Windows MSVC builds failed without `lib.exe`, blocking the v0.2.0 release
- What changed: Restored `macos-15-intel`, `macos-14`, `windows-latest` for the 3 cross-platform targets, matching the last successful run (Feb 24, `d2b0593`)
- What did **not** change: All Linux and Android target labels remain on self-hosted runners; all release safety gate logic (trigger guard, artifact guard, provenance, etc.) is untouched

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: XS`
- Scope labels: `ci`
- Module labels: n/a
- Contributor tier label: auto-managed

## Change Metadata

- Change type: `bug`
- Primary scope: `ci`

## Linked Issue

- Related #2604, #2610
- Linear issue key(s): RMN-331

## Validation Evidence (required)

- Compared current workflow against last successful Pub Release run (Feb 24, SHA `d2b0593`) — confirmed the 3 labels match exactly
- Verified all `runner.os` conditionals handle macOS/Windows correctly (binary size check skips Windows, rust-cache skips Windows, Unix/Windows packaging guards intact)
- Verified `check_binary_size.sh` handles both `stat -f%z` (macOS) and `stat -c%s` (Linux)
- Verified artifact contract (`.github/release/release-artifact-contract.json`) lists all 11 targets including the 3 fixed ones
- YAML change is 3 lines only — no structural or logic changes to the workflow

```bash
# Workflow-only change — no Rust code modified
# Validation was done by diffing against known-good SHA d2b0593
diff <(grep -n "os:" /tmp/pub-release-old.yml) <(grep -n "os:" .github/workflows/pub-release.yml)
```

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- Risk: Low — restoring known-good GitHub-hosted runner labels; no code execution path changes

## Privacy and Data Hygiene (required)

- No personal data, tokens, or credentials in this change
- No test fixtures or examples modified

## Rollback Plan (required)

- Revert the single commit (`git revert <sha>`)
- Self-hosted Linux labels would be restored, returning to the current broken state
- No data migration or config cleanup needed

## Remaining known issues (separate tracks)

- `x86_64-unknown-linux-gnu` binary size (24MB > 23MB safeguard)
- Transient runner env corruption (stale rustup on some hetzner runners)
- `armv7-unknown-linux-gnueabihf` missing `libc6-dev-armhf-cross` headers

## CodeRabbit response

- **Actions allowlist**: `sigstore/cosign-installer` and `softprops/action-gh-release` are already listed in `docs/actions-source-policy.md`. Pre-existing, not new.
- **YAML lint (86+ issues)**: All pre-existing in the file, not introduced by this 3-line change. Out of scope for this targeted fix.