### PR TITLE
fix(ci): unblock release builds — binary size limit + cross-compile headers

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -278,6 +278,14 @@ jobs:
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y "${{ matrix.cross_compiler }}"
+                  # Install matching libc dev headers for cross targets
+                  # (required by ring/aws-lc-sys C compilation)
+                  case "${{ matrix.target }}" in
+                    armv7-unknown-linux-gnueabihf)
+                      sudo apt-get install -y libc6-dev-armhf-cross ;;
+                    aarch64-unknown-linux-gnu)
+                      sudo apt-get install -y libc6-dev-arm64-cross ;;
+                  esac
 
             - name: Setup Android NDK
               if: matrix.android_ndk

--- a/scripts/ci/check_binary_size.sh
+++ b/scripts/ci/check_binary_size.sh
@@ -12,7 +12,7 @@
 #     >20MB  — hard error (safeguard)
 #     >15MB  — warning (advisory)
 #   Linux host:
-#     >23MB  — hard error (safeguard)
+#     >26MB  — hard error (safeguard)
 #     >20MB  — warning (advisory)
 #   All hosts:
 #     >5MB   — warning (target)
@@ -66,7 +66,7 @@ TARGET_LIMIT_BYTES=5242880    # 5MB
 HOST_OS="$(uname -s 2>/dev/null || echo "")"
 HOST_OS_LC="$(printf '%s' "$HOST_OS" | tr '[:upper:]' '[:lower:]')"
 if [ "$HOST_OS_LC" = "linux" ]; then
-  HARD_LIMIT_BYTES=24117248     # 23MB
+  HARD_LIMIT_BYTES=27262976     # 26MB
   ADVISORY_LIMIT_BYTES=20971520 # 20MB
 fi
 


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: Two pre-existing issues block Pub Release builds, preventing v0.2.0 tag
- Why it matters: Cannot ship v0.2.0 until these pass
- What changed: (1) Bump Linux binary size safeguard 23MB→26MB, (2) Add `libc6-dev-armhf-cross` and `libc6-dev-arm64-cross` for cross-compile targets
- What did **not** change: macOS/Windows/Android targets, release gate logic, publish pipeline

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `ci`, `scripts`

## Change Metadata

- Change type: `bug`
- Primary scope: `ci`

## Linked Issue

- Related #2613

## Validation Evidence (required)

- Binary size: last linux-gnu build was 24MB; new limit is 26MB (3MB headroom)
- armv7 headers: `ring` C compilation requires `bits/libc-header-start.h` from `libc6-dev-armhf-cross`, confirmed from failed build logs
- aarch64 headers: added preemptively for the same cross-compile pattern

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- No personal data or credentials

## Rollback Plan (required)

- Revert commit; binary size gate returns to 23MB, cross-compile may fail on headers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cross-compilation support for Linux builds by installing required development libraries for ARM architectures.
  * Updated binary size check thresholds to accommodate larger builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->