### PR TITLE
fix(web): add crypto.randomUUID fallback for older browsers. Fixes #3303

### DIFF
--- a/web/src/lib/uuid.ts
+++ b/web/src/lib/uuid.ts
@@ -1,0 +1,63 @@
+// Safe randomUUID for environments without crypto.randomUUID.
+// Order: ① crypto.randomUUID (standard) ② RFC4122 v4 via getRandomValues (crypto, then msCrypto).
+// No fallback: if neither is available, throws.
+
+function hasNativeRandomUUID(): boolean {
+  try {
+    return (
+      typeof globalThis.crypto !== 'undefined' &&
+      typeof (globalThis.crypto as Crypto).randomUUID === 'function'
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve Crypto for getRandomValues: standard crypto first, then msCrypto. */
+function getCryptoForGetRandomValues(): Crypto {
+  if (
+    typeof globalThis.crypto !== 'undefined' &&
+    typeof (globalThis.crypto as Crypto).getRandomValues === 'function'
+  ) {
+    return globalThis.crypto as Crypto;
+  }
+  const msCrypto = (globalThis as unknown as { msCrypto?: Crypto }).msCrypto;
+  if (
+    typeof msCrypto !== 'undefined' &&
+    typeof msCrypto.getRandomValues === 'function'
+  ) {
+    return msCrypto;
+  }
+  throw new Error(
+    'zeroclaw: crypto.randomUUID and crypto.getRandomValues are not available in this environment.'
+  );
+}
+
+function uuidV4FromGetRandomValues(): string {
+  const crypto = getCryptoForGetRandomValues();
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  // RFC4122 v4: version nibble 4, variant 10
+  bytes[6] = ((bytes[6] ?? 0) & 0x0f) | 0x40;
+  bytes[8] = ((bytes[8] ?? 0) & 0x3f) | 0x80;
+  const toHex = (n: number): string => n.toString(16).padStart(2, '0');
+  const hex = Array.from(bytes, toHex).join('');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join('-');
+}
+
+/**
+ * UUID v4 generator compatible with older browsers.
+ * Uses crypto.randomUUID() when available, otherwise RFC4122 v4 via getRandomValues (crypto or msCrypto).
+ */
+export function randomUUID(): string {
+  if (hasNativeRandomUUID()) {
+    return (globalThis.crypto as Crypto).randomUUID();
+  }
+  return uuidV4FromGetRandomValues();
+}

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -1,5 +1,6 @@
 import type { WsMessage } from '../types/api';
 import { getToken } from './auth';
+import { randomUUID } from './uuid';
 
 export type WsMessageHandler = (msg: WsMessage) => void;
 export type WsOpenHandler = () => void;
@@ -26,7 +27,7 @@ const SESSION_STORAGE_KEY = 'zeroclaw_session_id';
 function getOrCreateSessionId(): string {
   let id = sessionStorage.getItem(SESSION_STORAGE_KEY);
   if (!id) {
-    id = crypto.randomUUID();
+    id = randomUUID();
     sessionStorage.setItem(SESSION_STORAGE_KEY, id);
   }
   return id;

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Send, Bot, User, AlertCircle, Copy, Check } from 'lucide-react';
 import type { WsMessage } from '@/types/api';
 import { WebSocketClient } from '@/lib/ws';
+import { randomUUID } from '@/lib/uuid';
 
 interface ChatMessage {
   id: string;
@@ -53,7 +54,7 @@ export default function AgentChat() {
             setMessages((prev) => [
               ...prev,
               {
-                id: crypto.randomUUID(),
+                id: randomUUID(),
                 role: 'agent',
                 content,
                 timestamp: new Date(),
@@ -69,7 +70,7 @@ export default function AgentChat() {
           setMessages((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: randomUUID(),
               role: 'agent',
               content: `[Tool Call] ${msg.name ?? 'unknown'}(${JSON.stringify(msg.args ?? {})})`,
               timestamp: new Date(),
@@ -81,7 +82,7 @@ export default function AgentChat() {
           setMessages((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: randomUUID(),
               role: 'agent',
               content: `[Tool Result] ${msg.output ?? ''}`,
               timestamp: new Date(),
@@ -93,7 +94,7 @@ export default function AgentChat() {
           setMessages((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: randomUUID(),
               role: 'agent',
               content: `[Error] ${msg.message ?? 'Unknown error'}`,
               timestamp: new Date(),
@@ -124,7 +125,7 @@ export default function AgentChat() {
     setMessages((prev) => [
       ...prev,
       {
-        id: crypto.randomUUID(),
+        id: randomUUID(),
         role: 'user',
         content: trimmed,
         timestamp: new Date(),


### PR DESCRIPTION
## PR Summary

- **Base branch:** `master`
- **Type:** `bug`
- **Scope:** Web daemon runtime (`/agent` page)
- **Issue:** Closes #3303 – `/agent` throws `crypto.randomUUID is not a function` in older browsers / some Electron environments.

## What Changed

- Added `web/src/lib/uuid.ts` with a `randomUUID()` helper (Web Crypto–aligned naming). Resolution order:
  1. `crypto.randomUUID()` when available.
  2. RFC4122 v4 via `getRandomValues()` (standard `crypto` first, then `msCrypto`).
- No further fallback: if neither is available, throws a clear error.
- Replaced all direct `crypto.randomUUID()` usages in:
  - `web/src/lib/ws.ts` (WebSocket session ID).
  - `web/src/pages/AgentChat.tsx` (chat message IDs).

## Why It Matters

- Keeps `/agent` working where `crypto.randomUUID` is missing (e.g. older Safari, some Electron) without changing backend or Rust.

## Validation (Human)

**Repro steps:** Open `/agent`, pair if needed, then in the browser console run:

```js
window.crypto.randomUUID = undefined;
```

Then type a message and click Send.

| Branch / commit | Result |
|----------------|--------|
| **master** @ `b40c9e77` | `TypeError: crypto.randomUUID is not a function` when sending a message. |
| **This PR** | No error; message sends and renders; console 0 errors. |

### Screenshots (Chrome)

- **Master (repro):** Console shows `TypeError: crypto.randomUUID is not a function` after sending a message.

<img width="943" height="582" alt="before" src="https://github.com/user-attachments/assets/c48bd3bc-07cb-4f69-9e87-9433422b7e4f" />

- **This PR (fixed):** Same steps; message sends, console 0 errors.

<img width="951" height="496" alt="after" src="https://github.com/user-attachments/assets/76861c26-64d6-4aac-ab3a-958c29bb8c1c" />

## Risk & Rollback

- **Risk:** Low. Frontend ID generation only.
- **Rollback:** Revert the commit on `master`.
