### PR TITLE
fix(config): add channel secrets roundtrip test and gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,9 @@ credentials.json
 # Skill eval workspaces (test outputs, transcripts, grading)
 .claude/skills/*-workspace/
 
+# Local state backups
+.local-state-backups/
+*.local-state-backup/
+
 # Coverage artifacts
 lcov.info

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -8207,6 +8207,74 @@ require_otp_to_resume = true
         assert!(err.to_string().contains("gated_domains"));
     }
 
+    #[tokio::test]
+    async fn channel_secret_telegram_bot_token_roundtrip() {
+        let dir = std::env::temp_dir().join(format!(
+            "zeroclaw_test_tg_bot_token_{}",
+            uuid::Uuid::new_v4()
+        ));
+        fs::create_dir_all(&dir).await.unwrap();
+
+        let plaintext_token = "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11";
+
+        let mut config = Config::default();
+        config.workspace_dir = dir.join("workspace");
+        config.config_path = dir.join("config.toml");
+        config.channels_config.telegram = Some(TelegramConfig {
+            bot_token: plaintext_token.into(),
+            allowed_users: vec!["user1".into()],
+            stream_mode: StreamMode::default(),
+            draft_update_interval_ms: default_draft_update_interval_ms(),
+            interrupt_on_new_message: false,
+            mention_only: false,
+        });
+
+        // Save (triggers encryption)
+        config.save().await.unwrap();
+
+        // Read raw TOML and verify plaintext token is NOT present
+        let raw_toml = tokio::fs::read_to_string(&config.config_path)
+            .await
+            .unwrap();
+        assert!(
+            !raw_toml.contains(plaintext_token),
+            "Saved TOML must not contain the plaintext bot_token"
+        );
+
+        // Parse stored TOML and verify the value is encrypted
+        let stored: Config = toml::from_str(&raw_toml).unwrap();
+        let stored_token = &stored.channels_config.telegram.as_ref().unwrap().bot_token;
+        assert!(
+            crate::security::SecretStore::is_encrypted(stored_token),
+            "Stored bot_token must be marked as encrypted"
+        );
+
+        // Decrypt and verify it matches the original plaintext
+        let store = crate::security::SecretStore::new(&dir, true);
+        assert_eq!(store.decrypt(stored_token).unwrap(), plaintext_token);
+
+        // Simulate a full load: deserialize then decrypt (mirrors load_or_init logic)
+        let mut loaded: Config = toml::from_str(&raw_toml).unwrap();
+        loaded.config_path = dir.join("config.toml");
+        let load_store =
+            crate::security::SecretStore::new(&dir, loaded.secrets.encrypt);
+        if let Some(ref mut tg) = loaded.channels_config.telegram {
+            decrypt_secret(
+                &load_store,
+                &mut tg.bot_token,
+                "config.channels_config.telegram.bot_token",
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            loaded.channels_config.telegram.as_ref().unwrap().bot_token,
+            plaintext_token,
+            "Loaded bot_token must match the original plaintext after decryption"
+        );
+
+        let _ = fs::remove_dir_all(&dir).await;
+    }
+
     #[test]
     async fn security_validation_rejects_unknown_domain_category() {
         let mut config = Config::default();


### PR DESCRIPTION
## Summary
- Add `channel_secret_telegram_bot_token_roundtrip` test verifying that Telegram `bot_token` is encrypted on save and decrypted on load (validates fix from #3217)
- Add `.local-state-backups/` to `.gitignore` to prevent accidental commit of backup files

## Issues
Closes #3126

## Test plan
- [x] `cargo check` passes
- [x] `cargo test -- channel_secret_telegram_bot_token_roundtrip` passes
- [x] `.gitignore` correctly excludes `.local-state-backups/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)