### PR TITLE
fix(windows): increase stack size to resolve runtime overflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -24,3 +24,10 @@ linker = "clang"
 
 [target.aarch64-linux-android]
 linker = "clang"
+
+# Windows targets — increase stack size for large JsonSchema derives
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-args=/STACK:8388608"]
+
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "link-args=/STACK:8388608"]


### PR DESCRIPTION
## Problem
Running `cargo run --bin zeroclaw` on Windows fails with:
```
thread 'main' has overflowed its stack
error: process didn't exit successfully (exit code: 0xc00000fd, STATUS_STACK_OVERFLOW)
```

## Root Cause
Windows platforms have a default stack size (1-2MB) that is insufficient for:
- 133 `JsonSchema` derives in `src/config/schema.rs`
- Large trait implementations generated by `schemars` library at compile time

## Solution
Increase stack size to 8MB for Windows targets in `.cargo/config.toml`:
```toml
[target.x86_64-pc-windows-msvc]
rustflags = ["-C", "link-args=/STACK:8388608"]

[target.aarch64-pc-windows-msvc]
rustflags = ["-C", "link-args=/STACK:8388608"]
```

## Changes
- ✅ Add 8MB stack size for x86_64-pc-windows-msvc
- ✅ Add 8MB stack size for aarch64-pc-windows-msvc  
- ✅ Remove unused `ErrorKind` import in `src/update.rs`

## Testing
```bash
cargo run --bin zeroclaw -- --version  # ✅ Works
cargo run --bin zeroclaw -- status      # ✅ Works
```

Fixes: Windows runtime stack overflow on program startup

---

Supersedes #2591 by @killf

This PR carries forward the same Windows stack size fix from the original PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows MSVC platform configuration with enhanced stack size allocation for improved stability and compatibility on Windows x86_64 and ARM64 architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->