### PR TITLE
fix(ollama): normalize typed scalar tool args before dispatch

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -316,12 +316,46 @@ fn find_tool<'a>(tools: &'a [Box<dyn Tool>], name: &str) -> Option<&'a dyn Tool>
     tools.iter().find(|t| t.name() == name).map(|t| t.as_ref())
 }
 
+fn normalize_tool_argument_scalars(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(items) => serde_json::Value::Array(
+            items
+                .into_iter()
+                .map(normalize_tool_argument_scalars)
+                .collect(),
+        ),
+        serde_json::Value::Object(map) => {
+            let type_value = map.get("type").and_then(serde_json::Value::as_str);
+            let scalar_typed_wrapper = map.len() <= 2
+                && map.contains_key("value")
+                && type_value.is_some_and(|kind| {
+                    matches!(kind, "string" | "number" | "integer" | "boolean")
+                });
+
+            if scalar_typed_wrapper {
+                if let Some(inner) = map.get("value") {
+                    return normalize_tool_argument_scalars(inner.clone());
+                }
+            }
+
+            let mut normalized = serde_json::Map::new();
+            for (key, item) in map {
+                normalized.insert(key, normalize_tool_argument_scalars(item));
+            }
+            serde_json::Value::Object(normalized)
+        }
+        other => other,
+    }
+}
+
 fn parse_arguments_value(raw: Option<&serde_json::Value>) -> serde_json::Value {
     match raw {
-        Some(serde_json::Value::String(s)) => serde_json::from_str::<serde_json::Value>(s)
-            .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new())),
-        Some(value) => value.clone(),
-        None => serde_json::Value::Object(serde_json::Map::new()),
+        Some(serde_json::Value::String(s)) => normalize_tool_argument_scalars(
+            serde_json::from_str::<serde_json::Value>(s)
+                .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new())),
+        ),
+        Some(value) => normalize_tool_argument_scalars(value.clone()),
+        None => normalize_tool_argument_scalars(serde_json::Value::Object(serde_json::Map::new())),
     }
 }
 
@@ -4984,6 +5018,41 @@ Done."#;
         assert_eq!(
             result.arguments.get("command").and_then(|v| v.as_str()),
             Some("date")
+        );
+    }
+
+    #[test]
+    fn parse_tool_call_value_normalizes_typed_scalar_argument_wrappers() {
+        let value = serde_json::json!({
+            "function": {
+                "name": "shell",
+                "arguments": {
+                    "command": {
+                        "type": "string",
+                        "value": "date +%s"
+                    }
+                }
+            }
+        });
+        let result = parse_tool_call_value(&value).expect("tool call should parse");
+        assert_eq!(result.name, "shell");
+        assert_eq!(
+            result.arguments.get("command").and_then(|v| v.as_str()),
+            Some("date +%s")
+        );
+    }
+
+    #[test]
+    fn parse_tool_call_value_normalizes_string_encoded_typed_wrappers() {
+        let value = serde_json::json!({
+            "name": "shell",
+            "arguments": "{\"command\":{\"type\":\"string\",\"value\":\"date +%s\"}}"
+        });
+        let result = parse_tool_call_value(&value).expect("tool call should parse");
+        assert_eq!(result.name, "shell");
+        assert_eq!(
+            result.arguments.get("command").and_then(|v| v.as_str()),
+            Some("date +%s")
         );
     }
 


### PR DESCRIPTION
## Summary
- normalize tool-call argument wrappers like `{"type":"string","value":"..."}` before tool dispatch
- apply normalization for both native JSON args and string-encoded args
- add parser tests to lock behavior

## Why
Some Ollama models intermittently emit typed-wrapper argument payloads (for example `command: {type: string, value: ...}`), which can cause invalid tool execution attempts and iteration loops.

## Linked issue
- Refs #3079

## Validation
### Unit tests
- `cargo test -q parse_tool_call_value_normalizes`
  - passed (2 new tests)

### Local behavior checks (patched local binary)
- prompt: `Use the shell tool to run exactly: date +%s. Return only the command output.`
- observed improvement on wrapper-prone model output:
  - `qwen2.5-coder:7b-instruct`: from occasional non-execution/mixed output to consistent command execution in repeated runs
- this change is intentionally narrow (argument-shape normalization) and does not attempt to solve all small-model planning/pathology behaviors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved tool argument parsing to correctly handle various JSON object formats, ensuring arguments are processed consistently regardless of input structure.

* **Tests**
  * Added test coverage for tool argument normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->