### PR TITLE
fix(ci): preserve release URL in tweets instead of truncating

### DIFF
--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -120,14 +120,32 @@ jobs:
               "$RELEASE_TAG" "$FEATURES" "$TOTAL_COUNT" "$RELEASE_URL")
           fi
 
-          # Append release URL if not already present and we have one
-          if [ -n "$RELEASE_URL" ] && ! echo "$TWEET" | grep -q "$RELEASE_URL"; then
-            TWEET=$(printf "%s\n\n%s" "$TWEET" "$RELEASE_URL")
+          # X/Twitter counts any URL as 23 chars (t.co shortening).
+          # Extract the URL (if present), truncate the BODY to fit, then
+          # re-append the URL so it is never chopped.
+          URL=""
+          BODY="$TWEET"
+
+          # Pull URL out of existing tweet text or use RELEASE_URL
+          FOUND_URL=$(echo "$TWEET" | grep -oE 'https?://[^ ]+' | tail -1 || true)
+          if [ -n "$FOUND_URL" ]; then
+            URL="$FOUND_URL"
+            BODY=$(echo "$TWEET" | sed "s|${URL}||" | sed -e 's/[[:space:]]*$//')
+          elif [ -n "$RELEASE_URL" ]; then
+            URL="$RELEASE_URL"
           fi
 
-          # Truncate to 280 chars if needed
-          if [ ${#TWEET} -gt 280 ]; then
-            TWEET="${TWEET:0:277}..."
+          if [ -n "$URL" ]; then
+            # URL counts as 23 chars on X + 2 chars for \n\n separator = 25
+            MAX_BODY=$((280 - 25))
+            if [ ${#BODY} -gt $MAX_BODY ]; then
+              BODY="${BODY:0:$((MAX_BODY - 3))}..."
+            fi
+            TWEET=$(printf "%s\n\n%s" "$BODY" "$URL")
+          else
+            if [ ${#TWEET} -gt 280 ]; then
+              TWEET="${TWEET:0:277}..."
+            fi
           fi
 
           echo "--- Tweet preview ---"


### PR DESCRIPTION
## Summary

- The 280-char tweet truncation (`${TWEET:0:277}...`) was blindly chopping text, cutting off the GitHub release URL
- This caused tweets on X to show broken links like `https://github.com/zeroclaw-labs/zeroclaw/rele...`
- Now we extract the URL first, truncate only the **body** text to fit (accounting for X's 23-char t.co URL counting), then re-append the full URL so it always renders correctly

## How it works

1. Extract any URL from the tweet text (or use `RELEASE_URL`)
2. Remove the URL from the body temporarily
3. Truncate body to `280 - 25` chars (23 for t.co + 2 for `\n\n` separator)
4. Re-append the full URL at the end

This applies to both auto-generated release tweets and manual dispatch tweets.

## Test plan

- [ ] Dispatch a manual tweet with >280 chars including a URL — verify URL is preserved intact
- [ ] Trigger a release and confirm the auto-tweet includes the full release link