### PR TITLE
feat(integrations): support lmstudio custom connector endpoint

### DIFF
--- a/docs/providers-reference.md
+++ b/docs/providers-reference.md
@@ -76,6 +76,22 @@ credential is not reused for fallback providers.
 - This provider spawns a subprocess per request and is best suited for batch/script usage rather than high-throughput inference.
 - **Limitations**: Only the system prompt (if any) and the last user message are forwarded per request. Full multi-turn conversation history is not preserved because the headless CLI accepts a single prompt per invocation. Temperature control is not supported; non-default values return an explicit error.
 
+### LM Studio Notes
+
+- Provider ID: `lmstudio` (alias: `lm-studio`)
+- Default local endpoint: `http://localhost:1234/v1`
+- Override endpoint with `api_url` for remote server mode:
+
+```toml
+default_provider = "lmstudio"
+api_url = "http://10.0.0.20:1234/v1"
+default_model = "qwen2.5-coder:7b"
+```
+
+- Authentication:
+  - Optional. If your LM Studio server enforces auth, set `api_key` (or `API_KEY`/`ZEROCLAW_API_KEY`).
+  - If no key is set, ZeroClaw uses an internal placeholder token for compatibility with OpenAI-style auth headers.
+
 ### Vercel AI Gateway Notes
 
 - Provider ID: `vercel` (alias: `vercel-ai`)

--- a/src/integrations/registry.rs
+++ b/src/integrations/registry.rs
@@ -302,7 +302,16 @@ pub fn all_integrations() -> Vec<IntegrationEntry> {
             name: "LM Studio",
             description: "Local model server",
             category: IntegrationCategory::AiModel,
-            status_fn: |_| IntegrationStatus::ComingSoon,
+            status_fn: |c| {
+                if c.default_provider.as_deref().is_some_and(|provider| {
+                    provider.eq_ignore_ascii_case("lmstudio")
+                        || provider.eq_ignore_ascii_case("lm-studio")
+                }) {
+                    IntegrationStatus::Active
+                } else {
+                    IntegrationStatus::Available
+                }
+            },
         },
         IntegrationEntry {
             name: "Venice",
@@ -933,6 +942,38 @@ mod tests {
                 "{name} should be ComingSoon"
             );
         }
+    }
+
+    #[test]
+    fn lm_studio_available_when_not_selected_as_default_provider() {
+        let config = Config::default();
+        let entries = all_integrations();
+        let lm_studio = entries.iter().find(|e| e.name == "LM Studio").unwrap();
+        assert!(matches!(
+            (lm_studio.status_fn)(&config),
+            IntegrationStatus::Available
+        ));
+    }
+
+    #[test]
+    fn lm_studio_active_for_lmstudio_default_provider_aliases() {
+        let entries = all_integrations();
+        let lm_studio = entries.iter().find(|e| e.name == "LM Studio").unwrap();
+
+        let mut config = Config {
+            default_provider: Some("lmstudio".to_string()),
+            ..Config::default()
+        };
+        assert!(matches!(
+            (lm_studio.status_fn)(&config),
+            IntegrationStatus::Active
+        ));
+
+        config.default_provider = Some("lm-studio".to_string());
+        assert!(matches!(
+            (lm_studio.status_fn)(&config),
+            IntegrationStatus::Active
+        ));
     }
 
     #[test]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1126,6 +1126,20 @@ pub fn create_provider_with_url(
     create_provider_with_url_and_options(name, api_key, api_url, &ProviderRuntimeOptions::default())
 }
 
+fn resolve_lmstudio_connection(api_url: Option<&str>, key: Option<&str>) -> (String, String) {
+    let base_url = api_url
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("http://localhost:1234/v1")
+        .to_string();
+    let lm_studio_key = key
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("lm-studio")
+        .to_string();
+    (base_url, lm_studio_key)
+}
+
 /// Factory: create provider with optional base URL and runtime options.
 #[allow(clippy::too_many_lines)]
 fn create_provider_with_url_and_options(
@@ -1387,14 +1401,11 @@ fn create_provider_with_url_and_options(
         "copilot" | "github-copilot" => Ok(Box::new(copilot::CopilotProvider::new(key))),
         "cursor" => Ok(Box::new(cursor::CursorProvider::new())),
         "lmstudio" | "lm-studio" => {
-            let lm_studio_key = key
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .unwrap_or("lm-studio");
+            let (base_url, lm_studio_key) = resolve_lmstudio_connection(api_url, key);
             Ok(Box::new(OpenAiCompatibleProvider::new(
                 "LM Studio",
-                "http://localhost:1234/v1",
-                Some(lm_studio_key),
+                &base_url,
+                Some(&lm_studio_key),
                 AuthStyle::Bearer,
             )))
         }
@@ -2657,6 +2668,37 @@ mod tests {
         assert!(create_provider("lmstudio", Some("key")).is_ok());
         assert!(create_provider("lm-studio", Some("key")).is_ok());
         assert!(create_provider("lmstudio", None).is_ok());
+    }
+
+    #[test]
+    fn lmstudio_connection_prefers_custom_base_url() {
+        let (base_url, key) =
+            resolve_lmstudio_connection(Some("http://10.0.0.15:1234/v1"), Some("custom-key"));
+        assert_eq!(base_url, "http://10.0.0.15:1234/v1");
+        assert_eq!(key, "custom-key");
+    }
+
+    #[test]
+    fn lmstudio_connection_uses_safe_defaults_when_unset() {
+        let (base_url, key) = resolve_lmstudio_connection(Some("   "), None);
+        assert_eq!(base_url, "http://localhost:1234/v1");
+        assert_eq!(key, "lm-studio");
+    }
+
+    #[test]
+    fn factory_lmstudio_with_custom_url() {
+        assert!(create_provider_with_url(
+            "lmstudio",
+            Some("key"),
+            Some("http://10.0.0.22:1234/v1")
+        )
+        .is_ok());
+        assert!(create_provider_with_url(
+            "lm-studio",
+            None,
+            Some("http://host.docker.internal:1234")
+        )
+        .is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make LM Studio provider factory honor `api_url` override (default remains `http://localhost:1234/v1`)
- keep optional key behavior with compatibility placeholder when key is absent
- update integrations registry so LM Studio is `Available` by default and `Active` when selected as default provider (`lmstudio` or `lm-studio`)
- document LM Studio remote endpoint configuration and auth notes

## Root Cause
Runtime support existed for LM Studio, but connector creation ignored custom `api_url` and the integrations registry marked LM Studio as `ComingSoon`, making the dashboard path misleading/incomplete.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p zeroclaw lmstudio -- --nocapture`
- `cargo test -p zeroclaw integrations::registry::tests::lm_studio -- --nocapture`

Closes #2669
