### PR TITLE
fix(install): build web frontend before Rust compilation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1027,7 +1027,41 @@ MSG
   exit 1
 fi
 
+build_web_frontend() {
+  local web_dir="$1"
+  if [[ ! -d "$web_dir" ]]; then
+    warn "Web frontend directory not found: $web_dir"
+    return 1
+  fi
+
+  if ! have_cmd npm; then
+    warn "npm is not installed. Skipping web frontend build."
+    warn "The Web Dashboard will not be available. Install Node.js to enable it."
+    return 1
+  fi
+
+  info "Building web frontend"
+  cd "$web_dir"
+
+  if [[ ! -d "node_modules" ]]; then
+    info "Installing web dependencies"
+    npm install --silent
+  fi
+
+  npm run build
+  local build_status=$?
+  cd "$WORK_DIR"
+  return $build_status
+}
+
 if [[ "$SKIP_BUILD" == false ]]; then
+  # Build web frontend before Rust compilation (rust-embed requires assets at compile time)
+  if [[ -d "$WORK_DIR/web" ]]; then
+    if ! build_web_frontend "$WORK_DIR/web"; then
+      warn "Web frontend build failed or skipped. Web Dashboard may not be available."
+    fi
+  fi
+
   info "Building release binary"
   cargo build --release --locked
 else


### PR DESCRIPTION
## Summary

The install.sh script was missing a step to build the web frontend before compiling the Rust binary. Since ZeroClaw uses rust-embed to bundle static assets at compile time, the web frontend must must through the pre-compiled binary results in a "not found" error when accessing the Web Dashboard.

## Changes
- Added `build_web_frontend()` function that builds the web frontend
- Called before `cargo build --release --locked` when `SKIP_BUILD` is false
- Handles missing npm gracefully with a warning
- Handles missing web directory gracefully

## Test plan
- Run `./install.sh` locally and verify the web dashboard loads correctly
- Run `./install.sh --prefer-prebuilt` to verify pre-built fallback still works