### PR TITLE
fix(repo): update stale ZeroClaw GitHub URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,4 +67,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workspace escape prevention
 - Forbidden system path protection (`/etc`, `/root`, `~/.ssh`)
 
-[0.1.0]: https://github.com/theonlyhennygod/zeroclaw/releases/tag/v0.1.0
+[0.1.0]: https://github.com/zeroclaw-labs/zeroclaw/releases/tag/v0.1.0

--- a/RUN_TESTS.md
+++ b/RUN_TESTS.md
@@ -300,6 +300,6 @@ If all tests pass:
 
 ## 📞 Support
 
-- Issues: https://github.com/theonlyhennygod/zeroclaw/issues
+- Issues: https://github.com/zeroclaw-labs/zeroclaw/issues
 - Docs: `./TESTING_TELEGRAM.md`
 - Help: `zeroclaw --help`

--- a/TESTING_TELEGRAM.md
+++ b/TESTING_TELEGRAM.md
@@ -352,4 +352,4 @@ zeroclaw channel doctor
 - [Telegram Bot API Documentation](https://core.telegram.org/bots/api)
 - [ZeroClaw Main README](README.md)
 - [Contributing Guide](CONTRIBUTING.md)
-- [Issue Tracker](https://github.com/theonlyhennygod/zeroclaw/issues)
+- [Issue Tracker](https://github.com/zeroclaw-labs/zeroclaw/issues)

--- a/crates/robot-kit/PI5_SETUP.md
+++ b/crates/robot-kit/PI5_SETUP.md
@@ -171,7 +171,7 @@ sudo usermod -aG dialout $USER
 
 ```bash
 # Clone repo (or copy from USB)
-git clone https://github.com/theonlyhennygod/zeroclaw
+git clone https://github.com/zeroclaw-labs/zeroclaw
 cd zeroclaw
 
 # Build robot kit

--- a/docs/arduino-uno-q-setup.md
+++ b/docs/arduino-uno-q-setup.md
@@ -66,7 +66,7 @@ sudo apt-get update
 sudo apt-get install -y pkg-config libssl-dev
 
 # Clone zeroclaw (or scp your project)
-git clone https://github.com/theonlyhennygod/zeroclaw.git
+git clone https://github.com/zeroclaw-labs/zeroclaw.git
 cd zeroclaw
 
 # Build (takes ~15–30 min on Uno Q)
@@ -199,7 +199,7 @@ Now when you message your Telegram bot *"Turn on the LED"* or *"Set pin 13 high"
 | 2 | `ssh arduino@<IP>` |
 | 3 | `curl -sSf https://sh.rustup.rs \| sh -s -- -y && source ~/.cargo/env` |
 | 4 | `sudo apt-get install -y pkg-config libssl-dev` |
-| 5 | `git clone https://github.com/theonlyhennygod/zeroclaw.git && cd zeroclaw` |
+| 5 | `git clone https://github.com/zeroclaw-labs/zeroclaw.git && cd zeroclaw` |
 | 6 | `cargo build --release --features hardware` |
 | 7 | `zeroclaw onboard --api-key KEY --provider openrouter` |
 | 8 | Edit `~/.zeroclaw/config.toml` (add Telegram bot_token) |

--- a/docs/i18n/el/arduino-uno-q-setup.md
+++ b/docs/i18n/el/arduino-uno-q-setup.md
@@ -66,7 +66,7 @@ ssh arduino@<UNO_Q_IP>
 
 4. **Λήψη και Μεταγλώττιση**:
    ```bash
-   git clone https://github.com/theonlyhennygod/zeroclaw.git
+   git clone https://github.com/zeroclaw-labs/zeroclaw.git
    cd zeroclaw
    cargo build --release --features hardware
    ```

--- a/docs/i18n/vi/arduino-uno-q-setup.md
+++ b/docs/i18n/vi/arduino-uno-q-setup.md
@@ -66,7 +66,7 @@ sudo apt-get update
 sudo apt-get install -y pkg-config libssl-dev
 
 # Clone zeroclaw (hoặc scp project của bạn)
-git clone https://github.com/theonlyhennygod/zeroclaw.git
+git clone https://github.com/zeroclaw-labs/zeroclaw.git
 cd zeroclaw
 
 # Build (~15–30 phút trên Uno Q)
@@ -199,7 +199,7 @@ Giờ khi bạn nhắn tin cho Telegram bot *"Turn on the LED"* hoặc *"Set pin
 | 2 | `ssh arduino@<IP>` |
 | 3 | `curl -sSf https://sh.rustup.rs \| sh -s -- -y && source ~/.cargo/env` |
 | 4 | `sudo apt-get install -y pkg-config libssl-dev` |
-| 5 | `git clone https://github.com/theonlyhennygod/zeroclaw.git && cd zeroclaw` |
+| 5 | `git clone https://github.com/zeroclaw-labs/zeroclaw.git && cd zeroclaw` |
 | 6 | `cargo build --release --no-default-features` |
 | 7 | `zeroclaw onboard --api-key KEY --provider openrouter` |
 | 8 | Chỉnh sửa `~/.zeroclaw/config.toml` (thêm Telegram bot_token) |

--- a/src/integrations/mod.rs
+++ b/src/integrations/mod.rs
@@ -305,7 +305,7 @@ fn show_integration_info(config: &Config, name: &str) -> Result<()> {
         _ => {
             if status == IntegrationStatus::ComingSoon {
                 println!("  This integration is planned. Stay tuned!");
-                println!("  Track progress: https://github.com/theonlyhennygod/zeroclaw");
+                println!("  Track progress: https://github.com/zeroclaw-labs/zeroclaw");
             }
         }
     }

--- a/src/providers/openrouter.rs
+++ b/src/providers/openrouter.rs
@@ -382,7 +382,7 @@ impl Provider for OpenRouterProvider {
             .header("Authorization", format!("Bearer {credential}"))
             .header(
                 "HTTP-Referer",
-                "https://github.com/theonlyhennygod/zeroclaw",
+                "https://github.com/zeroclaw-labs/zeroclaw",
             )
             .header("X-Title", "ZeroClaw")
             .json(&request)
@@ -433,7 +433,7 @@ impl Provider for OpenRouterProvider {
             .header("Authorization", format!("Bearer {credential}"))
             .header(
                 "HTTP-Referer",
-                "https://github.com/theonlyhennygod/zeroclaw",
+                "https://github.com/zeroclaw-labs/zeroclaw",
             )
             .header("X-Title", "ZeroClaw")
             .json(&request)
@@ -482,7 +482,7 @@ impl Provider for OpenRouterProvider {
             .header("Authorization", format!("Bearer {credential}"))
             .header(
                 "HTTP-Referer",
-                "https://github.com/theonlyhennygod/zeroclaw",
+                "https://github.com/zeroclaw-labs/zeroclaw",
             )
             .header("X-Title", "ZeroClaw")
             .json(&native_request)
@@ -576,7 +576,7 @@ impl Provider for OpenRouterProvider {
             .header("Authorization", format!("Bearer {credential}"))
             .header(
                 "HTTP-Referer",
-                "https://github.com/theonlyhennygod/zeroclaw",
+                "https://github.com/zeroclaw-labs/zeroclaw",
             )
             .header("X-Title", "ZeroClaw")
             .json(&native_request)


### PR DESCRIPTION
## Summary
- replace stale `https://github.com/theonlyhennygod/zeroclaw` references with the current canonical repo URL
- update OpenRouter `HTTP-Referer` headers and docs/support links to `https://github.com/zeroclaw-labs/zeroclaw`

## Validation
- `cargo test --package zeroclaw openrouter::tests::`

Closes #2594


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository references across documentation and source files to reflect the project's new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->