### PR TITLE
fix: proactively truncate channel history to prevent context window overflow

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -189,6 +189,13 @@ const MEMORY_CONTEXT_ENTRY_MAX_CHARS: usize = 800;
 const MEMORY_CONTEXT_MAX_CHARS: usize = 4_000;
 const CHANNEL_HISTORY_COMPACT_KEEP_MESSAGES: usize = 12;
 const CHANNEL_HISTORY_COMPACT_CONTENT_CHARS: usize = 600;
+/// Conservative token budget for channel history. Before sending to the model,
+/// the history is proactively truncated to fit within this limit using a
+/// character-based estimate (~4 chars per token). This prevents context-window
+/// overflow errors that would otherwise require a round-trip to the API.
+const MAX_HISTORY_ESTIMATED_TOKENS: usize = 100_000;
+/// Approximate characters per token for the conservative estimator.
+const CHARS_PER_TOKEN_ESTIMATE: usize = 4;
 /// Guardrail for hook-modified outbound channel content.
 const CHANNEL_HOOK_MAX_OUTBOUND_CHARS: usize = 20_000;
 
@@ -917,6 +924,52 @@ fn compact_sender_history(ctx: &ChannelRuntimeContext, sender_key: &str) -> bool
 
     *turns = compacted;
     true
+}
+
+/// Estimate the total token count of a message list using a conservative
+/// character-based heuristic (~4 characters per token).
+fn estimate_history_tokens(messages: &[ChatMessage]) -> usize {
+    messages
+        .iter()
+        .map(|m| m.content.len().div_ceil(CHARS_PER_TOKEN_ESTIMATE))
+        .sum()
+}
+
+/// Proactively truncate conversation history so the estimated token count
+/// stays within `MAX_HISTORY_ESTIMATED_TOKENS`.  The system message (first
+/// element) and the most recent user message (last element) are always
+/// preserved; the oldest non-system turns are dropped first.
+///
+/// Returns `true` if any messages were removed.
+fn truncate_history_to_token_budget(history: &mut Vec<ChatMessage>) -> bool {
+    if history.len() <= 2 {
+        return false;
+    }
+
+    let mut estimated = estimate_history_tokens(history);
+    if estimated <= MAX_HISTORY_ESTIMATED_TOKENS {
+        return false;
+    }
+
+    let mut removed = 0usize;
+    // Remove oldest non-system messages (index 1 .. len-1) until within budget.
+    while estimated > MAX_HISTORY_ESTIMATED_TOKENS && history.len() > 2 {
+        let dropped_tokens = history[1].content.len().div_ceil(CHARS_PER_TOKEN_ESTIMATE);
+        history.remove(1);
+        estimated = estimated.saturating_sub(dropped_tokens);
+        removed += 1;
+    }
+
+    if removed > 0 {
+        tracing::info!(
+            removed_turns = removed,
+            estimated_tokens = estimated,
+            remaining_turns = history.len(),
+            "Proactively truncated channel history to fit token budget"
+        );
+    }
+
+    removed > 0
 }
 
 fn append_sender_turn(ctx: &ChannelRuntimeContext, sender_key: &str, turn: ChatMessage) {
@@ -1814,6 +1867,12 @@ async fn process_channel_message(
         build_channel_system_prompt(ctx.system_prompt.as_str(), &msg.channel, &msg.reply_target);
     let mut history = vec![ChatMessage::system(system_prompt)];
     history.extend(prior_turns);
+
+    // Proactively truncate history to avoid context-window overflow errors.
+    // This drops the oldest non-system turns until the estimated token count
+    // is within the budget, preventing a wasted round-trip to the API.
+    truncate_history_to_token_budget(&mut history);
+
     let use_streaming = target_channel
         .as_ref()
         .is_some_and(|ch| ch.supports_draft_updates());
@@ -4018,6 +4077,62 @@ mod tests {
                 || (len <= CHANNEL_HISTORY_COMPACT_CONTENT_CHARS + 3
                     && turn.content.ends_with("..."))
         }));
+    }
+
+    #[test]
+    fn estimate_history_tokens_basic() {
+        let messages = vec![
+            ChatMessage::system("a".repeat(400)),  // 100 tokens
+            ChatMessage::user("b".repeat(800)),    // 200 tokens
+        ];
+        assert_eq!(estimate_history_tokens(&messages), 300);
+    }
+
+    #[test]
+    fn truncate_history_within_budget_is_noop() {
+        let mut history = vec![
+            ChatMessage::system("sys"),
+            ChatMessage::user("short message"),
+        ];
+        assert!(!truncate_history_to_token_budget(&mut history));
+        assert_eq!(history.len(), 2);
+    }
+
+    #[test]
+    fn truncate_history_drops_oldest_non_system_turns() {
+        // Build history that exceeds MAX_HISTORY_ESTIMATED_TOKENS.
+        // Each turn ~25K tokens => 5 turns = 125K tokens > 100K budget.
+        let big = "x".repeat(100_000); // ~25K tokens each
+        let mut history = vec![
+            ChatMessage::system("system prompt"),
+            ChatMessage::user(big.clone()),
+            ChatMessage::assistant(big.clone()),
+            ChatMessage::user(big.clone()),
+            ChatMessage::assistant(big.clone()),
+            ChatMessage::user("latest question"),
+        ];
+        assert!(truncate_history_to_token_budget(&mut history));
+        // System prompt and latest question must survive
+        assert_eq!(history[0].role, "system");
+        assert_eq!(history.last().unwrap().content, "latest question");
+        // Total estimated tokens should now be within budget
+        assert!(estimate_history_tokens(&history) <= MAX_HISTORY_ESTIMATED_TOKENS);
+    }
+
+    #[test]
+    fn truncate_history_preserves_system_and_last_user() {
+        // Two messages only — should never truncate below 2
+        let big = "y".repeat(500_000);
+        let mut history = vec![
+            ChatMessage::system(big.clone()),
+            ChatMessage::user(big),
+        ];
+        // Even if over budget, cannot drop below 2
+        let result = truncate_history_to_token_budget(&mut history);
+        assert_eq!(history.len(), 2);
+        // If still over budget after removing all middle messages, that's OK —
+        // the function only drops middle turns.
+        assert!(!result);
     }
 
     #[test]

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4082,8 +4082,8 @@ mod tests {
     #[test]
     fn estimate_history_tokens_basic() {
         let messages = vec![
-            ChatMessage::system("a".repeat(400)),  // 100 tokens
-            ChatMessage::user("b".repeat(800)),    // 200 tokens
+            ChatMessage::system("a".repeat(400)), // 100 tokens
+            ChatMessage::user("b".repeat(800)),   // 200 tokens
         ];
         assert_eq!(estimate_history_tokens(&messages), 300);
     }
@@ -4123,10 +4123,7 @@ mod tests {
     fn truncate_history_preserves_system_and_last_user() {
         // Two messages only — should never truncate below 2
         let big = "y".repeat(500_000);
-        let mut history = vec![
-            ChatMessage::system(big.clone()),
-            ChatMessage::user(big),
-        ];
+        let mut history = vec![ChatMessage::system(big.clone()), ChatMessage::user(big)];
         // Even if over budget, cannot drop below 2
         let result = truncate_history_to_token_budget(&mut history);
         assert_eq!(history.len(), 2);


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Channel sessions accumulate up to 50 conversation turns with no token-budget check before the LLM call. On models with smaller context windows (e.g. GLM's 131K limit), extended conversations exceed the context window and fail. The existing compaction logic only runs *after* the API error, wasting a round-trip.
- Why it matters: Users on Feishu channels with GLM models hit "context window exceeded" errors after sustained conversations, degrading the experience.
- What changed: Added `truncate_history_to_token_budget()` which estimates tokens using a conservative 4-chars-per-token heuristic and drops the oldest non-system turns before sending to the model. Called immediately after building the outbound history, before any provider call.
- What did **not** change (scope boundary): The existing post-error compaction path (`compact_sender_history`) is unchanged and still serves as a secondary safety net. No config schema changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): medium
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): S
- Scope labels: channel
- Module labels: channel: lark
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: bug
- Primary scope: channel

## Linked Issue

- Closes #3460

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass
cargo test -- estimate_history_tokens truncate_history   # 4/4 pass
```

- Evidence provided: new unit tests covering budget estimation, no-op on small histories, truncation of oversized histories, and preservation of system+last-user messages.
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Confirmed truncation logic drops oldest middle turns, preserves system prompt and latest user message, and stays within 100K token budget.
- Edge cases checked: History with only 2 messages (system + user) is never reduced below 2. History within budget is not modified.
- What was not verified: Live Feishu + GLM end-to-end test (requires deployed environment).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Channel message processing pipeline only.
- Potential unintended effects: Very long conversations may lose older context earlier than before (by design).
- Guardrails/monitoring for early detection: Existing `tracing::info` log emitted when truncation occurs; `runtime_trace` events for context-window errors still fire if the budget is exceeded despite truncation.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: clippy, fmt, unit tests
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit.
- Feature flags or config toggles: None.
- Observable failure symptoms: "context window exceeded" errors reappear in channel sessions.

## Risks and Mitigations

- Risk: The 4-chars-per-token heuristic may over- or under-estimate for certain languages/encodings.
  - Mitigation: The 100K budget is conservative (well below most model limits), and the existing post-error compaction remains as a fallback.