### PR TITLE
fix(ci): install gh CLI for release trigger guard on self-hosted runners

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -106,7 +106,24 @@ jobs:
                   } >> "$GITHUB_STEP_SUMMARY"
 
             - name: Checkout
-              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+            - name: Install gh CLI
+              shell: bash
+              run: |
+                  if command -v gh &>/dev/null; then
+                    echo "gh already available: $(gh --version | head -1)"
+                    exit 0
+                  fi
+                  echo "Installing gh CLI..."
+                  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+                    | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+                  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+                    | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+                  sudo apt-get update -qq
+                  sudo apt-get install -y gh
+              env:
+                  GH_TOKEN: ${{ github.token }}
 
             - name: Validate release trigger and authorization guard
               shell: bash


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: `release_trigger_guard.py` requires `gh` CLI to verify CI Required Gate in publish mode. Self-hosted hetzner runners don't have `gh` pre-installed, causing `Pub Release` to fail with exit code 3 on v0.2.0 tag push.
- Why it matters: v0.2.0 release is blocked
- What changed: Add `gh` CLI install step (with skip if already present) before the trigger guard runs
- What did **not** change: Guard logic, other workflow steps

## Validation Evidence (required)

- Error confirmed from run #27 logs: `gh CLI not found; cannot enforce CI Required Gate in publish mode.`
- Install script uses official GitHub CLI apt repository

## Security Impact (required)

- New permissions/capabilities? No (uses existing `github.token`)
- New external network calls? Yes — apt install from `cli.github.com/packages` (official GitHub source, same trust boundary as `actions/checkout`)

## Rollback Plan (required)

- Revert commit; guard will fail again on runners without gh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to support GitHub CLI tooling for improved automation during the publish process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->