### PR TITLE
chore: bump version to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7945,7 +7945,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bumps version from `0.3.0` to `0.4.0` (minor release) to include Termux/Android release support

## Test plan

- [x] `cargo check` compiles successfully with new version
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)