### PR TITLE
fix(channel-lark): restore Lark/Feishu constructor wiring

### DIFF
--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -293,6 +293,7 @@ pub struct LarkChannel {
     verification_token: String,
     port: Option<u16>,
     allowed_users: Vec<String>,
+    platform: LarkPlatform,
     /// Bot open_id resolved at runtime via `/bot/v3/info`.
     resolved_bot_open_id: Arc<StdRwLock<Option<String>>>,
     mention_only: bool,
@@ -321,6 +322,7 @@ impl LarkChannel {
             verification_token,
             port,
             allowed_users,
+            mention_only,
             LarkPlatform::Lark,
         )
     }
@@ -331,6 +333,7 @@ impl LarkChannel {
         verification_token: String,
         port: Option<u16>,
         allowed_users: Vec<String>,
+        mention_only: bool,
         platform: LarkPlatform,
     ) -> Self {
         Self {
@@ -339,9 +342,10 @@ impl LarkChannel {
             verification_token,
             port,
             allowed_users,
+            platform,
             resolved_bot_open_id: Arc::new(StdRwLock::new(None)),
             mention_only,
-            use_feishu: true,
+            use_feishu: matches!(platform, LarkPlatform::Feishu),
             receive_mode: crate::config::schema::LarkReceiveMode::default(),
             tenant_token: Arc::new(RwLock::new(None)),
             ws_seen_ids: Arc::new(RwLock::new(HashMap::new())),
@@ -363,6 +367,35 @@ impl LarkChannel {
             config.port,
             config.allowed_users.clone(),
             config.mention_only,
+            platform,
+        );
+        ch.receive_mode = config.receive_mode.clone();
+        ch
+    }
+
+    pub fn from_lark_config(config: &crate::config::schema::LarkConfig) -> Self {
+        let mut ch = Self::new_with_platform(
+            config.app_id.clone(),
+            config.app_secret.clone(),
+            config.verification_token.clone().unwrap_or_default(),
+            config.port,
+            config.allowed_users.clone(),
+            config.mention_only,
+            LarkPlatform::Lark,
+        );
+        ch.receive_mode = config.receive_mode.clone();
+        ch
+    }
+
+    pub fn from_feishu_config(config: &crate::config::schema::FeishuConfig) -> Self {
+        let mut ch = Self::new_with_platform(
+            config.app_id.clone(),
+            config.app_secret.clone(),
+            config.verification_token.clone().unwrap_or_default(),
+            config.port,
+            config.allowed_users.clone(),
+            false,
+            LarkPlatform::Feishu,
         );
         ch.receive_mode = config.receive_mode.clone();
         ch
@@ -2078,6 +2111,7 @@ mod tests {
             encrypt_key: None,
             verification_token: Some("vtoken789".into()),
             allowed_users: vec!["*".into()],
+            mention_only: false,
             use_feishu: true,
             receive_mode: LarkReceiveMode::Webhook,
             port: Some(9898),


### PR DESCRIPTION
## Summary

Restore the missing Lark/Feishu constructor wiring so `--features channel-lark` builds again and the Feishu/Lark channel can be instantiated correctly.

This patch fixes the constructor/field mismatch that left `LarkChannel` half-migrated to `LarkPlatform`:

- add the missing `platform` field to `LarkChannel`
- pass `mention_only` through `new_with_platform(...)`
- derive `use_feishu` from the selected platform instead of hard-coding it
- restore the missing `from_lark_config(...)` and `from_feishu_config(...)` helpers used by `channels::mod`
- update the affected unit-test fixture to include the now-required `mention_only` field

## Why

`channel-lark` currently fails to compile because the code in `src/channels/mod.rs` expects explicit Lark/Feishu constructors, while `src/channels/lark.rs` only exposes a partially updated `from_config(...)` path and references a `platform` field that is not actually present on the struct.

That mismatch produces the same error surface described in #2230 and blocks Feishu/Lark usage entirely.

## Validation

I only validated this on **macOS arm64**.

Commands run locally:

- `cargo build --release --locked --features channel-lark`
- `cargo test --locked --features channel-lark channels::lark::tests::lark_from_lark_config_ignores_legacy_feishu_flag --lib -- --exact --nocapture`
- `cargo test --locked --features channel-lark channels::lark::tests::lark_from_feishu_config_sets_feishu_platform --lib -- --exact --nocapture`
- `zeroclaw channel doctor`
- `zeroclaw channel start`

Observed results on macOS:

- `channel-lark` release build succeeds
- both constructor-focused unit tests pass
- `zeroclaw channel doctor` reports both `Discord` and `Feishu` healthy
- `zeroclaw channel start` reaches:
  - `Lark: WS connected ...`
  - `Discord: connected and identified`

## Scope / Non-goals

- No behavior changes outside the broken constructor wiring
- No docs changes
- No claim of Windows or Linux validation in this PR

## Related

- Refs #2230
- Likely relevant to #2325


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit platform selection for Lark and Feishu configurations, enabling users to target their preferred endpoint while automatically aligning token handling, API routing, and locale behavior accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->