### PR TITLE
fix(skills): normalize path separators to forward slashes for XML output

### DIFF
--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -764,12 +764,16 @@ fn resolve_skill_location(skill: &Skill, workspace_dir: &Path) -> PathBuf {
 
 fn render_skill_location(skill: &Skill, workspace_dir: &Path, prefer_relative: bool) -> String {
     let location = resolve_skill_location(skill, workspace_dir);
-    if prefer_relative {
-        if let Ok(relative) = location.strip_prefix(workspace_dir) {
-            return relative.display().to_string();
+    let path_str = if prefer_relative {
+        match location.strip_prefix(workspace_dir) {
+            Ok(relative) => relative.display().to_string(),
+            Err(_) => location.display().to_string(),
         }
-    }
-    location.display().to_string()
+    } else {
+        location.display().to_string()
+    };
+    // Normalize path separators to forward slashes for XML output (portable across Windows/Unix)
+    path_str.replace('\\', "/")
 }
 
 /// Build the "Available Skills" system prompt section with full skill instructions.


### PR DESCRIPTION
## Summary
- On Windows, file paths use backslashes (`\`) but the test expected forward slashes (`/`)
- The `render_skill_location` function now normalizes all path separators to forward slashes for consistent XML output across platforms

## Test plan
- [x] `prompt_skills_compact_mode_omits_instructions_and_tools` now passes
- [x] All 3 related skills prompt tests pass
- [x] All 106 skills module tests pass

## Risk and Rollback
- Risk: Low - only affects XML path rendering for skills location
- Rollback: Revert commit if any issues arise

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling with fallback logic to use relative paths when preferred, falling back to full paths.
  * Normalized path separators in output to ensure cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->