### PR TITLE
fix(config): support socks proxy scheme for Clash Verge

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1885,10 +1885,10 @@ fn validate_proxy_url(field: &str, url: &str) -> Result<()> {
         .with_context(|| format!("Invalid {field} URL: '{url}' is not a valid URL"))?;
 
     match parsed.scheme() {
-        "http" | "https" | "socks5" | "socks5h" => {}
+        "http" | "https" | "socks5" | "socks5h" | "socks" => {}
         scheme => {
             anyhow::bail!(
-                "Invalid {field} URL scheme '{scheme}'. Allowed: http, https, socks5, socks5h"
+                "Invalid {field} URL scheme '{scheme}'. Allowed: http, https, socks5, socks5h, socks"
             );
         }
     }


### PR DESCRIPTION
# PR Description

## Summary

* Base branch target (`master` for all contributions): `master`
* Problem:
  `zeroclaw` proxy configuration validation rejected the `socks://` scheme used by some proxy tools (e.g., Clash on Ubuntu). This caused startup failure when `all_proxy=socks://127.0.0.1:7890` was present in the environment.
* Why it matters:
  Many proxy stacks (Clash / Proxychains / environment variables) export `socks://` rather than `socks5://`. Strict validation prevented Zeroclaw from running behind common SOCKS proxies.
* What changed:
  Added `socks` as an accepted proxy URL scheme in `validate_proxy_url`.
* What did **not** change (scope boundary):
  No changes to proxy transport logic, networking stack, runtime behavior, or proxy resolution. This change only relaxes schema validation.

---

# Label Snapshot

* Risk label (`risk: low`)
* Size label (`size: XS`)
* Scope labels
  `config, runtime`
* Module labels
  `config: schema`
* Contributor tier label
  auto-managed
* If any auto-label is incorrect, note requested correction:
  none

---

# Change Metadata

* Change type: `bug`
* Primary scope: `runtime`

---

# Linked Issue

* Closes #
* Related #
* Depends on #
* Supersedes #

---

# Validation Evidence

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Result summary:

* `cargo fmt` → pass
* `cargo clippy` → pass
* `cargo test` → pass

Manual validation:

```bash
export all_proxy=socks://127.0.0.1:7890
zeroclaw agent
```

Before change:

```
Invalid all_proxy URL scheme 'socks'
```

After change:

```
Agent started successfully using SOCKS proxy
```

Evidence provided:

* runtime log verification

---

# Security Impact

* New permissions/capabilities? `No`
* New external network calls? `No`
* Secrets/tokens handling changed? `No`
* File system access scope changed? `No`

Risk assessment:

Allowing `socks` only expands accepted configuration input.
Transport layer behavior remains unchanged.

---

# Privacy and Data Hygiene

* Data-hygiene status: `pass`
* Redaction/anonymization notes: none
* Neutral wording confirmation: yes

---

# Compatibility / Migration

* Backward compatible? `Yes`
* Config/env changes? `No`
* Migration needed? `No`

Existing configs remain valid.

---

# Human Verification

Verified scenarios:

* `all_proxy=socks://127.0.0.1:7890`
* `all_proxy=socks5://127.0.0.1:7890`
* `all_proxy=http://127.0.0.1:7890`

Edge cases checked:

* invalid scheme (`ftp://`)
* malformed URL
* missing port

What was not verified:

* proxy transport edge cases (outside this PR scope)

---

# Side Effects / Blast Radius

Affected subsystems:

* configuration validation (`config/schema.rs`)

Potential unintended effects:

* Users may configure `socks://` proxies that internally map to `socks5`

Mitigation:

* Underlying proxy client already supports SOCKS

---

# Agent Collaboration Notes

Agent tools used:

* none

Workflow summary:

1. reproduced error using Clash SOCKS proxy
2. traced validation logic to `validate_proxy_url`
3. identified missing `socks` scheme
4. implemented minimal schema change

Architecture boundaries confirmed:

* configuration validation only
* no runtime network stack change

---

# Rollback Plan

Fast rollback:

```bash
git revert <commit>
```

Or remove `"socks"` from allowed schemes in:

```
src/config/schema.rs
```

Observable failure symptoms:

```
Invalid proxy URL scheme 'socks'
```

---

# Risks and Mitigations

Risk:

Allowing `socks://` might mask proxy version ambiguity.

Mitigation:

Most proxy implementations treat `socks` as `socks5` by default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced proxy configuration validation to support the "socks" URL scheme alongside the existing "http", "https", "socks5", and "socks5h" schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->