### PR TITLE
fix(ci): tweet and README sync after all release artifacts are live

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -313,3 +313,19 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ── Post-publish: only run after ALL artifacts are live ──────────────
+  tweet:
+    name: Tweet Release
+    needs: [version, publish, docker, redeploy-website]
+    uses: ./.github/workflows/tweet-release.yml
+    with:
+      release_tag: ${{ needs.version.outputs.tag }}
+      release_url: https://github.com/zeroclaw-labs/zeroclaw/releases/tag/${{ needs.version.outputs.tag }}
+    secrets: inherit
+
+  sync-readme:
+    name: Sync README
+    needs: [publish, docker, redeploy-website]
+    uses: ./.github/workflows/sync-readme.yml
+    secrets: inherit

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -353,3 +353,19 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ── Post-publish: only run after ALL artifacts are live ──────────────
+  tweet:
+    name: Tweet Release
+    needs: [validate, publish, docker, crates-io, redeploy-website]
+    uses: ./.github/workflows/tweet-release.yml
+    with:
+      release_tag: ${{ needs.validate.outputs.tag }}
+      release_url: https://github.com/zeroclaw-labs/zeroclaw/releases/tag/${{ needs.validate.outputs.tag }}
+    secrets: inherit
+
+  sync-readme:
+    name: Sync README
+    needs: [publish, docker, crates-io, redeploy-website]
+    uses: ./.github/workflows/sync-readme.yml
+    secrets: inherit

--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -1,8 +1,11 @@
 name: Sync README
 
 on:
-  release:
-    types: [published]
+  # Called by release workflows AFTER all publish steps complete.
+  workflow_call:
+    secrets:
+      RELEASE_TOKEN:
+        required: true
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -1,8 +1,26 @@
 name: Tweet Release
 
 on:
-  release:
-    types: [published]
+  # Called by release workflows AFTER all publish steps (docker, crates, website) complete.
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Release tag (e.g. v0.3.0 or v0.3.0-beta.42)"
+        required: true
+        type: string
+      release_url:
+        description: "GitHub Release URL"
+        required: true
+        type: string
+    secrets:
+      TWITTER_CONSUMER_API_KEY:
+        required: false
+      TWITTER_CONSUMER_API_SECRET_KEY:
+        required: false
+      TWITTER_ACCESS_TOKEN:
+        required: false
+      TWITTER_ACCESS_TOKEN_SECRET:
+        required: false
   workflow_dispatch:
     inputs:
       tweet_text:
@@ -26,7 +44,7 @@ jobs:
         id: check
         shell: bash
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
+          RELEASE_TAG: ${{ inputs.release_tag || '' }}
           MANUAL_TEXT: ${{ inputs.tweet_text || '' }}
         run: |
           # Manual dispatch always proceeds
@@ -62,8 +80,8 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         shell: bash
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name || '' }}
-          RELEASE_URL: ${{ github.event.release.html_url || '' }}
+          RELEASE_TAG: ${{ inputs.release_tag || '' }}
+          RELEASE_URL: ${{ inputs.release_url || '' }}
           MANUAL_TEXT: ${{ inputs.tweet_text || '' }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- **Root cause**: `tweet-release.yml` and `sync-readme.yml` triggered on `release: published` — which fires the instant `gh release create` runs. But Docker push, crates.io publish, and website redeploy were still in-flight. Result: tweet goes out before users can actually `docker pull` or `cargo install` the new version.
- Converted both workflows to reusable `workflow_call` workflows (manual `workflow_dispatch` still works)
- Both release pipelines (beta + stable) now call tweet + README sync as **final jobs**, gated on completion of all upstream publish steps

### New job dependency graph

**Stable release:**
```
validate → build → publish (GitHub Release)
                 → docker (GHCR)
                 → crates-io
                 → redeploy-website
                       ↓ ALL complete
                 → tweet + sync-readme
```

**Beta release:**
```
version → build → publish (GitHub pre-release)
               → docker (GHCR :beta)
               → redeploy-website
                     ↓ ALL complete
               → tweet + sync-readme
```

## Files changed

| File | Change |
|---|---|
| `tweet-release.yml` | Replace `release: published` with `workflow_call` inputs (`release_tag`, `release_url`) |
| `sync-readme.yml` | Replace `release: published` with `workflow_call` |
| `release-stable-manual.yml` | Add `tweet` + `sync-readme` jobs at end, gated on all publish jobs |
| `release-beta-on-push.yml` | Same as above for beta flow |

## Test plan

- [ ] Merge and push to master — beta flow should: build → publish → docker + website → tweet + readme (in order)
- [ ] Verify tweet only posts after Docker image is pullable on GHCR
- [ ] Verify `workflow_dispatch` on `tweet-release.yml` still works for manual tweets
- [ ] Trigger stable release and confirm same ordering