### PR TITLE
fix(agent): prevent inclusion of IDENTITY.md when AIEOS is used

### DIFF
--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -93,15 +93,14 @@ impl PromptSection for IdentitySection {
         }
 
         if !has_aieos {
-            prompt.push_str(
-                "The following workspace files define your identity, behavior, and context.\n\n",
-            );
+            prompt.push_str("The following IDENTITY.md defines your identity.\n\n");
+            inject_workspace_file(&mut prompt, ctx.workspace_dir, "IDENTITY.md");
         }
+        prompt.push_str("The following files define your behavior and context.\n\n");
         for file in [
             "AGENTS.md",
             "SOUL.md",
             "TOOLS.md",
-            "IDENTITY.md",
             "USER.md",
             "HEARTBEAT.md",
             "BOOTSTRAP.md",


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: Currently, IDENTITY.md will still be included in standard prefaces of prompts even when AIEOS mode is enabled.
- Why it matters: This could lead to duplicated or conflicting context, is not token-efficient, and deviates from [what the docs imply](https://www.zeroclawlabs.ai/docs#identity).
- What changed: After this patch, when AIEOS is used, `IDENTITY.md` will not be automatically injected into the prompt. Related file descriptions are changed accordingly.
- What did **not** change (scope boundary): When AIEOS is not used, the list of files injected into the prompt is not changed.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): risk: low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): agent
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): agent: prompt
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): ?[^1]

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

All reported errors are in non-modified files, which means that these are errors already present in the base commit.

```console
$ cargo fmt --all --message-format short --check
/home/mantle/workspace/zeroclaw-labs-zeroclaw/src/config/mod.rs
/home/mantle/workspace/zeroclaw-labs-zeroclaw/src/config/schema.rs
/home/mantle/workspace/zeroclaw-labs-zeroclaw/src/config/mod.rs
/home/mantle/workspace/zeroclaw-labs-zeroclaw/src/config/schema.rs
$ cargo clippy --all-targets -- -D warnings
[...]
error: large future with a size of 16816 bytes
   --> src/main.rs:720:13
    |
720 |             onboard::run_channels_repair_wizard().await
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(onboard::run_channels_repair_wizard())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#large_futures
    = note: `-D clippy::large-futures` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::large_futures)]`

error: large future with a size of 16976 bytes
   --> src/main.rs:722:13
    |
722 |             onboard::run_wizard(force).await
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(onboard::run_wizard(force))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#large_futures

error: could not compile `zeroclaw` (bin "zeroclaw") due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `zeroclaw` (bin "zeroclaw" test) due to 2 previous errors
```

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`)
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Self-deployed ZeroClaw instance without AIEOS enabled.
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: agent
- Potential unintended effects: 
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): None.
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

None.
