### PR TITLE
fix(channel): correct Matrix image marker casing to match canonical format

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -746,7 +746,7 @@ impl Channel for MatrixChannel {
                     MessageType::Notice(content) => (content.body.clone(), None),
                     MessageType::Image(content) => {
                         let dl = media_info(&content.source, &content.body);
-                        (format!("[image: {}]", content.body), dl)
+                        (format!("[IMAGE:{}]", content.body), dl)
                     }
                     MessageType::File(content) => {
                         let dl = media_info(&content.source, &content.body);


### PR DESCRIPTION
## Summary
- **Base branch**: `master`
- **Problem**: Matrix image messages use the marker format `[image: <filename>]` (lowercase, with space) instead of the canonical `[IMAGE:<filename>]` format, causing the multimodal pipeline to skip image processing for Matrix channels (issue #3486)
- **Why it matters**: Users sending images via Matrix never get multimodal (vision) handling because the downstream parser expects `[IMAGE:...]` — the casing and spacing mismatch silently drops image context
- **What changed**: Updated the format string in `src/channels/matrix.rs` line 749 from `format!("[image: {}]", content.body)` to `format!("[IMAGE:{}]", content.body)`
- **What did NOT change**: No logic, no new dependencies, no other channels affected; only the string literal was corrected

## Label Snapshot
- risk: medium
- size: XS
- scope: channel
- module: matrix

## Change Metadata
- type: fix
- scope: channel

## Linked Issue
Closes #3486

## Supersede Attribution
N/A

## Validation Evidence
- `cargo fmt --check`: PASS
- `cargo clippy --all-targets -- -D warnings`: PASS
- `cargo test`: 7,169 passed, 0 failed, 11 ignored

## Security Impact
None — no new permissions, network calls, secrets, or filesystem access.

## Privacy and Data Hygiene
No user data changes.

## Compatibility / Migration
Backward compatible — only changes output format to match the existing canonical standard that all other channels already use.

## i18n Follow-Through
N/A