### PR TITLE
ci: ensure rustfmt/clippy components in production release build

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -53,6 +53,10 @@ jobs:
                   ENSURE_CARGO_COMPONENT_STRICT: "true"
               run: bash ./scripts/ci/ensure_cargo_component.sh 1.92.0
 
+            - name: Ensure rustfmt and clippy components
+              shell: bash
+              run: rustup component add rustfmt clippy --toolchain 1.92.0
+
             - name: Cache Cargo registry and target
               uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
               with:


### PR DESCRIPTION
## Summary
- add an explicit rustup component install step for rustfmt and clippy in Production Release Build
- keep canonical build command unchanged: cargo build --release --locked

## Why
Production Release Build failed on main with 'no such command: fmt'.
This ensures rustfmt/clippy are always available after toolchain normalization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release build process to ensure required Rust compiler tooling components are installed, improving build reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->