### PR TITLE
docs: align validation guidance with CI gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -44,9 +44,9 @@ Describe this PR in 2-5 bullets:
 Commands and result summary:
 
 ```bash
-cargo fmt --all -- --check
-cargo clippy --all-targets -- -D warnings
-cargo test
+./scripts/ci/rust_quality_gate.sh
+./scripts/ci/rust_strict_delta_gate.sh
+cargo test --locked
 ```
 
 - Evidence provided (test/log/trace/screenshot/perf):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Welcome — contributions of all sizes are valued. If this is your first contrib
 3. **Follow the fork → branch → change → test → PR workflow:**
    - Fork the repository and clone your fork
    - Create a feature branch (`git checkout -b fix/my-change`)
-   - Make your changes and run `cargo fmt && cargo clippy && cargo test`
+   - Make your changes and run `./scripts/ci/rust_quality_gate.sh && cargo test --locked`
    - Open a PR against `dev` using the PR template
 
 4. **Start with Track A.** ZeroClaw uses three [collaboration tracks](#collaboration-tracks-risk-based) (A/B/C) based on risk. First-time contributors should target **Track A** (docs, tests, chore) — these require lighter review and are the fastest path to a merged PR.
@@ -45,7 +45,7 @@ cargo test --locked
 # Optional strict lint audit (full repo, recommended periodically)
 ./scripts/ci/rust_quality_gate.sh --strict
 
-# Optional strict lint delta gate (blocks only changed Rust lines)
+# Optional strict lint delta gate (blocks only changed Rust lines; mirrors CI changed-line enforcement)
 ./scripts/ci/rust_strict_delta_gate.sh
 
 # Optional docs lint gate (blocks only markdown issues on changed lines)


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: contributor guidance and the PR template still suggest validation commands that do not match the repository's current CI gates.
- Why it matters: this can mislead contributors into running stricter or different commands than the merge-blocking workflow actually uses.
- What changed: updated `CONTRIBUTING.md` and `.github/pull_request_template.md` to point contributors at `./scripts/ci/rust_quality_gate.sh`, `./scripts/ci/rust_strict_delta_gate.sh`, and `cargo test --locked`.
- What did **not** change: no branch-target wording changes, no CI workflow changes, and no runtime behavior changes.

## Label Snapshot

- Risk label: `risk: low`
- Scope labels: `docs,ci`
- Module labels: none
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type: `docs`
- Primary scope: `docs`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #
- Linear issue key(s): `N/A`
- Linear issue URL(s): `N/A`

## Validation Evidence

Commands run:

    bash ./scripts/ci/docs_quality_gate.sh

- Evidence provided: local docs quality gate output
- Result: passed

## Security Impact

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Privacy and Data Hygiene

- Data-hygiene status: `pass`
- Redaction/anonymization notes: no secrets or personal data added
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## i18n Follow-Through

- i18n follow-through triggered? `No`
- Scope decision: this updates contributor workflow guidance and the PR template only; it does not change docs IA, locale navigation, or shared runtime-contract wording.

## Human Verification

- Verified scenarios: the updated docs-only files pass `docs_quality_gate`, and the validation examples now match the current CI scripts.
- Edge cases checked: the change remains docs-only and does not alter branch-target guidance.
- What was not verified: no workflow execution or runtime behavior was exercised, since this PR only updates documentation.

## Side Effects / Blast Radius

- Affected subsystems/workflows: contributor documentation and PR intake guidance
- Potential unintended effects: future CI changes could require the docs guidance to be updated again
- Guardrails/monitoring for early detection: docs quality gate and future reviewer checks against current CI scripts

## Agent Collaboration Notes

- Agent tools used: local shell commands for focused docs review and docs quality validation
- Workflow/plan summary: reviewed `main`-based docs, applied a minimal two-file patch in a clean worktree, and validated with the docs quality gate
- Verification focus: alignment between contributor-facing docs and current CI gates
- Confirmation: naming + architecture boundaries followed: `Yes`

## Rollback Plan

- Fast rollback command/path: revert this PR, or restore the previous validation examples in `CONTRIBUTING.md` and `.github/pull_request_template.md`
- Feature flags or config toggles: none
- Observable failure symptoms: contributor docs once again suggest validation commands that do not match current CI guidance

## Risks and Mitigations

- Risk: documentation-only guidance can drift again if CI expectations change later.
- Mitigation: the updated wording now points directly to the repository CI scripts, which is easier to keep aligned than repeating raw commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines and pull request templates to reflect reorganized continuous integration quality assurance processes.
  * Clarified quality enforcement procedures and their scope for code changes.

* **Chores**
  * Updated developer workflow documentation for local testing procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->