### PR TITLE
Echo Sec-WebSocket-Protocol for /ws/chat handshake

### DIFF
--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -58,17 +58,14 @@ pub async fn handle_ws_chat(
 
 fn parse_requested_subprotocols(headers: &HeaderMap) -> Vec<String> {
     headers
-        .get(header::SEC_WEBSOCKET_PROTOCOL)
-        .and_then(|value| value.to_str().ok())
-        .map(|value| {
-            value
-                .split(',')
-                .map(str::trim)
-                .filter(|part| !part.is_empty())
-                .map(ToString::to_string)
-                .collect()
-        })
-        .unwrap_or_default()
+        .get_all(header::SEC_WEBSOCKET_PROTOCOL)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(|value| value.split(','))
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(ToString::to_string)
+        .collect()
 }
 
 async fn handle_socket(socket: WebSocket, state: AppState) {
@@ -199,6 +196,7 @@ mod tests {
     use crate::providers::Provider;
     use crate::security::pairing::PairingGuard;
     use async_trait::async_trait;
+    use axum::http::HeaderValue;
     use axum::routing::get;
     use axum::Router;
     use parking_lot::Mutex;
@@ -252,6 +250,22 @@ mod tests {
             .is_none());
         drop(socket);
         server_task.abort();
+    }
+
+    #[test]
+    fn parse_requested_subprotocols_reads_all_duplicate_headers() {
+        let mut headers = HeaderMap::new();
+        headers.append(
+            header::SEC_WEBSOCKET_PROTOCOL,
+            HeaderValue::from_static("agent-chat, json"),
+        );
+        headers.append(
+            header::SEC_WEBSOCKET_PROTOCOL,
+            HeaderValue::from_static("telemetry"),
+        );
+
+        let parsed = parse_requested_subprotocols(&headers);
+        assert_eq!(parsed, vec!["agent-chat", "json", "telemetry"]);
     }
 
     async fn spawn_test_server(app: Router) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {


### PR DESCRIPTION
## Summary
- parse `Sec-WebSocket-Protocol` from `/ws/chat` upgrade requests
- pass requested protocols into `WebSocketUpgrade::protocols(...)` so the server negotiates and echoes the selected subprotocol
- add regression tests using real loopback websocket handshakes to verify:
  - requested subprotocol is echoed in handshake response
  - no subprotocol header is emitted when none is requested

Fixes #3010.

## Local verification
- `cargo test ws_handshake_ --lib`

## Behavior change validated
Before:
- `/ws/chat` handshake did not echo `Sec-WebSocket-Protocol`, causing strict websocket clients (including `/agent` reconnect path) to reject the handshake and reconnect repeatedly.

After:
- `/ws/chat` now negotiates from requested protocols and echoes the selected protocol in `Sec-WebSocket-Protocol`, so clients expecting protocol confirmation can establish and keep the connection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket subprotocol negotiation: clients can request one or multiple subprotocols during the connection handshake; requested protocols are parsed and applied when present.

* **Tests**
  * Added coverage for subprotocol negotiation, verifying behavior with requested protocols and when none are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->