### PR TITLE
fix(agent): one-time non-cli allow-all token now bypasses all approvals

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2113,30 +2113,35 @@ pub async fn run_tool_call_loop(
                     channel_name != "cli" && mgr.is_non_cli_session_granted(&tool_name);
                 let requires_interactive_approval =
                     mgr.needs_approval_for_call(&tool_name, &tool_args);
-                if (bypass_non_cli_approval_for_turn || non_cli_session_granted)
-                    && !requires_interactive_approval
-                {
+                if bypass_non_cli_approval_for_turn {
+                    // One-time bypass token: bypass ALL approvals (including interactive)
                     mgr.record_decision(
                         &tool_name,
                         &tool_args,
                         ApprovalResponse::Yes,
                         channel_name,
                     );
-                    if non_cli_session_granted {
-                        runtime_trace::record_event(
-                            "approval_bypass_non_cli_session_grant",
-                            Some(channel_name),
-                            Some(provider_name),
-                            Some(active_model.as_str()),
-                            Some(&turn_id),
-                            Some(true),
-                            Some("using runtime non-cli session approval grant"),
-                            serde_json::json!({
-                                "iteration": iteration + 1,
-                                "tool": tool_name.clone(),
-                            }),
-                        );
-                    }
+                } else if non_cli_session_granted && !requires_interactive_approval {
+                    // Session grant: bypass only non-interactive approvals
+                    mgr.record_decision(
+                        &tool_name,
+                        &tool_args,
+                        ApprovalResponse::Yes,
+                        channel_name,
+                    );
+                    runtime_trace::record_event(
+                        "approval_bypass_non_cli_session_grant",
+                        Some(channel_name),
+                        Some(provider_name),
+                        Some(active_model.as_str()),
+                        Some(&turn_id),
+                        Some(true),
+                        Some("using runtime non-cli session approval grant"),
+                        serde_json::json!({
+                            "iteration": iteration + 1,
+                            "tool": tool_name.clone(),
+                        }),
+                    );
                 } else if requires_interactive_approval {
                     let request = ApprovalRequest {
                         tool_name: tool_name.clone(),


### PR DESCRIPTION
## Summary
- Fixed one-time `non_cli_allow_all_once` token to bypass **all** approvals (including interactive)
- Previously only bypassed non-interactive approvals due to logic bug
- Tools like `shell` (which require interactive approval in supervised mode) were blocked even after consuming the token

## Test plan
- [x] Verified fix with test `run_tool_call_loop_consumes_one_time_non_cli_allow_all_token`
- [x] Test now passes (previously failed with `max_active = 0` instead of expected `1`)

## Side effects / Blast radius
- **Risk**: Low - change only affects non-cli approval bypass logic
- **Impact**: One-time bypass token now works as intended for all tools
- **Rollback**: Revert commit `5d38843f` if issues arise

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  - Refined approval handling logic for tool operations with improved bypass token path
  - Enhanced approval decision logging and control flow for better clarity and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->