### PR TITLE
fix(channel): align Matrix reply channel key with dispatch key

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -888,7 +888,7 @@ impl Channel for MatrixChannel {
                     sender: sender.clone(),
                     reply_target: format!("{}||{}", sender, room.room_id()),
                     content: body,
-                    channel: format!("matrix:{}", room.room_id()),
+                    channel: "matrix".to_string(),
                     timestamp: std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap_or_default()


### PR DESCRIPTION
## Summary

- Fixes Matrix replies being silently dropped because the incoming message channel field was set to `matrix:<room_id>` while the reply router looked up channels by the key `matrix`
- Changed `format!("matrix:{}", room.room_id())` to `"matrix".to_string()` to match how all other channels (telegram, discord, slack, etc.) set this field

Closes #3477

## Test plan

- [x] `cargo build` passes
- [x] `cargo test --locked` passes (all tests green)
- [x] `cargo fmt` applied
- [ ] Manual test: send a message via Matrix and verify the bot replies in the same room

🤖 Generated with [Claude Code](https://claude.com/claude-code)