### PR TITLE
fix(heartbeat): send agent response via Telegram channel

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -185,6 +185,15 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
     let interval_mins = config.heartbeat.interval_minutes.max(5);
     let mut interval = tokio::time::interval(Duration::from_secs(u64::from(interval_mins) * 60));
 
+    // Build Telegram channel once if configured
+    let telegram = config.channels_config.telegram.as_ref().map(|tg| {
+        crate::channels::TelegramChannel::new(
+            tg.bot_token.clone(),
+            tg.allowed_users.clone(),
+            tg.mention_only,
+        )
+    });
+
     loop {
         interval.tick().await;
 
@@ -196,7 +205,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
         for task in tasks {
             let prompt = format!("[Heartbeat Task] {task}");
             let temp = config.default_temperature;
-            if let Err(e) = crate::agent::run(
+            match crate::agent::loop_::run(
                 config.clone(),
                 Some(prompt),
                 None,
@@ -207,10 +216,30 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
             )
             .await
             {
-                crate::health::mark_component_error("heartbeat", e.to_string());
-                tracing::warn!("Heartbeat task failed: {e}");
-            } else {
-                crate::health::mark_component_ok("heartbeat");
+                Ok(response) => {
+                    crate::health::mark_component_ok("heartbeat");
+                    if let Some(ref tg) = telegram {
+                        let recipients = config
+                            .channels_config
+                            .telegram
+                            .as_ref()
+                            .map(|t| t.allowed_users.clone())
+                            .unwrap_or_default();
+                        for user_id in &recipients {
+                            let msg = crate::channels::SendMessage::new(
+                                response.clone(),
+                                user_id.clone(),
+                            );
+                            if let Err(e) = crate::channels::Channel::send(tg, &msg).await {
+                                tracing::warn!("Heartbeat: Telegram send failed: {e}");
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    crate::health::mark_component_error("heartbeat", e.to_string());
+                    tracing::warn!("Heartbeat task failed: {e}");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Base branch target: `main`
- Problem: Heartbeat worker calls `crate::agent::run()` which returns `()` and only prints to stdout — agent responses never reach any channel
- Why it matters: Heartbeat tasks in `HEARTBEAT.md` are silently executed but the output is never delivered to the user
- What changed: `run_heartbeat_worker` in `daemon/mod.rs` now uses `crate::agent::loop_::run()` and sends the response via `TelegramChannel::send()`
- What did not change: Heartbeat scheduling, task parsing, HEARTBEAT.md format, all other channels

## Label Snapshot

- Risk label: `risk: low`
- Scope labels: `daemon`, `heartbeat`, `channel`
- Module labels: `channel: telegram`
- Change type: `bug`

## Linked Issue

- Existing overlapping PR(s) reviewed: N/A
- Linear issue key(s): N/A

## Validation Evidence

- `cargo build --release` passes
- Verified on live server: heartbeat messages now arrive in Telegram correctly

## Security Impact

- New permissions/capabilities? No
- New external network calls? No (reuses existing TelegramChannel)
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene

- Data-hygiene status: pass
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification

- Verified scenarios: Heartbeat task in HEARTBEAT.md executes and message arrives in Telegram
- Edge cases checked: Empty task list (skipped correctly), Telegram not configured (skipped gracefully)
- What was not verified: Other channels (Discord, Slack etc.) — fix only targets Telegram

## Side Effects / Blast Radius

- Affected subsystems: heartbeat worker only
- Potential unintended effects: None — existing behavior for empty task lists unchanged
- Guardrails: If Telegram send fails, warning is logged and execution continues

## Rollback Plan

- Fast rollback: `git revert 2deebaf && cargo build --release && systemctl restart zeroclaw`
- Observable failure symptoms: Heartbeat tasks execute but no Telegram message arrives

## Risks and Mitigations

- Risk: Other channel types (Discord, Slack) still not supported for heartbeat delivery
  - Mitigation: Graceful skip if Telegram not configured; follow-up PR can add multi-channel support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Heartbeat task responses are now sent as Telegram notifications to all configured recipients when Telegram is enabled.

* **Improvements**
  * Enhanced error handling for failed heartbeat tasks with improved status tracking and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->