### PR TITLE
fix(channel): remove undeclared AtomicU32 in channels mod

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2407,10 +2407,7 @@ async fn run_message_dispatch_loop(
         String,
         InFlightSenderTaskState,
     >::new()));
-    #[cfg(target_has_atomic = "64")]
     let task_sequence = Arc::new(AtomicU64::new(1));
-    #[cfg(not(target_has_atomic = "64"))]
-    let task_sequence = Arc::new(AtomicU32::new(1));
 
     while let Some(msg) = rx.recv().await {
         let permit = match Arc::clone(&semaphore).acquire_owned().await {


### PR DESCRIPTION
## Summary
Fixes #3452 — removes the dead `#[cfg(not(target_has_atomic = "64"))]` fallback branch in `src/channels/mod.rs` that referenced `AtomicU32` without importing it, causing compilation failure on 32-bit targets.

## Changes
- Removed the conditional `cfg` branches for `AtomicU32`/`AtomicU64` in `run_message_dispatch_loop`
- Now uses `portable_atomic::AtomicU64` unconditionally (already imported), which works on all targets including 32-bit

## Context
Commit bd757996 switched the import from `std::sync::atomic::{AtomicU64, AtomicU32}` to `portable_atomic::AtomicU64` but left the cfg-gated usage of `AtomicU32` at the call site, creating a latent compilation failure on 32-bit targets.

## Testing
- `cargo build` — compiles successfully with no warnings
- `cargo test --locked` — all tests pass

## Risk
- **Risk level**: low — removes dead code, no behavior change on any platform
- **Rollback**: revert the single commit

Generated with [Claude Code](https://claude.com/claude-code)