### PR TITLE
fix(web): add fallback for crypto.randomUUID in older browsers

### DIFF
--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -1,6 +1,19 @@
 import type { WsMessage } from '../types/api';
 import { getToken } from './auth';
 
+/** Generate a UUID v4, with fallback for older browsers */
+export function generateUUID(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return generateUUID();
+  }
+  // Fallback for older browsers (e.g., Safari < 15.4, older mobile browsers)
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
 export type WsMessageHandler = (msg: WsMessage) => void;
 export type WsOpenHandler = () => void;
 export type WsCloseHandler = (ev: CloseEvent) => void;
@@ -26,7 +39,7 @@ const SESSION_STORAGE_KEY = 'zeroclaw_session_id';
 function getOrCreateSessionId(): string {
   let id = sessionStorage.getItem(SESSION_STORAGE_KEY);
   if (!id) {
-    id = crypto.randomUUID();
+    id = generateUUID();
     sessionStorage.setItem(SESSION_STORAGE_KEY, id);
   }
   return id;

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Send, Bot, User, AlertCircle, Copy, Check } from 'lucide-react';
 import type { WsMessage } from '@/types/api';
-import { WebSocketClient } from '@/lib/ws';
+import { WebSocketClient, generateUUID } from '@/lib/ws';
 
 interface ChatMessage {
   id: string;
@@ -53,7 +53,7 @@ export default function AgentChat() {
             setMessages((prev) => [
               ...prev,
               {
-                id: crypto.randomUUID(),
+                id: generateUUID(),
                 role: 'agent',
                 content,
                 timestamp: new Date(),
@@ -69,7 +69,7 @@ export default function AgentChat() {
           setMessages((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: generateUUID(),
               role: 'agent',
               content: `[Tool Call] ${msg.name ?? 'unknown'}(${JSON.stringify(msg.args ?? {})})`,
               timestamp: new Date(),
@@ -81,7 +81,7 @@ export default function AgentChat() {
           setMessages((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: generateUUID(),
               role: 'agent',
               content: `[Tool Result] ${msg.output ?? ''}`,
               timestamp: new Date(),
@@ -93,7 +93,7 @@ export default function AgentChat() {
           setMessages((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: generateUUID(),
               role: 'agent',
               content: `[Error] ${msg.message ?? 'Unknown error'}`,
               timestamp: new Date(),
@@ -124,7 +124,7 @@ export default function AgentChat() {
     setMessages((prev) => [
       ...prev,
       {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         role: 'user',
         content: trimmed,
         timestamp: new Date(),


### PR DESCRIPTION
## Summary
Add `generateUUID()` helper function that provides a fallback implementation for browsers that don't support `crypto.randomUUID` (e.g., Safari < 15.4, older mobile browsers on Raspberry Pi).

## Changes
- Added `generateUUID()` in `web/src/lib/ws.ts` with fallback implementation
- Updated `web/src/pages/AgentChat.tsx` to use the new helper

## Testing
The fallback uses the standard UUID v4 format for compatibility.

Fixes #3261