### PR TITLE
fix(install): avoid /dev/stdin file redirect in guided installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -420,8 +420,15 @@ bool_to_word() {
 }
 
 guided_input_stream() {
-  if [[ -t 0 ]]; then
+  # Some constrained containers report interactive stdin (-t 0) but deny
+  # opening /dev/stdin directly. Probe readability before selecting it.
+  if [[ -t 0 ]] && (: </dev/stdin) 2>/dev/null; then
     echo "/dev/stdin"
+    return 0
+  fi
+
+  if [[ -t 0 ]] && (: </proc/self/fd/0) 2>/dev/null; then
+    echo "/proc/self/fd/0"
     return 0
   fi
 


### PR DESCRIPTION
## Summary
- Probe `/dev/stdin` readability before selecting it in `guided_input_stream()`
- Add `/proc/self/fd/0` as fallback for containers where `/dev/stdin` is inaccessible
- Preserves existing `/dev/tty` fallback

Closes #3482

## Test plan
- [ ] Run `install.sh` guided mode on standard Linux/macOS
- [ ] Run in a minimal container without `/dev/stdin` mounted — verify fallback to `/proc/self/fd/0` or `/dev/tty`

🤖 Generated with [Claude Code](https://claude.com/claude-code)