### PR TITLE
docs(i18n): expand language support hubs across docs entry points

### DIFF
--- a/docs/i18n/README.md
+++ b/docs/i18n/README.md
@@ -4,8 +4,22 @@ Localized documentation trees live here and under `docs/`.
 
 ## Locales
 
+- العربية (Arabic): [ar/README.md](ar/README.md)
+- বাংলা (Bengali): [bn/README.md](bn/README.md)
+- Deutsch (German): [de/README.md](de/README.md)
+- Ελληνικά (Greek): [el/README.md](el/README.md)
+- Español (Spanish): [es/README.md](es/README.md)
+- Français (French): [fr/README.md](fr/README.md)
+- हिन्दी (Hindi): [hi/README.md](hi/README.md)
+- Italiano (Italian): [it/README.md](it/README.md)
+- 日本語 (Japanese): [ja/README.md](ja/README.md)
+- 한국어 (Korean): [ko/README.md](ko/README.md)
+- Português (Portuguese): [pt/README.md](pt/README.md)
+- Русский (Russian): [ru/README.md](ru/README.md)
+- Tagalog: [tl/README.md](tl/README.md)
+- Tiếng Việt (Vietnamese): [vi/README.md](vi/README.md)
 - Vietnamese (canonical): [`docs/vi/`](../vi/)
-- Chinese (Simplified): [`docs/i18n/zh-CN/`](zh-CN/)
+- 简体中文 (Chinese): [zh-CN/README.md](zh-CN/README.md)
 
 ## Structure
 

--- a/docs/i18n/ar/README.md
+++ b/docs/i18n/ar/README.md
@@ -1,0 +1,35 @@
+# ZeroClaw Documentation Hub (Arabic)
+
+This locale hub is enabled for Arabic community support.
+
+Last synchronized: **March 6, 2026**.
+
+## Quick Links
+
+- Arabic docs hub: [README.md](README.md)
+- Arabic summary: [SUMMARY.md](SUMMARY.md)
+- English docs hub: [../../README.md](../../README.md)
+- English summary: [../../SUMMARY.md](../../SUMMARY.md)
+
+## Coverage Status
+
+Current status: **hub-level support enabled**. Full document translation is in progress.
+
+## Other Languages
+
+- English: [../../../README.md](../../../README.md)
+- 简体中文: [../zh-CN/README.md](../zh-CN/README.md)
+- 日本語: [../ja/README.md](../ja/README.md)
+- 한국어: [../ko/README.md](../ko/README.md)
+- Tiếng Việt: [../vi/README.md](../vi/README.md)
+- Tagalog: [../tl/README.md](../tl/README.md)
+- Español: [../es/README.md](../es/README.md)
+- Português: [../pt/README.md](../pt/README.md)
+- Italiano: [../it/README.md](../it/README.md)
+- Deutsch: [../de/README.md](../de/README.md)
+- Français: [../fr/README.md](../fr/README.md)
+- العربية: [README.md](README.md)
+- हिन्दी: [../hi/README.md](../hi/README.md)
+- Русский: [../ru/README.md](../ru/README.md)
+- বাংলা: [../bn/README.md](../bn/README.md)
+- Ελληνικά: [../el/README.md](../el/README.md)

--- a/docs/i18n/ar/SUMMARY.md
+++ b/docs/i18n/ar/SUMMARY.md
@@ -1,0 +1,20 @@
+# ZeroClaw Docs Summary (Arabic)
+
+This is the Arabic locale summary entry point.
+
+Last synchronized: **March 6, 2026**.
+
+## Entry Points
+
+- Arabic docs hub: [README.md](README.md)
+- English docs hub: [../../README.md](../../README.md)
+- English unified summary: [../../SUMMARY.md](../../SUMMARY.md)
+
+## Operator References (English Source)
+
+- [../../commands-reference.md](../../commands-reference.md)
+- [../../config-reference.md](../../config-reference.md)
+- [../../providers-reference.md](../../providers-reference.md)
+- [../../channels-reference.md](../../channels-reference.md)
+- [../../operations-runbook.md](../../operations-runbook.md)
+- [../../troubleshooting.md](../../troubleshooting.md)

--- a/docs/i18n/bn/README.md
+++ b/docs/i18n/bn/README.md
@@ -1,0 +1,35 @@
+# ZeroClaw Documentation Hub (Bengali)
+
+This locale hub is enabled for Bengali community support.
+
+Last synchronized: **March 6, 2026**.
+
+## Quick Links
+
+- Bengali docs hub: [README.md](README.md)
+- Bengali summary: [SUMMARY.md](SUMMARY.md)
+- English docs hub: [../../README.md](../../README.md)
+- English summary: [../../SUMMARY.md](../../SUMMARY.md)
+
+## Coverage Status
+
+Current status: **hub-level support enabled**. Full document translation is in progress.
+
+## Other Languages
+
+- English: [../../../README.md](../../../README.md)
+- 简体中文: [../zh-CN/README.md](../zh-CN/README.md)
+- 日本語: [../ja/README.md](../ja/README.md)
+- 한국어: [../ko/README.md](../ko/README.md)
+- Tiếng Việt: [../vi/README.md](../vi/README.md)
+- Tagalog: [../tl/README.md](../tl/README.md)
+- Español: [../es/README.md](../es/README.md)
+- Português: [../pt/README.md](../pt/README.md)
+- Italiano: [../it/README.md](../it/README.md)
+- Deutsch: [../de/README.md](../de/README.md)
+- Français: [../fr/README.md](../fr/README.md)
+- العربية: [../ar/README.md](../ar/README.md)
+- हिन्दी: [../hi/README.md](../hi/README.md)
+- Русский: [../ru/README.md](../ru/README.md)
+- বাংলা: [README.md](README.md)
+- Ελληνικά: [../el/README.md](../el/README.md)

--- a/docs/i18n/bn/SUMMARY.md
+++ b/docs/i18n/bn/SUMMARY.md
@@ -1,0 +1,20 @@
+# ZeroClaw Docs Summary (Bengali)
+
+This is the Bengali locale summary entry point.
+
+Last synchronized: **March 6, 2026**.
+
+## Entry Points
+
+- Bengali docs hub: [README.md](README.md)
+- English docs hub: [../../README.md](../../README.md)
+- English unified summary: [../../SUMMARY.md](../../SUMMARY.md)
+
+## Operator References (English Source)
+
+- [../../commands-reference.md](../../commands-reference.md)
+- [../../config-reference.md](../../config-reference.md)
+- [../../providers-reference.md](../../providers-reference.md)
+- [../../channels-reference.md](../../channels-reference.md)
+- [../../operations-runbook.md](../../operations-runbook.md)
+- [../../troubleshooting.md](../../troubleshooting.md)

--- a/docs/i18n/de/README.md
+++ b/docs/i18n/de/README.md
@@ -1,0 +1,35 @@
+# ZeroClaw Documentation Hub (German)
+
+This locale hub is enabled for German community support.
+
+Last synchronized: **March 6, 2026**.
+
+## Quick Links
+
+- German docs hub: [README.md](README.md)
+- German summary: [SUMMARY.md](SUMMARY.md)
+- English docs hub: [../../README.md](../../README.md)
+- English summary: [../../SUMMARY.md](../../SUMMARY.md)
+
+## Coverage Status
+
+Current status: **hub-level support enabled**. Full document translation is in progress.
+
+## Other Languages
+
+- English: [../../../README.md](../../../README.md)
+- 简体中文: [../zh-CN/README.md](../zh-CN/README.md)
+- 日本語: [../ja/README.md](../ja/README.md)
+- 한국어: [../ko/README.md](../ko/README.md)
+- Tiếng Việt: [../vi/README.md](../vi/README.md)
+- Tagalog: [../tl/README.md](../tl/README.md)
+- Español: [../es/README.md](../es/README.md)
+- Português: [../pt/README.md](../pt/README.md)
+- Italiano: [../it/README.md](../it/README.md)
+- Deutsch: [README.md](README.md)
+- Français: [../fr/README.md](../fr/README.md)
+- العربية: [../ar/README.md](../ar/README.md)
+- हिन्दी: [../hi/README.md](../hi/README.md)
+- Русский: [../ru/README.md](../ru/README.md)
+- বাংলা: [../bn/README.md](../bn/README.md)
+- Ελληνικά: [../el/README.md](../el/README.md)

--- a/docs/i18n/de/SUMMARY.md
+++ b/docs/i18n/de/SUMMARY.md
@@ -1,0 +1,20 @@
+# ZeroClaw Docs Summary (German)
+
+This is the German locale summary entry point.
+
+Last synchronized: **March 6, 2026**.
+
+## Entry Points
+
+- German docs hub: [README.md](README.md)
+- English docs hub: [../../README.md](../../README.md)
+- English unified summary: [../../SUMMARY.md](../../SUMMARY.md)
+
+## Operator References (English Source)
+
+- [../../commands-reference.md](../../commands-reference.md)
+- [../../config-reference.md](../../config-reference.md)
+- [../../providers-reference.md](../../providers-reference.md)
+- [../../channels-reference.md](../../channels-reference.md)
+- [../../operations-runbook.md](../../operations-runbook.md)
+- [../../troubleshooting.md](../../troubleshooting.md)

--- a/docs/i18n/hi/README.md
+++ b/docs/i18n/hi/README.md
@@ -1,0 +1,35 @@
+# ZeroClaw Documentation Hub (Hindi)
+
+This locale hub is enabled for Hindi community support.
+
+Last synchronized: **March 6, 2026**.
+
+## Quick Links
+
+- Hindi docs hub: [README.md](README.md)
+- Hindi summary: [SUMMARY.md](SUMMARY.md)
+- English docs hub: [../../README.md](../../README.md)
+- English summary: [../../SUMMARY.md](../../SUMMARY.md)
+
+## Coverage Status
+
+Current status: **hub-level support enabled**. Full document translation is in progress.
+
+## Other Languages
+
+- English: [../../../README.md](../../../README.md)
+- 简体中文: [../zh-CN/README.md](../zh-CN/README.md)
+- 日本語: [../ja/README.md](../ja/README.md)
+- 한국어: [../ko/README.md](../ko/README.md)
+- Tiếng Việt: [../vi/README.md](../vi/README.md)
+- Tagalog: [../tl/README.md](../tl/README.md)
+- Español: [../es/README.md](../es/README.md)
+- Português: [../pt/README.md](../pt/README.md)
+- Italiano: [../it/README.md](../it/README.md)
+- Deutsch: [../de/README.md](../de/README.md)
+- Français: [../fr/README.md](../fr/README.md)
+- العربية: [../ar/README.md](../ar/README.md)
+- हिन्दी: [README.md](README.md)
+- Русский: [../ru/README.md](../ru/README.md)
+- বাংলা: [../bn/README.md](../bn/README.md)
+- Ελληνικά: [../el/README.md](../el/README.md)

--- a/docs/i18n/hi/SUMMARY.md
+++ b/docs/i18n/hi/SUMMARY.md
@@ -1,0 +1,20 @@
+# ZeroClaw Docs Summary (Hindi)
+
+This is the Hindi locale summary entry point.
+
+Last synchronized: **March 6, 2026**.
+
+## Entry Points
+
+- Hindi docs hub: [README.md](README.md)
+- English docs hub: [../../README.md](../../README.md)
+- English unified summary: [../../SUMMARY.md](../../SUMMARY.md)
+
+## Operator References (English Source)
+
+- [../../commands-reference.md](../../commands-reference.md)
+- [../../config-reference.md](../../config-reference.md)
+- [../../providers-reference.md](../../providers-reference.md)
+- [../../channels-reference.md](../../channels-reference.md)
+- [../../operations-runbook.md](../../operations-runbook.md)
+- [../../troubleshooting.md](../../troubleshooting.md)

--- a/docs/i18n/ko/README.md
+++ b/docs/i18n/ko/README.md
@@ -1,0 +1,35 @@
+# ZeroClaw Documentation Hub (Korean)
+
+This locale hub is enabled for Korean community support.
+
+Last synchronized: **March 6, 2026**.
+
+## Quick Links
+
+- Korean docs hub: [README.md](README.md)
+- Korean summary: [SUMMARY.md](SUMMARY.md)
+- English docs hub: [../../README.md](../../README.md)
+- English summary: [../../SUMMARY.md](../../SUMMARY.md)
+
+## Coverage Status
+
+Current status: **hub-level support enabled**. Full document translation is in progress.
+
+## Other Languages
+
+- English: [../../../README.md](../../../README.md)
+- 简体中文: [../zh-CN/README.md](../zh-CN/README.md)
+- 日本語: [../ja/README.md](../ja/README.md)
+- 한국어: [README.md](README.md)
+- Tiếng Việt: [../vi/README.md](../vi/README.md)
+- Tagalog: [../tl/README.md](../tl/README.md)
+- Español: [../es/README.md](../es/README.md)
+- Português: [../pt/README.md](../pt/README.md)
+- Italiano: [../it/README.md](../it/README.md)
+- Deutsch: [../de/README.md](../de/README.md)
+- Français: [../fr/README.md](../fr/README.md)
+- العربية: [../ar/README.md](../ar/README.md)
+- हिन्दी: [../hi/README.md](../hi/README.md)
+- Русский: [../ru/README.md](../ru/README.md)
+- বাংলা: [../bn/README.md](../bn/README.md)
+- Ελληνικά: [../el/README.md](../el/README.md)

--- a/docs/i18n/ko/SUMMARY.md
+++ b/docs/i18n/ko/SUMMARY.md
@@ -1,0 +1,20 @@
+# ZeroClaw Docs Summary (Korean)
+
+This is the Korean locale summary entry point.
+
+Last synchronized: **March 6, 2026**.
+
+## Entry Points
+
+- Korean docs hub: [README.md](README.md)
+- English docs hub: [../../README.md](../../README.md)
+- English unified summary: [../../SUMMARY.md](../../SUMMARY.md)
+
+## Operator References (English Source)
+
+- [../../commands-reference.md](../../commands-reference.md)
+- [../../config-reference.md](../../config-reference.md)
+- [../../providers-reference.md](../../providers-reference.md)
+- [../../channels-reference.md](../../channels-reference.md)
+- [../../operations-runbook.md](../../operations-runbook.md)
+- [../../troubleshooting.md](../../troubleshooting.md)

--- a/docs/i18n/tl/README.md
+++ b/docs/i18n/tl/README.md
@@ -1,0 +1,35 @@
+# ZeroClaw Documentation Hub (Tagalog)
+
+This locale hub is enabled for Tagalog community support.
+
+Last synchronized: **March 6, 2026**.
+
+## Quick Links
+
+- Tagalog docs hub: [README.md](README.md)
+- Tagalog summary: [SUMMARY.md](SUMMARY.md)
+- English docs hub: [../../README.md](../../README.md)
+- English summary: [../../SUMMARY.md](../../SUMMARY.md)
+
+## Coverage Status
+
+Current status: **hub-level support enabled**. Full document translation is in progress.
+
+## Other Languages
+
+- English: [../../../README.md](../../../README.md)
+- 简体中文: [../zh-CN/README.md](../zh-CN/README.md)
+- 日本語: [../ja/README.md](../ja/README.md)
+- 한국어: [../ko/README.md](../ko/README.md)
+- Tiếng Việt: [../vi/README.md](../vi/README.md)
+- Tagalog: [README.md](README.md)
+- Español: [../es/README.md](../es/README.md)
+- Português: [../pt/README.md](../pt/README.md)
+- Italiano: [../it/README.md](../it/README.md)
+- Deutsch: [../de/README.md](../de/README.md)
+- Français: [../fr/README.md](../fr/README.md)
+- العربية: [../ar/README.md](../ar/README.md)
+- हिन्दी: [../hi/README.md](../hi/README.md)
+- Русский: [../ru/README.md](../ru/README.md)
+- বাংলা: [../bn/README.md](../bn/README.md)
+- Ελληνικά: [../el/README.md](../el/README.md)

--- a/docs/i18n/tl/SUMMARY.md
+++ b/docs/i18n/tl/SUMMARY.md
@@ -1,0 +1,20 @@
+# ZeroClaw Docs Summary (Tagalog)
+
+This is the Tagalog locale summary entry point.
+
+Last synchronized: **March 6, 2026**.
+
+## Entry Points
+
+- Tagalog docs hub: [README.md](README.md)
+- English docs hub: [../../README.md](../../README.md)
+- English unified summary: [../../SUMMARY.md](../../SUMMARY.md)
+
+## Operator References (English Source)
+
+- [../../commands-reference.md](../../commands-reference.md)
+- [../../config-reference.md](../../config-reference.md)
+- [../../providers-reference.md](../../providers-reference.md)
+- [../../channels-reference.md](../../channels-reference.md)
+- [../../operations-runbook.md](../../operations-runbook.md)
+- [../../troubleshooting.md](../../troubleshooting.md)


### PR DESCRIPTION
## Summary
- add new locale hubs and summaries for Korean (`ko`), Tagalog (`tl`), German (`de`), Arabic (`ar`), Hindi (`hi`), and Bengali (`bn`)
- expand root/docs language navigation so all requested international channels are directly discoverable
- update i18n index and coverage metadata to reflect current hub-level support status

## Scope
- docs navigation surfaces: `README.md`, `docs/README.md`, `docs/SUMMARY.md`, `docs/i18n/README.md`
- coverage metadata: `docs/i18n-coverage.md`
- new locale files: `docs/i18n/{ko,tl,de,ar,hi,bn}/{README.md,SUMMARY.md}`

## Why
The community language set was expanded and needed canonical locale entry points for all listed international channels.

## Validation
- verified new locale hub files exist for all six new locales
- verified language navigation links resolve from root/docs entry pages
- docs-only change; no runtime code paths modified

## Risk
Low (documentation and localization topology only).

## Rollback
Revert this PR commit to restore previous locale topology and language navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded multilingual support with new language documentation hubs (Korean, Tagalog, Spanish, Portuguese, Italian, German, Arabic, Hindi, Bengali)
  * Reorganized documentation structure with improved navigation and clearer entry points
  * Renamed "Quick Start" section to "Getting Started"

* **Chores**
  * Updated social media links in the header
  * Enhanced language coverage tracking documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->