### PR TITLE
chore: bump version to v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7945,7 +7945,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.4.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.4.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Corrects version from `0.4.0` to `0.3.1` — Termux/Android support is a patch-level addition, not a minor bump
- Supersedes #3528

## Test plan

- [x] `cargo check` compiles with new version
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)