### PR TITLE
ci: add Blacksmith production release build workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,92 @@
+name: Production Release Build
+
+on:
+    push:
+        branches: ["main"]
+        tags: ["v*"]
+    workflow_dispatch:
+
+concurrency:
+    group: production-release-build-${{ github.ref || github.run_id }}
+    cancel-in-progress: false
+
+permissions:
+    contents: read
+
+env:
+    GIT_CONFIG_COUNT: "1"
+    GIT_CONFIG_KEY_0: core.hooksPath
+    GIT_CONFIG_VALUE_0: /dev/null
+    CARGO_TERM_COLOR: always
+
+jobs:
+    build-and-test:
+        name: Build and Test (Linux x86_64)
+        runs-on: [self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]
+        timeout-minutes: 120
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+            - name: Ensure C toolchain
+              shell: bash
+              run: bash ./scripts/ci/ensure_c_toolchain.sh
+
+            - name: Self-heal Rust toolchain cache
+              shell: bash
+              run: ./scripts/ci/self_heal_rust_toolchain.sh 1.92.0
+
+            - name: Setup Rust
+              uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+              with:
+                  toolchain: 1.92.0
+                  components: rustfmt, clippy
+
+            - name: Ensure C toolchain for Rust builds
+              shell: bash
+              run: ./scripts/ci/ensure_cc.sh
+
+            - name: Ensure cargo component
+              shell: bash
+              env:
+                  ENSURE_CARGO_COMPONENT_STRICT: "true"
+              run: bash ./scripts/ci/ensure_cargo_component.sh 1.92.0
+
+            - name: Cache Cargo registry and target
+              uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
+              with:
+                  prefix-key: production-release-build
+                  shared-key: ${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+                  cache-targets: true
+                  cache-bin: false
+
+            - name: Rust quality gates
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  cargo fmt --all -- --check
+                  cargo clippy --locked --all-targets -- -D warnings
+                  cargo test --locked --verbose
+
+            - name: Build production binary (canonical)
+              shell: bash
+              run: cargo build --release --locked
+
+            - name: Prepare artifact bundle
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  mkdir -p artifacts
+                  cp target/release/zeroclaw artifacts/zeroclaw
+                  sha256sum artifacts/zeroclaw > artifacts/zeroclaw.sha256
+
+            - name: Upload production artifact
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: zeroclaw-linux-amd64
+                  path: |
+                      artifacts/zeroclaw
+                      artifacts/zeroclaw.sha256
+                  if-no-files-found: error
+                  retention-days: 21

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -94,6 +94,7 @@ Last refreshed: **February 28, 2026**.
 - [pr-workflow.md](pr-workflow.md)
 - [reviewer-playbook.md](reviewer-playbook.md)
 - [ci-map.md](ci-map.md)
+- [ci-blacksmith.md](ci-blacksmith.md)
 - [actions-source-policy.md](actions-source-policy.md)
 - [cargo-slicer-speedup.md](cargo-slicer-speedup.md)
 

--- a/docs/ci-blacksmith.md
+++ b/docs/ci-blacksmith.md
@@ -1,0 +1,64 @@
+# Blacksmith Production Build Pipeline
+
+This document describes the production binary build lane for ZeroClaw on Blacksmith-backed GitHub Actions runners.
+
+## Workflow
+
+- File: `.github/workflows/release-build.yml`
+- Workflow name: `Production Release Build`
+- Triggers:
+    - Push to `main`
+    - Push tags matching `v*`
+    - Manual dispatch (`workflow_dispatch`)
+
+## Runner Labels
+
+The workflow runs on the same Blacksmith self-hosted runner label-set used by the rest of CI:
+
+`[self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]`
+
+This keeps runner routing consistent with existing CI jobs and actionlint policy.
+
+## Canonical Commands
+
+Quality gates (must pass before release build):
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --locked --all-targets -- -D warnings
+cargo test --locked --verbose
+```
+
+Production build command (canonical):
+
+```bash
+cargo build --release --locked
+```
+
+## Artifact Output
+
+- Binary path: `target/release/zeroclaw`
+- Uploaded artifact name: `zeroclaw-linux-amd64`
+- Uploaded files:
+    - `artifacts/zeroclaw`
+    - `artifacts/zeroclaw.sha256`
+
+## Re-run and Debug
+
+1. Open Actions run for `Production Release Build`.
+2. Use `Re-run failed jobs` (or full rerun) from the run page.
+3. Inspect step logs in this order: `Rust quality gates` -> `Build production binary (canonical)` -> `Prepare artifact bundle`.
+4. Download `zeroclaw-linux-amd64` from the run artifacts and verify checksum:
+
+```bash
+sha256sum -c zeroclaw.sha256
+```
+
+5. Reproduce locally from repository root with the same command set:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --locked --all-targets -- -D warnings
+cargo test --locked --verbose
+cargo build --release --locked
+```

--- a/docs/ci-map.md
+++ b/docs/ci-map.md
@@ -61,6 +61,11 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
     - Noise control: excludes common test/fixture paths and test file patterns by default (`include_tests=false`)
 - `.github/workflows/pub-release.yml` (`Release`)
     - Purpose: build release artifacts in verification mode (manual/scheduled) and publish GitHub releases on tag push or manual publish mode
+- `.github/workflows/release-build.yml` (`Production Release Build`)
+    - Purpose: build reproducible Linux x86_64 production binaries on `main` pushes and `v*` tags using Blacksmith runners
+    - Canonical build command: `cargo build --release --locked`
+    - Quality gates: `cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D warnings`, and `cargo test --locked --verbose` before release build
+    - Artifact output: `zeroclaw-linux-amd64` (`target/release/zeroclaw` + `.sha256`)
 - `.github/workflows/pr-label-policy-check.yml` (`Label Policy Sanity`)
     - Purpose: validate shared contributor-tier policy in `.github/label-policy.json` and ensure label workflows consume that policy
 
@@ -98,6 +103,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - `Feature Matrix`: push on Rust + workflow paths to `dev`, merge queue, weekly schedule, manual dispatch; PRs only when `ci:full` or `ci:feature-matrix` label is applied
 - `Nightly All-Features`: daily schedule and manual dispatch
 - `Release`: tag push (`v*`), weekly schedule (verification-only), manual dispatch (verification or publish)
+- `Production Release Build`: push to `main`, push tags matching `v*`, manual dispatch
 - `Security Audit`: push to `dev` and `main`, PRs to `dev` and `main`, weekly schedule
 - `Sec Vorpal Reviewdog`: manual dispatch only
 - `Workflow Sanity`: PR/push when `.github/workflows/**`, `.github/*.yml`, or `.github/*.yaml` change
@@ -116,12 +122,13 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 2. Docker failures on PRs: inspect `.github/workflows/pub-docker-img.yml` `pr-smoke` job.
    - For tag-publish failures, inspect `ghcr-publish-contract.json` / `audit-event-ghcr-publish-contract.json`, `ghcr-vulnerability-gate.json` / `audit-event-ghcr-vulnerability-gate.json`, and Trivy artifacts from `pub-docker-img.yml`.
 3. Release failures (tag/manual/scheduled): inspect `.github/workflows/pub-release.yml` and the `prepare` job outputs.
-4. Security failures: inspect `.github/workflows/sec-audit.yml` and `deny.toml`.
-5. Workflow syntax/lint failures: inspect `.github/workflows/workflow-sanity.yml`.
-6. PR intake failures: inspect `.github/workflows/pr-intake-checks.yml` sticky comment and run logs. If intake policy changed recently, trigger a fresh `pull_request_target` event (for example close/reopen PR) because `Re-run jobs` can reuse the original workflow snapshot.
-7. Label policy parity failures: inspect `.github/workflows/pr-label-policy-check.yml`.
-8. Docs failures in CI: inspect `docs-quality` job logs in `.github/workflows/ci-run.yml`.
-9. Strict delta lint failures in CI: inspect `lint-strict-delta` job logs and compare with `BASE_SHA` diff scope.
+4. Production release build failures (`main`/`v*`): inspect `.github/workflows/release-build.yml` quality-gate + build steps.
+5. Security failures: inspect `.github/workflows/sec-audit.yml` and `deny.toml`.
+6. Workflow syntax/lint failures: inspect `.github/workflows/workflow-sanity.yml`.
+7. PR intake failures: inspect `.github/workflows/pr-intake-checks.yml` sticky comment and run logs. If intake policy changed recently, trigger a fresh `pull_request_target` event (for example close/reopen PR) because `Re-run jobs` can reuse the original workflow snapshot.
+8. Label policy parity failures: inspect `.github/workflows/pr-label-policy-check.yml`.
+9. Docs failures in CI: inspect `docs-quality` job logs in `.github/workflows/ci-run.yml`.
+10. Strict delta lint failures in CI: inspect `lint-strict-delta` job logs and compare with `BASE_SHA` diff scope.
 
 ## Maintenance Rules
 
@@ -140,6 +147,7 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - Keep pre-release stage transition policy + matrix coverage + transition audit semantics current in `.github/release/prerelease-stage-gates.json`.
 - Keep required check naming stable and documented in `docs/operations/required-check-mapping.md` before changing branch protection settings.
 - Follow `docs/release-process.md` for verify-before-publish release cadence and tag discipline.
+- Keep production build reproducibility anchored to `cargo build --release --locked` in `.github/workflows/release-build.yml`.
 - Keep merge-blocking rust quality policy aligned across `.github/workflows/ci-run.yml`, `dev/ci.sh`, and `.githooks/pre-push` (`./scripts/ci/rust_quality_gate.sh` + `./scripts/ci/rust_strict_delta_gate.sh`).
 - Use `./scripts/ci/rust_strict_delta_gate.sh` (or `./dev/ci.sh lint-delta`) as the incremental strict merge gate for changed Rust lines.
 - Run full strict lint audits regularly via `./scripts/ci/rust_quality_gate.sh --strict` (for example through `./dev/ci.sh lint-strict`) and track cleanup in focused PRs.


### PR DESCRIPTION
## Summary\n- add `.github/workflows/release-build.yml` for production binaries on Blacksmith runners\n- enforce fmt/clippy/test quality gates before canonical release build\n- upload `zeroclaw-linux-amd64` artifact with checksum\n- document runner labels and debug flow in `docs/ci-blacksmith.md` and CI map\n\n## Canonical build command\n- `cargo build --release --locked`\n\n## Runner labels\n- `[self-hosted, Linux, X64, aws-india, blacksmith-2vcpu-ubuntu-2404, hetzner]`\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established automated production release build system with mandatory quality assurance gates (code formatting, static analysis, and comprehensive testing) to ensure reliability before packaging distribution binaries.

* **Documentation**
  * Added comprehensive CI/CD pipeline documentation describing the production build workflow, quality standards, artifact generation process, and procedures for local debugging and reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->