### PR TITLE
feat(matrix): add pin and unpin message support

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -684,6 +684,129 @@ impl Channel for MatrixChannel {
 
         self.matrix_client().await.is_ok()
     }
+
+    async fn pin_message(
+        &self,
+        _channel_id: &str,
+        message_id: &str,
+    ) -> anyhow::Result<()> {
+        let room_id = self.target_room_id().await?;
+        let encoded_room = Self::encode_path_segment(&room_id);
+
+        let url = format!(
+            "{}/_matrix/client/v3/rooms/{}/state/m.room.pinned_events",
+            self.homeserver, encoded_room
+        );
+        let resp = self
+            .http_client
+            .get(&url)
+            .header("Authorization", self.auth_header_value())
+            .send()
+            .await?;
+
+        let mut pinned: Vec<String> = if resp.status().is_success() {
+            let body: serde_json::Value = resp.json().await?;
+            body.get("pinned")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+
+        let msg_id = message_id.to_string();
+        if pinned.contains(&msg_id) {
+            return Ok(());
+        }
+        pinned.push(msg_id);
+
+        let put_url = format!(
+            "{}/_matrix/client/v3/rooms/{}/state/m.room.pinned_events",
+            self.homeserver, encoded_room
+        );
+        let body = serde_json::json!({ "pinned": pinned });
+        let resp = self
+            .http_client
+            .put(&put_url)
+            .header("Authorization", self.auth_header_value())
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let err = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Matrix pin_message failed: {err}");
+        }
+
+        Ok(())
+    }
+
+    async fn unpin_message(
+        &self,
+        _channel_id: &str,
+        message_id: &str,
+    ) -> anyhow::Result<()> {
+        let room_id = self.target_room_id().await?;
+        let encoded_room = Self::encode_path_segment(&room_id);
+
+        let url = format!(
+            "{}/_matrix/client/v3/rooms/{}/state/m.room.pinned_events",
+            self.homeserver, encoded_room
+        );
+        let resp = self
+            .http_client
+            .get(&url)
+            .header("Authorization", self.auth_header_value())
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            return Ok(());
+        }
+
+        let body: serde_json::Value = resp.json().await?;
+        let mut pinned: Vec<String> = body
+            .get("pinned")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let msg_id = message_id.to_string();
+        let original_len = pinned.len();
+        pinned.retain(|id| id != &msg_id);
+
+        if pinned.len() == original_len {
+            return Ok(());
+        }
+
+        let put_url = format!(
+            "{}/_matrix/client/v3/rooms/{}/state/m.room.pinned_events",
+            self.homeserver, encoded_room
+        );
+        let body = serde_json::json!({ "pinned": pinned });
+        let resp = self
+            .http_client
+            .put(&put_url)
+            .header("Authorization", self.auth_header_value())
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let err = resp.text().await.unwrap_or_default();
+            anyhow::bail!("Matrix unpin_message failed: {err}");
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/channels/traits.rs
+++ b/src/channels/traits.rs
@@ -142,6 +142,24 @@ pub trait Channel: Send + Sync {
     ) -> anyhow::Result<()> {
         Ok(())
     }
+
+    /// Pin a message in the channel.
+    async fn pin_message(
+        &self,
+        _channel_id: &str,
+        _message_id: &str,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    /// Unpin a previously pinned message.
+    async fn unpin_message(
+        &self,
+        _channel_id: &str,
+        _message_id: &str,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add `pin_message` and `unpin_message` methods to the `Channel` trait with default no-op implementations
- Implement Matrix-specific pin/unpin using the `m.room.pinned_events` state event (GET current pins, append/remove, PUT updated list)
- Idempotent: pinning an already-pinned message or unpinning a non-pinned message is a no-op

## Test plan
- [ ] Verify `cargo build` succeeds with no new warnings
- [ ] Verify `cargo test` passes (existing trait tests cover default no-op methods)
- [ ] Deploy to a test Matrix room and confirm `pin_message` adds the event ID to `m.room.pinned_events`
- [ ] Confirm `unpin_message` removes the event ID from the pinned list
- [ ] Confirm pinning an already-pinned message does not duplicate the entry
- [ ] Confirm unpinning a non-pinned message returns Ok without error