### PR TITLE
fix(docker): include embedded data and skills in smoke build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ COPY src/ src/
 COPY benches/ benches/
 COPY crates/ crates/
 COPY firmware/ firmware/
+COPY data/ data/
+COPY skills/ skills/
 COPY web/ web/
 # Keep release builds resilient when frontend dist assets are not prebuilt in Git.
 RUN mkdir -p web/dist && \


### PR DESCRIPTION
## Summary
- fix `PR Docker Smoke` compile failures caused by missing compile-time assets in Docker build context
- copy `data/` and `skills/` into the Docker builder stage before `cargo build --release`

## Root Cause
The Docker builder compiled code that uses compile-time embeds:
- `src/security/semantic_guard.rs` -> `include_str!("../../data/security/attack-corpus-v1.jsonl")`
- `src/skills/mod.rs` -> `include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/skills/.../SKILL.md"))`

`Dockerfile` was not copying those directories before the final build step, so buildx failed in `PR Docker Smoke`.

## Changes
- `Dockerfile`
  - add `COPY data/ data/`
  - add `COPY skills/ skills/`

## Validation
- attempted local `docker buildx build --platform linux/amd64 --load -t zeroclaw-pr-smoke:fix .`
- local validation blocked here because Docker daemon is unavailable in this environment
- expected verification: `Pub Docker Img -> PR Docker Smoke` passes in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include additional resources in the application image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->