### PR TITLE
feat(ci): add Termux (aarch64-linux-android) release target

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -170,6 +170,11 @@ jobs:
             target: aarch64-apple-darwin
             artifact: zeroclaw
             ext: tar.gz
+          - os: ubuntu-latest
+            target: aarch64-linux-android
+            artifact: zeroclaw
+            ext: tar.gz
+            ndk: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: zeroclaw.exe
@@ -193,6 +198,10 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y ${{ matrix.cross_compiler }}
+
+      - name: Setup Android NDK
+        if: matrix.ndk
+        run: echo "$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin" >> "$GITHUB_PATH"
 
       - name: Build release
         shell: bash

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -171,6 +171,11 @@ jobs:
             target: aarch64-apple-darwin
             artifact: zeroclaw
             ext: tar.gz
+          - os: ubuntu-latest
+            target: aarch64-linux-android
+            artifact: zeroclaw
+            ext: tar.gz
+            ndk: true
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: zeroclaw.exe
@@ -194,6 +199,10 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y ${{ matrix.cross_compiler }}
+
+      - name: Setup Android NDK
+        if: matrix.ndk
+        run: echo "$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin" >> "$GITHUB_PATH"
 
       - name: Build release
         shell: bash

--- a/install.sh
+++ b/install.sh
@@ -187,7 +187,12 @@ detect_release_target() {
       echo "x86_64-unknown-linux-gnu"
       ;;
     Linux:aarch64|Linux:arm64)
-      echo "aarch64-unknown-linux-gnu"
+      # Termux on Android needs the android target, not linux-gnu
+      if [[ -n "${TERMUX_VERSION:-}" || -d "/data/data/com.termux" ]]; then
+        echo "aarch64-linux-android"
+      else
+        echo "aarch64-unknown-linux-gnu"
+      fi
       ;;
     Linux:armv7l|Linux:armv6l)
       echo "armv7-unknown-linux-gnueabihf"
@@ -527,6 +532,8 @@ install_system_deps() {
           openssl \
           perl \
           ca-certificates
+      elif have_cmd pkg && [[ -n "${TERMUX_VERSION:-}" ]]; then
+        pkg install -y build-essential pkg-config git curl openssl perl
       else
         warn "Unsupported Linux distribution. Install compiler toolchain + pkg-config + git + curl + OpenSSL headers + perl manually."
       fi


### PR DESCRIPTION
## Summary

- Adds `aarch64-linux-android` to the stable and beta release build matrices, producing a prebuilt binary for Termux/Android ARM64 devices
- Adds Android NDK setup step in CI to provide the `aarch64-linux-android21-clang` linker
- Updates `install.sh` to detect Termux (via `TERMUX_VERSION` env or `/data/data/com.termux`) and map to the correct `aarch64-linux-android` target instead of `aarch64-unknown-linux-gnu`
- Adds Termux `pkg` package manager support in `install_system_deps()`

## Test plan

- [x] `bash -n install.sh` — syntax check passes
- [x] `cargo fmt --all -- --check` — passes
- [x] `cargo clippy --all-targets -- -D warnings` — passes
- [x] `cargo test` — all tests pass
- [ ] CI release matrix builds successfully for the new android target
- [ ] Verify prebuilt binary works on a Termux device

🤖 Generated with [Claude Code](https://claude.com/claude-code)