### PR TITLE
fix(provider): skip empty text content blocks in Anthropic API requests

### DIFF
--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -319,7 +319,7 @@ impl AnthropicProvider {
                             role: "assistant".to_string(),
                             content: blocks,
                         });
-                    } else {
+                    } else if !msg.content.trim().is_empty() {
                         native_messages.push(NativeMessage {
                             role: "assistant".to_string(),
                             content: vec![NativeContentOut::Text {
@@ -332,7 +332,7 @@ impl AnthropicProvider {
                 "tool" => {
                     let tool_msg = if let Some(tr) = Self::parse_tool_result_message(&msg.content) {
                         tr
-                    } else {
+                    } else if !msg.content.trim().is_empty() {
                         NativeMessage {
                             role: "user".to_string(),
                             content: vec![NativeContentOut::Text {
@@ -340,6 +340,8 @@ impl AnthropicProvider {
                                 cache_control: None,
                             }],
                         }
+                    } else {
+                        continue;
                     };
                     // Tool results map to role "user"; merge consecutive ones
                     // into a single message so Anthropic doesn't reject the
@@ -409,16 +411,18 @@ impl AnthropicProvider {
                         });
                     }
 
-                    // Add text content block
-                    let display_text = if text.is_empty() && !image_refs.is_empty() {
-                        "[image]".to_string()
-                    } else {
-                        text
-                    };
-                    content_blocks.push(NativeContentOut::Text {
-                        text: display_text,
-                        cache_control: None,
-                    });
+                    // Add text content block (skip empty text when images are present)
+                    if text.is_empty() && !image_refs.is_empty() {
+                        content_blocks.push(NativeContentOut::Text {
+                            text: "[image]".to_string(),
+                            cache_control: None,
+                        });
+                    } else if !text.trim().is_empty() {
+                        content_blocks.push(NativeContentOut::Text {
+                            text,
+                            cache_control: None,
+                        });
+                    }
 
                     // Merge into previous user message if present (e.g.
                     // when a user message immediately follows tool results


### PR DESCRIPTION
## Summary
- Skip empty/whitespace-only text content blocks in assistant messages
- Skip empty tool result messages instead of sending blank content
- Only add text block for user messages when text is non-empty (preserves `[image]` placeholder)

Closes #3483

## Test plan
- [ ] Send messages with empty assistant content — verify no empty text blocks in API request
- [ ] Send tool results with empty content — verify they are skipped
- [ ] Send image-only user messages — verify `[image]` placeholder still works
- [ ] Normal text messages still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)