### PR TITLE
fix(ci): include install.sh in release assets and website dispatch

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -157,6 +157,7 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/**/*
+            install.sh
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
@@ -168,7 +169,7 @@ jobs:
             -H "Authorization: token $PAT" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/zeroclaw-labs/zeroclaw-website/dispatches \
-            -d '{"event_type":"new-release"}'
+            -d '{"event_type":"new-release","client_payload":{"install_script_url":"https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh"}}'
 
   docker:
     name: Push Docker Image

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -175,6 +175,7 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/**/*
+            install.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -186,7 +187,7 @@ jobs:
             -H "Authorization: token $PAT" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/zeroclaw-labs/zeroclaw-website/dispatches \
-            -d '{"event_type":"new-release"}'
+            -d '{"event_type":"new-release","client_payload":{"install_script_url":"https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh"}}'
 
   docker:
     name: Push Docker Image


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The website at zeroclawlabs.ai shows a copy button with `curl -fsSL https://zeroclawlabs.ai/install.sh | bash` but the website does not serve the script, returning a 404 error (#3463).
- Why it matters: New users copying the install command from the official website cannot install ZeroClaw.
- What changed: Both release workflows now (1) attach `install.sh` as a GitHub release asset, and (2) pass the raw GitHub URL of `install.sh` in the `client_payload` of the website redeploy dispatch so the website can configure a redirect or proxy for `/install.sh`.
- What did **not** change (scope boundary): No changes to install.sh itself, no changes to README URLs (they already use the correct raw GitHub URL), no changes to the website repo (separate follow-up needed there to consume the new `client_payload`).

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `ci`
- Module labels: N/A
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `ci`

## Linked Issue

- Closes #3463

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
bash -n install.sh  # syntax OK
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-beta-on-push.yml'))"  # valid
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-stable-manual.yml'))"  # valid
```

- Evidence provided (test/log/trace/screenshot/perf): YAML validation and install.sh syntax check passed
- If any command is intentionally skipped, explain why: `cargo fmt/clippy/test` skipped -- no Rust code changed, CI-only change

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: YAML parses correctly, install.sh syntax valid, dispatch payload is well-formed JSON with static (non-injectable) values
- Edge cases checked: Verified no untrusted input is interpolated in the dispatch curl command
- What was not verified: Actual website-side consumption of `client_payload` (requires follow-up in zeroclaw-website repo)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `release-beta-on-push`, `release-stable-manual`
- Potential unintended effects: None -- adding a file to `files:` is additive and the dispatch payload change is backward-compatible (website ignores unknown fields)
- Guardrails/monitoring for early detection: Next release will show install.sh in release assets

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Investigated repo structure, confirmed README already uses raw GitHub URL, identified that website dispatch lacked install.sh context, added install.sh as release asset and enriched dispatch payload
- Verification focus: YAML validity, no command injection, backward compatibility
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit
- Feature flags or config toggles (if any): None
- Observable failure symptoms: install.sh missing from release assets