### PR TITLE
installer: keep TUI onboarding default for curl|bash flows

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd || 
 LOCAL_INSTALLER="$SCRIPT_DIR/zeroclaw_install.sh"
 
 declare -a FORWARDED_ARGS=("$@")
-if [[ $# -eq 0 && -t 0 && -t 1 ]]; then
+# In piped one-liners (`curl ... | bash`) stdin is not a TTY; prefer the
+# controlling terminal when available so interactive onboarding is still default.
+if [[ $# -eq 0 && -t 1 ]] && (: </dev/tty) 2>/dev/null; then
   FORWARDED_ARGS=(--interactive-onboard)
 fi
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1463,7 +1463,7 @@ if [[ "$GUIDED_MODE" == "auto" ]]; then
   fi
 fi
 
-if [[ "$ORIGINAL_ARG_COUNT" -eq 0 && -t 0 && -t 1 ]]; then
+if [[ "$ORIGINAL_ARG_COUNT" -eq 0 && -t 1 ]] && (: </dev/tty) 2>/dev/null; then
   RUN_ONBOARD=true
   INTERACTIVE_ONBOARD=true
 fi
@@ -1719,7 +1719,17 @@ if [[ "$RUN_ONBOARD" == true ]]; then
 
   if [[ "$INTERACTIVE_ONBOARD" == true ]]; then
     info "Running TUI onboarding"
-    "$ZEROCLAW_BIN" onboard --interactive-ui
+    if [[ -t 0 && -t 1 ]]; then
+      "$ZEROCLAW_BIN" onboard --interactive-ui
+    elif (: </dev/tty) 2>/dev/null; then
+      # `curl ... | bash` leaves stdin as a pipe; hand off terminal control to
+      # the onboarding TUI using the controlling tty.
+      "$ZEROCLAW_BIN" onboard --interactive-ui </dev/tty >/dev/tty 2>/dev/tty
+    else
+      error "TUI onboarding requires an interactive terminal."
+      error "Re-run from a terminal: zeroclaw onboard --interactive-ui"
+      exit 1
+    fi
   else
     if [[ -z "$API_KEY" ]]; then
       cat <<'MSG'


### PR DESCRIPTION
## Summary
- treat no-arg installer runs as interactive when a controlling terminal is available (not just stdin TTY)
- preserve default `--interactive-onboard` behavior for `curl ... | bash`
- launch `zeroclaw onboard --interactive-ui` via `/dev/tty` when stdin is piped

## Why
`curl -fsSL https://zeroclawlabs.ai/install.sh | bash` runs with piped stdin, so `-t 0` checks fail and TUI onboarding was not consistently launched.

## Validation
- `bash -n install.sh`
- `bash -n scripts/bootstrap.sh`
- pseudo-tty simulation confirmed `--interactive-onboard` forwarding under piped invocation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal detection for interactive onboarding to work reliably across various shell environments, including piped commands.
  * Enhanced compatibility with non-interactive terminal scenarios to prevent installation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->