### PR TITLE
fix(agent): track tool execution success status correctly

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -408,7 +408,7 @@ impl Agent {
     async fn execute_tool_call(&self, call: &ParsedToolCall) -> ToolExecutionResult {
         let start = Instant::now();
 
-        let result = if let Some(tool) = self.tools.iter().find(|t| t.name() == call.name) {
+        let (result, success) = if let Some(tool) = self.tools.iter().find(|t| t.name() == call.name) {
             match tool.execute(call.arguments.clone()).await {
                 Ok(r) => {
                     self.observer.record_event(&ObserverEvent::ToolCall {
@@ -417,9 +417,9 @@ impl Agent {
                         success: r.success,
                     });
                     if r.success {
-                        r.output
+                        (r.output, true)
                     } else {
-                        format!("Error: {}", r.error.unwrap_or(r.output))
+                        (format!("Error: {}", r.error.unwrap_or(r.output)), false)
                     }
                 }
                 Err(e) => {
@@ -428,17 +428,17 @@ impl Agent {
                         duration: start.elapsed(),
                         success: false,
                     });
-                    format!("Error executing {}: {e}", call.name)
+                    (format!("Error executing {}: {e}", call.name), false)
                 }
             }
         } else {
-            format!("Unknown tool: {}", call.name)
+            (format!("Unknown tool: {}", call.name), false)
         };
 
         ToolExecutionResult {
             name: call.name.clone(),
             output: result,
-            success: true,
+            success,
             tool_call_id: call.tool_call_id.clone(),
         }
     }


### PR DESCRIPTION
## Summary
- Track actual success status from tool execution results instead of assuming all tool calls succeed
- This helps ensure AI correctly detects when tool operations fail

## Problem
Previously, `ToolExecutionResult.success` was always set to `true`, meaning the AI could not detect when a tool call actually failed. This could lead to incorrect behavior where the AI believes an operation succeeded when it actually failed.

## Solution
- Track the actual success status from tool execution results
- Set `success` to `true` only when the tool executes successfully
- Set `success` to `false` for tool execution errors or unknown tools

## Risk
- Low risk: changes only affect success status tracking, not tool execution logic itself
- Existing error handling paths are preserved

## Testing
- Existing tool execution tests should validate the behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced tool execution to accurately track and propagate success/failure states across all execution paths, including error conditions and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->