### PR TITLE
chore: bump version to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7945,7 +7945,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump version from 0.2.0 → 0.2.1
- v0.2.0 tag is burned by GitHub's immutability policy (original release had no assets due to build failure, tag can't be reused after deletion)
- Once merged, dispatch the stable release workflow with version `0.2.1` to trigger the full auto-sync chain: GitHub release → tweet → website → crates.io → Docker

## Test plan

- [ ] Merge, then run `Release Stable` workflow with version `0.2.1`
- [ ] Verify all 5 downstream jobs complete: release, tweet, website, crates.io, Docker