### PR TITLE
fix(providers): explicitly set Content-Type for JSON requests

### DIFF
--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -848,7 +848,10 @@ impl OpenAiCompatibleProvider {
         let url = self.responses_url();
 
         let response = self
-            .apply_auth_header(self.http_client().post(&url).json(&request), credential)
+            .apply_auth_header(
+                super::with_json_content_type(self.http_client().post(&url)).json(&request),
+                credential,
+            )
             .send()
             .await?;
 
@@ -1161,7 +1164,10 @@ impl Provider for OpenAiCompatibleProvider {
         };
 
         let response = match self
-            .apply_auth_header(self.http_client().post(&url).json(&request), credential)
+            .apply_auth_header(
+                super::with_json_content_type(self.http_client().post(&url)).json(&request),
+                credential,
+            )
             .send()
             .await
         {
@@ -1271,7 +1277,10 @@ impl Provider for OpenAiCompatibleProvider {
 
         let url = self.chat_completions_url();
         let response = match self
-            .apply_auth_header(self.http_client().post(&url).json(&request), credential)
+            .apply_auth_header(
+                super::with_json_content_type(self.http_client().post(&url)).json(&request),
+                credential,
+            )
             .send()
             .await
         {
@@ -1389,7 +1398,10 @@ impl Provider for OpenAiCompatibleProvider {
 
         let url = self.chat_completions_url();
         let response = match self
-            .apply_auth_header(self.http_client().post(&url).json(&request), credential)
+            .apply_auth_header(
+                super::with_json_content_type(self.http_client().post(&url)).json(&request),
+                credential,
+            )
             .send()
             .await
         {
@@ -1486,7 +1498,7 @@ impl Provider for OpenAiCompatibleProvider {
         let url = self.chat_completions_url();
         let response = match self
             .apply_auth_header(
-                self.http_client().post(&url).json(&native_request),
+                super::with_json_content_type(self.http_client().post(&url)).json(&native_request),
                 credential,
             )
             .send()
@@ -1634,7 +1646,7 @@ impl Provider for OpenAiCompatibleProvider {
 
         tokio::spawn(async move {
             // Build request with auth
-            let mut req_builder = client.post(&url).json(&request);
+            let mut req_builder = super::with_json_content_type(client.post(&url)).json(&request);
 
             // Apply auth header
             req_builder = match &auth_header {
@@ -1704,6 +1716,8 @@ impl Provider for OpenAiCompatibleProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn make_provider(name: &str, url: &str, key: Option<&str>) -> OpenAiCompatibleProvider {
         OpenAiCompatibleProvider::new(name, url, key, AuthStyle::Bearer)
@@ -1744,6 +1758,27 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Venice API key not set"));
+    }
+
+    #[tokio::test]
+    async fn chat_with_system_sends_explicit_json_content_type_header() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("content-type", "application/json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{ "message": { "content": "ok from compatible" } }]
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = make_provider("custom", &server.uri(), Some("test-key"));
+        let text = provider
+            .chat_with_system(None, "hello", "gpt-4o-mini", 0.2)
+            .await
+            .expect("compatible chat should succeed");
+
+        assert_eq!(text, "ok from compatible");
     }
 
     #[test]

--- a/src/providers/copilot.rs
+++ b/src/providers/copilot.rs
@@ -337,6 +337,7 @@ impl CopilotProvider {
             .http_client()
             .post(&url)
             .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
             .json(&request);
 
         for (header, value) in &Self::COPILOT_HEADERS {
@@ -455,6 +456,7 @@ impl CopilotProvider {
             .http_client()
             .post(GITHUB_DEVICE_CODE_URL)
             .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
             .json(&serde_json::json!({
                 "client_id": GITHUB_CLIENT_ID,
                 "scope": "read:user"
@@ -484,6 +486,7 @@ impl CopilotProvider {
                 .http_client()
                 .post(GITHUB_ACCESS_TOKEN_URL)
                 .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
                 .json(&serde_json::json!({
                     "client_id": GITHUB_CLIENT_ID,
                     "device_code": response.device_code,

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -820,6 +820,7 @@ impl GeminiProvider {
         let response = client
             .post(LOAD_CODE_ASSIST_ENDPOINT)
             .bearer_auth(token)
+            .header("Content-Type", "application/json")
             .json(&serde_json::json!({
                 "cloudaicompanionProject": project_seed_for_request,
                 "metadata": {
@@ -880,7 +881,7 @@ impl GeminiProvider {
         project: Option<&str>,
         oauth_token: Option<&str>,
     ) -> reqwest::RequestBuilder {
-        let req = self.http_client().post(url).json(request);
+        let req = super::with_json_content_type(self.http_client().post(url)).json(request);
         match auth {
             GeminiAuth::OAuthToken(_) | GeminiAuth::ManagedOAuth => {
                 let token = oauth_token.unwrap_or_default();
@@ -902,6 +903,7 @@ impl GeminiProvider {
                 };
                 self.http_client()
                     .post(url)
+                    .header("Content-Type", "application/json")
                     .json(&internal_request)
                     .bearer_auth(token)
             }

--- a/src/providers/glm.rs
+++ b/src/providers/glm.rs
@@ -186,6 +186,7 @@ impl Provider for GlmProvider {
             .http_client()
             .post(&url)
             .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
             .json(&request)
             .send()
             .await?;
@@ -233,6 +234,7 @@ impl Provider for GlmProvider {
             .client
             .post(&url)
             .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
             .json(&request)
             .send()
             .await?;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -775,6 +775,11 @@ pub async fn api_error(provider: &str, response: reqwest::Response) -> anyhow::E
     anyhow::anyhow!("{provider} API error ({status}): {sanitized}")
 }
 
+/// Ensure JSON provider calls always send an explicit Content-Type header.
+pub(crate) fn with_json_content_type(req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    req.header(reqwest::header::CONTENT_TYPE, "application/json")
+}
+
 /// Resolve API key for a provider from config and environment variables.
 ///
 /// Resolution order:
@@ -2774,6 +2779,19 @@ mod tests {
         let input = "simple upstream timeout";
         let result = sanitize_api_error(input);
         assert_eq!(result, input);
+    }
+
+    #[test]
+    fn with_json_content_type_sets_header() {
+        let request = with_json_content_type(reqwest::Client::new().post("http://example.com"))
+            .body("{}")
+            .build()
+            .expect("request should build");
+        let content_type = request
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .expect("content type must be set");
+        assert_eq!(content_type, "application/json");
     }
 
     #[test]

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -367,7 +367,8 @@ impl OllamaProvider {
             request.tools.as_ref().map_or(0, |t| t.len()),
         );
 
-        let mut request_builder = self.http_client().post(&url).json(&request);
+        let mut request_builder =
+            super::with_json_content_type(self.http_client().post(&url)).json(&request);
 
         if should_auth {
             if let Some(key) = self.api_key.as_ref() {

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -328,13 +328,14 @@ impl Provider for OpenAiProvider {
             temperature,
         };
 
-        let response = self
-            .http_client()
-            .post(format!("{}/chat/completions", self.base_url))
-            .header("Authorization", format!("Bearer {credential}"))
-            .json(&request)
-            .send()
-            .await?;
+        let response = super::with_json_content_type(
+            self.http_client()
+                .post(format!("{}/chat/completions", self.base_url)),
+        )
+        .header("Authorization", format!("Bearer {credential}"))
+        .json(&request)
+        .send()
+        .await?;
 
         if !response.status().is_success() {
             return Err(super::api_error("OpenAI", response).await);
@@ -369,13 +370,14 @@ impl Provider for OpenAiProvider {
             tools,
         };
 
-        let response = self
-            .http_client()
-            .post(format!("{}/chat/completions", self.base_url))
-            .header("Authorization", format!("Bearer {credential}"))
-            .json(&native_request)
-            .send()
-            .await?;
+        let response = super::with_json_content_type(
+            self.http_client()
+                .post(format!("{}/chat/completions", self.base_url)),
+        )
+        .header("Authorization", format!("Bearer {credential}"))
+        .json(&native_request)
+        .send()
+        .await?;
 
         if !response.status().is_success() {
             return Err(super::api_error("OpenAI", response).await);
@@ -432,13 +434,14 @@ impl Provider for OpenAiProvider {
             tools: native_tools,
         };
 
-        let response = self
-            .http_client()
-            .post(format!("{}/chat/completions", self.base_url))
-            .header("Authorization", format!("Bearer {credential}"))
-            .json(&native_request)
-            .send()
-            .await?;
+        let response = super::with_json_content_type(
+            self.http_client()
+                .post(format!("{}/chat/completions", self.base_url)),
+        )
+        .header("Authorization", format!("Bearer {credential}"))
+        .json(&native_request)
+        .send()
+        .await?;
 
         if !response.status().is_success() {
             return Err(super::api_error("OpenAI", response).await);
@@ -476,6 +479,8 @@ impl Provider for OpenAiProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn creates_with_key() {
@@ -598,6 +603,28 @@ mod tests {
         let provider = OpenAiProvider::new(None);
         let result = provider.warmup().await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn chat_with_system_sends_explicit_json_content_type_header() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/chat/completions"))
+            .and(header("content-type", "application/json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "choices": [{ "message": { "content": "ok" } }]
+            })))
+            .mount(&server)
+            .await;
+
+        let base_url = format!("{}/v1", server.uri());
+        let provider = OpenAiProvider::with_base_url(Some(&base_url), Some("test-key"));
+        let text = provider
+            .chat_with_system(None, "hello", "gpt-4o-mini", 0.2)
+            .await
+            .expect("openai chat should succeed");
+
+        assert_eq!(text, "ok");
     }
 
     // ----------------------------------------------------------

--- a/src/providers/openrouter.rs
+++ b/src/providers/openrouter.rs
@@ -359,6 +359,7 @@ impl Provider for OpenRouterProvider {
             .header("Authorization", format!("Bearer {credential}"))
             .header("HTTP-Referer", "https://github.com/zeroclaw-labs/zeroclaw")
             .header("X-Title", "ZeroClaw")
+            .header("Content-Type", "application/json")
             .json(&request)
             .send()
             .await?;
@@ -406,6 +407,7 @@ impl Provider for OpenRouterProvider {
             .header("Authorization", format!("Bearer {credential}"))
             .header("HTTP-Referer", "https://github.com/zeroclaw-labs/zeroclaw")
             .header("X-Title", "ZeroClaw")
+            .header("Content-Type", "application/json")
             .json(&request)
             .send()
             .await?;
@@ -451,6 +453,7 @@ impl Provider for OpenRouterProvider {
             .header("Authorization", format!("Bearer {credential}"))
             .header("HTTP-Referer", "https://github.com/zeroclaw-labs/zeroclaw")
             .header("X-Title", "ZeroClaw")
+            .header("Content-Type", "application/json")
             .json(&native_request)
             .send()
             .await?;
@@ -542,6 +545,7 @@ impl Provider for OpenRouterProvider {
             .header("Authorization", format!("Bearer {credential}"))
             .header("HTTP-Referer", "https://github.com/zeroclaw-labs/zeroclaw")
             .header("X-Title", "ZeroClaw")
+            .header("Content-Type", "application/json")
             .json(&native_request)
             .send()
             .await?;


### PR DESCRIPTION
## Summary
- add a shared `with_json_content_type` helper in the provider module
- apply explicit `Content-Type: application/json` headers across JSON provider request paths (OpenAI, compatible, Ollama, GLM, OpenRouter, Copilot, Gemini)
- add tests to verify JSON Content-Type behavior in OpenAI and OpenAI-compatible provider flows

## Validation
- `cargo test chat_with_system_sends_explicit_json_content_type_header --quiet`
- `cargo test with_json_content_type_sets_header --quiet`

Closes #3132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed HTTP request handling across all AI provider integrations (OpenAI, Copilot, Gemini, GLM, Ollama, and OpenRouter) to ensure proper JSON content-type headers are consistently set on requests.

* **Tests**
  * Added validation tests to verify JSON content-type headers are correctly sent in provider requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->