### PR TITLE
fix: set default cargo run target and reuse openrouter client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 name = "zeroclaw"
 version = "0.1.7"
 edition = "2021"
+default-run = "zeroclaw"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"
 description = "Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant."

--- a/src/providers/openrouter.rs
+++ b/src/providers/openrouter.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 pub struct OpenRouterProvider {
     credential: Option<String>,
     max_tokens_override: Option<u32>,
+    client: Client,
 }
 
 #[derive(Debug, Serialize)]
@@ -159,6 +160,11 @@ impl OpenRouterProvider {
         Self {
             credential: credential.map(ToString::to_string),
             max_tokens_override: max_tokens_override.filter(|value| *value > 0),
+            client: crate::config::build_runtime_proxy_client_with_timeouts(
+                "provider.openrouter",
+                120,
+                10,
+            ),
         }
     }
 
@@ -305,8 +311,8 @@ impl OpenRouterProvider {
         }
     }
 
-    fn http_client(&self) -> Client {
-        crate::config::build_runtime_proxy_client_with_timeouts("provider.openrouter", 120, 10)
+    fn http_client(&self) -> &Client {
+        &self.client
     }
 }
 


### PR DESCRIPTION
## Summary

- Base branch target: `dev`
- Problem: `cargo run -- ...` does not work out of the box because this repo exposes multiple binaries, and `OpenRouterProvider` rebuilds its HTTP client on each request.
- Why it matters: this adds avoidable friction for local development and unnecessary overhead for repeated OpenRouter calls.
- What changed: added `default-run = "zeroclaw"` in `Cargo.toml`, and changed `OpenRouterProvider` to construct one `reqwest::Client` during initialization and reuse it.
- Scope boundary: no API/schema changes, no config contract changes, and no new dependencies.

## Label Snapshot

- Risk label: `risk: medium`
- Scope labels: `provider,dev`
- Module labels: `provider: openrouter`

## Change Metadata

- Change type: `bug`
- Primary scope: `multi`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #
- Linear issue key(s): `N/A`
- Linear issue URL(s): `N/A`

## Validation Evidence

Commands run:

    cargo +1.92.0 fmt --all -- --check
    cargo +1.92.0 clippy --locked --all-targets -- -D clippy::correctness
    cargo test --lib providers::openrouter -- --nocapture
    cargo run -- --help

- Evidence provided: local command output
- Note: `cargo +1.92.0 clippy --all-targets -- -D warnings` currently reports existing repository-wide strict warnings outside this patch, so validation was aligned to the repository’s required lint gate (`clippy::correctness`) plus focused tests.

## Security Impact

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Privacy and Data Hygiene

- Data-hygiene status: `pass`
- Redaction/anonymization notes: no secrets or personal data added
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## i18n Follow-Through

- i18n follow-through triggered? `No`

## Human Verification

- Verified scenarios: `cargo run -- --help` now launches `zeroclaw` directly; OpenRouter unit tests still pass after client reuse.
- Edge cases checked: provider construction with and without an API key still behaves as expected through existing tests.
- What was not verified: live OpenRouter requests against the upstream API.

## Side Effects / Blast Radius

- Affected subsystems/workflows: local Cargo startup flow; OpenRouter provider client lifecycle
- Potential unintended effects: OpenRouter now keeps one shared client per provider instance instead of constructing one per request
- Guardrails/monitoring for early detection: existing OpenRouter tests and direct startup smoke check

## Agent Collaboration Notes

- Agent tools used: local shell commands and focused test runs
- Workflow/plan summary: created a minimal two-file patch, then reapplied it onto a `dev`-based branch with cherry-pick and revalidated
- Verification focus: startup UX and provider-local request path behavior
- Confirmation: naming + architecture boundaries followed: `Yes`

## Rollback Plan

- Fast rollback command/path: revert this PR, or remove `default-run` from `Cargo.toml` and restore per-call client construction in `src/providers/openrouter.rs`
- Feature flags or config toggles: none
- Observable failure symptoms: `cargo run -- ...` no longer defaults to `zeroclaw`, or OpenRouter behavior regresses after provider initialization

## Risks and Mitigations

- Risk: this combines two small changes in one PR, which slightly broadens scope.
- Mitigation: both changes are isolated, touch only two files, and were validated with focused checks..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured zeroclaw as the default binary for streamlined CLI invocation without specifying an explicit target.
  * Enhanced OpenRouter provider's HTTP client initialization and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->