### PR TITLE
fix(ci): bump Docker timeout to 60m and skip duplicate crates.io publish

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -281,7 +281,7 @@ jobs:
     name: Push Docker Image
     needs: [version, build]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -290,9 +290,17 @@ jobs:
         run: rm -rf web/node_modules web/src web/package.json web/package-lock.json web/tsconfig*.json web/vite.config.ts web/index.html
 
       - name: Publish to crates.io
-        run: cargo publish --locked --allow-dirty --no-verify
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          # Skip if this version is already on crates.io (auto-sync may have published it)
+          CRATE_NAME=$(sed -n 's/^name = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
+          if curl -sfL "https://crates.io/api/v1/crates/${CRATE_NAME}/${VERSION}" | grep -q '"version"'; then
+            echo "::notice::${CRATE_NAME}@${VERSION} already published on crates.io — skipping"
+          else
+            cargo publish --locked --allow-dirty --no-verify
+          fi
 
   redeploy-website:
     name: Trigger Website Redeploy
@@ -313,7 +321,7 @@ jobs:
     name: Push Docker Image
     needs: [validate, build]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 


### PR DESCRIPTION
## Summary

- **Docker timeout**: Multi-platform builds (linux/amd64 + linux/arm64) with `fat` LTO and `codegen-units = 1` consistently exceed 30 minutes, causing the stable release Docker push to fail. Bumped to 60 minutes in both stable and beta workflows.
- **crates.io dedup**: The auto-sync workflow (`publish-crates-auto.yml`) may publish to crates.io before the stable release runs, causing `crate zeroclawlabs@X.Y.Z already exists` errors. Now checks crates.io first and skips gracefully.

## Test plan

- [ ] Re-dispatch `Release Stable` with version `0.2.1` — Docker should complete within 60m
- [ ] Verify crates.io step shows "already published" notice instead of failing