### PR TITLE
feat(channels): add ack_reactions config to disable channel reactions

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -293,6 +293,7 @@ struct ChannelRuntimeContext {
     non_cli_excluded_tools: Arc<Vec<String>>,
     tool_call_dedup_exempt: Arc<Vec<String>>,
     model_routes: Arc<Vec<crate::config::ModelRouteConfig>>,
+    ack_reactions: bool,
 }
 
 #[derive(Clone)]
@@ -1880,12 +1881,14 @@ async fn process_channel_message(
     };
 
     // React with 👀 to acknowledge the incoming message
-    if let Some(channel) = target_channel.as_ref() {
-        if let Err(e) = channel
-            .add_reaction(&msg.reply_target, &msg.id, "\u{1F440}")
-            .await
-        {
-            tracing::debug!("Failed to add reaction: {e}");
+    if ctx.ack_reactions {
+        if let Some(channel) = target_channel.as_ref() {
+            if let Err(e) = channel
+                .add_reaction(&msg.reply_target, &msg.id, "\u{1F440}")
+                .await
+            {
+                tracing::debug!("Failed to add reaction: {e}");
+            }
         }
     }
 
@@ -2321,13 +2324,15 @@ async fn process_channel_message(
     }
 
     // Swap 👀 → ✅ (or ⚠️ on error) to signal processing is complete
-    if let Some(channel) = target_channel.as_ref() {
-        let _ = channel
-            .remove_reaction(&msg.reply_target, &msg.id, "\u{1F440}")
-            .await;
-        let _ = channel
-            .add_reaction(&msg.reply_target, &msg.id, reaction_done_emoji)
-            .await;
+    if ctx.ack_reactions {
+        if let Some(channel) = target_channel.as_ref() {
+            let _ = channel
+                .remove_reaction(&msg.reply_target, &msg.id, "\u{1F440}")
+                .await;
+            let _ = channel
+                .add_reaction(&msg.reply_target, &msg.id, reaction_done_emoji)
+                .await;
+        }
     }
 }
 
@@ -3688,6 +3693,7 @@ pub async fn start_channels(config: Config) -> Result<()> {
         non_cli_excluded_tools: Arc::new(config.autonomy.non_cli_excluded_tools.clone()),
         tool_call_dedup_exempt: Arc::new(config.agent.tool_call_dedup_exempt.clone()),
         model_routes: Arc::new(config.model_routes.clone()),
+        ack_reactions: config.channels_config.ack_reactions,
     });
 
     run_message_dispatch_loop(rx, runtime_ctx, max_in_flight_messages).await;
@@ -3950,6 +3956,7 @@ mod tests {
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         };
 
         assert!(compact_sender_history(&ctx, &sender));
@@ -4001,6 +4008,7 @@ mod tests {
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         };
 
         append_sender_turn(&ctx, &sender, ChatMessage::user("hello"));
@@ -4055,6 +4063,7 @@ mod tests {
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         };
 
         assert!(rollback_orphan_user_turn(&ctx, &sender, "pending"));
@@ -4532,6 +4541,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -4594,6 +4604,7 @@ BTC is currently around $65,000 based on latest tool output."#
             multimodal: crate::config::MultimodalConfig::default(),
             hooks: None,
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -4670,6 +4681,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -4731,6 +4743,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -4802,6 +4815,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -4893,6 +4907,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -4966,6 +4981,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -5054,6 +5070,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -5127,6 +5144,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -5190,6 +5208,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -5364,6 +5383,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(4);
@@ -5446,6 +5466,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);
@@ -5540,6 +5561,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);
@@ -5616,6 +5638,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -5677,6 +5700,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -6236,6 +6260,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -6323,6 +6348,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -6410,6 +6436,7 @@ BTC is currently around $65,000 based on latest tool output."#
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(
@@ -6961,6 +6988,7 @@ This is an example JSON object for profile settings."#;
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         // Simulate a photo attachment message with [IMAGE:] marker.
@@ -7029,6 +7057,7 @@ This is an example JSON object for profile settings."#;
             non_cli_excluded_tools: Arc::new(Vec::new()),
             tool_call_dedup_exempt: Arc::new(Vec::new()),
             model_routes: Arc::new(Vec::new()),
+            ack_reactions: true,
         });
 
         process_channel_message(

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -3026,6 +3026,10 @@ pub struct ChannelsConfig {
     /// Default: 300s for on-device LLMs (Ollama) which are slower than cloud APIs.
     #[serde(default = "default_channel_message_timeout_secs")]
     pub message_timeout_secs: u64,
+    /// Whether to add acknowledgement reactions (👀 on receipt, ✅/⚠️ on
+    /// completion) to incoming channel messages. Default: `true`.
+    #[serde(default = "default_true")]
+    pub ack_reactions: bool,
 }
 
 impl ChannelsConfig {
@@ -3153,6 +3157,7 @@ impl Default for ChannelsConfig {
             nostr: None,
             clawdtalk: None,
             message_timeout_secs: default_channel_message_timeout_secs(),
+            ack_reactions: true,
         }
     }
 }
@@ -6062,6 +6067,7 @@ default_temperature = 0.7
                 nostr: None,
                 clawdtalk: None,
                 message_timeout_secs: 300,
+                ack_reactions: true,
             },
             memory: MemoryConfig::default(),
             storage: StorageConfig::default(),
@@ -6735,6 +6741,7 @@ allowed_users = ["@ops:matrix.org"]
             nostr: None,
             clawdtalk: None,
             message_timeout_secs: 300,
+            ack_reactions: true,
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();
@@ -6949,6 +6956,7 @@ channel_id = "C123"
             nostr: None,
             clawdtalk: None,
             message_timeout_secs: 300,
+            ack_reactions: true,
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The 👀/✅/⚠️ acknowledgement reactions on channel messages are hardcoded with no way to disable them.
- Why it matters: Some users/deployments find the reactions noisy or unnecessary and want the ability to turn them off.
- What changed: Added `ack_reactions` boolean field (default `true`) to `ChannelsConfig`; gated the two `add_reaction`/`remove_reaction` call sites in `src/channels/mod.rs` behind this flag.
- What did **not** change (scope boundary): No per-channel granularity — this is a global channels-level toggle only. Reaction emoji values are unchanged.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`, `config`
- Module labels: `channel: reactions`, `config: channels`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Closes #3403

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass
```

- Evidence provided: CLI output — both commands exit 0 with no warnings.
- If any command is intentionally skipped, explain why: `cargo test` deferred to CI.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes — defaults to `true`, preserving existing behavior.
- Config/env changes? Yes — new optional `ack_reactions` key in `[channels_config]`.
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Clippy and fmt pass; field wiring reviewed manually.
- Edge cases checked: Default value preserves existing behavior; omitting the key from config works via `serde(default)`.
- What was not verified: Runtime integration test with a live channel.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Channel message handler reaction logic only.
- Potential unintended effects: None — the flag is additive and opt-in to disable.
- Guardrails/monitoring for early detection: Existing channel integration tests cover the handler path.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Read config schema and channel handler, added field to `ChannelsConfig` + `ChannelRuntimeContext`, gated reaction calls, updated all test constructions.
- Verification focus: Compile-time correctness via clippy/fmt.
- Confirmation: naming + architecture boundaries followed.

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit.
- Feature flags or config toggles: `ack_reactions = true` restores previous behavior.
- Observable failure symptoms: Reactions unexpectedly absent if misconfigured.

## Risks and Mitigations

- Risk: None — additive, backward-compatible config option with safe default.