### PR TITLE
test(docs): guard main-first contributor PR base policy

### DIFF
--- a/tests/docs_pr_base_branch_consistency.rs
+++ b/tests/docs_pr_base_branch_consistency.rs
@@ -28,4 +28,9 @@ fn contributor_docs_use_main_as_default_pr_base_branch() {
         !contributing.contains("Open a PR against `dev` using the PR template"),
         "CONTRIBUTING.md still contains stale dev-first PR guidance"
     );
+
+    assert!(
+        !pr_workflow.contains("Open a PR against `dev` using the PR template"),
+        "docs/pr-workflow.md still contains stale dev-first PR guidance"
+    );
 }


### PR DESCRIPTION
## Summary
- add regression test to keep contributor docs aligned on main-first PR base
- assert CONTRIBUTING and docs/pr-workflow stay in sync
- prevent stale dev-first wording regressions

Closes #2697

## Validation
- CARGO_TARGET_DIR=/tmp/zc-target-lite cargo test --no-default-features --test docs_pr_base_branch_consistency contributor_docs_use_main_as_default_pr_base_branch -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated verification to ensure contributor documentation maintains consistency with current development practices and enforces established guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->