### PR TITLE
fix(channel): preserve inbound thread_ts in live tool notifications

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1872,7 +1872,10 @@ async fn process_channel_message(
     let notify_observer_flag = Arc::clone(&notify_observer);
     let notify_channel = target_channel.clone();
     let notify_reply_target = msg.reply_target.clone();
-    let notify_thread_root = msg.id.clone();
+    // Prefer the platform-native thread identifier (e.g. Slack `ts`) over
+    // msg.id, which is a composite key ("slack_{channel}_{ts}") and not a
+    // valid thread_ts on platforms that validate the format.
+    let notify_thread_root = msg.thread_ts.clone().unwrap_or_else(|| msg.id.clone());
     let notify_task = if msg.channel == "cli" {
         Some(tokio::spawn(async move {
             while notify_rx.recv().await.is_some() {}
@@ -1937,8 +1940,15 @@ async fn process_channel_message(
         let _ = handle.await;
     }
 
-    // Thread the final reply only if tools were used (multi-message response)
-    if notify_observer_flag.tools_used.load(Ordering::Relaxed) && msg.channel != "cli" {
+    // Thread the final reply only if tools were used (multi-message response).
+    // Preserve the existing thread_ts when the channel already set one from the
+    // inbound event (e.g. Slack sets it to the message `ts`). Overwriting with
+    // msg.id would produce an invalid thread identifier on platforms where msg.id
+    // is a composite key (e.g. "slack_{channel}_{ts}").
+    if notify_observer_flag.tools_used.load(Ordering::Relaxed)
+        && msg.channel != "cli"
+        && msg.thread_ts.is_none()
+    {
         msg.thread_ts = Some(msg.id.clone());
     }
     // Drop the notify sender so the forwarder task finishes


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: PR #3221 introduced a regression where `msg.id` (a composite key like `"slack_{channel}_{ts}"`) is used as a Slack `thread_ts`, causing `invalid_thread_ts` errors on every tool-using response.
- Why it matters: Any Slack deployment using live tool-call notifications is completely unable to reply to messages that trigger tool use. The agent silently drops its response.
- What changed: Two lines in `process_channel_message()` now prefer the platform-native `msg.thread_ts` (set by the channel's inbound parser) over `msg.id`, and the final-reply thread override no longer clobbers an already-valid `thread_ts`.
- What did **not** change (scope boundary): No observer, provider, memory, or config logic was touched. The `ChannelNotifyObserver` struct and notify task spawning from #3221 are preserved as-is.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels: `channel`
- Module labels: `channel: slack`
- Contributor tier label: N/A (first contribution)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes: N/A (no pre-existing issue)
- Related: #3221 (introduced the regression)
- Depends on: N/A
- Supersedes: N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check   # ✅ clean
cargo clippy --all-targets -- -D warnings  # ✅ zero warnings
cargo test --locked  # ✅ 65 passed, 0 failed
```

- Evidence provided: All three commands pass. Additionally, manually tested on a live Slack deployment — tool-using messages now reply correctly in-thread instead of producing `invalid_thread_ts`.
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Sent Slack DMs to a ZeroClaw-powered bot that triggered tool use (shell, file_read). Bot replied correctly in-thread. No `invalid_thread_ts` errors in logs.
- Edge cases checked: Messages that do NOT trigger tools still reply normally (no thread created). CLI channel is unaffected (short-circuited before thread logic).
- What was not verified: Telegram and Matrix channels (no test deployment available). However, code analysis confirms Telegram uses `reply_target` not `thread_ts` for threading, so it is unaffected. Matrix does not set `thread_ts` at all.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `process_channel_message()` in `src/channels/mod.rs` — the live tool-call notification thread and the final reply threading.
- Potential unintended effects: Channels that do NOT set `msg.thread_ts` on inbound (everything except Slack and Telegram) will fall back to `msg.id` as before, so behavior is unchanged for them.
- Guardrails/monitoring for early detection: The `invalid_thread_ts` error from the Slack API is logged. If it reappears, the thread_ts source should be inspected.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (investigation, code changes, validation)
- Workflow/plan summary: Traced the regression from Slack API error logs → `process_channel_message()` → PR #3221 commit `bd70c0f4`. Identified two locations where `msg.id` was incorrectly used as a thread identifier.
- Verification focus: Live Slack testing with tool-using messages
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>`
- Feature flags or config toggles (if any): None
- Observable failure symptoms: `invalid_thread_ts` errors return in Slack channel logs; bot stops replying to tool-using messages

## Risks and Mitigations

- Risk: Channels that intentionally rely on `msg.id` as thread_ts (none currently, but hypothetically)
  - Mitigation: The fallback `unwrap_or_else(|| msg.id.clone())` preserves the old behavior for any channel that does not set `thread_ts` on inbound messages, so the change is strictly additive.