### PR TITLE
fix: skip documentation URLs in cloudflare tunnel URL parser

### DIFF
--- a/src/tunnel/cloudflare.rs
+++ b/src/tunnel/cloudflare.rs
@@ -3,6 +3,34 @@ use anyhow::{bail, Result};
 use tokio::io::AsyncBufReadExt;
 use tokio::process::Command;
 
+/// Try to extract a real tunnel URL from a cloudflared log line.
+///
+/// Returns `Some(url)` when the line contains a genuine tunnel endpoint,
+/// skipping documentation and warning URLs (quic-go GitHub links,
+/// Cloudflare docs pages, etc.).
+fn extract_tunnel_url(line: &str) -> Option<String> {
+    let idx = line.find("https://")?;
+    let url_part = &line[idx..];
+    let end = url_part
+        .find(|c: char| c.is_whitespace())
+        .unwrap_or(url_part.len());
+    let candidate = &url_part[..end];
+
+    let is_tunnel_line = line.contains("Visit it at")
+        || line.contains("Route at")
+        || line.contains("Registered tunnel connection");
+    let is_tunnel_domain = candidate.contains(".trycloudflare.com");
+    let is_docs_url = candidate.contains("github.com")
+        || candidate.contains("cloudflare.com/docs")
+        || candidate.contains("developers.cloudflare.com");
+
+    if is_tunnel_line || is_tunnel_domain || !is_docs_url {
+        Some(candidate.to_string())
+    } else {
+        None
+    }
+}
+
 /// Cloudflare Tunnel — wraps the `cloudflared` binary.
 ///
 /// Requires `cloudflared` installed and a tunnel token from the
@@ -62,13 +90,8 @@ impl Tunnel for CloudflareTunnel {
             match line {
                 Ok(Ok(Some(l))) => {
                     tracing::debug!("cloudflared: {l}");
-                    // Look for the URL pattern in cloudflared output
-                    if let Some(idx) = l.find("https://") {
-                        let url_part = &l[idx..];
-                        let end = url_part
-                            .find(|c: char| c.is_whitespace())
-                            .unwrap_or(url_part.len());
-                        public_url = url_part[..end].to_string();
+                    if let Some(url) = extract_tunnel_url(&l) {
+                        public_url = url;
                         break;
                     }
                 }
@@ -137,5 +160,56 @@ mod tests {
     async fn health_check_is_false_before_start() {
         let tunnel = CloudflareTunnel::new("cf-token".into());
         assert!(!tunnel.health_check().await);
+    }
+
+    #[test]
+    fn extract_skips_quic_go_github_url() {
+        let line = "2024-01-01T00:00:00Z WRN failed to sufficiently increase receive buffer size. See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.";
+        assert_eq!(extract_tunnel_url(line), None);
+    }
+
+    #[test]
+    fn extract_skips_cloudflare_docs_url() {
+        let line = "2024-01-01T00:00:00Z INF For more info see https://cloudflare.com/docs/tunnels";
+        assert_eq!(extract_tunnel_url(line), None);
+    }
+
+    #[test]
+    fn extract_skips_developers_cloudflare_url() {
+        let line = "2024-01-01T00:00:00Z INF See https://developers.cloudflare.com/cloudflare-one/connections/connect-apps";
+        assert_eq!(extract_tunnel_url(line), None);
+    }
+
+    #[test]
+    fn extract_captures_trycloudflare_url() {
+        let line = "2024-01-01T00:00:00Z INF Visit it at https://my-tunnel-abc.trycloudflare.com";
+        assert_eq!(
+            extract_tunnel_url(line),
+            Some("https://my-tunnel-abc.trycloudflare.com".into())
+        );
+    }
+
+    #[test]
+    fn extract_captures_url_on_visit_it_at_line() {
+        let line = "2024-01-01T00:00:00Z INF Visit it at https://some-custom-domain.example.com";
+        assert_eq!(
+            extract_tunnel_url(line),
+            Some("https://some-custom-domain.example.com".into())
+        );
+    }
+
+    #[test]
+    fn extract_captures_url_on_route_at_line() {
+        let line = "2024-01-01T00:00:00Z INF Route at https://tunnel.example.com/path";
+        assert_eq!(
+            extract_tunnel_url(line),
+            Some("https://tunnel.example.com/path".into())
+        );
+    }
+
+    #[test]
+    fn extract_returns_none_for_line_without_url() {
+        let line = "2024-01-01T00:00:00Z INF Starting tunnel";
+        assert_eq!(extract_tunnel_url(line), None);
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The URL parser in `src/tunnel/cloudflare.rs` captures the first `https://` URL found in cloudflared stderr. When cloudflared emits a quic-go UDP buffer size warning containing a `github.com/quic-go` link, that documentation URL is incorrectly captured as the tunnel's public URL.
- Why it matters: Users get a GitHub documentation link instead of their actual tunnel endpoint, breaking tunnel connectivity.
- What changed: Extracted URL parsing into a testable `extract_tunnel_url()` helper that skips known documentation domains (`github.com`, `cloudflare.com/docs`, `developers.cloudflare.com`) and recognises tunnel-specific log prefixes (`Visit it at`, `Route at`, `Registered tunnel connection`) and the `.trycloudflare.com` domain.
- What did **not** change (scope boundary): No changes to the tunnel trait interface, process lifecycle, or any other tunnel provider.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels: `tunnel`
- Module labels: `tunnel: cloudflare`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `runtime`

## Linked Issue

- Closes #3413

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check    # pass
cargo clippy --all-targets -- -D warnings    # pass, no warnings
cargo test --lib tunnel::cloudflare    # 11 tests passed (7 new)
```

- Evidence provided (test/log/trace/screenshot/perf): Unit tests covering quic-go URL skip, cloudflare docs URL skip, developers.cloudflare.com URL skip, trycloudflare.com capture, "Visit it at" line capture, "Route at" line capture, and no-URL line.
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Unit tests validate that quic-go and cloudflare docs URLs are skipped while real tunnel URLs are captured.
- Edge cases checked: Lines with no URL, lines with tunnel-specific prefixes but non-trycloudflare domains, multiple documentation URL patterns.
- What was not verified: Live cloudflared process (requires valid token and network).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Cloudflare tunnel URL extraction only.
- Potential unintended effects: If cloudflared changes its log format, the prefix detection may need updating; the fallback still accepts any non-docs URL.
- Guardrails/monitoring for early detection: Existing timeout mechanism will surface failures if no URL is captured within 30s.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Read bug report context, identified root cause in URL parser, extracted testable helper, added filtering logic, wrote 7 unit tests.
- Verification focus: Correctness of URL filtering and backward compatibility with real tunnel URLs.
- Confirmation: naming + architecture boundaries followed.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles (if any): None
- Observable failure symptoms: Tunnel start fails with "did not produce a public URL within 30s" if filtering is too aggressive.

## Risks and Mitigations

- Risk: Overly aggressive URL filtering could reject legitimate tunnel URLs on unexpected domains.
  - Mitigation: The filter only blocks known documentation domains; any other `https://` URL is accepted. The 30s timeout provides a clear failure signal.