### PR TITLE
chore: bootstrap internal fork configuration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,39 @@
+# Internal Development Guidelines
+
+本文件为公司内部二开规范，不回馈上游。
+
+## Fork 管理
+
+- 上游 remote: `upstream`（开源社区原始仓库）
+- Fork 基线 tag: `fork-base-2026-03-12`
+- 同步策略: 定期 `git merge upstream/master` 到 `master`，用 tag `upstream-sync-<date>` 标记同步点
+
+## 分支命名
+
+| 类型 | 前缀 | 示例 |
+|------|------|------|
+| 内部功能 | `feat/` | `feat/custom-auth` |
+| 内部修复 | `bugfix/` | `bugfix/config-crash` |
+| 回馈上游 | `contrib/` | `contrib/fix-typo-in-docs` |
+
+规则：
+- `feat/` 和 `bugfix/` 分支 PR 到 `master`
+- `contrib/` 分支基于 `upstream/master` 创建，PR 到上游仓库
+- `contrib/` 分支不得包含内部业务逻辑、密钥或公司信息
+
+## 上游同步流程
+
+```bash
+git fetch upstream
+git checkout master
+git merge upstream/master
+# 解决冲突后
+git tag upstream-sync-$(date +%Y-%m-%d)
+git push origin master --tags
+```
+
+## CLAUDE.md 维护规则
+
+- 根目录 `CLAUDE.md`: 上游内容不做修改，仅末尾保留 `## Internal` 指引段落
+- 本文件 (`.claude/CLAUDE.md`): 存放所有内部规范，上游不存在此文件，不会产生合并冲突
+- 上游同步后如根 `CLAUDE.md` 有冲突，保留上游内容 + 重新追加 `## Internal` 段落即可

--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -1,8 +1,7 @@
 name: Release Beta
 
 on:
-  push:
-    branches: [master]
+  workflow_dispatch:
 
 concurrency:
   group: release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,3 +88,9 @@ Branch/commit/PR rules:
 - `@docs/contributing/change-playbooks.md` — adding providers, channels, tools, peripherals; security/gateway changes; architecture boundaries
 - `@docs/contributing/pr-discipline.md` — privacy rules, superseded-PR attribution/templates, handoff template
 - `@docs/contributing/docs-contract.md` — docs system contract, i18n rules, locale parity
+
+<!-- INTERNAL: DO NOT EDIT ABOVE THIS LINE — upstream content ends here -->
+
+## Internal
+
+See `.claude/CLAUDE.md` for company-internal development guidelines.


### PR DESCRIPTION
## Summary

- Add `.claude/CLAUDE.md` with internal development guidelines: branch naming conventions (`feat/`, `bugfix/`, `contrib/`), upstream sync workflow, and CLAUDE.md maintenance rules
- Add minimal internal pointer section at bottom of root `CLAUDE.md` (upstream content untouched)
- Change beta release workflow trigger from automatic (`push → master`) to manual (`workflow_dispatch`) to prevent unintended releases during upstream syncs

## Context

First commit after forking from the open-source ZeroClaw repo. Establishes the internal fork management foundation:
- `upstream` remote tracks the original open-source repo
- Fork baseline tagged as `fork-base-2026-03-12`
- Root `CLAUDE.md` is kept as upstream-managed with a minimal append-only internal section, avoiding merge conflicts on sync

## Test plan

- [x] No code logic changes — configuration and docs only
- [ ] Verify `release-beta-on-push.yml` no longer triggers on master push
- [ ] Verify CI quality gate (`checks-on-pr.yml`) still runs on this PR