### PR TITLE
feat(docker): add Debian-based container variant with shell tools

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,120 @@
+# syntax=docker/dockerfile:1.7
+
+# Dockerfile.debian — Shell-equipped variant of the ZeroClaw container.
+#
+# The default Dockerfile produces a distroless "release" image with no shell,
+# which is ideal for minimal attack surface but prevents the agent from using
+# shell-based tools (pwd, ls, git, curl, etc.).
+#
+# This variant uses debian:bookworm-slim as the runtime base and ships
+# essential CLI tools so the agent can operate as a full coding assistant.
+#
+# Build:
+#   docker build -f Dockerfile.debian -t zeroclaw:debian .
+#
+# Or with docker compose:
+#   docker compose -f docker-compose.yml -f docker-compose.debian.yml up
+
+# ── Stage 1: Build (identical to main Dockerfile) ───────────
+FROM rust:1.93-slim@sha256:9663b80a1621253d30b146454f903de48f0af925c967be48c84745537cd35d8b AS builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# 1. Copy manifests to cache dependencies
+COPY Cargo.toml Cargo.lock ./
+COPY crates/robot-kit/Cargo.toml crates/robot-kit/Cargo.toml
+# Create dummy targets declared in Cargo.toml so manifest parsing succeeds.
+RUN mkdir -p src benches crates/robot-kit/src \
+    && echo "fn main() {}" > src/main.rs \
+    && echo "fn main() {}" > benches/agent_benchmarks.rs \
+    && echo "pub fn placeholder() {}" > crates/robot-kit/src/lib.rs
+RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
+    cargo build --release --locked
+RUN rm -rf src benches crates/robot-kit/src
+
+# 2. Copy only build-relevant source paths (avoid cache-busting on docs/tests/scripts)
+COPY src/ src/
+COPY benches/ benches/
+COPY crates/ crates/
+COPY firmware/ firmware/
+COPY web/ web/
+# Keep release builds resilient when frontend dist assets are not prebuilt in Git.
+RUN mkdir -p web/dist && \
+    if [ ! -f web/dist/index.html ]; then \
+      printf '%s\n' \
+        '<!doctype html>' \
+        '<html lang="en">' \
+        '  <head>' \
+        '    <meta charset="utf-8" />' \
+        '    <meta name="viewport" content="width=device-width,initial-scale=1" />' \
+        '    <title>ZeroClaw Dashboard</title>' \
+        '  </head>' \
+        '  <body>' \
+        '    <h1>ZeroClaw Dashboard Unavailable</h1>' \
+        '    <p>Frontend assets are not bundled in this build. Build the web UI to populate <code>web/dist</code>.</p>' \
+        '  </body>' \
+        '</html>' > web/dist/index.html; \
+    fi
+RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
+    cargo build --release --locked && \
+    cp target/release/zeroclaw /app/zeroclaw && \
+    strip /app/zeroclaw
+
+# Prepare runtime directory structure and default config inline (no extra stage)
+RUN mkdir -p /zeroclaw-data/.zeroclaw /zeroclaw-data/workspace && \
+    printf '%s\n' \
+        'workspace_dir = "/zeroclaw-data/workspace"' \
+        'config_path = "/zeroclaw-data/.zeroclaw/config.toml"' \
+        'api_key = ""' \
+        'default_provider = "openrouter"' \
+        'default_model = "anthropic/claude-sonnet-4-20250514"' \
+        'default_temperature = 0.7' \
+        '' \
+        '[gateway]' \
+        'port = 42617' \
+        'host = "[::]"' \
+        'allow_public_bind = true' \
+        > /zeroclaw-data/.zeroclaw/config.toml && \
+    chown -R 65534:65534 /zeroclaw-data
+
+# ── Stage 2: Runtime (Debian with shell) ─────────────────────
+FROM debian:bookworm-slim AS runtime
+
+# Install essential tools for agent shell operations
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
+COPY --from=builder /zeroclaw-data /zeroclaw-data
+
+# Environment setup
+# Ensure UTF-8 locale so CJK / multibyte input is handled correctly
+ENV LANG=C.UTF-8
+ENV ZEROCLAW_WORKSPACE=/zeroclaw-data/workspace
+ENV HOME=/zeroclaw-data
+# Default provider and model are set in config.toml, not here,
+# so config file edits are not silently overridden
+ENV ZEROCLAW_GATEWAY_PORT=42617
+
+# API_KEY must be provided at runtime!
+
+WORKDIR /zeroclaw-data
+USER 65534:65534
+EXPOSE 42617
+ENTRYPOINT ["zeroclaw"]
+CMD ["gateway"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,12 @@
 services:
   zeroclaw:
     image: ghcr.io/zeroclaw-labs/zeroclaw:latest
-    # Or build locally:
+    # Or build locally (distroless, no shell):
     # build: .
+    # Or build the Debian variant (includes bash, git, curl):
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile.debian
     container_name: zeroclaw
     restart: unless-stopped
     


### PR DESCRIPTION
## Summary

- Add `Dockerfile.debian` that uses `debian:bookworm-slim` as the runtime base instead of distroless, shipping `bash`, `git`, `curl`, and `ca-certificates` so the agent can use shell-based tools
- The existing distroless `Dockerfile` is unchanged — security-conscious users keep their minimal image
- Update `docker-compose.yml` with a comment showing how to build the Debian variant

## Motivation

The default distroless image has no shell, which prevents the agent from using shell tools (`pwd`, `ls`, `git`, etc.). This is a blocker for users who need the agent to operate as a full coding assistant inside a container.

Closes #3359

## Risk

**Low** — additive change only. No existing files are modified beyond a comment in `docker-compose.yml`. The distroless production image is untouched.

## Test plan

- [ ] `docker build -f Dockerfile.debian -t zeroclaw:debian .` builds successfully
- [ ] Container starts and `docker exec <id> bash -c 'git --version && curl --version'` works
- [ ] Existing `docker build .` (distroless) still works unchanged
- [ ] CI passes