### PR TITLE
fix: increase recursion limit for matrix-sdk 0.16 on Rust 1.94+

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::assigning_clones,


### PR DESCRIPTION
## Summary
- Add `#![recursion_limit = "256"]` to `src/main.rs` to prevent compilation failure with matrix-sdk 0.16 on Rust 1.94+

Closes #3468

## Test plan
- [ ] Compile with `cargo build --features channel-matrix` on Rust 1.94+ and verify no recursion depth error
- [ ] Verify existing tests pass with `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)