### PR TITLE
fix(channel): use uppercase IMAGE tag in Matrix channel

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -746,7 +746,7 @@ impl Channel for MatrixChannel {
                     MessageType::Notice(content) => (content.body.clone(), None),
                     MessageType::Image(content) => {
                         let dl = media_info(&content.source, &content.body);
-                        (format!("[image: {}]", content.body), dl)
+                        (format!("[IMAGE:{}]", content.body), dl)
                     }
                     MessageType::File(content) => {
                         let dl = media_info(&content.source, &content.body);
@@ -783,7 +783,13 @@ impl Channel for MatrixChannel {
                     {
                         Ok(resp) if resp.status().is_success() => match resp.bytes().await {
                             Ok(bytes) => match tokio::fs::write(&dest, &bytes).await {
-                                Ok(()) => format!("{} — saved to {}", body, dest.display()),
+                                Ok(()) => {
+                                    if body.starts_with("[IMAGE:") {
+                                        format!("[IMAGE:{}]", dest.display())
+                                    } else {
+                                        format!("{} — saved to {}", body, dest.display())
+                                    }
+                                }
                                 Err(_) => format!("{} — failed to write to disk", body),
                             },
                             Err(_) => format!("{} — download failed", body),


### PR DESCRIPTION
## Summary

- Fix case mismatch where Matrix channel formatted image messages as `[image: filename]` (lowercase) instead of `[IMAGE:path]` (uppercase), causing the multimodal handler to miss them entirely
- After successful media download, rewrite the body to `[IMAGE:local_path]` so providers can extract and process the image

Closes #3486

## Test plan

- [x] `cargo build` passes
- [x] `cargo test --locked` passes (3425+ tests, 0 failures)
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)