### PR TITLE
fix: wire Signal channel into scheduled announcement delivery

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -1,7 +1,8 @@
 #[cfg(feature = "channel-matrix")]
 use crate::channels::MatrixChannel;
 use crate::channels::{
-    Channel, DiscordChannel, MattermostChannel, SendMessage, SlackChannel, TelegramChannel,
+    Channel, DiscordChannel, MattermostChannel, SendMessage, SignalChannel, SlackChannel,
+    TelegramChannel,
 };
 use crate::config::Config;
 use crate::cron::{
@@ -375,6 +376,22 @@ pub(crate) async fn deliver_announcement(
                 mm.allowed_users.clone(),
                 mm.thread_replies.unwrap_or(true),
                 mm.mention_only.unwrap_or(false),
+            );
+            channel.send(&SendMessage::new(output, target)).await?;
+        }
+        "signal" => {
+            let sg = config
+                .channels_config
+                .signal
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("signal channel not configured"))?;
+            let channel = SignalChannel::new(
+                sg.http_url.clone(),
+                sg.account.clone(),
+                sg.group_id.clone(),
+                sg.allowed_from.clone(),
+                sg.ignore_attachments,
+                sg.ignore_stories,
             );
             channel.send(&SendMessage::new(output, target)).await?;
         }


### PR DESCRIPTION
## Summary
- Add `SignalChannel` import to `src/cron/scheduler.rs`
- Add `"signal"` match arm in `deliver_announcement()` following the same pattern as other channels

Closes #3476

## Test plan
- [ ] Create a cron job with `delivery.channel = "signal"` and verify it no longer errors with "unsupported delivery channel"
- [ ] Verify signal delivery works end-to-end with a running signal-cli daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)