### PR TITLE
fix(channel): resolve Matrix channel compilation errors

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -5,9 +5,9 @@ use matrix_sdk::{
     config::SyncSettings,
     ruma::{
         events::reaction::ReactionEventContent,
-        events::relation::{Annotation, InReplyTo, Thread},
+        events::relation::{Annotation, Thread},
         events::room::message::{
-            MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent,
+            MessageType, OriginalSyncRoomMessageEvent, Relation, RoomMessageEventContent,
         },
         events::room::MediaSource,
         OwnedEventId, OwnedRoomId, OwnedUserId,
@@ -540,12 +540,7 @@ impl Channel for MatrixChannel {
     async fn send(&self, message: &SendMessage) -> anyhow::Result<()> {
         let client = self.matrix_client().await?;
         let target_room_id = if message.recipient.contains("||") {
-            message
-                .recipient
-                .splitn(2, "||")
-                .nth(1)
-                .unwrap()
-                .to_string()
+            message.recipient.split_once("||").unwrap().1.to_string()
         } else {
             self.target_room_id().await?
         };
@@ -589,8 +584,7 @@ impl Channel for MatrixChannel {
             let tts_text = message
                 .content
                 .replace("**", "")
-                .replace("*", "")
-                .replace("`", "")
+                .replace(['*', '`'], "")
                 .replace("# ", "");
 
             let tts_ok = tokio::process::Command::new("edge-tts")
@@ -703,7 +697,7 @@ impl Channel for MatrixChannel {
 
         client.add_event_handler(move |event: OriginalSyncRoomMessageEvent, room: Room| {
             let tx = tx_handler.clone();
-            let target_room = target_room_for_handler.clone();
+            let _target_room = target_room_for_handler.clone();
             let my_user_id = my_user_id_for_handler.clone();
             let allowed_users = allowed_users_for_handler.clone();
             let dedupe = Arc::clone(&dedupe_for_handler);
@@ -736,7 +730,7 @@ impl Channel for MatrixChannel {
                                 format!("{}/_matrix/client/v1/media/download/{}", homeserver, rest);
                             Some((url, name.to_string()))
                         }
-                        _ => None,
+                        MediaSource::Encrypted(_) => None,
                     }
                 };
 
@@ -782,7 +776,7 @@ impl Channel for MatrixChannel {
                     {
                         Ok(resp) if resp.status().is_success() => match resp.bytes().await {
                             Ok(bytes) => match tokio::fs::write(&dest, &bytes).await {
-                                Ok(_) => format!("{} — saved to {}", body, dest.display()),
+                                Ok(()) => format!("{} — saved to {}", body, dest.display()),
                                 Err(_) => format!("{} — failed to write to disk", body),
                             },
                             Err(_) => format!("{} — download failed", body),

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2990,6 +2990,7 @@ fn collect_configured_channels(
     config: &Config,
     matrix_skip_context: &str,
 ) -> Vec<ConfiguredChannel> {
+    let _ = matrix_skip_context;
     let mut channels = Vec::new();
 
     if let Some(ref tg) = config.channels_config.telegram {


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Compiling with `--features channel-matrix` fails due to missing `Relation` type import, unused `InReplyTo` import, unused `matrix_skip_context` variable, and additional clippy lint violations.
- Why it matters: The Matrix channel feature cannot be compiled, blocking any build that enables it.
- What changed: Fixed imports in `matrix.rs` (added `Relation` from `events::room::message`, removed unused `InReplyTo`), suppressed unused `matrix_skip_context` in `mod.rs`, and resolved clippy lints (`split_once`, single-char patterns, collapsible replace, wildcard match, ignored unit pattern).
- What did **not** change (scope boundary): No behavioral changes; only import/lint fixes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `channel`
- Module labels: `channel: matrix`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #3425

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check     # pass
cargo clippy --all-targets --features channel-matrix -- -D warnings  # pass
```

- Evidence provided (test/log/trace/screenshot/perf): clippy and fmt pass locally
- If any command is intentionally skipped, explain why: `cargo test` not run as changes are import/lint-only with no behavioral impact

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: `cargo clippy --all-targets --features channel-matrix -- -D warnings` passes cleanly
- Edge cases checked: Confirmed `Relation` is the correct generic enum from `ruma::events::room::message`
- What was not verified: Runtime Matrix message sending (import-only change)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Matrix channel compilation only
- Potential unintended effects: None
- Guardrails/monitoring for early detection: CI with `channel-matrix` feature gate

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Identified missing `Relation` import path, removed unused `InReplyTo`, fixed unused variable, and resolved additional clippy lints
- Verification focus: Compilation and lint checks with `channel-matrix` feature enabled
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: `channel-matrix` feature flag
- Observable failure symptoms: Compilation failure with `--features channel-matrix`

## Risks and Mitigations

- None