### PR TITLE
fix(install): resolve cargo binary conflict from package rename

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1199,6 +1199,17 @@ fi
 
 if [[ "$SKIP_INSTALL" == false ]]; then
   step_dot "Installing zeroclaw to cargo bin"
+
+  # Clean up stale cargo install tracking from the old "zeroclaw" package name
+  # (renamed to "zeroclawlabs"). Without this, `cargo install zeroclawlabs` from
+  # crates.io fails with "binary already exists as part of `zeroclaw`".
+  if have_cmd cargo; then
+    if [[ -f "$HOME/.cargo/.crates.toml" ]] && grep -q '^"zeroclaw ' "$HOME/.cargo/.crates.toml" 2>/dev/null; then
+      step_dot "Removing stale cargo tracking for old 'zeroclaw' package name"
+      cargo uninstall zeroclaw 2>/dev/null || true
+    fi
+  fi
+
   cargo install --path "$WORK_DIR" --force --locked
   step_ok "ZeroClaw installed"
 else


### PR DESCRIPTION
## Summary

- Fixes `cargo install zeroclawlabs` failing with `binary already exists as part of zeroclaw v0.1.9` for users who previously installed via `install.sh` or the old `zeroclaw` package name
- The crate was renamed from `zeroclaw` to `zeroclawlabs`, but cargo's install tracking still records the binary under the old package name
- The installer now detects and removes stale tracking before installing, so both `install.sh` and `cargo install zeroclawlabs` work cleanly as upgrade paths

## Root cause

```
# Old install (tracked as package "zeroclaw" from local path):
cargo install --path /tmp/zeroclaw-bootstrap-XXXXX --force --locked

# Later upgrade attempt fails:
cargo install zeroclawlabs
# error: binary `zeroclaw` already exists as part of `zeroclaw v0.1.9 (/tmp/...)`
```

Cargo refuses to overwrite a binary owned by a different package. The fix checks `~/.cargo/.crates.toml` for the old `zeroclaw` package name and runs `cargo uninstall zeroclaw` before installing.

## Test plan

- [ ] Run `install.sh` on a machine that has the old `zeroclaw` package installed — should cleanly upgrade
- [ ] Run `cargo install zeroclawlabs` after — should work without `--force`
- [ ] Fresh install (no prior `zeroclaw`) — should work unchanged

## Workaround (for users right now)

```bash
cargo install zeroclawlabs --force
```