### PR TITLE
fix(channels): Suppress HEARTBEAT_OK sentinel in channel replies

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -11826,14 +11826,20 @@ BTC is currently around $65,000 based on latest tool output."#;
         let ChannelSanitizationResult::Sanitized(result) = result else {
             panic!("expected sanitized output");
         };
-        assert_eq!(result, "", "HEARTBEAT_OK should be suppressed to empty string");
+        assert_eq!(
+            result, "",
+            "HEARTBEAT_OK should be suppressed to empty string"
+        );
 
         // With whitespace
         let result = sanitize_channel_response("  HEARTBEAT_OK  \n", &tools, &leak_guard);
         let ChannelSanitizationResult::Sanitized(result) = result else {
             panic!("expected sanitized output");
         };
-        assert_eq!(result, "", "HEARTBEAT_OK with whitespace should be suppressed");
+        assert_eq!(
+            result, "",
+            "HEARTBEAT_OK with whitespace should be suppressed"
+        );
 
         // Case insensitive
         let result = sanitize_channel_response("heartbeat_ok", &tools, &leak_guard);


### PR DESCRIPTION
## Summary

Fixes #2513

When the agent emits `HEARTBEAT_OK` for heartbeat ticks with no substantive update, this sentinel was being sent as a literal outbound message in Telegram (and other) channel conversations.

## Root Cause

The daemon heartbeat delivery path already treats `HEARTBEAT_OK` as "skip delivery", but the channel reply path did not have this filtering, causing an inconsistency between heartbeat-related code paths.

## Changes

1. **Added `is_heartbeat_ok_sentinel()` helper function** - Detects HEARTBEAT_OK responses (case-insensitive, handles whitespace)
2. **Modified `sanitize_channel_response()`** - Filters HEARTBEAT_OK before sending to channels, returning empty string
3. **Added comprehensive tests** - Test both the helper function and the sanitization behavior

## Testing

- Unit tests added for `is_heartbeat_ok_sentinel()` with various inputs
- Unit tests added for `sanitize_channel_response()` with HEARTBEAT_OK suppression
- Tests cover: exact match, whitespace, case-insensitivity, and normal text passthrough

## Impact

- **Before**: Telegram channels received literal "HEARTBEAT_OK" messages
- **After**: HEARTBEAT_OK is suppressed (no message sent), matching daemon behavior

## Checklist

- [x] Code compiles (Rust)
- [x] Tests added
- [x] Fixes issue #2513
- [x] Follows existing code patterns (matches daemon implementation)
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Channel response sanitization now suppresses stray HEARTBEAT_OK sentinel values, including case and whitespace variations, preventing them from appearing to users.

* **Tests**
  * Added tests covering suppression behavior and detection of heartbeat sentinel variations to ensure robust response handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->