### PR TITLE
fix(bootstrap): support macOS bash for docker install

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1257,7 +1257,7 @@ MSG
 
     if [[ "$CONTAINER_CLI" == "podman" ]]; then
       "$CONTAINER_CLI" run --rm -it \
-        "${container_run_namespace_args[@]}" \
+        "${container_run_namespace_args[@]+"${container_run_namespace_args[@]}"}" \
         "${container_run_user_args[@]}" \
         "${container_extra_run_args[@]+${container_extra_run_args[@]}}" \
         -e HOME=/zeroclaw-data \

--- a/scripts/ci/tests/test_ci_scripts.py
+++ b/scripts/ci/tests/test_ci_scripts.py
@@ -3428,6 +3428,16 @@ class CiScriptsBehaviorTest(unittest.TestCase):
         self.assertIn("required_checks.rc", joined)
         self.assertIn("required_checks.stable", joined)
 
+    def test_bootstrap_uses_bash32_safe_optional_array_expansion(self) -> None:
+        bootstrap = (ROOT / "scripts" / "bootstrap.sh").read_text(encoding="utf-8")
+        self.assertIn(
+            '"${container_run_namespace_args[@]+"${container_run_namespace_args[@]}"}"',
+            bootstrap,
+        )
+        self.assertNotIn(
+            '"${container_run_namespace_args[@]}" \\\n        "${container_run_user_args[@]}"',
+            bootstrap,
+        )
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #2930

## Summary
- fix Docker bootstrap to avoid Bash 3.2 empty-array nounset failures on macOS
- add a regression test that guards the Bash 3.2-safe expansion path

## Validation
- python3 -m unittest scripts.ci.tests.test_ci_scripts.CiScriptsBehaviorTest.test_bootstrap_uses_bash32_safe_optional_array_expansion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved shell script robustness by refining how optional arguments are passed.
  * Enhanced test coverage to ensure compatibility with Bash 3.2 standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->