### PR TITLE
fix(telegram): avoid duplicate finalize_draft messages

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -315,6 +315,13 @@ pub struct TelegramChannel {
     workspace_dir: Option<std::path::PathBuf>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EditMessageResult {
+    Success,
+    NotModified,
+    Failed(reqwest::StatusCode),
+}
+
 impl TelegramChannel {
     pub fn new(bot_token: String, allowed_users: Vec<String>, mention_only: bool) -> Self {
         let normalized_allowed = Self::normalize_allowed_users(allowed_users);
@@ -519,6 +526,20 @@ impl TelegramChannel {
 
     fn api_url(&self, method: &str) -> String {
         format!("{}/bot{}/{method}", self.api_base, self.bot_token)
+    }
+
+    async fn classify_edit_message_response(resp: reqwest::Response) -> EditMessageResult {
+        if resp.status().is_success() {
+            return EditMessageResult::Success;
+        }
+
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if body.contains("message is not modified") {
+            return EditMessageResult::NotModified;
+        }
+
+        EditMessageResult::Failed(status)
     }
 
     async fn fetch_bot_username(&self) -> anyhow::Result<String> {
@@ -2355,11 +2376,17 @@ impl Channel for TelegramChannel {
             .send()
             .await?;
 
-        if resp.status().is_success() {
-            return Ok(());
+        match Self::classify_edit_message_response(resp).await {
+            EditMessageResult::Success | EditMessageResult::NotModified => return Ok(()),
+            EditMessageResult::Failed(status) => {
+                tracing::debug!(
+                    status = ?status,
+                    "Telegram finalize_draft HTML edit failed; retrying without parse_mode"
+                );
+            }
         }
 
-        // Markdown failed — retry without parse_mode
+        // HTML failed — retry without parse_mode
         let plain_body = serde_json::json!({
             "chat_id": chat_id,
             "message_id": id,
@@ -2373,14 +2400,45 @@ impl Channel for TelegramChannel {
             .send()
             .await?;
 
-        if resp.status().is_success() {
-            return Ok(());
+        match Self::classify_edit_message_response(resp).await {
+            EditMessageResult::Success | EditMessageResult::NotModified => return Ok(()),
+            EditMessageResult::Failed(status) => {
+                tracing::warn!(
+                    status = ?status,
+                    "Telegram finalize_draft plain edit failed; attempting delete+send fallback"
+                );
+            }
         }
 
-        // Edit failed entirely — fall back to new message
-        tracing::warn!("Telegram finalize_draft edit failed; falling back to sendMessage");
-        self.send_text_chunks(text, &chat_id, thread_id.as_deref())
-            .await
+        let delete_resp = self
+            .client
+            .post(self.api_url("deleteMessage"))
+            .json(&serde_json::json!({
+                "chat_id": chat_id,
+                "message_id": id,
+            }))
+            .send()
+            .await;
+
+        match delete_resp {
+            Ok(resp) if resp.status().is_success() => {
+                self.send_text_chunks(text, &chat_id, thread_id.as_deref())
+                    .await
+            }
+            Ok(resp) => {
+                tracing::warn!(
+                    status = ?resp.status(),
+                    "Telegram finalize_draft delete failed; skipping sendMessage to avoid duplicate"
+                );
+                Ok(())
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "Telegram finalize_draft delete request failed: {err}; skipping sendMessage to avoid duplicate"
+                );
+                Ok(())
+            }
+        }
     }
 
     async fn cancel_draft(&self, recipient: &str, message_id: &str) -> anyhow::Result<()> {

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -5,3 +5,4 @@ mod hooks;
 mod memory_comparison;
 mod memory_restart;
 mod telegram_attachment_fallback;
+mod telegram_finalize_draft;

--- a/tests/integration/telegram_finalize_draft.rs
+++ b/tests/integration/telegram_finalize_draft.rs
@@ -1,0 +1,208 @@
+use serde_json::json;
+use wiremock::matchers::{body_partial_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use zeroclaw::channels::telegram::TelegramChannel;
+use zeroclaw::channels::traits::Channel;
+
+fn test_channel(mock_url: &str) -> TelegramChannel {
+    TelegramChannel::new("TEST_TOKEN".into(), vec!["*".into()], false)
+        .with_api_base(mock_url.to_string())
+}
+
+fn telegram_ok_response(message_id: i64) -> serde_json::Value {
+    json!({
+        "ok": true,
+        "result": {
+            "message_id": message_id,
+            "chat": {"id": 123},
+            "text": "ok"
+        }
+    })
+}
+
+fn telegram_error_response(description: &str) -> serde_json::Value {
+    json!({
+        "ok": false,
+        "error_code": 400,
+        "description": description,
+    })
+}
+
+#[tokio::test]
+async fn finalize_draft_treats_not_modified_as_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/botTEST_TOKEN/editMessageText"))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_json(telegram_error_response(
+                "Bad Request: message is not modified",
+            )),
+        )
+        .mount(&server)
+        .await;
+
+    let channel = test_channel(&server.uri());
+    let result = channel.finalize_draft("123", "42", "final text").await;
+
+    assert!(
+        result.is_ok(),
+        "not modified should be treated as success, got: {result:?}"
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("requests should be captured");
+    assert_eq!(requests.len(), 1, "should stop after first edit response");
+    assert_eq!(requests[0].url.path(), "/botTEST_TOKEN/editMessageText");
+}
+
+#[tokio::test]
+async fn finalize_draft_plain_retry_treats_not_modified_as_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/botTEST_TOKEN/editMessageText"))
+        .and(body_partial_json(json!({
+            "chat_id": "123",
+            "message_id": 42,
+            "parse_mode": "HTML",
+        })))
+        .respond_with(
+            ResponseTemplate::new(400)
+                .set_body_json(telegram_error_response("Bad Request: can't parse entities")),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/botTEST_TOKEN/editMessageText"))
+        .and(body_partial_json(json!({
+            "chat_id": "123",
+            "message_id": 42,
+            "text": "Use **bold**",
+        })))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_json(telegram_error_response(
+                "Bad Request: message is not modified",
+            )),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let channel = test_channel(&server.uri());
+    let result = channel.finalize_draft("123", "42", "Use **bold**").await;
+
+    assert!(
+        result.is_ok(),
+        "plain retry should accept not modified, got: {result:?}"
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("requests should be captured");
+    assert_eq!(requests.len(), 2, "should only attempt the two edit calls");
+}
+
+#[tokio::test]
+async fn finalize_draft_skips_send_message_when_delete_fails() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/botTEST_TOKEN/editMessageText"))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_json(telegram_error_response(
+                "Bad Request: message cannot be edited",
+            )),
+        )
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/botTEST_TOKEN/deleteMessage"))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_json(telegram_error_response(
+                "Bad Request: message to delete not found",
+            )),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let channel = test_channel(&server.uri());
+    let result = channel.finalize_draft("123", "42", "final text").await;
+
+    assert!(
+        result.is_ok(),
+        "delete failure should skip sendMessage instead of erroring, got: {result:?}"
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("requests should be captured");
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|req| req.url.path() == "/botTEST_TOKEN/sendMessage")
+            .count(),
+        0,
+        "sendMessage should be skipped when deleteMessage fails"
+    );
+}
+
+#[tokio::test]
+async fn finalize_draft_sends_fresh_message_after_successful_delete() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/botTEST_TOKEN/editMessageText"))
+        .respond_with(
+            ResponseTemplate::new(400).set_body_json(telegram_error_response(
+                "Bad Request: message cannot be edited",
+            )),
+        )
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/botTEST_TOKEN/deleteMessage"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(telegram_ok_response(42)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/botTEST_TOKEN/sendMessage"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(telegram_ok_response(43)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let channel = test_channel(&server.uri());
+    let result = channel.finalize_draft("123", "42", "final text").await;
+
+    assert!(
+        result.is_ok(),
+        "successful delete should allow safe sendMessage fallback, got: {result:?}"
+    );
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("requests should be captured");
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|req| req.url.path() == "/botTEST_TOKEN/sendMessage")
+            .count(),
+        1,
+        "sendMessage should be attempted exactly once after delete succeeds"
+    );
+}


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: `TelegramChannel::finalize_draft()` on current `upstream/master` falls back to `sendMessage` after edit failures without treating `message is not modified` as success and without gating the fallback on draft deletion.
- Why it matters: Telegram users can see duplicate final responses when the draft already contains the final text or when the fallback path sends a new message while the draft is still visible.
- What changed: Added explicit `editMessageText` outcome classification, treated `message is not modified` as success on both edit attempts, guarded the final fallback behind a successful `deleteMessage`, and added `wiremock` regression tests for the duplicate-message paths.
- What did **not** change (scope boundary): No changes to `update_draft()`, `send_text_chunks()`, config/schema, or any non-Telegram channel behavior.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `channel: telegram`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `auto-managed/read-only`
- If any auto-label is incorrect, note requested correction: `None`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #
- Related #1694 (historical PR with similar intent; current `master` still lacks this behavior)
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N.A.`
- Integrated scope by source PR (what was materially carried forward): `N.A.`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `N.A.`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): `N.A.`
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `N.A.`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): `All commands passed on the rebased branch. cargo test passed with 3398 tests passed, 0 failed, 9 ignored. Added wiremock regression coverage for Telegram finalize_draft duplicate-message paths.`
- If any command is intentionally skipped, explain why: `None`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: `N.A.`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: `The new path does not add raw Telegram response-body logging; it only classifies the edit response and logs HTTP status or request errors.`
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): `Yes`

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N.A.`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `N.A.`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N.A.`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N.A.`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: `Code-only change; no user-facing docs or runtime wording changed.`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `Mocked Telegram finalize_draft flow where HTML edit returns message-is-not-modified, plain retry returns message-is-not-modified, deleteMessage fails, and deleteMessage succeeds before fallback sendMessage.`
- Edge cases checked: `Draft already contains the final text; delete failure avoids sending a duplicate; delete success still allows safe fallback delivery.`
- What was not verified: `Live Telegram Bot API behavior against a real bot/chat.`

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `Telegram draft finalization only.`
- Potential unintended effects: `If both edit attempts fail and deleteMessage also fails, the new behavior prefers skipping sendMessage to avoid duplicates, which can suppress a final send in that rare path.`
- Guardrails/monitoring for early detection: `Regression tests cover both safe-fallback and skip-send paths; warning logs are emitted for plain edit failure and delete failure.`

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `Codex terminal tools (exec_command, apply_patch)`
- Workflow/plan summary (if any): `Verified current upstream/master still had the bug, implemented a Telegram-only fix, added wiremock regression tests, rebased onto latest upstream/master, and reran full validation.`
- Verification focus: `Duplicate-message prevention and safe fallback behavior in finalize_draft.`
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: `git revert 4e1f9926`
- Feature flags or config toggles (if any): `None`
- Observable failure symptoms: `Telegram draft finalization either reintroduces duplicate messages or stops delivering a fallback message after edit failures.`

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: `Telegram may change the exact "message is not modified" error text in the future.`
  - Mitigation: `The behavior is isolated to finalize_draft, warning logs remain in place for the failure path, and the regression tests document the expected Bot API contract.`
- Risk: `Skipping sendMessage when deleteMessage fails can drop a final fallback message in a rare double-failure path.`
  - Mitigation: `That path already indicates Telegram-side edit/delete failures after prior draft updates; preferring skip-send avoids the more visible duplicate-message regression, and the behavior is covered by regression tests.`
