### PR TITLE
ci(release): pin GNU Linux release runners back to Ubuntu 22.04

### DIFF
--- a/.github/workflows/pub-release.yml
+++ b/.github/workflows/pub-release.yml
@@ -202,7 +202,7 @@ jobs:
                 include:
                     # Keep GNU Linux release artifacts on Ubuntu 22.04 to preserve
                     # a broadly compatible GLIBC baseline for user distributions.
-                    - os: ubuntu-22.04
+                    - os: [self-hosted, Linux, X64, blacksmith-2vcpu-ubuntu-2204]
                       target: x86_64-unknown-linux-gnu
                       artifact: zeroclaw
                       archive_ext: tar.gz
@@ -217,7 +217,7 @@ jobs:
                       linker_env: ""
                       linker: ""
                       use_cross: true
-                    - os: ubuntu-22.04
+                    - os: [self-hosted, Linux, X64, blacksmith-2vcpu-ubuntu-2204]
                       target: aarch64-unknown-linux-gnu
                       artifact: zeroclaw
                       archive_ext: tar.gz
@@ -232,7 +232,7 @@ jobs:
                       linker_env: ""
                       linker: ""
                       use_cross: true
-                    - os: ubuntu-22.04
+                    - os: [self-hosted, Linux, X64, blacksmith-2vcpu-ubuntu-2204]
                       target: armv7-unknown-linux-gnueabihf
                       artifact: zeroclaw
                       archive_ext: tar.gz


### PR DESCRIPTION
## Summary

- Base branch target (`main` by default; use `dev` only when maintainers explicitly request integration batching): `dev` to preserve the existing contributor lane for this supersede replay.
- Problem: PR #3128 is conflicted against current `dev` because the same GNU release-matrix rows changed underneath it.
- Why it matters: the conflicted PR cannot merge, but the original intent to keep GNU Linux release builds on Ubuntu 22.04-era infrastructure still needs a clean review path.
- What changed: switched the three GNU release targets in `.github/workflows/pub-release.yml` from plain `ubuntu-22.04` back to `blacksmith-2vcpu-ubuntu-2204`.
- What did **not** change (scope boundary): no other workflow jobs, non-GNU targets, release logic, scripts, or Rust code changed.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high` (workflow file touched)
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `ci`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `N/A`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `distinguished contributor` (expected auto-label)
- If any auto-label is incorrect, note requested correction: `N/A`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `ci`

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Existing overlapping PR(s) reviewed for this issue (list `#<pr> by @<author>` or `N/A`): `#3128 by @theonlyhennygod`
- Supersedes # (if replacing older PR): `#3128`
- Linear issue key(s) (required, e.g. `RMN-123`): `N/A - local Linear auth unavailable in this environment`
- Linear issue URL(s): `N/A`

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `#3128 by @theonlyhennygod`
- Integrated scope by source PR (what was materially carried forward): `Reapplied the exact three runner-label changes for GNU Linux release targets onto current dev.`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): `Same contributor account authored both the original conflicted PR and this replacement PR.`
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
git diff --check
python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path(.github/workflows/pub-release.yml).read_text())"
```

- Evidence provided (test/log/trace/screenshot/perf): `Local diff hygiene check and YAML parse succeeded.`
- If any command is intentionally skipped, explain why: `Cargo/clippy/test were skipped because this PR only changes one GitHub Actions workflow matrix and does not touch Rust sources.`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: `N/A`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: `No user or secret data added.`
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): `Confirmed.`

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N/A`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `N/A`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N/A`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N/A`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: `Workflow-only change; no user-facing docs or strings changed.`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `Only the x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, and armv7-unknown-linux-gnueabihf entries switched to Blacksmith Ubuntu 22.04 labels.`
- Edge cases checked: `The musl, Android, FreeBSD, macOS, and Windows matrix rows stayed unchanged.`
- What was not verified: `A live GitHub Actions run has not completed yet on this replacement branch.`

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `Pub Release workflow GNU Linux artifact jobs.`
- Potential unintended effects: `If Blacksmith Ubuntu 22.04 capacity or labels are unavailable, those three release jobs would queue or fail.`
- Guardrails/monitoring for early detection: `Review the workflow run on the replacement PR and confirm the three GNU targets pick the intended runner labels.`

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `gh`, `git`, `apply_patch`
- Workflow/plan summary (if any): `Compared current dev vs conflicted PR #3128, recreated the intended runner-pin change on a fresh branch from origin/dev, and superseded the conflicted PR.`
- Verification focus: `Conflict-free replay of the intended matrix-only change.`
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Confirmed.`

## Rollback Plan (required)

- Fast rollback command/path: `Revert this PR commit or restore the three GNU matrix rows in .github/workflows/pub-release.yml back to their prior labels.`
- Feature flags or config toggles (if any): `None`
- Observable failure symptoms: `GNU Linux release jobs run on the wrong runner image or fail due to runner-label mismatch.`

## Risks and Mitigations

- Risk: The repository may have intentionally moved those three GNU jobs away from Blacksmith since #3128 was opened.
- Mitigation: This PR is constrained to the three original rows only, clearly documents the replay rationale, and keeps the live workflow run as the merge gate.
