### PR TITLE
fix: add crypto.randomUUID fallback for older browsers

### DIFF
--- a/web/src/lib/uuid.ts
+++ b/web/src/lib/uuid.ts
@@ -1,0 +1,27 @@
+/**
+ * Generate a UUID v4 string.
+ *
+ * Uses `crypto.randomUUID()` when available (modern browsers, secure contexts)
+ * and falls back to a manual implementation backed by `crypto.getRandomValues()`
+ * for older browsers (e.g. Safari < 15.4, some Electron/Raspberry-Pi builds).
+ *
+ * Closes #3303, #3261.
+ */
+export function generateUUID(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  // Fallback: RFC 4122 version 4 UUID via getRandomValues
+  // crypto must exist if we reached here (only randomUUID is missing)
+  const c = globalThis.crypto;
+  const bytes = new Uint8Array(16);
+  c.getRandomValues(bytes);
+
+  // Set version (4) and variant (10xx) bits per RFC 4122
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -1,5 +1,6 @@
 import type { WsMessage } from '../types/api';
 import { getToken } from './auth';
+import { generateUUID } from './uuid';
 
 export type WsMessageHandler = (msg: WsMessage) => void;
 export type WsOpenHandler = () => void;
@@ -26,7 +27,7 @@ const SESSION_STORAGE_KEY = 'zeroclaw_session_id';
 function getOrCreateSessionId(): string {
   let id = sessionStorage.getItem(SESSION_STORAGE_KEY);
   if (!id) {
-    id = crypto.randomUUID();
+    id = generateUUID();
     sessionStorage.setItem(SESSION_STORAGE_KEY, id);
   }
   return id;

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Send, Bot, User, AlertCircle, Copy, Check } from 'lucide-react';
 import type { WsMessage } from '@/types/api';
 import { WebSocketClient } from '@/lib/ws';
+import { generateUUID } from '@/lib/uuid';
 
 interface ChatMessage {
   id: string;
@@ -53,7 +54,7 @@ export default function AgentChat() {
             setMessages((prev) => [
               ...prev,
               {
-                id: crypto.randomUUID(),
+                id: generateUUID(),
                 role: 'agent',
                 content,
                 timestamp: new Date(),
@@ -69,7 +70,7 @@ export default function AgentChat() {
           setMessages((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: generateUUID(),
               role: 'agent',
               content: `[Tool Call] ${msg.name ?? 'unknown'}(${JSON.stringify(msg.args ?? {})})`,
               timestamp: new Date(),
@@ -81,7 +82,7 @@ export default function AgentChat() {
           setMessages((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: generateUUID(),
               role: 'agent',
               content: `[Tool Result] ${msg.output ?? ''}`,
               timestamp: new Date(),
@@ -93,7 +94,7 @@ export default function AgentChat() {
           setMessages((prev) => [
             ...prev,
             {
-              id: crypto.randomUUID(),
+              id: generateUUID(),
               role: 'agent',
               content: `[Error] ${msg.message ?? 'Unknown error'}`,
               timestamp: new Date(),
@@ -124,7 +125,7 @@ export default function AgentChat() {
     setMessages((prev) => [
       ...prev,
       {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         role: 'user',
         content: trimmed,
         timestamp: new Date(),


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: `crypto.randomUUID()` is not available in older browsers (Safari < 15.4, some Electron versions, Raspberry Pi browsers), causing `Uncaught TypeError: crypto.randomUUID is not a function` on the `/agent` chat page.
- Why it matters: Users on older browsers cannot use the web dashboard at all.
- What changed: Introduced a `generateUUID()` utility in `web/src/lib/uuid.ts` that uses `crypto.randomUUID()` when available and falls back to a manual UUID v4 implementation via `crypto.getRandomValues()` (which has much wider browser support). All 6 call sites in `AgentChat.tsx` and `ws.ts` now use this utility.
- What did **not** change (scope boundary): No backend changes; no changes to UUID format or semantics.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `gateway`
- Module labels: N/A (web frontend utility)
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `runtime`

## Linked Issue

- Closes #3303
- Closes #3261

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cd web && npx tsc -b  # exit 0, no errors
```

- Evidence provided: TypeScript type-check passes with zero errors.
- If any command is intentionally skipped, explain why: `cargo` commands skipped — this PR touches only frontend TypeScript files.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: TypeScript compiles cleanly; fallback logic reviewed for RFC 4122 v4 compliance (version bits 0100, variant bits 10xx).
- Edge cases checked: Environment where `crypto` exists but `randomUUID` does not (the exact reported bug scenario).
- What was not verified: Manual browser testing on Safari < 15.4.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Web dashboard `/agent` chat page, WebSocket session ID generation.
- Potential unintended effects: None — the generated UUIDs are format-identical to `crypto.randomUUID()` output.
- Guardrails/monitoring for early detection: Existing browser console error monitoring will surface any regressions.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Searched for all `crypto.randomUUID` usage in web/, created shared utility with fallback, replaced all call sites, verified TypeScript compiles.
- Verification focus: Type safety, RFC 4122 v4 compliance of fallback.
- Confirmation: naming + architecture boundaries followed.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None needed
- Observable failure symptoms: If reverted, older browsers would crash again on `/agent` page.

## Risks and Mitigations

- Risk: None — strictly additive fallback with no behavior change for modern browsers.
  - Mitigation: N/A