### PR TITLE
feat(gateway): add cron run history API and dashboard panel

### DIFF
--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -60,6 +60,11 @@ pub struct MemoryStoreBody {
 }
 
 #[derive(Deserialize)]
+pub struct CronRunsQuery {
+    pub limit: Option<u32>,
+}
+
+#[derive(Deserialize)]
 pub struct CronAddBody {
     pub name: Option<String>,
     pub schedule: String,
@@ -277,6 +282,55 @@ pub async fn handle_api_cron_add(
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": format!("Failed to add cron job: {e}")})),
+        )
+            .into_response(),
+    }
+}
+
+/// GET /api/cron/:id/runs — list recent runs for a cron job
+pub async fn handle_api_cron_runs(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Query(params): Query<CronRunsQuery>,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let limit = params.limit.unwrap_or(20).clamp(1, 100) as usize;
+    let config = state.config.lock().clone();
+
+    // Verify the job exists before listing runs.
+    if let Err(e) = crate::cron::get_job(&config, &id) {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": format!("Cron job not found: {e}")})),
+        )
+            .into_response();
+    }
+
+    match crate::cron::list_runs(&config, &id, limit) {
+        Ok(runs) => {
+            let runs_json: Vec<serde_json::Value> = runs
+                .iter()
+                .map(|r| {
+                    serde_json::json!({
+                        "id": r.id,
+                        "job_id": r.job_id,
+                        "started_at": r.started_at.to_rfc3339(),
+                        "finished_at": r.finished_at.to_rfc3339(),
+                        "status": r.status,
+                        "output": r.output,
+                        "duration_ms": r.duration_ms,
+                    })
+                })
+                .collect();
+            Json(serde_json::json!({"runs": runs_json})).into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Failed to list cron runs: {e}")})),
         )
             .into_response(),
     }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -683,6 +683,7 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         .route("/api/cron", get(api::handle_api_cron_list))
         .route("/api/cron", post(api::handle_api_cron_add))
         .route("/api/cron/{id}", delete(api::handle_api_cron_delete))
+        .route("/api/cron/{id}/runs", get(api::handle_api_cron_runs))
         .route("/api/integrations", get(api::handle_api_integrations))
         .route(
             "/api/integrations/settings",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   StatusResponse,
   ToolSpec,
   CronJob,
+  CronRun,
   Integration,
   DiagResult,
   MemoryEntry,
@@ -172,6 +173,16 @@ export function deleteCronJob(id: string): Promise<void> {
   return apiFetch<void>(`/api/cron/${encodeURIComponent(id)}`, {
     method: 'DELETE',
   });
+}
+
+export function getCronRuns(
+  jobId: string,
+  limit: number = 20,
+): Promise<CronRun[]> {
+  const params = new URLSearchParams({ limit: String(limit) });
+  return apiFetch<CronRun[] | { runs: CronRun[] }>(
+    `/api/cron/${encodeURIComponent(jobId)}/runs?${params}`,
+  ).then((data) => unwrapField(data, 'runs'));
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/pages/Cron.tsx
+++ b/web/src/pages/Cron.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Clock,
   Plus,
@@ -7,14 +7,132 @@ import {
   CheckCircle,
   XCircle,
   AlertCircle,
+  ChevronDown,
+  ChevronRight,
+  RefreshCw,
 } from 'lucide-react';
-import type { CronJob } from '@/types/api';
-import { getCronJobs, addCronJob, deleteCronJob } from '@/lib/api';
+import type { CronJob, CronRun } from '@/types/api';
+import { getCronJobs, addCronJob, deleteCronJob, getCronRuns } from '@/lib/api';
 
 function formatDate(iso: string | null): string {
   if (!iso) return '-';
   const d = new Date(iso);
   return d.toLocaleString();
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null || ms === undefined) return '-';
+  if (ms < 1000) return `${ms}ms`;
+  const secs = ms / 1000;
+  if (secs < 60) return `${secs.toFixed(1)}s`;
+  return `${(secs / 60).toFixed(1)}m`;
+}
+
+function RunHistoryPanel({ jobId }: { jobId: string }) {
+  const [runs, setRuns] = useState<CronRun[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRuns = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    getCronRuns(jobId, 20)
+      .then(setRuns)
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [jobId]);
+
+  useEffect(() => {
+    fetchRuns();
+  }, [fetchRuns]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 px-4 py-3 text-gray-400 text-xs">
+        <div className="animate-spin rounded-full h-4 w-4 border border-blue-500 border-t-transparent" />
+        Loading run history...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="px-4 py-3">
+        <div className="flex items-center justify-between">
+          <span className="text-xs text-red-400">
+            Failed to load run history: {error}
+          </span>
+          <button
+            onClick={fetchRuns}
+            className="text-gray-400 hover:text-white transition-colors"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (runs.length === 0) {
+    return (
+      <div className="px-4 py-3 flex items-center justify-between">
+        <span className="text-xs text-gray-500">No runs recorded yet.</span>
+        <button
+          onClick={fetchRuns}
+          className="text-gray-400 hover:text-white transition-colors"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 py-3">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs font-medium text-gray-400">
+          Recent Runs ({runs.length})
+        </span>
+        <button
+          onClick={fetchRuns}
+          className="text-gray-400 hover:text-white transition-colors"
+          title="Refresh runs"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <div className="space-y-1.5 max-h-60 overflow-y-auto">
+        {runs.map((run) => (
+          <div
+            key={run.id}
+            className="bg-gray-800/60 rounded-lg px-3 py-2 text-xs"
+          >
+            <div className="flex items-center justify-between mb-1">
+              <div className="flex items-center gap-2">
+                {run.status === 'ok' ? (
+                  <CheckCircle className="h-3.5 w-3.5 text-green-400" />
+                ) : (
+                  <XCircle className="h-3.5 w-3.5 text-red-400" />
+                )}
+                <span className="text-gray-300 capitalize">{run.status}</span>
+              </div>
+              <span className="text-gray-500">
+                {formatDuration(run.duration_ms)}
+              </span>
+            </div>
+            <div className="flex items-center gap-3 text-gray-500">
+              <span>{formatDate(run.started_at)}</span>
+            </div>
+            {run.output && (
+              <pre className="mt-1.5 bg-gray-900/70 rounded p-2 text-gray-400 text-xs overflow-x-auto max-h-24 whitespace-pre-wrap break-words">
+                {run.output}
+              </pre>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export default function Cron() {
@@ -23,6 +141,7 @@ export default function Cron() {
   const [error, setError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [expandedJob, setExpandedJob] = useState<string | null>(null);
 
   // Form state
   const [formName, setFormName] = useState('');
@@ -250,68 +369,91 @@ export default function Cron() {
             </thead>
             <tbody>
               {jobs.map((job) => (
-                <tr
-                  key={job.id}
-                  className="border-b border-gray-800/50 hover:bg-gray-800/30 transition-colors"
-                >
-                  <td className="px-4 py-3 text-gray-400 font-mono text-xs">
-                    {job.id.slice(0, 8)}
-                  </td>
-                  <td className="px-4 py-3 text-white font-medium">
-                    {job.name ?? '-'}
-                  </td>
-                  <td className="px-4 py-3 text-gray-300 font-mono text-xs max-w-[200px] truncate">
-                    {job.command}
-                  </td>
-                  <td className="px-4 py-3 text-gray-400 text-xs">
-                    {formatDate(job.next_run)}
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-1.5">
-                      {statusIcon(job.last_status)}
-                      <span className="text-gray-300 text-xs capitalize">
-                        {job.last_status ?? '-'}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3">
-                    <span
-                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
-                        job.enabled
-                          ? 'bg-green-900/40 text-green-400 border border-green-700/50'
-                          : 'bg-gray-800 text-gray-500 border border-gray-700'
-                      }`}
-                    >
-                      {job.enabled ? 'Enabled' : 'Disabled'}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    {confirmDelete === job.id ? (
-                      <div className="flex items-center justify-end gap-2">
-                        <span className="text-xs text-red-400">Delete?</span>
-                        <button
-                          onClick={() => handleDelete(job.id)}
-                          className="text-red-400 hover:text-red-300 text-xs font-medium"
-                        >
-                          Yes
-                        </button>
-                        <button
-                          onClick={() => setConfirmDelete(null)}
-                          className="text-gray-400 hover:text-white text-xs font-medium"
-                        >
-                          No
-                        </button>
-                      </div>
-                    ) : (
+                <React.Fragment key={job.id}>
+                  <tr
+                    className="border-b border-gray-800/50 hover:bg-gray-800/30 transition-colors"
+                  >
+                    <td className="px-4 py-3 text-gray-400 font-mono text-xs">
                       <button
-                        onClick={() => setConfirmDelete(job.id)}
-                        className="text-gray-400 hover:text-red-400 transition-colors"
+                        onClick={() =>
+                          setExpandedJob((prev) =>
+                            prev === job.id ? null : job.id,
+                          )
+                        }
+                        className="flex items-center gap-1 text-gray-400 hover:text-white transition-colors"
+                        title="Toggle run history"
                       >
-                        <Trash2 className="h-4 w-4" />
+                        {expandedJob === job.id ? (
+                          <ChevronDown className="h-3.5 w-3.5" />
+                        ) : (
+                          <ChevronRight className="h-3.5 w-3.5" />
+                        )}
+                        {job.id.slice(0, 8)}
                       </button>
-                    )}
-                  </td>
-                </tr>
+                    </td>
+                    <td className="px-4 py-3 text-white font-medium">
+                      {job.name ?? '-'}
+                    </td>
+                    <td className="px-4 py-3 text-gray-300 font-mono text-xs max-w-[200px] truncate">
+                      {job.command}
+                    </td>
+                    <td className="px-4 py-3 text-gray-400 text-xs">
+                      {formatDate(job.next_run)}
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-1.5">
+                        {statusIcon(job.last_status)}
+                        <span className="text-gray-300 text-xs capitalize">
+                          {job.last_status ?? '-'}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span
+                        className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                          job.enabled
+                            ? 'bg-green-900/40 text-green-400 border border-green-700/50'
+                            : 'bg-gray-800 text-gray-500 border border-gray-700'
+                        }`}
+                      >
+                        {job.enabled ? 'Enabled' : 'Disabled'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      {confirmDelete === job.id ? (
+                        <div className="flex items-center justify-end gap-2">
+                          <span className="text-xs text-red-400">Delete?</span>
+                          <button
+                            onClick={() => handleDelete(job.id)}
+                            className="text-red-400 hover:text-red-300 text-xs font-medium"
+                          >
+                            Yes
+                          </button>
+                          <button
+                            onClick={() => setConfirmDelete(null)}
+                            className="text-gray-400 hover:text-white text-xs font-medium"
+                          >
+                            No
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => setConfirmDelete(job.id)}
+                          className="text-gray-400 hover:text-red-400 transition-colors"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                  {expandedJob === job.id && (
+                    <tr className="bg-gray-900/50">
+                      <td colSpan={7}>
+                        <RunHistoryPanel jobId={job.id} />
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
               ))}
             </tbody>
           </table>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -42,6 +42,16 @@ export interface CronJob {
   enabled: boolean;
 }
 
+export interface CronRun {
+  id: number;
+  job_id: string;
+  started_at: string;
+  finished_at: string;
+  status: string;
+  output: string | null;
+  duration_ms: number | null;
+}
+
 export interface Integration {
   name: string;
   description: string;


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: No way to view historical cron job execution results via the API or web dashboard.
- Why it matters: Operators need visibility into past cron runs (status, duration, output) for debugging and monitoring.
- What changed: Added `GET /api/cron/{id}/runs?limit=N` endpoint and an expandable run history panel on the Cron dashboard page.
- What did **not** change: Existing cron create/delete/list flows, scheduler execution logic, and run storage/pruning logic are untouched.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `gateway`, `cron`
- Module labels: `gateway: api`, `cron: dashboard`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type: `feature`
- Primary scope: `gateway`

## Linked Issue

- Closes #3299

## Changes

### Backend (`src/gateway/api.rs`, `src/gateway/mod.rs`)

- Added `CronRunsQuery` deserialization struct for the `?limit=` query parameter.
- Added `handle_api_cron_runs` handler for `GET /api/cron/{id}/runs`:
  - Validates the job exists (returns 404 if not found).
  - Clamps `limit` to 1-100, defaults to 20.
  - Returns JSON `{ "runs": [...] }` with id, job_id, started_at, finished_at, status, output, duration_ms.
- Registered route `/api/cron/{id}/runs` in the gateway router.

### Frontend (`web/src/types/api.ts`, `web/src/lib/api.ts`, `web/src/pages/Cron.tsx`)

- Added `CronRun` TypeScript interface.
- Added `getCronRuns(jobId, limit)` API client function.
- Added `RunHistoryPanel` component with loading, empty, error, and data states plus a refresh button.
- Made job table rows expandable via chevron toggle to show/hide the run history panel inline.

## Test plan

- [ ] Verify `cargo check` passes (only pre-existing `str_as_str` warnings in `security/policy.rs`)
- [ ] Verify `cargo fmt --all -- --check` passes
- [ ] Verify `npx tsc --noEmit` passes in `web/`
- [ ] Create a cron job, trigger a run, then call `GET /api/cron/{id}/runs` and verify JSON response
- [ ] Verify limit clamping: `?limit=0` returns 1 run, `?limit=200` returns at most 100
- [ ] Verify 404 for non-existent job ID
- [ ] Verify the dashboard Cron page loads, expand a job row, and confirm history panel renders
- [ ] Verify existing cron create and delete flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)