### PR TITLE
fix(ci): use RELEASE_TOKEN for stable release tag creation

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -254,7 +254,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           gh release create "$TAG" release-assets/* \


### PR DESCRIPTION
## Summary

- Stable release workflow was using `GITHUB_TOKEN` which lacks permission to create tags via the GitHub API
- Error: `Published releases must have a valid tag`
- Switch to `RELEASE_TOKEN` (same PAT the beta workflow uses successfully)
- This is the last piece blocking the full auto-sync chain for stable releases

## Test plan

- [ ] Merge, then dispatch `Release Stable` with version `0.2.1`
- [ ] Verify full chain: GitHub release with assets → tweet → website → crates.io → Docker