### PR TITLE
feat(streaming): add native tool-event streaming parity

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -3,6 +3,7 @@ use crate::config::Config;
 use crate::memory::{self, Memory, MemoryCategory};
 use crate::multimodal;
 use crate::observability::{self, runtime_trace, Observer, ObserverEvent};
+use crate::providers::traits::StreamEvent;
 use crate::providers::{
     self, ChatMessage, ChatRequest, Provider, ProviderCapabilityError, ToolCall,
 };
@@ -500,6 +501,7 @@ pub(crate) fn is_tool_iteration_limit_error(err: &anyhow::Error) -> bool {
 #[derive(Debug, Default)]
 struct StreamedChatOutcome {
     response_text: String,
+    tool_calls: Vec<ToolCall>,
     forwarded_live_deltas: bool,
 }
 
@@ -540,13 +542,17 @@ async fn call_provider_chat(
 async fn consume_provider_streaming_response(
     provider: &dyn Provider,
     messages: &[ChatMessage],
+    request_tools: Option<&[crate::tools::ToolSpec]>,
     model: &str,
     temperature: f64,
     cancellation_token: Option<&CancellationToken>,
     on_delta: Option<&tokio::sync::mpsc::Sender<String>>,
 ) -> Result<StreamedChatOutcome> {
-    let mut provider_stream = provider.stream_chat_with_history(
-        messages,
+    let mut provider_stream = provider.stream_chat(
+        ChatRequest {
+            messages,
+            tools: request_tools,
+        },
         model,
         temperature,
         crate::providers::traits::StreamOptions::new(true),
@@ -566,51 +572,63 @@ async fn consume_provider_streaming_response(
             provider_stream.next().await
         };
 
-        let Some(chunk_result) = next_chunk else {
+        let Some(event_result) = next_chunk else {
             break;
         };
 
-        let chunk = chunk_result.map_err(|err| anyhow::anyhow!("provider stream error: {err}"))?;
-        if chunk.is_final {
-            break;
-        }
-        if chunk.delta.is_empty() {
-            continue;
-        }
-
-        outcome.response_text.push_str(&chunk.delta);
-        marker_window.push_str(&chunk.delta);
-
-        if marker_window.len() > STREAM_TOOL_MARKER_WINDOW_CHARS {
-            let keep_from = marker_window.len() - STREAM_TOOL_MARKER_WINDOW_CHARS;
-            let boundary = marker_window
-                .char_indices()
-                .find(|(idx, _)| *idx >= keep_from)
-                .map_or(0, |(idx, _)| idx);
-            marker_window.drain(..boundary);
-        }
-
-        if !suppress_forwarding && looks_like_streamed_tool_payload(&marker_window) {
-            suppress_forwarding = true;
-            if outcome.forwarded_live_deltas {
-                if let Some(tx) = delta_sender {
-                    let _ = tx.send(DRAFT_CLEAR_SENTINEL.to_string()).await;
+        let event = event_result.map_err(|err| anyhow::anyhow!("provider stream error: {err}"))?;
+        match event {
+            StreamEvent::Final => break,
+            StreamEvent::ToolCall(tool_call) => {
+                outcome.tool_calls.push(tool_call);
+                suppress_forwarding = true;
+                if outcome.forwarded_live_deltas {
+                    if let Some(tx) = delta_sender {
+                        let _ = tx.send(DRAFT_CLEAR_SENTINEL.to_string()).await;
+                    }
+                    outcome.forwarded_live_deltas = false;
                 }
-                outcome.forwarded_live_deltas = false;
             }
-        }
+            StreamEvent::TextDelta(chunk) => {
+                if chunk.delta.is_empty() {
+                    continue;
+                }
 
-        if suppress_forwarding {
-            continue;
-        }
+                outcome.response_text.push_str(&chunk.delta);
+                marker_window.push_str(&chunk.delta);
 
-        if let Some(tx) = delta_sender {
-            if !outcome.forwarded_live_deltas {
-                let _ = tx.send(DRAFT_CLEAR_SENTINEL.to_string()).await;
-                outcome.forwarded_live_deltas = true;
-            }
-            if tx.send(chunk.delta).await.is_err() {
-                delta_sender = None;
+                if marker_window.len() > STREAM_TOOL_MARKER_WINDOW_CHARS {
+                    let keep_from = marker_window.len() - STREAM_TOOL_MARKER_WINDOW_CHARS;
+                    let boundary = marker_window
+                        .char_indices()
+                        .find(|(idx, _)| *idx >= keep_from)
+                        .map_or(0, |(idx, _)| idx);
+                    marker_window.drain(..boundary);
+                }
+
+                if !suppress_forwarding && looks_like_streamed_tool_payload(&marker_window) {
+                    suppress_forwarding = true;
+                    if outcome.forwarded_live_deltas {
+                        if let Some(tx) = delta_sender {
+                            let _ = tx.send(DRAFT_CLEAR_SENTINEL.to_string()).await;
+                        }
+                        outcome.forwarded_live_deltas = false;
+                    }
+                }
+
+                if suppress_forwarding {
+                    continue;
+                }
+
+                if let Some(tx) = delta_sender {
+                    if !outcome.forwarded_live_deltas {
+                        let _ = tx.send(DRAFT_CLEAR_SENTINEL.to_string()).await;
+                        outcome.forwarded_live_deltas = true;
+                    }
+                    if tx.send(chunk.delta).await.is_err() {
+                        delta_sender = None;
+                    }
+                }
             }
         }
     }
@@ -903,14 +921,16 @@ pub(crate) async fn run_tool_call_loop(
         } else {
             None
         };
-        let should_consume_provider_stream =
-            on_delta.is_some() && provider.supports_streaming() && request_tools.is_none();
+        let should_consume_provider_stream = on_delta.is_some()
+            && provider.supports_streaming()
+            && (request_tools.is_none() || provider.supports_streaming_tool_events());
         let mut streamed_live_deltas = false;
 
         let chat_result = if should_consume_provider_stream {
             match consume_provider_streaming_response(
                 provider,
                 &prepared_messages.messages,
+                request_tools,
                 model,
                 temperature,
                 cancellation_token.as_ref(),
@@ -922,7 +942,7 @@ pub(crate) async fn run_tool_call_loop(
                     streamed_live_deltas = streamed.forwarded_live_deltas;
                     Ok(crate::providers::ChatResponse {
                         text: Some(streamed.response_text),
-                        tool_calls: Vec::new(),
+                        tool_calls: streamed.tool_calls,
                         usage: None,
                         reasoning_content: None,
                     })
@@ -2566,7 +2586,8 @@ mod tests {
 
     use crate::memory::{Memory, MemoryCategory, SqliteMemory};
     use crate::observability::NoopObserver;
-    use crate::providers::traits::{ProviderCapabilities, StreamChunk, StreamOptions};
+    use crate::providers::router::{Route, RouterProvider};
+    use crate::providers::traits::{ProviderCapabilities, StreamChunk, StreamEvent, StreamOptions};
     use crate::providers::ChatResponse;
     use crate::runtime::NativeRuntime;
     use crate::security::{AutonomyLevel, SecurityPolicy, ShellRedirectPolicy};
@@ -2769,6 +2790,177 @@ mod tests {
 
             Box::pin(futures_util::stream::iter(vec![
                 Ok(StreamChunk::delta(response)),
+                Ok(StreamChunk::final_chunk()),
+            ]))
+        }
+    }
+
+    enum NativeStreamTurn {
+        ToolCall(ToolCall),
+        Text(String),
+    }
+
+    struct StreamingNativeToolEventProvider {
+        turns: Arc<Mutex<VecDeque<NativeStreamTurn>>>,
+        stream_calls: Arc<AtomicUsize>,
+        stream_tool_requests: Arc<AtomicUsize>,
+        chat_calls: Arc<AtomicUsize>,
+    }
+
+    impl StreamingNativeToolEventProvider {
+        fn with_turns(turns: Vec<NativeStreamTurn>) -> Self {
+            Self {
+                turns: Arc::new(Mutex::new(turns.into())),
+                stream_calls: Arc::new(AtomicUsize::new(0)),
+                stream_tool_requests: Arc::new(AtomicUsize::new(0)),
+                chat_calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for StreamingNativeToolEventProvider {
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                native_tool_calling: true,
+                vision: false,
+            }
+        }
+
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            anyhow::bail!(
+                "chat_with_system should not be used in streaming native tool event provider tests"
+            );
+        }
+
+        async fn chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<ChatResponse> {
+            self.chat_calls.fetch_add(1, Ordering::SeqCst);
+            anyhow::bail!("chat should not be called when native streaming events succeed")
+        }
+
+        fn supports_streaming(&self) -> bool {
+            true
+        }
+
+        fn supports_streaming_tool_events(&self) -> bool {
+            true
+        }
+
+        fn stream_chat(
+            &self,
+            request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: f64,
+            options: StreamOptions,
+        ) -> futures_util::stream::BoxStream<
+            'static,
+            crate::providers::traits::StreamResult<StreamEvent>,
+        > {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            if request.tools.is_some_and(|tools| !tools.is_empty()) {
+                self.stream_tool_requests.fetch_add(1, Ordering::SeqCst);
+            }
+            if !options.enabled {
+                return Box::pin(futures_util::stream::empty());
+            }
+
+            let turn = self
+                .turns
+                .lock()
+                .expect("turns lock should be valid")
+                .pop_front()
+                .expect("streaming turns should have scripted output");
+            match turn {
+                NativeStreamTurn::ToolCall(tool_call) => {
+                    Box::pin(futures_util::stream::iter(vec![
+                        Ok(StreamEvent::ToolCall(tool_call)),
+                        Ok(StreamEvent::Final),
+                    ]))
+                }
+                NativeStreamTurn::Text(text) => Box::pin(futures_util::stream::iter(vec![
+                    Ok(StreamEvent::TextDelta(StreamChunk::delta(text))),
+                    Ok(StreamEvent::Final),
+                ])),
+            }
+        }
+    }
+
+    struct RouteAwareStreamingProvider {
+        response: String,
+        stream_calls: Arc<AtomicUsize>,
+        chat_calls: Arc<AtomicUsize>,
+        last_model: Arc<Mutex<String>>,
+    }
+
+    impl RouteAwareStreamingProvider {
+        fn new(response: &str) -> Self {
+            Self {
+                response: response.to_string(),
+                stream_calls: Arc::new(AtomicUsize::new(0)),
+                chat_calls: Arc::new(AtomicUsize::new(0)),
+                last_model: Arc::new(Mutex::new(String::new())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for RouteAwareStreamingProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            anyhow::bail!("chat_with_system should not be used in route-aware stream tests");
+        }
+
+        async fn chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<ChatResponse> {
+            self.chat_calls.fetch_add(1, Ordering::SeqCst);
+            anyhow::bail!("chat should not be called when routed streaming succeeds")
+        }
+
+        fn supports_streaming(&self) -> bool {
+            true
+        }
+
+        fn stream_chat_with_history(
+            &self,
+            _messages: &[ChatMessage],
+            model: &str,
+            _temperature: f64,
+            options: StreamOptions,
+        ) -> futures_util::stream::BoxStream<
+            'static,
+            crate::providers::traits::StreamResult<StreamChunk>,
+        > {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            *self
+                .last_model
+                .lock()
+                .expect("last_model lock should be valid") = model.to_string();
+            if !options.enabled {
+                return Box::pin(futures_util::stream::empty());
+            }
+
+            Box::pin(futures_util::stream::iter(vec![
+                Ok(StreamChunk::delta(self.response.clone())),
                 Ok(StreamChunk::final_chunk()),
             ]))
         }
@@ -3916,6 +4108,146 @@ mod tests {
         assert!(
             !visible_deltas.contains("<tool_call"),
             "draft text should not leak streamed tool payload markers"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_streams_native_tool_events_without_chat_fallback() {
+        let provider = StreamingNativeToolEventProvider::with_turns(vec![
+            NativeStreamTurn::ToolCall(ToolCall {
+                id: "call_native_1".to_string(),
+                name: "count_tool".to_string(),
+                arguments: r#"{"value":"A"}"#.to_string(),
+            }),
+            NativeStreamTurn::Text("done".to_string()),
+        ]);
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+            "count_tool",
+            Arc::clone(&invocations),
+        ))];
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("run native tools"),
+        ];
+        let observer = NoopObserver;
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(64);
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            0.0,
+            true,
+            None,
+            "telegram",
+            &crate::config::MultimodalConfig::default(),
+            5,
+            None,
+            Some(tx),
+            None,
+            &[],
+        )
+        .await
+        .expect("native streaming events should preserve tool loop semantics");
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if delta == DRAFT_CLEAR_SENTINEL || delta.starts_with(DRAFT_PROGRESS_SENTINEL) {
+                continue;
+            }
+            visible_deltas.push_str(&delta);
+        }
+
+        assert_eq!(result, "done");
+        assert_eq!(invocations.load(Ordering::SeqCst), 1);
+        assert_eq!(provider.stream_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(provider.stream_tool_requests.load(Ordering::SeqCst), 2);
+        assert_eq!(provider.chat_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(visible_deltas, "done");
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_routed_streaming_uses_live_provider_deltas_once() {
+        let default_provider = RouteAwareStreamingProvider::new("default answer");
+        let default_stream_calls = Arc::clone(&default_provider.stream_calls);
+        let default_chat_calls = Arc::clone(&default_provider.chat_calls);
+
+        let routed_provider = RouteAwareStreamingProvider::new("routed streamed answer");
+        let routed_stream_calls = Arc::clone(&routed_provider.stream_calls);
+        let routed_chat_calls = Arc::clone(&routed_provider.chat_calls);
+        let routed_last_model = Arc::clone(&routed_provider.last_model);
+
+        let router = RouterProvider::new(
+            vec![
+                ("default".to_string(), Box::new(default_provider)),
+                ("fast".to_string(), Box::new(routed_provider)),
+            ],
+            vec![(
+                "fast".to_string(),
+                Route {
+                    provider_name: "fast".to_string(),
+                    model: "routed-model".to_string(),
+                },
+            )],
+            "default-model".to_string(),
+        );
+
+        let tools_registry: Vec<Box<dyn Tool>> = Vec::new();
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("say hi"),
+        ];
+        let observer = NoopObserver;
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(32);
+
+        let result = run_tool_call_loop(
+            &router,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "router",
+            "hint:fast",
+            0.0,
+            true,
+            None,
+            "telegram",
+            &crate::config::MultimodalConfig::default(),
+            4,
+            None,
+            Some(tx),
+            None,
+            &[],
+        )
+        .await
+        .expect("routed streaming provider should complete");
+
+        let mut visible_deltas = String::new();
+        while let Some(delta) = rx.recv().await {
+            if delta == DRAFT_CLEAR_SENTINEL || delta.starts_with(DRAFT_PROGRESS_SENTINEL) {
+                continue;
+            }
+            visible_deltas.push_str(&delta);
+        }
+
+        assert_eq!(result, "routed streamed answer");
+        assert_eq!(
+            visible_deltas, "routed streamed answer",
+            "routed draft should receive upstream deltas once without post-hoc duplication"
+        );
+        assert_eq!(default_stream_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(routed_stream_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(default_chat_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(routed_chat_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            routed_last_model
+                .lock()
+                .expect("routed_last_model lock should be valid")
+                .as_str(),
+            "routed-model"
         );
     }
 

--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -5,7 +5,7 @@
 use crate::multimodal;
 use crate::providers::traits::{
     ChatMessage, ChatRequest as ProviderChatRequest, ChatResponse as ProviderChatResponse,
-    Provider, StreamChunk, StreamError, StreamOptions, StreamResult, TokenUsage,
+    Provider, StreamChunk, StreamError, StreamEvent, StreamOptions, StreamResult, TokenUsage,
     ToolCall as ProviderToolCall,
 };
 use async_trait::async_trait;
@@ -698,61 +698,155 @@ struct ResponsesWebSocketCreateEvent {
 /// Server-Sent Event stream chunk for OpenAI-compatible streaming.
 #[derive(Debug, Deserialize)]
 struct StreamChunkResponse {
+    #[serde(default)]
     choices: Vec<StreamChoice>,
 }
 
 #[derive(Debug, Deserialize)]
 struct StreamChoice {
+    #[serde(default)]
     delta: StreamDelta,
+    #[serde(default)]
     finish_reason: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 struct StreamDelta {
     #[serde(default)]
     content: Option<String>,
     /// Reasoning/thinking models may stream output via `reasoning_content`.
     #[serde(default)]
     reasoning_content: Option<String>,
+    /// Native tool-calling deltas in OpenAI chat-completions streaming format.
+    #[serde(default)]
+    tool_calls: Option<Vec<StreamToolCallDelta>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamToolCallDelta {
+    #[serde(default)]
+    index: Option<usize>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: Option<StreamFunctionDelta>,
+    // Compatibility: some providers stream name/arguments at top-level.
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamFunctionDelta {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct StreamToolCallAccumulator {
+    id: Option<String>,
+    name: Option<String>,
+    arguments: String,
+}
+
+impl StreamToolCallAccumulator {
+    fn apply_delta(&mut self, delta: &StreamToolCallDelta) {
+        if let Some(id) = delta.id.as_ref().filter(|value| !value.is_empty()) {
+            self.id = Some(id.clone());
+        }
+
+        let delta_name = delta
+            .function
+            .as_ref()
+            .and_then(|function| function.name.as_ref())
+            .or(delta.name.as_ref())
+            .filter(|value| !value.is_empty());
+        if let Some(name) = delta_name {
+            self.name = Some(name.clone());
+        }
+
+        if let Some(arguments_delta) = delta
+            .function
+            .as_ref()
+            .and_then(|function| function.arguments.as_ref())
+            .or(delta.arguments.as_ref())
+            .filter(|value| !value.is_empty())
+        {
+            self.arguments.push_str(arguments_delta);
+        }
+    }
+
+    fn into_provider_tool_call(self) -> Option<ProviderToolCall> {
+        let name = self.name?;
+        let arguments = if self.arguments.trim().is_empty() {
+            "{}".to_string()
+        } else {
+            self.arguments
+        };
+        let normalized_arguments = if serde_json::from_str::<serde_json::Value>(&arguments).is_ok()
+        {
+            arguments
+        } else {
+            tracing::warn!(
+                function = %name,
+                arguments = %arguments,
+                "Invalid JSON in streamed native tool-call arguments, using empty object"
+            );
+            "{}".to_string()
+        };
+
+        Some(ProviderToolCall {
+            id: self.id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+            name,
+            arguments: normalized_arguments,
+        })
+    }
+}
+
+fn parse_sse_chunk(line: &str) -> StreamResult<Option<StreamChunkResponse>> {
+    let line = line.trim();
+
+    if line.is_empty() || line.starts_with(':') {
+        return Ok(None);
+    }
+
+    let Some(data) = line.strip_prefix("data:") else {
+        return Ok(None);
+    };
+    let data = data.trim();
+
+    if data == "[DONE]" {
+        return Ok(None);
+    }
+
+    serde_json::from_str(data)
+        .map(Some)
+        .map_err(StreamError::Json)
+}
+
+fn extract_sse_text_delta(choice: &StreamChoice) -> Option<String> {
+    if let Some(content) = &choice.delta.content {
+        if !content.is_empty() {
+            return Some(content.clone());
+        }
+    }
+
+    choice
+        .delta
+        .reasoning_content
+        .as_ref()
+        .filter(|value| !value.is_empty())
+        .cloned()
 }
 
 /// Parse SSE (Server-Sent Events) stream from OpenAI-compatible providers.
 /// Handles the `data: {...}` format and `[DONE]` sentinel.
 fn parse_sse_line(line: &str) -> StreamResult<Option<String>> {
-    let line = line.trim();
-
-    // Skip empty lines and comments
-    if line.is_empty() || line.starts_with(':') {
-        return Ok(None);
-    }
-
-    // SSE format: "data: {...}"
-    if let Some(data) = line.strip_prefix("data:") {
-        let data = data.trim();
-
-        // Check for [DONE] sentinel
-        if data == "[DONE]" {
-            return Ok(None);
-        }
-
-        // Parse JSON delta
-        let chunk: StreamChunkResponse = serde_json::from_str(data).map_err(StreamError::Json)?;
-
-        // Extract content from delta
-        if let Some(choice) = chunk.choices.first() {
-            if let Some(content) = &choice.delta.content {
-                if !content.is_empty() {
-                    return Ok(Some(content.clone()));
-                }
-            }
-            // Fallback to reasoning_content for thinking models
-            if let Some(reasoning) = &choice.delta.reasoning_content {
-                return Ok(Some(reasoning.clone()));
-            }
-        }
-    }
-
-    Ok(None)
+    Ok(parse_sse_chunk(line)?
+        .and_then(|chunk| chunk.choices.first().and_then(extract_sse_text_delta)))
 }
 
 /// Convert SSE byte stream to text chunks.
@@ -760,14 +854,11 @@ fn sse_bytes_to_chunks(
     response: reqwest::Response,
     count_tokens: bool,
 ) -> stream::BoxStream<'static, StreamResult<StreamChunk>> {
-    // Create a channel to send chunks
     let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamChunk>>(100);
 
     tokio::spawn(async move {
-        // Buffer for incomplete lines
         let mut buffer = String::new();
 
-        // Get response body as bytes stream
         match response.error_for_status_ref() {
             Ok(_) => {}
             Err(e) => {
@@ -781,7 +872,6 @@ fn sse_bytes_to_chunks(
         while let Some(item) = bytes_stream.next().await {
             match item {
                 Ok(bytes) => {
-                    // Convert bytes to string and process line by line
                     let text = match String::from_utf8(bytes.to_vec()) {
                         Ok(t) => t,
                         Err(e) => {
@@ -797,10 +887,9 @@ fn sse_bytes_to_chunks(
 
                     buffer.push_str(&text);
 
-                    // Process complete lines
                     while let Some(pos) = buffer.find('\n') {
-                        let line = buffer.drain(..=pos).collect::<String>();
-                        buffer = buffer[pos + 1..].to_string();
+                        let line = buffer[..pos].to_string();
+                        buffer.drain(..=pos);
 
                         match parse_sse_line(&line) {
                             Ok(Some(content)) => {
@@ -822,18 +911,141 @@ fn sse_bytes_to_chunks(
                 }
                 Err(e) => {
                     let _ = tx.send(Err(StreamError::Http(e))).await;
-                    break;
+                    return;
                 }
             }
         }
 
-        // Send final chunk
         let _ = tx.send(Ok(StreamChunk::final_chunk())).await;
     });
 
-    // Convert channel receiver to stream
     stream::unfold(rx, |mut rx| async {
         rx.recv().await.map(|chunk| (chunk, rx))
+    })
+    .boxed()
+}
+
+/// Convert SSE byte stream to structured streaming events.
+fn sse_bytes_to_events(
+    response: reqwest::Response,
+    count_tokens: bool,
+) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+    let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(100);
+
+    tokio::spawn(async move {
+        let mut buffer = String::new();
+        let mut tool_calls: Vec<StreamToolCallAccumulator> = Vec::new();
+        let mut emitted_tool_calls = false;
+
+        match response.error_for_status_ref() {
+            Ok(_) => {}
+            Err(e) => {
+                let _ = tx.send(Err(StreamError::Http(e))).await;
+                return;
+            }
+        }
+
+        let mut bytes_stream = response.bytes_stream();
+        while let Some(item) = bytes_stream.next().await {
+            match item {
+                Ok(bytes) => {
+                    let text = match String::from_utf8(bytes.to_vec()) {
+                        Ok(t) => t,
+                        Err(e) => {
+                            let _ = tx
+                                .send(Err(StreamError::InvalidSse(format!(
+                                    "Invalid UTF-8: {}",
+                                    e
+                                ))))
+                                .await;
+                            return;
+                        }
+                    };
+
+                    buffer.push_str(&text);
+
+                    while let Some(pos) = buffer.find('\n') {
+                        let line = buffer[..pos].to_string();
+                        buffer.drain(..=pos);
+
+                        let chunk = match parse_sse_chunk(&line) {
+                            Ok(Some(chunk)) => chunk,
+                            Ok(None) => continue,
+                            Err(e) => {
+                                let _ = tx.send(Err(e)).await;
+                                return;
+                            }
+                        };
+
+                        let mut should_emit_tool_calls = false;
+                        for choice in &chunk.choices {
+                            if let Some(text_delta) = extract_sse_text_delta(choice) {
+                                let mut text_chunk = StreamChunk::delta(text_delta);
+                                if count_tokens {
+                                    text_chunk = text_chunk.with_token_estimate();
+                                }
+                                if tx
+                                    .send(Ok(StreamEvent::TextDelta(text_chunk)))
+                                    .await
+                                    .is_err()
+                                {
+                                    return;
+                                }
+                            }
+
+                            if let Some(deltas) = choice.delta.tool_calls.as_ref() {
+                                for delta in deltas {
+                                    let index = delta.index.unwrap_or(tool_calls.len());
+                                    if index >= tool_calls.len() {
+                                        tool_calls.resize_with(index + 1, Default::default);
+                                    }
+                                    if let Some(acc) = tool_calls.get_mut(index) {
+                                        acc.apply_delta(delta);
+                                    }
+                                }
+                            }
+
+                            if choice.finish_reason.as_deref() == Some("tool_calls") {
+                                should_emit_tool_calls = true;
+                            }
+                        }
+
+                        if should_emit_tool_calls && !emitted_tool_calls {
+                            emitted_tool_calls = true;
+                            for tool_call in tool_calls
+                                .drain(..)
+                                .filter_map(StreamToolCallAccumulator::into_provider_tool_call)
+                            {
+                                if tx.send(Ok(StreamEvent::ToolCall(tool_call))).await.is_err() {
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(e) => {
+                    let _ = tx.send(Err(StreamError::Http(e))).await;
+                    return;
+                }
+            }
+        }
+
+        if !emitted_tool_calls {
+            for tool_call in tool_calls
+                .drain(..)
+                .filter_map(StreamToolCallAccumulator::into_provider_tool_call)
+            {
+                if tx.send(Ok(StreamEvent::ToolCall(tool_call))).await.is_err() {
+                    return;
+                }
+            }
+        }
+
+        let _ = tx.send(Ok(StreamEvent::Final)).await;
+    });
+
+    stream::unfold(rx, |mut rx| async move {
+        rx.recv().await.map(|event| (event, rx))
     })
     .boxed()
 }
@@ -2213,6 +2425,157 @@ impl Provider for OpenAiCompatibleProvider {
 
     fn supports_streaming(&self) -> bool {
         true
+    }
+
+    fn supports_streaming_tool_events(&self) -> bool {
+        self.native_tool_calling
+    }
+
+    fn stream_chat(
+        &self,
+        request: ProviderChatRequest<'_>,
+        model: &str,
+        temperature: f64,
+        options: StreamOptions,
+    ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+        if !options.enabled {
+            return stream::once(async { Ok(StreamEvent::Final) }).boxed();
+        }
+
+        let credential = match self.credential.as_ref() {
+            Some(value) => value.clone(),
+            None => {
+                let provider_name = self.name.clone();
+                return stream::once(async move {
+                    Err(StreamError::Provider(format!(
+                        "{} API key not set",
+                        provider_name
+                    )))
+                })
+                .boxed();
+            }
+        };
+
+        let has_tools = request.tools.is_some_and(|tools| !tools.is_empty());
+        let effective_messages = if self.merge_system_into_user {
+            Self::flatten_system_messages(request.messages)
+        } else {
+            request.messages.to_vec()
+        };
+
+        if self.should_use_responses_mode() {
+            if has_tools {
+                let provider_name = self.name.clone();
+                return stream::once(async move {
+                    Err(StreamError::Provider(format!(
+                        "{provider_name} responses mode does not support structured tool-call streaming"
+                    )))
+                })
+                .boxed();
+            }
+
+            return self
+                .stream_chat_with_history(request.messages, model, temperature, options)
+                .map(|chunk_result| chunk_result.map(StreamEvent::from_chunk))
+                .boxed();
+        }
+
+        let tools = Self::convert_tool_specs(request.tools);
+        let payload = if has_tools {
+            serde_json::to_value(NativeChatRequest {
+                model: model.to_string(),
+                messages: Self::convert_messages_for_native(
+                    &effective_messages,
+                    !self.merge_system_into_user,
+                ),
+                temperature,
+                max_tokens: self.effective_max_tokens(),
+                stream: Some(options.enabled),
+                tools: tools.clone(),
+                tool_choice: tools.as_ref().map(|_| "auto".to_string()),
+            })
+        } else {
+            let messages = effective_messages
+                .iter()
+                .map(|message| Message {
+                    role: message.role.clone(),
+                    content: Self::to_message_content(
+                        &message.role,
+                        &message.content,
+                        !self.merge_system_into_user,
+                    ),
+                })
+                .collect();
+
+            serde_json::to_value(ApiChatRequest {
+                model: model.to_string(),
+                messages,
+                temperature,
+                max_tokens: self.effective_max_tokens(),
+                stream: Some(options.enabled),
+                tools: None,
+                tool_choice: None,
+            })
+        };
+
+        let payload = match payload {
+            Ok(payload) => payload,
+            Err(error) => {
+                return stream::once(async move { Err(StreamError::Json(error)) }).boxed();
+            }
+        };
+
+        let url = self.chat_completions_url();
+        let client = self.http_client();
+        let auth_header = self.auth_header.clone();
+        let count_tokens = options.count_tokens;
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(100);
+
+        tokio::spawn(async move {
+            let mut req_builder = client.post(&url).json(&payload);
+
+            req_builder = match &auth_header {
+                AuthStyle::Bearer => {
+                    req_builder.header("Authorization", format!("Bearer {}", credential))
+                }
+                AuthStyle::XApiKey => req_builder.header("x-api-key", &credential),
+                AuthStyle::Custom(header) => req_builder.header(header, &credential),
+            };
+            req_builder = req_builder.header("Accept", "text/event-stream");
+
+            let response = match req_builder.send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    let _ = tx.send(Err(StreamError::Http(e))).await;
+                    return;
+                }
+            };
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let error = match response.text().await {
+                    Ok(text) => text,
+                    Err(_) => format!("HTTP error: {}", status),
+                };
+                let _ = tx
+                    .send(Err(StreamError::Provider(format!("{}: {}", status, error))))
+                    .await;
+                return;
+            }
+
+            let mut event_stream = sse_bytes_to_events(response, count_tokens);
+            while let Some(event) = event_stream.next().await {
+                if tx.send(event).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|event| (event, rx))
+        })
+        .boxed()
     }
 
     fn stream_chat_with_system(
@@ -3632,6 +3995,62 @@ mod tests {
         let line = "data: [DONE]";
         let result = parse_sse_line(line).unwrap();
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn parse_sse_chunk_with_tool_call_delta() {
+        let line = r#"data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"shell","arguments":"{\"command\":\"date\"}"}}]}}]}"#;
+        let chunk = parse_sse_chunk(line)
+            .unwrap()
+            .expect("chunk should be parsed");
+        let choice = chunk.choices.first().expect("choice should exist");
+        let tool_calls = choice
+            .delta
+            .tool_calls
+            .as_ref()
+            .expect("tool call deltas should exist");
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(tool_calls[0].index, Some(0));
+        assert_eq!(tool_calls[0].id.as_deref(), Some("call_1"));
+        assert_eq!(
+            tool_calls[0]
+                .function
+                .as_ref()
+                .and_then(|function| function.name.as_deref()),
+            Some("shell")
+        );
+    }
+
+    #[test]
+    fn stream_tool_call_accumulator_combines_deltas() {
+        let mut acc = StreamToolCallAccumulator::default();
+        acc.apply_delta(&StreamToolCallDelta {
+            index: Some(0),
+            id: Some("call_1".to_string()),
+            function: Some(StreamFunctionDelta {
+                name: Some("shell".to_string()),
+                arguments: Some("{\"command\":\"".to_string()),
+            }),
+            name: None,
+            arguments: None,
+        });
+        acc.apply_delta(&StreamToolCallDelta {
+            index: Some(0),
+            id: None,
+            function: Some(StreamFunctionDelta {
+                name: None,
+                arguments: Some("date\"}".to_string()),
+            }),
+            name: None,
+            arguments: None,
+        });
+
+        let tool_call = acc
+            .into_provider_tool_call()
+            .expect("accumulator should emit tool call");
+        assert_eq!(tool_call.id, "call_1");
+        assert_eq!(tool_call.name, "shell");
+        assert_eq!(tool_call.arguments, r#"{"command":"date"}"#);
     }
 
     #[test]

--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -1,5 +1,5 @@
 use super::traits::{
-    ChatMessage, ChatRequest, ChatResponse, StreamChunk, StreamOptions, StreamResult,
+    ChatMessage, ChatRequest, ChatResponse, StreamChunk, StreamEvent, StreamOptions, StreamResult,
 };
 use super::Provider;
 use async_trait::async_trait;
@@ -865,6 +865,80 @@ impl Provider for ReliableProvider {
         self.providers.iter().any(|(_, p)| p.supports_streaming())
     }
 
+    fn supports_streaming_tool_events(&self) -> bool {
+        self.providers
+            .iter()
+            .any(|(_, p)| p.supports_streaming_tool_events())
+    }
+
+    fn stream_chat(
+        &self,
+        request: ChatRequest<'_>,
+        model: &str,
+        temperature: f64,
+        options: StreamOptions,
+    ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+        let needs_tool_events = request.tools.is_some_and(|tools| !tools.is_empty());
+
+        for (provider_index, (provider_name, provider)) in self.providers.iter().enumerate() {
+            if !provider.supports_streaming() || !options.enabled {
+                continue;
+            }
+
+            if needs_tool_events && !provider.supports_streaming_tool_events() {
+                continue;
+            }
+
+            let provider_clone = provider_name.clone();
+
+            let base_model = match self.model_chain(model).first() {
+                Some(m) => *m,
+                None => model,
+            };
+            let current_model = self
+                .provider_model_chain(base_model, provider_name, provider_index == 0)
+                .first()
+                .copied()
+                .unwrap_or(base_model)
+                .to_string();
+
+            let req = ChatRequest {
+                messages: request.messages,
+                tools: request.tools,
+            };
+            let stream = provider.stream_chat(req, &current_model, temperature, options);
+            let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(100);
+
+            tokio::spawn(async move {
+                let mut stream = stream;
+                while let Some(event) = stream.next().await {
+                    if let Err(ref e) = event {
+                        tracing::warn!(
+                            provider = provider_clone,
+                            model = current_model,
+                            "Streaming error: {e}"
+                        );
+                    }
+                    if tx.send(event).await.is_err() {
+                        break;
+                    }
+                }
+            });
+
+            return stream::unfold(rx, |mut rx| async move {
+                rx.recv().await.map(|event| (event, rx))
+            })
+            .boxed();
+        }
+
+        let message = if needs_tool_events {
+            "No provider supports streaming tool events".to_string()
+        } else {
+            "No provider supports streaming".to_string()
+        };
+        stream::once(async move { Err(super::traits::StreamError::Provider(message)) }).boxed()
+    }
+
     fn stream_chat_with_system(
         &self,
         system_prompt: Option<&str>,
@@ -944,6 +1018,8 @@ impl Provider for ReliableProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::ToolSpec;
+    use futures_util::StreamExt;
     use std::sync::Arc;
 
     struct MockProvider {
@@ -2179,5 +2255,185 @@ mod tests {
         );
         // No override set → should defer to provider default (false)
         assert!(!provider.supports_vision());
+    }
+
+    struct StreamingToolEventMock {
+        stream_calls: Arc<AtomicUsize>,
+        supports_tool_events: bool,
+    }
+
+    impl StreamingToolEventMock {
+        fn new(supports_tool_events: bool) -> Self {
+            Self {
+                stream_calls: Arc::new(AtomicUsize::new(0)),
+                supports_tool_events,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for StreamingToolEventMock {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            Ok("ok".to_string())
+        }
+
+        fn supports_streaming(&self) -> bool {
+            true
+        }
+
+        fn supports_streaming_tool_events(&self) -> bool {
+            self.supports_tool_events
+        }
+
+        fn stream_chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: f64,
+            _options: StreamOptions,
+        ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            stream::iter(vec![
+                Ok(StreamEvent::ToolCall(super::super::traits::ToolCall {
+                    id: "call_1".to_string(),
+                    name: "shell".to_string(),
+                    arguments: r#"{"command":"date"}"#.to_string(),
+                })),
+                Ok(StreamEvent::Final),
+            ])
+            .boxed()
+        }
+    }
+
+    #[async_trait]
+    impl Provider for Arc<StreamingToolEventMock> {
+        async fn chat_with_system(
+            &self,
+            system_prompt: Option<&str>,
+            message: &str,
+            model: &str,
+            temperature: f64,
+        ) -> anyhow::Result<String> {
+            self.as_ref()
+                .chat_with_system(system_prompt, message, model, temperature)
+                .await
+        }
+
+        fn supports_streaming(&self) -> bool {
+            self.as_ref().supports_streaming()
+        }
+
+        fn supports_streaming_tool_events(&self) -> bool {
+            self.as_ref().supports_streaming_tool_events()
+        }
+
+        fn stream_chat(
+            &self,
+            request: ChatRequest<'_>,
+            model: &str,
+            temperature: f64,
+            options: StreamOptions,
+        ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+            self.as_ref()
+                .stream_chat(request, model, temperature, options)
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_chat_prefers_provider_with_tool_event_support() {
+        let primary = Arc::new(StreamingToolEventMock::new(false));
+        let fallback = Arc::new(StreamingToolEventMock::new(true));
+        let provider = ReliableProvider::new(
+            vec![
+                (
+                    "primary".into(),
+                    Box::new(Arc::clone(&primary)) as Box<dyn Provider>,
+                ),
+                (
+                    "fallback".into(),
+                    Box::new(Arc::clone(&fallback)) as Box<dyn Provider>,
+                ),
+            ],
+            0,
+            1,
+        );
+
+        let messages = vec![ChatMessage::user("hello")];
+        let tools = vec![ToolSpec {
+            name: "shell".to_string(),
+            description: "run shell".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "command": { "type": "string" }
+                }
+            }),
+        }];
+        let mut stream = provider.stream_chat(
+            ChatRequest {
+                messages: &messages,
+                tools: Some(&tools),
+            },
+            "model",
+            0.0,
+            StreamOptions::new(true),
+        );
+
+        let first = stream.next().await.unwrap().unwrap();
+        let second = stream.next().await.unwrap().unwrap();
+        assert!(stream.next().await.is_none());
+
+        match first {
+            StreamEvent::ToolCall(call) => assert_eq!(call.name, "shell"),
+            other => panic!("expected tool-call event, got {other:?}"),
+        }
+        assert!(matches!(second, StreamEvent::Final));
+        assert_eq!(primary.stream_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(fallback.stream_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn stream_chat_errors_when_no_provider_supports_tool_events() {
+        let primary = Arc::new(StreamingToolEventMock::new(false));
+        let provider = ReliableProvider::new(
+            vec![(
+                "primary".into(),
+                Box::new(Arc::clone(&primary)) as Box<dyn Provider>,
+            )],
+            0,
+            1,
+        );
+
+        let messages = vec![ChatMessage::user("hello")];
+        let tools = vec![ToolSpec {
+            name: "shell".to_string(),
+            description: "run shell".to_string(),
+            parameters: serde_json::json!({"type": "object"}),
+        }];
+        let mut stream = provider.stream_chat(
+            ChatRequest {
+                messages: &messages,
+                tools: Some(&tools),
+            },
+            "model",
+            0.0,
+            StreamOptions::new(true),
+        );
+
+        let first = stream.next().await.unwrap();
+        let err = first.expect_err("stream should fail without tool-event support");
+        assert!(
+            err.to_string()
+                .contains("No provider supports streaming tool events"),
+            "unexpected stream error: {err}"
+        );
+        assert!(stream.next().await.is_none());
+        assert_eq!(primary.stream_calls.load(Ordering::SeqCst), 0);
     }
 }

--- a/src/providers/router.rs
+++ b/src/providers/router.rs
@@ -1,5 +1,5 @@
 use super::traits::{
-    ChatMessage, ChatRequest, ChatResponse, StreamChunk, StreamOptions, StreamResult,
+    ChatMessage, ChatRequest, ChatResponse, StreamChunk, StreamEvent, StreamOptions, StreamResult,
 };
 use super::Provider;
 use async_trait::async_trait;
@@ -176,6 +176,12 @@ impl Provider for RouterProvider {
             .any(|(_, provider)| provider.supports_streaming())
     }
 
+    fn supports_streaming_tool_events(&self) -> bool {
+        self.providers
+            .iter()
+            .any(|(_, provider)| provider.supports_streaming_tool_events())
+    }
+
     fn stream_chat_with_history(
         &self,
         messages: &[ChatMessage],
@@ -186,6 +192,18 @@ impl Provider for RouterProvider {
         let (provider_idx, resolved_model) = self.resolve(model);
         let (_, provider) = &self.providers[provider_idx];
         provider.stream_chat_with_history(messages, &resolved_model, temperature, options)
+    }
+
+    fn stream_chat(
+        &self,
+        request: ChatRequest<'_>,
+        model: &str,
+        temperature: f64,
+        options: StreamOptions,
+    ) -> BoxStream<'static, StreamResult<StreamEvent>> {
+        let (provider_idx, resolved_model) = self.resolve(model);
+        let (_, provider) = &self.providers[provider_idx];
+        provider.stream_chat(request, &resolved_model, temperature, options)
     }
 
     fn supports_vision(&self) -> bool {
@@ -210,6 +228,7 @@ impl Provider for RouterProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::ToolSpec;
     use futures_util::StreamExt;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -383,6 +402,100 @@ mod tests {
         ) -> BoxStream<'static, StreamResult<StreamChunk>> {
             self.as_ref()
                 .stream_chat_with_history(messages, model, temperature, options)
+        }
+    }
+
+    struct ToolEventStreamingMockProvider {
+        stream_calls: Arc<AtomicUsize>,
+        tool_event_calls: Arc<AtomicUsize>,
+        last_stream_model: parking_lot::Mutex<String>,
+    }
+
+    impl ToolEventStreamingMockProvider {
+        fn new() -> Self {
+            Self {
+                stream_calls: Arc::new(AtomicUsize::new(0)),
+                tool_event_calls: Arc::new(AtomicUsize::new(0)),
+                last_stream_model: parking_lot::Mutex::new(String::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for ToolEventStreamingMockProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            Ok("ok".to_string())
+        }
+
+        fn supports_streaming(&self) -> bool {
+            true
+        }
+
+        fn supports_streaming_tool_events(&self) -> bool {
+            true
+        }
+
+        fn stream_chat(
+            &self,
+            request: ChatRequest<'_>,
+            model: &str,
+            _temperature: f64,
+            _options: StreamOptions,
+        ) -> BoxStream<'static, StreamResult<StreamEvent>> {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            if request.tools.is_some_and(|tools| !tools.is_empty()) {
+                self.tool_event_calls.fetch_add(1, Ordering::SeqCst);
+            }
+            *self.last_stream_model.lock() = model.to_string();
+            futures_util::stream::iter(vec![
+                Ok(StreamEvent::ToolCall(crate::providers::ToolCall {
+                    id: "call_router_1".to_string(),
+                    name: "shell".to_string(),
+                    arguments: r#"{"command":"date"}"#.to_string(),
+                })),
+                Ok(StreamEvent::Final),
+            ])
+            .boxed()
+        }
+    }
+
+    #[async_trait]
+    impl Provider for Arc<ToolEventStreamingMockProvider> {
+        async fn chat_with_system(
+            &self,
+            system_prompt: Option<&str>,
+            message: &str,
+            model: &str,
+            temperature: f64,
+        ) -> anyhow::Result<String> {
+            self.as_ref()
+                .chat_with_system(system_prompt, message, model, temperature)
+                .await
+        }
+
+        fn supports_streaming(&self) -> bool {
+            self.as_ref().supports_streaming()
+        }
+
+        fn supports_streaming_tool_events(&self) -> bool {
+            self.as_ref().supports_streaming_tool_events()
+        }
+
+        fn stream_chat(
+            &self,
+            request: ChatRequest<'_>,
+            model: &str,
+            temperature: f64,
+            options: StreamOptions,
+        ) -> BoxStream<'static, StreamResult<StreamEvent>> {
+            self.as_ref()
+                .stream_chat(request, model, temperature, options)
         }
     }
 
@@ -641,6 +754,69 @@ mod tests {
 
         assert_eq!(collected, "streamed response");
         assert_eq!(streaming.stream_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(*streaming.last_stream_model.lock(), "claude-opus");
+    }
+
+    #[tokio::test]
+    async fn stream_chat_routes_hint_with_structured_tool_events() {
+        let streaming = Arc::new(ToolEventStreamingMockProvider::new());
+        let router = RouterProvider::new(
+            vec![
+                (
+                    "default".into(),
+                    Box::new(MockProvider::new("default")) as Box<dyn Provider>,
+                ),
+                (
+                    "streaming".into(),
+                    Box::new(Arc::clone(&streaming)) as Box<dyn Provider>,
+                ),
+            ],
+            vec![(
+                "reasoning".into(),
+                Route {
+                    provider_name: "streaming".into(),
+                    model: "claude-opus".into(),
+                },
+            )],
+            "model".into(),
+        );
+
+        let messages = vec![ChatMessage::user("hello")];
+        let tools = vec![ToolSpec {
+            name: "shell".to_string(),
+            description: "run shell commands".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "command": { "type": "string" }
+                }
+            }),
+        }];
+
+        let mut stream = router.stream_chat(
+            ChatRequest {
+                messages: &messages,
+                tools: Some(&tools),
+            },
+            "hint:reasoning",
+            0.0,
+            StreamOptions::new(true),
+        );
+
+        let first = stream.next().await.unwrap().unwrap();
+        let second = stream.next().await.unwrap().unwrap();
+        assert!(stream.next().await.is_none());
+
+        match first {
+            StreamEvent::ToolCall(call) => {
+                assert_eq!(call.name, "shell");
+                assert_eq!(call.arguments, r#"{"command":"date"}"#);
+            }
+            other => panic!("expected tool-call event, got {other:?}"),
+        }
+        assert!(matches!(second, StreamEvent::Final));
+        assert_eq!(streaming.stream_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(streaming.tool_event_calls.load(Ordering::SeqCst), 1);
         assert_eq!(*streaming.last_stream_model.lock(), "claude-opus");
     }
 }

--- a/src/providers/traits.rs
+++ b/src/providers/traits.rs
@@ -162,6 +162,30 @@ impl StreamChunk {
     }
 }
 
+/// Structured events emitted by provider streaming APIs.
+///
+/// This extends plain text chunk streaming with explicit tool-call signals so
+/// agent loops can preserve native tool semantics without parsing payload text.
+#[derive(Debug, Clone)]
+pub enum StreamEvent {
+    /// Text delta from the assistant.
+    TextDelta(StreamChunk),
+    /// Structured tool call emitted during streaming.
+    ToolCall(ToolCall),
+    /// Stream has completed.
+    Final,
+}
+
+impl StreamEvent {
+    pub(crate) fn from_chunk(chunk: StreamChunk) -> Self {
+        if chunk.is_final {
+            Self::Final
+        } else {
+            Self::TextDelta(chunk)
+        }
+    }
+}
+
 /// Options for streaming chat requests.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct StreamOptions {
@@ -419,6 +443,14 @@ pub trait Provider: Send + Sync {
         false
     }
 
+    /// Whether provider can emit structured tool-call stream events.
+    ///
+    /// Providers should return true only when `stream_chat(...)` can produce
+    /// `StreamEvent::ToolCall` for native tool-calling requests.
+    fn supports_streaming_tool_events(&self) -> bool {
+        false
+    }
+
     /// Streaming chat with optional system prompt.
     /// Returns an async stream of text chunks.
     /// Default implementation falls back to non-streaming chat.
@@ -454,6 +486,22 @@ pub trait Provider: Send + Sync {
             .map(|m| m.content.as_str())
             .unwrap_or("");
         self.stream_chat_with_system(system, last_user, model, temperature, options)
+    }
+
+    /// Structured streaming chat interface.
+    ///
+    /// Default implementation adapts legacy text chunks from
+    /// `stream_chat_with_history` into `StreamEvent::TextDelta` / `Final`.
+    fn stream_chat(
+        &self,
+        request: ChatRequest<'_>,
+        model: &str,
+        temperature: f64,
+        options: StreamOptions,
+    ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+        self.stream_chat_with_history(request.messages, model, temperature, options)
+            .map(|chunk_result| chunk_result.map(StreamEvent::from_chunk))
+            .boxed()
     }
 }
 
@@ -493,6 +541,7 @@ pub fn build_tool_instructions_text(tools: &[ToolSpec]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::StreamExt;
 
     struct CapabilityMockProvider;
 
@@ -951,5 +1000,62 @@ mod tests {
         let message = err.to_string();
 
         assert!(message.contains("non-prompt-guided"));
+    }
+
+    struct StreamingChunkOnlyProvider;
+
+    #[async_trait]
+    impl Provider for StreamingChunkOnlyProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            Ok("ok".to_string())
+        }
+
+        fn supports_streaming(&self) -> bool {
+            true
+        }
+
+        fn stream_chat_with_history(
+            &self,
+            _messages: &[ChatMessage],
+            _model: &str,
+            _temperature: f64,
+            _options: StreamOptions,
+        ) -> stream::BoxStream<'static, StreamResult<StreamChunk>> {
+            stream::iter(vec![
+                Ok(StreamChunk::delta("hello")),
+                Ok(StreamChunk::final_chunk()),
+            ])
+            .boxed()
+        }
+    }
+
+    #[tokio::test]
+    async fn provider_stream_chat_default_maps_legacy_chunks_to_events() {
+        let provider = StreamingChunkOnlyProvider;
+        let mut stream = provider.stream_chat(
+            ChatRequest {
+                messages: &[ChatMessage::user("hi")],
+                tools: None,
+            },
+            "model",
+            0.0,
+            StreamOptions::new(true),
+        );
+
+        let first = stream.next().await.unwrap().unwrap();
+        let second = stream.next().await.unwrap().unwrap();
+        assert!(stream.next().await.is_none());
+
+        match first {
+            StreamEvent::TextDelta(chunk) => assert_eq!(chunk.delta, "hello"),
+            other => panic!("expected text delta event, got {other:?}"),
+        }
+        assert!(matches!(second, StreamEvent::Final));
     }
 }


### PR DESCRIPTION
## Summary
- extend provider streaming contract with structured `StreamEvent` (`TextDelta`, `ToolCall`, `Final`)
- wire `run_tool_call_loop` to consume structured streaming, including native tool-call events without leaking payload text
- add native tool-event streaming implementation for OpenAI-compatible provider SSE parsing
- propagate structured streaming passthrough in RouterProvider and ReliableProvider
- add regression tests for routed streaming and native-tool streaming parity paths

## Validation
- `cargo fmt --all`
- `cargo test provider_stream_chat_default_maps_legacy_chunks_to_events`
- `cargo test stream_chat_routes_hint_with_structured_tool_events`
- `cargo test stream_chat_prefers_provider_with_tool_event_support`
- `cargo test stream_chat_errors_when_no_provider_supports_tool_events`
- `cargo test parse_sse_chunk_with_tool_call_delta`
- `cargo test stream_tool_call_accumulator_combines_deltas`
- `cargo test run_tool_call_loop_streams_native_tool_events_without_chat_fallback`
- `cargo test run_tool_call_loop_routed_streaming_uses_live_provider_deltas_once`
- `cargo test run_tool_call_loop_consumes_provider_stream_for_final_response`
- `cargo test run_tool_call_loop_streaming_path_preserves_tool_loop_semantics`

Closes #2869
