### PR TITLE
fix: Invalid path resolution causing creation of unwanted '~' folder

### DIFF
--- a/src/channels/whatsapp_web.rs
+++ b/src/channels/whatsapp_web.rs
@@ -31,6 +31,7 @@ use super::whatsapp_storage::RusqliteStore;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use parking_lot::Mutex;
+use shellexpand;
 use std::sync::Arc;
 use tokio::select;
 
@@ -82,8 +83,16 @@ impl WhatsAppWebChannel {
         pair_code: Option<String>,
         allowed_numbers: Vec<String>,
     ) -> Self {
+        let expanded = shellexpand::tilde(&session_path);
+        if expanded == "~" || expanded.starts_with("~/") {
+            panic!(
+                "Failed to expand '~' in session_path '{}': home directory not found. \
+                 Please provide an absolute path or ensure $HOME is set.",
+                session_path
+            );
+        }
         Self {
-            session_path,
+            session_path: expanded.to_string(),
             pair_phone,
             pair_code,
             allowed_numbers,


### PR DESCRIPTION
Origin of the Bug:
The WhatsApp Web channel accepts a session_path config value containing '~' (e.g., '~/.zeroclaw/state/whatsapp-web/session.db'). The code used `shellexpand::tilde()` to expand this path at runtime in the `listen()` method. However, when the home directory cannot be determined (e.g., /home/user not set in the environment), shellexpand returns the original string unchanged, including the literal '~' character. This caused SQLite to create a database file at './~/session.db', effectively creating a '~' folder in the current working directory.

What was Fixed:
Moved the tilde expansion from the listen() loop to the constructor (WhatsAppWebChannel::new()), and added validation to detect expansion failure. If the expanded path still starts with '~' or '~/', the constructor now panics with a clear error message instructing the user to provide an absolute path or ensure /home/user is set.

This ensures the bug is caught early at startup rather than silently creating unexpected directories.

## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions):
- Problem: `shellexpand::tilde()` returns the original string unchanged when `$HOME` is not set
- Why it matters: This causes SQLite to create a database at `./~` (literal ~ folder)
- What changed: Moved tilde expansion to constructor with validation - now panics with a clear error message if expansion fails
- What did **not** change (scope boundary):

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): XS
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): channel
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): channel:whatsapp
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): new contributor
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): channel

## Linked Issue

- Closes #3417
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```
❯ cargo fmt --all -- --check

❯ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.20s

❯ cargo test --bin zeroclaw > ~/Downloads/test.txt
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running unittests src/main.rs (target/debug/deps/zeroclaw-7ae75706244e63ac)
running 3271 tests
test agent::classifier::tests::empty_rules_returns_none ... ok
[...]
test providers::bedrock::tests::chat_fails_without_credentials ... ok

test result: ok. 3269 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 3.91s
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): Yes
- If any `Yes`, describe risk and mitigation:
  App creates/accesses folder with correctly expanded path now

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: #3417 

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  -  Code compiles
  - Folder is created in the expected path
<img width="638" height="136" alt="image" src="https://github.com/user-attachments/assets/b4353f4c-4066-4b1b-98e1-d785d44990e2" />

- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: None
- Potential unintended effects: None
- Guardrails/monitoring for early detection: N/A

## Agent Collaboration Notes (recommended)

- Agent tools used (if any):
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path: `git revert`
- Feature flags or config toggles (if any): N/A
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: None
  - Mitigation:
