### PR TITLE
refactor(update): remove unused ErrorKind import

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -5,7 +5,6 @@
 use anyhow::{bail, Context, Result};
 use std::env;
 use std::fs;
-use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -329,7 +328,7 @@ fn replace_binary(new_binary: &Path, current_exe: &Path) -> Result<()> {
             .context("Failed to set permissions on staged binary")?;
 
         if let Err(err) = fs::remove_file(&backup_path) {
-            if err.kind() != ErrorKind::NotFound {
+            if err.kind() != std::io::ErrorKind::NotFound {
                 return Err(err).context("Failed to remove stale backup binary");
             }
         }


### PR DESCRIPTION
## Summary
- Remove unused `std::io::ErrorKind` import in `src/update.rs`
- Use fully qualified path `std::io::ErrorKind::NotFound` instead

## Test plan
- [x] Code compiles without errors
- [x] No functional changes (import cleanup only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal import handling without affecting functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->