### PR TITLE
fix: use lossy UTF-8 decoding for CLI stdin to prevent crash on CJK input with spaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,7 @@ RUN chown 65534:65534 /zeroclaw-data/.zeroclaw/config.toml
 # Use consistent workspace path
 ENV ZEROCLAW_WORKSPACE=/zeroclaw-data/workspace
 ENV HOME=/zeroclaw-data
+ENV LANG=C.UTF-8
 # Defaults for local dev (Ollama) - matches config.template.toml
 ENV PROVIDER="ollama"
 ENV ZEROCLAW_MODEL="llama3.2"
@@ -116,6 +117,7 @@ COPY --from=builder /zeroclaw-data /zeroclaw-data
 # Environment setup
 ENV ZEROCLAW_WORKSPACE=/zeroclaw-data/workspace
 ENV HOME=/zeroclaw-data
+ENV LANG=C.UTF-8
 # Default provider and model are set in config.toml, not here,
 # so config file edits are not silently overridden
 #ENV PROVIDER=

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -14,7 +14,7 @@ use anyhow::Result;
 use regex::{Regex, RegexSet};
 use std::collections::HashSet;
 use std::fmt::Write;
-use std::io::Write as _;
+use std::io::{BufRead as _, Write as _};
 use std::sync::{Arc, LazyLock};
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
@@ -3054,8 +3054,9 @@ pub async fn run(
             print!("> ");
             let _ = std::io::stdout().flush();
 
-            let mut input = String::new();
-            match std::io::stdin().read_line(&mut input) {
+            // 使用字节级读取避免 kubectl exec PTY 链路中 UTF-8 多字节字符被拆帧导致的解码错误
+            let mut raw_buf = Vec::new();
+            match std::io::stdin().lock().read_until(b'\n', &mut raw_buf) {
                 Ok(0) => break,
                 Ok(_) => {}
                 Err(e) => {
@@ -3064,7 +3065,7 @@ pub async fn run(
                 }
             }
 
-            let user_input = input.trim().to_string();
+            let user_input = String::from_utf8_lossy(&raw_buf).trim().to_string();
             if user_input.is_empty() {
                 continue;
             }
@@ -3085,10 +3086,11 @@ pub async fn run(
                     print!("Continue? [y/N] ");
                     let _ = std::io::stdout().flush();
 
-                    let mut confirm = String::new();
-                    if std::io::stdin().read_line(&mut confirm).is_err() {
+                    let mut confirm_buf = Vec::new();
+                    if std::io::stdin().lock().read_until(b'\n', &mut confirm_buf).is_err() {
                         continue;
                     }
+                    let confirm = String::from_utf8_lossy(&confirm_buf);
                     if !matches!(confirm.trim().to_lowercase().as_str(), "y" | "yes") {
                         println!("Cancelled.\n");
                         continue;


### PR DESCRIPTION
## Summary

Fixes #2984 — CLI agent crashes with `Error reading input: stream did not contain valid UTF-8` when Chinese (CJK) text contains ASCII spaces.

- Base branch target (`master` for all contributions): `master`
- Problem: CLI agent crashes on CJK input with spaces when running through PTY-proxied terminals (kubectl exec -it, SSH)
- Why it matters: Prevents Chinese/Japanese/Korean users from interacting with CLI agent in container environments
- What changed: Replaced `stdin().read_line()` with byte-level `read_until(b'\n')` + `String::from_utf8_lossy()`; added `ENV LANG=C.UTF-8` to Dockerfile
- What did **not** change (scope boundary): No changes to agent orchestration logic, provider/channel/tool behavior, config schema, or any other subsystem

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `agent`
- Module labels: `agent: loop`
- Contributor tier label: N/A (first contribution)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `runtime`

## Linked Issue

- Closes #2984
- Related: N/A
- Depends on: N/A
- Supersedes: N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings  # pass
cargo test  # pass
```

- Evidence provided: Manual testing via `kubectl exec -it` on Kubernetes (Debian trixie-slim container, user nobody). Before fix: crash on CJK+space input. After fix: input processed normally.
- If any command is intentionally skipped, explain why: N/A — all commands passed

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No personal data in changes
- Neutral wording confirmation: All test examples use generic Chinese text, no identity-like content

## Compatibility / Migration

- Backward compatible? Yes — `from_utf8_lossy` produces identical output for valid UTF-8 input
- Config/env changes? Yes — added `ENV LANG=C.UTF-8` to Dockerfile (defense-in-depth, no behavioral change for properly configured environments)
- Migration needed? No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No — no docs or user-facing wording changes
- If `Yes`, locale navigation parity updated: N/A
- If `Yes`, localized runtime-contract docs updated: N/A
- If `Yes`, Vietnamese canonical docs synced: N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: Pure code fix, no docs changes

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: CJK input with ASCII spaces via `kubectl exec -it` on Kubernetes pod (Debian trixie-slim, user nobody)
- Edge cases checked: Pure ASCII input (unchanged behavior), CJK without spaces (unchanged behavior), empty input (continue loop), EOF (break loop)
- What was not verified: SSH-proxied terminal (same PTY mechanism, expected to behave identically)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: CLI interactive REPL input reading only (`src/agent/loop_.rs`)
- Potential unintended effects: None — lossy conversion only replaces genuinely invalid bytes with U+FFFD (replacement character), all valid input is preserved exactly
- Guardrails/monitoring for early detection: Any encoding issue would surface immediately as visible U+FFFD characters in agent input

## Agent Collaboration Notes (recommended)

- Agent tools used: Cursor
- Workflow/plan summary: Identified root cause via error message analysis → implemented byte-level read with lossy decoding → tested in production-like k8s environment
- Verification focus: CJK input with spaces in PTY-proxied terminal
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>` — single commit, clean revert
- Feature flags or config toggles (if any): None
- Observable failure symptoms: If rollback needed, CJK+space input would crash again with `stream did not contain valid UTF-8`

## Risks and Mitigations

- Risk: Lossy decoding silently replaces genuinely invalid bytes with U+FFFD instead of erroring
  - Mitigation: This is strictly better than crashing the agent loop; invalid bytes in stdin are extremely rare outside the PTY splitting scenario, and U+FFFD is the standard Unicode replacement visible to the user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced runtime environment configuration to improve text encoding support across deployment stages.

* **Refactor**
  * Improved input handling mechanism for better performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->