### PR TITLE
fix(provider): skip empty text content blocks in Anthropic API requests

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2153,6 +2153,10 @@ async fn process_channel_message(
                 && !outbound_response.trim().is_empty()
             {
                 "I encountered malformed tool-call output and could not produce a safe reply. Please try again.".to_string()
+            } else if sanitized_response.trim().is_empty() {
+                // Prevent empty responses from being stored in history, which
+                // would cause Anthropic API 400 errors on subsequent turns.
+                "(no response)".to_string()
             } else {
                 sanitized_response
             };

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -320,19 +320,23 @@ impl AnthropicProvider {
                             content: blocks,
                         });
                     } else {
-                        native_messages.push(NativeMessage {
-                            role: "assistant".to_string(),
-                            content: vec![NativeContentOut::Text {
-                                text: msg.content.clone(),
-                                cache_control: None,
-                            }],
-                        });
+                        // Skip assistant messages with empty content to avoid
+                        // Anthropic API 400 error: "text content blocks must be non-empty"
+                        if !msg.content.trim().is_empty() {
+                            native_messages.push(NativeMessage {
+                                role: "assistant".to_string(),
+                                content: vec![NativeContentOut::Text {
+                                    text: msg.content.clone(),
+                                    cache_control: None,
+                                }],
+                            });
+                        }
                     }
                 }
                 "tool" => {
                     if let Some(tool_result) = Self::parse_tool_result_message(&msg.content) {
                         native_messages.push(tool_result);
-                    } else {
+                    } else if !msg.content.trim().is_empty() {
                         native_messages.push(NativeMessage {
                             role: "user".to_string(),
                             content: vec![NativeContentOut::Text {


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Empty assistant or tool messages in conversation history cause Anthropic API 400 errors (`"text content blocks must be non-empty"`), permanently breaking all subsequent turns in the session until daemon restart.
- Why it matters: A single empty LLM response (e.g. from a failed web search) poisons the entire session — every future message fails with a non-retryable 400 error, requiring manual daemon restart to recover.
- What changed: Two-layer defense against empty content blocks — filter at API send layer and prevent empty responses from entering history.
- What did **not** change: No changes to config schema, session management, or other providers.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `provider`, `channel`
- Module labels: `provider: anthropic`, `channel: core`
- Contributor tier label: N/A (first contribution)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `provider`

## Linked Issue

- Closes #
- Related #

## Validation Evidence (required)

```bash
# Reproduced the issue:
# 1. Send a message that triggers web search returning empty content
# 2. Empty assistant message stored in session history
# 3. All subsequent API calls fail with 400: "text content blocks must be non-empty"
# 4. Only daemon restart recovers the session
```

- Evidence provided: Log trace showing the exact failure chain from daemon journal
- If any command is intentionally skipped, explain why: `cargo fmt`/`clippy`/`test` not run locally — build environment on Raspberry Pi; CI will validate

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Human Verification (required)

- Verified scenarios: Reproduced the exact bug via Telegram channel — empty web search response poisoned session history, all subsequent messages returned 400 error
- Edge cases checked: Assistant messages with only whitespace, tool messages with empty content
- What was not verified: Full cargo test suite (CI will cover)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Anthropic provider message construction, channel response storage
- Potential unintended effects: Silently dropped empty assistant turns could theoretically affect conversation flow, but empty messages carry no information anyway
- Guardrails/monitoring for early detection: The `"(no response)"` placeholder in history makes empty responses visible rather than silently failing

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None needed — change is purely defensive
- Observable failure symptoms: If reverted, same 400 errors would recur on empty responses

## Risks and Mitigations

- Risk: Skipping empty assistant messages could break alternating user/assistant message ordering expected by the API
  - Mitigation: Empty messages carry no semantic content; the API rejects them anyway, so skipping is strictly better than sending