### PR TITLE
feat(gateway): enable multi-turn chat for WebSocket (chat-only, no tool execution)

### DIFF
--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -20,6 +20,7 @@ use axum::{
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
+use crate::providers::ChatMessage;
 
 /// The sub-protocol we support for the chat WebSocket.
 const WS_PROTOCOL: &str = "zeroclaw.v1";
@@ -119,6 +120,9 @@ pub async fn handle_ws_chat(
 async fn handle_socket(socket: WebSocket, state: AppState, _session_id: Option<String>) {
     let (mut sender, mut receiver) = socket.split();
 
+    // Maintain conversation history for this WebSocket connection (chat-only, no tool execution)
+    let mut conversation_history: Vec<ChatMessage> = Vec::new();
+
     while let Some(msg) = receiver.next().await {
         let msg = match msg {
             Ok(Message::Text(text)) => text,
@@ -161,7 +165,7 @@ async fn handle_socket(socket: WebSocket, state: AppState, _session_id: Option<S
             "model": state.model,
         }));
 
-        // Simple single-turn chat (no streaming for now — use provider.chat_with_system)
+        // Chat-only mode with conversation history (no tool execution for security)
         let system_prompt = {
             let config_guard = state.config.lock();
             crate::channels::build_system_prompt(
@@ -174,10 +178,10 @@ async fn handle_socket(socket: WebSocket, state: AppState, _session_id: Option<S
             )
         };
 
-        let messages = vec![
-            crate::providers::ChatMessage::system(system_prompt),
-            crate::providers::ChatMessage::user(&content),
-        ];
+        // Build messages: system prompt + conversation history + current user message
+        let mut messages = vec![ChatMessage::system(system_prompt)];
+        messages.extend(conversation_history.clone());
+        messages.push(ChatMessage::user(&content));
 
         let multimodal_config = state.config.lock().multimodal.clone();
         let prepared =
@@ -207,6 +211,10 @@ async fn handle_socket(socket: WebSocket, state: AppState, _session_id: Option<S
                     "full_response": response,
                 });
                 let _ = sender.send(Message::Text(done.to_string().into())).await;
+
+                // Update conversation history with this turn (chat-only, no tool execution)
+                conversation_history.push(ChatMessage::user(&content));
+                conversation_history.push(ChatMessage::assistant(&response));
 
                 // Broadcast agent_end event
                 let _ = state.event_tx.send(serde_json::json!({


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: WebSocket chat was implemented as single-turn only, losing conversation context after each message
- Why it matters: Multi-turn chat enables natural conversation flow where agent can reference previous messages in same connection
- What changed: Maintained conversation history per WebSocket connection using `chat_with_history` (chat-only, no tool execution)
- What did not change: WebSocket protocol, authentication flow, error handling structure, security model (still chat-only)

## Label Snapshot

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `gateway`
- Module labels: `gateway: ws`
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `gateway`

## Linked Issue

- Closes: N/A (new feature)
- Related: #3467 (supersedes)
- Depends on: N/A
- Supersedes: #3467

## Supersedes #3467

This PR supersedes #3467 by addressing the security concern raised during review.

**Previous approach (PR #3467):** Used `Agent::turn()` which enabled full tool loop including shell commands, filesystem access, browser, etc. This was flagged as a security risk because any authenticated WebSocket client could trigger arbitrary tool execution on the server.

**New approach (this PR):** Maintains conversation history locally and uses `provider.chat_with_history()` which:
- Enables multi-turn dialogue (primary goal)
- Remains chat-only (same security model as original code)
- Does not allow tool execution via WebSocket interface

## Validation Evidence

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided: Code compiled successfully with Rust 1.92.0
- If any command is intentionally skipped, explain why: N/A

## Security Impact

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

**Security Note:** This PR maintains the chat-only security model. The WebSocket interface does not expose tool execution capabilities (shell, filesystem, browser, etc.). Conversation history is maintained in-memory per connection and discarded when the connection closes.

## Privacy and Data Hygiene

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## i18n Follow-Through

- i18n follow-through triggered? `No` (code change only, no user-facing docs/wording changes)

## Human Verification

What was personally validated beyond CI:
- Verified scenarios: WebSocket connection maintains conversation context across multiple turns
- Edge cases checked: Empty messages are handled gracefully, error responses are not added to history
- What was not verified: Extensive load testing with many concurrent connections

## Side Effects / Blast Radius

- Affected subsystems/workflows: WebSocket gateway chat handler only
- Potential unintended effects: Memory usage per connection increases due to persisted conversation history
- Guardrails/monitoring for early detection: Consider adding connection-level memory limits in future (conversation history is in-memory only)

## Rollback Plan

- Fast rollback command/path: Revert commit 2140af19
- Feature flags or config toggles: N/A
- Observable failure symptoms: None expected, behavior change is enhancement-only

## Risks and Mitigations

- Risk: Increased memory usage per WebSocket connection due to conversation history
  - Mitigation: Conversation history is in-memory and discarded on connection close. Consider adding history size limits in future enhancements.

## Test Plan

To test this feature:
1. Start WebSocket server: `zeroclaw gateway start`
2. Connect via WebSocket client (e.g., browser console):
   ```javascript
   const ws = new WebSocket('ws://localhost:port/ws/chat?token=YOUR_TOKEN');
   ws.onmessage = (e) => console.log(JSON.parse(e.data));
   ws.send(JSON.stringify({ type: "message", content: "Hello, what is 2+2?" }));
   ws.send(JSON.stringify({ type: "message", content: "And what about 5+5?" }));
   ```
3. Verify:
   - Agent responds correctly to both questions
   - Agent maintains context (understands "And what about..." reference)
   - Tool execution is **not** available (attempting shell commands should fail gracefully)

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>