### PR TITLE
fix(daemon,channels): backport shutdown + routed-provider startup fixes to dev

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -8112,7 +8112,6 @@ BTC is currently around $65,000 based on latest tool output."#
             model: "gpt-5.3-codex".to_string(),
             max_tokens: Some(512),
             api_key: Some("route-specific-key".to_string()),
-            transport: Some("sse".to_string()),
         }];
 
         let config_path = cfg.config_path.clone();

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -45,7 +45,7 @@ async fn wait_for_shutdown_signal() -> Result<ShutdownSignal> {
             }
             sigterm_result = sigterm.recv() => match sigterm_result {
                 Some(()) => Ok(ShutdownSignal::SigTerm),
-                None => bail!("SIGTERM signal stream unexpectedly closed"),
+                None => anyhow::bail!("SIGTERM signal stream unexpectedly closed"),
             },
         }
     }


### PR DESCRIPTION
## Summary
- backport daemon shutdown handling improvements so Unix SIGTERM is treated as a first-class shutdown signal
- backport shutdown grace-window handling and signal-aware shutdown hint parity
- backport channel startup provider-routing fix so route-scoped credentials are honored when global provider key is missing
- include the runtime config cleanup test stabilization from the original track
- apply minimal dev-compatibility adjustments (no `transport` field in `ModelRouteConfig`, fully-qualified `anyhow::bail!`)

## Validation
- `cargo test --no-run`
- `cargo test shutdown_ -- --nocapture`
- `cargo test start_channels_uses_model_routes_when_global_provider_key_is_missing -- --nocapture`

Refs #2529
Refs #2537
