### PR TITLE
fix(ci): pass GH_TOKEN to release trigger guard step

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -144,6 +144,8 @@ jobs:
                     --output-json artifacts/release-trigger-guard.json \
                     --output-md artifacts/release-trigger-guard.md \
                     --fail-on-violation
+              env:
+                  GH_TOKEN: ${{ github.token }}
 
             - name: Emit release trigger audit event
               if: always()


### PR DESCRIPTION
## Summary
- The `gh` CLI install step had `GH_TOKEN` but the validate step that actually calls `gh` was missing it
- Also propagates checkout auth headers to `git ls-remote`/`git fetch` in the trigger guard script for private repo compatibility

## Context
- v0.2.0 Pub Release run #29 failed: `gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable`

## Changes
- `.github/workflows/pub-release.yml`: add `GH_TOKEN` env to the validate step
- `scripts/ci/release_trigger_guard.py`: use checkout-configured git auth for `ls-remote` and temp dir fetch

## Test plan
- [ ] Merge and re-trigger v0.2.0 release
- [ ] Verify Prepare Release Context passes

## Risk and rollback
- Risk: Low — adds env var to one step, git auth fallback preserved
- Rollback: Revert commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This release contains no user-facing changes. Internal infrastructure improvements have been made to release automation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->