### PR TITLE
Fix: Address clippy pedantic warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -766,8 +766,7 @@ async fn main() -> Result<()> {
     }
 
     match cli.command {
-        Commands::Onboard { .. } => unreachable!(),
-        Commands::Completions { .. } => unreachable!(),
+        Commands::Onboard { .. } | Commands::Completions { .. } => unreachable!(),
 
         Commands::Agent {
             message,

--- a/src/security/leak_detector.rs
+++ b/src/security/leak_detector.rs
@@ -311,7 +311,7 @@ mod tests {
                 assert!(patterns.iter().any(|p| p.contains("Stripe")));
                 assert!(redacted.contains("[REDACTED"));
             }
-            _ => panic!("Should detect Stripe key"),
+            LeakResult::Clean => panic!("Should detect Stripe key"),
         }
     }
 
@@ -324,7 +324,7 @@ mod tests {
             LeakResult::Detected { patterns, .. } => {
                 assert!(patterns.iter().any(|p| p.contains("AWS")));
             }
-            _ => panic!("Should detect AWS key"),
+            LeakResult::Clean => panic!("Should detect AWS key"),
         }
     }
 
@@ -342,7 +342,7 @@ MIIEowIBAAKCAQEA0ZPr5JeyVDonXsKhfq...
                 assert!(patterns.iter().any(|p| p.contains("private key")));
                 assert!(redacted.contains("[REDACTED_PRIVATE_KEY]"));
             }
-            _ => panic!("Should detect private key"),
+            LeakResult::Clean => panic!("Should detect private key"),
         }
     }
 
@@ -356,7 +356,7 @@ MIIEowIBAAKCAQEA0ZPr5JeyVDonXsKhfq...
                 assert!(patterns.iter().any(|p| p.contains("JWT")));
                 assert!(redacted.contains("[REDACTED_JWT]"));
             }
-            _ => panic!("Should detect JWT"),
+            LeakResult::Clean => panic!("Should detect JWT"),
         }
     }
 
@@ -369,7 +369,7 @@ MIIEowIBAAKCAQEA0ZPr5JeyVDonXsKhfq...
             LeakResult::Detected { patterns, .. } => {
                 assert!(patterns.iter().any(|p| p.contains("PostgreSQL")));
             }
-            _ => panic!("Should detect database URL"),
+            LeakResult::Clean => panic!("Should detect database URL"),
         }
     }
 


### PR DESCRIPTION
## Summary

This PR fixes minor clippy pedantic warnings to improve code quality:

### Changes

1. **Merge identical match arms in `src/main.rs`**
   - `Commands::Onboard { .. }` and `Commands::Completions { .. }` both used `unreachable!()`
   - Merged into a single pattern match using the `|` operator

2. **Replace wildcard matches with specific variants in `src/security/leak_detector.rs`**
   - Changed `_ => panic!(...)` to `LeakResult::Clean => panic!(...)`
   - This makes the code more explicit and safer for future enum additions
   - Affects 5 test functions: `detects_stripe_keys`, `detects_aws_credentials`, `detects_private_keys`, `detects_jwt_tokens`, `detects_database_urls`

### Impact

- No functional changes - only code quality improvements
- Makes the code more maintainable and future-proof
- Addresses `clippy::match_same_arms` and `clippy::match_wildcard_for_single_variants` warnings

## Test plan

- [x] Code compiles without warnings
- [x] Existing tests pass

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined CLI command handling structure for improved code maintainability.

* **Tests**
  * Enhanced leak detection test assertions for improved verification accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->