### PR TITLE
fix(nextcloud_talk): accept Create event type for new messages

### DIFF
--- a/src/channels/nextcloud_talk.rs
+++ b/src/channels/nextcloud_talk.rs
@@ -63,14 +63,18 @@ impl NextcloudTalkChannel {
     /// Parse a Nextcloud Talk webhook payload into channel messages.
     ///
     /// Relevant payload fields:
-    /// - `type` (expects `message`)
+    /// - `type` (accepts `message` or `Create`)
     /// - `object.token` (room token for reply routing)
     /// - `message.actorType`, `message.actorId`, `message.message`, `message.timestamp`
     pub fn parse_webhook_payload(&self, payload: &serde_json::Value) -> Vec<ChannelMessage> {
         let mut messages = Vec::new();
 
         if let Some(event_type) = payload.get("type").and_then(|v| v.as_str()) {
-            if !event_type.eq_ignore_ascii_case("message") {
+            // Nextcloud Talk bot webhooks send "Create" for new chat messages,
+            // but some setups may use "message". Accept both.
+            let is_message_event = event_type.eq_ignore_ascii_case("message")
+                || event_type.eq_ignore_ascii_case("create");
+            if !is_message_event {
                 tracing::debug!("Nextcloud Talk: skipping non-message event: {event_type}");
                 return messages;
             }
@@ -336,6 +340,36 @@ mod tests {
         assert_eq!(messages[0].content, "Hello from Nextcloud");
         assert_eq!(messages[0].channel, "nextcloud_talk");
         assert_eq!(messages[0].timestamp, 1_735_701_200);
+    }
+
+    #[test]
+    fn nextcloud_talk_parse_create_event_type() {
+        let channel = make_channel();
+        let payload = serde_json::json!({
+            "type": "Create",
+            "object": {
+                "id": "42",
+                "token": "room-token-123",
+                "name": "Team Room",
+                "type": "room"
+            },
+            "message": {
+                "id": 88,
+                "token": "room-token-123",
+                "actorType": "users",
+                "actorId": "user_a",
+                "actorDisplayName": "User A",
+                "timestamp": 1_735_701_300,
+                "messageType": "comment",
+                "systemMessage": "",
+                "message": "Hello via Create event"
+            }
+        });
+
+        let messages = channel.parse_webhook_payload(&payload);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].id, "88");
+        assert_eq!(messages[0].content, "Hello via Create event");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Nextcloud Talk channel skips valid message events with `skipping non-message event: Create` because the webhook parser only accepts `type: "message"`, but Nextcloud Talk bot webhooks send `type: "Create"` for new chat messages.
- Why it matters: Nextcloud Talk integration is broken without a proxy workaround.
- What changed: `parse_webhook_payload` now accepts both `"message"` and `"Create"` as valid event types. Added a test for the `"Create"` event type.
- What did **not** change: All other filtering (systemMessage, messageType, bot detection, user allowlist) remains unchanged.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: nextcloud_talk`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #3491
- Related #2698

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass
cargo test --lib channels::nextcloud_talk   # 12/12 passed
```

- Evidence provided: all 12 nextcloud_talk tests pass, including new `nextcloud_talk_parse_create_event_type` test.
- If any command is intentionally skipped, explain why: full `cargo test` not run; only nextcloud_talk module tests are relevant.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: valid message with `type: "Create"`, valid message with `type: "message"`, non-message event types still skipped
- Edge cases checked: case-insensitive matching for "create"/"CREATE"
- What was not verified: live Nextcloud Talk instance

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Nextcloud Talk channel webhook parsing only
- Potential unintended effects: None; additional event types are still filtered, and message-level filtering (systemMessage, messageType, bot detection) is unchanged
- Guardrails/monitoring for early detection: existing debug logging for skipped events

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: event type filtering logic and test coverage
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: revert this commit
- Feature flags or config toggles: none
- Observable failure symptoms: Nextcloud Talk messages skipped with "skipping non-message event: Create" in logs