### PR TITLE
fix(gateway): add health and pairing proxy routes to vite dev server

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,6 +16,14 @@ export default defineConfig({
   },
   server: {
     proxy: {
+      "/health": {
+        target: "http://localhost:5555",
+        changeOrigin: true,
+      },
+      "/pair": {
+        target: "http://localhost:5555",
+        changeOrigin: true,
+      },
       "/api": {
         target: "http://localhost:5555",
         changeOrigin: true,


### PR DESCRIPTION
## Summary
- Replaces #3056 — only the vite.config.ts proxy fix, without committed dist artifacts
- Adds `/health` and `/pair` proxy routes to the vite dev server config so local dev correctly proxies these endpoints to the backend

## Test plan
- [x] Vite config syntax is valid
- [x] No dist artifacts included