### PR TITLE
fix(channels): skip tools summary for native tools

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -5522,9 +5522,8 @@ Let me check the result."#;
     }
 
     /// When `build_system_prompt_with_mode` is called with `native_tools = true`,
-    /// the output must contain ZERO XML protocol artifacts. In the native path
-    /// `build_tool_instructions` is never called, so the system prompt alone
-    /// must be clean of XML tool-call protocol.
+    /// the output must contain ZERO XML protocol artifacts and must not inject
+    /// the duplicate non-native tools summary.
     #[test]
     fn native_tools_system_prompt_contains_zero_xml() {
         use crate::channels::build_system_prompt_with_mode;
@@ -5567,10 +5566,10 @@ Let me check the result."#;
             "Native prompt must not contain XML protocol header"
         );
 
-        // Positive: native prompt should still list tools and contain task instructions
+        // Positive: native prompt should still contain the native-task framing.
         assert!(
-            system_prompt.contains("shell"),
-            "Native prompt must list tool names"
+            !system_prompt.contains("## Tools"),
+            "Native prompt should skip the duplicate tools summary"
         );
         assert!(
             system_prompt.contains("## Your Task"),

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2438,7 +2438,7 @@ pub fn build_system_prompt_with_mode(
     let mut prompt = String::with_capacity(8192);
 
     // ── 1. Tooling ──────────────────────────────────────────────
-    if !tools.is_empty() {
+    if !tools.is_empty() && !native_tools {
         prompt.push_str("## Tools\n\n");
         prompt.push_str("You have access to the following tools:\n\n");
         for (name, desc) in tools {
@@ -5496,6 +5496,32 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(prompt.contains("**shell**"));
         assert!(prompt.contains("Run commands"));
         assert!(prompt.contains("**memory_recall**"));
+    }
+
+    #[test]
+    fn prompt_skips_tools_summary_when_native_tools_enabled() {
+        let ws = make_workspace();
+        let tools = vec![
+            ("shell", "Run commands"),
+            ("memory_recall", "Search memory"),
+        ];
+        let prompt = build_system_prompt_with_mode(
+            ws.path(),
+            "gpt-4o",
+            &tools,
+            &[],
+            None,
+            None,
+            true,
+            crate::config::SkillsPromptInjectionMode::Full,
+        );
+
+        assert!(
+            !prompt.contains("## Tools"),
+            "native tools mode should skip the duplicate tools summary"
+        );
+        assert!(prompt.contains("## Safety"));
+        assert!(prompt.contains("## Workspace"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: `build_system_prompt_with_mode` still injects the `## Tools` summary when `native_tools = true`, even though native-tool providers do not use the XML tool protocol prompt.
- Why it matters: This duplicates tool information, wastes prompt tokens, and lightly pollutes the native-tools system prompt without adding execution behavior.
- What changed: Skipped the `## Tools` block when `native_tools = true`; added a prompt regression test in `src/channels/mod.rs`; updated the native-tools prompt test in `src/agent/loop_.rs` to assert the new no-duplicate-summary behavior while still checking that XML protocol text stays absent.
- What did **not** change (scope boundary): No changes to non-native prompts, native tool specs, channel routing, or tool execution behavior.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel,agent,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `channel: prompt`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `auto-managed/read-only`
- If any auto-label is incorrect, note requested correction: `None`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N.A.`
- Integrated scope by source PR (what was materially carried forward): `N.A.`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `N.A.`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): `N.A.`
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `N.A.`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): `All commands passed on a fresh branch from upstream/master. Added a new prompt regression test for native-tools mode and updated the existing native-tools prompt assertion in agent loop tests to match the new behavior.`
- If any command is intentionally skipped, explain why: `None`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: `N.A.`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: `Prompt content is reduced in native-tools mode; no new logging or data surfaces were added.`
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): `Yes`

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N.A.`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `N.A.`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N.A.`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N.A.`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: `Code-only change.`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `Native-tools prompt generation no longer emits the duplicate `## Tools` section; non-native prompts still retain the tools summary.`
- Edge cases checked: `The native-tools prompt remains free of XML tool protocol markers and still keeps the `## Your Task` section.`
- What was not verified: `Live prompt/token deltas against production providers.`

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `System prompt construction for native-tools providers only.`
- Potential unintended effects: `Any tests or downstream assumptions that expected tool names to appear inside the generic `## Tools` section in native-tools mode need to rely on native tool specs instead.`
- Guardrails/monitoring for early detection: `Regression tests now assert both the absence of the duplicate `## Tools` block and the absence of XML protocol artifacts in native-tools mode.`

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `Codex terminal tools (exec_command, apply_patch)`
- Workflow/plan summary (if any): `Replayed the referenced prompt cleanup against current upstream/master, added the minimal prompt gate, aligned the affected unit test with the intended native-tools behavior, and reran full validation.`
- Verification focus: `Keeping native-tools prompts lean without changing non-native tool prompting.`
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: `git revert 76f885e9`
- Feature flags or config toggles (if any): `None`
- Observable failure symptoms: `Native-tools prompts would stop including the duplicated `## Tools` summary until the revert is applied.`

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: `Some code or expectations may have been implicitly reading tool names from the generic tools-summary section even in native-tools mode.`
  - Mitigation: `This PR updates the affected unit test, keeps the native-task instructions intact, and leaves actual native tool specs/execution unchanged.`
