### PR TITLE
feat(matrix): add multi-room support

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -530,7 +530,11 @@ impl Channel for MatrixChannel {
 
     async fn send(&self, message: &SendMessage) -> anyhow::Result<()> {
         let client = self.matrix_client().await?;
-        let target_room_id = self.target_room_id().await?;
+        let target_room_id = if message.recipient.contains("||") {
+            message.recipient.splitn(2, "||").nth(1).unwrap().to_string()
+        } else {
+            self.target_room_id().await?
+        };
         let target_room: OwnedRoomId = target_room_id.parse()?;
 
         let mut room = client.get_room(&target_room);
@@ -602,7 +606,7 @@ impl Channel for MatrixChannel {
             let dedupe = Arc::clone(&dedupe_for_handler);
 
             async move {
-                if room.room_id().as_str() != target_room.as_str() {
+                if false /* multi-room: room_id filter disabled */ {
                     return;
                 }
 
@@ -637,9 +641,9 @@ impl Channel for MatrixChannel {
                 let msg = ChannelMessage {
                     id: event_id,
                     sender: sender.clone(),
-                    reply_target: sender,
+                    reply_target: format!("{}||{}", sender, room.room_id()),
                     content: body,
-                    channel: "matrix".to_string(),
+                    channel: format!("matrix:{}", room.room_id()),
                     timestamp: std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap_or_default()


### PR DESCRIPTION
## Summary
- Disable the room_id filter in `listen()` so messages from all joined rooms are processed
- Embed room_id in `reply_target` as `user||room_id` for routing replies back to the correct room
- Include room_id in the `channel` field (e.g. `matrix:\!room_id`) for per-room conversation isolation
- Extract room_id from recipient in `send()` for correct message routing; falls back to configured room_id for direct sends

## Details
This enables a single Matrix bot instance to respond in multiple rooms without needing separate channel configurations per room. The configured `room_id` still serves as a fallback when the recipient does not contain a `||` separator.

## Test plan
- [ ] Bot responds to messages in the configured primary room
- [ ] Bot responds to messages in other joined rooms
- [ ] Replies are routed to the correct room (not the configured default)
- [ ] Conversation history is isolated per room via the channel field
- [ ] Direct sends without `||` in recipient still use the configured room

🤖 Generated with [Claude Code](https://claude.com/claude-code)