### PR TITLE
fix(ci): propagate checkout auth to release trigger guard

### DIFF
--- a/scripts/ci/release_trigger_guard.py
+++ b/scripts/ci/release_trigger_guard.py
@@ -183,12 +183,23 @@ def main() -> int:
                 )
 
         origin_url = args.origin_url.strip() or f"https://github.com/{args.repository}.git"
-        ls_remote = subprocess.run(
-            ["git", "ls-remote", "--tags", origin_url],
-            text=True,
-            capture_output=True,
-            check=False,
-        )
+
+        # Prefer ls-remote from repo_root (inherits checkout auth headers) over
+        # a bare URL which fails on private repos.
+        if (repo_root / ".git").exists():
+            ls_remote = subprocess.run(
+                ["git", "-C", str(repo_root), "ls-remote", "--tags", "origin"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        else:
+            ls_remote = subprocess.run(
+                ["git", "ls-remote", "--tags", origin_url],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
         if ls_remote.returncode != 0:
             violations.append(f"Failed to list origin tags from `{origin_url}`: {ls_remote.stderr.strip()}")
         else:
@@ -225,6 +236,21 @@ def main() -> int:
                 try:
                     run_git(["init", "-q"], cwd=tmp_repo)
                     run_git(["remote", "add", "origin", origin_url], cwd=tmp_repo)
+                    # Propagate auth extraheader from checkout so fetch works
+                    # on private repos where bare URL access is forbidden.
+                    if (repo_root / ".git").exists():
+                        try:
+                            extraheader = run_git(
+                                ["config", "--get", "http.https://github.com/.extraheader"],
+                                cwd=repo_root,
+                            )
+                            if extraheader:
+                                run_git(
+                                    ["config", "http.https://github.com/.extraheader", extraheader],
+                                    cwd=tmp_repo,
+                                )
+                        except RuntimeError:
+                            pass  # No extraheader configured; proceed without it.
                     run_git(
                         [
                             "fetch",


### PR DESCRIPTION
## Summary
- Release trigger guard (`release_trigger_guard.py`) runs `git ls-remote` and `git fetch` against bare HTTPS URLs, which fail on private repos with 403
- Fix: use the checkout directory's configured `origin` remote for `ls-remote` (inherits `actions/checkout` auth headers), and propagate the extraheader config to the temp dir used for tag validation

## Context
- v0.2.0 Pub Release failed because the trigger guard couldn't access the remote
- Error: `remote: Repository 'zeroclaw-labs/zeroclaw' is disabled` (transient account flag + private repo auth)

## Changes
- `scripts/ci/release_trigger_guard.py`: prefer `git -C <repo_root> ls-remote --tags origin` when checkout dir exists; copy `http.*.extraheader` from checkout to temp repo for fetch

## Test plan
- [ ] Merge and re-trigger v0.2.0 tag push
- [ ] Verify Prepare Release Context job passes

## Risk and rollback
- Risk: Low — fallback to bare URL preserved when checkout dir is absent
- Rollback: Revert single commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI authentication handling to properly support private repositories. The release trigger process now correctly propagates GitHub authentication credentials and uses repository-aware tag lookups, ensuring seamless operation with authenticated repository access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->