### PR TITLE
fix(channels): pass embedding routes to channel memory init

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3104,8 +3104,9 @@ pub async fn start_channels(config: Config) -> Result<()> {
     ));
     let model = resolved_default_model(&config);
     let temperature = config.default_temperature;
-    let mem: Arc<dyn Memory> = Arc::from(memory::create_memory_with_storage(
+    let mem: Arc<dyn Memory> = Arc::from(memory::create_memory_with_storage_and_routes(
         &config.memory,
+        &config.embedding_routes,
         Some(&config.storage.provider.config),
         &config.workspace_dir,
         config.api_key.as_deref(),


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Channel startup initializes memory without forwarding `embedding_routes`, unlike the main agent startup path.
- Why it matters: Channel-triggered memory recall can miss route-specific embedding provider/model/API-key selection and fall back to the wrong embedding config.
- What changed: Switched `start_channels()` to use the route-aware memory factory and pass `config.embedding_routes` through.
- What did **not** change (scope boundary): No memory backend logic, route resolution logic, or config schema behavior changed.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel,memory`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `channel: startup`, `memory: routing`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `auto-managed`
- If any auto-label is incorrect, note requested correction: `N/A`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #: `N/A`
- Related #: `N/A`
- Depends on # (if stacked): `N/A`
- Supersedes # (if replacing older PR): `N/A`

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Integrated scope by source PR (what was materially carried forward): `N/A`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): `The fix was re-applied directly on latest master without copying prior branch commits.`
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): `Repo-standard validation passed locally after aligning channel startup with the existing route-aware memory factory.`
- If any command is intentionally skipped, explain why: `None`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: `N/A`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: `No new persisted fields or user data handling changes.`
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): `Confirmed`

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N/A`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `N/A`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N/A`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N/A`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: `No docs changed.`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `Channel startup now uses the same route-aware memory factory already used by the main agent startup path.`
- Edge cases checked: `No-regression verification via full fmt/clippy/test on latest master.`
- What was not verified: `A live channel message exercising a route like hint:semantic was not replayed manually against an external provider.`

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `Channel startup memory wiring and any channel-driven memory recall that depends on embedding route selection.`
- Potential unintended effects: `Channels now honor route-specific embedding provider/model selection where they previously ignored it.`
- Guardrails/monitoring for early detection: `The change reuses the existing route-aware factory already exercised by agent startup and covered by full-suite validation.`

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `Codex terminal tools, git, gh`
- Workflow/plan summary (if any): `Aligned channel startup memory wiring with agent startup on latest master, then ran repo-standard validation.`
- Verification focus: `Wiring consistency between channel startup and the existing memory route resolution path.`
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Confirmed`

## Rollback Plan (required)

- Fast rollback command/path: `git revert 7cacdef2`
- Feature flags or config toggles (if any): `None`
- Observable failure symptoms: `Channel-triggered memory recall would again ignore embedding route overrides and may fall back to the wrong embedding config.`

## Risks and Mitigations

- Risk: Channel sessions that rely on implicit fallback behavior may now pick the route-specific embedding provider/model/API key instead.
  - Mitigation: This matches the existing agent startup path and is the intended configured behavior for `embedding_routes`.
