### PR TITLE
chore: bump version to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7945,7 +7945,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bumps version from v0.2.2 to v0.3.0

### What's in v0.3.0

- **Channel matrix test suite** — 50 integration tests covering the full Channel trait contract across all 16 platforms (identity, threading, drafts, reactions, pinning, concurrency, edge cases)
- **README auto-sync** — CI workflow auto-generates What's New and Contributors sections across 31 localized READMEs on every release
- **Anthropic fix** — merge consecutive same-role messages to prevent 500 errors
- **Nextcloud Talk** — accept "Create" event type for new messages
- **Tweet dedup** — content-hash deduplication prevents duplicate release tweets
- **CI/CD hardening** — Docker timeout bump, release token fix, tweet URL preservation

## Test plan

- [ ] CI passes
- [ ] Version reflected in `Cargo.toml` and `Cargo.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)