### PR TITLE
fix(ci): auto-detect Docker API version for Buildx

### DIFF
--- a/.github/workflows/pub-docker-img.yml
+++ b/.github/workflows/pub-docker-img.yml
@@ -46,6 +46,20 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+            - name: Resolve Docker API version
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  server_api="$(docker version --format '{{.Server.APIVersion}}')"
+                  min_api="$(docker version --format '{{.Server.MinAPIVersion}}' 2>/dev/null || true)"
+                  if [[ -z "${server_api}" || "${server_api}" == "<no value>" ]]; then
+                    echo "::error::Unable to detect Docker server API version."
+                    docker version || true
+                    exit 1
+                  fi
+                  echo "DOCKER_API_VERSION=${server_api}" >> "$GITHUB_ENV"
+                  echo "Using Docker API version ${server_api} (server min: ${min_api:-unknown})"
+
             - name: Setup Buildx
               uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -89,6 +103,20 @@ jobs:
               uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
               with:
                   ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_tag) || github.ref }}
+
+            - name: Resolve Docker API version
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  server_api="$(docker version --format '{{.Server.APIVersion}}')"
+                  min_api="$(docker version --format '{{.Server.MinAPIVersion}}' 2>/dev/null || true)"
+                  if [[ -z "${server_api}" || "${server_api}" == "<no value>" ]]; then
+                    echo "::error::Unable to detect Docker server API version."
+                    docker version || true
+                    exit 1
+                  fi
+                  echo "DOCKER_API_VERSION=${server_api}" >> "$GITHUB_ENV"
+                  echo "Using Docker API version ${server_api} (server min: ${min_api:-unknown})"
 
             - name: Setup Buildx
               uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3


### PR DESCRIPTION
## Summary
- detect Docker server API version at runtime and export `DOCKER_API_VERSION` before Buildx setup
- apply to both `pr-smoke` and `publish` jobs in `pub-docker-img.yml`

## Why
Self-hosted runners are heterogeneous: some daemons reject old client API (min 1.44), others reject new client API (max 1.41).
Dynamic API negotiation prevents Buildx init failure across both classes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker workflow configuration to ensure proper API version detection during the build process, improving build reliability across multiple deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->