### PR TITLE
fix(agent): strip prompt-guided tool artifacts from visible replies

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1694,6 +1694,26 @@ fn parse_tool_calls(response: &str) -> (String, Vec<ParsedToolCall>) {
     (text_parts.join("\n"), calls)
 }
 
+/// Strip prompt-guided tool artifacts from visible output while preserving
+/// raw model text in history for future turns.
+fn strip_tool_result_blocks(text: &str) -> String {
+    static TOOL_RESULT_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?s)<tool_result[^>]*>.*?</tool_result>").unwrap());
+    static THINKING_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?s)<thinking>.*?</thinking>").unwrap());
+    static TOOL_RESULTS_PREFIX_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?m)^\[Tool results\]\s*\n?").unwrap());
+    static EXCESS_BLANK_LINES_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\n{3,}").unwrap());
+
+    let result = TOOL_RESULT_RE.replace_all(text, "");
+    let result = THINKING_RE.replace_all(&result, "");
+    let result = TOOL_RESULTS_PREFIX_RE.replace_all(&result, "");
+    let result = EXCESS_BLANK_LINES_RE.replace_all(result.trim(), "\n\n");
+
+    result.trim().to_string()
+}
+
 fn detect_tool_call_parse_issue(response: &str, parsed_calls: &[ParsedToolCall]) -> Option<String> {
     if !parsed_calls.is_empty() {
         return None;
@@ -2320,6 +2340,7 @@ pub(crate) async fn run_tool_call_loop(
         } else {
             parsed_text
         };
+        let display_text = strip_tool_result_blocks(&display_text);
 
         // ── Progress: LLM responded ─────────────────────────────
         if let Some(ref tx) = on_delta {
@@ -4773,6 +4794,52 @@ Done."#;
         let (text, calls) = parse_tool_calls(response);
         assert!(text.contains("Done."));
         assert!(calls.is_empty());
+    }
+
+    #[test]
+    fn strip_tool_result_blocks_removes_single_block() {
+        let input = r#"<tool_result name="memory_recall" status="ok">
+{"matches":["hello"]}
+</tool_result>
+Here is my answer."#;
+        assert_eq!(strip_tool_result_blocks(input), "Here is my answer.");
+    }
+
+    #[test]
+    fn strip_tool_result_blocks_removes_multiple_blocks() {
+        let input = r#"<tool_result name="memory_recall" status="ok">
+{"matches":[]}
+</tool_result>
+<tool_result name="shell" status="ok">
+done
+</tool_result>
+Final answer."#;
+        assert_eq!(strip_tool_result_blocks(input), "Final answer.");
+    }
+
+    #[test]
+    fn strip_tool_result_blocks_removes_prefix() {
+        let input =
+            "[Tool results]\n<tool_result name=\"shell\" status=\"ok\">\nok\n</tool_result>\nDone.";
+        assert_eq!(strip_tool_result_blocks(input), "Done.");
+    }
+
+    #[test]
+    fn strip_tool_result_blocks_removes_thinking() {
+        let input = "<thinking>\nLet me think...\n</thinking>\nHere is the answer.";
+        assert_eq!(strip_tool_result_blocks(input), "Here is the answer.");
+    }
+
+    #[test]
+    fn strip_tool_result_blocks_preserves_clean_text() {
+        let input = "Hello, this is a normal response.";
+        assert_eq!(strip_tool_result_blocks(input), input);
+    }
+
+    #[test]
+    fn strip_tool_result_blocks_returns_empty_for_only_tags() {
+        let input = "<tool_result name=\"memory_recall\" status=\"ok\">\n{}\n</tool_result>";
+        assert_eq!(strip_tool_result_blocks(input), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Prompt-guided providers can echo `<tool_result>` and `<thinking>` blocks back into the assistant text shown to users.
- Why it matters: Channel users can see internal tool/result artifacts instead of a clean reply.
- What changed: Strip prompt-guided tool artifacts from visible `display_text` only and add regression tests for the cleanup cases.
- What did **not** change (scope boundary): Raw provider response history is unchanged; tool parsing and history persistence behavior stay the same.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `agent,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `agent: loop`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `auto-managed`
- If any auto-label is incorrect, note requested correction: `N/A`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `runtime`

## Linked Issue

- Closes #: `N/A`
- Related #: `N/A`
- Depends on # (if stacked): `N/A`
- Supersedes # (if replacing older PR): `N/A`

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Integrated scope by source PR (what was materially carried forward): `N/A`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): `Direct code was reimplemented on current master layout without copying prior branch commits.`
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): `Added 6 regression tests for visible reply cleanup; all commands passed locally.`
- If any command is intentionally skipped, explain why: `None`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: `N/A`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: `No new user data persisted; visible output cleanup only.`
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): `Confirmed`

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N/A`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `N/A`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N/A`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N/A`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: `No docs or user-facing copy contract changed.`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `Visible reply text now strips echoed <tool_result> blocks, [Tool results] prefixes, and <thinking> blocks while preserving clean text.`
- Edge cases checked: `Single block, multiple blocks, only-tag payloads, prefix-only cases, and clean replies.`
- What was not verified: `Manual live-channel reproduction against an external provider was not performed.`

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `Agent visible reply rendering across channel and CLI paths that consume display_text.`
- Potential unintended effects: `Literal user-visible strings matching these internal tags will be hidden from final display.`
- Guardrails/monitoring for early detection: `Raw response history remains unchanged, and new regression tests cover the stripping rules.`

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `Codex terminal tools, git, gh`
- Workflow/plan summary (if any): `Reimplemented the fix on latest master layout, added regression tests, and validated with repo-standard commands.`
- Verification focus: `Visible-output cleanup without altering stored raw history.`
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Confirmed`

## Rollback Plan (required)

- Fast rollback command/path: `git revert 1c2a4945`
- Feature flags or config toggles (if any): `None`
- Observable failure symptoms: `Users would again see echoed tool-result/thinking artifacts in replies.`

## Risks and Mitigations

- Risk: Legitimate literal `<thinking>` or `<tool_result>` content in a final reply could be removed from visible output.
  - Mitigation: Scope is limited to visible `display_text`; raw response history is preserved, and tests document the intended stripping behavior.
