### PR TITLE
Fix unbound variable error in bootstrap.sh with set -u

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -707,13 +707,24 @@ MSG
     fi
   fi
 
+  # Build docker run args, handling empty arrays safely with set -u
+  local docker_run_args=(
+    -e HOME=/zeroclaw-data
+    -e ZEROCLAW_WORKSPACE=/zeroclaw-data/workspace
+    -v "$config_mount"
+    -v "$workspace_mount"
+  )
+
+  # Add namespace/user args only if non-empty (bash set -u safety)
+  if [[ ${#container_run_namespace_args[@]} -gt 0 ]]; then
+    docker_run_args+=("${container_run_namespace_args[@]}")
+  fi
+  if [[ ${#container_run_user_args[@]} -gt 0 ]]; then
+    docker_run_args+=("${container_run_user_args[@]}")
+  fi
+
   "$CONTAINER_CLI" run --rm -it \
-    "${container_run_namespace_args[@]}" \
-    "${container_run_user_args[@]}" \
-    -e HOME=/zeroclaw-data \
-    -e ZEROCLAW_WORKSPACE=/zeroclaw-data/workspace \
-    -v "$config_mount" \
-    -v "$workspace_mount" \
+    "${docker_run_args[@]}" \
     "$docker_image" \
     "${onboard_cmd[@]}"
 }


### PR DESCRIPTION
Fixes #2930. The bootstrap.sh script uses set -euo pipefail which includes -u (nounset). When the script references empty arrays with ${array[@]} under set -u, some bash versions (especially on macOS) treat them as unbound variables and error out.

The fix builds the docker run arguments in a new array that is always non-empty, then conditionally adds the namespace and user args only when they contain values. This avoids the unbound variable error while maintaining the same functionality.