### PR TITLE
feat(matrix): add read markers and typing notifications

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -4,7 +4,9 @@ use matrix_sdk::{
     authentication::matrix::MatrixSession,
     config::SyncSettings,
     ruma::{
+        api::client::receipt::create_receipt,
         events::reaction::ReactionEventContent,
+        events::receipt::ReceiptThread,
         events::relation::{Annotation, Thread},
         events::room::message::{
             MessageType, OriginalSyncRoomMessageEvent, Relation, RoomMessageEventContent,
@@ -560,6 +562,11 @@ impl Channel for MatrixChannel {
             anyhow::bail!("Matrix room '{}' is not in joined state", target_room_id);
         }
 
+        // Stop typing notification before sending the response
+        if let Err(error) = room.typing_notice(false).await {
+            tracing::warn!("Matrix failed to stop typing notification: {error}");
+        }
+
         let mut content = RoomMessageEventContent::text_markdown(&message.content);
 
         if let Some(ref thread_ts) = message.thread_ts {
@@ -853,6 +860,23 @@ impl Channel for MatrixChannel {
                     if MatrixChannel::cache_event_id(&event_id, recent_order, recent_lookup) {
                         return;
                     }
+                }
+
+                // Send a read receipt for the incoming event
+                if let Err(error) = room
+                    .send_single_receipt(
+                        create_receipt::v3::ReceiptType::Read,
+                        ReceiptThread::Unthreaded,
+                        event.event_id.clone(),
+                    )
+                    .await
+                {
+                    tracing::warn!("Matrix failed to send read receipt: {error}");
+                }
+
+                // Start typing notification while processing begins
+                if let Err(error) = room.typing_notice(true).await {
+                    tracing::warn!("Matrix failed to start typing notification: {error}");
                 }
 
                 let thread_ts = match &event.content.relates_to {


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Matrix users get no visual feedback when the bot receives their message or is processing a response.
- Why it matters: Read markers and typing indicators are standard Matrix UX signals that help users know the bot is active.
- What changed: After receiving a message, the bot sends a read receipt, starts a typing notification, and stops it before sending the reply.
- What did **not** change: No new dependencies, no config changes, no changes to other channels or the agent loop.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: matrix`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Closes #3357

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # matrix.rs clean (pre-existing issue in tools/shell.rs only)
cargo clippy --features channel-matrix -- -D warnings  # clean
cargo test --features channel-matrix -- channels::matrix  # 32 passed, 0 failed
```

- Evidence provided: all 32 matrix unit tests pass, clippy clean, no new warnings.