### PR TITLE
fix(docker): enable BuildKit and write config.toml via printf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,20 +58,20 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
 
 # Prepare runtime directory structure and default config inline (no extra stage)
 RUN mkdir -p /zeroclaw-data/.zeroclaw /zeroclaw-data/workspace && \
-    cat > /zeroclaw-data/.zeroclaw/config.toml <<EOF && \
+    printf '%s\n' \
+        'workspace_dir = "/zeroclaw-data/workspace"' \
+        'config_path = "/zeroclaw-data/.zeroclaw/config.toml"' \
+        'api_key = ""' \
+        'default_provider = "openrouter"' \
+        'default_model = "anthropic/claude-sonnet-4-20250514"' \
+        'default_temperature = 0.7' \
+        '' \
+        '[gateway]' \
+        'port = 42617' \
+        'host = "[::]"' \
+        'allow_public_bind = true' \
+        > /zeroclaw-data/.zeroclaw/config.toml && \
     chown -R 65534:65534 /zeroclaw-data
-workspace_dir = "/zeroclaw-data/workspace"
-config_path = "/zeroclaw-data/.zeroclaw/config.toml"
-api_key = ""
-default_provider = "openrouter"
-default_model = "anthropic/claude-sonnet-4-20250514"
-default_temperature = 0.7
-
-[gateway]
-port = 42617
-host = "[::]"
-allow_public_bind = true
-EOF
 
 # ── Stage 2: Development Runtime (Debian) ────────────────────
 FROM debian:trixie-slim@sha256:f6e2cfac5cf956ea044b4bd75e6397b4372ad88fe00908045e9a0d21712ae3ba AS dev

--- a/install.sh
+++ b/install.sh
@@ -689,7 +689,7 @@ run_docker_bootstrap() {
 
   if [[ "$SKIP_BUILD" == false ]]; then
     info "Building Docker image ($docker_image)"
-    "$CONTAINER_CLI" build --target release -t "$docker_image" "$WORK_DIR"
+    DOCKER_BUILDKIT=1 "$CONTAINER_CLI" build --target release -t "$docker_image" "$WORK_DIR"
   else
     info "Skipping Docker image build"
     if ! "$CONTAINER_CLI" image inspect "$docker_image" >/dev/null 2>&1; then


### PR DESCRIPTION
- Dockerfile: replace heredoc with printf for config.toml to avoid Docker parse error (unknown instruction WORKSPACE_DIR)
- install.sh: set DOCKER_BUILDKIT=1 when building image so RUN --mount works

## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions):
- Problem:
- Why it matters:
- What changed:
- What did **not** change (scope boundary):

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`):
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`):
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`):
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- File system access scope changed? (`Yes/No`)
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`)
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any):
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
  - Mitigation:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build performance by enabling BuildKit support for faster image compilation
  * Streamlined configuration file generation through an improved write mechanism

This release includes internal infrastructure improvements focused on deployment efficiency. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->