### PR TITLE
feat(provider): add vision support to anthropic provider

### DIFF
--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -7,6 +7,10 @@ use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
+/// MIME types supported by the Anthropic Messages API for image content blocks.
+const ANTHROPIC_SUPPORTED_IMAGE_TYPES: &[&str] =
+    &["image/jpeg", "image/png", "image/gif", "image/webp"];
+
 pub struct AnthropicProvider {
     credential: Option<String>,
     base_url: String,
@@ -85,7 +89,11 @@ enum NativeContentOut {
     },
     /// Anthropic-native base64 image content block.
     #[serde(rename = "image")]
-    Image { source: NativeImageSource },
+    Image {
+        source: NativeImageSource,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<CacheControl>,
+    },
 }
 
 /// Source payload for an Anthropic image content block.
@@ -219,10 +227,11 @@ impl AnthropicProvider {
             if let Some(last_content) = last_msg.content.last_mut() {
                 match last_content {
                     NativeContentOut::Text { cache_control, .. }
-                    | NativeContentOut::ToolResult { cache_control, .. } => {
+                    | NativeContentOut::ToolResult { cache_control, .. }
+                    | NativeContentOut::Image { cache_control, .. } => {
                         *cache_control = Some(CacheControl::ephemeral());
                     }
-                    NativeContentOut::ToolUse { .. } | NativeContentOut::Image { .. } => {}
+                    NativeContentOut::ToolUse { .. } => {}
                 }
             }
         }
@@ -394,14 +403,18 @@ impl AnthropicProvider {
                     if let Some(semi) = rest.find(';') {
                         let mime = &rest[..semi];
                         if let Some(b64) = rest[semi + 1..].strip_prefix("base64,") {
-                            blocks.push(NativeContentOut::Image {
-                                source: NativeImageSource {
-                                    source_type: "base64".to_string(),
-                                    media_type: mime.to_string(),
-                                    data: b64.to_string(),
-                                },
-                            });
-                            continue;
+                            if ANTHROPIC_SUPPORTED_IMAGE_TYPES.contains(&mime) {
+                                blocks.push(NativeContentOut::Image {
+                                    source: NativeImageSource {
+                                        source_type: "base64".to_string(),
+                                        media_type: mime.to_string(),
+                                        data: b64.to_string(),
+                                    },
+                                    cache_control: None,
+                                });
+                                continue;
+                            }
+                            // Unsupported MIME type: fall through to text reference
                         }
                     }
                 }
@@ -1495,7 +1508,7 @@ mod tests {
         }
 
         match &blocks[1] {
-            NativeContentOut::Image { source } => {
+            NativeContentOut::Image { source, .. } => {
                 assert_eq!(source.source_type, "base64");
                 assert_eq!(source.media_type, "image/png");
                 assert_eq!(source.data, "abcd");
@@ -1511,7 +1524,7 @@ mod tests {
         assert_eq!(blocks.len(), 2);
 
         match &blocks[0] {
-            NativeContentOut::Image { source } => {
+            NativeContentOut::Image { source, .. } => {
                 assert_eq!(source.media_type, "image/jpeg");
                 assert_eq!(source.data, "img1");
             }
@@ -1519,7 +1532,7 @@ mod tests {
         }
 
         match &blocks[1] {
-            NativeContentOut::Image { source } => {
+            NativeContentOut::Image { source, .. } => {
                 assert_eq!(source.media_type, "image/webp");
                 assert_eq!(source.data, "img2");
             }
@@ -1535,6 +1548,7 @@ mod tests {
                 media_type: "image/jpeg".to_string(),
                 data: "abc123".to_string(),
             },
+            cache_control: None,
         };
         let json = serde_json::to_string(&content).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -1564,7 +1578,7 @@ mod tests {
         }
 
         match &native_msgs[0].content[1] {
-            NativeContentOut::Image { source } => {
+            NativeContentOut::Image { source, .. } => {
                 assert_eq!(source.source_type, "base64");
                 assert_eq!(source.media_type, "image/png");
                 assert_eq!(source.data, "iVBOR");
@@ -1587,7 +1601,7 @@ mod tests {
         }
 
         match &blocks[1] {
-            NativeContentOut::Image { source } => {
+            NativeContentOut::Image { source, .. } => {
                 assert_eq!(source.source_type, "base64");
                 assert_eq!(source.media_type, "image/png");
                 assert_eq!(source.data, "abcd");
@@ -1600,6 +1614,47 @@ mod tests {
                 assert_eq!(text, " after");
             }
             _ => panic!("Expected Text variant for third block"),
+        }
+    }
+
+    #[test]
+    fn parse_user_content_blocks_rejects_unsupported_mime() {
+        let content = "[IMAGE:data:image/tiff;base64,abcd]";
+        let blocks = AnthropicProvider::parse_user_content_blocks(content);
+        assert_eq!(blocks.len(), 1);
+        match &blocks[0] {
+            NativeContentOut::Text { text, .. } => {
+                assert!(
+                    text.contains("[image:"),
+                    "unsupported MIME should fall back to text: {text}"
+                );
+            }
+            _ => panic!("Expected Text fallback for unsupported MIME type"),
+        }
+    }
+
+    #[test]
+    fn apply_cache_to_last_message_image() {
+        let mut messages = vec![NativeMessage {
+            role: "user".to_string(),
+            content: vec![NativeContentOut::Image {
+                source: NativeImageSource {
+                    source_type: "base64".to_string(),
+                    media_type: "image/png".to_string(),
+                    data: "abcd".to_string(),
+                },
+                cache_control: None,
+            }],
+        }];
+        AnthropicProvider::apply_cache_to_last_message(&mut messages);
+        match &messages[0].content[0] {
+            NativeContentOut::Image { cache_control, .. } => {
+                assert!(
+                    cache_control.is_some(),
+                    "image block should have cache_control set"
+                );
+            }
+            _ => panic!("Expected Image variant"),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The Anthropic provider has no vision/image support. Image markers in user messages are not converted to Anthropic API image content blocks.
- Why it matters: OpenRouter, Compatible, Ollama, and Bedrock all support vision already. Anthropic should too.
- What changed: Added `NativeContentOut::Image` variant and `parse_user_content_blocks()` to turn `[IMAGE:data:...]` markers into base64 image blocks. Replaced `supports_native_tools()` with `capabilities()` returning `vision: true`.
- What did **not** change (scope boundary): No changes to the shared `multimodal` module, traits, config, other providers, or any non-Anthropic code.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels: `provider`
- Module labels: `provider: anthropic`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `provider`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check        # pass — no issues
./scripts/ci/rust_quality_gate.sh # pass — exit 0 (warnings are pre-existing, none in changed files)
cargo test --locked               # pass — 3,288 tests passed, 0 failures
```

- Evidence provided (test/log/trace/screenshot/perf): 6 new unit tests covering no-image passthrough, single/multiple image extraction, serialization format, and end-to-end `convert_messages` integration.
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A, no real data introduced
- Neutral wording confirmation: Tests use synthetic base64 payloads (`abcd`, `img1`, `abc123`, `iVBOR`) with no identity-like data.

## Compatibility / Migration

- Backward compatible? Yes. `capabilities()` has a default impl in the trait; `supports_native_tools()` was already removed from the trait contract.
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No, no docs or user-facing wording changes.

## Human Verification (required)

- Verified scenarios: Image marker parsing with single and multiple data URIs, no-image passthrough, non-data-URI fallback to text, serialization output matches Anthropic API format.
- Edge cases checked: Empty content after marker removal, multiple consecutive image markers with no text, malformed data URIs falling back to text reference.
- Deployed changes onto my server and successfully tested image parsing on multiple images using real scenarios that were failing before.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Anthropic provider only. User messages containing `[IMAGE:data:...]` markers will now produce multipart content blocks instead of plain text.
- Potential unintended effects: None. Messages without image markers follow the same code path as before.
- Guardrails/monitoring for early detection: Existing test suite covers both image and non-image paths.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code with Opus 4.6
- Workflow/plan summary: Reviewed diff, cross-referenced with existing vision implementations in OpenRouter/Compatible/Ollama/Bedrock providers, verified pattern adherence, ran full validation suite.
- Verification focus: Pattern consistency with other vision-enabled providers, correct Anthropic API serialization format.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>`
- Feature flags or config toggles (if any): None
- Observable failure symptoms: If broken, the Anthropic API will reject malformed image blocks, which will show up as provider errors in agent logs.

## Risks and Mitigations

- Risk: Non-data-URI image refs silently degrade to a text placeholder instead of erroring.
  - Mitigation: This matches how the Bedrock provider handles it. Upstream `multimodal::prepare_messages_for_provider` normalizes all refs to data URIs before they reach the provider anyway, so this path is just a defensive fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image support: user messages can include interleaved text and images; multipart messages preserve original order.
  * Provider capabilities now report native tool-calling and vision support.

* **Bug Fixes / Behavior**
  * Message conversion and caching updated to handle image blocks and multipart user content correctly, including caching image blocks.
  * System chats reject inline image markers with guidance to use the structured vision API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->