### PR TITLE
installer: use raw refs/heads/main bootstrap URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Canonical remote installer entrypoint.
 # Default behavior for no-arg interactive shells is TUI onboarding.
 
-BOOTSTRAP_URL="${ZEROCLAW_BOOTSTRAP_URL:-https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/main/scripts/bootstrap.sh}"
+BOOTSTRAP_URL="${ZEROCLAW_BOOTSTRAP_URL:-https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/refs/heads/main/scripts/bootstrap.sh}"
 
 have_cmd() {
   command -v "$1" >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- switch installer bootstrap default URL from `raw/.../main/...` to `raw/.../refs/heads/main/...`

## Why
Immediately after merge, GitHub `raw/.../main/...` branch URL served stale `install.sh` content, while `refs/heads/main` returned the latest commit. This hardens one-click installer behavior against branch alias cache lag.

## Change
- `install.sh`: `BOOTSTRAP_URL` now points to:
  - `https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/refs/heads/main/scripts/bootstrap.sh`
