### PR TITLE
feat(web): preserve message draft in agent chat across view switches

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import Cost from './pages/Cost';
 import Logs from './pages/Logs';
 import Doctor from './pages/Doctor';
 import { AuthProvider, useAuth } from './hooks/useAuth';
+import { DraftContext, useDraftStore } from './hooks/useDraft';
 import { setLocale, type Locale } from './lib/i18n';
 
 // Locale context
@@ -82,6 +83,7 @@ function PairingDialog({ onPair }: { onPair: (code: string) => Promise<void> }) 
 function AppContent() {
   const { isAuthenticated, requiresPairing, loading, pair, logout } = useAuth();
   const [locale, setLocaleState] = useState('tr');
+  const draftStore = useDraftStore();
 
   const setAppLocale = (newLocale: string) => {
     setLocaleState(newLocale);
@@ -110,23 +112,25 @@ function AppContent() {
   }
 
   return (
-    <LocaleContext.Provider value={{ locale, setAppLocale }}>
-      <Routes>
-        <Route element={<Layout />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/agent" element={<AgentChat />} />
-          <Route path="/tools" element={<Tools />} />
-          <Route path="/cron" element={<Cron />} />
-          <Route path="/integrations" element={<Integrations />} />
-          <Route path="/memory" element={<Memory />} />
-          <Route path="/config" element={<Config />} />
-          <Route path="/cost" element={<Cost />} />
-          <Route path="/logs" element={<Logs />} />
-          <Route path="/doctor" element={<Doctor />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Route>
-      </Routes>
-    </LocaleContext.Provider>
+    <DraftContext.Provider value={draftStore}>
+      <LocaleContext.Provider value={{ locale, setAppLocale }}>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/agent" element={<AgentChat />} />
+            <Route path="/tools" element={<Tools />} />
+            <Route path="/cron" element={<Cron />} />
+            <Route path="/integrations" element={<Integrations />} />
+            <Route path="/memory" element={<Memory />} />
+            <Route path="/config" element={<Config />} />
+            <Route path="/cost" element={<Cost />} />
+            <Route path="/logs" element={<Logs />} />
+            <Route path="/doctor" element={<Doctor />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Route>
+        </Routes>
+      </LocaleContext.Provider>
+    </DraftContext.Provider>
   );
 }
 

--- a/web/src/hooks/useDraft.ts
+++ b/web/src/hooks/useDraft.ts
@@ -1,0 +1,45 @@
+import { createContext, useContext, useCallback, useRef } from 'react';
+
+/**
+ * In-memory draft store that survives component unmounts but not page reloads.
+ * Keyed by an arbitrary string (e.g. route path or conversation id).
+ */
+
+export interface DraftContextType {
+  getDraft: (key: string) => string;
+  setDraft: (key: string, value: string) => void;
+  clearDraft: (key: string) => void;
+}
+
+export const DraftContext = createContext<DraftContextType>({
+  getDraft: () => '',
+  setDraft: () => {},
+  clearDraft: () => {},
+});
+
+export function useDraftStore(): DraftContextType {
+  const store = useRef<Map<string, string>>(new Map());
+
+  const getDraft = useCallback((key: string): string => {
+    return store.current.get(key) ?? '';
+  }, []);
+
+  const setDraft = useCallback((key: string, value: string): void => {
+    store.current.set(key, value);
+  }, []);
+
+  const clearDraft = useCallback((key: string): void => {
+    store.current.delete(key);
+  }, []);
+
+  return { getDraft, setDraft, clearDraft };
+}
+
+export function useDraft(key: string) {
+  const { getDraft, setDraft, clearDraft } = useContext(DraftContext);
+  return {
+    draft: getDraft(key),
+    saveDraft: (value: string) => setDraft(key, value),
+    clearDraft: () => clearDraft(key),
+  };
+}

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -3,6 +3,7 @@ import { Send, Bot, User, AlertCircle, Copy, Check } from 'lucide-react';
 import type { WsMessage } from '@/types/api';
 import { WebSocketClient } from '@/lib/ws';
 import { generateUUID } from '@/lib/uuid';
+import { useDraft } from '@/hooks/useDraft';
 
 interface ChatMessage {
   id: string;
@@ -11,9 +12,12 @@ interface ChatMessage {
   timestamp: Date;
 }
 
+const DRAFT_KEY = 'agent-chat';
+
 export default function AgentChat() {
+  const { draft, saveDraft, clearDraft } = useDraft(DRAFT_KEY);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [input, setInput] = useState('');
+  const [input, setInput] = useState(draft);
   const [typing, setTyping] = useState(false);
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -23,6 +27,11 @@ export default function AgentChat() {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const pendingContentRef = useRef('');
+
+  // Persist draft to in-memory store so it survives route changes
+  useEffect(() => {
+    saveDraft(input);
+  }, [input, saveDraft]);
 
   useEffect(() => {
     const ws = new WebSocketClient();
@@ -141,6 +150,7 @@ export default function AgentChat() {
     }
 
     setInput('');
+    clearDraft();
     if (inputRef.current) {
       inputRef.current.style.height = 'auto';
       inputRef.current.focus();


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: When a user is typing a message in the agent chat and switches to another dashboard view (settings, logs, etc.), their draft message is lost because the component unmounts.
- Why it matters: Users lose work-in-progress messages when navigating, causing friction.
- What changed: Added an in-memory `DraftContext` provider and `useDraft` hook. The `AgentChat` component now initializes its input from the draft store and syncs changes back, so drafts survive route navigation within the same session.
- What did **not** change (scope boundary): No localStorage or persistence beyond the current browser session. No changes to the WebSocket, message history, or any other page.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): risk: low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): size: XS
- Scope labels: web
- Module labels: web: dashboard
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): feature
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): web

## Linked Issue

- Closes #3129

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cd web && npx tsc -b --noEmit  # passes with zero errors
```

- Evidence provided (test/log/trace/screenshot/perf): TypeScript compiles cleanly
- If any command is intentionally skipped, explain why: `cargo` commands skipped — this PR touches only the `web/` TypeScript frontend, no Rust changes.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: TypeScript compilation passes; draft store logic reviewed for correctness.
- Edge cases checked: Empty draft returns empty string; clearing draft on send; multiple mounts/unmounts.
- What was not verified: Manual browser testing of the full navigation flow (requires running dev server with backend).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Agent chat input only.
- Potential unintended effects: None — the DraftContext is additive and only consumed by AgentChat.
- Guardrails/monitoring for early detection: TypeScript strict mode catches misuse.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Claude Code
- Workflow/plan summary (if any): Created DraftContext + useDraft hook, wired provider in App.tsx, consumed in AgentChat.tsx.
- Verification focus: TypeScript compilation
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit (single commit, no migration).
- Feature flags or config toggles (if any): None
- Observable failure symptoms: Agent chat input field empty on navigation return (original behavior).

## Risks and Mitigations

- Risk: None — purely additive in-memory state with no side effects on other components.