### PR TITLE
Fix /api/integrations/settings JSON response for integrations UI

### DIFF
--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -325,6 +325,16 @@ pub async fn handle_api_integrations(
     Json(serde_json::json!({"integrations": integrations})).into_response()
 }
 
+/// GET /api/integrations/settings — backward-compatible integrations settings payload
+pub async fn handle_api_integrations_settings(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> axum::response::Response {
+    handle_api_integrations(State(state), headers)
+        .await
+        .into_response()
+}
+
 /// POST /api/doctor — run diagnostics
 pub async fn handle_api_doctor(
     State(state): State<AppState>,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -674,6 +674,10 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         .route("/api/cron/{id}", delete(api::handle_api_cron_delete))
         .route("/api/integrations", get(api::handle_api_integrations))
         .route(
+            "/api/integrations/settings",
+            get(api::handle_api_integrations_settings),
+        )
+        .route(
             "/api/doctor",
             get(api::handle_api_doctor).post(api::handle_api_doctor),
         )
@@ -1525,11 +1529,16 @@ mod tests {
     use crate::memory::{Memory, MemoryCategory, MemoryEntry};
     use crate::providers::Provider;
     use async_trait::async_trait;
+    use axum::body::Body;
     use axum::http::HeaderValue;
+    use axum::http::Request;
     use axum::response::IntoResponse;
+    use axum::routing::get;
+    use axum::Router;
     use http_body_util::BodyExt;
     use parking_lot::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use tower::ServiceExt;
 
     /// Generate a random hex secret at runtime to avoid hard-coded cryptographic values.
     fn generate_test_secret() -> String {
@@ -1657,6 +1666,65 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let text = String::from_utf8(body.to_vec()).unwrap();
         assert!(text.contains("zeroclaw_heartbeat_ticks_total 1"));
+    }
+
+    #[tokio::test]
+    async fn integrations_settings_endpoint_returns_json_instead_of_spa_html() {
+        let state = AppState {
+            config: Arc::new(Mutex::new(Config::default())),
+            provider: Arc::new(MockProvider::default()),
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: Arc::new(MockMemory),
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            linq: None,
+            linq_signing_secret: None,
+            nextcloud_talk: None,
+            nextcloud_talk_webhook_secret: None,
+            wati: None,
+            observer: Arc::new(crate::observability::NoopObserver),
+            tools_registry: Arc::new(Vec::new()),
+            cost_tracker: None,
+            event_tx: tokio::sync::broadcast::channel(16).0,
+        };
+
+        let app = Router::new()
+            .route(
+                "/api/integrations/settings",
+                get(api::handle_api_integrations_settings),
+            )
+            .fallback(get(static_files::handle_spa_fallback))
+            .with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/integrations/settings")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
+
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["integrations"].is_array());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a dedicated `/api/integrations/settings` API handler that returns JSON
- register `/api/integrations/settings` in the gateway router so it no longer falls through to SPA HTML fallback
- add a regression test proving `/api/integrations/settings` resolves to `application/json` and contains an `integrations` array

Fixes #3009.

## Local verification
- `cargo test integrations_settings_endpoint_returns_json_instead_of_spa_html --lib`

## Behavior change validated
Before:
- `GET /api/integrations/settings` matched SPA fallback and returned HTML (`index.html`), which broke `/integrations` API parsing.

After:
- `GET /api/integrations/settings` matches an API route and returns JSON with `Content-Type: application/json` and an `integrations` payload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `/api/integrations/settings` GET endpoint providing backward-compatible access to integrations settings data.

* **Tests**
  * Expanded test coverage to validate the new endpoint returns JSON responses with integrations data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->