### PR TITLE
style: fix rustfmt drift blocking production release build

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -408,32 +408,33 @@ impl Agent {
     async fn execute_tool_call(&self, call: &ParsedToolCall) -> ToolExecutionResult {
         let start = Instant::now();
 
-        let (result, success) = if let Some(tool) = self.tools.iter().find(|t| t.name() == call.name) {
-            match tool.execute(call.arguments.clone()).await {
-                Ok(r) => {
-                    self.observer.record_event(&ObserverEvent::ToolCall {
-                        tool: call.name.clone(),
-                        duration: start.elapsed(),
-                        success: r.success,
-                    });
-                    if r.success {
-                        (r.output, true)
-                    } else {
-                        (format!("Error: {}", r.error.unwrap_or(r.output)), false)
+        let (result, success) =
+            if let Some(tool) = self.tools.iter().find(|t| t.name() == call.name) {
+                match tool.execute(call.arguments.clone()).await {
+                    Ok(r) => {
+                        self.observer.record_event(&ObserverEvent::ToolCall {
+                            tool: call.name.clone(),
+                            duration: start.elapsed(),
+                            success: r.success,
+                        });
+                        if r.success {
+                            (r.output, true)
+                        } else {
+                            (format!("Error: {}", r.error.unwrap_or(r.output)), false)
+                        }
+                    }
+                    Err(e) => {
+                        self.observer.record_event(&ObserverEvent::ToolCall {
+                            tool: call.name.clone(),
+                            duration: start.elapsed(),
+                            success: false,
+                        });
+                        (format!("Error executing {}: {e}", call.name), false)
                     }
                 }
-                Err(e) => {
-                    self.observer.record_event(&ObserverEvent::ToolCall {
-                        tool: call.name.clone(),
-                        duration: start.elapsed(),
-                        success: false,
-                    });
-                    (format!("Error executing {}: {e}", call.name), false)
-                }
-            }
-        } else {
-            (format!("Unknown tool: {}", call.name), false)
-        };
+            } else {
+                (format!("Unknown tool: {}", call.name), false)
+            };
 
         ToolExecutionResult {
             name: call.name.clone(),

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -484,9 +484,11 @@ pub(crate) async fn deliver_announcement(
                         );
                     }
                 } else {
-                    anyhow::bail!("feishu channel not configured: \
+                    anyhow::bail!(
+                        "feishu channel not configured: \
                                    neither [channels_config.feishu] nor [channels_config.lark] \
-                                   with use_feishu=true is configured");
+                                   with use_feishu=true is configured"
+                    );
                 }
             }
             #[cfg(not(feature = "channel-lark"))]


### PR DESCRIPTION
## Summary
- format src/agent/agent.rs and src/cron/scheduler.rs with rustfmt
- unblock Production Release Build gate (cargo fmt --all -- --check)

## Why
The strict production workflow failed on main due to rustfmt drift in these files, preventing stable release gating.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for misconfigured channel settings, providing clearer guidance on configuration requirements.
  * Enhanced error handling for tool execution with consistent event recording for both success and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->