### PR TITLE
feat(email): make default email subject configurable

### DIFF
--- a/src/channels/email_channel.rs
+++ b/src/channels/email_channel.rs
@@ -67,6 +67,9 @@ pub struct EmailConfig {
     /// Allowed sender addresses/domains (empty = deny all, ["*"] = allow all)
     #[serde(default)]
     pub allowed_senders: Vec<String>,
+    /// Default subject line for outgoing emails when none is specified
+    #[serde(default = "default_subject")]
+    pub default_subject: String,
 }
 
 impl crate::config::traits::ChannelConfig for EmailConfig {
@@ -93,6 +96,9 @@ fn default_idle_timeout() -> u64 {
 fn default_true() -> bool {
     true
 }
+fn default_subject() -> String {
+    "ZeroClaw Message".into()
+}
 
 impl Default for EmailConfig {
     fn default() -> Self {
@@ -108,6 +114,7 @@ impl Default for EmailConfig {
             from_address: String::new(),
             idle_timeout_secs: default_idle_timeout(),
             allowed_senders: Vec::new(),
+            default_subject: default_subject(),
         }
     }
 }
@@ -511,17 +518,17 @@ impl Channel for EmailChannel {
     }
 
     async fn send(&self, message: &SendMessage) -> Result<()> {
-        // Use explicit subject if provided, otherwise fall back to legacy parsing or default
+        // Use explicit subject if provided, otherwise fall back to legacy parsing or config default
         let (subject, body) = if let Some(ref subj) = message.subject {
             (subj.as_str(), message.content.as_str())
         } else if message.content.starts_with("Subject: ") {
             if let Some(pos) = message.content.find('\n') {
                 (&message.content[9..pos], message.content[pos + 1..].trim())
             } else {
-                ("ZeroClaw Message", message.content.as_str())
+                (self.config.default_subject.as_str(), message.content.as_str())
             }
         } else {
-            ("ZeroClaw Message", message.content.as_str())
+            (self.config.default_subject.as_str(), message.content.as_str())
         };
 
         let email = Message::builder()
@@ -619,6 +626,7 @@ mod tests {
         assert_eq!(config.from_address, "");
         assert_eq!(config.idle_timeout_secs, 1740);
         assert!(config.allowed_senders.is_empty());
+        assert_eq!(config.default_subject, "ZeroClaw Message");
     }
 
     #[test]
@@ -635,10 +643,12 @@ mod tests {
             from_address: "bot@example.com".to_string(),
             idle_timeout_secs: 1200,
             allowed_senders: vec!["allowed@example.com".to_string()],
+            default_subject: "Custom Subject".to_string(),
         };
         assert_eq!(config.imap_host, "imap.example.com");
         assert_eq!(config.imap_folder, "Archive");
         assert_eq!(config.idle_timeout_secs, 1200);
+        assert_eq!(config.default_subject, "Custom Subject");
     }
 
     #[test]
@@ -655,11 +665,13 @@ mod tests {
             from_address: "bot@test.com".to_string(),
             idle_timeout_secs: 1740,
             allowed_senders: vec!["*".to_string()],
+            default_subject: "Test Subject".to_string(),
         };
         let cloned = config.clone();
         assert_eq!(cloned.imap_host, config.imap_host);
         assert_eq!(cloned.smtp_port, config.smtp_port);
         assert_eq!(cloned.allowed_senders, config.allowed_senders);
+        assert_eq!(cloned.default_subject, config.default_subject);
     }
 
     // EmailChannel tests
@@ -900,6 +912,7 @@ mod tests {
             from_address: "bot@example.com".to_string(),
             idle_timeout_secs: 1740,
             allowed_senders: vec!["allowed@example.com".to_string()],
+            default_subject: "Serialized Subject".to_string(),
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -908,6 +921,7 @@ mod tests {
         assert_eq!(deserialized.imap_host, config.imap_host);
         assert_eq!(deserialized.smtp_port, config.smtp_port);
         assert_eq!(deserialized.allowed_senders, config.allowed_senders);
+        assert_eq!(deserialized.default_subject, config.default_subject);
     }
 
     #[test]
@@ -925,6 +939,22 @@ mod tests {
         assert_eq!(config.smtp_port, 465); // default
         assert!(config.smtp_tls); // default
         assert_eq!(config.idle_timeout_secs, 1740); // default
+        assert_eq!(config.default_subject, "ZeroClaw Message"); // default
+    }
+
+    #[test]
+    fn email_config_deserialize_custom_subject() {
+        let json = r#"{
+            "imap_host": "imap.test.com",
+            "smtp_host": "smtp.test.com",
+            "username": "user",
+            "password": "pass",
+            "from_address": "bot@test.com",
+            "default_subject": "My Custom Bot"
+        }"#;
+
+        let config: EmailConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.default_subject, "My Custom Bot");
     }
 
     #[test]

--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -1026,6 +1026,7 @@ mod tests {
             from_address: "agent@example.com".to_string(),
             idle_timeout_secs: 1740,
             allowed_senders: vec!["*".to_string()],
+            default_subject: "ZeroClaw Message".to_string(),
         });
         cfg.model_routes = vec![crate::config::schema::ModelRouteConfig {
             hint: "reasoning".to_string(),
@@ -1159,6 +1160,7 @@ mod tests {
             from_address: "agent@example.com".to_string(),
             idle_timeout_secs: 1740,
             allowed_senders: vec!["*".to_string()],
+            default_subject: "ZeroClaw Message".to_string(),
         });
         current.model_routes = vec![
             crate::config::schema::ModelRouteConfig {


### PR DESCRIPTION
## Summary

Add `default_subject` config option to `EmailConfig` so users can customize the fallback subject line for outgoing emails.

- Previously the subject was hardcoded as `"ZeroClaw Message"` when no explicit subject was provided
- Now users can set their own default via config
- Original default preserved for backward compatibility

## Usage

```toml
[channels_config.email]
default_subject = "My Assistant"
```

## Changes

- `src/channels/email_channel.rs`: Added `default_subject` field with serde default, updated `send()` to use config value
- `src/gateway/api.rs`: Updated test fixtures to include new field

## Test plan

- [x] All existing email channel tests pass
- [x] New test for custom subject deserialization added
- [x] Full test suite passes (3045+ tests)
- [x] Backward compatible - existing configs without the field use default

Closes #2878

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email configuration now includes a customizable default subject line. When sending emails without an explicit subject, the configured default is used instead of a hardcoded system value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->