### PR TITLE
feat(onboarding): make TUI wizard default one-click flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,10 +851,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cbc"
@@ -1106,6 +1121,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,7 +1169,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1164,6 +1193,15 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -1476,6 +1514,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "derive_more 2.1.1",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,8 +1660,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1598,12 +1689,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1692,7 +1807,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58cb0719583cbe4e81fb40434ace2f0d22ccc3e39a74bb3796c22b451b4f139d"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
@@ -1791,6 +1906,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -2090,7 +2206,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_plain",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
 ]
 
@@ -2114,7 +2230,7 @@ dependencies = [
  "object 0.38.1",
  "serde",
  "sha2",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.18",
 ]
 
@@ -2645,6 +2761,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
  "serde",
 ]
@@ -3244,6 +3362,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3251,6 +3378,19 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3604,6 +3744,15 @@ dependencies = [
  "thiserror 2.0.18",
  "ttf-parser",
  "weezl",
+]
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -4324,7 +4473,7 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7462c9d8ae5ef6a28d66a192d399ad2530f1f2130b13186296dbb11bdef5b3d1"
 dependencies = [
- "lru",
+ "lru 0.16.3",
  "nostr",
  "tokio",
 ]
@@ -4348,7 +4497,7 @@ dependencies = [
  "async-wsocket",
  "atomic-destructor",
  "hex",
- "lru",
+ "lru 0.16.3",
  "negentropy",
  "nostr",
  "nostr-database",
@@ -4648,6 +4797,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -5516,6 +5671,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.0",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru 0.12.5",
+ "paste",
+ "strum 0.26.3",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6067,7 +6243,7 @@ dependencies = [
  "nix 0.30.1",
  "radix_trie",
  "unicode-segmentation",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "utf8parse",
  "windows-sys 0.60.2",
 ]
@@ -6498,6 +6674,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6595,6 +6792,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stop-token"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6660,11 +6863,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7526,6 +7751,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7533,9 +7769,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -8510,7 +8746,7 @@ dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "wasm-encoder 0.245.1",
 ]
 
@@ -9237,6 +9473,7 @@ dependencies = [
  "console",
  "criterion",
  "cron",
+ "crossterm 0.29.0",
  "dialoguer",
  "directories",
  "fantoccini",
@@ -9269,6 +9506,7 @@ dependencies = [
  "qrcode",
  "quick-xml",
  "rand 0.10.0",
+ "ratatui",
  "regex",
  "reqwest",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,8 @@ cron = "0.15"
 dialoguer = { version = "0.12", features = ["fuzzy-select"] }
 rustyline = "17.0"
 console = "0.16"
+crossterm = "0.29"
+ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
 
 # Hardware discovery (device path globbing)
 glob = "0.3"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ Use this board for important notices (breaking changes, security advisories, mai
 
 ## Quick Start
 
+### Option 0: One-line Installer (Default TUI Onboarding)
+
+```bash
+curl -fsSL https://zeroclawlabs.ai/install.sh | bash
+```
+
 ### Option 1: Homebrew (macOS/Linuxbrew)
 
 ```bash

--- a/docs/one-click-bootstrap.md
+++ b/docs/one-click-bootstrap.md
@@ -2,7 +2,7 @@
 
 This page defines the fastest supported path to install and initialize ZeroClaw.
 
-Last verified: **February 20, 2026**.
+Last verified: **March 4, 2026**.
 
 ## Option 0: Homebrew (macOS/Linuxbrew)
 
@@ -22,6 +22,7 @@ What it does by default:
 
 1. `cargo build --release --locked`
 2. `cargo install --path . --force --locked`
+3. In interactive no-flag sessions, launches TUI onboarding (`zeroclaw onboard --interactive-ui`)
 
 ### Resource preflight and pre-built flow
 
@@ -50,7 +51,8 @@ To bypass pre-built flow and force source compilation:
 
 ## Dual-mode bootstrap
 
-Default behavior is **app-only** (build/install ZeroClaw) and expects existing Rust toolchain.
+Default behavior builds/install ZeroClaw and, for interactive no-flag runs, starts TUI onboarding.
+It still expects an existing Rust toolchain unless you enable bootstrap flags below.
 
 For fresh machines, enable environment bootstrap explicitly:
 
@@ -69,10 +71,18 @@ Notes:
 ## Option B: Remote one-liner
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/bootstrap.sh | bash
+curl -fsSL https://zeroclawlabs.ai/install.sh | bash
+```
+
+Equivalent GitHub-hosted installer entrypoint:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/install.sh | bash
 ```
 
 For high-security environments, prefer Option A so you can review the script before execution.
+
+No-arg interactive runs default to full-screen TUI onboarding.
 
 Legacy compatibility:
 
@@ -123,6 +133,8 @@ ZEROCLAW_API_KEY="sk-..." ZEROCLAW_PROVIDER="openrouter" ./bootstrap.sh --onboar
 ```bash
 ./bootstrap.sh --interactive-onboard
 ```
+
+This launches the full-screen TUI onboarding flow (`zeroclaw onboard --interactive-ui`).
 
 ## Useful flags
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -403,11 +403,12 @@ The `.cargo/config.toml` in this repository already pins `x86_64-apple-darwin` b
 Both still work:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/bootstrap.sh | bash
+curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/install.sh | bash
 curl -fsSL https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/install.sh | bash
 ```
 
-`install.sh` is a compatibility entry and forwards/falls back to bootstrap behavior.
+Root `install.sh` is the canonical remote entrypoint and defaults to TUI onboarding for no-arg interactive sessions.
+`scripts/install.sh` remains a compatibility entry and forwards/falls back to bootstrap behavior.
 
 ## Still Stuck?
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Canonical remote installer entrypoint.
+# Default behavior for no-arg interactive shells is TUI onboarding.
+
+BOOTSTRAP_URL="${ZEROCLAW_BOOTSTRAP_URL:-https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/bootstrap.sh}"
+
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+run_remote_bootstrap() {
+  local -a args=("$@")
+
+  if have_cmd curl; then
+    if [[ ${#args[@]} -eq 0 ]]; then
+      curl -fsSL "$BOOTSTRAP_URL" | bash
+    else
+      curl -fsSL "$BOOTSTRAP_URL" | bash -s -- "${args[@]}"
+    fi
+    return 0
+  fi
+
+  if have_cmd wget; then
+    if [[ ${#args[@]} -eq 0 ]]; then
+      wget -qO- "$BOOTSTRAP_URL" | bash
+    else
+      wget -qO- "$BOOTSTRAP_URL" | bash -s -- "${args[@]}"
+    fi
+    return 0
+  fi
+
+  echo "error: curl or wget is required to run remote installer bootstrap." >&2
+  return 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd || pwd)"
+LOCAL_INSTALLER="$SCRIPT_DIR/zeroclaw_install.sh"
+
+declare -a FORWARDED_ARGS=("$@")
+if [[ $# -eq 0 && -t 0 && -t 1 ]]; then
+  FORWARDED_ARGS=(--interactive-onboard)
+fi
+
+if [[ -x "$LOCAL_INSTALLER" ]]; then
+  exec "$LOCAL_INSTALLER" "${FORWARDED_ARGS[@]}"
+fi
+
+run_remote_bootstrap "${FORWARDED_ARGS[@]}"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -22,7 +22,8 @@ Usage:
   ./bootstrap.sh [options]         # compatibility entrypoint
 
 Modes:
-  Default mode installs/builds ZeroClaw only (requires existing Rust toolchain).
+  Default mode installs/builds ZeroClaw (requires existing Rust toolchain).
+  No-flag interactive sessions run full-screen TUI onboarding after install.
   Guided mode asks setup questions and configures options interactively.
   Optional bootstrap mode can also install system dependencies and Rust.
 
@@ -41,7 +42,7 @@ Options:
   --force-source-build       Disable prebuilt flow and always build from source
   --cargo-features <list>    Extra Cargo features for local source build/install (comma-separated)
   --onboard                  Run onboarding after install
-  --interactive-onboard      Run interactive onboarding (implies --onboard)
+  --interactive-onboard      Run full-screen TUI onboarding (implies --onboard; default in no-flag interactive sessions)
   --api-key <key>            API key for non-interactive onboarding
   --provider <id>            Provider for non-interactive onboarding (default: openrouter)
   --model <id>               Model for non-interactive onboarding (optional)
@@ -634,9 +635,12 @@ run_guided_installer() {
     SKIP_INSTALL=true
   fi
 
-  if prompt_yes_no "Run onboarding after install?" "no"; then
+  if [[ "$INTERACTIVE_ONBOARD" == true ]]; then
     RUN_ONBOARD=true
-    if prompt_yes_no "Use interactive onboarding?" "yes"; then
+    info "Onboarding mode preselected: full-screen TUI."
+  elif prompt_yes_no "Run onboarding after install?" "yes"; then
+    RUN_ONBOARD=true
+    if prompt_yes_no "Use full-screen TUI onboarding?" "yes"; then
       INTERACTIVE_ONBOARD=true
     else
       INTERACTIVE_ONBOARD=false
@@ -657,7 +661,7 @@ run_guided_installer() {
       fi
 
       if [[ -z "$API_KEY" ]]; then
-        if ! guided_read api_key_input "API key (hidden, leave empty to switch to interactive onboarding): " true; then
+        if ! guided_read api_key_input "API key (hidden, leave empty to switch to TUI onboarding): " true; then
           echo
           error "guided installer input was interrupted."
           exit 1
@@ -666,11 +670,14 @@ run_guided_installer() {
         if [[ -n "$api_key_input" ]]; then
           API_KEY="$api_key_input"
         else
-          warn "No API key entered. Using interactive onboarding instead."
+          warn "No API key entered. Using TUI onboarding instead."
           INTERACTIVE_ONBOARD=true
         fi
       fi
     fi
+  else
+    RUN_ONBOARD=false
+    INTERACTIVE_ONBOARD=false
   fi
 
   echo
@@ -1236,8 +1243,8 @@ run_docker_bootstrap() {
   if [[ "$RUN_ONBOARD" == true ]]; then
     local onboard_cmd=()
     if [[ "$INTERACTIVE_ONBOARD" == true ]]; then
-      info "Launching interactive onboarding in container"
-      onboard_cmd=(onboard --interactive)
+      info "Launching TUI onboarding in container"
+      onboard_cmd=(onboard --interactive-ui)
     else
       if [[ -z "$API_KEY" ]]; then
         cat <<'MSG'
@@ -1246,7 +1253,7 @@ Use either:
   --api-key "sk-..."
 or:
   ZEROCLAW_API_KEY="sk-..." ./zeroclaw_install.sh --docker
-or run interactive:
+or run TUI onboarding:
   ./zeroclaw_install.sh --docker --interactive-onboard
 MSG
         exit 1
@@ -1454,6 +1461,11 @@ if [[ "$GUIDED_MODE" == "auto" ]]; then
   else
     GUIDED_MODE="off"
   fi
+fi
+
+if [[ "$ORIGINAL_ARG_COUNT" -eq 0 && -t 0 && -t 1 ]]; then
+  RUN_ONBOARD=true
+  INTERACTIVE_ONBOARD=true
 fi
 
 if [[ "$DOCKER_MODE" == true && "$GUIDED_MODE" == "on" ]]; then
@@ -1706,8 +1718,8 @@ if [[ "$RUN_ONBOARD" == true ]]; then
   fi
 
   if [[ "$INTERACTIVE_ONBOARD" == true ]]; then
-    info "Running interactive onboarding"
-    "$ZEROCLAW_BIN" onboard --interactive
+    info "Running TUI onboarding"
+    "$ZEROCLAW_BIN" onboard --interactive-ui
   else
     if [[ -z "$API_KEY" ]]; then
       cat <<'MSG'
@@ -1716,7 +1728,7 @@ Use either:
   --api-key "sk-..."
 or:
   ZEROCLAW_API_KEY="sk-..." ./zeroclaw_install.sh --onboard
-or run interactive:
+or run TUI onboarding:
   ./zeroclaw_install.sh --interactive-onboard
 MSG
       exit 1

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -65,7 +65,7 @@ Usage: install-release.sh [--no-onboard]
 Installs the latest Linux ZeroClaw binary from official GitHub releases.
 
 Options:
-  --no-onboard   Install only; do not run `zeroclaw onboard`
+  --no-onboard   Install only; do not run onboarding
 
 Environment:
   ZEROCLAW_INSTALL_DIR  Override install directory
@@ -141,4 +141,9 @@ if [ "$NO_ONBOARD" -eq 1 ]; then
 fi
 
 echo "==> Starting onboarding"
+if [ -t 0 ] && [ -t 1 ]; then
+  exec "$BIN_PATH" onboard --interactive-ui
+fi
+
+echo "note: non-interactive shell detected; falling back to quick onboarding mode" >&2
 exec "$BIN_PATH" onboard

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,10 @@ enum Commands {
         #[arg(long)]
         interactive: bool,
 
+        /// Run the full-screen TUI onboarding flow (ratatui)
+        #[arg(long)]
+        interactive_ui: bool,
+
         /// Overwrite existing config without confirmation
         #[arg(long)]
         force: bool,
@@ -162,7 +166,7 @@ enum Commands {
         #[arg(long)]
         channels_only: bool,
 
-        /// API key (used in quick mode, ignored with --interactive)
+        /// API key (used in quick mode, ignored with --interactive or --interactive-ui)
         #[arg(long)]
         api_key: Option<String>,
 
@@ -831,12 +835,14 @@ async fn main() -> Result<()> {
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    // Onboard runs quick setup by default, or the interactive wizard with --interactive.
+    // Onboard runs quick setup by default, interactive wizard with --interactive,
+    // or full-screen TUI with --interactive-ui.
     // The onboard wizard uses reqwest::blocking internally, which creates its own
     // Tokio runtime. To avoid "Cannot drop a runtime in a context where blocking is
     // not allowed", we run the wizard on a blocking thread via spawn_blocking.
     if let Commands::Onboard {
         interactive,
+        interactive_ui,
         force,
         channels_only,
         api_key,
@@ -850,6 +856,7 @@ async fn main() -> Result<()> {
     } = &cli.command
     {
         let interactive = *interactive;
+        let interactive_ui = *interactive_ui;
         let force = *force;
         let channels_only = *channels_only;
         let api_key = api_key.clone();
@@ -863,8 +870,25 @@ async fn main() -> Result<()> {
         let openclaw_migration_enabled =
             migrate_openclaw || openclaw_source.is_some() || openclaw_config.is_some();
 
+        if interactive && interactive_ui {
+            bail!("Use either --interactive or --interactive-ui, not both");
+        }
         if interactive && channels_only {
             bail!("Use either --interactive or --channels-only, not both");
+        }
+        if interactive_ui && channels_only {
+            bail!("Use either --interactive-ui or --channels-only, not both");
+        }
+        if interactive_ui
+            && (api_key.is_some()
+                || provider.is_some()
+                || model.is_some()
+                || memory.is_some()
+                || no_totp)
+        {
+            bail!(
+                "--interactive-ui does not accept --api-key, --provider, --model, --memory, or --no-totp"
+            );
         }
         if channels_only
             && (api_key.is_some()
@@ -885,6 +909,16 @@ async fn main() -> Result<()> {
         }
         let config = if channels_only {
             Box::pin(onboard::run_channels_repair_wizard()).await
+        } else if interactive_ui {
+            Box::pin(onboard::run_wizard_tui_with_migration(
+                force,
+                onboard::OpenClawOnboardMigrationOptions {
+                    enabled: openclaw_migration_enabled,
+                    source_workspace: openclaw_source,
+                    source_config: openclaw_config,
+                },
+            ))
+            .await
         } else if interactive {
             Box::pin(onboard::run_wizard_with_migration(
                 force,
@@ -2448,6 +2482,24 @@ mod tests {
 
         match cli.command {
             Commands::Onboard { force, .. } => assert!(force),
+            other => panic!("expected onboard command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn onboard_cli_accepts_interactive_ui_flag() {
+        let cli = Cli::try_parse_from(["zeroclaw", "onboard", "--interactive-ui"])
+            .expect("onboard --interactive-ui should parse");
+
+        match cli.command {
+            Commands::Onboard {
+                interactive,
+                interactive_ui,
+                ..
+            } => {
+                assert!(!interactive);
+                assert!(interactive_ui);
+            }
             other => panic!("expected onboard command, got {other:?}"),
         }
     }

--- a/src/onboard/mod.rs
+++ b/src/onboard/mod.rs
@@ -1,6 +1,9 @@
+pub mod tui;
 pub mod wizard;
 
 // Re-exported for CLI and external use
+#[allow(unused_imports)]
+pub use tui::{run_wizard_tui, run_wizard_tui_with_migration};
 #[allow(unused_imports)]
 pub use wizard::{
     run_channels_repair_wizard, run_models_list, run_models_refresh, run_models_refresh_all,
@@ -21,6 +24,8 @@ mod tests {
         assert_reexport_exists(run_quick_setup);
         assert_reexport_exists(run_quick_setup_with_migration);
         assert_reexport_exists(run_wizard_with_migration);
+        assert_reexport_exists(run_wizard_tui);
+        assert_reexport_exists(run_wizard_tui_with_migration);
         let _: Option<OpenClawOnboardMigrationOptions> = None;
         assert_reexport_exists(run_models_refresh);
         assert_reexport_exists(run_models_list);

--- a/src/onboard/tui.rs
+++ b/src/onboard/tui.rs
@@ -1,0 +1,2690 @@
+use crate::config::schema::{CloudflareTunnelConfig, NgrokTunnelConfig};
+use crate::config::{
+    default_model_fallback_for_provider, ChannelsConfig, Config, DiscordConfig, ProgressMode,
+    StreamMode, TelegramConfig, TunnelConfig,
+};
+use crate::onboard::wizard::{run_quick_setup_with_migration, OpenClawOnboardMigrationOptions};
+use anyhow::{bail, Context, Result};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use console::style;
+use crossterm::cursor::{Hide, Show};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::execute;
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap};
+use ratatui::{Frame, Terminal};
+use reqwest::blocking::Client;
+use serde_json::Value;
+use std::io::{self, IsTerminal};
+use std::path::PathBuf;
+use std::time::Duration;
+
+const PROVIDER_OPTIONS: [&str; 5] = ["openrouter", "openai", "anthropic", "gemini", "ollama"];
+const MEMORY_OPTIONS: [&str; 4] = ["sqlite", "lucid", "markdown", "none"];
+const TUNNEL_OPTIONS: [&str; 3] = ["none", "cloudflare", "ngrok"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Step {
+    Welcome,
+    Workspace,
+    Provider,
+    ProviderDiagnostics,
+    Runtime,
+    Channels,
+    ChannelDiagnostics,
+    Tunnel,
+    TunnelDiagnostics,
+    Review,
+}
+
+impl Step {
+    const ORDER: [Self; 10] = [
+        Self::Welcome,
+        Self::Workspace,
+        Self::Provider,
+        Self::ProviderDiagnostics,
+        Self::Runtime,
+        Self::Channels,
+        Self::ChannelDiagnostics,
+        Self::Tunnel,
+        Self::TunnelDiagnostics,
+        Self::Review,
+    ];
+
+    fn title(self) -> &'static str {
+        match self {
+            Self::Welcome => "Welcome",
+            Self::Workspace => "Workspace",
+            Self::Provider => "AI Provider",
+            Self::ProviderDiagnostics => "Provider Diagnostics",
+            Self::Runtime => "Memory & Security",
+            Self::Channels => "Channels",
+            Self::ChannelDiagnostics => "Channel Diagnostics",
+            Self::Tunnel => "Tunnel",
+            Self::TunnelDiagnostics => "Tunnel Diagnostics",
+            Self::Review => "Review & Apply",
+        }
+    }
+
+    fn help(self) -> &'static str {
+        match self {
+            Self::Welcome => "Review controls and continue to setup.",
+            Self::Workspace => "Pick where config.toml and workspace files should live.",
+            Self::Provider => "Select provider, API key, and default model.",
+            Self::ProviderDiagnostics => "Run live checks against your selected provider.",
+            Self::Runtime => "Choose memory backend and security defaults.",
+            Self::Channels => "Optional: configure Telegram/Discord entry points.",
+            Self::ChannelDiagnostics => "Run channel checks before writing config.",
+            Self::Tunnel => "Optional: expose gateway with Cloudflare or ngrok.",
+            Self::TunnelDiagnostics => "Probe tunnel credentials before apply.",
+            Self::Review => "Validate final config and apply onboarding.",
+        }
+    }
+
+    fn index(self) -> usize {
+        Self::ORDER
+            .iter()
+            .position(|candidate| *candidate == self)
+            .unwrap_or(0)
+    }
+
+    fn next(self) -> Self {
+        let idx = self.index();
+        if idx + 1 >= Self::ORDER.len() {
+            self
+        } else {
+            Self::ORDER[idx + 1]
+        }
+    }
+
+    fn previous(self) -> Self {
+        let idx = self.index();
+        if idx == 0 {
+            self
+        } else {
+            Self::ORDER[idx - 1]
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FieldKey {
+    Continue,
+    WorkspacePath,
+    ForceOverwrite,
+    Provider,
+    ApiKey,
+    Model,
+    MemoryBackend,
+    DisableTotp,
+    EnableTelegram,
+    TelegramToken,
+    TelegramAllowedUsers,
+    EnableDiscord,
+    DiscordToken,
+    DiscordGuildId,
+    DiscordAllowedUsers,
+    AutostartChannels,
+    TunnelProvider,
+    CloudflareToken,
+    NgrokAuthToken,
+    NgrokDomain,
+    RunProviderProbe,
+    ProviderProbeResult,
+    ProviderProbeDetails,
+    ProviderProbeRemediation,
+    RunTelegramProbe,
+    TelegramProbeResult,
+    TelegramProbeDetails,
+    TelegramProbeRemediation,
+    RunDiscordProbe,
+    DiscordProbeResult,
+    DiscordProbeDetails,
+    DiscordProbeRemediation,
+    RunCloudflareProbe,
+    CloudflareProbeResult,
+    CloudflareProbeDetails,
+    CloudflareProbeRemediation,
+    RunNgrokProbe,
+    NgrokProbeResult,
+    NgrokProbeDetails,
+    NgrokProbeRemediation,
+    AllowFailedDiagnostics,
+    Apply,
+}
+
+#[derive(Debug, Clone)]
+struct FieldView {
+    key: FieldKey,
+    label: &'static str,
+    value: String,
+    hint: &'static str,
+    required: bool,
+    editable: bool,
+}
+
+#[derive(Debug, Clone)]
+enum CheckStatus {
+    NotRun,
+    Passed(String),
+    Failed(String),
+    Skipped(String),
+}
+
+impl CheckStatus {
+    fn as_line(&self) -> String {
+        match self {
+            Self::NotRun => "not run".to_string(),
+            Self::Passed(details) => format!("pass: {details}"),
+            Self::Failed(details) => format!("fail: {details}"),
+            Self::Skipped(details) => format!("skipped: {details}"),
+        }
+    }
+
+    fn badge(&self) -> &'static str {
+        match self {
+            Self::NotRun => "idle",
+            Self::Passed(_) => "pass",
+            Self::Failed(_) => "fail",
+            Self::Skipped(_) => "skip",
+        }
+    }
+
+    fn is_failed(&self) -> bool {
+        matches!(self, Self::Failed(_))
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TuiOnboardPlan {
+    workspace_path: String,
+    force_overwrite: bool,
+    provider_idx: usize,
+    api_key: String,
+    model: String,
+    memory_idx: usize,
+    disable_totp: bool,
+    enable_telegram: bool,
+    telegram_token: String,
+    telegram_allowed_users: String,
+    enable_discord: bool,
+    discord_token: String,
+    discord_guild_id: String,
+    discord_allowed_users: String,
+    autostart_channels: bool,
+    tunnel_idx: usize,
+    cloudflare_token: String,
+    ngrok_auth_token: String,
+    ngrok_domain: String,
+    allow_failed_diagnostics: bool,
+}
+
+impl TuiOnboardPlan {
+    fn new(default_workspace: PathBuf, force: bool) -> Self {
+        let provider = PROVIDER_OPTIONS[0];
+        Self {
+            workspace_path: default_workspace.display().to_string(),
+            force_overwrite: force,
+            provider_idx: 0,
+            api_key: String::new(),
+            model: provider_default_model(provider),
+            memory_idx: 0,
+            disable_totp: false,
+            enable_telegram: false,
+            telegram_token: String::new(),
+            telegram_allowed_users: String::new(),
+            enable_discord: false,
+            discord_token: String::new(),
+            discord_guild_id: String::new(),
+            discord_allowed_users: String::new(),
+            autostart_channels: true,
+            tunnel_idx: 0,
+            cloudflare_token: String::new(),
+            ngrok_auth_token: String::new(),
+            ngrok_domain: String::new(),
+            allow_failed_diagnostics: false,
+        }
+    }
+
+    fn provider(&self) -> &str {
+        PROVIDER_OPTIONS[self.provider_idx]
+    }
+
+    fn memory_backend(&self) -> &str {
+        MEMORY_OPTIONS[self.memory_idx]
+    }
+
+    fn tunnel_provider(&self) -> &str {
+        TUNNEL_OPTIONS[self.tunnel_idx]
+    }
+}
+
+#[derive(Debug, Clone)]
+struct EditingState {
+    key: FieldKey,
+    value: String,
+    secret: bool,
+}
+
+#[derive(Debug, Clone)]
+struct TuiState {
+    step: Step,
+    focus: usize,
+    editing: Option<EditingState>,
+    status: String,
+    plan: TuiOnboardPlan,
+    model_touched: bool,
+    force_locked: bool,
+    provider_probe: CheckStatus,
+    telegram_probe: CheckStatus,
+    discord_probe: CheckStatus,
+    cloudflare_probe: CheckStatus,
+    ngrok_probe: CheckStatus,
+}
+
+impl TuiState {
+    fn new(default_workspace: PathBuf, force: bool) -> Self {
+        Self {
+            step: Step::Welcome,
+            focus: 0,
+            editing: None,
+            status: "Controls: arrows/jkhl + Enter. Use n/p for next/back steps, Ctrl+S to save edits, q to quit."
+                .to_string(),
+            plan: TuiOnboardPlan::new(default_workspace, force),
+            model_touched: false,
+            force_locked: force,
+            provider_probe: CheckStatus::NotRun,
+            telegram_probe: CheckStatus::NotRun,
+            discord_probe: CheckStatus::NotRun,
+            cloudflare_probe: CheckStatus::NotRun,
+            ngrok_probe: CheckStatus::NotRun,
+        }
+    }
+
+    fn visible_fields(&self) -> Vec<FieldView> {
+        match self.step {
+            Step::Welcome => vec![FieldView {
+                key: FieldKey::Continue,
+                label: "Start",
+                value: "Press Enter to begin onboarding".to_string(),
+                hint: "Move to the first setup step.",
+                required: false,
+                editable: false,
+            }],
+            Step::Workspace => vec![
+                FieldView {
+                    key: FieldKey::WorkspacePath,
+                    label: "Workspace path",
+                    value: display_value(&self.plan.workspace_path, false),
+                    hint: "~ is supported and will be expanded.",
+                    required: true,
+                    editable: true,
+                },
+                FieldView {
+                    key: FieldKey::ForceOverwrite,
+                    label: "Overwrite existing config",
+                    value: bool_label(self.plan.force_overwrite),
+                    hint: if self.force_locked {
+                        "Locked on because --force was passed on CLI."
+                    } else {
+                        "Enable to overwrite existing config.toml."
+                    },
+                    required: false,
+                    editable: !self.force_locked,
+                },
+            ],
+            Step::Provider => vec![
+                FieldView {
+                    key: FieldKey::Provider,
+                    label: "Provider",
+                    value: self.plan.provider().to_string(),
+                    hint: "Pick your primary model provider.",
+                    required: true,
+                    editable: true,
+                },
+                FieldView {
+                    key: FieldKey::ApiKey,
+                    label: "API key",
+                    value: display_value(&self.plan.api_key, true),
+                    hint: "Optional for keyless/local providers.",
+                    required: false,
+                    editable: true,
+                },
+                FieldView {
+                    key: FieldKey::Model,
+                    label: "Default model",
+                    value: display_value(&self.plan.model, false),
+                    hint: "Used as default for `zeroclaw agent`.",
+                    required: true,
+                    editable: true,
+                },
+            ],
+            Step::ProviderDiagnostics => vec![
+                FieldView {
+                    key: FieldKey::RunProviderProbe,
+                    label: "Run provider probe",
+                    value: "Press Enter to test connectivity".to_string(),
+                    hint: "Uses provider-specific model-list/API health request.",
+                    required: false,
+                    editable: false,
+                },
+                FieldView {
+                    key: FieldKey::ProviderProbeResult,
+                    label: "Provider probe status",
+                    value: self.provider_probe.as_line(),
+                    hint: "Probe is advisory; apply is still allowed on failure.",
+                    required: false,
+                    editable: false,
+                },
+                FieldView {
+                    key: FieldKey::ProviderProbeDetails,
+                    label: "Provider check details",
+                    value: self.provider_probe_details(),
+                    hint: "Shows what was checked in this probe run.",
+                    required: false,
+                    editable: false,
+                },
+                FieldView {
+                    key: FieldKey::ProviderProbeRemediation,
+                    label: "Provider remediation",
+                    value: self.provider_probe_remediation(),
+                    hint: "Actionable next step for failures/skips.",
+                    required: false,
+                    editable: false,
+                },
+            ],
+            Step::Runtime => vec![
+                FieldView {
+                    key: FieldKey::MemoryBackend,
+                    label: "Memory backend",
+                    value: self.plan.memory_backend().to_string(),
+                    hint: "sqlite is the safest default for most setups.",
+                    required: true,
+                    editable: true,
+                },
+                FieldView {
+                    key: FieldKey::DisableTotp,
+                    label: "Disable TOTP",
+                    value: bool_label(self.plan.disable_totp),
+                    hint: "Keep off unless you explicitly want no OTP challenge.",
+                    required: false,
+                    editable: true,
+                },
+            ],
+            Step::Channels => {
+                let mut rows = vec![
+                    FieldView {
+                        key: FieldKey::EnableTelegram,
+                        label: "Enable Telegram",
+                        value: bool_label(self.plan.enable_telegram),
+                        hint: "Adds Telegram bot channel config.",
+                        required: false,
+                        editable: true,
+                    },
+                    FieldView {
+                        key: FieldKey::EnableDiscord,
+                        label: "Enable Discord",
+                        value: bool_label(self.plan.enable_discord),
+                        hint: "Adds Discord bot channel config.",
+                        required: false,
+                        editable: true,
+                    },
+                    FieldView {
+                        key: FieldKey::AutostartChannels,
+                        label: "Autostart channels",
+                        value: bool_label(self.plan.autostart_channels),
+                        hint: "If enabled, channel server starts after onboarding.",
+                        required: false,
+                        editable: true,
+                    },
+                ];
+                if self.plan.enable_telegram {
+                    rows.insert(
+                        1,
+                        FieldView {
+                            key: FieldKey::TelegramToken,
+                            label: "Telegram bot token",
+                            value: display_value(&self.plan.telegram_token, true),
+                            hint: "Token from @BotFather.",
+                            required: true,
+                            editable: true,
+                        },
+                    );
+                    rows.insert(
+                        2,
+                        FieldView {
+                            key: FieldKey::TelegramAllowedUsers,
+                            label: "Telegram allowlist",
+                            value: display_value(&self.plan.telegram_allowed_users, false),
+                            hint: "Comma-separated user IDs/usernames; empty blocks all.",
+                            required: false,
+                            editable: true,
+                        },
+                    );
+                }
+                if self.plan.enable_discord {
+                    let base = if self.plan.enable_telegram { 4 } else { 2 };
+                    rows.insert(
+                        base,
+                        FieldView {
+                            key: FieldKey::DiscordToken,
+                            label: "Discord bot token",
+                            value: display_value(&self.plan.discord_token, true),
+                            hint: "Bot token from Discord Developer Portal.",
+                            required: true,
+                            editable: true,
+                        },
+                    );
+                    rows.insert(
+                        base + 1,
+                        FieldView {
+                            key: FieldKey::DiscordGuildId,
+                            label: "Discord guild ID",
+                            value: display_value(&self.plan.discord_guild_id, false),
+                            hint: "Optional server scope.",
+                            required: false,
+                            editable: true,
+                        },
+                    );
+                    rows.insert(
+                        base + 2,
+                        FieldView {
+                            key: FieldKey::DiscordAllowedUsers,
+                            label: "Discord allowlist",
+                            value: display_value(&self.plan.discord_allowed_users, false),
+                            hint: "Comma-separated user IDs; empty blocks all.",
+                            required: false,
+                            editable: true,
+                        },
+                    );
+                }
+                rows
+            }
+            Step::ChannelDiagnostics => {
+                let mut rows = Vec::new();
+                if self.plan.enable_telegram {
+                    rows.push(FieldView {
+                        key: FieldKey::RunTelegramProbe,
+                        label: "Run Telegram test",
+                        value: "Press Enter to call getMe".to_string(),
+                        hint: "Validates bot token with Telegram API.",
+                        required: false,
+                        editable: false,
+                    });
+                    rows.push(FieldView {
+                        key: FieldKey::TelegramProbeResult,
+                        label: "Telegram status",
+                        value: self.telegram_probe.as_line(),
+                        hint: "Requires internet connectivity.",
+                        required: false,
+                        editable: false,
+                    });
+                    rows.push(FieldView {
+                        key: FieldKey::TelegramProbeDetails,
+                        label: "Telegram check details",
+                        value: self.telegram_probe_details(),
+                        hint: "Connection + token health for Telegram bot.",
+                        required: false,
+                        editable: false,
+                    });
+                    rows.push(FieldView {
+                        key: FieldKey::TelegramProbeRemediation,
+                        label: "Telegram remediation",
+                        value: self.telegram_probe_remediation(),
+                        hint: "What to fix when Telegram checks fail.",
+                        required: false,
+                        editable: false,
+                    });
+                }
+                if self.plan.enable_discord {
+                    rows.push(FieldView {
+                        key: FieldKey::RunDiscordProbe,
+                        label: "Run Discord test",
+                        value: "Press Enter to query bot guilds".to_string(),
+                        hint: "Validates bot token and optional guild scope.",
+                        required: false,
+                        editable: false,
+                    });
+                    rows.push(FieldView {
+                        key: FieldKey::DiscordProbeResult,
+                        label: "Discord status",
+                        value: self.discord_probe.as_line(),
+                        hint: "Requires internet connectivity.",
+                        required: false,
+                        editable: false,
+                    });
+                    rows.push(FieldView {
+                        key: FieldKey::DiscordProbeDetails,
+                        label: "Discord check details",
+                        value: self.discord_probe_details(),
+                        hint: "Token + optional guild visibility checks.",
+                        required: false,
+                        editable: false,
+                    });
+                    rows.push(FieldView {
+                        key: FieldKey::DiscordProbeRemediation,
+                        label: "Discord remediation",
+                        value: self.discord_probe_remediation(),
+                        hint: "What to fix when Discord checks fail.",
+                        required: false,
+                        editable: false,
+                    });
+                }
+
+                if rows.is_empty() {
+                    rows.push(FieldView {
+                        key: FieldKey::Continue,
+                        label: "No checks configured",
+                        value: "Enable Telegram or Discord in previous step".to_string(),
+                        hint: "Use n or PageDown to continue.",
+                        required: false,
+                        editable: false,
+                    });
+                }
+
+                rows
+            }
+            Step::Tunnel => {
+                let mut rows = vec![FieldView {
+                    key: FieldKey::TunnelProvider,
+                    label: "Tunnel provider",
+                    value: self.plan.tunnel_provider().to_string(),
+                    hint: "none keeps ZeroClaw local-only.",
+                    required: true,
+                    editable: true,
+                }];
+                match self.plan.tunnel_provider() {
+                    "cloudflare" => rows.push(FieldView {
+                        key: FieldKey::CloudflareToken,
+                        label: "Cloudflare token",
+                        value: display_value(&self.plan.cloudflare_token, true),
+                        hint: "Token from Cloudflare Zero Trust dashboard.",
+                        required: true,
+                        editable: true,
+                    }),
+                    "ngrok" => {
+                        rows.push(FieldView {
+                            key: FieldKey::NgrokAuthToken,
+                            label: "ngrok auth token",
+                            value: display_value(&self.plan.ngrok_auth_token, true),
+                            hint: "Token from dashboard.ngrok.com.",
+                            required: true,
+                            editable: true,
+                        });
+                        rows.push(FieldView {
+                            key: FieldKey::NgrokDomain,
+                            label: "ngrok domain",
+                            value: display_value(&self.plan.ngrok_domain, false),
+                            hint: "Optional custom domain.",
+                            required: false,
+                            editable: true,
+                        });
+                    }
+                    _ => {}
+                }
+                rows
+            }
+            Step::TunnelDiagnostics => match self.plan.tunnel_provider() {
+                "cloudflare" => vec![
+                    FieldView {
+                        key: FieldKey::RunCloudflareProbe,
+                        label: "Run Cloudflare token probe",
+                        value: "Press Enter to decode token payload".to_string(),
+                        hint: "Checks JWT-like tunnel token structure and claims.",
+                        required: false,
+                        editable: false,
+                    },
+                    FieldView {
+                        key: FieldKey::CloudflareProbeResult,
+                        label: "Cloudflare status",
+                        value: self.cloudflare_probe.as_line(),
+                        hint: "Probe is offline and does not call Cloudflare API.",
+                        required: false,
+                        editable: false,
+                    },
+                    FieldView {
+                        key: FieldKey::CloudflareProbeDetails,
+                        label: "Cloudflare check details",
+                        value: self.cloudflare_probe_details(),
+                        hint: "Token shape/claim diagnostics from local decode.",
+                        required: false,
+                        editable: false,
+                    },
+                    FieldView {
+                        key: FieldKey::CloudflareProbeRemediation,
+                        label: "Cloudflare remediation",
+                        value: self.cloudflare_probe_remediation(),
+                        hint: "How to recover from token parse failures.",
+                        required: false,
+                        editable: false,
+                    },
+                ],
+                "ngrok" => vec![
+                    FieldView {
+                        key: FieldKey::RunNgrokProbe,
+                        label: "Run ngrok API probe",
+                        value: "Press Enter to verify API token".to_string(),
+                        hint: "Calls ngrok API /tunnels with auth token.",
+                        required: false,
+                        editable: false,
+                    },
+                    FieldView {
+                        key: FieldKey::NgrokProbeResult,
+                        label: "ngrok status",
+                        value: self.ngrok_probe.as_line(),
+                        hint: "Probe is advisory; apply blocks on explicit failures.",
+                        required: false,
+                        editable: false,
+                    },
+                    FieldView {
+                        key: FieldKey::NgrokProbeDetails,
+                        label: "ngrok check details",
+                        value: self.ngrok_probe_details(),
+                        hint: "API token auth + active tunnel visibility.",
+                        required: false,
+                        editable: false,
+                    },
+                    FieldView {
+                        key: FieldKey::NgrokProbeRemediation,
+                        label: "ngrok remediation",
+                        value: self.ngrok_probe_remediation(),
+                        hint: "How to recover from ngrok auth/network failures.",
+                        required: false,
+                        editable: false,
+                    },
+                ],
+                _ => vec![FieldView {
+                    key: FieldKey::Continue,
+                    label: "No tunnel diagnostics",
+                    value: "Diagnostics available for cloudflare or ngrok providers".to_string(),
+                    hint: "Use n or PageDown to continue.",
+                    required: false,
+                    editable: false,
+                }],
+            },
+            Step::Review => vec![
+                FieldView {
+                    key: FieldKey::AllowFailedDiagnostics,
+                    label: "Allow failed diagnostics",
+                    value: bool_label(self.plan.allow_failed_diagnostics),
+                    hint: "Keep off for production safety. Toggle only if failures are understood.",
+                    required: false,
+                    editable: true,
+                },
+                FieldView {
+                    key: FieldKey::Apply,
+                    label: "Apply onboarding",
+                    value: "Press Enter (or a/s) to generate config".to_string(),
+                    hint: "Use p/PageUp to revisit steps. Enter, a, or s applies.",
+                    required: false,
+                    editable: false,
+                },
+            ],
+        }
+    }
+
+    fn current_field_key(&self) -> Option<FieldKey> {
+        let fields = self.visible_fields();
+        fields.get(self.focus).map(|field| field.key)
+    }
+
+    fn move_focus(&mut self, delta: isize) {
+        let total = self.visible_fields().len();
+        if total == 0 {
+            self.focus = 0;
+            return;
+        }
+
+        let mut next = self.focus as isize + delta;
+        if next < 0 {
+            next = total as isize - 1;
+        }
+        if next >= total as isize {
+            next = 0;
+        }
+        self.focus = next as usize;
+    }
+
+    fn clamp_focus(&mut self) {
+        let total = self.visible_fields().len();
+        if total == 0 {
+            self.focus = 0;
+        } else if self.focus >= total {
+            self.focus = total - 1;
+        }
+    }
+
+    fn validate_step(&self, step: Step) -> Result<()> {
+        match step {
+            Step::Welcome => Ok(()),
+            Step::Workspace => {
+                if self.plan.workspace_path.trim().is_empty() {
+                    bail!("Workspace path is required")
+                }
+                Ok(())
+            }
+            Step::Provider => {
+                if self.plan.model.trim().is_empty() {
+                    bail!("Default model is required")
+                }
+                Ok(())
+            }
+            Step::ProviderDiagnostics => Ok(()),
+            Step::Runtime => Ok(()),
+            Step::Channels => {
+                if self.plan.enable_telegram && self.plan.telegram_token.trim().is_empty() {
+                    bail!("Telegram is enabled but bot token is empty")
+                }
+                if self.plan.enable_discord && self.plan.discord_token.trim().is_empty() {
+                    bail!("Discord is enabled but bot token is empty")
+                }
+                Ok(())
+            }
+            Step::ChannelDiagnostics => Ok(()),
+            Step::Tunnel => match self.plan.tunnel_provider() {
+                "cloudflare" if self.plan.cloudflare_token.trim().is_empty() => {
+                    bail!("Cloudflare tunnel token is required when tunnel provider is cloudflare")
+                }
+                "ngrok" if self.plan.ngrok_auth_token.trim().is_empty() => {
+                    bail!("ngrok auth token is required when tunnel provider is ngrok")
+                }
+                _ => Ok(()),
+            },
+            Step::TunnelDiagnostics => Ok(()),
+            Step::Review => {
+                self.validate_all()?;
+                let failures = self.blocking_diagnostic_failures();
+                if !failures.is_empty() && !self.plan.allow_failed_diagnostics {
+                    bail!(
+                        "Blocking diagnostics failed: {}. Re-run checks or enable 'Allow failed diagnostics' to continue.",
+                        failures.join(", ")
+                    );
+                }
+                if let Some(config_path) = self.selected_config_path()? {
+                    if config_path.exists() && !self.plan.force_overwrite {
+                        bail!(
+                            "Config already exists at {}. Enable overwrite to continue.",
+                            config_path.display()
+                        )
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn validate_all(&self) -> Result<()> {
+        for step in [
+            Step::Workspace,
+            Step::Provider,
+            Step::ProviderDiagnostics,
+            Step::Runtime,
+            Step::Channels,
+            Step::ChannelDiagnostics,
+            Step::Tunnel,
+            Step::TunnelDiagnostics,
+        ] {
+            self.validate_step(step)?;
+        }
+        Ok(())
+    }
+
+    fn blocking_diagnostic_failures(&self) -> Vec<String> {
+        let mut failures = Vec::new();
+
+        if self.provider_probe.is_failed() {
+            failures.push("provider".to_string());
+        }
+        if self.plan.enable_telegram && self.telegram_probe.is_failed() {
+            failures.push("telegram".to_string());
+        }
+        if self.plan.enable_discord && self.discord_probe.is_failed() {
+            failures.push("discord".to_string());
+        }
+        match self.plan.tunnel_provider() {
+            "cloudflare" if self.cloudflare_probe.is_failed() => {
+                failures.push("cloudflare-tunnel".to_string());
+            }
+            "ngrok" if self.ngrok_probe.is_failed() => {
+                failures.push("ngrok-tunnel".to_string());
+            }
+            _ => {}
+        }
+
+        failures
+    }
+
+    fn provider_probe_details(&self) -> String {
+        let provider = self.plan.provider();
+        match &self.provider_probe {
+            CheckStatus::NotRun => {
+                format!("{provider}: probe not run yet (model listing endpoint check).")
+            }
+            CheckStatus::Passed(details) => format!("{provider}: {details}"),
+            CheckStatus::Failed(details) => format!("{provider}: {details}"),
+            CheckStatus::Skipped(details) => format!("{provider}: {details}"),
+        }
+    }
+
+    fn provider_probe_remediation(&self) -> String {
+        let provider = self.plan.provider();
+        match &self.provider_probe {
+            CheckStatus::NotRun => "Run provider probe with Enter or r.".to_string(),
+            CheckStatus::Passed(_) => "No provider remediation required.".to_string(),
+            CheckStatus::Skipped(details) => {
+                if details.contains("missing API key") {
+                    format!(
+                        "Set a {provider} API key in AI Provider step, or switch to ollama for local usage."
+                    )
+                } else {
+                    format!("Review skip reason and re-run: {details}")
+                }
+            }
+            CheckStatus::Failed(details) => {
+                if provider == "ollama" {
+                    "Start Ollama (`ollama serve`) and verify http://127.0.0.1:11434 is reachable."
+                        .to_string()
+                } else if contains_http_status(details, 401) || contains_http_status(details, 403) {
+                    format!(
+                        "Verify {provider} API key permissions and organization scope, then re-run."
+                    )
+                } else if looks_like_network_error(details) {
+                    "Check network/firewall/proxy access to provider API, then re-run probe."
+                        .to_string()
+                } else {
+                    format!("Resolve provider error and re-run probe: {details}")
+                }
+            }
+        }
+    }
+
+    fn telegram_probe_details(&self) -> String {
+        if !self.plan.enable_telegram {
+            return "Telegram channel disabled.".to_string();
+        }
+
+        let allow_count = parse_csv_list(&self.plan.telegram_allowed_users).len();
+        let allowlist_summary = if allow_count == 0 {
+            "allowlist empty (messages blocked until populated)".to_string()
+        } else {
+            format!("allowlist entries: {allow_count}")
+        };
+
+        match &self.telegram_probe {
+            CheckStatus::NotRun => format!("Telegram probe not run; {allowlist_summary}."),
+            CheckStatus::Passed(details) => format!("{details}; {allowlist_summary}."),
+            CheckStatus::Failed(details) => format!("{details}; {allowlist_summary}."),
+            CheckStatus::Skipped(details) => format!("{details}; {allowlist_summary}."),
+        }
+    }
+
+    fn telegram_probe_remediation(&self) -> String {
+        if !self.plan.enable_telegram {
+            return "Enable Telegram in Channels step to run diagnostics.".to_string();
+        }
+
+        let allow_count = parse_csv_list(&self.plan.telegram_allowed_users).len();
+        match &self.telegram_probe {
+            CheckStatus::NotRun => "Run Telegram test with Enter or r.".to_string(),
+            CheckStatus::Passed(_) if allow_count == 0 => {
+                "Optional hardening: add Telegram allowlist entries before production use."
+                    .to_string()
+            }
+            CheckStatus::Passed(_) => "No Telegram remediation required.".to_string(),
+            CheckStatus::Skipped(details) => format!("Review skip reason and re-run: {details}"),
+            CheckStatus::Failed(details) => {
+                let lower = details.to_ascii_lowercase();
+                if details.contains("bot token is empty") {
+                    "Set Telegram bot token from @BotFather in Channels step.".to_string()
+                } else if contains_http_status(details, 401)
+                    || contains_http_status(details, 403)
+                    || lower.contains("unauthorized")
+                {
+                    "Regenerate Telegram bot token in @BotFather and update Channels step."
+                        .to_string()
+                } else if looks_like_network_error(details) {
+                    "Verify connectivity to api.telegram.org (proxy/firewall/DNS), then re-run."
+                        .to_string()
+                } else {
+                    format!("Resolve Telegram error and re-run: {details}")
+                }
+            }
+        }
+    }
+
+    fn discord_probe_details(&self) -> String {
+        if !self.plan.enable_discord {
+            return "Discord channel disabled.".to_string();
+        }
+
+        let guild_id = self.plan.discord_guild_id.trim();
+        let guild_scope = if guild_id.is_empty() {
+            "guild scope: all guilds visible to bot token".to_string()
+        } else {
+            format!("guild scope: {guild_id}")
+        };
+        let allow_count = parse_csv_list(&self.plan.discord_allowed_users).len();
+        let allowlist_summary = if allow_count == 0 {
+            "allowlist empty (messages blocked until populated)".to_string()
+        } else {
+            format!("allowlist entries: {allow_count}")
+        };
+
+        match &self.discord_probe {
+            CheckStatus::NotRun => {
+                format!("Discord probe not run; {guild_scope}; {allowlist_summary}.")
+            }
+            CheckStatus::Passed(details) => {
+                format!("{details}; {guild_scope}; {allowlist_summary}.")
+            }
+            CheckStatus::Failed(details) => {
+                format!("{details}; {guild_scope}; {allowlist_summary}.")
+            }
+            CheckStatus::Skipped(details) => {
+                format!("{details}; {guild_scope}; {allowlist_summary}.")
+            }
+        }
+    }
+
+    fn discord_probe_remediation(&self) -> String {
+        if !self.plan.enable_discord {
+            return "Enable Discord in Channels step to run diagnostics.".to_string();
+        }
+
+        let allow_count = parse_csv_list(&self.plan.discord_allowed_users).len();
+        match &self.discord_probe {
+            CheckStatus::NotRun => "Run Discord test with Enter or r.".to_string(),
+            CheckStatus::Passed(_) if allow_count == 0 => {
+                "Optional hardening: add Discord allowlist user IDs before production use."
+                    .to_string()
+            }
+            CheckStatus::Passed(_) => "No Discord remediation required.".to_string(),
+            CheckStatus::Skipped(details) => format!("Review skip reason and re-run: {details}"),
+            CheckStatus::Failed(details) => {
+                let lower = details.to_ascii_lowercase();
+                if details.contains("bot token is empty") {
+                    "Set Discord bot token from Discord Developer Portal in Channels step."
+                        .to_string()
+                } else if contains_http_status(details, 401)
+                    || contains_http_status(details, 403)
+                    || lower.contains("unauthorized")
+                {
+                    "Rotate Discord bot token and verify bot app permissions/intents.".to_string()
+                } else if details.contains("not found in bot membership") {
+                    "Invite bot to target guild or correct Guild ID, then re-run.".to_string()
+                } else if looks_like_network_error(details) {
+                    "Verify connectivity to discord.com API (proxy/firewall/DNS), then re-run."
+                        .to_string()
+                } else {
+                    format!("Resolve Discord error and re-run: {details}")
+                }
+            }
+        }
+    }
+
+    fn cloudflare_probe_details(&self) -> String {
+        match &self.cloudflare_probe {
+            CheckStatus::NotRun => {
+                "Cloudflare token probe not run; validates local token structure only.".to_string()
+            }
+            CheckStatus::Passed(details) => {
+                format!("Token payload decoded successfully ({details}).")
+            }
+            CheckStatus::Failed(details) => format!("Token decode failed ({details})."),
+            CheckStatus::Skipped(details) => details.clone(),
+        }
+    }
+
+    fn cloudflare_probe_remediation(&self) -> String {
+        match &self.cloudflare_probe {
+            CheckStatus::NotRun => "Run Cloudflare token probe with Enter or r.".to_string(),
+            CheckStatus::Passed(_) => "No Cloudflare token remediation required.".to_string(),
+            CheckStatus::Skipped(details) => format!("Review skip reason and re-run: {details}"),
+            CheckStatus::Failed(details) => {
+                if details.contains("token is empty") {
+                    "Set Cloudflare tunnel token in Tunnel step.".to_string()
+                } else if details.contains("JWT-like") {
+                    "Use full token from Cloudflare Zero Trust (cloudflared tunnel token output)."
+                        .to_string()
+                } else if details.contains("payload decode failed") {
+                    "Token appears truncated/corrupted; paste a fresh Cloudflare token.".to_string()
+                } else if details.contains("payload parse failed") {
+                    "Regenerate tunnel token in Cloudflare dashboard and retry.".to_string()
+                } else {
+                    format!("Resolve Cloudflare token error and re-run: {details}")
+                }
+            }
+        }
+    }
+
+    fn ngrok_probe_details(&self) -> String {
+        let domain_note = if self.plan.ngrok_domain.trim().is_empty() {
+            "custom domain: not set".to_string()
+        } else {
+            format!(
+                "custom domain: {} (domain ownership not validated here)",
+                self.plan.ngrok_domain.trim()
+            )
+        };
+
+        match &self.ngrok_probe {
+            CheckStatus::NotRun => format!("ngrok probe not run; {domain_note}."),
+            CheckStatus::Passed(details) => format!("{details}; {domain_note}."),
+            CheckStatus::Failed(details) => format!("{details}; {domain_note}."),
+            CheckStatus::Skipped(details) => format!("{details}; {domain_note}."),
+        }
+    }
+
+    fn ngrok_probe_remediation(&self) -> String {
+        match &self.ngrok_probe {
+            CheckStatus::NotRun => "Run ngrok API probe with Enter or r.".to_string(),
+            CheckStatus::Passed(_) => "No ngrok remediation required.".to_string(),
+            CheckStatus::Skipped(details) => format!("Review skip reason and re-run: {details}"),
+            CheckStatus::Failed(details) => {
+                if details.contains("auth token is empty") {
+                    "Set ngrok auth token in Tunnel step.".to_string()
+                } else if contains_http_status(details, 401) || contains_http_status(details, 403) {
+                    "Rotate/verify ngrok API token in dashboard.ngrok.com and re-run.".to_string()
+                } else if looks_like_network_error(details) {
+                    "Verify connectivity to api.ngrok.com (proxy/firewall/DNS), then re-run."
+                        .to_string()
+                } else {
+                    format!("Resolve ngrok error and re-run: {details}")
+                }
+            }
+        }
+    }
+
+    fn selected_config_path(&self) -> Result<Option<PathBuf>> {
+        let trimmed = self.plan.workspace_path.trim();
+        if trimmed.is_empty() {
+            return Ok(None);
+        }
+        let expanded = shellexpand::tilde(trimmed).to_string();
+        let path = PathBuf::from(expanded);
+        let (config_dir, _) = crate::config::schema::resolve_config_dir_for_workspace(&path);
+        Ok(Some(config_dir.join("config.toml")))
+    }
+
+    fn start_editing(&mut self) {
+        if self.editing.is_some() {
+            return;
+        }
+
+        let Some(field_key) = self.current_field_key() else {
+            return;
+        };
+
+        let (value, secret) = match field_key {
+            FieldKey::WorkspacePath => (self.plan.workspace_path.clone(), false),
+            FieldKey::ApiKey => (self.plan.api_key.clone(), true),
+            FieldKey::Model => (self.plan.model.clone(), false),
+            FieldKey::TelegramToken => (self.plan.telegram_token.clone(), true),
+            FieldKey::TelegramAllowedUsers => (self.plan.telegram_allowed_users.clone(), false),
+            FieldKey::DiscordToken => (self.plan.discord_token.clone(), true),
+            FieldKey::DiscordGuildId => (self.plan.discord_guild_id.clone(), false),
+            FieldKey::DiscordAllowedUsers => (self.plan.discord_allowed_users.clone(), false),
+            FieldKey::CloudflareToken => (self.plan.cloudflare_token.clone(), true),
+            FieldKey::NgrokAuthToken => (self.plan.ngrok_auth_token.clone(), true),
+            FieldKey::NgrokDomain => (self.plan.ngrok_domain.clone(), false),
+            _ => return,
+        };
+
+        self.editing = Some(EditingState {
+            key: field_key,
+            value,
+            secret,
+        });
+        self.status =
+            "Editing field: Enter or Ctrl+S saves, Esc cancels, Ctrl+U clears.".to_string();
+    }
+
+    fn commit_editing(&mut self) {
+        let Some(editing) = self.editing.take() else {
+            return;
+        };
+
+        let value = editing.value.trim().to_string();
+        match editing.key {
+            FieldKey::WorkspacePath => self.plan.workspace_path = value,
+            FieldKey::ApiKey => {
+                self.plan.api_key = value;
+                self.provider_probe = CheckStatus::NotRun;
+            }
+            FieldKey::Model => {
+                self.plan.model = value;
+                self.model_touched = true;
+                self.provider_probe = CheckStatus::NotRun;
+            }
+            FieldKey::TelegramToken => {
+                self.plan.telegram_token = value;
+                self.telegram_probe = CheckStatus::NotRun;
+            }
+            FieldKey::TelegramAllowedUsers => self.plan.telegram_allowed_users = value,
+            FieldKey::DiscordToken => {
+                self.plan.discord_token = value;
+                self.discord_probe = CheckStatus::NotRun;
+            }
+            FieldKey::DiscordGuildId => {
+                self.plan.discord_guild_id = value;
+                self.discord_probe = CheckStatus::NotRun;
+            }
+            FieldKey::DiscordAllowedUsers => self.plan.discord_allowed_users = value,
+            FieldKey::CloudflareToken => {
+                self.plan.cloudflare_token = value;
+                self.cloudflare_probe = CheckStatus::NotRun;
+            }
+            FieldKey::NgrokAuthToken => {
+                self.plan.ngrok_auth_token = value;
+                self.ngrok_probe = CheckStatus::NotRun;
+            }
+            FieldKey::NgrokDomain => {
+                self.plan.ngrok_domain = value;
+                self.ngrok_probe = CheckStatus::NotRun;
+            }
+            _ => {}
+        }
+        self.status = "Field updated".to_string();
+    }
+
+    fn cancel_editing(&mut self) {
+        self.editing = None;
+        self.status = "Edit canceled".to_string();
+    }
+
+    fn adjust_current_field(&mut self, direction: i8) {
+        let Some(field_key) = self.current_field_key() else {
+            return;
+        };
+
+        match field_key {
+            FieldKey::ForceOverwrite => {
+                if !self.force_locked {
+                    self.plan.force_overwrite = !self.plan.force_overwrite;
+                }
+            }
+            FieldKey::Provider => {
+                self.plan.provider_idx =
+                    advance_index(self.plan.provider_idx, PROVIDER_OPTIONS.len(), direction);
+                if !self.model_touched {
+                    self.plan.model = provider_default_model(self.plan.provider());
+                }
+                self.provider_probe = CheckStatus::NotRun;
+            }
+            FieldKey::MemoryBackend => {
+                self.plan.memory_idx =
+                    advance_index(self.plan.memory_idx, MEMORY_OPTIONS.len(), direction);
+            }
+            FieldKey::DisableTotp => {
+                self.plan.disable_totp = !self.plan.disable_totp;
+            }
+            FieldKey::EnableTelegram => {
+                self.plan.enable_telegram = !self.plan.enable_telegram;
+                self.telegram_probe = CheckStatus::NotRun;
+            }
+            FieldKey::EnableDiscord => {
+                self.plan.enable_discord = !self.plan.enable_discord;
+                self.discord_probe = CheckStatus::NotRun;
+            }
+            FieldKey::AutostartChannels => {
+                self.plan.autostart_channels = !self.plan.autostart_channels;
+            }
+            FieldKey::TunnelProvider => {
+                self.plan.tunnel_idx =
+                    advance_index(self.plan.tunnel_idx, TUNNEL_OPTIONS.len(), direction);
+                self.cloudflare_probe = CheckStatus::NotRun;
+                self.ngrok_probe = CheckStatus::NotRun;
+            }
+            FieldKey::AllowFailedDiagnostics => {
+                self.plan.allow_failed_diagnostics = !self.plan.allow_failed_diagnostics;
+            }
+            _ => {}
+        }
+
+        self.clamp_focus();
+    }
+
+    fn next_step(&mut self) -> Result<()> {
+        self.validate_step(self.step)?;
+        self.step = self.step.next();
+        self.focus = 0;
+        self.clamp_focus();
+        self.status = format!("Moved to {}", self.step.title());
+        Ok(())
+    }
+
+    fn previous_step(&mut self) {
+        self.step = self.step.previous();
+        self.focus = 0;
+        self.clamp_focus();
+        self.status = format!("Moved to {}", self.step.title());
+    }
+
+    fn run_probe_for_field(&mut self, field_key: FieldKey) -> bool {
+        match field_key {
+            FieldKey::RunProviderProbe => {
+                self.status = "Running provider probe...".to_string();
+                self.provider_probe = run_provider_probe(&self.plan);
+                self.status = format!("Provider probe {}", self.provider_probe.badge());
+                true
+            }
+            FieldKey::RunTelegramProbe => {
+                self.status = "Running Telegram probe...".to_string();
+                self.telegram_probe = run_telegram_probe(&self.plan);
+                self.status = format!("Telegram probe {}", self.telegram_probe.badge());
+                true
+            }
+            FieldKey::RunDiscordProbe => {
+                self.status = "Running Discord probe...".to_string();
+                self.discord_probe = run_discord_probe(&self.plan);
+                self.status = format!("Discord probe {}", self.discord_probe.badge());
+                true
+            }
+            FieldKey::RunCloudflareProbe => {
+                self.status = "Running Cloudflare token probe...".to_string();
+                self.cloudflare_probe = run_cloudflare_probe(&self.plan);
+                self.status = format!("Cloudflare probe {}", self.cloudflare_probe.badge());
+                true
+            }
+            FieldKey::RunNgrokProbe => {
+                self.status = "Running ngrok API probe...".to_string();
+                self.ngrok_probe = run_ngrok_probe(&self.plan);
+                self.status = format!("ngrok probe {}", self.ngrok_probe.badge());
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> Result<LoopAction> {
+        if let Some(editing) = self.editing.as_mut() {
+            match key.code {
+                KeyCode::Esc => self.cancel_editing(),
+                KeyCode::Enter => self.commit_editing(),
+                KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.commit_editing();
+                }
+                KeyCode::Backspace => {
+                    editing.value.pop();
+                }
+                KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    editing.value.clear();
+                }
+                KeyCode::Char(ch) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    editing.value.push(ch);
+                }
+                _ => {}
+            }
+            return Ok(LoopAction::Continue);
+        }
+
+        match key.code {
+            KeyCode::Char('q') => return Ok(LoopAction::Cancel),
+            KeyCode::PageDown => {
+                self.next_step()?;
+            }
+            KeyCode::PageUp => {
+                self.previous_step();
+            }
+            KeyCode::Char('n')
+                if key.modifiers.is_empty() || key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                self.next_step()?;
+            }
+            KeyCode::Char('p')
+                if key.modifiers.is_empty() || key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                self.previous_step();
+            }
+            KeyCode::Up => self.move_focus(-1),
+            KeyCode::Down => self.move_focus(1),
+            KeyCode::Char('k') if key.modifiers.is_empty() => self.move_focus(-1),
+            KeyCode::Char('j') if key.modifiers.is_empty() => self.move_focus(1),
+            KeyCode::Tab => self.move_focus(1),
+            KeyCode::BackTab => self.move_focus(-1),
+            KeyCode::Left => self.adjust_current_field(-1),
+            KeyCode::Right => self.adjust_current_field(1),
+            KeyCode::Char('h') if key.modifiers.is_empty() => self.adjust_current_field(-1),
+            KeyCode::Char('l') if key.modifiers.is_empty() => self.adjust_current_field(1),
+            KeyCode::Char(' ') => self.adjust_current_field(1),
+            KeyCode::Char('r') => {
+                if let Some(field_key) = self.current_field_key() {
+                    let _ = self.run_probe_for_field(field_key);
+                }
+            }
+            KeyCode::Char('e') if key.modifiers.is_empty() => {
+                if let Some(field_key) = self.current_field_key() {
+                    if is_text_input_field(field_key) {
+                        self.start_editing();
+                    }
+                }
+            }
+            KeyCode::Char('a') if self.step == Step::Review => {
+                self.validate_step(Step::Review)?;
+                return Ok(LoopAction::Submit);
+            }
+            KeyCode::Char('s')
+                if self.step == Step::Review
+                    && (key.modifiers.is_empty()
+                        || key.modifiers.contains(KeyModifiers::CONTROL)) =>
+            {
+                self.validate_step(Step::Review)?;
+                return Ok(LoopAction::Submit);
+            }
+            KeyCode::Enter => {
+                if self.step == Step::Review {
+                    self.validate_step(Step::Review)?;
+                    return Ok(LoopAction::Submit);
+                }
+
+                match self.current_field_key() {
+                    Some(FieldKey::Continue) => self.next_step()?,
+                    Some(field_key @ FieldKey::RunProviderProbe)
+                    | Some(field_key @ FieldKey::RunTelegramProbe)
+                    | Some(field_key @ FieldKey::RunDiscordProbe)
+                    | Some(field_key @ FieldKey::RunCloudflareProbe)
+                    | Some(field_key @ FieldKey::RunNgrokProbe) => {
+                        let _ = self.run_probe_for_field(field_key);
+                    }
+                    Some(field_key) if is_text_input_field(field_key) => self.start_editing(),
+                    Some(_) | None => self.adjust_current_field(1),
+                }
+            }
+            _ => {}
+        }
+
+        self.clamp_focus();
+        Ok(LoopAction::Continue)
+    }
+
+    fn review_text(&self) -> String {
+        let mut lines = Vec::new();
+        lines.push(format!(
+            "Workspace: {}",
+            self.plan.workspace_path.trim().if_empty("(empty)")
+        ));
+        if let Ok(Some(path)) = self.selected_config_path() {
+            lines.push(format!("Config path: {}", path.display()));
+            if path.exists() {
+                lines.push(if self.plan.force_overwrite {
+                    "Overwrite existing config: enabled".to_string()
+                } else {
+                    "Overwrite existing config: disabled (will block apply)".to_string()
+                });
+            }
+        }
+
+        lines.push(format!("Provider: {}", self.plan.provider()));
+        lines.push(format!(
+            "Model: {}",
+            self.plan.model.trim().if_empty("(empty)")
+        ));
+        lines.push(format!(
+            "API key: {}",
+            if self.plan.api_key.trim().is_empty() {
+                "not set"
+            } else {
+                "set"
+            }
+        ));
+        lines.push(format!(
+            "Provider diagnostics: {}",
+            self.provider_probe.as_line()
+        ));
+        lines.push(format!("Memory backend: {}", self.plan.memory_backend()));
+        lines.push(format!(
+            "TOTP: {}",
+            if self.plan.disable_totp {
+                "disabled"
+            } else {
+                "enabled"
+            }
+        ));
+
+        let mut channel_notes = vec!["CLI".to_string()];
+        if self.plan.enable_telegram {
+            channel_notes.push("Telegram".to_string());
+        }
+        if self.plan.enable_discord {
+            channel_notes.push("Discord".to_string());
+        }
+        lines.push(format!("Channels: {}", channel_notes.join(", ")));
+        if self.plan.enable_telegram {
+            lines.push(format!(
+                "Telegram diagnostics: {}",
+                self.telegram_probe.as_line()
+            ));
+        }
+        if self.plan.enable_discord {
+            lines.push(format!(
+                "Discord diagnostics: {}",
+                self.discord_probe.as_line()
+            ));
+        }
+        lines.push(format!("Tunnel: {}", self.plan.tunnel_provider()));
+        if self.plan.tunnel_provider() == "cloudflare" {
+            lines.push(format!(
+                "Cloudflare diagnostics: {}",
+                self.cloudflare_probe.as_line()
+            ));
+        } else if self.plan.tunnel_provider() == "ngrok" {
+            lines.push(format!("ngrok diagnostics: {}", self.ngrok_probe.as_line()));
+        }
+        lines.push(format!(
+            "Allow failed diagnostics: {}",
+            if self.plan.allow_failed_diagnostics {
+                "yes"
+            } else {
+                "no"
+            }
+        ));
+        let blockers = self.blocking_diagnostic_failures();
+        lines.push(if blockers.is_empty() {
+            "Blocking diagnostic failures: none".to_string()
+        } else {
+            format!("Blocking diagnostic failures: {}", blockers.join(", "))
+        });
+        lines.push(format!(
+            "Autostart channels: {}",
+            if self.plan.autostart_channels {
+                "yes"
+            } else {
+                "no"
+            }
+        ));
+
+        lines.join("\n")
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LoopAction {
+    Continue,
+    Submit,
+    Cancel,
+}
+
+fn probe_http_client() -> Result<Client> {
+    Client::builder()
+        .timeout(Duration::from_secs(8))
+        .build()
+        .context("failed to build probe HTTP client")
+}
+
+fn run_provider_probe(plan: &TuiOnboardPlan) -> CheckStatus {
+    let provider = plan.provider();
+    let api_key = plan.api_key.trim();
+
+    match provider {
+        "openrouter" => {
+            if api_key.is_empty() {
+                return CheckStatus::Skipped(
+                    "missing API key (required for OpenRouter probe)".to_string(),
+                );
+            }
+            let client = match probe_http_client() {
+                Ok(client) => client,
+                Err(error) => return CheckStatus::Failed(error.to_string()),
+            };
+            match client
+                .get("https://openrouter.ai/api/v1/models")
+                .header("Authorization", format!("Bearer {api_key}"))
+                .send()
+            {
+                Ok(response) if response.status().is_success() => {
+                    CheckStatus::Passed("models endpoint reachable".to_string())
+                }
+                Ok(response) => CheckStatus::Failed(format!("HTTP {}", response.status())),
+                Err(error) => CheckStatus::Failed(error.to_string()),
+            }
+        }
+        "openai" => {
+            if api_key.is_empty() {
+                return CheckStatus::Skipped(
+                    "missing API key (required for OpenAI probe)".to_string(),
+                );
+            }
+            let client = match probe_http_client() {
+                Ok(client) => client,
+                Err(error) => return CheckStatus::Failed(error.to_string()),
+            };
+            match client
+                .get("https://api.openai.com/v1/models")
+                .header("Authorization", format!("Bearer {api_key}"))
+                .send()
+            {
+                Ok(response) if response.status().is_success() => {
+                    CheckStatus::Passed("models endpoint reachable".to_string())
+                }
+                Ok(response) => CheckStatus::Failed(format!("HTTP {}", response.status())),
+                Err(error) => CheckStatus::Failed(error.to_string()),
+            }
+        }
+        "anthropic" => {
+            if api_key.is_empty() {
+                return CheckStatus::Skipped(
+                    "missing API key (required for Anthropic probe)".to_string(),
+                );
+            }
+            let client = match probe_http_client() {
+                Ok(client) => client,
+                Err(error) => return CheckStatus::Failed(error.to_string()),
+            };
+            match client
+                .get("https://api.anthropic.com/v1/models")
+                .header("x-api-key", api_key)
+                .header("anthropic-version", "2023-06-01")
+                .send()
+            {
+                Ok(response) if response.status().is_success() => {
+                    CheckStatus::Passed("models endpoint reachable".to_string())
+                }
+                Ok(response) => CheckStatus::Failed(format!("HTTP {}", response.status())),
+                Err(error) => CheckStatus::Failed(error.to_string()),
+            }
+        }
+        "gemini" => {
+            if api_key.is_empty() {
+                return CheckStatus::Skipped(
+                    "missing API key (required for Gemini probe)".to_string(),
+                );
+            }
+            let client = match probe_http_client() {
+                Ok(client) => client,
+                Err(error) => return CheckStatus::Failed(error.to_string()),
+            };
+            let url =
+                format!("https://generativelanguage.googleapis.com/v1beta/models?key={api_key}");
+            match client.get(url).send() {
+                Ok(response) if response.status().is_success() => {
+                    CheckStatus::Passed("models endpoint reachable".to_string())
+                }
+                Ok(response) => CheckStatus::Failed(format!("HTTP {}", response.status())),
+                Err(error) => CheckStatus::Failed(error.to_string()),
+            }
+        }
+        "ollama" => {
+            let client = match probe_http_client() {
+                Ok(client) => client,
+                Err(error) => return CheckStatus::Failed(error.to_string()),
+            };
+            match client.get("http://127.0.0.1:11434/api/tags").send() {
+                Ok(response) if response.status().is_success() => {
+                    CheckStatus::Passed("local Ollama reachable".to_string())
+                }
+                Ok(response) => CheckStatus::Failed(format!("HTTP {}", response.status())),
+                Err(error) => CheckStatus::Failed(error.to_string()),
+            }
+        }
+        _ => CheckStatus::Skipped(format!("no probe implemented for provider `{provider}`")),
+    }
+}
+
+fn run_telegram_probe(plan: &TuiOnboardPlan) -> CheckStatus {
+    if !plan.enable_telegram {
+        return CheckStatus::Skipped("telegram channel is disabled".to_string());
+    }
+
+    let token = plan.telegram_token.trim();
+    if token.is_empty() {
+        return CheckStatus::Failed("telegram bot token is empty".to_string());
+    }
+
+    let client = match probe_http_client() {
+        Ok(client) => client,
+        Err(error) => return CheckStatus::Failed(error.to_string()),
+    };
+
+    let url = format!("https://api.telegram.org/bot{token}/getMe");
+    let response = match client.get(url).send() {
+        Ok(response) => response,
+        Err(error) => return CheckStatus::Failed(error.to_string()),
+    };
+    if !response.status().is_success() {
+        return CheckStatus::Failed(format!("HTTP {}", response.status()));
+    }
+
+    let json: Value = match response.json() {
+        Ok(json) => json,
+        Err(error) => return CheckStatus::Failed(error.to_string()),
+    };
+
+    if json.get("ok").and_then(Value::as_bool) == Some(true) {
+        let username = json
+            .pointer("/result/username")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        return CheckStatus::Passed(format!("token accepted (bot @{username})"));
+    }
+
+    let description = json
+        .get("description")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown Telegram error");
+    CheckStatus::Failed(description.to_string())
+}
+
+fn run_discord_probe(plan: &TuiOnboardPlan) -> CheckStatus {
+    if !plan.enable_discord {
+        return CheckStatus::Skipped("discord channel is disabled".to_string());
+    }
+
+    let token = plan.discord_token.trim();
+    if token.is_empty() {
+        return CheckStatus::Failed("discord bot token is empty".to_string());
+    }
+
+    let client = match probe_http_client() {
+        Ok(client) => client,
+        Err(error) => return CheckStatus::Failed(error.to_string()),
+    };
+
+    let response = match client
+        .get("https://discord.com/api/v10/users/@me/guilds")
+        .header("Authorization", format!("Bot {token}"))
+        .send()
+    {
+        Ok(response) => response,
+        Err(error) => return CheckStatus::Failed(error.to_string()),
+    };
+
+    if !response.status().is_success() {
+        return CheckStatus::Failed(format!("HTTP {}", response.status()));
+    }
+
+    let json: Value = match response.json() {
+        Ok(json) => json,
+        Err(error) => return CheckStatus::Failed(error.to_string()),
+    };
+
+    let guilds = match json.as_array() {
+        Some(guilds) => guilds,
+        None => return CheckStatus::Failed("unexpected Discord response payload".to_string()),
+    };
+
+    let guild_id = plan.discord_guild_id.trim();
+    if guild_id.is_empty() {
+        return CheckStatus::Passed(format!("token accepted ({} guilds visible)", guilds.len()));
+    }
+
+    let matched = guilds.iter().any(|guild| {
+        guild
+            .get("id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| id == guild_id)
+    });
+    if matched {
+        CheckStatus::Passed(format!("guild {guild_id} visible to bot token"))
+    } else {
+        CheckStatus::Failed(format!("guild {guild_id} not found in bot membership"))
+    }
+}
+
+fn run_cloudflare_probe(plan: &TuiOnboardPlan) -> CheckStatus {
+    if plan.tunnel_provider() != "cloudflare" {
+        return CheckStatus::Skipped("cloudflare tunnel is not selected".to_string());
+    }
+
+    let token = plan.cloudflare_token.trim();
+    if token.is_empty() {
+        return CheckStatus::Failed("cloudflare tunnel token is empty".to_string());
+    }
+
+    let mut segments = token.split('.');
+    let (Some(_header), Some(payload), Some(_signature), None) = (
+        segments.next(),
+        segments.next(),
+        segments.next(),
+        segments.next(),
+    ) else {
+        return CheckStatus::Failed("token is not JWT-like (expected 3 segments)".to_string());
+    };
+
+    let decoded = match URL_SAFE_NO_PAD.decode(payload.as_bytes()) {
+        Ok(decoded) => decoded,
+        Err(error) => return CheckStatus::Failed(format!("payload decode failed: {error}")),
+    };
+    let payload_json: Value = match serde_json::from_slice(&decoded) {
+        Ok(json) => json,
+        Err(error) => return CheckStatus::Failed(format!("payload parse failed: {error}")),
+    };
+
+    let aud = payload_json
+        .get("aud")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let subject = payload_json
+        .get("sub")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+
+    CheckStatus::Passed(format!("jwt parsed (aud={aud}, sub={subject})"))
+}
+
+fn run_ngrok_probe(plan: &TuiOnboardPlan) -> CheckStatus {
+    if plan.tunnel_provider() != "ngrok" {
+        return CheckStatus::Skipped("ngrok tunnel is not selected".to_string());
+    }
+
+    let token = plan.ngrok_auth_token.trim();
+    if token.is_empty() {
+        return CheckStatus::Failed("ngrok auth token is empty".to_string());
+    }
+
+    let client = match probe_http_client() {
+        Ok(client) => client,
+        Err(error) => return CheckStatus::Failed(error.to_string()),
+    };
+
+    let response = match client
+        .get("https://api.ngrok.com/tunnels")
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Ngrok-Version", "2")
+        .send()
+    {
+        Ok(response) => response,
+        Err(error) => return CheckStatus::Failed(error.to_string()),
+    };
+
+    if !response.status().is_success() {
+        return CheckStatus::Failed(format!("HTTP {}", response.status()));
+    }
+
+    let json: Value = match response.json() {
+        Ok(json) => json,
+        Err(error) => return CheckStatus::Failed(error.to_string()),
+    };
+    let count = json
+        .get("tunnels")
+        .and_then(Value::as_array)
+        .map_or(0, std::vec::Vec::len);
+
+    CheckStatus::Passed(format!("token accepted ({} active tunnels)", count))
+}
+
+pub async fn run_wizard_tui(force: bool) -> Result<Config> {
+    run_wizard_tui_with_migration(force, OpenClawOnboardMigrationOptions::default()).await
+}
+
+pub async fn run_wizard_tui_with_migration(
+    force: bool,
+    migration_options: OpenClawOnboardMigrationOptions,
+) -> Result<Config> {
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        bail!("TUI onboarding requires an interactive terminal")
+    }
+
+    let (_, default_workspace_dir) =
+        crate::config::schema::resolve_runtime_dirs_for_onboarding().await?;
+
+    let plan = tokio::task::spawn_blocking(move || run_tui_session(default_workspace_dir, force))
+        .await
+        .context("TUI onboarding thread failed")??;
+
+    let workspace_value = plan.workspace_path.trim();
+    if workspace_value.is_empty() {
+        bail!("Workspace path is required")
+    }
+
+    let expanded_workspace = shellexpand::tilde(workspace_value).to_string();
+    let selected_workspace = PathBuf::from(expanded_workspace);
+    let (config_dir, resolved_workspace_dir) =
+        crate::config::schema::resolve_config_dir_for_workspace(&selected_workspace);
+    let config_path = config_dir.join("config.toml");
+
+    if config_path.exists() && !(force || plan.force_overwrite) {
+        bail!(
+            "Config already exists at {}. Re-run with --force or enable overwrite inside TUI.",
+            config_path.display()
+        );
+    }
+
+    let _workspace_guard = ScopedEnvVar::set(
+        "ZEROCLAW_WORKSPACE",
+        resolved_workspace_dir.to_string_lossy().as_ref(),
+    );
+
+    let provider = plan.provider().to_string();
+    let model = if plan.model.trim().is_empty() {
+        provider_default_model(&provider)
+    } else {
+        plan.model.trim().to_string()
+    };
+    let memory_backend = plan.memory_backend().to_string();
+    let api_key = (!plan.api_key.trim().is_empty()).then_some(plan.api_key.trim());
+
+    let mut config = run_quick_setup_with_migration(
+        api_key,
+        Some(&provider),
+        Some(&model),
+        Some(&memory_backend),
+        true,
+        plan.disable_totp,
+        migration_options,
+    )
+    .await?;
+
+    apply_channel_overrides(&mut config, &plan);
+    apply_tunnel_overrides(&mut config, &plan);
+    config.save().await?;
+
+    if plan.autostart_channels && has_launchable_channels(&config.channels_config) {
+        std::env::set_var("ZEROCLAW_AUTOSTART_CHANNELS", "1");
+    }
+
+    println!();
+    println!(
+        "  {} {}",
+        style("✓").green().bold(),
+        style("TUI onboarding complete.").white().bold()
+    );
+    println!(
+        "  {} {}",
+        style("Provider:").cyan().bold(),
+        style(config.default_provider.as_deref().unwrap_or("openrouter")).green()
+    );
+    println!(
+        "  {} {}",
+        style("Model:").cyan().bold(),
+        style(config.default_model.as_deref().unwrap_or("(default)")).green()
+    );
+    let tunnel_summary = match plan.tunnel_provider() {
+        "none" => "none (local only)".to_string(),
+        "cloudflare" => "cloudflare".to_string(),
+        "ngrok" => "ngrok".to_string(),
+        other => other.to_string(),
+    };
+    println!(
+        "  {} {}",
+        style("Tunnel:").cyan().bold(),
+        style(tunnel_summary).green()
+    );
+    println!(
+        "  {} {}",
+        style("Config:").cyan().bold(),
+        style(config.config_path.display()).green()
+    );
+    println!();
+
+    Ok(config)
+}
+
+fn run_tui_session(default_workspace_dir: PathBuf, force: bool) -> Result<TuiOnboardPlan> {
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        bail!("TUI onboarding requires an interactive terminal")
+    }
+
+    enable_raw_mode().context("failed to enable raw mode")?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, Hide).context("failed to enter alternate screen")?;
+
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).context("failed to initialize terminal backend")?;
+    let mut state = TuiState::new(default_workspace_dir, force);
+
+    let result = run_tui_loop(&mut terminal, &mut state);
+    let restore = restore_terminal(&mut terminal);
+
+    match (result, restore) {
+        (Ok(plan), Ok(())) => Ok(plan),
+        (Err(err), Ok(())) => Err(err),
+        (Ok(_), Err(restore_err)) => Err(restore_err),
+        (Err(err), Err(_restore_err)) => Err(err),
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+fn run_tui_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    state: &mut TuiState,
+) -> Result<TuiOnboardPlan> {
+    loop {
+        terminal
+            .draw(|frame| draw_ui(frame, state))
+            .context("failed to draw onboarding UI")?;
+
+        if !event::poll(Duration::from_millis(120)).context("failed to poll terminal events")? {
+            continue;
+        }
+
+        let event = event::read().context("failed to read terminal event")?;
+        let Event::Key(key) = event else {
+            continue;
+        };
+
+        match state.handle_key(key) {
+            Ok(LoopAction::Continue) => {}
+            Ok(LoopAction::Submit) => {
+                state.validate_step(Step::Review)?;
+                return Ok(state.plan.clone());
+            }
+            Ok(LoopAction::Cancel) => bail!("Onboarding canceled by user"),
+            Err(error) => {
+                state.status = error.to_string();
+            }
+        }
+    }
+}
+
+fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
+    disable_raw_mode().context("failed to disable raw mode")?;
+    execute!(terminal.backend_mut(), Show, LeaveAlternateScreen)
+        .context("failed to leave alternate screen")?;
+    terminal.show_cursor().context("failed to restore cursor")?;
+    Ok(())
+}
+
+fn draw_ui(frame: &mut Frame<'_>, state: &TuiState) {
+    let root = frame.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(12),
+            Constraint::Length(7),
+        ])
+        .split(root);
+
+    let header = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "ZeroClaw Onboarding UI",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  "),
+        Span::styled(
+            format!(
+                "Step {}/{}: {}",
+                state.step.index() + 1,
+                Step::ORDER.len(),
+                state.step.title()
+            ),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]))
+    .block(Block::default().borders(Borders::BOTTOM));
+    frame.render_widget(header, chunks[0]);
+
+    let body = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(26), Constraint::Min(50)])
+        .split(chunks[1]);
+
+    render_steps(frame, state, body[0]);
+
+    if state.step == Step::Review {
+        render_review(frame, state, body[1]);
+    } else {
+        render_fields(frame, state, body[1]);
+    }
+
+    let footer_text = vec![
+        Line::from(vec![
+            Span::styled(
+                "Help: ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(state.step.help()),
+        ]),
+        Line::from("Nav: ↑/↓ or j/k move | Tab/Shift+Tab cycle fields | n/PgDn next step | p/PgUp back"),
+        Line::from("Select: ←/→ or h/l or Space toggles/options | Enter runs checks on probe rows"),
+        Line::from("Edit: Enter or e opens text editor | Enter or Ctrl+S saves | Esc cancels | Ctrl+U clears"),
+        Line::from("Apply/Quit: Review step -> Enter, a, or s applies config | q quits"),
+        Line::from(state.status.as_str()),
+    ];
+
+    let footer = Paragraph::new(footer_text)
+        .block(Block::default().borders(Borders::TOP))
+        .wrap(Wrap { trim: true });
+    frame.render_widget(footer, chunks[2]);
+
+    if let Some(editing) = &state.editing {
+        render_editor_popup(frame, editing);
+    }
+}
+
+fn render_steps(frame: &mut Frame<'_>, state: &TuiState, area: Rect) {
+    let items: Vec<ListItem<'_>> = Step::ORDER
+        .iter()
+        .enumerate()
+        .map(|(idx, step)| {
+            let prefix = if idx < state.step.index() {
+                "✓"
+            } else {
+                "•"
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(prefix, Style::default().fg(Color::Cyan)),
+                Span::raw(" "),
+                Span::raw(step.title()),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(Block::default().borders(Borders::ALL).title("Flow"))
+        .highlight_style(
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    let mut stateful = ListState::default();
+    stateful.select(Some(state.step.index()));
+    frame.render_stateful_widget(list, area, &mut stateful);
+}
+
+fn render_fields(frame: &mut Frame<'_>, state: &TuiState, area: Rect) {
+    let fields = state.visible_fields();
+    let items: Vec<ListItem<'_>> = fields
+        .iter()
+        .map(|field| {
+            let required = if field.required { "*" } else { " " };
+            let label_style = if field.editable {
+                Style::default().fg(Color::Cyan)
+            } else {
+                Style::default()
+                    .fg(Color::LightCyan)
+                    .add_modifier(Modifier::DIM)
+            };
+            let line = Line::from(vec![
+                Span::styled(format!("{} {:<24}", required, field.label), label_style),
+                Span::styled(field.value.clone(), Style::default().fg(Color::White)),
+            ]);
+            let hint = Line::from(Span::styled(
+                format!("   {}", field.hint),
+                Style::default().fg(Color::DarkGray),
+            ));
+            ListItem::new(vec![line, hint])
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(state.step.title()),
+        )
+        .highlight_style(
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
+
+    let mut stateful = ListState::default();
+    if !fields.is_empty() {
+        stateful.select(Some(state.focus.min(fields.len() - 1)));
+    }
+    frame.render_stateful_widget(list, area, &mut stateful);
+}
+
+fn render_review(frame: &mut Frame<'_>, state: &TuiState, area: Rect) {
+    let split = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(8), Constraint::Length(5)])
+        .split(area);
+
+    let summary = Paragraph::new(state.review_text())
+        .block(Block::default().borders(Borders::ALL).title("Summary"))
+        .wrap(Wrap { trim: true });
+    frame.render_widget(summary, split[0]);
+
+    render_fields(frame, state, split[1]);
+}
+
+fn render_editor_popup(frame: &mut Frame<'_>, editing: &EditingState) {
+    let area = centered_rect(70, 25, frame.area());
+    frame.render_widget(Clear, area);
+
+    let value = if editing.secret {
+        if editing.value.is_empty() {
+            "<empty>".to_string()
+        } else {
+            "*".repeat(editing.value.chars().count().min(24))
+        }
+    } else if editing.value.is_empty() {
+        "<empty>".to_string()
+    } else {
+        editing.value.clone()
+    };
+
+    let input = Paragraph::new(vec![
+        Line::from("Type your value, then press Enter or Ctrl+S to save."),
+        Line::from("Esc cancels, Ctrl+U clears."),
+        Line::from(""),
+        Line::from(Span::styled(
+            value,
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        )),
+    ])
+    .block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Edit Field")
+            .border_style(Style::default().fg(Color::Cyan)),
+    )
+    .wrap(Wrap { trim: false });
+
+    frame.render_widget(input, area);
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+fn provider_default_model(provider: &str) -> String {
+    default_model_fallback_for_provider(Some(provider)).to_string()
+}
+
+fn display_value(value: &str, secret: bool) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return "<empty>".to_string();
+    }
+    if !secret {
+        return trimmed.to_string();
+    }
+
+    let chars: Vec<char> = trimmed.chars().collect();
+    if chars.len() <= 4 {
+        return "*".repeat(chars.len());
+    }
+
+    let suffix: String = chars[chars.len() - 4..].iter().collect();
+    format!("{}{}", "*".repeat(chars.len().saturating_sub(4)), suffix)
+}
+
+fn bool_label(value: bool) -> String {
+    if value {
+        "yes".to_string()
+    } else {
+        "no".to_string()
+    }
+}
+
+fn contains_http_status(message: &str, code: u16) -> bool {
+    message.contains(&format!("HTTP {code}"))
+}
+
+fn looks_like_network_error(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    [
+        "timeout",
+        "timed out",
+        "connection",
+        "dns",
+        "resolve",
+        "refused",
+        "unreachable",
+        "network",
+        "tls",
+        "socket",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle))
+}
+
+fn advance_index(current: usize, len: usize, direction: i8) -> usize {
+    if len == 0 {
+        return 0;
+    }
+    if direction < 0 {
+        if current == 0 {
+            len - 1
+        } else {
+            current - 1
+        }
+    } else if current + 1 >= len {
+        0
+    } else {
+        current + 1
+    }
+}
+
+fn apply_channel_overrides(config: &mut Config, plan: &TuiOnboardPlan) {
+    let mut channels = ChannelsConfig::default();
+
+    if plan.enable_telegram {
+        channels.telegram = Some(TelegramConfig {
+            bot_token: plan.telegram_token.trim().to_string(),
+            allowed_users: parse_csv_list(&plan.telegram_allowed_users),
+            stream_mode: StreamMode::Off,
+            draft_update_interval_ms: 1000,
+            interrupt_on_new_message: false,
+            mention_only: false,
+            progress_mode: ProgressMode::Compact,
+            group_reply: None,
+            base_url: None,
+            ack_enabled: true,
+        });
+    }
+
+    if plan.enable_discord {
+        let guild_id = plan.discord_guild_id.trim();
+        channels.discord = Some(DiscordConfig {
+            bot_token: plan.discord_token.trim().to_string(),
+            guild_id: if guild_id.is_empty() {
+                None
+            } else {
+                Some(guild_id.to_string())
+            },
+            allowed_users: parse_csv_list(&plan.discord_allowed_users),
+            listen_to_bots: false,
+            mention_only: false,
+            group_reply: None,
+        });
+    }
+
+    config.channels_config = channels;
+}
+
+fn apply_tunnel_overrides(config: &mut Config, plan: &TuiOnboardPlan) {
+    config.tunnel = match plan.tunnel_provider() {
+        "cloudflare" => TunnelConfig {
+            provider: "cloudflare".to_string(),
+            cloudflare: Some(CloudflareTunnelConfig {
+                token: plan.cloudflare_token.trim().to_string(),
+            }),
+            tailscale: None,
+            ngrok: None,
+            custom: None,
+        },
+        "ngrok" => {
+            let domain = plan.ngrok_domain.trim();
+            TunnelConfig {
+                provider: "ngrok".to_string(),
+                cloudflare: None,
+                tailscale: None,
+                ngrok: Some(NgrokTunnelConfig {
+                    auth_token: plan.ngrok_auth_token.trim().to_string(),
+                    domain: if domain.is_empty() {
+                        None
+                    } else {
+                        Some(domain.to_string())
+                    },
+                }),
+                custom: None,
+            }
+        }
+        _ => TunnelConfig::default(),
+    };
+}
+
+fn has_launchable_channels(channels: &ChannelsConfig) -> bool {
+    channels
+        .channels_except_webhook()
+        .iter()
+        .any(|(_, enabled)| *enabled)
+}
+
+fn is_text_input_field(field_key: FieldKey) -> bool {
+    matches!(
+        field_key,
+        FieldKey::WorkspacePath
+            | FieldKey::ApiKey
+            | FieldKey::Model
+            | FieldKey::TelegramToken
+            | FieldKey::TelegramAllowedUsers
+            | FieldKey::DiscordToken
+            | FieldKey::DiscordGuildId
+            | FieldKey::DiscordAllowedUsers
+            | FieldKey::CloudflareToken
+            | FieldKey::NgrokAuthToken
+            | FieldKey::NgrokDomain
+    )
+}
+
+fn parse_csv_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+trait EmptyFallback {
+    fn if_empty(self, fallback: &str) -> String;
+}
+
+impl EmptyFallback for &str {
+    fn if_empty(self, fallback: &str) -> String {
+        if self.trim().is_empty() {
+            fallback.to_string()
+        } else {
+            self.to_string()
+        }
+    }
+}
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<String>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        if let Some(previous) = &self.previous {
+            std::env::set_var(self.key, previous);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn sample_plan() -> TuiOnboardPlan {
+        TuiOnboardPlan::new(Path::new("/tmp/zeroclaw-tui-tests").to_path_buf(), false)
+    }
+
+    #[test]
+    fn parse_csv_list_ignores_empty_segments() {
+        let parsed = parse_csv_list("alice, bob ,,carol");
+        assert_eq!(parsed, vec!["alice", "bob", "carol"]);
+    }
+
+    #[test]
+    fn provider_default_model_changes_with_provider() {
+        let openai = provider_default_model("openai");
+        let anthropic = provider_default_model("anthropic");
+        assert_ne!(openai, anthropic);
+    }
+
+    #[test]
+    fn advance_index_wraps_both_directions() {
+        assert_eq!(advance_index(0, 3, -1), 2);
+        assert_eq!(advance_index(2, 3, 1), 0);
+        assert_eq!(advance_index(1, 3, 1), 2);
+    }
+
+    #[test]
+    fn cloudflare_probe_fails_for_invalid_token_shape() {
+        let mut plan = sample_plan();
+        plan.tunnel_idx = 1; // cloudflare
+        plan.cloudflare_token = "not-a-jwt".to_string();
+
+        let status = run_cloudflare_probe(&plan);
+        assert!(matches!(status, CheckStatus::Failed(_)));
+    }
+
+    #[test]
+    fn cloudflare_probe_parses_minimal_jwt_payload() {
+        let mut plan = sample_plan();
+        plan.tunnel_idx = 1; // cloudflare
+
+        let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"HS256","typ":"JWT"}"#.as_bytes());
+        let payload = URL_SAFE_NO_PAD.encode(r#"{"aud":"demo","sub":"tunnel"}"#.as_bytes());
+        plan.cloudflare_token = format!("{header}.{payload}.signature");
+
+        let status = run_cloudflare_probe(&plan);
+        assert!(matches!(status, CheckStatus::Passed(_)));
+    }
+
+    #[test]
+    fn provider_probe_skips_without_required_api_key() {
+        let mut plan = sample_plan();
+        plan.provider_idx = 1; // openai
+        plan.api_key.clear();
+
+        let status = run_provider_probe(&plan);
+        assert!(matches!(status, CheckStatus::Skipped(_)));
+    }
+
+    #[test]
+    fn ngrok_probe_skips_when_tunnel_not_selected() {
+        let plan = sample_plan();
+        let status = run_ngrok_probe(&plan);
+        assert!(matches!(status, CheckStatus::Skipped(_)));
+    }
+
+    #[test]
+    fn review_validation_blocks_failed_diagnostics_by_default() {
+        let workspace = Path::new("/tmp/zeroclaw-review-gate").to_path_buf();
+        let mut state = TuiState::new(workspace, true);
+        state.provider_probe = CheckStatus::Failed("network timeout".to_string());
+
+        let err = state
+            .validate_step(Step::Review)
+            .expect_err("review should fail when blocking diagnostics fail");
+        assert!(err
+            .to_string()
+            .contains("Blocking diagnostics failed: provider"));
+    }
+
+    #[test]
+    fn review_validation_allows_failed_diagnostics_with_override() {
+        let workspace = Path::new("/tmp/zeroclaw-review-gate-override").to_path_buf();
+        let mut state = TuiState::new(workspace, true);
+        state.provider_probe = CheckStatus::Failed("network timeout".to_string());
+        state.plan.allow_failed_diagnostics = true;
+
+        state
+            .validate_step(Step::Review)
+            .expect("override should allow review validation to pass");
+    }
+
+    #[test]
+    fn step_navigation_resets_focus_to_first_field() {
+        let workspace = Path::new("/tmp/zeroclaw-focus-reset").to_path_buf();
+        let mut state = TuiState::new(workspace, true);
+
+        state.step = Step::Tunnel;
+        state.plan.tunnel_idx = 1; // cloudflare
+        state.plan.cloudflare_token = "token.payload.signature".to_string();
+        state.focus = 1; // cloudflare token row
+
+        state
+            .next_step()
+            .expect("tunnel step should validate when token is present");
+        assert_eq!(state.step, Step::TunnelDiagnostics);
+        assert_eq!(state.focus, 0);
+
+        state.focus = 1; // status row
+        state
+            .next_step()
+            .expect("tunnel diagnostics should advance");
+        assert_eq!(state.step, Step::Review);
+        assert_eq!(state.focus, 0);
+
+        state.focus = 1;
+        state.previous_step();
+        assert_eq!(state.step, Step::TunnelDiagnostics);
+        assert_eq!(state.focus, 0);
+    }
+
+    #[test]
+    fn provider_remediation_recommends_api_key_for_skipped_cloud_provider() {
+        let workspace = Path::new("/tmp/zeroclaw-provider-remediation").to_path_buf();
+        let mut state = TuiState::new(workspace, true);
+        state.plan.provider_idx = 1; // openai
+        state.provider_probe =
+            CheckStatus::Skipped("missing API key (required for OpenAI probe)".to_string());
+
+        let remediation = state.provider_probe_remediation();
+        assert!(remediation.contains("API key"));
+        assert!(remediation.contains("openai"));
+    }
+
+    #[test]
+    fn discord_remediation_guides_guild_membership_fix() {
+        let workspace = Path::new("/tmp/zeroclaw-discord-remediation").to_path_buf();
+        let mut state = TuiState::new(workspace, true);
+        state.plan.enable_discord = true;
+        state.discord_probe =
+            CheckStatus::Failed("guild 1234 not found in bot membership".to_string());
+
+        let remediation = state.discord_probe_remediation();
+        assert!(remediation.contains("Invite bot"));
+        assert!(remediation.contains("Guild ID"));
+    }
+
+    #[test]
+    fn cloudflare_remediation_explains_jwt_shape_failures() {
+        let workspace = Path::new("/tmp/zeroclaw-cloudflare-remediation").to_path_buf();
+        let mut state = TuiState::new(workspace, true);
+        state.plan.tunnel_idx = 1; // cloudflare
+        state.cloudflare_probe =
+            CheckStatus::Failed("token is not JWT-like (expected 3 segments)".to_string());
+
+        let remediation = state.cloudflare_probe_remediation();
+        assert!(remediation.contains("Cloudflare Zero Trust"));
+    }
+
+    #[test]
+    fn provider_diagnostics_page_shows_details_and_remediation_rows() {
+        let workspace = Path::new("/tmp/zeroclaw-provider-diag-rows").to_path_buf();
+        let mut state = TuiState::new(workspace, true);
+        state.step = Step::ProviderDiagnostics;
+
+        let labels: Vec<&str> = state.visible_fields().iter().map(|row| row.label).collect();
+        assert!(labels.contains(&"Provider check details"));
+        assert!(labels.contains(&"Provider remediation"));
+    }
+
+    #[test]
+    fn channel_diagnostics_page_shows_advanced_rows_for_enabled_channels() {
+        let workspace = Path::new("/tmp/zeroclaw-channel-diag-rows").to_path_buf();
+        let mut state = TuiState::new(workspace, true);
+        state.step = Step::ChannelDiagnostics;
+        state.plan.enable_telegram = true;
+        state.plan.enable_discord = true;
+
+        let labels: Vec<&str> = state.visible_fields().iter().map(|row| row.label).collect();
+        assert!(labels.contains(&"Telegram check details"));
+        assert!(labels.contains(&"Telegram remediation"));
+        assert!(labels.contains(&"Discord check details"));
+        assert!(labels.contains(&"Discord remediation"));
+    }
+
+    #[test]
+    fn tunnel_diagnostics_page_shows_cloudflare_details_and_remediation_rows() {
+        let workspace = Path::new("/tmp/zeroclaw-tunnel-diag-rows").to_path_buf();
+        let mut state = TuiState::new(workspace, true);
+        state.step = Step::TunnelDiagnostics;
+        state.plan.tunnel_idx = 1; // cloudflare
+
+        let labels: Vec<&str> = state.visible_fields().iter().map(|row| row.label).collect();
+        assert!(labels.contains(&"Cloudflare check details"));
+        assert!(labels.contains(&"Cloudflare remediation"));
+    }
+
+    #[test]
+    fn key_aliases_allow_step_navigation_and_field_navigation() {
+        let workspace = Path::new("/tmp/zeroclaw-key-alias-nav").to_path_buf();
+        let mut state = TuiState::new(workspace, true);
+
+        state
+            .handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE))
+            .expect("n should move to next step");
+        assert_eq!(state.step, Step::Workspace);
+
+        state
+            .handle_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE))
+            .expect("p should move to previous step");
+        assert_eq!(state.step, Step::Welcome);
+
+        state.step = Step::Runtime;
+        state.focus = 0;
+
+        state
+            .handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE))
+            .expect("j should move focus down");
+        assert_eq!(state.focus, 1);
+
+        state
+            .handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE))
+            .expect("k should move focus up");
+        assert_eq!(state.focus, 0);
+
+        state.focus = 1; // DisableTotp toggle
+        state
+            .handle_key(KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE))
+            .expect("l should toggle on");
+        assert!(state.plan.disable_totp);
+
+        state
+            .handle_key(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE))
+            .expect("h should toggle off");
+        assert!(!state.plan.disable_totp);
+    }
+
+    #[test]
+    fn edit_shortcuts_support_e_to_open_and_ctrl_s_to_save() {
+        let workspace = Path::new("/tmp/zeroclaw-key-alias-edit").to_path_buf();
+        let mut state = TuiState::new(workspace, true);
+        state.step = Step::Provider;
+        state.focus = 2; // Model
+        let original = state.plan.model.clone();
+
+        state
+            .handle_key(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE))
+            .expect("e should open editor for text fields");
+        assert!(state.editing.is_some());
+
+        state
+            .handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE))
+            .expect("typing while editing should append to value");
+        state
+            .handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL))
+            .expect("ctrl+s should save editing");
+
+        assert!(state.editing.is_none());
+        assert_eq!(state.plan.model, format!("{original}x"));
+    }
+
+    #[test]
+    fn review_step_accepts_s_as_apply_shortcut() {
+        let workspace = Path::new("/tmp/zeroclaw-key-alias-review-apply").to_path_buf();
+        let mut state = TuiState::new(workspace, true);
+        state.step = Step::Review;
+
+        let action = state
+            .handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::NONE))
+            .expect("s should be accepted on review step");
+
+        assert_eq!(action, LoopAction::Submit);
+    }
+}

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -28,13 +28,15 @@ use crate::providers::{
     is_siliconflow_alias, is_stepfun_alias, is_zai_alias, is_zai_cn_alias,
 };
 use anyhow::{bail, Context, Result};
-use console::style;
+use console::{style, Style};
+use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Confirm, Input, Select};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::Duration;
 use tokio::fs;
 
@@ -78,9 +80,62 @@ const MODEL_PREVIEW_LIMIT: usize = 20;
 const MODEL_CACHE_FILE: &str = "models_cache.json";
 const MODEL_CACHE_TTL_SECS: u64 = 12 * 60 * 60;
 const CUSTOM_MODEL_SENTINEL: &str = "__custom_model__";
+const STEP_PROGRESS_BAR_WIDTH: usize = 24;
+const STEP_DIVIDER_WIDTH: usize = 62;
+const FULL_ONBOARDING_STEPS: [&str; 11] = [
+    "Workspace Setup",
+    "AI Provider & API Key",
+    "Channels",
+    "Tunnel",
+    "Tool Mode & Security",
+    "Web & Internet Tools",
+    "Hardware",
+    "Memory",
+    "Identity Backend",
+    "Project Context",
+    "Workspace Files",
+];
 
 fn has_launchable_channels(channels: &ChannelsConfig) -> bool {
     channels.channels_except_webhook().iter().any(|(_, ok)| *ok)
+}
+
+fn wizard_theme() -> &'static ColorfulTheme {
+    static THEME: OnceLock<ColorfulTheme> = OnceLock::new();
+    THEME.get_or_init(|| ColorfulTheme {
+        defaults_style: Style::new().for_stderr().cyan(),
+        prompt_style: Style::new().for_stderr().bold().white(),
+        prompt_prefix: style(">".to_string()).for_stderr().cyan().bold(),
+        prompt_suffix: style("::".to_string()).for_stderr().black().bright(),
+        success_prefix: style("✓".to_string()).for_stderr().green().bold(),
+        success_suffix: style("::".to_string()).for_stderr().black().bright(),
+        error_prefix: style("!".to_string()).for_stderr().red().bold(),
+        error_style: Style::new().for_stderr().red().bold(),
+        hint_style: Style::new().for_stderr().black().bright(),
+        values_style: Style::new().for_stderr().green().bold(),
+        active_item_style: Style::new().for_stderr().cyan().bold(),
+        inactive_item_style: Style::new().for_stderr(),
+        active_item_prefix: style("›".to_string()).for_stderr().cyan().bold(),
+        inactive_item_prefix: style(" ".to_string()).for_stderr(),
+        checked_item_prefix: style("✓".to_string()).for_stderr().green().bold(),
+        unchecked_item_prefix: style("○".to_string()).for_stderr().black().bright(),
+        picked_item_prefix: style("✓".to_string()).for_stderr().green().bold(),
+        unpicked_item_prefix: style(" ".to_string()).for_stderr(),
+        fuzzy_cursor_style: Style::new().for_stderr().black().on_white(),
+        fuzzy_match_highlight_style: Style::new().for_stderr().cyan().bold(),
+    })
+}
+
+fn print_onboarding_overview() {
+    println!("  {}", style("Wizard flow").white().bold());
+    for (idx, step) in FULL_ONBOARDING_STEPS.iter().enumerate() {
+        println!(
+            "    {} {}",
+            style(format!("{:>2}.", idx + 1)).cyan().bold(),
+            style(*step).dim()
+        );
+    }
+    println!();
 }
 
 // ── Main wizard entry point ──────────────────────────────────────
@@ -116,6 +171,7 @@ pub async fn run_wizard_with_migration(
         style("This wizard will configure your agent in under 60 seconds.").dim()
     );
     println!();
+    print_onboarding_overview();
 
     print_step(1, 11, "Workspace Setup");
     let (workspace_dir, config_path) = setup_workspace().await?;
@@ -263,7 +319,7 @@ pub async fn run_wizard_with_migration(
     let has_channels = has_launchable_channels(&config.channels_config);
 
     if has_channels && config.api_key.is_some() {
-        let launch: bool = Confirm::new()
+        let launch: bool = Confirm::with_theme(wizard_theme())
             .with_prompt(format!(
                 "  {} Launch channels now? (connected channels → AI → reply)",
                 style("🚀").cyan()
@@ -315,7 +371,7 @@ pub async fn run_channels_repair_wizard() -> Result<Config> {
     let has_channels = has_launchable_channels(&config.channels_config);
 
     if has_channels && config.api_key.is_some() {
-        let launch: bool = Confirm::new()
+        let launch: bool = Confirm::with_theme(wizard_theme())
             .with_prompt(format!(
                 "  {} Launch channels now? (connected channels → AI → reply)",
                 style("🚀").cyan()
@@ -378,7 +434,7 @@ async fn run_provider_update_wizard(workspace_dir: &Path, config_path: &Path) ->
 
     let has_channels = has_launchable_channels(&config.channels_config);
     if has_channels && config.api_key.is_some() {
-        let launch: bool = Confirm::new()
+        let launch: bool = Confirm::with_theme(wizard_theme())
             .with_prompt(format!(
                 "  {} Launch channels now? (connected channels → AI → reply)",
                 style("🚀").cyan()
@@ -542,7 +598,7 @@ async fn maybe_run_openclaw_migration(
             "  {} OpenClaw data detected. Optional merge migration is available.",
             style("↻").cyan().bold()
         );
-        Confirm::new()
+        Confirm::with_theme(wizard_theme())
             .with_prompt(
                 "  Merge OpenClaw data into this ZeroClaw workspace now? (preserve existing data)",
             )
@@ -2308,17 +2364,28 @@ pub async fn run_models_refresh_all(config: &Config, force: bool) -> Result<()> 
 // ── Step helpers ─────────────────────────────────────────────────
 
 fn print_step(current: u8, total: u8, title: &str) {
+    let total = total.max(1);
+    let completed = current
+        .saturating_sub(1)
+        .min(total)
+        .saturating_mul(STEP_PROGRESS_BAR_WIDTH as u8)
+        / total;
+    let completed = usize::from(completed);
+    let remaining = STEP_PROGRESS_BAR_WIDTH.saturating_sub(completed);
+    let progress = format!("[{}{}]", "=".repeat(completed), ".".repeat(remaining));
+
     println!();
     println!(
-        "  {} {}",
+        "  {} {} {}",
         style(format!("[{current}/{total}]")).cyan().bold(),
+        style(progress).cyan(),
         style(title).white().bold()
     );
-    println!("  {}", style("─".repeat(50)).dim());
+    println!("  {}", style("─".repeat(STEP_DIVIDER_WIDTH)).dim());
 }
 
 fn print_bullet(text: &str) {
-    println!("  {} {}", style("›").cyan(), text);
+    println!("  {} {}", style("•").cyan().bold(), text);
 }
 
 fn resolve_interactive_onboarding_mode(
@@ -2351,7 +2418,7 @@ fn resolve_interactive_onboarding_mode(
         "Cancel",
     ];
 
-    let mode = Select::new()
+    let mode = Select::with_theme(wizard_theme())
         .with_prompt(format!(
             "  Existing config found at {}. Select setup mode",
             config_path.display()
@@ -2388,7 +2455,7 @@ fn ensure_onboard_overwrite_allowed(config_path: &Path, force: bool) -> Result<(
         );
     }
 
-    let confirmed = Confirm::new()
+    let confirmed = Confirm::with_theme(wizard_theme())
         .with_prompt(format!(
             "  Existing config found at {}. Re-running onboarding will overwrite config.toml and may create missing workspace files (including BOOTSTRAP.md). Continue?",
             config_path.display()
@@ -2428,7 +2495,7 @@ async fn setup_workspace() -> Result<(PathBuf, PathBuf)> {
         style(default_workspace_dir.display()).green()
     ));
 
-    let use_default = Confirm::new()
+    let use_default = Confirm::with_theme(wizard_theme())
         .with_prompt("  Use default workspace location?")
         .default(true)
         .interact()?;
@@ -2436,7 +2503,7 @@ async fn setup_workspace() -> Result<(PathBuf, PathBuf)> {
     let (config_dir, workspace_dir) = if use_default {
         (default_config_dir, default_workspace_dir)
     } else {
-        let custom: String = Input::new()
+        let custom: String = Input::with_theme(wizard_theme())
             .with_prompt("  Enter workspace path")
             .interact_text()?;
         let expanded = shellexpand::tilde(&custom).to_string();
@@ -2472,7 +2539,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
         "🔧 Custom — bring your own OpenAI-compatible API",
     ];
 
-    let tier_idx = Select::new()
+    let tier_idx = Select::with_theme(wizard_theme())
         .with_prompt("  Select provider category")
         .items(&tiers)
         .default(0)
@@ -2578,7 +2645,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
         print_bullet("Examples: LiteLLM, LocalAI, vLLM, text-generation-webui, LM Studio, etc.");
         println!();
 
-        let base_url: String = Input::new()
+        let base_url: String = Input::with_theme(wizard_theme())
             .with_prompt("  API base URL (e.g. http://localhost:1234 or https://my-api.com)")
             .interact_text()?;
 
@@ -2587,12 +2654,12 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
             anyhow::bail!("Custom provider requires a base URL.");
         }
 
-        let api_key: String = Input::new()
+        let api_key: String = Input::with_theme(wizard_theme())
             .with_prompt("  API key (or Enter to skip if not needed)")
             .allow_empty(true)
             .interact_text()?;
 
-        let model: String = Input::new()
+        let model: String = Input::with_theme(wizard_theme())
             .with_prompt("  Model name (e.g. llama3, gpt-4o, mistral)")
             .default("default".into())
             .interact_text()?;
@@ -2611,7 +2678,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
 
     let provider_labels: Vec<&str> = providers.iter().map(|(_, label)| *label).collect();
 
-    let provider_idx = Select::new()
+    let provider_idx = Select::with_theme(wizard_theme())
         .with_prompt("  Select your AI provider")
         .items(&provider_labels)
         .default(0)
@@ -2622,13 +2689,13 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
     // ── API key / endpoint ──
     let mut provider_api_url: Option<String> = None;
     let api_key = if provider_name == "ollama" {
-        let use_remote_ollama = Confirm::new()
+        let use_remote_ollama = Confirm::with_theme(wizard_theme())
             .with_prompt("  Use a remote Ollama endpoint (for example Ollama Cloud)?")
             .default(false)
             .interact()?;
 
         if use_remote_ollama {
-            let raw_url: String = Input::new()
+            let raw_url: String = Input::with_theme(wizard_theme())
                 .with_prompt("  Remote Ollama endpoint URL")
                 .default("https://ollama.com".into())
                 .interact_text()?;
@@ -2657,7 +2724,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
                 style(":cloud").yellow()
             ));
 
-            let key: String = Input::new()
+            let key: String = Input::with_theme(wizard_theme())
                 .with_prompt("  API key for remote Ollama endpoint (or Enter to skip)")
                 .allow_empty(true)
                 .interact_text()?;
@@ -2675,7 +2742,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
             String::new()
         }
     } else if matches!(provider_name, "llamacpp" | "llama.cpp") {
-        let raw_url: String = Input::new()
+        let raw_url: String = Input::with_theme(wizard_theme())
             .with_prompt("  llama.cpp server endpoint URL")
             .default("http://localhost:8080/v1".into())
             .interact_text()?;
@@ -2692,7 +2759,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
         ));
         print_bullet("No API key needed unless your llama.cpp server is started with --api-key.");
 
-        let key: String = Input::new()
+        let key: String = Input::with_theme(wizard_theme())
             .with_prompt("  API key for llama.cpp server (or Enter to skip)")
             .allow_empty(true)
             .interact_text()?;
@@ -2706,7 +2773,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
 
         key
     } else if provider_name == "sglang" {
-        let raw_url: String = Input::new()
+        let raw_url: String = Input::with_theme(wizard_theme())
             .with_prompt("  SGLang server endpoint URL")
             .default("http://localhost:30000/v1".into())
             .interact_text()?;
@@ -2723,7 +2790,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
         ));
         print_bullet("No API key needed unless your SGLang server requires authentication.");
 
-        let key: String = Input::new()
+        let key: String = Input::with_theme(wizard_theme())
             .with_prompt("  API key for SGLang server (or Enter to skip)")
             .allow_empty(true)
             .interact_text()?;
@@ -2737,7 +2804,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
 
         key
     } else if provider_name == "vllm" {
-        let raw_url: String = Input::new()
+        let raw_url: String = Input::with_theme(wizard_theme())
             .with_prompt("  vLLM server endpoint URL")
             .default("http://localhost:8000/v1".into())
             .interact_text()?;
@@ -2754,7 +2821,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
         ));
         print_bullet("No API key needed unless your vLLM server requires authentication.");
 
-        let key: String = Input::new()
+        let key: String = Input::with_theme(wizard_theme())
             .with_prompt("  API key for vLLM server (or Enter to skip)")
             .allow_empty(true)
             .interact_text()?;
@@ -2768,7 +2835,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
 
         key
     } else if provider_name == "osaurus" {
-        let raw_url: String = Input::new()
+        let raw_url: String = Input::with_theme(wizard_theme())
             .with_prompt("  Osaurus server endpoint URL")
             .default("http://localhost:1337/v1".into())
             .interact_text()?;
@@ -2785,7 +2852,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
         ));
         print_bullet("No API key needed unless your Osaurus server requires authentication.");
 
-        let key: String = Input::new()
+        let key: String = Input::with_theme(wizard_theme())
             .with_prompt("  API key for Osaurus server (or Enter to skip)")
             .allow_empty(true)
             .interact_text()?;
@@ -2804,7 +2871,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
         print_bullet("Optional: paste a GitHub token now to skip the first-run device prompt.");
         println!();
 
-        let key: String = Input::new()
+        let key: String = Input::with_theme(wizard_theme())
             .with_prompt("  Paste your GitHub token (optional; Enter = device flow)")
             .allow_empty(true)
             .interact_text()?;
@@ -2826,7 +2893,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
             print_bullet("ZeroClaw will reuse your existing Gemini CLI authentication.");
             println!();
 
-            let use_cli: bool = dialoguer::Confirm::new()
+            let use_cli: bool = dialoguer::Confirm::with_theme(wizard_theme())
                 .with_prompt("  Use existing Gemini CLI authentication?")
                 .default(true)
                 .interact()?;
@@ -2839,7 +2906,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
                 String::new() // Empty key = will use CLI tokens
             } else {
                 print_bullet("Get your API key at: https://aistudio.google.com/app/apikey");
-                Input::new()
+                Input::with_theme(wizard_theme())
                     .with_prompt("  Paste your Gemini API key")
                     .allow_empty(true)
                     .interact_text()?
@@ -2855,7 +2922,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
             print_bullet("Or run `gemini` CLI to authenticate (tokens will be reused).");
             println!();
 
-            Input::new()
+            Input::with_theme(wizard_theme())
                 .with_prompt("  Paste your Gemini API key (or press Enter to skip)")
                 .allow_empty(true)
                 .interact_text()?
@@ -2883,7 +2950,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
             print_bullet("Or run `claude setup-token` to get an OAuth setup-token.");
             println!();
 
-            let key: String = Input::new()
+            let key: String = Input::with_theme(wizard_theme())
                 .with_prompt("  Paste your API key or setup-token (or press Enter to skip)")
                 .allow_empty(true)
                 .interact_text()?;
@@ -2915,7 +2982,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
             print_bullet("You can also set QWEN_OAUTH_TOKEN directly.");
             println!();
 
-            let key: String = Input::new()
+            let key: String = Input::with_theme(wizard_theme())
                 .with_prompt(
                     "  Paste your Qwen OAuth token (or press Enter to auto-detect cached OAuth)",
                 )
@@ -3011,7 +3078,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
             print_bullet("You can also set it later via env var or config file.");
             println!();
 
-            let key: String = Input::new()
+            let key: String = Input::with_theme(wizard_theme())
                 .with_prompt("  Paste your API key (or press Enter to skip)")
                 .allow_empty(true)
                 .interact_text()?;
@@ -3080,7 +3147,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
                 ));
             }
 
-            let should_fetch_now = Confirm::new()
+            let should_fetch_now = Confirm::with_theme(wizard_theme())
                 .with_prompt(if live_options.is_some() {
                     "  Refresh models from provider now?"
                 } else {
@@ -3164,7 +3231,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
             format!("Curated starter list ({})", model_options.len()),
         ];
 
-        let source_idx = Select::new()
+        let source_idx = Select::with_theme(wizard_theme())
             .with_prompt("  Model source")
             .items(&source_options)
             .default(0)
@@ -3192,7 +3259,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
         .map(|(model_id, label)| format!("{label} — {}", style(model_id).dim()))
         .collect();
 
-    let model_idx = Select::new()
+    let model_idx = Select::with_theme(wizard_theme())
         .with_prompt("  Select your default model")
         .items(&model_labels)
         .default(0)
@@ -3200,7 +3267,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
 
     let selected_model = model_options[model_idx].0.clone();
     let model = if selected_model == CUSTOM_MODEL_SENTINEL {
-        Input::new()
+        Input::with_theme(wizard_theme())
             .with_prompt("  Enter custom model ID")
             .default(default_model_for_provider(provider_name))
             .interact_text()?
@@ -3357,7 +3424,7 @@ fn prompt_allowed_domains_for_tool(tool_name: &str) -> Result<Vec<String>> {
             "Allow all public domains (*)",
             "Custom domain list (comma-separated)",
         ];
-        let choice = Select::new()
+        let choice = Select::with_theme(wizard_theme())
             .with_prompt("  HTTP domain policy")
             .items(&options)
             .default(0)
@@ -3367,7 +3434,7 @@ fn prompt_allowed_domains_for_tool(tool_name: &str) -> Result<Vec<String>> {
             0 => Ok(http_request_productivity_allowed_domains()),
             1 => Ok(vec!["*".to_string()]),
             _ => {
-                let raw: String = Input::new()
+                let raw: String = Input::with_theme(wizard_theme())
                     .with_prompt("  http_request.allowed_domains (comma-separated, '*' allows all)")
                     .allow_empty(true)
                     .default("api.github.com,api.linear.app,calendar.googleapis.com".to_string())
@@ -3387,7 +3454,7 @@ fn prompt_allowed_domains_for_tool(tool_name: &str) -> Result<Vec<String>> {
         "  {}.allowed_domains (comma-separated, '*' allows all)",
         tool_name
     );
-    let raw: String = Input::new()
+    let raw: String = Input::with_theme(wizard_theme())
         .with_prompt(prompt)
         .allow_empty(true)
         .default("*".to_string())
@@ -3455,7 +3522,7 @@ fn setup_http_request_credential_profiles(
         "This avoids passing raw tokens in tool arguments (use credential_profile instead).",
     );
 
-    let configure_profiles = Confirm::new()
+    let configure_profiles = Confirm::with_theme(wizard_theme())
         .with_prompt("  Configure HTTP credential profiles now?")
         .default(false)
         .interact()?;
@@ -3472,7 +3539,7 @@ fn setup_http_request_credential_profiles(
                 http_request_config.credential_profiles.len() + 1
             )
         };
-        let raw_name: String = Input::new()
+        let raw_name: String = Input::with_theme(wizard_theme())
             .with_prompt("  Profile name (e.g., github, linear)")
             .default(default_name)
             .interact_text()?;
@@ -3492,7 +3559,7 @@ fn setup_http_request_credential_profiles(
         }
 
         let env_var_default = default_env_var_for_profile(&profile_name);
-        let env_var_raw: String = Input::new()
+        let env_var_raw: String = Input::with_theme(wizard_theme())
             .with_prompt("  Environment variable containing token/secret")
             .default(env_var_default)
             .interact_text()?;
@@ -3503,7 +3570,7 @@ fn setup_http_request_credential_profiles(
             );
         }
 
-        let header_name: String = Input::new()
+        let header_name: String = Input::with_theme(wizard_theme())
             .with_prompt("  Header name")
             .default("Authorization".to_string())
             .interact_text()?;
@@ -3512,7 +3579,7 @@ fn setup_http_request_credential_profiles(
             anyhow::bail!("Header name must not be empty");
         }
 
-        let value_prefix: String = Input::new()
+        let value_prefix: String = Input::with_theme(wizard_theme())
             .with_prompt("  Header value prefix (e.g., 'Bearer ', empty for raw token)")
             .allow_empty(true)
             .default("Bearer ".to_string())
@@ -3533,7 +3600,7 @@ fn setup_http_request_credential_profiles(
             style(profile_name).green()
         );
 
-        let add_another = Confirm::new()
+        let add_another = Confirm::with_theme(wizard_theme())
             .with_prompt("  Add another credential profile?")
             .default(false)
             .interact()?;
@@ -3554,7 +3621,7 @@ fn setup_web_tools() -> Result<(WebSearchConfig, WebFetchConfig, HttpRequestConf
 
     // ── Web Search ──────────────────────────────────────────────
     let mut web_search_config = WebSearchConfig::default();
-    let enable_web_search = Confirm::new()
+    let enable_web_search = Confirm::with_theme(wizard_theme())
         .with_prompt("  Enable web_search_tool?")
         .default(false)
         .interact()?;
@@ -3568,7 +3635,7 @@ fn setup_web_tools() -> Result<(WebSearchConfig, WebFetchConfig, HttpRequestConf
             #[cfg(feature = "firecrawl")]
             "Firecrawl (requires API key + firecrawl feature)",
         ];
-        let provider_choice = Select::new()
+        let provider_choice = Select::with_theme(wizard_theme())
             .with_prompt("  web_search provider")
             .items(&provider_options)
             .default(0)
@@ -3577,7 +3644,7 @@ fn setup_web_tools() -> Result<(WebSearchConfig, WebFetchConfig, HttpRequestConf
         match provider_choice {
             1 => {
                 web_search_config.provider = "brave".to_string();
-                let key: String = Input::new()
+                let key: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Brave Search API key")
                     .interact_text()?;
                 if !key.trim().is_empty() {
@@ -3587,13 +3654,13 @@ fn setup_web_tools() -> Result<(WebSearchConfig, WebFetchConfig, HttpRequestConf
             #[cfg(feature = "firecrawl")]
             2 => {
                 web_search_config.provider = "firecrawl".to_string();
-                let key: String = Input::new()
+                let key: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Firecrawl API key")
                     .interact_text()?;
                 if !key.trim().is_empty() {
                     web_search_config.api_key = Some(key.trim().to_string());
                 }
-                let url: String = Input::new()
+                let url: String = Input::with_theme(wizard_theme())
                     .with_prompt(
                         "  Firecrawl API URL (leave blank for cloud https://api.firecrawl.dev)",
                     )
@@ -3625,7 +3692,7 @@ fn setup_web_tools() -> Result<(WebSearchConfig, WebFetchConfig, HttpRequestConf
 
     // ── Web Fetch ───────────────────────────────────────────────
     let mut web_fetch_config = WebFetchConfig::default();
-    let enable_web_fetch = Confirm::new()
+    let enable_web_fetch = Confirm::with_theme(wizard_theme())
         .with_prompt("  Enable web_fetch tool (fetch and read web pages)?")
         .default(false)
         .interact()?;
@@ -3639,7 +3706,7 @@ fn setup_web_tools() -> Result<(WebSearchConfig, WebFetchConfig, HttpRequestConf
             #[cfg(feature = "firecrawl")]
             "firecrawl (cloud conversion, requires API key)",
         ];
-        let provider_choice = Select::new()
+        let provider_choice = Select::with_theme(wizard_theme())
             .with_prompt("  web_fetch provider")
             .items(&provider_options)
             .default(0)
@@ -3652,13 +3719,13 @@ fn setup_web_tools() -> Result<(WebSearchConfig, WebFetchConfig, HttpRequestConf
             #[cfg(feature = "firecrawl")]
             2 => {
                 web_fetch_config.provider = "firecrawl".to_string();
-                let key: String = Input::new()
+                let key: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Firecrawl API key")
                     .interact_text()?;
                 if !key.trim().is_empty() {
                     web_fetch_config.api_key = Some(key.trim().to_string());
                 }
-                let url: String = Input::new()
+                let url: String = Input::with_theme(wizard_theme())
                     .with_prompt(
                         "  Firecrawl API URL (leave blank for cloud https://api.firecrawl.dev)",
                     )
@@ -3690,7 +3757,7 @@ fn setup_web_tools() -> Result<(WebSearchConfig, WebFetchConfig, HttpRequestConf
 
     // ── HTTP Request ────────────────────────────────────────────
     let mut http_request_config = HttpRequestConfig::default();
-    let enable_http_request = Confirm::new()
+    let enable_http_request = Confirm::with_theme(wizard_theme())
         .with_prompt("  Enable http_request tool for direct API calls?")
         .default(false)
         .interact()?;
@@ -3743,7 +3810,7 @@ fn setup_tool_mode() -> Result<(ComposioConfig, SecretsConfig)> {
         "Composio (managed OAuth) — 1000+ apps via OAuth, no raw keys shared",
     ];
 
-    let choice = Select::new()
+    let choice = Select::with_theme(wizard_theme())
         .with_prompt("  Select tool mode")
         .items(&options)
         .default(0)
@@ -3760,7 +3827,7 @@ fn setup_tool_mode() -> Result<(ComposioConfig, SecretsConfig)> {
         print_bullet("ZeroClaw uses Composio as a tool — your core agent stays local.");
         println!();
 
-        let api_key: String = Input::new()
+        let api_key: String = Input::with_theme(wizard_theme())
             .with_prompt("  Composio API key (or Enter to skip)")
             .allow_empty(true)
             .interact_text()?;
@@ -3797,7 +3864,7 @@ fn setup_tool_mode() -> Result<(ComposioConfig, SecretsConfig)> {
     print_bullet("ZeroClaw can encrypt API keys stored in config.toml.");
     print_bullet("A local key file protects against plaintext exposure and accidental leaks.");
 
-    let encrypt = Confirm::new()
+    let encrypt = Confirm::with_theme(wizard_theme())
         .with_prompt("  Enable encrypted secret storage?")
         .default(true)
         .interact()?;
@@ -3880,7 +3947,7 @@ fn setup_hardware() -> Result<HardwareConfig> {
 
     let recommended = hardware::recommended_wizard_default(&devices);
 
-    let choice = Select::new()
+    let choice = Select::with_theme(wizard_theme())
         .with_prompt("  How should ZeroClaw interact with the physical world?")
         .items(&options)
         .default(recommended)
@@ -3907,7 +3974,7 @@ fn setup_hardware() -> Result<HardwareConfig> {
                 })
                 .collect();
 
-            let port_idx = Select::new()
+            let port_idx = Select::with_theme(wizard_theme())
                 .with_prompt("  Multiple serial devices found — select one")
                 .items(&port_labels)
                 .default(0)
@@ -3916,7 +3983,7 @@ fn setup_hardware() -> Result<HardwareConfig> {
             hw_config.serial_port = serial_devices[port_idx].device_path.clone();
         } else if serial_devices.is_empty() {
             // User chose serial but no device discovered — ask for manual path
-            let manual_port: String = Input::new()
+            let manual_port: String = Input::with_theme(wizard_theme())
                 .with_prompt("  Serial port path (e.g. /dev/ttyUSB0)")
                 .default("/dev/ttyUSB0".into())
                 .interact_text()?;
@@ -3931,7 +3998,7 @@ fn setup_hardware() -> Result<HardwareConfig> {
             "230400",
             "Custom",
         ];
-        let baud_idx = Select::new()
+        let baud_idx = Select::with_theme(wizard_theme())
             .with_prompt("  Serial baud rate")
             .items(&baud_options)
             .default(0)
@@ -3942,7 +4009,7 @@ fn setup_hardware() -> Result<HardwareConfig> {
             2 => 57600,
             3 => 230_400,
             4 => {
-                let custom: String = Input::new()
+                let custom: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Custom baud rate")
                     .default("115200".into())
                     .interact_text()?;
@@ -3956,7 +4023,7 @@ fn setup_hardware() -> Result<HardwareConfig> {
     if hw_config.transport_mode() == hardware::HardwareTransport::Probe
         && hw_config.probe_target.is_none()
     {
-        let target: String = Input::new()
+        let target: String = Input::with_theme(wizard_theme())
             .with_prompt("  Target MCU chip (e.g. STM32F411CEUx, nRF52840_xxAA)")
             .default("STM32F411CEUx".into())
             .interact_text()?;
@@ -3965,7 +4032,7 @@ fn setup_hardware() -> Result<HardwareConfig> {
 
     // ── Datasheet RAG ──
     if hw_config.enabled {
-        let datasheets = Confirm::new()
+        let datasheets = Confirm::with_theme(wizard_theme())
             .with_prompt("  Enable datasheet RAG? (index PDF schematics for AI pin lookups)")
             .default(true)
             .interact()?;
@@ -4016,7 +4083,7 @@ fn setup_project_context() -> Result<ProjectContext> {
     print_bullet("Press Enter to accept defaults.");
     println!();
 
-    let user_name: String = Input::new()
+    let user_name: String = Input::with_theme(wizard_theme())
         .with_prompt("  Your name")
         .default("User".into())
         .interact_text()?;
@@ -4034,14 +4101,14 @@ fn setup_project_context() -> Result<ProjectContext> {
         "Other (type manually)",
     ];
 
-    let tz_idx = Select::new()
+    let tz_idx = Select::with_theme(wizard_theme())
         .with_prompt("  Your timezone")
         .items(&tz_options)
         .default(0)
         .interact()?;
 
     let timezone = if tz_idx == tz_options.len() - 1 {
-        Input::new()
+        Input::with_theme(wizard_theme())
             .with_prompt("  Enter timezone (e.g. America/New_York)")
             .default("UTC".into())
             .interact_text()?
@@ -4055,7 +4122,7 @@ fn setup_project_context() -> Result<ProjectContext> {
             .to_string()
     };
 
-    let agent_name: String = Input::new()
+    let agent_name: String = Input::with_theme(wizard_theme())
         .with_prompt("  Agent name")
         .default("ZeroClaw".into())
         .interact_text()?;
@@ -4070,7 +4137,7 @@ fn setup_project_context() -> Result<ProjectContext> {
         "Custom — write your own style guide",
     ];
 
-    let style_idx = Select::new()
+    let style_idx = Select::with_theme(wizard_theme())
         .with_prompt("  Communication style")
         .items(&style_options)
         .default(1)
@@ -4083,7 +4150,7 @@ fn setup_project_context() -> Result<ProjectContext> {
         3 => "Be expressive and playful when appropriate. Use relevant emojis naturally (0-2 max), and keep serious topics emoji-light.".to_string(),
         4 => "Be technical and detailed. Thorough explanations, code-first.".to_string(),
         5 => "Adapt to the situation. Default to warm and clear communication; be concise when needed, thorough when it matters.".to_string(),
-        _ => Input::new()
+        _ => Input::with_theme(wizard_theme())
             .with_prompt("  Custom communication style")
             .default(
                 "Be warm, natural, and clear. Use occasional relevant emojis (1-2 max) and avoid robotic phrasing.".into(),
@@ -4120,7 +4187,7 @@ fn setup_memory() -> Result<MemoryConfig> {
         .map(|backend| backend.label)
         .collect();
 
-    let choice = Select::new()
+    let choice = Select::with_theme(wizard_theme())
         .with_prompt("  Select memory backend")
         .items(&options)
         .default(0)
@@ -4130,7 +4197,7 @@ fn setup_memory() -> Result<MemoryConfig> {
     let profile = memory_backend_profile(backend);
 
     let auto_save = profile.auto_save_default
-        && Confirm::new()
+        && Confirm::with_theme(wizard_theme())
             .with_prompt("  Auto-save conversations to memory?")
             .default(true)
             .interact()?;
@@ -4161,7 +4228,7 @@ fn configure_hybrid_qdrant_memory(config: &mut MemoryConfig) -> Result<()> {
         .url
         .clone()
         .unwrap_or_else(|| "http://localhost:6333".to_string());
-    let qdrant_url: String = Input::new()
+    let qdrant_url: String = Input::with_theme(wizard_theme())
         .with_prompt("  Qdrant URL")
         .default(qdrant_url_default)
         .interact_text()?;
@@ -4171,7 +4238,7 @@ fn configure_hybrid_qdrant_memory(config: &mut MemoryConfig) -> Result<()> {
     }
     config.qdrant.url = Some(qdrant_url.to_string());
 
-    let qdrant_collection: String = Input::new()
+    let qdrant_collection: String = Input::with_theme(wizard_theme())
         .with_prompt("  Qdrant collection")
         .default(config.qdrant.collection.clone())
         .interact_text()?;
@@ -4180,7 +4247,7 @@ fn configure_hybrid_qdrant_memory(config: &mut MemoryConfig) -> Result<()> {
         config.qdrant.collection = qdrant_collection.to_string();
     }
 
-    let qdrant_api_key: String = Input::new()
+    let qdrant_api_key: String = Input::with_theme(wizard_theme())
         .with_prompt("  Qdrant API key (optional, Enter to skip)")
         .allow_empty(true)
         .interact_text()?;
@@ -4217,7 +4284,7 @@ fn setup_identity_backend() -> Result<IdentityConfig> {
         .map(|profile| format!("{} — {}", profile.label, profile.description))
         .collect();
 
-    let selected = Select::new()
+    let selected = Select::with_theme(wizard_theme())
         .with_prompt("  Select identity backend")
         .items(&options)
         .default(0)
@@ -4440,7 +4507,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
             })
             .collect();
 
-        let selection = Select::new()
+        let selection = Select::with_theme(wizard_theme())
             .with_prompt("  Connect a channel (or Done to continue)")
             .items(&options)
             .default(options.len() - 1)
@@ -4465,7 +4532,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("3. Copy the bot token and paste it below");
                 println!();
 
-                let token: String = Input::new()
+                let token: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Bot token (from @BotFather)")
                     .interact_text()?;
 
@@ -4517,7 +4584,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 );
                 print_bullet("Use '*' only for temporary open testing.");
 
-                let users_str: String = Input::new()
+                let users_str: String = Input::with_theme(wizard_theme())
                     .with_prompt(
                         "  Allowed Telegram identities (comma-separated: username without '@' and/or numeric user ID, '*' for all)",
                     )
@@ -4568,7 +4635,9 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("4. Invite bot to your server with messages permission");
                 println!();
 
-                let token: String = Input::new().with_prompt("  Bot token").interact_text()?;
+                let token: String = Input::with_theme(wizard_theme())
+                    .with_prompt("  Bot token")
+                    .interact_text()?;
 
                 if token.trim().is_empty() {
                     println!("  {} Skipped", style("→").dim());
@@ -4610,7 +4679,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     }
                 }
 
-                let guild: String = Input::new()
+                let guild: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Server (guild) ID (optional, Enter to skip)")
                     .allow_empty(true)
                     .interact_text()?;
@@ -4621,7 +4690,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 );
                 print_bullet("Use '*' only for temporary open testing.");
 
-                let allowed_users_str: String = Input::new()
+                let allowed_users_str: String = Input::with_theme(wizard_theme())
                     .with_prompt(
                         "  Allowed Discord user IDs (comma-separated, recommended: your own ID, '*' for all)",
                     )
@@ -4667,7 +4736,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("3. Install to workspace and copy the Bot Token");
                 println!();
 
-                let token: String = Input::new()
+                let token: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Bot token (xoxb-...)")
                     .interact_text()?;
 
@@ -4724,12 +4793,12 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     }
                 }
 
-                let app_token: String = Input::new()
+                let app_token: String = Input::with_theme(wizard_theme())
                     .with_prompt("  App token (xapp-..., optional, Enter to skip)")
                     .allow_empty(true)
                     .interact_text()?;
 
-                let channel: String = Input::new()
+                let channel: String = Input::with_theme(wizard_theme())
                     .with_prompt(
                         "  Default channel ID (optional, Enter to skip for all accessible channels; '*' also means all)",
                     )
@@ -4742,7 +4811,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 );
                 print_bullet("Use '*' only for temporary open testing.");
 
-                let allowed_users_str: String = Input::new()
+                let allowed_users_str: String = Input::with_theme(wizard_theme())
                     .with_prompt(
                         "  Allowed Slack user IDs (comma-separated, recommended: your own member ID, '*' for all)",
                     )
@@ -4806,7 +4875,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 );
                 println!();
 
-                let contacts_str: String = Input::new()
+                let contacts_str: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Allowed contacts (comma-separated phone/email, or * for all)")
                     .default("*".into())
                     .interact_text()?;
@@ -4839,7 +4908,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("Get a token via Element → Settings → Help & About → Access Token.");
                 println!();
 
-                let homeserver: String = Input::new()
+                let homeserver: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Homeserver URL (e.g. https://matrix.org)")
                     .interact_text()?;
 
@@ -4848,8 +4917,9 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     continue;
                 }
 
-                let access_token: String =
-                    Input::new().with_prompt("  Access token").interact_text()?;
+                let access_token: String = Input::with_theme(wizard_theme())
+                    .with_prompt("  Access token")
+                    .interact_text()?;
 
                 if access_token.trim().is_empty() {
                     println!("  {} Skipped — token required", style("→").dim());
@@ -4915,11 +4985,11 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     }
                 };
 
-                let room_id: String = Input::new()
+                let room_id: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Room ID (e.g. !abc123:matrix.org)")
                     .interact_text()?;
 
-                let users_str: String = Input::new()
+                let users_str: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Allowed users (comma-separated @user:server, or * for all)")
                     .default("*".into())
                     .interact_text()?;
@@ -4953,7 +5023,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("3. Optionally scope to DMs only or to a specific group.");
                 println!();
 
-                let http_url: String = Input::new()
+                let http_url: String = Input::with_theme(wizard_theme())
                     .with_prompt("  signal-cli HTTP URL")
                     .default("http://127.0.0.1:8686".into())
                     .interact_text()?;
@@ -4963,7 +5033,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     continue;
                 }
 
-                let account: String = Input::new()
+                let account: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Account number (E.164, e.g. +1234567890)")
                     .interact_text()?;
 
@@ -4977,7 +5047,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     "DM only",
                     "Specific group ID",
                 ];
-                let scope_choice = Select::new()
+                let scope_choice = Select::with_theme(wizard_theme())
                     .with_prompt("  Message scope")
                     .items(scope_options)
                     .default(0)
@@ -4986,8 +5056,9 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 let group_id = match scope_choice {
                     1 => Some("dm".to_string()),
                     2 => {
-                        let group_input: String =
-                            Input::new().with_prompt("  Group ID").interact_text()?;
+                        let group_input: String = Input::with_theme(wizard_theme())
+                            .with_prompt("  Group ID")
+                            .interact_text()?;
                         let group_input = group_input.trim().to_string();
                         if group_input.is_empty() {
                             println!("  {} Skipped — group ID required", style("→").dim());
@@ -4998,7 +5069,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     _ => None,
                 };
 
-                let allowed_from_raw: String = Input::new()
+                let allowed_from_raw: String = Input::with_theme(wizard_theme())
                     .with_prompt(
                         "  Allowed sender numbers (comma-separated +1234567890, or * for all)",
                     )
@@ -5015,12 +5086,12 @@ fn setup_channels() -> Result<ChannelsConfig> {
                         .collect()
                 };
 
-                let ignore_attachments = Confirm::new()
+                let ignore_attachments = Confirm::with_theme(wizard_theme())
                     .with_prompt("  Ignore attachment-only messages?")
                     .default(false)
                     .interact()?;
 
-                let ignore_stories = Confirm::new()
+                let ignore_stories = Confirm::with_theme(wizard_theme())
                     .with_prompt("  Ignore incoming stories?")
                     .default(true)
                     .interact()?;
@@ -5045,7 +5116,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     "WhatsApp Web (QR / pair-code, no Meta Business API)",
                     "WhatsApp Business Cloud API (webhook)",
                 ];
-                let mode_idx = Select::new()
+                let mode_idx = Select::with_theme(wizard_theme())
                     .with_prompt("  Choose WhatsApp mode")
                     .items(&mode_options)
                     .default(0)
@@ -5060,7 +5131,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     print_bullet("3. Keep session_path persistent so relogin is not required");
                     println!();
 
-                    let session_path: String = Input::new()
+                    let session_path: String = Input::with_theme(wizard_theme())
                         .with_prompt("  Session database path")
                         .default("~/.zeroclaw/state/whatsapp-web/session.db".into())
                         .interact_text()?;
@@ -5070,7 +5141,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                         continue;
                     }
 
-                    let pair_phone: String = Input::new()
+                    let pair_phone: String = Input::with_theme(wizard_theme())
                         .with_prompt(
                             "  Pair phone (optional, digits only; leave empty to use QR flow)",
                         )
@@ -5080,7 +5151,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     let pair_code: String = if pair_phone.trim().is_empty() {
                         String::new()
                     } else {
-                        Input::new()
+                        Input::with_theme(wizard_theme())
                             .with_prompt(
                                 "  Custom pair code (optional, leave empty for auto-generated)",
                             )
@@ -5088,7 +5159,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                             .interact_text()?
                     };
 
-                    let users_str: String = Input::new()
+                    let users_str: String = Input::with_theme(wizard_theme())
                         .with_prompt(
                             "  Allowed phone numbers (comma-separated +1234567890, or * for all)",
                         )
@@ -5132,7 +5203,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("4. Configure webhook URL to: https://your-domain/whatsapp");
                 println!();
 
-                let access_token: String = Input::new()
+                let access_token: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Access token (from Meta Developers)")
                     .interact_text()?;
 
@@ -5141,7 +5212,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     continue;
                 }
 
-                let phone_number_id: String = Input::new()
+                let phone_number_id: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Phone number ID (from WhatsApp app settings)")
                     .interact_text()?;
 
@@ -5150,7 +5221,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     continue;
                 }
 
-                let verify_token: String = Input::new()
+                let verify_token: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Webhook verify token (create your own)")
                     .default("zeroclaw-whatsapp-verify".into())
                     .interact_text()?;
@@ -5191,7 +5262,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     }
                 }
 
-                let users_str: String = Input::new()
+                let users_str: String = Input::with_theme(wizard_theme())
                     .with_prompt(
                         "  Allowed phone numbers (comma-separated +1234567890, or * for all)",
                     )
@@ -5228,7 +5299,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("3. Configure webhook URL to: https://your-domain/linq");
                 println!();
 
-                let api_token: String = Input::new()
+                let api_token: String = Input::with_theme(wizard_theme())
                     .with_prompt("  API token (Linq Partner API token)")
                     .interact_text()?;
 
@@ -5237,7 +5308,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     continue;
                 }
 
-                let from_phone: String = Input::new()
+                let from_phone: String = Input::with_theme(wizard_theme())
                     .with_prompt("  From phone number (E.164 format, e.g. +12223334444)")
                     .interact_text()?;
 
@@ -5278,7 +5349,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     }
                 }
 
-                let users_str: String = Input::new()
+                let users_str: String = Input::with_theme(wizard_theme())
                     .with_prompt(
                         "  Allowed sender numbers (comma-separated +1234567890, or * for all)",
                     )
@@ -5291,7 +5362,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     users_str.split(',').map(|s| s.trim().to_string()).collect()
                 };
 
-                let signing_secret: String = Input::new()
+                let signing_secret: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Webhook signing secret (optional, press Enter to skip)")
                     .allow_empty(true)
                     .interact_text()?;
@@ -5319,7 +5390,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("Supports SASL PLAIN and NickServ authentication");
                 println!();
 
-                let server: String = Input::new()
+                let server: String = Input::with_theme(wizard_theme())
                     .with_prompt("  IRC server (hostname)")
                     .interact_text()?;
 
@@ -5328,7 +5399,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     continue;
                 }
 
-                let port_str: String = Input::new()
+                let port_str: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Port")
                     .default("6697".into())
                     .interact_text()?;
@@ -5341,15 +5412,16 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     }
                 };
 
-                let nickname: String =
-                    Input::new().with_prompt("  Bot nickname").interact_text()?;
+                let nickname: String = Input::with_theme(wizard_theme())
+                    .with_prompt("  Bot nickname")
+                    .interact_text()?;
 
                 if nickname.trim().is_empty() {
                     println!("  {} Skipped — nickname required", style("→").dim());
                     continue;
                 }
 
-                let channels_str: String = Input::new()
+                let channels_str: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Channels to join (comma-separated: #channel1,#channel2)")
                     .allow_empty(true)
                     .interact_text()?;
@@ -5369,7 +5441,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 );
                 print_bullet("Use '*' to allow anyone (not recommended for production).");
 
-                let users_str: String = Input::new()
+                let users_str: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Allowed nicknames (comma-separated, or * for all)")
                     .allow_empty(true)
                     .interact_text()?;
@@ -5393,22 +5465,22 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 println!();
                 print_bullet("Optional authentication (press Enter to skip each):");
 
-                let server_password: String = Input::new()
+                let server_password: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Server password (for bouncers like ZNC, leave empty if none)")
                     .allow_empty(true)
                     .interact_text()?;
 
-                let nickserv_password: String = Input::new()
+                let nickserv_password: String = Input::with_theme(wizard_theme())
                     .with_prompt("  NickServ password (leave empty if none)")
                     .allow_empty(true)
                     .interact_text()?;
 
-                let sasl_password: String = Input::new()
+                let sasl_password: String = Input::with_theme(wizard_theme())
                     .with_prompt("  SASL PLAIN password (leave empty if none)")
                     .allow_empty(true)
                     .interact_text()?;
 
-                let verify_tls: bool = Confirm::new()
+                let verify_tls: bool = Confirm::with_theme(wizard_theme())
                     .with_prompt("  Verify TLS certificate?")
                     .default(true)
                     .interact()?;
@@ -5455,12 +5527,12 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     style("— HTTP endpoint for custom integrations").dim()
                 );
 
-                let port: String = Input::new()
+                let port: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Port")
                     .default("8080".into())
                     .interact_text()?;
 
-                let secret: String = Input::new()
+                let secret: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Secret (optional, Enter to skip)")
                     .allow_empty(true)
                     .interact_text()?;
@@ -5494,7 +5566,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 );
                 println!();
 
-                let base_url: String = Input::new()
+                let base_url: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Nextcloud base URL (e.g. https://cloud.example.com)")
                     .interact_text()?;
 
@@ -5504,7 +5576,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     continue;
                 }
 
-                let app_token: String = Input::new()
+                let app_token: String = Input::with_theme(wizard_theme())
                     .with_prompt("  App token (Talk bot token)")
                     .interact_text()?;
 
@@ -5513,12 +5585,12 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     continue;
                 }
 
-                let webhook_secret: String = Input::new()
+                let webhook_secret: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Webhook secret (optional, Enter to skip)")
                     .allow_empty(true)
                     .interact_text()?;
 
-                let allowed_users_raw: String = Input::new()
+                let allowed_users_raw: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Allowed Nextcloud actor IDs (comma-separated, or * for all)")
                     .default("*".into())
                     .interact_text()?;
@@ -5559,7 +5631,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("3. Copy the Client ID (AppKey) and Client Secret (AppSecret)");
                 println!();
 
-                let client_id: String = Input::new()
+                let client_id: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Client ID (AppKey)")
                     .interact_text()?;
 
@@ -5568,7 +5640,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     continue;
                 }
 
-                let client_secret: String = Input::new()
+                let client_secret: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Client Secret (AppSecret)")
                     .interact_text()?;
 
@@ -5599,7 +5671,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     }
                 }
 
-                let users_str: String = Input::new()
+                let users_str: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Allowed staff IDs (comma-separated, '*' for all)")
                     .allow_empty(true)
                     .interact_text()?;
@@ -5629,15 +5701,18 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("3. Copy the App ID and App Secret");
                 println!();
 
-                let app_id: String = Input::new().with_prompt("  App ID").interact_text()?;
+                let app_id: String = Input::with_theme(wizard_theme())
+                    .with_prompt("  App ID")
+                    .interact_text()?;
 
                 if app_id.trim().is_empty() {
                     println!("  {} Skipped", style("→").dim());
                     continue;
                 }
 
-                let app_secret: String =
-                    Input::new().with_prompt("  App Secret").interact_text()?;
+                let app_secret: String = Input::with_theme(wizard_theme())
+                    .with_prompt("  App Secret")
+                    .interact_text()?;
 
                 // Test connection
                 print!("  {} Testing connection... ", style("⏳").dim());
@@ -5675,7 +5750,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     }
                 }
 
-                let users_str: String = Input::new()
+                let users_str: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Allowed user IDs (comma-separated, '*' for all)")
                     .allow_empty(true)
                     .interact_text()?;
@@ -5686,7 +5761,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     .filter(|s| !s.is_empty())
                     .collect();
 
-                let receive_mode_choice = Select::new()
+                let receive_mode_choice = Select::with_theme(wizard_theme())
                     .with_prompt("  Receive mode")
                     .items(["Webhook (recommended)", "WebSocket (legacy fallback)"])
                     .default(0)
@@ -5697,7 +5772,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     QQReceiveMode::Websocket
                 };
 
-                let environment_choice = Select::new()
+                let environment_choice = Select::with_theme(wizard_theme())
                     .with_prompt("  API environment")
                     .items(["Production", "Sandbox (for unpublished bot testing)"])
                     .default(0)
@@ -5731,7 +5806,9 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("3. Copy the App ID and App Secret");
                 println!();
 
-                let app_id: String = Input::new().with_prompt("  App ID").interact_text()?;
+                let app_id: String = Input::with_theme(wizard_theme())
+                    .with_prompt("  App ID")
+                    .interact_text()?;
                 let app_id = app_id.trim().to_string();
 
                 if app_id.trim().is_empty() {
@@ -5739,8 +5816,9 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     continue;
                 }
 
-                let app_secret: String =
-                    Input::new().with_prompt("  App Secret").interact_text()?;
+                let app_secret: String = Input::with_theme(wizard_theme())
+                    .with_prompt("  App Secret")
+                    .interact_text()?;
                 let app_secret = app_secret.trim().to_string();
 
                 if app_secret.is_empty() {
@@ -5748,7 +5826,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     continue;
                 }
 
-                let use_feishu = Select::new()
+                let use_feishu = Select::with_theme(wizard_theme())
                     .with_prompt("  Region")
                     .items(["Feishu (CN)", "Lark (International)"])
                     .default(0)
@@ -5828,7 +5906,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     }
                 }
 
-                let receive_mode_choice = Select::new()
+                let receive_mode_choice = Select::with_theme(wizard_theme())
                     .with_prompt("  Receive Mode")
                     .items([
                         "WebSocket (recommended, no public IP needed)",
@@ -5844,7 +5922,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 };
 
                 let verification_token = if receive_mode == LarkReceiveMode::Webhook {
-                    let token: String = Input::new()
+                    let token: String = Input::with_theme(wizard_theme())
                         .with_prompt("  Verification Token (optional, for Webhook mode)")
                         .allow_empty(true)
                         .interact_text()?;
@@ -5865,7 +5943,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 }
 
                 let port = if receive_mode == LarkReceiveMode::Webhook {
-                    let p: String = Input::new()
+                    let p: String = Input::with_theme(wizard_theme())
                         .with_prompt("  Webhook Port")
                         .default("8080".into())
                         .interact_text()?;
@@ -5874,7 +5952,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     None
                 };
 
-                let users_str: String = Input::new()
+                let users_str: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Allowed user Open IDs (comma-separated, '*' for all)")
                     .allow_empty(true)
                     .interact_text()?;
@@ -5919,7 +5997,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("You need a Nostr private key (hex or nsec) and at least one relay.");
                 println!();
 
-                let private_key: String = Input::new()
+                let private_key: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Private key (hex or nsec1...)")
                     .interact_text()?;
 
@@ -5947,7 +6025,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 }
 
                 let default_relays = default_nostr_relays().join(",");
-                let relays_str: String = Input::new()
+                let relays_str: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Relay URLs (comma-separated, Enter for defaults)")
                     .default(default_relays)
                     .interact_text()?;
@@ -5961,7 +6039,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 print_bullet("Allowlist pubkeys that can message the bot (hex or npub).");
                 print_bullet("Use '*' to allow anyone (not recommended for production).");
 
-                let pubkeys_str: String = Input::new()
+                let pubkeys_str: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Allowed pubkeys (comma-separated, or * for all)")
                     .allow_empty(true)
                     .interact_text()?;
@@ -6038,7 +6116,7 @@ fn setup_tunnel() -> Result<crate::config::TunnelConfig> {
         "Custom — bring your own (bore, frp, ssh, etc.)",
     ];
 
-    let choice = Select::new()
+    let choice = Select::with_theme(wizard_theme())
         .with_prompt("  Select tunnel provider")
         .items(&options)
         .default(0)
@@ -6048,7 +6126,7 @@ fn setup_tunnel() -> Result<crate::config::TunnelConfig> {
         1 => {
             println!();
             print_bullet("Get your tunnel token from the Cloudflare Zero Trust dashboard.");
-            let tunnel_value: String = Input::new()
+            let tunnel_value: String = Input::with_theme(wizard_theme())
                 .with_prompt("  Cloudflare tunnel token")
                 .interact_text()?;
             if tunnel_value.trim().is_empty() {
@@ -6072,7 +6150,7 @@ fn setup_tunnel() -> Result<crate::config::TunnelConfig> {
         2 => {
             println!();
             print_bullet("Tailscale must be installed and authenticated (tailscale up).");
-            let funnel = Confirm::new()
+            let funnel = Confirm::with_theme(wizard_theme())
                 .with_prompt("  Use Funnel (public internet)? No = tailnet only")
                 .default(false)
                 .interact()?;
@@ -6100,14 +6178,14 @@ fn setup_tunnel() -> Result<crate::config::TunnelConfig> {
             print_bullet(
                 "Get your auth token at https://dashboard.ngrok.com/get-started/your-authtoken",
             );
-            let auth_token: String = Input::new()
+            let auth_token: String = Input::with_theme(wizard_theme())
                 .with_prompt("  ngrok auth token")
                 .interact_text()?;
             if auth_token.trim().is_empty() {
                 println!("  {} Skipped", style("→").dim());
                 TunnelConfig::default()
             } else {
-                let domain: String = Input::new()
+                let domain: String = Input::with_theme(wizard_theme())
                     .with_prompt("  Custom domain (optional, Enter to skip)")
                     .allow_empty(true)
                     .interact_text()?;
@@ -6135,7 +6213,7 @@ fn setup_tunnel() -> Result<crate::config::TunnelConfig> {
             print_bullet("Enter the command to start your tunnel.");
             print_bullet("Use {port} and {host} as placeholders.");
             print_bullet("Example: bore local {port} --to bore.pub");
-            let cmd: String = Input::new()
+            let cmd: String = Input::with_theme(wizard_theme())
                 .with_prompt("  Start command")
                 .interact_text()?;
             if cmd.trim().is_empty() {

--- a/zeroclaw_install.sh
+++ b/zeroclaw_install.sh
@@ -82,7 +82,12 @@ fi
 ensure_bash
 
 if [ "$#" -eq 0 ]; then
-  exec bash "$BOOTSTRAP_SCRIPT" --guided
+  if [ -t 0 ] && [ -t 1 ]; then
+    # Default one-click interactive path: guided install + full-screen TUI onboarding.
+    exec bash "$BOOTSTRAP_SCRIPT" --guided --interactive-onboard
+  fi
+  # Non-interactive no-arg path remains install-only.
+  exec bash "$BOOTSTRAP_SCRIPT"
 fi
 
 exec bash "$BOOTSTRAP_SCRIPT" "$@"


### PR DESCRIPTION
## Summary
- make the onboarding TUI (`--interactive-ui`) production-ready with clearer cross-device controls and save/apply shortcuts
- make one-click installer defaults route to TUI onboarding for interactive no-arg sessions
- add canonical root `install.sh` entrypoint for remote one-liner installs
- update docs/README so install instructions and troubleshooting point at the canonical path

## Validation
- `bash -n install.sh zeroclaw_install.sh scripts/bootstrap.sh scripts/install-release.sh scripts/install.sh`
- `cargo check -q`
- `cargo test -q onboard::tui::tests`

## Rollout notes
- after merge, configure `zeroclawlabs.ai/install.sh` to serve repository root `install.sh` (or raw `main/install.sh`)
- this aligns one-click install behavior with TUI onboarding by default


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced full-screen terminal UI onboarding experience for interactive setup
  * Added one-line installer command for quick deployment
  * Automatic interactive terminal detection for enhanced onboarding flows
  * Visual progress indicators and step overview in wizard

* **Documentation**
  * Updated quick start guide with new installer option
  * Refreshed onboarding documentation with TUI flow details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->