### PR TITLE
fix(channel): fix missing Relation import in matrix channel

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -5,9 +5,9 @@ use matrix_sdk::{
     config::SyncSettings,
     ruma::{
         events::reaction::ReactionEventContent,
-        events::relation::{Annotation, InReplyTo, Thread},
+        events::relation::{Annotation, Thread},
         events::room::message::{
-            MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent,
+            MessageType, OriginalSyncRoomMessageEvent, Relation, RoomMessageEventContent,
         },
         events::room::MediaSource,
         OwnedEventId, OwnedRoomId, OwnedUserId,


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `cargo build --all-features` fails with `error[E0433]: use of undeclared type Relation` at `src/channels/matrix.rs:572` and `:862`. The `Relation` enum is used for thread-aware message sending/receiving but was never imported.
- Why it matters: The build is broken on `master` for anyone building with the `matrix` feature enabled.
- What changed: Moved `Relation` import to `events::room::message` (where `ruma-events` 0.32.x defines it) and removed unused `InReplyTo` import from `events::relation`.
- What did **not** change: No logic changes, no new dependencies, no config changes.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: matrix`
- Contributor tier label: N/A (first contribution)
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes: N/A (no existing issue filed)
- Related: N/A

## Validation Evidence (required)

Build tested on a live deployment (Debian 12, rustc stable, `--all-features --locked`):

```
cargo install --path . --all-features --locked
# Before fix: error[E0433] at matrix.rs:572 and :862
# After fix: compiles successfully with 2 pre-existing warnings (unused variables in matrix.rs:706 and mod.rs:2948)
```

- `cargo fmt`: Not modified — import ordering follows existing file convention.
- `cargo clippy`: Fix resolves the only compilation errors; no new warnings introduced.
- `cargo test`: Build must succeed for tests to run; this unblocks that.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: N/A (no user-facing wording)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Full `cargo install --path . --all-features --locked` build succeeds; ZeroClaw daemon starts and Matrix channel connects successfully (E2EE verified, room listening active).
- Edge cases checked: Confirmed `Relation::Thread` pattern matching at line 862 works correctly for incoming threaded messages.
- What was not verified: `cargo test` suite (requires full dev environment setup).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Matrix channel compilation only.
- Potential unintended effects: None — this is a pure import fix.
- Guardrails/monitoring: CI build gate will confirm.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (Anthropic CLI)
- Workflow/plan summary: Discovered during routine update of ZeroClaw deployment from `main` to `master`. Build failed, diagnosed missing import, applied fix, validated full build + runtime.
- Verification focus: Compilation and runtime startup of matrix channel.
- Confirmation: naming + architecture boundaries followed.

## Rollback Plan (required)

- Fast rollback: `git revert <commit>`
- Feature flags or config toggles: N/A
- Observable failure symptoms: Build failure (same `E0433` error) if reverted without alternative fix.

## Risks and Mitigations

- Risk: None — this is a 2-line import correction that unblocks compilation.