### PR TITLE
feat(approval): add command-level shell approval rules

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -961,7 +961,7 @@ Environment overrides:
 | `level` | `supervised` | `read_only`, `supervised`, or `full` |
 | `workspace_only` | `true` | reject absolute path inputs unless explicitly disabled |
 | `allowed_commands` | _required for shell execution_ | allowlist of executable names, explicit executable paths, or `"*"` |
-| `command_context_rules` | `[]` | per-command context-aware allow/deny rules (domain/path constraints, optional high-risk override) |
+| `command_context_rules` | `[]` | per-command context-aware allow/deny/require-approval rules (domain/path constraints, optional high-risk override) |
 | `forbidden_paths` | built-in protected list | explicit path denylist (system paths + sensitive dotdirs by default) |
 | `allowed_roots` | `[]` | additional roots allowed outside workspace after canonicalization |
 | `max_actions_per_hour` | `20` | per-policy action budget |
@@ -986,6 +986,7 @@ Notes:
 - `command_context_rules` can narrow or override `allowed_commands` for matching commands:
   - `action = "allow"` rules are restrictive when present for a command: at least one allow rule must match.
   - `action = "deny"` rules explicitly block matching contexts.
+  - `action = "require_approval"` forces explicit approval (`approved=true`) in supervised mode for matching segments, even if `shell` is in `auto_approve`.
   - `allow_high_risk = true` allows a matching high-risk command to pass the hard block, but supervised mode still requires `approved=true`.
 - `file_read` blocks sensitive secret-bearing files/directories by default. Set `allow_sensitive_file_reads = true` only for controlled debugging sessions.
 - `file_write` and `file_edit` block sensitive secret-bearing files/directories by default. Set `allow_sensitive_file_writes = true` only for controlled break-glass sessions.
@@ -1034,6 +1035,10 @@ command = "rm"
 action = "allow"
 allowed_path_prefixes = ["/tmp"]
 allow_high_risk = true
+
+[[autonomy.command_context_rules]]
+command = "rm"
+action = "require_approval"
 ```
 
 ## `[memory]`

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1953,7 +1953,11 @@ pub async fn run_tool_call_loop(
             if let Some(mgr) = approval {
                 let non_cli_session_granted =
                     channel_name != "cli" && mgr.is_non_cli_session_granted(&tool_name);
-                if bypass_non_cli_approval_for_turn || non_cli_session_granted {
+                let requires_interactive_approval =
+                    mgr.needs_approval_for_call(&tool_name, &tool_args);
+                if (bypass_non_cli_approval_for_turn || non_cli_session_granted)
+                    && !requires_interactive_approval
+                {
                     mgr.record_decision(
                         &tool_name,
                         &tool_args,
@@ -1975,7 +1979,7 @@ pub async fn run_tool_call_loop(
                             }),
                         );
                     }
-                } else if mgr.needs_approval(&tool_name) {
+                } else if requires_interactive_approval {
                     let request = ApprovalRequest {
                         tool_name: tool_name.clone(),
                         arguments: tool_args.clone(),
@@ -2043,6 +2047,24 @@ pub async fn run_tool_call_loop(
                             },
                         ));
                         continue;
+                    }
+
+                    if matches!(decision, ApprovalResponse::Yes | ApprovalResponse::Always) {
+                        match &mut tool_args {
+                            serde_json::Value::Object(map) => {
+                                map.insert("approved".to_string(), serde_json::Value::Bool(true));
+                            }
+                            serde_json::Value::String(command) => {
+                                let normalized_command = command.trim().to_string();
+                                if !normalized_command.is_empty() {
+                                    tool_args = serde_json::json!({
+                                        "command": normalized_command,
+                                        "approved": true
+                                    });
+                                }
+                            }
+                            _ => {}
+                        }
                     }
                 }
             }
@@ -3317,7 +3339,7 @@ mod tests {
     use async_trait::async_trait;
     use base64::{engine::general_purpose::STANDARD, Engine as _};
     use std::collections::VecDeque;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -3633,6 +3655,16 @@ mod tests {
         max_active: Arc<AtomicUsize>,
     }
 
+    struct ApprovalFlagTool {
+        approved_seen: Arc<AtomicBool>,
+    }
+
+    impl ApprovalFlagTool {
+        fn new(approved_seen: Arc<AtomicBool>) -> Self {
+            Self { approved_seen }
+        }
+    }
+
     impl DelayTool {
         fn new(
             name: &str,
@@ -3744,6 +3776,44 @@ mod tests {
                 success: true,
                 output: format!("ok:{value}"),
                 error: None,
+            })
+        }
+    }
+
+    #[async_trait]
+    impl Tool for ApprovalFlagTool {
+        fn name(&self) -> &str {
+            "shell"
+        }
+
+        fn description(&self) -> &str {
+            "Captures the approved flag for approval-flow tests"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "command": { "type": "string" },
+                    "approved": { "type": "boolean" }
+                },
+                "required": ["command"]
+            })
+        }
+
+        async fn execute(
+            &self,
+            args: serde_json::Value,
+        ) -> anyhow::Result<crate::tools::ToolResult> {
+            let approved = args
+                .get("approved")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false);
+            self.approved_seen.store(approved, Ordering::SeqCst);
+            Ok(crate::tools::ToolResult {
+                success: approved,
+                output: format!("approved={approved}"),
+                error: (!approved).then(|| "missing approved=true".to_string()),
             })
         }
     }
@@ -3955,6 +4025,76 @@ mod tests {
         ];
         let approval_cfg = crate::config::AutonomyConfig {
             level: crate::security::AutonomyLevel::Full,
+            ..crate::config::AutonomyConfig::default()
+        };
+        let approval_mgr = ApprovalManager::from_config(&approval_cfg);
+
+        assert!(should_execute_tools_in_parallel(
+            &calls,
+            Some(&approval_mgr)
+        ));
+    }
+
+    #[test]
+    fn should_execute_tools_in_parallel_returns_false_when_command_rule_requires_approval() {
+        let calls = vec![
+            ParsedToolCall {
+                name: "shell".to_string(),
+                arguments: serde_json::json!({"command": "rm -f ./tmp.txt"}),
+                tool_call_id: None,
+            },
+            ParsedToolCall {
+                name: "file_read".to_string(),
+                arguments: serde_json::json!({"path": "README.md"}),
+                tool_call_id: None,
+            },
+        ];
+        let approval_cfg = crate::config::AutonomyConfig {
+            auto_approve: vec!["shell".to_string(), "file_read".to_string()],
+            always_ask: vec![],
+            command_context_rules: vec![crate::config::CommandContextRuleConfig {
+                command: "rm".to_string(),
+                action: crate::config::CommandContextRuleAction::RequireApproval,
+                allowed_domains: vec![],
+                allowed_path_prefixes: vec![],
+                denied_path_prefixes: vec![],
+                allow_high_risk: false,
+            }],
+            ..crate::config::AutonomyConfig::default()
+        };
+        let approval_mgr = ApprovalManager::from_config(&approval_cfg);
+
+        assert!(!should_execute_tools_in_parallel(
+            &calls,
+            Some(&approval_mgr)
+        ));
+    }
+
+    #[test]
+    fn should_execute_tools_in_parallel_returns_true_when_command_rule_does_not_match() {
+        let calls = vec![
+            ParsedToolCall {
+                name: "shell".to_string(),
+                arguments: serde_json::json!({"command": "ls -la"}),
+                tool_call_id: None,
+            },
+            ParsedToolCall {
+                name: "file_read".to_string(),
+                arguments: serde_json::json!({"path": "README.md"}),
+                tool_call_id: None,
+            },
+        ];
+        let approval_cfg = crate::config::AutonomyConfig {
+            auto_approve: vec!["shell".to_string(), "file_read".to_string()],
+            always_ask: vec![],
+            command_context_rules: vec![crate::config::CommandContextRuleConfig {
+                command: "rm".to_string(),
+                action: crate::config::CommandContextRuleAction::RequireApproval,
+                allowed_domains: vec![],
+                allowed_path_prefixes: vec![],
+                denied_path_prefixes: vec![],
+                allow_high_risk: false,
+            }],
             ..crate::config::AutonomyConfig::default()
         };
         let approval_mgr = ApprovalManager::from_config(&approval_cfg);
@@ -4243,6 +4383,84 @@ mod tests {
             max_active.load(Ordering::SeqCst),
             1,
             "shell tool should execute after non-cli approval is resolved"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_injects_approved_flag_after_non_cli_approval() {
+        let provider = ScriptedProvider::from_text_responses(vec![
+            r#"<tool_call>
+{"name":"shell","arguments":{"command":"rm -f ./tmp.txt"}}
+</tool_call>"#,
+            "done",
+        ]);
+
+        let approved_seen = Arc::new(AtomicBool::new(false));
+        let tools_registry: Vec<Box<dyn Tool>> =
+            vec![Box::new(ApprovalFlagTool::new(Arc::clone(&approved_seen)))];
+
+        let approval_mgr = Arc::new(ApprovalManager::from_config(
+            &crate::config::AutonomyConfig::default(),
+        ));
+        let (prompt_tx, mut prompt_rx) =
+            tokio::sync::mpsc::unbounded_channel::<NonCliApprovalPrompt>();
+        let approval_mgr_for_task = Arc::clone(&approval_mgr);
+        let approval_task = tokio::spawn(async move {
+            let prompt = prompt_rx
+                .recv()
+                .await
+                .expect("approval prompt should arrive");
+            approval_mgr_for_task
+                .confirm_non_cli_pending_request(
+                    &prompt.request_id,
+                    "alice",
+                    "telegram",
+                    "chat-approved-flag",
+                )
+                .expect("pending approval should confirm");
+            approval_mgr_for_task
+                .record_non_cli_pending_resolution(&prompt.request_id, ApprovalResponse::Yes);
+        });
+
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("run shell"),
+        ];
+        let observer = NoopObserver;
+
+        let result = run_tool_call_loop_with_non_cli_approval_context(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            0.0,
+            true,
+            Some(approval_mgr.as_ref()),
+            "telegram",
+            Some(NonCliApprovalContext {
+                sender: "alice".to_string(),
+                reply_target: "chat-approved-flag".to_string(),
+                prompt_tx,
+            }),
+            &crate::config::MultimodalConfig::default(),
+            4,
+            None,
+            None,
+            None,
+            &[],
+            ProgressMode::Verbose,
+            None,
+        )
+        .await
+        .expect("tool loop should continue after non-cli approval");
+
+        approval_task.await.expect("approval task should complete");
+        assert_eq!(result, "done");
+        assert!(
+            approved_seen.load(Ordering::SeqCst),
+            "approved=true should be injected after prompt approval"
         );
     }
 

--- a/src/agent/loop_/execution.rs
+++ b/src/agent/loop_/execution.rs
@@ -107,7 +107,10 @@ pub(super) fn should_execute_tools_in_parallel(
     }
 
     if let Some(mgr) = approval {
-        if tool_calls.iter().any(|call| mgr.needs_approval(&call.name)) {
+        if tool_calls
+            .iter()
+            .any(|call| mgr.needs_approval_for_call(&call.name, &call.arguments))
+        {
             // Approval-gated calls must keep sequential handling so the caller can
             // enforce CLI prompt/deny policy consistently.
             return false;

--- a/src/approval/mod.rs
+++ b/src/approval/mod.rs
@@ -3,7 +3,7 @@
 //! Provides a pre-execution hook that prompts the user before tool calls,
 //! with session-scoped "Always" allowlists and audit logging.
 
-use crate::config::{AutonomyConfig, NonCliNaturalLanguageApprovalMode};
+use crate::config::{AutonomyConfig, CommandContextRuleAction, NonCliNaturalLanguageApprovalMode};
 use crate::security::AutonomyLevel;
 use chrono::{Duration, Utc};
 use parking_lot::{Mutex, RwLock};
@@ -75,6 +75,11 @@ pub struct ApprovalManager {
     auto_approve: RwLock<HashSet<String>>,
     /// Tools that always need approval, ignoring session allowlist (config + runtime updates).
     always_ask: RwLock<HashSet<String>>,
+    /// Command patterns requiring approval even when a tool is auto-approved.
+    ///
+    /// Sourced from `autonomy.command_context_rules` entries where
+    /// `action = "require_approval"`.
+    command_level_require_approval_rules: RwLock<Vec<String>>,
     /// Autonomy level from config.
     autonomy_level: AutonomyLevel,
     /// Session-scoped allowlist built from "Always" responses.
@@ -124,11 +129,24 @@ impl ApprovalManager {
             .collect()
     }
 
+    fn extract_command_level_approval_rules(config: &AutonomyConfig) -> Vec<String> {
+        config
+            .command_context_rules
+            .iter()
+            .filter(|rule| rule.action == CommandContextRuleAction::RequireApproval)
+            .map(|rule| rule.command.trim().to_string())
+            .filter(|command| !command.is_empty())
+            .collect()
+    }
+
     /// Create from autonomy config.
     pub fn from_config(config: &AutonomyConfig) -> Self {
         Self {
             auto_approve: RwLock::new(config.auto_approve.iter().cloned().collect()),
             always_ask: RwLock::new(config.always_ask.iter().cloned().collect()),
+            command_level_require_approval_rules: RwLock::new(
+                Self::extract_command_level_approval_rules(config),
+            ),
             autonomy_level: config.level,
             session_allowlist: Mutex::new(HashSet::new()),
             non_cli_allowlist: Mutex::new(HashSet::new()),
@@ -182,6 +200,33 @@ impl ApprovalManager {
 
         // Default: supervised mode requires approval.
         true
+    }
+
+    /// Check whether a specific tool call (including arguments) needs interactive approval.
+    ///
+    /// This extends [`Self::needs_approval`] with command-level approval matching:
+    /// when a call carries a `command` argument that matches a
+    /// `command_context_rules[action=require_approval]` pattern, the call is
+    /// approval-gated in supervised mode even if the tool is in `auto_approve`.
+    pub fn needs_approval_for_call(&self, tool_name: &str, args: &serde_json::Value) -> bool {
+        if self.needs_approval(tool_name) {
+            return true;
+        }
+
+        if self.autonomy_level != AutonomyLevel::Supervised {
+            return false;
+        }
+
+        let rules = self.command_level_require_approval_rules.read();
+        if rules.is_empty() {
+            return false;
+        }
+
+        let Some(command) = extract_command_argument(args) else {
+            return false;
+        };
+
+        command_matches_require_approval_rules(&command, &rules)
     }
 
     /// Record an approval decision and update session state.
@@ -356,6 +401,7 @@ impl ApprovalManager {
         &self,
         auto_approve: &[String],
         always_ask: &[String],
+        command_context_rules: &[crate::config::CommandContextRuleConfig],
         non_cli_approval_approvers: &[String],
         non_cli_natural_language_approval_mode: NonCliNaturalLanguageApprovalMode,
         non_cli_natural_language_approval_mode_by_channel: &HashMap<
@@ -370,6 +416,15 @@ impl ApprovalManager {
         {
             let mut always = self.always_ask.write();
             *always = always_ask.iter().cloned().collect();
+        }
+        {
+            let mut rules = self.command_level_require_approval_rules.write();
+            *rules = command_context_rules
+                .iter()
+                .filter(|rule| rule.action == CommandContextRuleAction::RequireApproval)
+                .map(|rule| rule.command.trim().to_string())
+                .filter(|command| !command.is_empty())
+                .collect();
         }
         {
             let mut approvers = self.non_cli_approval_approvers.write();
@@ -638,6 +693,186 @@ fn summarize_args(args: &serde_json::Value) -> String {
     }
 }
 
+fn extract_command_argument(args: &serde_json::Value) -> Option<String> {
+    for alias in ["command", "cmd", "shell_command", "bash", "sh", "input"] {
+        if let Some(command) = args
+            .get(alias)
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|cmd| !cmd.is_empty())
+        {
+            return Some(command.to_string());
+        }
+    }
+
+    args.as_str()
+        .map(str::trim)
+        .filter(|cmd| !cmd.is_empty())
+        .map(ToString::to_string)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuoteState {
+    None,
+    Single,
+    Double,
+}
+
+fn split_unquoted_segments(command: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut quote = QuoteState::None;
+    let mut escaped = false;
+    let mut chars = command.chars().peekable();
+
+    let push_segment = |segments: &mut Vec<String>, current: &mut String| {
+        let trimmed = current.trim();
+        if !trimmed.is_empty() {
+            segments.push(trimmed.to_string());
+        }
+        current.clear();
+    };
+
+    while let Some(ch) = chars.next() {
+        match quote {
+            QuoteState::Single => {
+                if ch == '\'' {
+                    quote = QuoteState::None;
+                }
+                current.push(ch);
+            }
+            QuoteState::Double => {
+                if escaped {
+                    escaped = false;
+                    current.push(ch);
+                    continue;
+                }
+                if ch == '\\' {
+                    escaped = true;
+                    current.push(ch);
+                    continue;
+                }
+                if ch == '"' {
+                    quote = QuoteState::None;
+                }
+                current.push(ch);
+            }
+            QuoteState::None => {
+                if escaped {
+                    escaped = false;
+                    current.push(ch);
+                    continue;
+                }
+                if ch == '\\' {
+                    escaped = true;
+                    current.push(ch);
+                    continue;
+                }
+
+                match ch {
+                    '\'' => {
+                        quote = QuoteState::Single;
+                        current.push(ch);
+                    }
+                    '"' => {
+                        quote = QuoteState::Double;
+                        current.push(ch);
+                    }
+                    ';' | '\n' => push_segment(&mut segments, &mut current),
+                    '|' => {
+                        if chars.next_if_eq(&'|').is_some() {
+                            // consume full `||`
+                        }
+                        push_segment(&mut segments, &mut current);
+                    }
+                    '&' => {
+                        if chars.next_if_eq(&'&').is_some() {
+                            // consume full `&&`
+                            push_segment(&mut segments, &mut current);
+                        } else {
+                            current.push(ch);
+                        }
+                    }
+                    _ => current.push(ch),
+                }
+            }
+        }
+    }
+
+    let trimmed = current.trim();
+    if !trimmed.is_empty() {
+        segments.push(trimmed.to_string());
+    }
+
+    segments
+}
+
+fn skip_env_assignments(s: &str) -> &str {
+    let mut rest = s;
+    loop {
+        let Some(word) = rest.split_whitespace().next() else {
+            return rest;
+        };
+
+        if word.contains('=')
+            && word
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        {
+            rest = rest[word.len()..].trim_start();
+        } else {
+            return rest;
+        }
+    }
+}
+
+fn strip_wrapping_quotes(token: &str) -> &str {
+    let bytes = token.as_bytes();
+    if bytes.len() >= 2
+        && ((bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[bytes.len() - 1] == b'\''))
+    {
+        &token[1..token.len() - 1]
+    } else {
+        token
+    }
+}
+
+fn command_rule_matches(rule: &str, executable: &str, executable_base: &str) -> bool {
+    let normalized_rule = strip_wrapping_quotes(rule).trim();
+    if normalized_rule.is_empty() {
+        return false;
+    }
+
+    if normalized_rule == "*" {
+        return true;
+    }
+
+    if normalized_rule.contains('/') {
+        strip_wrapping_quotes(executable).trim() == normalized_rule
+    } else {
+        normalized_rule == executable_base
+    }
+}
+
+fn command_matches_require_approval_rules(command: &str, rules: &[String]) -> bool {
+    split_unquoted_segments(command).into_iter().any(|segment| {
+        let cmd_part = skip_env_assignments(&segment);
+        let mut words = cmd_part.split_whitespace();
+        let executable = strip_wrapping_quotes(words.next().unwrap_or("")).trim();
+        let base_cmd = executable.rsplit('/').next().unwrap_or("").trim();
+
+        if base_cmd.is_empty() {
+            return false;
+        }
+
+        rules
+            .iter()
+            .any(|rule| command_rule_matches(rule, executable, base_cmd))
+    })
+}
+
 fn truncate_for_summary(input: &str, max_chars: usize) -> String {
     let mut chars = input.chars();
     let truncated: String = chars.by_ref().take(max_chars).collect();
@@ -667,7 +902,7 @@ fn prune_expired_pending_requests(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::AutonomyConfig;
+    use crate::config::{AutonomyConfig, CommandContextRuleConfig};
 
     fn supervised_config() -> AutonomyConfig {
         AutonomyConfig {
@@ -681,6 +916,23 @@ mod tests {
     fn full_config() -> AutonomyConfig {
         AutonomyConfig {
             level: AutonomyLevel::Full,
+            ..AutonomyConfig::default()
+        }
+    }
+
+    fn shell_auto_approve_with_command_rule_approval() -> AutonomyConfig {
+        AutonomyConfig {
+            level: AutonomyLevel::Supervised,
+            auto_approve: vec!["shell".into()],
+            always_ask: vec![],
+            command_context_rules: vec![CommandContextRuleConfig {
+                command: "rm".into(),
+                action: CommandContextRuleAction::RequireApproval,
+                allowed_domains: vec![],
+                allowed_path_prefixes: vec![],
+                denied_path_prefixes: vec![],
+                allow_high_risk: false,
+            }],
             ..AutonomyConfig::default()
         }
     }
@@ -705,6 +957,21 @@ mod tests {
         let mgr = ApprovalManager::from_config(&supervised_config());
         assert!(mgr.needs_approval("file_write"));
         assert!(mgr.needs_approval("http_request"));
+    }
+
+    #[test]
+    fn command_level_rule_requires_prompt_even_when_tool_is_auto_approved() {
+        let mgr = ApprovalManager::from_config(&shell_auto_approve_with_command_rule_approval());
+        assert!(!mgr.needs_approval("shell"));
+
+        assert!(!mgr.needs_approval_for_call("shell", &serde_json::json!({"command": "ls -la"})));
+        assert!(
+            mgr.needs_approval_for_call("shell", &serde_json::json!({"command": "rm -f tmp.txt"}))
+        );
+        assert!(mgr.needs_approval_for_call(
+            "shell",
+            &serde_json::json!({"command": "ls && rm -f tmp.txt"})
+        ));
     }
 
     #[test]
@@ -1029,9 +1296,19 @@ mod tests {
             NonCliNaturalLanguageApprovalMode::RequestConfirm,
         );
 
+        let command_context_rules = vec![CommandContextRuleConfig {
+            command: "rm".to_string(),
+            action: CommandContextRuleAction::RequireApproval,
+            allowed_domains: vec![],
+            allowed_path_prefixes: vec![],
+            denied_path_prefixes: vec![],
+            allow_high_risk: false,
+        }];
+
         mgr.replace_runtime_non_cli_policy(
             &["mock_price".to_string()],
             &["shell".to_string()],
+            &command_context_rules,
             &["telegram:alice".to_string()],
             NonCliNaturalLanguageApprovalMode::Direct,
             &mode_overrides,
@@ -1053,6 +1330,8 @@ mod tests {
             mgr.non_cli_natural_language_approval_mode_for_channel("slack"),
             NonCliNaturalLanguageApprovalMode::Direct
         );
+        assert!(mgr
+            .needs_approval_for_call("shell", &serde_json::json!({"command": "rm -f notes.txt"})));
     }
 
     // ── audit log ────────────────────────────────────────────

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -279,6 +279,7 @@ struct RuntimeConfigState {
 struct RuntimeAutonomyPolicy {
     auto_approve: Vec<String>,
     always_ask: Vec<String>,
+    command_context_rules: Vec<crate::config::CommandContextRuleConfig>,
     non_cli_excluded_tools: Vec<String>,
     non_cli_approval_approvers: Vec<String>,
     non_cli_natural_language_approval_mode: NonCliNaturalLanguageApprovalMode,
@@ -1106,6 +1107,7 @@ fn runtime_autonomy_policy_from_config(config: &Config) -> RuntimeAutonomyPolicy
     RuntimeAutonomyPolicy {
         auto_approve: config.autonomy.auto_approve.clone(),
         always_ask: config.autonomy.always_ask.clone(),
+        command_context_rules: config.autonomy.command_context_rules.clone(),
         non_cli_excluded_tools: config.autonomy.non_cli_excluded_tools.clone(),
         non_cli_approval_approvers: config.autonomy.non_cli_approval_approvers.clone(),
         non_cli_natural_language_approval_mode: config
@@ -1721,6 +1723,7 @@ async fn maybe_apply_runtime_config_update(ctx: &ChannelRuntimeContext) -> Resul
     ctx.approval_manager.replace_runtime_non_cli_policy(
         &next_autonomy_policy.auto_approve,
         &next_autonomy_policy.always_ask,
+        &next_autonomy_policy.command_context_rules,
         &next_autonomy_policy.non_cli_approval_approvers,
         next_autonomy_policy.non_cli_natural_language_approval_mode,
         &next_autonomy_policy.non_cli_natural_language_approval_mode_by_channel,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -3348,9 +3348,13 @@ pub enum CommandContextRuleAction {
     Allow,
     /// Matching context is explicitly denied.
     Deny,
+    /// Matching context requires interactive approval in supervised mode.
+    ///
+    /// This does not allow a command by itself; allowlist and deny checks still apply.
+    RequireApproval,
 }
 
-/// Context-aware allow/deny rule for shell commands.
+/// Context-aware command rule for shell commands.
 ///
 /// Rules are evaluated per command segment. Command matching accepts command
 /// names (`curl`), explicit paths (`/usr/bin/curl`), and wildcard (`*`).
@@ -3359,6 +3363,8 @@ pub enum CommandContextRuleAction {
 /// - `action = "deny"`: if all constraints match, the segment is rejected.
 /// - `action = "allow"`: if at least one allow rule exists for a command,
 ///   segments must match at least one of those allow rules.
+/// - `action = "require_approval"`: matching segments require explicit
+///   `approved=true` in supervised mode, even when `shell` is auto-approved.
 ///
 /// Constraints are optional:
 /// - `allowed_domains`: require URL arguments to match these hosts/patterns.
@@ -3371,7 +3377,7 @@ pub struct CommandContextRuleConfig {
     /// Command name/path pattern (`git`, `/usr/bin/curl`, or `*`).
     pub command: String,
 
-    /// Rule action (`allow` | `deny`). Defaults to `allow`.
+    /// Rule action (`allow` | `deny` | `require_approval`). Defaults to `allow`.
     #[serde(default)]
     pub action: CommandContextRuleAction,
 
@@ -9830,6 +9836,34 @@ allowed_roots = []
         assert!(err
             .to_string()
             .contains("autonomy.command_context_rules[0].allowed_domains[0]"));
+    }
+
+    #[test]
+    async fn autonomy_command_context_rule_supports_require_approval_action() {
+        let raw = r#"
+level = "supervised"
+workspace_only = true
+allowed_commands = ["ls", "rm"]
+forbidden_paths = ["/etc"]
+max_actions_per_hour = 20
+max_cost_per_day_cents = 500
+require_approval_for_medium_risk = true
+block_high_risk_commands = true
+shell_env_passthrough = []
+auto_approve = ["shell"]
+always_ask = []
+allowed_roots = []
+
+[[command_context_rules]]
+command = "rm"
+action = "require_approval"
+"#;
+        let parsed: AutonomyConfig = toml::from_str(raw).expect("autonomy config should parse");
+        assert_eq!(parsed.command_context_rules.len(), 1);
+        assert_eq!(
+            parsed.command_context_rules[0].action,
+            CommandContextRuleAction::RequireApproval
+        );
     }
 
     #[test]

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -53,6 +53,7 @@ pub enum ToolOperation {
 pub enum CommandContextRuleAction {
     Allow,
     Deny,
+    RequireApproval,
 }
 
 /// Context-aware allow/deny rule for shell commands.
@@ -601,11 +602,13 @@ enum SegmentRuleDecision {
 struct SegmentRuleOutcome {
     decision: SegmentRuleDecision,
     allow_high_risk: bool,
+    requires_approval: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 struct CommandAllowlistEvaluation {
     high_risk_overridden: bool,
+    requires_explicit_approval: bool,
 }
 
 fn is_high_risk_base_command(base: &str) -> bool {
@@ -786,7 +789,7 @@ impl SecurityPolicy {
                     .any(|prefix| self.path_matches_rule_prefix(path, prefix))
             });
             match rule.action {
-                CommandContextRuleAction::Allow => {
+                CommandContextRuleAction::Allow | CommandContextRuleAction::RequireApproval => {
                     if has_denied_path {
                         return false;
                     }
@@ -811,6 +814,7 @@ impl SecurityPolicy {
         let mut has_allow_rules = false;
         let mut allow_match = false;
         let mut allow_high_risk = false;
+        let mut requires_approval = false;
 
         for rule in &self.command_context_rules {
             if !is_allowlist_entry_match(&rule.command, executable, base_cmd) {
@@ -830,11 +834,15 @@ impl SecurityPolicy {
                     return SegmentRuleOutcome {
                         decision: SegmentRuleDecision::Deny,
                         allow_high_risk: false,
+                        requires_approval: false,
                     };
                 }
                 CommandContextRuleAction::Allow => {
                     allow_match = true;
                     allow_high_risk |= rule.allow_high_risk;
+                }
+                CommandContextRuleAction::RequireApproval => {
+                    requires_approval = true;
                 }
             }
         }
@@ -844,17 +852,20 @@ impl SecurityPolicy {
                 SegmentRuleOutcome {
                     decision: SegmentRuleDecision::Allow,
                     allow_high_risk,
+                    requires_approval,
                 }
             } else {
                 SegmentRuleOutcome {
                     decision: SegmentRuleDecision::Deny,
                     allow_high_risk: false,
+                    requires_approval: false,
                 }
             }
         } else {
             SegmentRuleOutcome {
                 decision: SegmentRuleDecision::NoMatch,
                 allow_high_risk: false,
+                requires_approval,
             }
         }
     }
@@ -894,6 +905,7 @@ impl SecurityPolicy {
         let mut has_cmd = false;
         let mut saw_high_risk_segment = false;
         let mut all_high_risk_segments_overridden = true;
+        let mut requires_explicit_approval = false;
 
         for segment in &segments {
             let cmd_part = skip_env_assignments(segment);
@@ -914,6 +926,7 @@ impl SecurityPolicy {
             if context_outcome.decision == SegmentRuleDecision::Deny {
                 return Err(format!("context rule denied command segment `{base_cmd}`"));
             }
+            requires_explicit_approval |= context_outcome.requires_approval;
 
             if context_outcome.decision != SegmentRuleDecision::Allow
                 && !self
@@ -949,6 +962,7 @@ impl SecurityPolicy {
 
         Ok(CommandAllowlistEvaluation {
             high_risk_overridden: saw_high_risk_segment && all_high_risk_segments_overridden,
+            requires_explicit_approval,
         })
     }
 
@@ -1038,7 +1052,9 @@ impl SecurityPolicy {
     // Validation follows a strict precedence order:
     //   1. Allowlist check (is the base command permitted at all?)
     //   2. Risk classification (high / medium / low)
-    //   3. Policy flags (block_high_risk_commands, require_approval_for_medium_risk)
+    //   3. Policy flags and context approval rules
+    //      (block_high_risk_commands, require_approval_for_medium_risk,
+    //       command_context_rules[action=require_approval])
     //   4. Autonomy level × approval status (supervised requires explicit approval)
     // This ordering ensures deny-by-default: unknown commands are rejected
     // before any risk or autonomy logic runs.
@@ -1076,6 +1092,16 @@ impl SecurityPolicy {
                         .into(),
                 );
             }
+        }
+
+        if self.autonomy == AutonomyLevel::Supervised
+            && allowlist_eval.requires_explicit_approval
+            && !approved
+        {
+            return Err(
+                "Command requires explicit approval (approved=true): matched command_context_rules action=require_approval"
+                    .into(),
+            );
         }
 
         if risk == CommandRiskLevel::Medium
@@ -1540,6 +1566,9 @@ impl SecurityPolicy {
                         crate::config::CommandContextRuleAction::Deny => {
                             CommandContextRuleAction::Deny
                         }
+                        crate::config::CommandContextRuleAction::RequireApproval => {
+                            CommandContextRuleAction::RequireApproval
+                        }
                     },
                     allowed_domains: rule.allowed_domains.clone(),
                     allowed_path_prefixes: rule.allowed_path_prefixes.clone(),
@@ -1867,6 +1896,58 @@ mod tests {
     }
 
     #[test]
+    fn context_require_approval_rule_demands_approval_for_matching_low_risk_command() {
+        let p = SecurityPolicy {
+            autonomy: AutonomyLevel::Supervised,
+            require_approval_for_medium_risk: false,
+            allowed_commands: vec!["ls".into()],
+            command_context_rules: vec![CommandContextRule {
+                command: "ls".into(),
+                action: CommandContextRuleAction::RequireApproval,
+                allowed_domains: vec![],
+                allowed_path_prefixes: vec![],
+                denied_path_prefixes: vec![],
+                allow_high_risk: false,
+            }],
+            ..SecurityPolicy::default()
+        };
+
+        let denied = p.validate_command_execution("ls -la", false);
+        assert!(denied.is_err());
+        assert!(denied.unwrap_err().contains("requires explicit approval"));
+
+        let allowed = p.validate_command_execution("ls -la", true);
+        assert_eq!(allowed.unwrap(), CommandRiskLevel::Low);
+    }
+
+    #[test]
+    fn context_require_approval_rule_is_still_constrained_by_domains() {
+        let p = SecurityPolicy {
+            autonomy: AutonomyLevel::Supervised,
+            block_high_risk_commands: false,
+            allowed_commands: vec!["curl".into()],
+            command_context_rules: vec![CommandContextRule {
+                command: "curl".into(),
+                action: CommandContextRuleAction::RequireApproval,
+                allowed_domains: vec!["api.example.com".into()],
+                allowed_path_prefixes: vec![],
+                denied_path_prefixes: vec![],
+                allow_high_risk: false,
+            }],
+            ..SecurityPolicy::default()
+        };
+
+        // Non-matching domain does not trigger the context approval rule.
+        let unmatched = p.validate_command_execution("curl https://other.example.com/health", true);
+        assert_eq!(unmatched.unwrap(), CommandRiskLevel::High);
+
+        // Matching domain triggers explicit approval requirement.
+        let denied = p.validate_command_execution("curl https://api.example.com/v1/health", false);
+        assert!(denied.is_err());
+        assert!(denied.unwrap_err().contains("requires explicit approval"));
+    }
+
+    #[test]
     fn command_risk_low_for_read_commands() {
         let p = default_policy();
         assert_eq!(p.command_risk_level("git status"), CommandRiskLevel::Low);
@@ -2089,6 +2170,29 @@ mod tests {
 
         assert_eq!(policy.allowed_roots[0], expected_home_root);
         assert_eq!(policy.allowed_roots[1], workspace.join("shared-data"));
+    }
+
+    #[test]
+    fn from_config_maps_command_rule_require_approval_action() {
+        let autonomy_config = crate::config::AutonomyConfig {
+            command_context_rules: vec![crate::config::CommandContextRuleConfig {
+                command: "rm".into(),
+                action: crate::config::CommandContextRuleAction::RequireApproval,
+                allowed_domains: vec![],
+                allowed_path_prefixes: vec![],
+                denied_path_prefixes: vec![],
+                allow_high_risk: false,
+            }],
+            ..crate::config::AutonomyConfig::default()
+        };
+        let workspace = PathBuf::from("/tmp/test-workspace");
+        let policy = SecurityPolicy::from_config(&autonomy_config, &workspace);
+
+        assert_eq!(policy.command_context_rules.len(), 1);
+        assert!(matches!(
+            policy.command_context_rules[0].action,
+            CommandContextRuleAction::RequireApproval
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Implements granular command-level approval for shell/process execution by extending command context rules with a dedicated `require_approval` action.

### Root cause
Approval policy was primarily tool-level (`auto_approve` / `always_ask`), so users could not express `approve rm, but not ls` when both run through the same `shell` tool.

### What changed
- Added `require_approval` action to `autonomy.command_context_rules` schema and runtime policy mapping.
- Extended security policy evaluation to detect matching `require_approval` segments and require explicit `approved=true` in supervised mode.
- Extended `ApprovalManager` with call-level checks (`needs_approval_for_call`) so command-specific rules can trigger prompts even if `shell` is globally auto-approved.
- Updated tool-loop execution to use call-level approval checks and inject `approved=true` into tool args after a human approval decision, allowing execution to pass policy gates safely.
- Kept existing behavior for `allow`/`deny`, medium-risk approvals, and high-risk blocking/override logic.
- Updated runtime config-reload path to refresh command-level approval rules.
- Added docs for `action = "require_approval"` in config reference.

### Tests
- `cargo fmt --all`
- `CARGO_TARGET_DIR=target_ci/issue2606-check cargo check --lib -p zeroclaw`
- `CARGO_TARGET_DIR=target_ci/issue2606 cargo test approval::tests:: -- --nocapture`
- `CARGO_TARGET_DIR=target_ci/issue2606 cargo test security::policy::tests:: -- --nocapture`
- `CARGO_TARGET_DIR=target_ci/issue2606 cargo test should_execute_tools_in_parallel_returns_ -- --nocapture`
- `CARGO_TARGET_DIR=target_ci/issue2606 cargo test run_tool_call_loop_injects_approved_flag_after_non_cli_approval -- --nocapture`
- `CARGO_TARGET_DIR=target_ci/issue2606 cargo test autonomy_command_context_rule_supports_require_approval_action -- --nocapture`

Closes #2606
