### PR TITLE
chore(quality): reduce high-impact clippy debt in critical modules

### DIFF
--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -290,13 +290,23 @@ fn is_audio_attachment(content_type: &str, filename: &str, url: &str) -> bool {
 }
 
 fn parse_attachment_duration_secs(attachment: &serde_json::Value) -> Option<u64> {
-    let raw = attachment
-        .get("duration_secs")
-        .and_then(|value| value.as_f64().or_else(|| value.as_u64().map(|v| v as f64)))?;
+    let value = attachment.get("duration_secs")?;
+
+    if let Some(seconds) = value.as_u64() {
+        return Some(seconds);
+    }
+
+    let raw = value.as_f64()?;
     if !raw.is_finite() || raw.is_sign_negative() {
         return None;
     }
-    Some(raw.ceil() as u64)
+
+    let rounded = raw.ceil();
+    if rounded > u64::MAX as f64 {
+        return None;
+    }
+
+    format!("{rounded:.0}").parse().ok()
 }
 
 fn extension_from_media_path(value: &str) -> Option<String> {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -3129,11 +3129,11 @@ Reminder set successfully."#;
             event_tx: tokio::sync::broadcast::channel(16).0,
         };
 
-        let response = handle_nextcloud_talk_webhook(
+        let response = Box::pin(handle_nextcloud_talk_webhook(
             State(state),
             HeaderMap::new(),
             Bytes::from_static(br#"{"type":"message"}"#),
-        )
+        ))
         .await
         .into_response();
 
@@ -3198,9 +3198,13 @@ Reminder set successfully."#;
             HeaderValue::from_str(invalid_signature).unwrap(),
         );
 
-        let response = handle_nextcloud_talk_webhook(State(state), headers, Bytes::from(body))
-            .await
-            .into_response();
+        let response = Box::pin(handle_nextcloud_talk_webhook(
+            State(state),
+            headers,
+            Bytes::from(body),
+        ))
+        .await
+        .into_response();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 0);
     }
@@ -3240,11 +3244,11 @@ Reminder set successfully."#;
             event_tx: tokio::sync::broadcast::channel(16).0,
         };
 
-        let response = handle_qq_webhook(
+        let response = Box::pin(handle_qq_webhook(
             State(state),
             HeaderMap::new(),
             Bytes::from_static(br#"{"op":13,"d":{"plain_token":"p","event_ts":"1"}}"#),
-        )
+        ))
         .await
         .into_response();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
@@ -3294,13 +3298,13 @@ Reminder set successfully."#;
         let mut headers = HeaderMap::new();
         headers.insert("X-Bot-Appid", HeaderValue::from_static("11111111"));
 
-        let response = handle_qq_webhook(
+        let response = Box::pin(handle_qq_webhook(
             State(state),
             headers,
             Bytes::from_static(
                 br#"{"op":13,"d":{"plain_token":"Arq0D5A61EgUu4OxUvOp","event_ts":"1725442341"}}"#,
             ),
-        )
+        ))
         .await
         .into_response();
         assert_eq!(response.status(), StatusCode::OK);

--- a/src/main.rs
+++ b/src/main.rs
@@ -785,17 +785,17 @@ async fn main() -> Result<()> {
             bail!("--channels-only does not accept --force");
         }
         let config = if channels_only {
-            onboard::run_channels_repair_wizard().await
+            Box::pin(onboard::run_channels_repair_wizard()).await
         } else if interactive {
-            onboard::run_wizard(force).await
+            Box::pin(onboard::run_wizard(force)).await
         } else {
-            onboard::run_quick_setup(
+            Box::pin(onboard::run_quick_setup(
                 api_key.as_deref(),
                 provider.as_deref(),
                 model.as_deref(),
                 memory.as_deref(),
                 force,
-            )
+            ))
             .await
         }?;
         // Auto-start channels if user said yes during wizard
@@ -857,7 +857,7 @@ async fn main() -> Result<()> {
             if let Some(ref backend) = memory_backend {
                 config.memory.backend = backend.clone();
             }
-            agent::run(
+            Box::pin(agent::run(
                 config,
                 message,
                 provider,
@@ -865,7 +865,7 @@ async fn main() -> Result<()> {
                 temperature,
                 peripheral,
                 true,
-            )
+            ))
             .await
             .map(|_| ())
         }


### PR DESCRIPTION
Closes #2747
Resolves RMN-372

## Summary
- Reduce high-impact clippy debt in touched critical modules.
- Box high-size futures at selected onboarding/agent dispatch and gateway webhook test await boundaries.
- Replace risky float-to-int attachment duration conversion with bounded parsing logic.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -W clippy::large_futures -W clippy::await_holding_lock -W clippy::cast_possible_truncation -W clippy::cast_sign_loss -W clippy::cast_possible_wrap -W clippy::cast_lossless`
- `cargo test nextcloud_talk_webhook -- --nocapture`
- `cargo test qq_webhook -- --nocapture`
- `cargo test process_attachments_skips_audio_when_duration_exceeds_limit -- --nocapture`
