### PR TITLE
ci: activate toolchain PATH for release-build cargo fmt/clippy

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -57,6 +57,13 @@ jobs:
               shell: bash
               run: rustup component add rustfmt clippy --toolchain 1.92.0
 
+            - name: Activate toolchain binaries on PATH
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  toolchain_bin="$(dirname "$(rustup which --toolchain 1.92.0 cargo)")"
+                  echo "$toolchain_bin" >> "$GITHUB_PATH"
+
             - name: Cache Cargo registry and target
               uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v3
               with:


### PR DESCRIPTION
## Summary
- activate Rust 1.92 toolchain bin directory on PATH in release-build workflow
- keep canonical build command cargo build --release --locked unchanged

## Why
Production Release Build still failed with 'no such command: fmt' even after component install.
This makes cargo subcommands discoverable on Blacksmith runners consistently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process reliability by enhancing the release workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->