### PR TITLE
fix: use cfg-conditional AtomicU32 fallback in mcp_client for 32-bit targets

### DIFF
--- a/src/tools/mcp_client.rs
+++ b/src/tools/mcp_client.rs
@@ -3,7 +3,11 @@
 //! Supports multiple transports: stdio (spawn local process), HTTP, and SSE.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(not(target_has_atomic = "64"))]
+use std::sync::atomic::AtomicU32;
+#[cfg(target_has_atomic = "64")]
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -32,7 +36,10 @@ const MAX_TOOL_TIMEOUT_SECS: u64 = 600;
 struct McpServerInner {
     config: McpServerConfig,
     transport: Box<dyn McpTransportConn>,
+    #[cfg(target_has_atomic = "64")]
     next_id: AtomicU64,
+    #[cfg(not(target_has_atomic = "64"))]
+    next_id: AtomicU32,
     tools: Vec<McpToolDef>,
 }
 
@@ -123,7 +130,10 @@ impl McpServer {
         let inner = McpServerInner {
             config,
             transport,
+            #[cfg(target_has_atomic = "64")]
             next_id: AtomicU64::new(3), // Start at 3 since we used 1 and 2
+            #[cfg(not(target_has_atomic = "64"))]
+            next_id: AtomicU32::new(3), // Start at 3 since we used 1 and 2
             tools: tool_list.tools,
         };
 
@@ -155,7 +165,7 @@ impl McpServer {
         arguments: serde_json::Value,
     ) -> Result<serde_json::Value> {
         let mut inner = self.inner.lock().await;
-        let id = inner.next_id.fetch_add(1, Ordering::Relaxed);
+        let id = inner.next_id.fetch_add(1, Ordering::Relaxed) as u64;
         let req = JsonRpcRequest::new(
             id,
             "tools/call",


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: `src/tools/mcp_client.rs` uses `AtomicU64` which doesn't exist on 32-bit targets, causing build failures.
- Why it matters: 32-bit builds are broken for any platform without 64-bit atomics.
- What changed: Applied the same `cfg(target_has_atomic = "64")` conditional compilation pattern already used in `src/channels/irc.rs` to fall back to `AtomicU32` on 32-bit targets. The `fetch_add` result is cast to `u64` for `JsonRpcRequest::new()`.
- What did **not** change (scope boundary): No behavioral changes on 64-bit targets. No changes to MCP protocol logic.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): risk: low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): size: XS
- Scope labels: tool
- Module labels: tool: mcp
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): tool

## Linked Issue

- Closes #3430
- Related #3409

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass, no warnings
```

- Evidence provided (test/log/trace/screenshot/perf): CLI output confirms clean checks
- If any command is intentionally skipped, explain why: `cargo test` not run locally — deferring to CI

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Confirmed pattern matches existing usage in `src/channels/irc.rs`
- Edge cases checked: `as u64` cast is safe — AtomicU32 counter values fit in u64
- What was not verified: Actual 32-bit target compilation (no 32-bit toolchain available locally)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: MCP client only
- Potential unintended effects: None — identical behavior on 64-bit targets
- Guardrails/monitoring for early detection: CI 32-bit build target

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Identified AtomicU64 usage, matched existing cfg pattern from irc.rs, applied fix, ran checks
- Verification focus: Format and clippy pass
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles (if any): None
- Observable failure symptoms: 32-bit build failure returns

## Risks and Mitigations

- Risk: Counter wraps at u32::MAX on 32-bit targets instead of u64::MAX
  - Mitigation: MCP request IDs only need to be unique within a session; u32 range (~4 billion) is more than sufficient