### PR TITLE
ci(docker): publish GHCR image built with all cargo features

### DIFF
--- a/.github/workflows/pub-docker-img.yml
+++ b/.github/workflows/pub-docker-img.yml
@@ -179,6 +179,8 @@ jobs:
               with:
                   context: .
                   push: true
+                  build-args: |
+                      ZEROCLAW_CARGO_ALL_FEATURES=true
                   tags: ${{ steps.meta.outputs.tags }}
                   platforms: linux/amd64,linux/arm64
                   cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,13 @@ FROM rust:1.93-slim@sha256:7e6fa79cf81be23fd45d857f75f583d80cfdbb11c91fa06180fd7
 
 WORKDIR /app
 ARG ZEROCLAW_CARGO_FEATURES=""
+ARG ZEROCLAW_CARGO_ALL_FEATURES="false"
 
 # Install build dependencies
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y \
+        libudev-dev \
         pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
@@ -29,8 +31,10 @@ RUN mkdir -p src benches crates/robot-kit/src crates/zeroclaw-types/src crates/z
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
-    if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
-      cargo build --release --features "$ZEROCLAW_CARGO_FEATURES"; \
+    if [ "$ZEROCLAW_CARGO_ALL_FEATURES" = "true" ]; then \
+      cargo build --release --locked --all-features; \
+    elif [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
+      cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \
       cargo build --release --locked; \
     fi
@@ -63,8 +67,10 @@ RUN mkdir -p web/dist && \
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
-    if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
-      cargo build --release --features "$ZEROCLAW_CARGO_FEATURES"; \
+    if [ "$ZEROCLAW_CARGO_ALL_FEATURES" = "true" ]; then \
+      cargo build --release --locked --all-features; \
+    elif [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
+      cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \
       cargo build --release --locked; \
     fi && \


### PR DESCRIPTION
## Summary
- add Docker build arg `ZEROCLAW_CARGO_ALL_FEATURES` and use `--all-features` when enabled
- keep feature-list path intact while ensuring `--locked` is consistently applied
- install `libudev-dev` in builder stage for all-features compile requirements
- set GHCR publish workflow build arg `ZEROCLAW_CARGO_ALL_FEATURES=true`

## Testing
- ruby -e "require "yaml"; YAML.load_file(".github/workflows/pub-docker-img.yml"); puts "ok""
- docker build smoke was attempted locally but Docker daemon socket was unavailable in this environment

Closes #2628

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker build pipeline with flexible feature compilation configuration
  * Build process now supports conditional feature inclusion during container image creation
  * Added system-level dependency to enhance device compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->