### PR TITLE
fix(ci): overhaul release pipeline

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -75,6 +75,13 @@ jobs:
             cross_compiler: gcc-aarch64-linux-gnu
             linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
             linker: aarch64-linux-gnu-gcc
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            artifact: zeroclaw
+            ext: tar.gz
+            cross_compiler: gcc-arm-linux-gnueabihf
+            linker_env: CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER
+            linker: arm-linux-gnueabihf-gcc
           - os: macos-14
             target: aarch64-apple-darwin
             artifact: zeroclaw

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -79,6 +79,10 @@ jobs:
             target: aarch64-apple-darwin
             artifact: zeroclaw
             ext: tar.gz
+          - os: macos-14
+            target: x86_64-apple-darwin
+            artifact: zeroclaw
+            ext: tar.gz
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: zeroclaw.exe
@@ -142,16 +146,15 @@ jobs:
           cat SHA256SUMS
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.validate.outputs.tag }}
-          name: ${{ needs.validate.outputs.tag }}
-          prerelease: false
-          generate_release_notes: true
-          files: |
-            artifacts/**/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ needs.validate.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --title "${{ needs.validate.outputs.tag }}" \
+            --latest \
+            --generate-notes \
+            artifacts/**/*.tar.gz artifacts/**/*.zip artifacts/**/SHA256SUMS
 
   docker:
     name: Push Docker Image

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -158,6 +158,7 @@ jobs:
         run: |
           gh release create "${{ needs.validate.outputs.tag }}" \
             --repo "${{ github.repository }}" \
+            --target "$GITHUB_SHA" \
             --title "${{ needs.validate.outputs.tag }}" \
             --latest \
             --generate-notes \

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -161,7 +161,7 @@ jobs:
             --title "${{ needs.validate.outputs.tag }}" \
             --latest \
             --generate-notes \
-            artifacts/**/*.tar.gz artifacts/**/*.zip artifacts/**/SHA256SUMS
+            artifacts/*/*.tar.gz artifacts/*/*.zip artifacts/SHA256SUMS
 
   docker:
     name: Push Docker Image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,13 @@ jobs:
             cross_compiler: gcc-aarch64-linux-gnu
             linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
             linker: aarch64-linux-gnu-gcc
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            artifact: zeroclaw
+            ext: tar.gz
+            cross_compiler: gcc-arm-linux-gnueabihf
+            linker_env: CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER
+            linker: arm-linux-gnueabihf-gcc
           - os: macos-14
             target: aarch64-apple-darwin
             artifact: zeroclaw

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
-name: Beta Release
+name: Daily Beta Release
 
 on:
-  push:
-    branches: [master]
+  schedule:
+    - cron: '0 8 * * *'  # Daily at 08:00 UTC
+  workflow_dispatch: {}
 
 concurrency:
   group: release
@@ -59,6 +60,10 @@ jobs:
             linker: aarch64-linux-gnu-gcc
           - os: macos-14
             target: aarch64-apple-darwin
+            artifact: zeroclaw
+            ext: tar.gz
+          - os: macos-14
+            target: x86_64-apple-darwin
             artifact: zeroclaw
             ext: tar.gz
           - os: windows-latest
@@ -124,16 +129,15 @@ jobs:
           cat SHA256SUMS
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.version.outputs.tag }}
-          name: ${{ needs.version.outputs.tag }}
-          prerelease: true
-          generate_release_notes: true
-          files: |
-            artifacts/**/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ needs.version.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --title "${{ needs.version.outputs.tag }}" \
+            --prerelease \
+            --generate-notes \
+            artifacts/**/*.tar.gz artifacts/**/*.zip artifacts/**/SHA256SUMS
 
   docker:
     name: Push Docker Image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   version:
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     name: Resolve Version
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,7 @@ jobs:
         run: |
           gh release create "${{ needs.version.outputs.tag }}" \
             --repo "${{ github.repository }}" \
+            --target "$GITHUB_SHA" \
             --title "${{ needs.version.outputs.tag }}" \
             --prerelease \
             --generate-notes \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
             --title "${{ needs.version.outputs.tag }}" \
             --prerelease \
             --generate-notes \
-            artifacts/**/*.tar.gz artifacts/**/*.zip artifacts/**/SHA256SUMS
+            artifacts/*/*.tar.gz artifacts/*/*.zip artifacts/SHA256SUMS
 
   docker:
     name: Push Docker Image

--- a/docs/actions-source-policy.md
+++ b/docs/actions-source-policy.md
@@ -16,7 +16,6 @@ Selected allowlist (all actions currently used across CI, Beta Release, and Prom
 | `actions/download-artifact@v4` | release, promote-release | Download build artifacts for packaging |
 | `dtolnay/rust-toolchain@stable` | All workflows | Install Rust toolchain (1.92.0) |
 | `Swatinem/rust-cache@v2` | All workflows | Cargo build/dependency caching |
-| `softprops/action-gh-release@v2` | release, promote-release | Create GitHub Releases |
 | `docker/setup-buildx-action@v3` | release, promote-release | Docker Buildx setup |
 | `docker/login-action@v3` | release, promote-release | GHCR authentication |
 | `docker/build-push-action@v6` | release, promote-release | Multi-platform Docker image build and push |
@@ -26,7 +25,6 @@ Equivalent allowlist patterns:
 - `actions/*`
 - `dtolnay/rust-toolchain@*`
 - `Swatinem/rust-cache@*`
-- `softprops/action-gh-release@*`
 - `docker/*`
 
 ## Workflows
@@ -34,7 +32,7 @@ Equivalent allowlist patterns:
 | Workflow | File | Trigger |
 |----------|------|---------|
 | CI | `.github/workflows/ci.yml` | Pull requests to `master` |
-| Beta Release | `.github/workflows/release.yml` | Push to `master` |
+| Daily Beta Release | `.github/workflows/release.yml` | Daily schedule (08:00 UTC) + manual `workflow_dispatch` |
 | Promote Release | `.github/workflows/promote-release.yml` | Manual `workflow_dispatch` |
 
 ## Change Control
@@ -68,6 +66,11 @@ gh api repos/zeroclaw-labs/zeroclaw/actions/permissions/selected-actions
     - Retained: `actions/*`, `dtolnay/rust-toolchain@*`, `softprops/action-gh-release@*`, `docker/*`
 - 2026-03-05: CI build optimization — added mold linker, cargo-nextest, CARGO_INCREMENTAL=0
     - sccache removed due to fragile GHA cache backend causing build failures
+- 2026-03-07: Release pipeline overhaul
+    - Removed: `softprops/action-gh-release@*` (replaced with built-in `gh` CLI)
+    - Beta trigger changed from push-on-master to daily schedule + workflow_dispatch
+    - Added default-branch guard on beta workflow_dispatch
+    - Added build targets: `armv7-unknown-linux-gnueabihf`, `x86_64-apple-darwin` (cross-compiled from macos-14)
 
 ## Rollback
 


### PR DESCRIPTION
## Summary
- **Daily beta releases** instead of per-merge — runs at 08:00 UTC via cron schedule, plus manual `workflow_dispatch` trigger
- **Replace `softprops/action-gh-release`** with `gh release create` CLI to fix the "Finalizing release" retry bug that left `v0.1.7-beta.2` as a stuck draft
- **Beta = `--prerelease`**, stable = `--latest`** so the stable version keeps the "Latest" badge on the releases page regardless of beta accumulation
- **Restore `x86_64-apple-darwin`** target via cross-compile from `macos-14` ARM runner (replaces deprecated `macos-13` Intel runner)

## What changed
| File | Change |
|------|--------|
| `release.yml` | Trigger: `push` → `schedule` + `workflow_dispatch`; name: "Daily Beta Release"; publish via `gh` CLI with `--prerelease`; add x86_64-apple-darwin matrix entry |
| `promote-release.yml` | Publish via `gh` CLI with `--latest`; add x86_64-apple-darwin matrix entry |

## Build targets (5)
| Target | Runner | Notes |
|--------|--------|-------|
| `x86_64-unknown-linux-gnu` | `ubuntu-latest` | Linux AMD64 |
| `aarch64-unknown-linux-gnu` | `ubuntu-latest` | Linux ARM64 (cross-compiled) |
| `aarch64-apple-darwin` | `macos-14` | macOS Apple Silicon |
| `x86_64-apple-darwin` | `macos-14` | macOS Intel (cross-compiled from ARM) |
| `x86_64-pc-windows-msvc` | `windows-latest` | Windows |

## Side effects
- Published the stuck draft release `v0.1.7-beta.2` as a prerelease
- Next beta will be created on the daily schedule or manual trigger, not on next merge

## Risk and Rollback
- **Risk:** Low — workflow changes only, no code changes
- **Rollback:** Revert commit to restore per-merge trigger and softprops action

## Test plan
- [ ] Trigger `Daily Beta Release` manually via workflow_dispatch after merge
- [ ] Verify all 5 build matrix jobs succeed (especially x86_64-apple-darwin cross-compile)
- [ ] Verify release is created as prerelease (not draft)
- [ ] Verify stable releases still get "Latest" badge via promote-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added build targets: Linux ARMv7 and macOS x86_64.
  * Renamed workflow to "Daily Beta Release" with daily schedule and manual trigger; publish guarded to default branch.

* **Chores**
  * Switched release publishing to gh CLI-based flow, specifying artifacts and checksums.
  * Changed publish token handling to GH_TOKEN.

* **Documentation**
  * Updated actions policy and change log to remove prior release action and reflect workflow changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->