### PR TITLE
fix(agent): relay tool-call text via on_delta

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2452,10 +2452,16 @@ pub(crate) async fn run_tool_call_loop(
             return Ok(display_text);
         }
 
-        // Print any text the LLM produced alongside tool calls (unless silent)
-        if !silent && !display_text.is_empty() {
-            print!("{display_text}");
-            let _ = std::io::stdout().flush();
+        // Relay any text the LLM produced alongside tool calls so streaming
+        // channels can surface intermediate explanations before tool results.
+        if !display_text.is_empty() {
+            if let Some(ref tx) = on_delta {
+                let _ = tx.send(display_text.clone()).await;
+            }
+            if !silent {
+                print!("{display_text}");
+                let _ = std::io::stdout().flush();
+            }
         }
 
         // Execute tool calls and build results. `individual_results` tracks per-call output so
@@ -4072,6 +4078,78 @@ mod tests {
             .expect("prompt-mode tool result payload should be present");
         assert!(tool_results.content.contains("counted:A"));
         assert!(tool_results.content.contains("Skipped duplicate tool call"));
+    }
+
+    #[tokio::test]
+    async fn run_tool_call_loop_relays_tool_call_text_via_on_delta() {
+        let provider = ScriptedProvider::from_text_responses(vec![
+            r#"Let me check that first.
+<tool_call>
+{"name":"count_tool","arguments":{"value":"A"}}
+</tool_call>"#,
+            "Final answer",
+        ]);
+
+        let invocations = Arc::new(AtomicUsize::new(0));
+        let tools_registry: Vec<Box<dyn Tool>> = vec![Box::new(CountingTool::new(
+            "count_tool",
+            Arc::clone(&invocations),
+        ))];
+
+        let mut history = vec![
+            ChatMessage::system("test-system"),
+            ChatMessage::user("run tool calls"),
+        ];
+        let observer = NoopObserver;
+        let (tx, mut rx) = tokio::sync::mpsc::channel(16);
+
+        let result = run_tool_call_loop(
+            &provider,
+            &mut history,
+            &tools_registry,
+            &observer,
+            "mock-provider",
+            "mock-model",
+            0.0,
+            true,
+            None,
+            "telegram",
+            &crate::config::MultimodalConfig::default(),
+            4,
+            None,
+            Some(tx),
+            None,
+            &[],
+        )
+        .await
+        .expect("loop should relay tool-call text through on_delta");
+
+        let mut deltas = Vec::new();
+        while let Some(delta) = rx.recv().await {
+            deltas.push(delta);
+        }
+
+        let explanation_idx = deltas
+            .iter()
+            .position(|delta| delta == "Let me check that first.")
+            .expect("intermediate explanation should be relayed to on_delta");
+        let clear_idx = deltas
+            .iter()
+            .position(|delta| delta == DRAFT_CLEAR_SENTINEL)
+            .expect("final answer streaming should clear prior draft state");
+
+        assert!(
+            deltas
+                .iter()
+                .any(|delta| delta.starts_with("\u{1f4ac} Got 1 tool call(s)")),
+            "tool-call progress line should still be relayed"
+        );
+        assert!(
+            explanation_idx < clear_idx,
+            "intermediate explanation should arrive before final answer streaming"
+        );
+        assert_eq!(result, "Final answer");
+        assert_eq!(invocations.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: When a model response contains both explanatory text and tool calls, `run_tool_call_loop` only prints that intermediate text to stdout and does not relay it through `on_delta`.
- Why it matters: Streaming channels that rely on draft updates, especially Telegram, miss the LLM's interim explanation while tools are running, so the draft looks empty or less informative until later updates arrive.
- What changed: Relayed non-empty `display_text` through `on_delta` before tool execution while preserving the existing stdout behavior; added a regression test that verifies mixed text+tool-call responses send the explanation before final-answer streaming clears the draft.
- What did **not** change (scope boundary): No changes to Telegram transport methods, tool execution order, final-answer chunking, or non-streaming CLI behavior.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `agent,channel,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `agent: loop`, `channel: streaming`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `auto-managed/read-only`
- If any auto-label is incorrect, note requested correction: `None`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N.A.`
- Integrated scope by source PR (what was materially carried forward): `N.A.`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `N.A.`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): `N.A.`
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `N.A.`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): `All commands passed after rebasing onto current upstream/master (`9e905263`). Added a regression test that captures `on_delta` output and asserts the intermediate explanation is relayed before final-answer streaming clears the draft.`
- If any command is intentionally skipped, explain why: `None`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: `N.A.`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: `The change reuses existing draft-update text only; it does not add new logging or expose additional raw provider payloads beyond the already derived display text.`
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): `Yes`

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N.A.`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `N.A.`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N.A.`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N.A.`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: `Code-only change.`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `A mixed explanation + tool-call response now sends the explanation through `on_delta`, and the final answer still streams after `DRAFT_CLEAR_SENTINEL`.`
- Edge cases checked: `Stdout behavior for non-silent runs remains intact, and tool-call progress lines still appear alongside the relayed explanation.`
- What was not verified: `Live Telegram chat flow against the real Bot API.`

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `Agent tool loop draft streaming for channels that pass `on_delta` (Telegram and any other draft-capable channels).`
- Potential unintended effects: `Streaming drafts may now show an extra explanatory line before tool progress, which slightly changes intermediate draft content ordering.`
- Guardrails/monitoring for early detection: `The new regression test asserts the explanation is emitted and that it arrives before final-answer draft clearing.`

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `Codex terminal tools (exec_command, apply_patch) and one read-only explorer sub-agent for codebase location confirmation`
- Workflow/plan summary (if any): `Rebased onto the latest upstream/master, applied the minimal `on_delta` relay in `run_tool_call_loop`, added a focused loop-level regression test, and reran full validation.`
- Verification focus: `Preserving current tool execution/final streaming semantics while making intermediate tool-call explanations visible to streaming channels.`
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: `git revert 996906b8`
- Feature flags or config toggles (if any): `None`
- Observable failure symptoms: `Streaming channels would stop showing the model's intermediate explanation text before tool execution.`

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: `Draft-capable channels may now show slightly more intermediate text than before when tool calls are present.`
  - Mitigation: `Only existing sanitized `display_text` is relayed, final-answer streaming is unchanged, and the regression test covers ordering around `DRAFT_CLEAR_SENTINEL`.`
