### PR TITLE
fix(docs): use absolute URL for install.sh One-Click Setup link

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -58,7 +58,7 @@ Construit par des étudiants et membres des communautés Harvard, MIT et Sundai.
 
 <p align="center">
   <a href="#démarrage-rapide">Démarrage</a> |
-  <a href="install.sh">Configuration en un clic</a> |
+  <a href="https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh">Configuration en un clic</a> |
   <a href="docs/README.md">Hub Documentation</a> |
   <a href="docs/SUMMARY.md">Table des matières Documentation</a>
 </p>

--- a/README.ja.md
+++ b/README.ja.md
@@ -53,7 +53,7 @@
 </p>
 
 <p align="center">
-  <a href="install.sh">ワンクリック導入</a> |
+  <a href="https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh">ワンクリック導入</a> |
   <a href="docs/setup-guides/README.md">導入ガイド</a> |
   <a href="docs/README.ja.md">ドキュメントハブ</a> |
   <a href="docs/SUMMARY.md">Docs TOC</a>

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Built by students and members of the Harvard, MIT, and Sundai.Club communities.
 
 <p align="center">
   <a href="#quick-start">Getting Started</a> |
-  <a href="install.sh">One-Click Setup</a> |
+  <a href="https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh">One-Click Setup</a> |
   <a href="docs/README.md">Docs Hub</a> |
   <a href="docs/SUMMARY.md">Docs TOC</a>
 </p>

--- a/README.ru.md
+++ b/README.ru.md
@@ -53,7 +53,7 @@
 </p>
 
 <p align="center">
-  <a href="install.sh">Установка в 1 клик</a> |
+  <a href="https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh">Установка в 1 клик</a> |
   <a href="docs/setup-guides/README.md">Быстрый старт</a> |
   <a href="docs/README.ru.md">Хаб документации</a> |
   <a href="docs/SUMMARY.md">TOC docs</a>

--- a/README.vi.md
+++ b/README.vi.md
@@ -58,7 +58,7 @@
 
 <p align="center">
   <a href="#quick-start">Bắt đầu</a> |
-  <a href="install.sh">Cài đặt một lần bấm</a> |
+  <a href="https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh">Cài đặt một lần bấm</a> |
   <a href="docs/i18n/vi/README.md">Trung tâm tài liệu</a> |
   <a href="docs/SUMMARY.md">Mục lục tài liệu</a>
 </p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -53,7 +53,7 @@
 </p>
 
 <p align="center">
-  <a href="install.sh">一键部署</a> |
+  <a href="https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh">一键部署</a> |
   <a href="docs/i18n/zh-CN/setup-guides/README.zh-CN.md">安装入门</a> |
   <a href="docs/README.zh-CN.md">文档总览</a> |
   <a href="docs/SUMMARY.zh-CN.md">文档目录</a>


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The "One-Click Setup" link in README nav headers uses a relative `href="install.sh"`, which resolves to `zeroclawlabs.ai/install.sh` when viewed on the website — returning 404 since the website does not serve repo-root files.
- Why it matters: Users clicking "One-Click Setup" or copying the URL get a broken install experience.
- What changed: Replaced the relative `install.sh` href with the absolute `https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh` URL across all 6 README files that contain the link (en, fr, zh-CN, ja, ru, vi).
- What did **not** change (scope boundary): No changes to `install.sh` itself, no changes to curl one-liner examples (those already use the correct raw URL), no changes to non-README files.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `docs`
- Module labels: N/A
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `docs`

## Linked Issue

- Closes #3463

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Docs-only change. Verified with grep that no `href="install.sh"` relative links remain:

```bash
grep -r 'href="install.sh"' README*.md
# no output (all replaced)
```

- Evidence provided (test/log/trace/screenshot/perf): grep confirmation
- If any command is intentionally skipped, explain why: cargo fmt/clippy/test skipped — docs-only change, no Rust code modified

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? Yes
- If `Yes`, locale navigation parity updated in `README*` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? Yes — all 6 locales with the link were updated in this PR.
- If `Yes`, localized runtime-contract docs updated where equivalents exist? N/A (nav link only)
- If `Yes`, Vietnamese canonical docs synced? N/A (nav link only)

## Human Verification (required)

- Verified scenarios: Confirmed all 6 README files with `href="install.sh"` were updated; confirmed no other files contain the relative link pattern.
- Edge cases checked: Checked that READMEs without the nav header link (shorter translations) were not affected.
- What was not verified: Live website rendering (requires deployment).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: README rendering on GitHub and zeroclawlabs.ai
- Potential unintended effects: None — the link now points to a stable raw GitHub URL
- Guardrails/monitoring for early detection: N/A

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Investigated issue #3463, identified relative `install.sh` links in 6 README files, replaced with absolute raw GitHub URLs
- Verification focus: Ensuring all locales with the link were updated
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: Revert the commit
- Feature flags or config toggles: None
- Observable failure symptoms: "One-Click Setup" link broken again

## Risks and Mitigations

- Risk: None — straightforward URL fix in documentation.