### PR TITLE
fix(release): isolate rust toolchain homes in pub-release matrix

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -111,6 +111,7 @@ jobs:
             - name: Install gh CLI
               shell: bash
               run: |
+                  set -euo pipefail
                   if command -v gh &>/dev/null; then
                     echo "gh already available: $(gh --version | head -1)"
                     exit 0
@@ -120,6 +121,16 @@ jobs:
                     | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
                   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
                     | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+                  for i in {1..60}; do
+                    if sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 \
+                      || sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 \
+                      || sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1; then
+                      echo "apt/dpkg locked; waiting ($i/60)..."
+                      sleep 5
+                    else
+                      break
+                    fi
+                  done
                   sudo apt-get update -qq
                   sudo apt-get install -y gh
               env:
@@ -186,6 +197,7 @@ jobs:
         env:
             CARGO_HOME: ${{ github.workspace }}/.ci-rust/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.target }}/cargo
             RUSTUP_HOME: ${{ github.workspace }}/.ci-rust/${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ matrix.target }}/rustup
+            CARGO_TARGET_DIR: ${{ github.workspace }}/target
         strategy:
             fail-fast: false
             matrix:
@@ -296,12 +308,28 @@ jobs:
 
             - name: Install cross for cross-built targets
               if: matrix.use_cross
+              shell: bash
               run: |
-                  cargo install cross --git https://github.com/cross-rs/cross
+                  set -euo pipefail
+                  echo "${CARGO_HOME:-$HOME/.cargo}/bin" >> "$GITHUB_PATH"
+                  cargo install cross --locked --version 0.2.5
+                  command -v cross
+                  cross --version
 
             - name: Install cross-compilation toolchain (Linux)
               if: runner.os == 'Linux' && matrix.cross_compiler != ''
               run: |
+                  set -euo pipefail
+                  for i in {1..60}; do
+                    if sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 \
+                      || sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 \
+                      || sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1; then
+                      echo "apt/dpkg locked; waiting ($i/60)..."
+                      sleep 5
+                    else
+                      break
+                    fi
+                  done
                   sudo apt-get update -qq
                   sudo apt-get install -y "${{ matrix.cross_compiler }}"
                   # Install matching libc dev headers for cross targets
@@ -324,6 +352,16 @@ jobs:
                   NDK_ROOT="${RUNNER_TEMP}/android-ndk"
                   NDK_HOME="${NDK_ROOT}/android-ndk-${NDK_VERSION}"
 
+                  for i in {1..60}; do
+                    if sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 \
+                      || sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 \
+                      || sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1; then
+                      echo "apt/dpkg locked; waiting ($i/60)..."
+                      sleep 5
+                    else
+                      break
+                    fi
+                  done
                   sudo apt-get update -qq
                   sudo apt-get install -y unzip
 


### PR DESCRIPTION
## Summary
- isolate CARGO_HOME/RUSTUP_HOME per release matrix job to avoid shared runner rustup conflicts
- run scripts/ci/self_heal_rust_toolchain.sh 1.92.0 before dtolnay/rust-toolchain

## Why
Release jobs failed with rustup component conflicts on self-hosted runners (detected conflict while installing musl/android std).

## Scope
- workflow-only change in .github/workflows/pub-release.yml
- no runtime code changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline robustness with Rust toolchain isolation and expanded self-healing cache steps
  * Added retry/wait handling for package-manager locks to reduce intermittent CI failures
  * Hardened cross-compilation setup (ensured tool availability and verification)
  * Extended Android NDK setup to export needed environment variables
  * Expanded binary size validation across build, verify, and publish flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->