### PR TITLE
feat: add crates.io publish support

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,80 @@
+name: Publish to crates.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (e.g. 0.2.0) — must match Cargo.toml"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run (validate without publishing)"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: publish-crates
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check version matches Cargo.toml
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          cargo_version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
+          if [[ "$cargo_version" != "$INPUT_VERSION" ]]; then
+            echo "::error::Cargo.toml version (${cargo_version}) does not match input (${INPUT_VERSION})"
+            exit 1
+          fi
+
+  publish:
+    name: Publish to crates.io
+    needs: [validate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build web dashboard
+        run: cd web && npm ci && npm run build
+
+      - name: Verify package
+        run: cargo package --locked
+
+      - name: Publish (dry run)
+        if: inputs.dry_run
+        run: cargo publish --dry-run --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish to crates.io
+        if: "!inputs.dry_run"
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -263,6 +263,34 @@ jobs:
             --notes-file release-notes.md \
             --latest
 
+  crates-io:
+    name: Publish to crates.io
+    needs: [validate, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build web dashboard
+        run: cd web && npm ci && npm run build
+
+      - name: Publish to crates.io
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   redeploy-website:
     name: Trigger Website Redeploy
     needs: [publish]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,15 @@ readme = "README.md"
 keywords = ["ai", "agent", "cli", "assistant", "chatbot"]
 categories = ["command-line-utilities", "api-bindings"]
 rust-version = "1.87"
+include = [
+  "/src/**/*",
+  "/build.rs",
+  "/Cargo.toml",
+  "/Cargo.lock",
+  "/LICENSE*",
+  "/README.md",
+  "/web/dist/**/*",
+]
 
 [dependencies]
 # CLI - minimal and fast


### PR DESCRIPTION
## Summary

- Add `include` filter to `Cargo.toml` — reduces crate package from **750 files** to **235 files** (only `src/`, `build.rs`, licenses, README, web/dist assets)
- Add `publish-crates.yml` standalone workflow — manual trigger with version validation and dry-run support
- Add `crates-io` job to `release-stable-manual.yml` — auto-publishes to crates.io after every stable GitHub release

## Setup required

Add `CARGO_REGISTRY_TOKEN` secret to the repo:
**Settings → Secrets and variables → Actions → New repository secret**

Once merged and the secret is set, users will be able to install via:
```bash
cargo install zeroclaw
```

## Test plan

- [ ] Merge PR and add `CARGO_REGISTRY_TOKEN` secret
- [ ] Run `Publish to crates.io` workflow with `dry_run: true` to validate packaging
- [ ] Run `Publish to crates.io` workflow with `dry_run: false` to publish v0.2.0
- [ ] Verify `cargo install zeroclaw` works from a clean machine