### PR TITLE
fix(packaging): ensure Homebrew var directory exists on first start

### DIFF
--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -1332,20 +1332,14 @@ mod tests {
     fn detect_homebrew_var_dir_from_cellar_path() {
         let exe = PathBuf::from("/opt/homebrew/Cellar/zeroclaw/1.2.3/bin/zeroclaw");
         let var_dir = detect_homebrew_var_dir(&exe);
-        assert_eq!(
-            var_dir,
-            Some(PathBuf::from("/opt/homebrew/var/zeroclaw"))
-        );
+        assert_eq!(var_dir, Some(PathBuf::from("/opt/homebrew/var/zeroclaw")));
     }
 
     #[test]
     fn detect_homebrew_var_dir_intel_cellar_path() {
         let exe = PathBuf::from("/usr/local/Cellar/zeroclaw/1.0.0/bin/zeroclaw");
         let var_dir = detect_homebrew_var_dir(&exe);
-        assert_eq!(
-            var_dir,
-            Some(PathBuf::from("/usr/local/var/zeroclaw"))
-        );
+        assert_eq!(var_dir, Some(PathBuf::from("/usr/local/var/zeroclaw")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Detect Homebrew installations by checking if the binary lives under a Homebrew prefix (`/opt/homebrew/Cellar/...` or `/usr/local/Cellar/...`, or a symlinked `bin/` with a `Cellar` sibling)
- Create `/opt/homebrew/var/zeroclaw` (or the Intel equivalent) during `zeroclaw service install` on macOS, and set `ZEROCLAW_CONFIG_DIR` + `WorkingDirectory` in the generated launchd plist
- Defensively ensure the var directory exists during `zeroclaw service start` as well

Closes #3464

## Test plan

- [ ] Verify `detect_homebrew_var_dir` returns correct path for Cellar paths (covered by new unit tests)
- [ ] Verify `detect_homebrew_var_dir` returns `None` for non-Homebrew paths (covered by new unit tests)
- [ ] Install via Homebrew on Apple Silicon and run `zeroclaw service install && zeroclaw service start` -- should succeed without manual directory creation
- [ ] Install via Homebrew on Intel Mac and verify `/usr/local/var/zeroclaw` is created
- [ ] Install via cargo and verify no Homebrew-specific behavior is triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)