### PR TITLE
fix tool_call bugs

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1836,6 +1836,18 @@ fn build_assistant_history_with_tool_calls(text: &str, tool_calls: &[ToolCall]) 
     parts.join("\n")
 }
 
+fn resolve_display_text(response_text: &str, parsed_text: &str, has_tool_calls: bool) -> String {
+    if has_tool_calls {
+        return parsed_text.to_string();
+    }
+
+    if parsed_text.is_empty() {
+        response_text.to_string()
+    } else {
+        parsed_text.to_string()
+    }
+}
+
 #[derive(Debug, Clone)]
 struct ParsedToolCall {
     name: String,
@@ -2315,11 +2327,8 @@ pub(crate) async fn run_tool_call_loop(
                 }
             };
 
-        let display_text = if parsed_text.is_empty() {
-            response_text.clone()
-        } else {
-            parsed_text
-        };
+        let display_text =
+            resolve_display_text(&response_text, &parsed_text, !tool_calls.is_empty());
 
         // ── Progress: LLM responded ─────────────────────────────
         if let Some(ref tx) = on_delta {
@@ -4058,6 +4067,32 @@ mod tests {
                 .all(|msg| !(msg.role == "user" && msg.content.starts_with("[Tool results]"))),
             "native mode should use role=tool history instead of prompt fallback wrapper"
         );
+    }
+
+    #[test]
+    fn resolve_display_text_hides_raw_payload_for_tool_only_turns() {
+        let display = resolve_display_text(
+            "<tool_call>{\"name\":\"memory_store\"}</tool_call>",
+            "",
+            true,
+        );
+        assert!(display.is_empty());
+    }
+
+    #[test]
+    fn resolve_display_text_keeps_plain_text_for_tool_turns() {
+        let display = resolve_display_text(
+            "<tool_call>{\"name\":\"shell\"}</tool_call>",
+            "Let me check that.",
+            true,
+        );
+        assert_eq!(display, "Let me check that.");
+    }
+
+    #[test]
+    fn resolve_display_text_uses_response_text_for_final_turns() {
+        let display = resolve_display_text("Final answer", "", false);
+        assert_eq!(display, "Final answer");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: In CLI tool-execution turns, ZeroClaw could print raw internal protocol payloads like `<tool_call>{...}</tool_call>` when no natural-language text was present.
- Why it matters: This leaks internal tool protocol details into end-user output, degrades readability, and makes supervised approval flow noisy.
- What changed: Added an explicit display-text policy helper (`resolve_display_text`) and switched `run_tool_call_loop` to use it, so tool-only turns render no raw protocol text while preserving normal final responses and explanatory prefaces.
- What did **not** change: Tool parsing/execution, approval semantics, provider behavior, channel transport behavior, config schema, or security policy.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `agent`
- Module labels: `agent: loop`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `agent`

## Linked Issue

- Closes #TBD
- Related #3046 (style reference only)
- Depends on #N/A
- Supersedes #N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A — this PR does not supersede any prior PR.

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo test resolve_display_text -- --nocapture
cargo test parse_tool_calls_extracts_single_call -- --nocapture
```

- `cargo test resolve_display_text -- --nocapture`: passed
- `cargo test parse_tool_calls_extracts_single_call -- --nocapture`: passed
- `cargo fmt --all -- --check`: failed due pre-existing formatting diff in unrelated file `src/peripherals/serial.rs` import order; intentionally not changed to keep this PR scoped to P0 CLI display fix.
- If any command is intentionally skipped: `cargo clippy --all-targets -- -D warnings` and full `cargo test` were not run in this pass to keep validation focused on the changed behavior.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No user data introduced
- Neutral wording confirmation: Uses project-scoped neutral wording only

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (no shared navigation/runtime-contract wording changes)

## Human Verification (required)

- Verified scenarios:
  - Tool-only turn display policy resolves to empty output (no raw protocol echo)
  - Tool turn with explanatory text keeps explanatory text
  - Final non-tool turn still displays response text
- Edge cases checked:
  - Helper behavior for all three combinations above via unit tests
- What was not verified:
  - Full end-to-end manual CLI session against live provider in this patch

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `src/agent/loop_.rs` display-text selection only
- Potential unintended effects: Minimal; only user-visible CLI text rendering in tool rounds
- Guardrails/monitoring for early detection: Unit tests added for display policy

## Agent Collaboration Notes (recommended)

- Agent tools used: local code search/edit + targeted cargo tests
- Workflow/plan summary: read contribution guide -> identify display-text branch -> implement helper + tests -> produce issue/PR docs
- Verification focus: regression-proof display behavior for tool-only turns
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`)

## Rollback Plan (required)

- Fast rollback command/path: revert the commit touching `src/agent/loop_.rs`
- Feature flags or config toggles (if any): None
- Observable failure symptoms: raw `<tool_call>` payloads reappear in CLI output during tool-only turns

## Risks and Mitigations

- Risk: helper-level behavior drift could hide intended user-visible text in tool turns
  - Mitigation: explicit unit tests for tool-only/tool+text/final-response cases
  #3049 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored tool-call loop display text handling by extracting previously inline logic into a dedicated helper function, improving code clarity and maintainability across the loop implementation.

* **Tests**
  * Added unit tests to verify correct display text resolution behavior for various tool-call scenarios, including tool-only turns, plain-text turns, and final turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->