### PR TITLE
feat(config): support env refs for telegram allowed_users

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -7603,10 +7603,8 @@ tool_dispatcher = "xml"
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
-            progress_mode: ProgressMode::default(),
             group_reply: None,
             base_url: None,
-            ack_enabled: true,
         });
 
         let result = resolve_telegram_allowed_users_env_refs(&mut channels);
@@ -7630,10 +7628,8 @@ tool_dispatcher = "xml"
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
-            progress_mode: ProgressMode::default(),
             group_reply: None,
             base_url: None,
-            ack_enabled: true,
         });
 
         let result = resolve_telegram_allowed_users_env_refs(&mut channels);
@@ -7657,10 +7653,8 @@ tool_dispatcher = "xml"
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
-            progress_mode: ProgressMode::default(),
             group_reply: None,
             base_url: None,
-            ack_enabled: true,
         });
 
         let err = resolve_telegram_allowed_users_env_refs(&mut channels)
@@ -7680,10 +7674,8 @@ tool_dispatcher = "xml"
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
-            progress_mode: ProgressMode::default(),
             group_reply: None,
             base_url: None,
-            ack_enabled: true,
         });
 
         let err = resolve_telegram_allowed_users_env_refs(&mut channels)


### PR DESCRIPTION
## Summary
- support env refs in `telegram.allowed_users`
- expand CSV or JSON array values from `${env:VAR}`
- validate env names and fail fast on missing/invalid vars

## Validation
- cargo test --lib telegram_allowed_users_env_ref_ -- --nocapture

Supersedes #2705 for `dev` compatibility.
Refs #2601


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram allowed users configuration now supports environment variable references using `${env:VARIABLE_NAME}` syntax, enabling dynamic configuration through environment variables. Supports both JSON array and comma-separated list formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->