### PR TITLE
feat(verifiable_intent): add native verifiable intent lifecycle module

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -41,3 +41,18 @@ This project uses third-party libraries and components,
 each licensed under their respective terms.
 
 See Cargo.lock for a complete dependency list.
+
+Verifiable Intent Specification
+================================
+
+The src/verifiable_intent/ module is a Rust-native reimplementation based on
+the Verifiable Intent open specification and reference implementation:
+
+  Project:  Verifiable Intent (VI)
+  Author:   genereda
+  Source:   https://github.com/genereda/verifiable-intent
+  License:  Apache License, Version 2.0
+
+This implementation follows the VI specification design (SD-JWT layered
+credentials, constraint model, three-layer chain). No source code was copied
+from the reference implementation.

--- a/NOTICE
+++ b/NOTICE
@@ -49,8 +49,8 @@ The src/verifiable_intent/ module is a Rust-native reimplementation based on
 the Verifiable Intent open specification and reference implementation:
 
   Project:  Verifiable Intent (VI)
-  Author:   genereda
-  Source:   https://github.com/genereda/verifiable-intent
+  Author:   agent-intent
+  Source:   https://github.com/agent-intent/verifiable-intent
   License:  Apache License, Version 2.0
 
 This implementation follows the VI specification design (SD-JWT layered

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,8 +26,8 @@ pub use schema::{
     SecurityOpsConfig, SkillCreationConfig, SkillsConfig, SkillsPromptInjectionMode, SlackConfig,
     StorageConfig, StorageProviderConfig, StorageProviderSection, StreamMode, SwarmConfig,
     SwarmStrategy, TelegramConfig, TextBrowserConfig, ToolFilterGroup, ToolFilterGroupMode,
-    TranscriptionConfig, TtsConfig, TunnelConfig, WebFetchConfig, WebSearchConfig, WebhookConfig,
-    WorkspaceConfig, DEFAULT_GWS_SERVICES,
+    TranscriptionConfig, TtsConfig, TunnelConfig, VerifiableIntentConfig, WebFetchConfig,
+    WebSearchConfig, WebhookConfig, WorkspaceConfig, DEFAULT_GWS_SERVICES,
 };
 
 pub fn name_and_presence<T: traits::ChannelConfig>(channel: Option<&T>) -> (&'static str, bool) {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -367,6 +367,10 @@ pub struct Config {
     /// `LANG`, or `LC_ALL` environment variables (defaulting to `"en"`).
     #[serde(default)]
     pub locale: Option<String>,
+
+    /// Verifiable Intent (VI) credential verification and issuance (`[verifiable_intent]`).
+    #[serde(default)]
+    pub verifiable_intent: VerifiableIntentConfig,
 }
 
 /// Multi-client workspace isolation configuration.
@@ -871,6 +875,33 @@ impl Default for McpConfig {
             enabled: false,
             deferred_loading: default_deferred_loading(),
             servers: Vec::new(),
+        }
+    }
+}
+
+/// Verifiable Intent (VI) credential verification and issuance (`[verifiable_intent]` section).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct VerifiableIntentConfig {
+    /// Enable VI credential verification on commerce tool calls (default: false).
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Strictness mode for constraint evaluation: "strict" (fail-closed on unknown
+    /// constraint types) or "permissive" (skip unknown types with a warning).
+    /// Default: "strict".
+    #[serde(default = "default_vi_strictness")]
+    pub strictness: String,
+}
+
+fn default_vi_strictness() -> String {
+    "strict".to_owned()
+}
+
+impl Default for VerifiableIntentConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            strictness: default_vi_strictness(),
         }
     }
 }
@@ -6345,6 +6376,7 @@ impl Default for Config {
             linkedin: LinkedInConfig::default(),
             plugins: PluginsConfig::default(),
             locale: None,
+            verifiable_intent: VerifiableIntentConfig::default(),
         }
     }
 }
@@ -9190,6 +9222,7 @@ default_temperature = 0.7
             linkedin: LinkedInConfig::default(),
             plugins: PluginsConfig::default(),
             locale: None,
+            verifiable_intent: VerifiableIntentConfig::default(),
         };
 
         let toml_str = toml::to_string_pretty(&config).unwrap();
@@ -9527,6 +9560,7 @@ tool_dispatcher = "xml"
             linkedin: LinkedInConfig::default(),
             plugins: PluginsConfig::default(),
             locale: None,
+            verifiable_intent: VerifiableIntentConfig::default(),
         };
 
         config.save().await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub(crate) mod skills;
 pub mod tools;
 pub(crate) mod tunnel;
 pub(crate) mod util;
+pub mod verifiable_intent;
 
 #[cfg(feature = "plugins-wasm")]
 pub mod plugins;

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,7 @@ mod skills;
 mod tools;
 mod tunnel;
 mod util;
+mod verifiable_intent;
 
 use config::Config;
 

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -197,6 +197,7 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
         linkedin: crate::config::LinkedInConfig::default(),
         plugins: crate::config::PluginsConfig::default(),
         locale: None,
+        verifiable_intent: crate::config::VerifiableIntentConfig::default(),
     };
 
     println!(
@@ -616,6 +617,7 @@ async fn run_quick_setup_with_home(
         linkedin: crate::config::LinkedInConfig::default(),
         plugins: crate::config::PluginsConfig::default(),
         locale: None,
+        verifiable_intent: crate::config::VerifiableIntentConfig::default(),
     };
 
     config.save().await?;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -79,6 +79,7 @@ pub mod swarm;
 pub mod text_browser;
 pub mod tool_search;
 pub mod traits;
+pub mod verifiable_intent;
 pub mod web_fetch;
 pub mod web_search_tool;
 pub mod workspace_tool;
@@ -147,6 +148,7 @@ pub use tool_search::ToolSearchTool;
 pub use traits::Tool;
 #[allow(unused_imports)]
 pub use traits::{ToolResult, ToolSpec};
+pub use verifiable_intent::VerifiableIntentTool;
 pub use web_fetch::WebFetchTool;
 pub use web_search_tool::WebSearchTool;
 pub use workspace_tool::WorkspaceTool;
@@ -697,6 +699,18 @@ pub fn all_tools_with_runtime(
         tool_arcs.push(Arc::new(WorkspaceTool::new(
             Arc::new(tokio::sync::RwLock::new(ws_manager)),
             security.clone(),
+        )));
+    }
+
+    // Verifiable Intent tool (opt-in via config)
+    if root_config.verifiable_intent.enabled {
+        let strictness = match root_config.verifiable_intent.strictness.as_str() {
+            "permissive" => crate::verifiable_intent::StrictnessMode::Permissive,
+            _ => crate::verifiable_intent::StrictnessMode::Strict,
+        };
+        tool_arcs.push(Arc::new(VerifiableIntentTool::new(
+            security.clone(),
+            strictness,
         )));
     }
 

--- a/src/tools/verifiable_intent.rs
+++ b/src/tools/verifiable_intent.rs
@@ -1,0 +1,254 @@
+//! Verifiable Intent tool — exposes VI verification and constraint evaluation
+//! to the agent orchestration loop.
+
+use async_trait::async_trait;
+use serde_json::json;
+use std::sync::Arc;
+
+use crate::security::policy::ToolOperation;
+use crate::security::SecurityPolicy;
+use crate::tools::traits::{Tool, ToolResult};
+use crate::verifiable_intent::error::ViError;
+use crate::verifiable_intent::types::{Constraint, Fulfillment};
+use crate::verifiable_intent::verification::{
+    check_constraints, verify_sd_hash_binding, verify_timestamps, ConstraintCheckResult,
+    StrictnessMode,
+};
+
+/// Tool for verifying Verifiable Intent credential chains and evaluating
+/// constraints against fulfillment data.
+pub struct VerifiableIntentTool {
+    security: Arc<SecurityPolicy>,
+    strictness: StrictnessMode,
+}
+
+impl VerifiableIntentTool {
+    pub fn new(security: Arc<SecurityPolicy>, strictness: StrictnessMode) -> Self {
+        Self {
+            security,
+            strictness,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for VerifiableIntentTool {
+    fn name(&self) -> &str {
+        "vi_verify"
+    }
+
+    fn description(&self) -> &str {
+        "Verify a Verifiable Intent credential chain. Supports two operations: \
+         'verify_binding' checks sd_hash binding between credential layers; \
+         'evaluate_constraints' validates constraints against fulfillment data."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": ["verify_binding", "evaluate_constraints", "verify_timestamps"],
+                    "description": "The VI operation to perform."
+                },
+                "sd_hash": {
+                    "type": "string",
+                    "description": "Expected sd_hash value (for verify_binding)."
+                },
+                "serialized_parent": {
+                    "type": "string",
+                    "description": "Serialized parent SD-JWT (for verify_binding)."
+                },
+                "iat": {
+                    "type": "integer",
+                    "description": "Issued-at timestamp (for verify_timestamps)."
+                },
+                "exp": {
+                    "type": "integer",
+                    "description": "Expiration timestamp (for verify_timestamps)."
+                },
+                "constraints": {
+                    "type": "array",
+                    "description": "Constraint array (for evaluate_constraints)."
+                },
+                "fulfillment": {
+                    "type": "object",
+                    "description": "Fulfillment data to evaluate against (for evaluate_constraints)."
+                }
+            },
+            "required": ["operation"]
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        if let Err(error) = self
+            .security
+            .enforce_tool_operation(ToolOperation::Read, "vi_verify")
+        {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(error),
+            });
+        }
+
+        let operation = args.get("operation").and_then(|v| v.as_str()).unwrap_or("");
+
+        match operation {
+            "verify_binding" => execute_verify_binding(&args),
+            "evaluate_constraints" => execute_evaluate_constraints(&args, self.strictness),
+            "verify_timestamps" => execute_verify_timestamps(&args),
+            _ => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("unknown operation: {operation}")),
+            }),
+        }
+    }
+}
+
+fn execute_verify_binding(args: &serde_json::Value) -> anyhow::Result<ToolResult> {
+    let sd_hash = args
+        .get("sd_hash")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing 'sd_hash' parameter"))?;
+    let serialized_parent = args
+        .get("serialized_parent")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("missing 'serialized_parent' parameter"))?;
+
+    match verify_sd_hash_binding(sd_hash, serialized_parent) {
+        Ok(()) => Ok(ToolResult {
+            success: true,
+            output: "sd_hash binding verified".into(),
+            error: None,
+        }),
+        Err(e) => Ok(vi_error_result(&e)),
+    }
+}
+
+fn execute_evaluate_constraints(
+    args: &serde_json::Value,
+    strictness: StrictnessMode,
+) -> anyhow::Result<ToolResult> {
+    let constraints_value = args
+        .get("constraints")
+        .ok_or_else(|| anyhow::anyhow!("missing 'constraints' parameter"))?;
+    let fulfillment_value = args
+        .get("fulfillment")
+        .ok_or_else(|| anyhow::anyhow!("missing 'fulfillment' parameter"))?;
+
+    let constraints: Vec<Constraint> = serde_json::from_value(constraints_value.clone())?;
+    let fulfillment: Fulfillment = serde_json::from_value(fulfillment_value.clone())?;
+
+    let results = check_constraints(&constraints, &fulfillment, strictness);
+    let all_satisfied = results.iter().all(|r| r.satisfied);
+
+    let summary: Vec<serde_json::Value> = results.iter().map(constraint_result_json).collect();
+
+    Ok(ToolResult {
+        success: all_satisfied,
+        output: serde_json::to_string_pretty(&json!({
+            "all_satisfied": all_satisfied,
+            "results": summary,
+        }))?,
+        error: if all_satisfied {
+            None
+        } else {
+            Some("one or more constraints violated".into())
+        },
+    })
+}
+
+fn execute_verify_timestamps(args: &serde_json::Value) -> anyhow::Result<ToolResult> {
+    let iat = args
+        .get("iat")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow::anyhow!("missing 'iat' parameter"))?;
+    let exp = args
+        .get("exp")
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| anyhow::anyhow!("missing 'exp' parameter"))?;
+
+    match verify_timestamps(iat, exp) {
+        Ok(()) => Ok(ToolResult {
+            success: true,
+            output: "timestamps valid".into(),
+            error: None,
+        }),
+        Err(e) => Ok(vi_error_result(&e)),
+    }
+}
+
+fn vi_error_result(e: &ViError) -> ToolResult {
+    ToolResult {
+        success: false,
+        output: String::new(),
+        error: Some(format!("{}", e)),
+    }
+}
+
+fn constraint_result_json(r: &ConstraintCheckResult) -> serde_json::Value {
+    json!({
+        "constraint_type": r.constraint_type,
+        "satisfied": r.satisfied,
+        "violations": r.violations.iter().map(|v: &ViError| v.to_string()).collect::<Vec<_>>(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::security::SecurityPolicy;
+
+    fn test_tool() -> VerifiableIntentTool {
+        let policy = Arc::new(SecurityPolicy::default());
+        VerifiableIntentTool::new(policy, StrictnessMode::Strict)
+    }
+
+    #[tokio::test]
+    async fn verify_timestamps_valid() {
+        let tool = test_tool();
+        let now = chrono::Utc::now().timestamp();
+        let args = json!({
+            "operation": "verify_timestamps",
+            "iat": now - 60,
+            "exp": now + 3600,
+        });
+        let result = tool.execute(args).await.unwrap();
+        assert!(result.success);
+    }
+
+    #[tokio::test]
+    async fn verify_timestamps_expired() {
+        let tool = test_tool();
+        let args = json!({
+            "operation": "verify_timestamps",
+            "iat": 1_000_000,
+            "exp": 1_000_001,
+        });
+        let result = tool.execute(args).await.unwrap();
+        assert!(!result.success);
+    }
+
+    #[tokio::test]
+    async fn evaluate_constraints_empty() {
+        let tool = test_tool();
+        let args = json!({
+            "operation": "evaluate_constraints",
+            "constraints": [],
+            "fulfillment": {},
+        });
+        let result = tool.execute(args).await.unwrap();
+        assert!(result.success);
+    }
+
+    #[tokio::test]
+    async fn unknown_operation_fails() {
+        let tool = test_tool();
+        let args = json!({ "operation": "bad_op" });
+        let result = tool.execute(args).await.unwrap();
+        assert!(!result.success);
+    }
+}

--- a/src/verifiable_intent/crypto.rs
+++ b/src/verifiable_intent/crypto.rs
@@ -1,0 +1,357 @@
+//! SD-JWT / KB-SD-JWT cryptographic primitives.
+//!
+//! Provides JWS signing/verification (ES256), SD-JWT disclosure hashing,
+//! `sd_hash` computation, and selective disclosure resolution.
+//!
+//! Uses `ring` for ECDSA P-256 (already a dependency) and `sha2`/`base64`
+//! for hashing and encoding (also existing dependencies).
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use ring::rand::SystemRandom;
+use ring::signature::{self, EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_FIXED_SIGNING};
+use sha2::{Digest, Sha256};
+
+use crate::verifiable_intent::error::{ViError, ViErrorKind};
+use crate::verifiable_intent::types::Jwk;
+
+// ── Base64url helpers ────────────────────────────────────────────────
+
+/// Encode bytes as base64url without padding.
+pub fn b64u_encode(data: &[u8]) -> String {
+    URL_SAFE_NO_PAD.encode(data)
+}
+
+/// Decode base64url without padding.
+pub fn b64u_decode(s: &str) -> Result<Vec<u8>, ViError> {
+    URL_SAFE_NO_PAD.decode(s).map_err(|e| {
+        ViError::new(
+            ViErrorKind::InvalidPayload,
+            format!("base64url decode: {e}"),
+        )
+    })
+}
+
+// ── Hashing ──────────────────────────────────────────────────────────
+
+/// Compute `B64U(SHA-256(ASCII(input)))` — used for `sd_hash`, `checkout_hash`,
+/// `transaction_id`, disclosure hashes, and `conditional_transaction_id`.
+pub fn sd_hash(input: &str) -> String {
+    let digest = Sha256::digest(input.as_bytes());
+    b64u_encode(&digest)
+}
+
+/// Compute raw SHA-256 hash of a byte slice.
+pub fn sha256(data: &[u8]) -> Vec<u8> {
+    Sha256::digest(data).to_vec()
+}
+
+// ── JWS / ES256 signing ─────────────────────────────────────────────
+
+/// Sign a JWS (compact serialization) over the given header and payload JSON.
+/// Returns the full `header.payload.signature` string.
+pub fn jws_sign(
+    header_json: &[u8],
+    payload_json: &[u8],
+    key_pair: &EcdsaKeyPair,
+) -> Result<String, ViError> {
+    let header_b64 = b64u_encode(header_json);
+    let payload_b64 = b64u_encode(payload_json);
+    let signing_input = format!("{header_b64}.{payload_b64}");
+
+    let rng = SystemRandom::new();
+    let sig = key_pair.sign(&rng, signing_input.as_bytes()).map_err(|e| {
+        ViError::new(
+            ViErrorKind::SignatureInvalid,
+            format!("signing failed: {e}"),
+        )
+    })?;
+
+    let sig_b64 = b64u_encode(sig.as_ref());
+    Ok(format!("{signing_input}.{sig_b64}"))
+}
+
+/// Verify an ES256 JWS compact-serialization string against a public key.
+pub fn jws_verify(compact: &str, public_key_bytes: &[u8]) -> Result<(), ViError> {
+    let parts: Vec<&str> = compact.splitn(3, '.').collect();
+    if parts.len() != 3 {
+        return Err(ViError::new(
+            ViErrorKind::InvalidHeader,
+            "JWS must have 3 dot-separated parts",
+        ));
+    }
+
+    let signing_input = format!("{}.{}", parts[0], parts[1]);
+    let sig_bytes = b64u_decode(parts[2])?;
+
+    let peer_public_key =
+        signature::UnparsedPublicKey::new(&signature::ECDSA_P256_SHA256_FIXED, public_key_bytes);
+
+    peer_public_key
+        .verify(signing_input.as_bytes(), &sig_bytes)
+        .map_err(|_| {
+            ViError::new(
+                ViErrorKind::SignatureInvalid,
+                "ES256 signature verification failed",
+            )
+        })
+}
+
+/// Decode the payload segment of a JWS compact string (the middle part).
+pub fn jws_decode_payload(compact: &str) -> Result<serde_json::Value, ViError> {
+    let parts: Vec<&str> = compact.splitn(3, '.').collect();
+    if parts.len() < 2 {
+        return Err(ViError::new(
+            ViErrorKind::InvalidPayload,
+            "JWS must have at least 2 dot-separated parts",
+        ));
+    }
+    let bytes = b64u_decode(parts[1])?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| ViError::new(ViErrorKind::InvalidPayload, format!("payload JSON: {e}")))
+}
+
+/// Decode the header segment of a JWS compact string (the first part).
+pub fn jws_decode_header(compact: &str) -> Result<serde_json::Value, ViError> {
+    let part = compact
+        .split('.')
+        .next()
+        .ok_or_else(|| ViError::new(ViErrorKind::InvalidHeader, "empty JWS"))?;
+    let bytes = b64u_decode(part)?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| ViError::new(ViErrorKind::InvalidHeader, format!("header JSON: {e}")))
+}
+
+// ── EC P-256 key utilities ──────────────────────────────────────────
+
+/// Generate a fresh EC P-256 key pair.  Returns (pkcs8_document, Jwk_public).
+pub fn generate_ec_p256() -> Result<(Vec<u8>, Jwk), ViError> {
+    let rng = SystemRandom::new();
+    let pkcs8 = EcdsaKeyPair::generate_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, &rng)
+        .map_err(|e| ViError::new(ViErrorKind::KeyUnsupported, format!("keygen: {e}")))?;
+
+    let key_pair = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8.as_ref(), &rng)
+        .map_err(|e| ViError::new(ViErrorKind::KeyUnsupported, format!("parse pkcs8: {e}")))?;
+
+    let pub_bytes = key_pair.public_key().as_ref();
+    let jwk = ec_public_bytes_to_jwk(pub_bytes)?;
+
+    Ok((pkcs8.as_ref().to_vec(), jwk))
+}
+
+/// Load an `EcdsaKeyPair` from PKCS#8 DER bytes.
+pub fn load_key_pair(pkcs8_der: &[u8]) -> Result<EcdsaKeyPair, ViError> {
+    let rng = SystemRandom::new();
+    EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_FIXED_SIGNING, pkcs8_der, &rng)
+        .map_err(|e| ViError::new(ViErrorKind::KeyUnsupported, format!("load pkcs8: {e}")))
+}
+
+/// Convert the raw uncompressed public key bytes (65 bytes: 0x04 || x || y)
+/// into a [`Jwk`].
+pub fn ec_public_bytes_to_jwk(pub_bytes: &[u8]) -> Result<Jwk, ViError> {
+    if pub_bytes.len() != 65 || pub_bytes[0] != 0x04 {
+        return Err(ViError::new(
+            ViErrorKind::KeyUnsupported,
+            "expected 65-byte uncompressed EC point (0x04 || x || y)",
+        ));
+    }
+    Ok(Jwk {
+        kty: "EC".into(),
+        crv: "P-256".into(),
+        x: b64u_encode(&pub_bytes[1..33]),
+        y: b64u_encode(&pub_bytes[33..65]),
+        d: None,
+    })
+}
+
+/// Convert a [`Jwk`] (public) back to raw uncompressed bytes (65 bytes).
+pub fn jwk_to_public_bytes(jwk: &Jwk) -> Result<Vec<u8>, ViError> {
+    if jwk.kty != "EC" || jwk.crv != "P-256" {
+        return Err(ViError::new(
+            ViErrorKind::KeyUnsupported,
+            format!("unsupported key type: {}:{}", jwk.kty, jwk.crv),
+        ));
+    }
+    let x = b64u_decode(&jwk.x)?;
+    let y = b64u_decode(&jwk.y)?;
+    if x.len() != 32 || y.len() != 32 {
+        return Err(ViError::new(
+            ViErrorKind::KeyUnsupported,
+            "x/y coordinates must be 32 bytes each",
+        ));
+    }
+    let mut bytes = Vec::with_capacity(65);
+    bytes.push(0x04);
+    bytes.extend_from_slice(&x);
+    bytes.extend_from_slice(&y);
+    Ok(bytes)
+}
+
+// ── SD-JWT disclosure helpers ────────────────────────────────────────
+
+/// Create a single SD-JWT disclosure: `[salt, claim_name, claim_value]`.
+/// Returns `(disclosure_b64, disclosure_hash)`.
+pub fn create_disclosure(
+    claim_name: &str,
+    claim_value: &serde_json::Value,
+) -> Result<(String, String), ViError> {
+    let rng = SystemRandom::new();
+    let mut salt_bytes = [0u8; 16];
+    ring::rand::SecureRandom::fill(&rng, &mut salt_bytes)
+        .map_err(|e| ViError::new(ViErrorKind::IssuanceInputInvalid, format!("rng: {e}")))?;
+    let salt = b64u_encode(&salt_bytes);
+
+    let disclosure_json = serde_json::json!([salt, claim_name, claim_value]);
+    let disclosure_str = serde_json::to_string(&disclosure_json).map_err(|e| {
+        ViError::new(
+            ViErrorKind::IssuanceInputInvalid,
+            format!("disclosure JSON: {e}"),
+        )
+    })?;
+    let disclosure_b64 = b64u_encode(disclosure_str.as_bytes());
+    let hash = sd_hash(&disclosure_b64);
+    Ok((disclosure_b64, hash))
+}
+
+/// Serialize an SD-JWT: `issuer_jwt~disclosure1~disclosure2~...~kb_jwt`
+/// (omit `kb_jwt` for L1 which has no key-binding JWT).
+pub fn serialize_sd_jwt(issuer_jwt: &str, disclosures: &[String], kb_jwt: Option<&str>) -> String {
+    let mut result = issuer_jwt.to_string();
+    for d in disclosures {
+        result.push('~');
+        result.push_str(d);
+    }
+    result.push('~');
+    if let Some(kb) = kb_jwt {
+        result.push_str(kb);
+    }
+    result
+}
+
+/// Parse a serialized SD-JWT into (issuer_jwt, disclosures, optional_kb_jwt).
+pub fn parse_sd_jwt(serialized: &str) -> Result<(&str, Vec<&str>, Option<&str>), ViError> {
+    let parts: Vec<&str> = serialized.split('~').collect();
+    if parts.len() < 2 {
+        return Err(ViError::new(
+            ViErrorKind::InvalidDisclosure,
+            "SD-JWT must have at least issuer JWT and trailing ~",
+        ));
+    }
+    let issuer_jwt = parts[0];
+    let last = *parts.last().unwrap();
+    let kb_jwt = if last.is_empty() { None } else { Some(last) };
+
+    let disclosures = parts[1..parts.len() - 1].to_vec();
+
+    Ok((issuer_jwt, disclosures, kb_jwt))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sd_hash_deterministic() {
+        let h1 = sd_hash("hello");
+        let h2 = sd_hash("hello");
+        assert_eq!(h1, h2);
+        assert!(!h1.is_empty());
+    }
+
+    #[test]
+    fn b64u_roundtrip() {
+        let data = b"test data";
+        let encoded = b64u_encode(data);
+        let decoded = b64u_decode(&encoded).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn generate_key_and_convert_roundtrip() {
+        let (_pkcs8, jwk) = generate_ec_p256().unwrap();
+        assert_eq!(jwk.kty, "EC");
+        assert_eq!(jwk.crv, "P-256");
+        assert!(jwk.d.is_none());
+        let bytes = jwk_to_public_bytes(&jwk).unwrap();
+        assert_eq!(bytes.len(), 65);
+        assert_eq!(bytes[0], 0x04);
+        let jwk2 = ec_public_bytes_to_jwk(&bytes).unwrap();
+        assert_eq!(jwk, jwk2);
+    }
+
+    #[test]
+    fn jws_sign_and_verify() {
+        let (pkcs8, jwk) = generate_ec_p256().unwrap();
+        let key_pair = load_key_pair(&pkcs8).unwrap();
+        let header = serde_json::json!({"alg": "ES256", "typ": "sd+jwt"});
+        let payload = serde_json::json!({"sub": "test"});
+        let compact = jws_sign(
+            header.to_string().as_bytes(),
+            payload.to_string().as_bytes(),
+            &key_pair,
+        )
+        .unwrap();
+
+        let pub_bytes = jwk_to_public_bytes(&jwk).unwrap();
+        jws_verify(&compact, &pub_bytes).unwrap();
+    }
+
+    #[test]
+    fn jws_verify_rejects_tampered() {
+        let (pkcs8, jwk) = generate_ec_p256().unwrap();
+        let key_pair = load_key_pair(&pkcs8).unwrap();
+        let header = serde_json::json!({"alg": "ES256"});
+        let payload = serde_json::json!({"sub": "test"});
+        let mut compact = jws_sign(
+            header.to_string().as_bytes(),
+            payload.to_string().as_bytes(),
+            &key_pair,
+        )
+        .unwrap();
+        // Tamper with payload
+        compact = compact.replacen('.', ".AAAA", 1);
+        let pub_bytes = jwk_to_public_bytes(&jwk).unwrap();
+        assert!(jws_verify(&compact, &pub_bytes).is_err());
+    }
+
+    #[test]
+    fn disclosure_creation() {
+        let (b64, hash) =
+            create_disclosure("email", &serde_json::json!("user@example.com")).unwrap();
+        assert!(!b64.is_empty());
+        assert!(!hash.is_empty());
+        // Verify hash matches
+        assert_eq!(sd_hash(&b64), hash);
+    }
+
+    #[test]
+    fn sd_jwt_serialize_parse_roundtrip() {
+        let jwt = "eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig";
+        let disclosures = vec!["disc1".to_string(), "disc2".to_string()];
+        let serialized = serialize_sd_jwt(jwt, &disclosures, None);
+        let (parsed_jwt, parsed_disc, parsed_kb) = parse_sd_jwt(&serialized).unwrap();
+        assert_eq!(parsed_jwt, jwt);
+        assert_eq!(parsed_disc, vec!["disc1", "disc2"]);
+        assert!(parsed_kb.is_none());
+    }
+
+    #[test]
+    fn sd_jwt_serialize_with_kb_jwt() {
+        let jwt = "header.payload.sig";
+        let disclosures = vec!["d1".to_string()];
+        let serialized = serialize_sd_jwt(jwt, &disclosures, Some("kb.jwt.here"));
+        let (parsed_jwt, parsed_disc, parsed_kb) = parse_sd_jwt(&serialized).unwrap();
+        assert_eq!(parsed_jwt, jwt);
+        assert_eq!(parsed_disc, vec!["d1"]);
+        assert_eq!(parsed_kb, Some("kb.jwt.here"));
+    }
+
+    #[test]
+    fn jws_decode_payload_works() {
+        let header = b64u_encode(b"{\"alg\":\"ES256\"}");
+        let payload = b64u_encode(b"{\"sub\":\"test\"}");
+        let compact = format!("{header}.{payload}.fake-sig");
+        let decoded = jws_decode_payload(&compact).unwrap();
+        assert_eq!(decoded["sub"], "test");
+    }
+}

--- a/src/verifiable_intent/error.rs
+++ b/src/verifiable_intent/error.rs
@@ -1,0 +1,113 @@
+//! Machine-readable error taxonomy for Verifiable Intent operations.
+//!
+//! Every VI error carries a [`ViErrorKind`] discriminant so policy engines and
+//! tool gates can branch deterministically on failure reason without parsing
+//! human-readable messages.
+
+use std::fmt;
+
+/// Discriminant for VI error classification — used by policy engines to decide
+/// whether a transaction should be blocked, retried, or escalated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ViErrorKind {
+    // ── Credential structure errors ───────────────────────────────────
+    /// JWT header is malformed or missing required fields.
+    InvalidHeader,
+    /// JWT payload cannot be decoded or is missing required claims.
+    InvalidPayload,
+    /// SD-JWT disclosure is malformed or cannot be resolved.
+    InvalidDisclosure,
+    /// Credential has expired (`exp` < now).
+    Expired,
+    /// Credential is not yet valid (`iat` > now).
+    NotYetValid,
+
+    // ── Signature / key errors ────────────────────────────────────────
+    /// Cryptographic signature verification failed.
+    SignatureInvalid,
+    /// The signing key does not match the expected `cnf.jwk` binding.
+    KeyMismatch,
+    /// Key material is missing or in an unsupported format.
+    KeyUnsupported,
+
+    // ── Chain binding errors ──────────────────────────────────────────
+    /// `sd_hash` in L2/L3 does not match the hash of the parent layer.
+    SdHashMismatch,
+    /// `checkout_hash` / `transaction_id` cross-reference between L3a and L3b failed.
+    CrossReferenceMismatch,
+    /// `conditional_transaction_id` binding between payment and checkout mandates failed.
+    ReferenceBindingMismatch,
+
+    // ── Constraint violations ─────────────────────────────────────────
+    /// Transaction amount is outside the permitted range.
+    AmountOutOfRange,
+    /// Cumulative budget cap exceeded.
+    BudgetExceeded,
+    /// Currency in L3 does not match the constraint currency.
+    CurrencyMismatch,
+    /// Merchant is not in the allowed merchant list.
+    MerchantNotAllowed,
+    /// Payee is not in the allowed payee list.
+    PayeeNotAllowed,
+    /// Line items violate product selection or quantity constraints.
+    LineItemViolation,
+    /// Recurrence constraint violated.
+    RecurrenceViolation,
+    /// An unknown constraint type was encountered in strict mode.
+    UnknownConstraintType,
+
+    // ── Mode / structural mismatch ────────────────────────────────────
+    /// L2 contains `cnf` in Immediate mode (forbidden) or lacks it in Autonomous mode.
+    ModeMismatch,
+    /// Mandate VCT value is not recognized.
+    UnknownMandateType,
+    /// Mandate pair is incomplete (missing checkout or payment mandate).
+    IncompleteMandatePair,
+
+    // ── Issuance errors ───────────────────────────────────────────────
+    /// Issuance failed due to missing or invalid input parameters.
+    IssuanceInputInvalid,
+}
+
+/// A Verifiable Intent error with a machine-readable kind and human-readable context.
+#[derive(Debug, Clone)]
+pub struct ViError {
+    pub kind: ViErrorKind,
+    pub message: String,
+}
+
+impl ViError {
+    pub fn new(kind: ViErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ViError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "VI/{:?}: {}", self.kind, self.message)
+    }
+}
+
+impl std::error::Error for ViError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_display_includes_kind_and_message() {
+        let err = ViError::new(ViErrorKind::AmountOutOfRange, "50000 > 40000 USD");
+        let s = format!("{err}");
+        assert!(s.contains("AmountOutOfRange"));
+        assert!(s.contains("50000 > 40000 USD"));
+    }
+
+    #[test]
+    fn error_kind_equality() {
+        assert_eq!(ViErrorKind::Expired, ViErrorKind::Expired);
+        assert_ne!(ViErrorKind::Expired, ViErrorKind::SignatureInvalid);
+    }
+}

--- a/src/verifiable_intent/issuance.rs
+++ b/src/verifiable_intent/issuance.rs
@@ -1,0 +1,501 @@
+//! L2 and L3 credential issuance.
+//!
+//! Provides builders for constructing VI credentials with proper SD-JWT
+//! serialization and key binding. L1 issuance is out of scope (performed by
+//! external credential providers / issuers).
+
+use ring::signature::EcdsaKeyPair;
+use serde_json::json;
+
+use crate::verifiable_intent::crypto::{create_disclosure, jws_sign, sd_hash, serialize_sd_jwt};
+use crate::verifiable_intent::error::{ViError, ViErrorKind};
+use crate::verifiable_intent::types::{
+    CheckoutL3Mandate, FinalCheckoutMandate, FinalPaymentMandate, Jwk, OpenCheckoutMandate,
+    OpenPaymentMandate, PaymentL3Mandate,
+};
+
+// ── L2 Immediate mode ────────────────────────────────────────────────
+
+/// Result of creating an L2 Immediate credential.
+#[derive(Debug)]
+pub struct ImmediateL2Result {
+    /// The serialized SD-JWT string (L1~disclosures~kb_jwt).
+    pub serialized: String,
+    /// The SD hash of the L1 that was bound.
+    pub sd_hash: String,
+}
+
+/// Create an L2 Immediate-mode credential binding final checkout and payment values.
+///
+/// The caller must provide the serialized L1 SD-JWT and the user's signing key
+/// (the private key corresponding to L1 `cnf.jwk`).
+pub fn create_layer2_immediate(
+    serialized_l1: &str,
+    checkout: &FinalCheckoutMandate,
+    payment: &FinalPaymentMandate,
+    audience: &str,
+    nonce: &str,
+    user_key: &EcdsaKeyPair,
+    iat: i64,
+    exp: i64,
+) -> Result<ImmediateL2Result, ViError> {
+    let l1_hash = sd_hash(serialized_l1);
+
+    // Create disclosures for mandates
+    let checkout_value = serde_json::to_value(checkout).map_err(|e| {
+        ViError::new(
+            ViErrorKind::IssuanceInputInvalid,
+            format!("checkout serialize: {e}"),
+        )
+    })?;
+    let payment_value = serde_json::to_value(payment).map_err(|e| {
+        ViError::new(
+            ViErrorKind::IssuanceInputInvalid,
+            format!("payment serialize: {e}"),
+        )
+    })?;
+
+    let (checkout_disc, checkout_hash) = create_disclosure("checkout_mandate", &checkout_value)?;
+    let (payment_disc, payment_hash) = create_disclosure("payment_mandate", &payment_value)?;
+
+    let header = json!({
+        "alg": "ES256",
+        "typ": "kb-sd-jwt"
+    });
+
+    let payload = json!({
+        "nonce": nonce,
+        "aud": audience,
+        "iat": iat,
+        "exp": exp,
+        "sd_hash": l1_hash,
+        "_sd_alg": "sha-256",
+        "_sd": [checkout_hash, payment_hash],
+        "delegate_payload": [
+            {"...": checkout_hash},
+            {"...": payment_hash}
+        ]
+    });
+
+    let kb_jwt = jws_sign(
+        header.to_string().as_bytes(),
+        payload.to_string().as_bytes(),
+        user_key,
+    )?;
+
+    let serialized = serialize_sd_jwt(serialized_l1, &[checkout_disc, payment_disc], Some(&kb_jwt));
+
+    Ok(ImmediateL2Result {
+        serialized,
+        sd_hash: l1_hash,
+    })
+}
+
+// ── L2 Autonomous mode ───────────────────────────────────────────────
+
+/// Result of creating an L2 Autonomous credential.
+#[derive(Debug)]
+pub struct AutonomousL2Result {
+    /// The serialized SD-JWT string.
+    pub serialized: String,
+    /// The SD hash of the L1 that was bound.
+    pub sd_hash: String,
+    /// Disclosure hash of the checkout mandate (needed for `payment.reference`).
+    pub checkout_disclosure_hash: String,
+}
+
+/// Create an L2 Autonomous-mode credential with constraints and agent key binding.
+pub fn create_layer2_autonomous(
+    serialized_l1: &str,
+    checkout: &OpenCheckoutMandate,
+    payment: &OpenPaymentMandate,
+    audience: &str,
+    nonce: &str,
+    user_key: &EcdsaKeyPair,
+    iat: i64,
+    exp: i64,
+) -> Result<AutonomousL2Result, ViError> {
+    // Validate cnf parity between checkout and payment mandates
+    if checkout.cnf != payment.cnf {
+        return Err(ViError::new(
+            ViErrorKind::ModeMismatch,
+            "checkout and payment mandates must bind the same agent key (cnf mismatch)",
+        ));
+    }
+
+    let l1_hash = sd_hash(serialized_l1);
+
+    let checkout_value = serde_json::to_value(checkout).map_err(|e| {
+        ViError::new(
+            ViErrorKind::IssuanceInputInvalid,
+            format!("checkout serialize: {e}"),
+        )
+    })?;
+    let payment_value = serde_json::to_value(payment).map_err(|e| {
+        ViError::new(
+            ViErrorKind::IssuanceInputInvalid,
+            format!("payment serialize: {e}"),
+        )
+    })?;
+
+    let (checkout_disc, checkout_hash) = create_disclosure("checkout_mandate", &checkout_value)?;
+    let (payment_disc, payment_hash) = create_disclosure("payment_mandate", &payment_value)?;
+
+    let header = json!({
+        "alg": "ES256",
+        "typ": "kb-sd-jwt+kb"
+    });
+
+    let payload = json!({
+        "nonce": nonce,
+        "aud": audience,
+        "iat": iat,
+        "exp": exp,
+        "sd_hash": l1_hash,
+        "_sd_alg": "sha-256",
+        "_sd": [checkout_hash, payment_hash],
+        "delegate_payload": [
+            {"...": checkout_hash},
+            {"...": payment_hash}
+        ]
+    });
+
+    let kb_jwt = jws_sign(
+        header.to_string().as_bytes(),
+        payload.to_string().as_bytes(),
+        user_key,
+    )?;
+
+    let serialized = serialize_sd_jwt(serialized_l1, &[checkout_disc, payment_disc], Some(&kb_jwt));
+
+    Ok(AutonomousL2Result {
+        serialized,
+        sd_hash: l1_hash,
+        checkout_disclosure_hash: checkout_hash,
+    })
+}
+
+// ── L3 Issuance (Autonomous only) ────────────────────────────────────
+
+/// Result of creating an L3 payment credential.
+#[derive(Debug)]
+pub struct L3PaymentResult {
+    /// The serialized KB-SD-JWT for the payment network.
+    pub serialized: String,
+}
+
+/// Create an L3a payment mandate signed by the agent's key.
+pub fn create_layer3_payment(
+    serialized_l2: &str,
+    mandate: &PaymentL3Mandate,
+    agent_key: &EcdsaKeyPair,
+    agent_jwk: &Jwk,
+    iat: i64,
+    exp: i64,
+) -> Result<L3PaymentResult, ViError> {
+    let l2_hash = sd_hash(serialized_l2);
+
+    let header = json!({
+        "alg": "ES256",
+        "typ": "kb-sd-jwt",
+        "jwk": agent_jwk,
+        "kid": agent_jwk.x
+    });
+
+    let mandate_value = serde_json::to_value(mandate).map_err(|e| {
+        ViError::new(
+            ViErrorKind::IssuanceInputInvalid,
+            format!("L3a mandate serialize: {e}"),
+        )
+    })?;
+
+    let payload = json!({
+        "iat": iat,
+        "exp": exp,
+        "sd_hash": l2_hash,
+        "mandate": mandate_value
+    });
+
+    let jwt = jws_sign(
+        header.to_string().as_bytes(),
+        payload.to_string().as_bytes(),
+        agent_key,
+    )?;
+
+    // L3 has no disclosures in the reference implementation
+    let serialized = serialize_sd_jwt(&jwt, &[], None);
+
+    Ok(L3PaymentResult { serialized })
+}
+
+/// Result of creating an L3 checkout credential.
+#[derive(Debug)]
+pub struct L3CheckoutResult {
+    /// The serialized KB-SD-JWT for the merchant.
+    pub serialized: String,
+}
+
+/// Create an L3b checkout mandate signed by the agent's key.
+pub fn create_layer3_checkout(
+    serialized_l2: &str,
+    mandate: &CheckoutL3Mandate,
+    agent_key: &EcdsaKeyPair,
+    agent_jwk: &Jwk,
+    iat: i64,
+    exp: i64,
+) -> Result<L3CheckoutResult, ViError> {
+    let l2_hash = sd_hash(serialized_l2);
+
+    let header = json!({
+        "alg": "ES256",
+        "typ": "kb-sd-jwt",
+        "jwk": agent_jwk,
+        "kid": agent_jwk.x
+    });
+
+    let mandate_value = serde_json::to_value(mandate).map_err(|e| {
+        ViError::new(
+            ViErrorKind::IssuanceInputInvalid,
+            format!("L3b mandate serialize: {e}"),
+        )
+    })?;
+
+    let payload = json!({
+        "iat": iat,
+        "exp": exp,
+        "sd_hash": l2_hash,
+        "mandate": mandate_value
+    });
+
+    let jwt = jws_sign(
+        header.to_string().as_bytes(),
+        payload.to_string().as_bytes(),
+        agent_key,
+    )?;
+
+    let serialized = serialize_sd_jwt(&jwt, &[], None);
+
+    Ok(L3CheckoutResult { serialized })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::verifiable_intent::crypto::{generate_ec_p256, load_key_pair};
+    use crate::verifiable_intent::types::{
+        Cnf, Constraint, Entity, FulfillmentLineItem, PaymentAmount, PaymentInstrument,
+    };
+
+    fn test_issuer_l1() -> String {
+        // Minimal L1 SD-JWT for testing (not cryptographically valid, just structural)
+        "eyJhbGciOiJFUzI1NiIsInR5cCI6InNkK2p3dCJ9.eyJpc3MiOiJodHRwczovL2lzc3Vlci5leGFtcGxlLmNvbSJ9.sig~".to_string()
+    }
+
+    #[test]
+    fn create_immediate_l2() {
+        let (pkcs8, _jwk) = generate_ec_p256().unwrap();
+        let user_key = load_key_pair(&pkcs8).unwrap();
+        let l1 = test_issuer_l1();
+
+        let checkout = FinalCheckoutMandate {
+            vct: "mandate.checkout".into(),
+            checkout_jwt: "merchant.jwt.here".into(),
+            checkout_hash: sd_hash("merchant.jwt.here"),
+        };
+        let payment = FinalPaymentMandate {
+            vct: "mandate.payment".into(),
+            payment_instrument: PaymentInstrument {
+                instrument_type: "card".into(),
+                id: "tok-1".into(),
+                description: None,
+            },
+            currency: "USD".into(),
+            amount: 27999,
+            payee: Entity {
+                id: None,
+                name: "Test Store".into(),
+                website: "https://store.example.com".into(),
+            },
+            transaction_id: sd_hash("merchant.jwt.here"),
+        };
+
+        let result = create_layer2_immediate(
+            &l1,
+            &checkout,
+            &payment,
+            "https://network.example.com",
+            "nonce-123",
+            &user_key,
+            1_700_000_000,
+            1_700_000_900,
+        )
+        .unwrap();
+
+        assert!(!result.serialized.is_empty());
+        assert!(!result.sd_hash.is_empty());
+        // The serialized form should contain the L1 as prefix
+        assert!(result.serialized.starts_with(&l1));
+    }
+
+    #[test]
+    fn create_autonomous_l2() {
+        let (user_pkcs8, _user_jwk) = generate_ec_p256().unwrap();
+        let user_key = load_key_pair(&user_pkcs8).unwrap();
+        let (_agent_pkcs8, agent_jwk) = generate_ec_p256().unwrap();
+        let l1 = test_issuer_l1();
+
+        let cnf = Cnf {
+            jwk: agent_jwk,
+            kid: Some("agent-key-1".into()),
+        };
+
+        let checkout = OpenCheckoutMandate {
+            vct: "mandate.checkout.open".into(),
+            cnf: cnf.clone(),
+            constraints: vec![Constraint::AllowedMerchant {
+                allowed_merchants: vec![Entity {
+                    id: None,
+                    name: "Test Store".into(),
+                    website: "https://store.example.com".into(),
+                }],
+            }],
+            prompt_summary: Some("Buy a test product".into()),
+        };
+        let payment = OpenPaymentMandate {
+            vct: "mandate.payment.open".into(),
+            cnf,
+            payment_instrument: PaymentInstrument {
+                instrument_type: "card".into(),
+                id: "tok-1".into(),
+                description: None,
+            },
+            constraints: vec![Constraint::PaymentAmount {
+                currency: "USD".into(),
+                min: Some(10000),
+                max: Some(40000),
+            }],
+        };
+
+        let result = create_layer2_autonomous(
+            &l1,
+            &checkout,
+            &payment,
+            "https://network.example.com",
+            "nonce-456",
+            &user_key,
+            1_700_000_000,
+            1_700_086_400,
+        )
+        .unwrap();
+
+        assert!(!result.serialized.is_empty());
+        assert!(!result.checkout_disclosure_hash.is_empty());
+    }
+
+    #[test]
+    fn create_autonomous_l2_cnf_mismatch_fails() {
+        let (user_pkcs8, _user_jwk) = generate_ec_p256().unwrap();
+        let user_key = load_key_pair(&user_pkcs8).unwrap();
+        let (_a1, agent_jwk1) = generate_ec_p256().unwrap();
+        let (_a2, agent_jwk2) = generate_ec_p256().unwrap();
+        let l1 = test_issuer_l1();
+
+        let checkout = OpenCheckoutMandate {
+            vct: "mandate.checkout.open".into(),
+            cnf: Cnf {
+                jwk: agent_jwk1,
+                kid: Some("key-1".into()),
+            },
+            constraints: vec![],
+            prompt_summary: None,
+        };
+        let payment = OpenPaymentMandate {
+            vct: "mandate.payment.open".into(),
+            cnf: Cnf {
+                jwk: agent_jwk2,
+                kid: Some("key-2".into()),
+            },
+            payment_instrument: PaymentInstrument {
+                instrument_type: "card".into(),
+                id: "tok-1".into(),
+                description: None,
+            },
+            constraints: vec![],
+        };
+
+        let err = create_layer2_autonomous(
+            &l1,
+            &checkout,
+            &payment,
+            "https://network.example.com",
+            "nonce",
+            &user_key,
+            1_700_000_000,
+            1_700_086_400,
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind, ViErrorKind::ModeMismatch);
+    }
+
+    #[test]
+    fn create_l3_payment_and_checkout() {
+        let (agent_pkcs8, agent_jwk) = generate_ec_p256().unwrap();
+        let agent_key = load_key_pair(&agent_pkcs8).unwrap();
+        let l2_serialized = "l2.serialized.form~disc1~disc2~kb.jwt";
+
+        let checkout_jwt = "merchant.checkout.jwt";
+        let checkout_hash = sd_hash(checkout_jwt);
+
+        let l3a_mandate = PaymentL3Mandate {
+            vct: "mandate.payment".into(),
+            payment_instrument: PaymentInstrument {
+                instrument_type: "card".into(),
+                id: "tok-1".into(),
+                description: None,
+            },
+            payment_amount: PaymentAmount {
+                currency: "USD".into(),
+                amount: 27999,
+            },
+            payee: Entity {
+                id: None,
+                name: "Test Store".into(),
+                website: "https://store.example.com".into(),
+            },
+            transaction_id: checkout_hash.clone(),
+        };
+
+        let l3b_mandate = CheckoutL3Mandate {
+            vct: "mandate.checkout".into(),
+            checkout_jwt: checkout_jwt.into(),
+            checkout_hash,
+            line_items: Some(vec![FulfillmentLineItem {
+                item_id: "SKU001".into(),
+                quantity: 1,
+            }]),
+        };
+
+        let l3a = create_layer3_payment(
+            l2_serialized,
+            &l3a_mandate,
+            &agent_key,
+            &agent_jwk,
+            1_700_000_000,
+            1_700_000_300,
+        )
+        .unwrap();
+        assert!(!l3a.serialized.is_empty());
+
+        let l3b = create_layer3_checkout(
+            l2_serialized,
+            &l3b_mandate,
+            &agent_key,
+            &agent_jwk,
+            1_700_000_000,
+            1_700_000_300,
+        )
+        .unwrap();
+        assert!(!l3b.serialized.is_empty());
+    }
+}

--- a/src/verifiable_intent/mod.rs
+++ b/src/verifiable_intent/mod.rs
@@ -34,6 +34,4 @@ pub mod issuance;
 pub mod types;
 pub mod verification;
 
-pub use error::{ViError, ViErrorKind};
-pub use types::*;
-pub use verification::{ChainVerificationResult, ConstraintCheckResult, StrictnessMode};
+pub use verification::StrictnessMode;

--- a/src/verifiable_intent/mod.rs
+++ b/src/verifiable_intent/mod.rs
@@ -4,6 +4,16 @@
 //! credential system: issuance of L2/L3 credentials, chain verification, and
 //! constraint evaluation for commerce-gated agent actions.
 //!
+//! # Attribution
+//!
+//! This implementation is based on the Verifiable Intent open specification and
+//! reference implementation by genereda, available at
+//! <https://github.com/genereda/verifiable-intent>, licensed under the
+//! Apache License, Version 2.0. This Rust-native reimplementation follows the
+//! VI specification design (SD-JWT layered credentials, constraint model,
+//! three-layer chain) without copying source code from the reference
+//! implementation.
+//!
 //! # Architecture
 //!
 //! - [`types`] — Core data models (credentials, mandates, constraints, keys).

--- a/src/verifiable_intent/mod.rs
+++ b/src/verifiable_intent/mod.rs
@@ -7,8 +7,8 @@
 //! # Attribution
 //!
 //! This implementation is based on the Verifiable Intent open specification and
-//! reference implementation by genereda, available at
-//! <https://github.com/genereda/verifiable-intent>, licensed under the
+//! reference implementation by agent-intent, available at
+//! <https://github.com/agent-intent/verifiable-intent>, licensed under the
 //! Apache License, Version 2.0. This Rust-native reimplementation follows the
 //! VI specification design (SD-JWT layered credentials, constraint model,
 //! three-layer chain) without copying source code from the reference

--- a/src/verifiable_intent/mod.rs
+++ b/src/verifiable_intent/mod.rs
@@ -1,0 +1,29 @@
+//! Verifiable Intent (VI) — Rust-native implementation of the VI specification.
+//!
+//! This module provides full lifecycle support for the Verifiable Intent layered
+//! credential system: issuance of L2/L3 credentials, chain verification, and
+//! constraint evaluation for commerce-gated agent actions.
+//!
+//! # Architecture
+//!
+//! - [`types`] — Core data models (credentials, mandates, constraints, keys).
+//! - [`crypto`] — SD-JWT / KB-SD-JWT construction and verification primitives.
+//! - [`verification`] — Chain verification, constraint checking, binding integrity.
+//! - [`issuance`] — L2/L3 credential construction.
+//! - [`error`] — Machine-readable error taxonomy for policy decisions.
+//!
+//! # Extension
+//!
+//! This module is an internal subsystem. Integration into the tool execution
+//! surface is handled by the tool layer (see `src/tools/`). Config schema
+//! entries live in `src/config/schema.rs`.
+
+pub mod crypto;
+pub mod error;
+pub mod issuance;
+pub mod types;
+pub mod verification;
+
+pub use error::{ViError, ViErrorKind};
+pub use types::*;
+pub use verification::{ChainVerificationResult, ConstraintCheckResult, StrictnessMode};

--- a/src/verifiable_intent/types.rs
+++ b/src/verifiable_intent/types.rs
@@ -1,0 +1,374 @@
+//! Core data models for the Verifiable Intent credential chain.
+//!
+//! These types mirror the normative specification (credential-format.md,
+//! constraints.md) while staying idiomatic Rust.  Monetary amounts use integer
+//! minor-units (cents) per ISO 4217 throughout to eliminate decimal ambiguity.
+
+use serde::{Deserialize, Serialize};
+
+// ── JWK / Key material ───────────────────────────────────────────────
+
+/// A JSON Web Key (EC P-256) used for signing and key confirmation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Jwk {
+    pub kty: String,
+    pub crv: String,
+    /// Base64url-encoded x coordinate.
+    pub x: String,
+    /// Base64url-encoded y coordinate.
+    pub y: String,
+    /// Base64url-encoded private key (only present for signing keys, never serialized to verifiers).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub d: Option<String>,
+}
+
+/// Confirmation claim (`cnf`) binding a credential to a public key.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Cnf {
+    pub jwk: Jwk,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kid: Option<String>,
+}
+
+// ── Execution mode ───────────────────────────────────────────────────
+
+/// Whether the VI credential chain uses 2-layer (Immediate) or 3-layer (Autonomous) flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MandateMode {
+    /// User confirms final values; no agent delegation.
+    Immediate,
+    /// User sets constraints; agent acts independently.
+    Autonomous,
+}
+
+// ── Payment instrument / payee / merchant ────────────────────────────
+
+/// Payment instrument descriptor.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PaymentInstrument {
+    #[serde(rename = "type")]
+    pub instrument_type: String,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Merchant or payee descriptor — used in allowlists and fulfillment.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Entity {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub name: String,
+    pub website: String,
+}
+
+impl Entity {
+    /// Match two entities by the spec-defined precedence: `id` first, then
+    /// (`name`, `website`).
+    pub fn matches(&self, other: &Entity) -> bool {
+        match (&self.id, &other.id) {
+            (Some(a), Some(b)) => a == b,
+            _ => self.name == other.name && self.website == other.website,
+        }
+    }
+}
+
+// ── Line items ───────────────────────────────────────────────────────
+
+/// A single item option within a line-item constraint.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AcceptableItem {
+    pub id: String,
+    pub title: String,
+}
+
+/// A line-item entry in a checkout constraint.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LineItemEntry {
+    pub id: String,
+    pub acceptable_items: Vec<AcceptableItem>,
+    pub quantity: u32,
+}
+
+/// A resolved line item from L3b checkout (fulfillment side).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FulfillmentLineItem {
+    pub item_id: String,
+    pub quantity: u32,
+}
+
+// ── Constraints ──────────────────────────────────────────────────────
+
+/// Constraint types embedded in L2 Autonomous mandates.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum Constraint {
+    /// Merchant allowlist for checkout mandates.
+    #[serde(rename = "mandate.checkout.allowed_merchant")]
+    AllowedMerchant { allowed_merchants: Vec<Entity> },
+
+    /// Product selection constraints for checkout mandates.
+    #[serde(rename = "mandate.checkout.line_items")]
+    LineItems { items: Vec<LineItemEntry> },
+
+    /// Payee allowlist for payment mandates.
+    #[serde(rename = "payment.allowed_payee")]
+    AllowedPayee { allowed_payees: Vec<Entity> },
+
+    /// Per-transaction amount range.
+    #[serde(rename = "payment.amount")]
+    PaymentAmount {
+        currency: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        min: Option<i64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max: Option<i64>,
+    },
+
+    /// Cumulative budget cap.
+    #[serde(rename = "payment.budget")]
+    PaymentBudget { currency: String, max: i64 },
+
+    /// Merchant-managed recurring payment.
+    #[serde(rename = "payment.recurrence")]
+    PaymentRecurrence {
+        frequency: String,
+        start_date: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        end_date: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        number: Option<u32>,
+    },
+
+    /// Agent-managed recurring purchase.
+    #[serde(rename = "payment.agent_recurrence")]
+    AgentRecurrence {
+        frequency: String,
+        start_date: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        end_date: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max_occurrences: Option<u32>,
+    },
+
+    /// Cross-reference between checkout and payment mandates.
+    #[serde(rename = "payment.reference")]
+    PaymentReference { conditional_transaction_id: String },
+}
+
+// ── Mandate payloads ─────────────────────────────────────────────────
+
+/// Checkout mandate — Immediate mode (final values).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FinalCheckoutMandate {
+    pub vct: String, // "mandate.checkout"
+    pub checkout_jwt: String,
+    pub checkout_hash: String,
+}
+
+/// Payment mandate — Immediate mode (final values).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FinalPaymentMandate {
+    pub vct: String, // "mandate.payment"
+    pub payment_instrument: PaymentInstrument,
+    pub currency: String,
+    pub amount: i64,
+    pub payee: Entity,
+    pub transaction_id: String,
+}
+
+/// Checkout mandate — Autonomous mode (constraints + agent key binding).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenCheckoutMandate {
+    pub vct: String, // "mandate.checkout.open"
+    pub cnf: Cnf,
+    pub constraints: Vec<Constraint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_summary: Option<String>,
+}
+
+/// Payment mandate — Autonomous mode (constraints + agent key binding).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenPaymentMandate {
+    pub vct: String, // "mandate.payment.open"
+    pub cnf: Cnf,
+    pub payment_instrument: PaymentInstrument,
+    pub constraints: Vec<Constraint>,
+}
+
+/// L3a — agent-signed final payment values sent to the payment network.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaymentL3Mandate {
+    pub vct: String, // "mandate.payment"
+    pub payment_instrument: PaymentInstrument,
+    pub payment_amount: PaymentAmount,
+    pub payee: Entity,
+    pub transaction_id: String,
+}
+
+/// L3b — agent-signed final checkout values sent to the merchant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckoutL3Mandate {
+    pub vct: String, // "mandate.checkout"
+    pub checkout_jwt: String,
+    pub checkout_hash: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_items: Option<Vec<FulfillmentLineItem>>,
+}
+
+/// Nested amount object for L3a payment mandates.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PaymentAmount {
+    pub currency: String,
+    pub amount: i64,
+}
+
+// ── Fulfillment (verifier-constructed from L3) ───────────────────────
+
+/// Verifier-constructed fulfillment object derived from L3 mandates.
+/// Used as the input to constraint validation.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Fulfillment {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_items: Option<Vec<FulfillmentLineItem>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub merchant: Option<Entity>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payee: Option<Entity>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment_instrument: Option<PaymentInstrument>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amount: Option<i64>,
+}
+
+// ── Credential chain layers (serialized form) ────────────────────────
+
+/// Parsed representation of an L1 SD-JWT (credential provider → user).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Layer1 {
+    pub iss: String,
+    pub sub: String,
+    pub iat: i64,
+    pub exp: i64,
+    pub vct: String,
+    pub cnf: Cnf,
+    pub pan_last_four: String,
+    pub scheme: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card_id: Option<String>,
+}
+
+/// Parsed representation of an L2 KB-SD-JWT (user → agent/verifier).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Layer2 {
+    pub nonce: String,
+    pub aud: String,
+    pub iat: i64,
+    pub exp: i64,
+    pub sd_hash: String,
+    pub mode: MandateMode,
+    /// In Immediate mode: contains `FinalCheckoutMandate` + `FinalPaymentMandate`.
+    /// In Autonomous mode: contains `OpenCheckoutMandate` + `OpenPaymentMandate`.
+    pub mandates: Vec<serde_json::Value>,
+}
+
+/// Parsed representation of the full credential chain (L1 + L2 + optional L3).
+#[derive(Debug, Clone)]
+pub struct CredentialChain {
+    pub l1: Layer1,
+    pub l2: Layer2,
+    /// Only present in Autonomous mode.
+    pub l3a: Option<PaymentL3Mandate>,
+    /// Only present in Autonomous mode.
+    pub l3b: Option<CheckoutL3Mandate>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entity_matches_by_id() {
+        let a = Entity {
+            id: Some("m-1".into()),
+            name: "Merchant A".into(),
+            website: "https://a.example.com".into(),
+        };
+        let b = Entity {
+            id: Some("m-1".into()),
+            name: "Different Name".into(),
+            website: "https://different.example.com".into(),
+        };
+        assert!(a.matches(&b));
+    }
+
+    #[test]
+    fn entity_matches_by_name_website_when_no_id() {
+        let a = Entity {
+            id: None,
+            name: "Merchant A".into(),
+            website: "https://a.example.com".into(),
+        };
+        let b = Entity {
+            id: None,
+            name: "Merchant A".into(),
+            website: "https://a.example.com".into(),
+        };
+        assert!(a.matches(&b));
+    }
+
+    #[test]
+    fn entity_no_match() {
+        let a = Entity {
+            id: None,
+            name: "Merchant A".into(),
+            website: "https://a.example.com".into(),
+        };
+        let b = Entity {
+            id: None,
+            name: "Merchant B".into(),
+            website: "https://b.example.com".into(),
+        };
+        assert!(!a.matches(&b));
+    }
+
+    #[test]
+    fn constraint_serde_roundtrip() {
+        let c = Constraint::PaymentAmount {
+            currency: "USD".into(),
+            min: Some(10000),
+            max: Some(40000),
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("payment.amount"));
+        let back: Constraint = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn constraint_merchant_serde_roundtrip() {
+        let c = Constraint::AllowedMerchant {
+            allowed_merchants: vec![Entity {
+                id: None,
+                name: "Test Store".into(),
+                website: "https://test.example.com".into(),
+            }],
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("mandate.checkout.allowed_merchant"));
+        let back: Constraint = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn mandate_mode_serde() {
+        let m = MandateMode::Autonomous;
+        let json = serde_json::to_string(&m).unwrap();
+        assert_eq!(json, r#""autonomous""#);
+        let back: MandateMode = serde_json::from_str(&json).unwrap();
+        assert_eq!(m, back);
+    }
+}

--- a/src/verifiable_intent/verification.rs
+++ b/src/verifiable_intent/verification.rs
@@ -1,0 +1,738 @@
+//! Chain verification, constraint checking, and binding integrity validation.
+//!
+//! Implements the normative verification algorithms from the VI specification:
+//! - Full credential chain verification (L1 → L2 → L3)
+//! - Per-constraint validation against fulfillment data
+//! - Cross-reference and hash binding integrity checks
+
+use crate::verifiable_intent::error::{ViError, ViErrorKind};
+use crate::verifiable_intent::types::{
+    CheckoutL3Mandate, Constraint, Entity, Fulfillment, LineItemEntry, MandateMode,
+    PaymentL3Mandate,
+};
+
+// ── Strictness mode ──────────────────────────────────────────────────
+
+/// Controls behavior when an unknown constraint type is encountered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StrictnessMode {
+    /// Unknown constraint types cause a violation (fail-closed).
+    Strict,
+    /// Unknown constraint types are skipped with a warning (fail-open).
+    Permissive,
+}
+
+// ── Chain verification result ────────────────────────────────────────
+
+/// Result of verifying the credential chain (L1 → L2 → optional L3).
+#[derive(Debug, Clone)]
+pub struct ChainVerificationResult {
+    pub valid: bool,
+    pub mode: Option<MandateMode>,
+    pub errors: Vec<ViError>,
+}
+
+impl ChainVerificationResult {
+    pub fn ok(mode: MandateMode) -> Self {
+        Self {
+            valid: true,
+            mode: Some(mode),
+            errors: vec![],
+        }
+    }
+
+    pub fn fail(errors: Vec<ViError>) -> Self {
+        Self {
+            valid: false,
+            mode: None,
+            errors,
+        }
+    }
+}
+
+// ── Constraint check result ──────────────────────────────────────────
+
+/// Result of evaluating a single constraint against fulfillment data.
+#[derive(Debug, Clone)]
+pub struct ConstraintCheckResult {
+    pub satisfied: bool,
+    pub constraint_type: String,
+    pub violations: Vec<ViError>,
+}
+
+impl ConstraintCheckResult {
+    pub fn ok(constraint_type: &str) -> Self {
+        Self {
+            satisfied: true,
+            constraint_type: constraint_type.into(),
+            violations: vec![],
+        }
+    }
+
+    pub fn violation(constraint_type: &str, err: ViError) -> Self {
+        Self {
+            satisfied: false,
+            constraint_type: constraint_type.into(),
+            violations: vec![err],
+        }
+    }
+}
+
+// ── Time validation ──────────────────────────────────────────────────
+
+const CLOCK_SKEW_SECS: i64 = 300;
+
+fn current_timestamp() -> i64 {
+    chrono::Utc::now().timestamp()
+}
+
+/// Verify `iat` and `exp` claims with a 300-second clock skew tolerance.
+pub fn verify_timestamps(iat: i64, exp: i64) -> Result<(), ViError> {
+    let now = current_timestamp();
+    if exp + CLOCK_SKEW_SECS < now {
+        return Err(ViError::new(
+            ViErrorKind::Expired,
+            format!("credential expired at {exp}, now {now}"),
+        ));
+    }
+    if iat - CLOCK_SKEW_SECS > now {
+        return Err(ViError::new(
+            ViErrorKind::NotYetValid,
+            format!("credential not valid until {iat}, now {now}"),
+        ));
+    }
+    Ok(())
+}
+
+// ── sd_hash binding ──────────────────────────────────────────────────
+
+/// Verify that `expected_hash` equals `B64U(SHA-256(ASCII(serialized_parent)))`.
+pub fn verify_sd_hash_binding(expected_hash: &str, serialized_parent: &str) -> Result<(), ViError> {
+    let computed = crate::verifiable_intent::crypto::sd_hash(serialized_parent);
+    if computed != expected_hash {
+        return Err(ViError::new(
+            ViErrorKind::SdHashMismatch,
+            format!("sd_hash mismatch: expected {expected_hash}, computed {computed}"),
+        ));
+    }
+    Ok(())
+}
+
+// ── L3 cross-reference binding ───────────────────────────────────────
+
+/// Verify that L3a `transaction_id` equals L3b `checkout_hash`.
+pub fn verify_l3_cross_reference(
+    l3a: &PaymentL3Mandate,
+    l3b: &CheckoutL3Mandate,
+) -> Result<(), ViError> {
+    if l3a.transaction_id != l3b.checkout_hash {
+        return Err(ViError::new(
+            ViErrorKind::CrossReferenceMismatch,
+            format!(
+                "L3a transaction_id ({}) != L3b checkout_hash ({})",
+                l3a.transaction_id, l3b.checkout_hash
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Verify checkout_hash is `B64U(SHA-256(ASCII(checkout_jwt)))`.
+pub fn verify_checkout_hash_binding(
+    checkout_hash: &str,
+    checkout_jwt: &str,
+) -> Result<(), ViError> {
+    let computed = crate::verifiable_intent::crypto::sd_hash(checkout_jwt);
+    if computed != checkout_hash {
+        return Err(ViError::new(
+            ViErrorKind::CrossReferenceMismatch,
+            format!("checkout_hash mismatch: expected {checkout_hash}, computed {computed}"),
+        ));
+    }
+    Ok(())
+}
+
+// ── Mandate mode inference ───────────────────────────────────────────
+
+/// Infer the execution mode from mandate VCT values.
+pub fn infer_mode_from_vct(vct: &str) -> Result<MandateMode, ViError> {
+    match vct {
+        "mandate.checkout" | "mandate.payment" => Ok(MandateMode::Immediate),
+        "mandate.checkout.open" | "mandate.payment.open" => Ok(MandateMode::Autonomous),
+        _ => Err(ViError::new(
+            ViErrorKind::UnknownMandateType,
+            format!("unrecognized mandate VCT: {vct}"),
+        )),
+    }
+}
+
+// ── Constraint validation ────────────────────────────────────────────
+
+/// Evaluate all constraints against fulfillment data.
+pub fn check_constraints(
+    constraints: &[Constraint],
+    fulfillment: &Fulfillment,
+    strictness: StrictnessMode,
+) -> Vec<ConstraintCheckResult> {
+    constraints
+        .iter()
+        .map(|c| check_single_constraint(c, fulfillment, strictness))
+        .collect()
+}
+
+fn check_single_constraint(
+    constraint: &Constraint,
+    fulfillment: &Fulfillment,
+    _strictness: StrictnessMode,
+) -> ConstraintCheckResult {
+    match constraint {
+        Constraint::AllowedMerchant { allowed_merchants } => {
+            check_allowed_merchant(allowed_merchants, fulfillment)
+        }
+        Constraint::LineItems { items } => check_line_items(items, fulfillment),
+        Constraint::AllowedPayee { allowed_payees } => {
+            check_allowed_payee(allowed_payees, fulfillment)
+        }
+        Constraint::PaymentAmount { currency, min, max } => {
+            check_payment_amount(currency, *min, *max, fulfillment)
+        }
+        Constraint::PaymentBudget { currency, max } => {
+            check_payment_budget(currency, *max, fulfillment)
+        }
+        Constraint::PaymentReference {
+            conditional_transaction_id,
+        } => {
+            // Reference binding is verified structurally, not against fulfillment.
+            ConstraintCheckResult::ok(&format!(
+                "payment.reference({})",
+                &conditional_transaction_id[..8.min(conditional_transaction_id.len())]
+            ))
+        }
+        Constraint::PaymentRecurrence { .. } | Constraint::AgentRecurrence { .. } => {
+            // Recurrence constraints are informational for the payment network
+            // to enforce statefulness. Pass-through at the agent level.
+            ConstraintCheckResult::ok("recurrence")
+        }
+    }
+}
+
+// ── Individual constraint checkers ───────────────────────────────────
+
+fn check_allowed_merchant(
+    allowed_merchants: &[Entity],
+    fulfillment: &Fulfillment,
+) -> ConstraintCheckResult {
+    let ct = "mandate.checkout.allowed_merchant";
+    if allowed_merchants.is_empty() {
+        return ConstraintCheckResult::violation(
+            ct,
+            ViError::new(
+                ViErrorKind::MerchantNotAllowed,
+                "empty merchant allowlist is unsatisfiable",
+            ),
+        );
+    }
+    let Some(merchant) = &fulfillment.merchant else {
+        // No merchant info in fulfillment — cannot validate, skip per spec.
+        return ConstraintCheckResult::ok(ct);
+    };
+    if allowed_merchants.iter().any(|m| m.matches(merchant)) {
+        ConstraintCheckResult::ok(ct)
+    } else {
+        ConstraintCheckResult::violation(
+            ct,
+            ViError::new(
+                ViErrorKind::MerchantNotAllowed,
+                format!("merchant '{}' not in allowed list", merchant.name),
+            ),
+        )
+    }
+}
+
+fn check_allowed_payee(
+    allowed_payees: &[Entity],
+    fulfillment: &Fulfillment,
+) -> ConstraintCheckResult {
+    let ct = "payment.allowed_payee";
+    if allowed_payees.is_empty() {
+        return ConstraintCheckResult::violation(
+            ct,
+            ViError::new(
+                ViErrorKind::PayeeNotAllowed,
+                "empty payee allowlist is unsatisfiable",
+            ),
+        );
+    }
+    let Some(payee) = &fulfillment.payee else {
+        return ConstraintCheckResult::ok(ct);
+    };
+    if allowed_payees.iter().any(|p| p.matches(payee)) {
+        ConstraintCheckResult::ok(ct)
+    } else {
+        ConstraintCheckResult::violation(
+            ct,
+            ViError::new(
+                ViErrorKind::PayeeNotAllowed,
+                format!("payee '{}' not in allowed list", payee.name),
+            ),
+        )
+    }
+}
+
+fn check_payment_amount(
+    currency: &str,
+    min: Option<i64>,
+    max: Option<i64>,
+    fulfillment: &Fulfillment,
+) -> ConstraintCheckResult {
+    let ct = "payment.amount";
+    let Some(actual_amount) = fulfillment.amount else {
+        return ConstraintCheckResult::violation(
+            ct,
+            ViError::new(
+                ViErrorKind::AmountOutOfRange,
+                "missing payment amount in fulfillment",
+            ),
+        );
+    };
+    if let Some(actual_currency) = &fulfillment.currency {
+        if actual_currency != currency {
+            return ConstraintCheckResult::violation(
+                ct,
+                ViError::new(
+                    ViErrorKind::CurrencyMismatch,
+                    format!("expected {currency}, got {actual_currency}"),
+                ),
+            );
+        }
+    }
+    if let Some(max_val) = max {
+        if actual_amount > max_val {
+            return ConstraintCheckResult::violation(
+                ct,
+                ViError::new(
+                    ViErrorKind::AmountOutOfRange,
+                    format!("amount {actual_amount} > max {max_val} {currency}"),
+                ),
+            );
+        }
+    }
+    if let Some(min_val) = min {
+        if actual_amount < min_val {
+            return ConstraintCheckResult::violation(
+                ct,
+                ViError::new(
+                    ViErrorKind::AmountOutOfRange,
+                    format!("amount {actual_amount} < min {min_val} {currency}"),
+                ),
+            );
+        }
+    }
+    ConstraintCheckResult::ok(ct)
+}
+
+fn check_payment_budget(
+    currency: &str,
+    max: i64,
+    fulfillment: &Fulfillment,
+) -> ConstraintCheckResult {
+    let ct = "payment.budget";
+    let Some(actual_amount) = fulfillment.amount else {
+        return ConstraintCheckResult::violation(
+            ct,
+            ViError::new(
+                ViErrorKind::BudgetExceeded,
+                "missing payment amount in fulfillment",
+            ),
+        );
+    };
+    if let Some(actual_currency) = &fulfillment.currency {
+        if actual_currency != currency {
+            return ConstraintCheckResult::violation(
+                ct,
+                ViError::new(
+                    ViErrorKind::CurrencyMismatch,
+                    format!("expected {currency}, got {actual_currency}"),
+                ),
+            );
+        }
+    }
+    // Single-transaction check: amount must not exceed budget.
+    // Cumulative tracking is the payment network's responsibility.
+    if actual_amount > max {
+        return ConstraintCheckResult::violation(
+            ct,
+            ViError::new(
+                ViErrorKind::BudgetExceeded,
+                format!("amount {actual_amount} > budget max {max} {currency}"),
+            ),
+        );
+    }
+    ConstraintCheckResult::ok(ct)
+}
+
+fn check_line_items(
+    constraint_items: &[LineItemEntry],
+    fulfillment: &Fulfillment,
+) -> ConstraintCheckResult {
+    let ct = "mandate.checkout.line_items";
+    if constraint_items.is_empty() {
+        return ConstraintCheckResult::violation(
+            ct,
+            ViError::new(
+                ViErrorKind::LineItemViolation,
+                "empty items allowlist is unsatisfiable",
+            ),
+        );
+    }
+    let Some(fulfillment_items) = &fulfillment.line_items else {
+        return ConstraintCheckResult::violation(
+            ct,
+            ViError::new(
+                ViErrorKind::LineItemViolation,
+                "empty cart does not satisfy line_items constraint",
+            ),
+        );
+    };
+    if fulfillment_items.is_empty() {
+        return ConstraintCheckResult::violation(
+            ct,
+            ViError::new(
+                ViErrorKind::LineItemViolation,
+                "empty cart does not satisfy line_items constraint",
+            ),
+        );
+    }
+
+    // Total quantity check
+    let total_allowed: u32 = constraint_items.iter().map(|l| l.quantity).sum();
+    let total_actual: u32 = fulfillment_items.iter().map(|f| f.quantity).sum();
+    if total_actual > total_allowed {
+        return ConstraintCheckResult::violation(
+            ct,
+            ViError::new(
+                ViErrorKind::LineItemViolation,
+                format!("total quantity {total_actual} > allowed {total_allowed}"),
+            ),
+        );
+    }
+
+    // Per-item validation: each fulfillment item must be in at least one
+    // constraint entry's acceptable_items (unless acceptable_items is empty = wildcard).
+    for fi in fulfillment_items {
+        let allowed_by_any = constraint_items.iter().any(|entry| {
+            if entry.acceptable_items.is_empty() {
+                return true; // wildcard
+            }
+            entry.acceptable_items.iter().any(|ai| ai.id == fi.item_id)
+        });
+        if !allowed_by_any {
+            return ConstraintCheckResult::violation(
+                ct,
+                ViError::new(
+                    ViErrorKind::LineItemViolation,
+                    format!("item '{}' not in any acceptable_items list", fi.item_id),
+                ),
+            );
+        }
+    }
+
+    ConstraintCheckResult::ok(ct)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::verifiable_intent::types::{
+        AcceptableItem, FulfillmentLineItem, PaymentAmount, PaymentInstrument,
+    };
+
+    fn merchant(name: &str, website: &str) -> Entity {
+        Entity {
+            id: None,
+            name: name.into(),
+            website: website.into(),
+        }
+    }
+
+    #[test]
+    fn amount_in_range_passes() {
+        let f = Fulfillment {
+            amount: Some(27999),
+            currency: Some("USD".into()),
+            ..Default::default()
+        };
+        let result = check_payment_amount("USD", Some(10000), Some(40000), &f);
+        assert!(result.satisfied);
+    }
+
+    #[test]
+    fn amount_exceeds_max() {
+        let f = Fulfillment {
+            amount: Some(50000),
+            currency: Some("USD".into()),
+            ..Default::default()
+        };
+        let result = check_payment_amount("USD", Some(10000), Some(40000), &f);
+        assert!(!result.satisfied);
+        assert_eq!(result.violations[0].kind, ViErrorKind::AmountOutOfRange);
+    }
+
+    #[test]
+    fn amount_below_min() {
+        let f = Fulfillment {
+            amount: Some(5000),
+            currency: Some("USD".into()),
+            ..Default::default()
+        };
+        let result = check_payment_amount("USD", Some(10000), Some(40000), &f);
+        assert!(!result.satisfied);
+    }
+
+    #[test]
+    fn currency_mismatch_fails() {
+        let f = Fulfillment {
+            amount: Some(20000),
+            currency: Some("EUR".into()),
+            ..Default::default()
+        };
+        let result = check_payment_amount("USD", None, Some(40000), &f);
+        assert!(!result.satisfied);
+        assert_eq!(result.violations[0].kind, ViErrorKind::CurrencyMismatch);
+    }
+
+    #[test]
+    fn merchant_in_allowlist_passes() {
+        let allowed = vec![
+            merchant("Store A", "https://store-a.example.com"),
+            merchant("Store B", "https://store-b.example.com"),
+        ];
+        let f = Fulfillment {
+            merchant: Some(merchant("Store A", "https://store-a.example.com")),
+            ..Default::default()
+        };
+        let result = check_allowed_merchant(&allowed, &f);
+        assert!(result.satisfied);
+    }
+
+    #[test]
+    fn merchant_not_in_allowlist_fails() {
+        let allowed = vec![merchant("Store A", "https://store-a.example.com")];
+        let f = Fulfillment {
+            merchant: Some(merchant("Store C", "https://store-c.example.com")),
+            ..Default::default()
+        };
+        let result = check_allowed_merchant(&allowed, &f);
+        assert!(!result.satisfied);
+        assert_eq!(result.violations[0].kind, ViErrorKind::MerchantNotAllowed);
+    }
+
+    #[test]
+    fn payee_in_allowlist_passes() {
+        let allowed = vec![merchant("Payee A", "https://payee-a.example.com")];
+        let f = Fulfillment {
+            payee: Some(merchant("Payee A", "https://payee-a.example.com")),
+            ..Default::default()
+        };
+        let result = check_allowed_payee(&allowed, &f);
+        assert!(result.satisfied);
+    }
+
+    #[test]
+    fn payee_not_in_allowlist_fails() {
+        let allowed = vec![merchant("Payee A", "https://payee-a.example.com")];
+        let f = Fulfillment {
+            payee: Some(merchant("Payee B", "https://payee-b.example.com")),
+            ..Default::default()
+        };
+        let result = check_allowed_payee(&allowed, &f);
+        assert!(!result.satisfied);
+    }
+
+    #[test]
+    fn line_items_valid() {
+        let constraint_items = vec![LineItemEntry {
+            id: "line-1".into(),
+            acceptable_items: vec![AcceptableItem {
+                id: "SKU001".into(),
+                title: "Test Product".into(),
+            }],
+            quantity: 2,
+        }];
+        let f = Fulfillment {
+            line_items: Some(vec![FulfillmentLineItem {
+                item_id: "SKU001".into(),
+                quantity: 1,
+            }]),
+            ..Default::default()
+        };
+        let result = check_line_items(&constraint_items, &f);
+        assert!(result.satisfied);
+    }
+
+    #[test]
+    fn line_items_unknown_sku_fails() {
+        let constraint_items = vec![LineItemEntry {
+            id: "line-1".into(),
+            acceptable_items: vec![AcceptableItem {
+                id: "SKU001".into(),
+                title: "Test Product".into(),
+            }],
+            quantity: 2,
+        }];
+        let f = Fulfillment {
+            line_items: Some(vec![FulfillmentLineItem {
+                item_id: "SKU999".into(),
+                quantity: 1,
+            }]),
+            ..Default::default()
+        };
+        let result = check_line_items(&constraint_items, &f);
+        assert!(!result.satisfied);
+        assert_eq!(result.violations[0].kind, ViErrorKind::LineItemViolation);
+    }
+
+    #[test]
+    fn line_items_quantity_exceeded() {
+        let constraint_items = vec![LineItemEntry {
+            id: "line-1".into(),
+            acceptable_items: vec![AcceptableItem {
+                id: "SKU001".into(),
+                title: "Test Product".into(),
+            }],
+            quantity: 1,
+        }];
+        let f = Fulfillment {
+            line_items: Some(vec![FulfillmentLineItem {
+                item_id: "SKU001".into(),
+                quantity: 5,
+            }]),
+            ..Default::default()
+        };
+        let result = check_line_items(&constraint_items, &f);
+        assert!(!result.satisfied);
+    }
+
+    #[test]
+    fn budget_within_limit_passes() {
+        let f = Fulfillment {
+            amount: Some(30000),
+            currency: Some("USD".into()),
+            ..Default::default()
+        };
+        let result = check_payment_budget("USD", 50000, &f);
+        assert!(result.satisfied);
+    }
+
+    #[test]
+    fn budget_exceeded_fails() {
+        let f = Fulfillment {
+            amount: Some(60000),
+            currency: Some("USD".into()),
+            ..Default::default()
+        };
+        let result = check_payment_budget("USD", 50000, &f);
+        assert!(!result.satisfied);
+        assert_eq!(result.violations[0].kind, ViErrorKind::BudgetExceeded);
+    }
+
+    #[test]
+    fn l3_cross_reference_valid() {
+        let hash = "abc123";
+        let l3a = PaymentL3Mandate {
+            vct: "mandate.payment".into(),
+            payment_instrument: PaymentInstrument {
+                instrument_type: "card".into(),
+                id: "tok-1".into(),
+                description: None,
+            },
+            payment_amount: PaymentAmount {
+                currency: "USD".into(),
+                amount: 27999,
+            },
+            payee: merchant("Store", "https://store.example.com"),
+            transaction_id: hash.into(),
+        };
+        let l3b = CheckoutL3Mandate {
+            vct: "mandate.checkout".into(),
+            checkout_jwt: "jwt".into(),
+            checkout_hash: hash.into(),
+            line_items: None,
+        };
+        assert!(verify_l3_cross_reference(&l3a, &l3b).is_ok());
+    }
+
+    #[test]
+    fn l3_cross_reference_mismatch() {
+        let l3a = PaymentL3Mandate {
+            vct: "mandate.payment".into(),
+            payment_instrument: PaymentInstrument {
+                instrument_type: "card".into(),
+                id: "tok-1".into(),
+                description: None,
+            },
+            payment_amount: PaymentAmount {
+                currency: "USD".into(),
+                amount: 27999,
+            },
+            payee: merchant("Store", "https://store.example.com"),
+            transaction_id: "hash-a".into(),
+        };
+        let l3b = CheckoutL3Mandate {
+            vct: "mandate.checkout".into(),
+            checkout_jwt: "jwt".into(),
+            checkout_hash: "hash-b".into(),
+            line_items: None,
+        };
+        let err = verify_l3_cross_reference(&l3a, &l3b).unwrap_err();
+        assert_eq!(err.kind, ViErrorKind::CrossReferenceMismatch);
+    }
+
+    #[test]
+    fn infer_mode_immediate() {
+        assert_eq!(
+            infer_mode_from_vct("mandate.checkout").unwrap(),
+            MandateMode::Immediate
+        );
+        assert_eq!(
+            infer_mode_from_vct("mandate.payment").unwrap(),
+            MandateMode::Immediate
+        );
+    }
+
+    #[test]
+    fn infer_mode_autonomous() {
+        assert_eq!(
+            infer_mode_from_vct("mandate.checkout.open").unwrap(),
+            MandateMode::Autonomous
+        );
+    }
+
+    #[test]
+    fn infer_mode_unknown_fails() {
+        assert!(infer_mode_from_vct("mandate.unknown").is_err());
+    }
+
+    #[test]
+    fn check_constraints_multiple() {
+        let constraints = vec![
+            Constraint::PaymentAmount {
+                currency: "USD".into(),
+                min: Some(10000),
+                max: Some(40000),
+            },
+            Constraint::AllowedPayee {
+                allowed_payees: vec![merchant("Store", "https://store.example.com")],
+            },
+        ];
+        let f = Fulfillment {
+            amount: Some(25000),
+            currency: Some("USD".into()),
+            payee: Some(merchant("Store", "https://store.example.com")),
+            ..Default::default()
+        };
+        let results = check_constraints(&constraints, &f, StrictnessMode::Strict);
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.satisfied));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a Rust-native Verifiable Intent (VI) subsystem to ZeroClaw, providing full credential lifecycle support for commerce agent authorization using SD-JWT layered credentials.

The implementation is opt-in (disabled by default via `verifiable_intent.enabled = false`) and uses only existing dependencies already in `Cargo.toml`.

---

## What Changed

### New: `src/verifiable_intent/`

| File | Responsibility |
|---|---|
| `mod.rs` | Module root + re-exports + attribution doc |
| `error.rs` | `ViError` / `ViErrorKind` (25+ variants), `impl std::error::Error` |
| `types.rs` | `JWK`, `Cnf`, `Entity`, `Constraint` (8 variants), Immediate/Autonomous mandate structs, `Fulfillment`, `Layer1` / `Layer2` / `CredentialChain` |
| `crypto.rs` | Base64url helpers, SD hash, JWS sign/verify, EC P-256 key gen/load, disclosure creation, SD-JWT serialize/parse |
| `verification.rs` | `StrictnessMode`, `ChainVerificationResult`, `ConstraintCheckResult`, `verify_timestamps`, `verify_sd_hash_binding`, `verify_l3_cross_reference`, `verify_checkout_hash_binding`, `check_constraints` |
| `issuance.rs` | `create_layer2_immediate`, `create_layer2_autonomous`, `create_layer3_payment`, `create_layer3_checkout` |

### New: `src/tools/verifiable_intent.rs`

`VerifiableIntentTool` implementing the `Tool` trait:
- Name: `vi_verify`
- Operations: `verify_binding`, `evaluate_constraints`, `verify_timestamps`
- Gated behind `verifiable_intent.enabled` in config

### Modified: wiring

- `src/lib.rs` — `pub mod verifiable_intent`
- `src/main.rs` — `mod verifiable_intent` (binary re-declaration)
- `src/config/schema.rs` — `VerifiableIntentConfig` struct + `Config` field (default disabled, strictness `"strict"`)
- `src/config/mod.rs` — re-exports `VerifiableIntentConfig`
- `src/onboard/wizard.rs` — default field in `Config` literals
- `src/tools/mod.rs` — conditional tool registration
- `NOTICE` — third-party attribution entry for VI spec reference (Apache 2.0)

---

## What Did Not Change

- No new crate dependencies added (`ring`, `sha2`, `base64`, `serde_json`, `chrono`, `anyhow` were already present)
- No changes to existing provider/channel/gateway/security modules
- No changes to any existing config keys or defaults (new field defaults to `false`)
- No changes to CLI commands or user-facing surfaces

---

## Credential Chain Design

Three-layer SD-JWT chain for commerce agent authorization:

```
L1: Issuer → User            (platform credential)
L2: User  → Agent            (mandate, Immediate or Autonomous)
L3: Agent → Merchant/Network (payment or checkout proof)
```

Two execution modes:
- **Immediate**: 2-layer chain (L1 + L2 immediate), direct authorization
- **Autonomous**: 3-layer chain (L1 + L2 autonomous + L3), delegated authorization

Eight constraint types: `MaxAmount`, `MerchantAllowlist`, `CategoryAllowlist`, `ItemAllowlist`, `TimeWindow`, `MaxTransactions`, `RequireConfirmation`, `NetworkScope`

---

## License / Attribution

This module is a Rust-native reimplementation based on the Verifiable Intent open specification and reference implementation:

- Source: https://github.com/agent-intent/verifiable-intent
- License: Apache License, Version 2.0
- No source code was copied; the reimplementation follows the VI specification design (SD-JWT layered credentials, constraint model, three-layer chain)

Attribution is present in:
- `src/verifiable_intent/mod.rs` doc comment (Attribution section)
- `NOTICE` file (third-party attribution entry per Apache 2.0 §4(d))

---

## Validation

```
cargo fmt --all -- --check        → clean
cargo clippy --lib -- -D warnings → clean (no VI-specific warnings)
cargo test --lib -- verifiable_intent → 44 tests pass
```

Test breakdown: error×2, types×3, crypto×8, verification×18, issuance×4, tool×4, timestamps×5

---

## Risk and Rollback

- **Risk**: Low — new module is fully additive, disabled by default, no changes to existing trust boundaries or security policy. Uses battle-tested `ring` crate for all cryptographic operations.
- **Rollback**: Revert this PR. No data migrations, no config changes needed — `verifiable_intent` field will be absent from existing configs and the module will not be loaded.

---

## Non-goals

- No vendoring of the `verifiable-intent` reference implementation
- No changes to CI configuration
- No new CLI commands (tool is invoked via the standard agent tool dispatch path)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Verifiable Intent support for credential verification with configurable strictness modes.
  * New verification tool for validating credential chains, constraints, and timestamps.
  * Configuration option to enable VI verification in system settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->