### PR TITLE
ci(release): pin GNU Linux release runners back to Ubuntu 22.04

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -202,7 +202,7 @@ jobs:
                 include:
                     # Keep GNU Linux release artifacts on Ubuntu 22.04 to preserve
                     # a broadly compatible GLIBC baseline for user distributions.
-                    - os: [self-hosted, Linux, X64, blacksmith-2vcpu-ubuntu-2404]
+                    - os: [self-hosted, Linux, X64, blacksmith-2vcpu-ubuntu-2204]
                       target: x86_64-unknown-linux-gnu
                       artifact: zeroclaw
                       archive_ext: tar.gz
@@ -217,7 +217,7 @@ jobs:
                       linker_env: ""
                       linker: ""
                       use_cross: true
-                    - os: [self-hosted, Linux, X64, blacksmith-2vcpu-ubuntu-2404]
+                    - os: [self-hosted, Linux, X64, blacksmith-2vcpu-ubuntu-2204]
                       target: aarch64-unknown-linux-gnu
                       artifact: zeroclaw
                       archive_ext: tar.gz
@@ -232,7 +232,7 @@ jobs:
                       linker_env: ""
                       linker: ""
                       use_cross: true
-                    - os: [self-hosted, Linux, X64, blacksmith-2vcpu-ubuntu-2404]
+                    - os: [self-hosted, Linux, X64, blacksmith-2vcpu-ubuntu-2204]
                       target: armv7-unknown-linux-gnueabihf
                       artifact: zeroclaw
                       archive_ext: tar.gz


### PR DESCRIPTION
## Summary

Switch the GNU Linux release matrix back from the Ubuntu 24.04 Blacksmith runner to the Ubuntu 22.04 runner.

## Why

The release workflow comment already states that GNU Linux artifacts should stay on Ubuntu 22.04 to preserve a broadly compatible GLIBC baseline for user distributions. This change restores the runner labels to match that intent.

## What changed

Updated `.github/workflows/pub-release.yml` for these GNU Linux release targets:

- `x86_64-unknown-linux-gnu`
- `aarch64-unknown-linux-gnu`
- `armv7-unknown-linux-gnueabihf`

Each now uses:

- `blacksmith-2vcpu-ubuntu-2204`

instead of:

- `blacksmith-2vcpu-ubuntu-2404`

## Validation

- `git diff --check origin/dev..HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->