### PR TITLE
fix: resolve prebuilt download 404 by querying releases API

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -211,8 +211,35 @@ should_attempt_prebuilt_for_resources() {
   return 1
 }
 
+resolve_asset_url() {
+  local asset_name="$1"
+  local api_url="https://api.github.com/repos/zeroclaw-labs/zeroclaw/releases"
+  local releases_json download_url
+
+  # Fetch up to 10 recent releases (includes prereleases) and find the first
+  # one that contains the requested asset.
+  releases_json="$(curl -fsSL "${api_url}?per_page=10" 2>/dev/null || true)"
+  if [[ -z "$releases_json" ]]; then
+    return 1
+  fi
+
+  # Parse with simple grep/sed — avoids jq dependency.
+  download_url="$(printf '%s\n' "$releases_json" \
+    | tr ',' '\n' \
+    | grep '"browser_download_url"' \
+    | sed 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' \
+    | grep "/${asset_name}\$" \
+    | head -n 1)"
+
+  if [[ -z "$download_url" ]]; then
+    return 1
+  fi
+
+  echo "$download_url"
+}
+
 install_prebuilt_binary() {
-  local target archive_url temp_dir archive_path extracted_bin install_dir
+  local target archive_url temp_dir archive_path extracted_bin install_dir asset_name
 
   if ! have_cmd curl; then
     warn "curl is required for pre-built binary installation."
@@ -229,9 +256,17 @@ install_prebuilt_binary() {
     return 1
   fi
 
-  archive_url="https://github.com/zeroclaw-labs/zeroclaw/releases/latest/download/zeroclaw-${target}.tar.gz"
+  asset_name="zeroclaw-${target}.tar.gz"
+
+  # Try the GitHub API first to find the newest release (including prereleases)
+  # that actually contains the asset, then fall back to /releases/latest/.
+  archive_url="$(resolve_asset_url "$asset_name" || true)"
+  if [[ -z "$archive_url" ]]; then
+    archive_url="https://github.com/zeroclaw-labs/zeroclaw/releases/latest/download/${asset_name}"
+  fi
+
   temp_dir="$(mktemp -d -t zeroclaw-prebuilt-XXXXXX)"
-  archive_path="$temp_dir/zeroclaw-${target}.tar.gz"
+  archive_path="$temp_dir/${asset_name}"
 
   info "Attempting pre-built binary install for target: $target"
   if ! curl -fsSL "$archive_url" -o "$archive_path"; then


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: `install.sh --prebuilt-only` downloads from `/releases/latest/download/` which resolves to the latest non-prerelease release. When that release (e.g. `v0.1.9a`) has no binary assets, the download 404s. Beta releases that *do* have assets are skipped because they are marked `prerelease: true`.
- Why it matters: Users running `install.sh --prebuilt-only` or `--prefer-prebuilt` cannot install ZeroClaw; they get a hard failure.
- What changed: Added `resolve_asset_url()` function that queries the GitHub releases API (`per_page=10`) to find the newest release (including prereleases) that actually contains the requested asset. Falls back to the original `/releases/latest/` URL if the API call fails.
- What did **not** change (scope boundary): No changes to the release workflows, build matrix, or any other install.sh logic.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `scripts`
- Module labels: N/A
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `scripts`

## Linked Issue

- Closes #3389

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
bash -n install.sh  # passes — syntax valid
```

- Evidence provided: syntax validation via `bash -n`
- If any command is intentionally skipped, explain why: `cargo fmt/clippy/test` skipped — no Rust code changed; only shell script modified.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? Yes — one additional `curl` to `api.github.com/repos/zeroclaw-labs/zeroclaw/releases?per_page=10` (public, unauthenticated, read-only). Falls back gracefully if it fails.
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: The API call is read-only against a public endpoint and only fetches release metadata. If it fails for any reason (rate limit, network), the function returns empty and the script falls back to the original `/releases/latest/` URL.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Confirmed `v0.1.9a` (latest non-prerelease) has zero assets; `v0.1.7-beta.33` (prerelease) has all expected assets including `zeroclaw-x86_64-unknown-linux-gnu.tar.gz`. The new API query would resolve to beta assets correctly.
- Edge cases checked: API failure (falls back to original URL), empty response, no matching asset name.
- What was not verified: Live download on Linux (macOS development machine).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `install.sh` prebuilt download path only
- Potential unintended effects: Slightly slower first attempt (one extra API call). GitHub API rate limit for unauthenticated requests is 60/hr — unlikely to hit for installer usage.
- Guardrails/monitoring for early detection: Graceful fallback to original URL if API call fails.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: Confirmed asset naming matches between workflow and install.sh; root cause is `/releases/latest/` pointing to an asset-less release.
- Confirmation: naming + architecture boundaries followed.

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit
- Feature flags or config toggles: None
- Observable failure symptoms: Same 404 as before if reverted

## Risks and Mitigations

- Risk: GitHub API rate limiting (60 req/hr unauthenticated)
  - Mitigation: Falls back to `/releases/latest/` URL if API call fails; installer is not expected to be called frequently enough to hit limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)