### PR TITLE
fix: channel-lark feature compilation errors

### DIFF
--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -296,8 +296,8 @@ pub struct LarkChannel {
     /// Bot open_id resolved at runtime via `/bot/v3/info`.
     resolved_bot_open_id: Arc<StdRwLock<Option<String>>>,
     mention_only: bool,
-    /// When true, use Feishu (CN) endpoints; when false, use Lark (international).
-    use_feishu: bool,
+    /// Platform variant (Lark vs Feishu)
+    platform: LarkPlatform,
     /// How to receive events: WebSocket long-connection or HTTP webhook.
     receive_mode: crate::config::schema::LarkReceiveMode,
     /// Cached tenant access token
@@ -321,6 +321,7 @@ impl LarkChannel {
             verification_token,
             port,
             allowed_users,
+            mention_only,
             LarkPlatform::Lark,
         )
     }
@@ -331,6 +332,7 @@ impl LarkChannel {
         verification_token: String,
         port: Option<u16>,
         allowed_users: Vec<String>,
+        mention_only: bool,
         platform: LarkPlatform,
     ) -> Self {
         Self {
@@ -341,7 +343,7 @@ impl LarkChannel {
             allowed_users,
             resolved_bot_open_id: Arc::new(StdRwLock::new(None)),
             mention_only,
-            use_feishu: true,
+            platform,
             receive_mode: crate::config::schema::LarkReceiveMode::default(),
             tenant_token: Arc::new(RwLock::new(None)),
             ws_seen_ids: Arc::new(RwLock::new(HashMap::new())),
@@ -363,6 +365,37 @@ impl LarkChannel {
             config.port,
             config.allowed_users.clone(),
             config.mention_only,
+            platform,
+        );
+        ch.receive_mode = config.receive_mode.clone();
+        ch
+    }
+
+    /// Build from `LarkConfig` explicitly as Lark (international) endpoint.
+    pub fn from_lark_config(config: &crate::config::schema::LarkConfig) -> Self {
+        let mut ch = Self::new_with_platform(
+            config.app_id.clone(),
+            config.app_secret.clone(),
+            config.verification_token.clone().unwrap_or_default(),
+            config.port,
+            config.allowed_users.clone(),
+            config.mention_only,
+            LarkPlatform::Lark,
+        );
+        ch.receive_mode = config.receive_mode.clone();
+        ch
+    }
+
+    /// Build from `FeishuConfig` for Feishu (China) endpoint.
+    pub fn from_feishu_config(config: &crate::config::schema::FeishuConfig) -> Self {
+        let mut ch = Self::new_with_platform(
+            config.app_id.clone(),
+            config.app_secret.clone(),
+            config.verification_token.clone().unwrap_or_default(),
+            config.port,
+            config.allowed_users.clone(),
+            false, // mention_only not part of FeishuConfig
+            LarkPlatform::Feishu,
         );
         ch.receive_mode = config.receive_mode.clone();
         ch
@@ -2078,6 +2111,7 @@ mod tests {
             encrypt_key: None,
             verification_token: Some("vtoken789".into()),
             allowed_users: vec!["*".into()],
+            mention_only: false,
             use_feishu: true,
             receive_mode: LarkReceiveMode::Webhook,
             port: Some(9898),

--- a/src/peripherals/serial.rs
+++ b/src/peripherals/serial.rs
@@ -4,8 +4,8 @@
 //! Request:  {"id":"1","cmd":"gpio_write","args":{"pin":13,"value":1}}
 //! Response: {"id":"1","ok":true,"result":"done"}
 
-use crate::peripherals::Peripheral;
 use crate::config::PeripheralBoardConfig;
+use crate::peripherals::Peripheral;
 use crate::tools::traits::{Tool, ToolResult};
 use async_trait::async_trait;
 use serde_json::{json, Value};


### PR DESCRIPTION
Fix compilation errors when enabling the channel-lark feature:

- Add platform field to LarkChannel struct (replaces use_feishu bool)
- Add mention_only parameter to new_with_platform function
- Implement from_lark_config and from_feishu_config methods
- Fix test fixture with mention_only field

Also fix import ordering in src/peripherals/serial.rs (cargo fmt).

## Validation
- cargo check --features channel-lark ✓
- cargo test --features channel-lark -- lark (48/48 passing) ✓
- cargo fmt --check ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal platform selection logic for Lark/Feishu integration, replacing a boolean flag with a typed platform representation for more robust configuration handling.
  * Reorganized internal import statements for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->