### PR TITLE
docs(readme): remove stale What's New and Contributors sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,6 @@ Built by students and members of the Harvard, MIT, and Sundai.Club communities.
 <p align="center"><code>Trait-driven architecture · secure-by-default runtime · provider/channel/tool swappable · pluggable everything</code></p>
 
 <!-- BEGIN:WHATS_NEW -->
-
-### 🚀 What's New in v0.3.1 (March 2026)
-
-| Area | Highlights |
-|---|---|
-| ci | add Termux (aarch64-linux-android) release target |
-
 <!-- END:WHATS_NEW -->
 
 ### 📢 Announcements
@@ -481,17 +474,6 @@ A heartfelt thank you to the communities and institutions that inspire and fuel 
 We're building in the open because the best ideas come from everywhere. If you're reading this, you're part of it. Welcome. 🦀❤️
 
 <!-- BEGIN:RECENT_CONTRIBUTORS -->
-
-### 🌟 Recent Contributors (v0.3.1)
-
-3 contributors shipped features, fixes, and improvements in this release cycle:
-
-- **Argenis**
-- **argenis de la rosa**
-- **Claude Opus 4.6**
-
-Thank you to everyone who opened issues, reviewed PRs, translated docs, and helped test. Every contribution matters. 🦀
-
 <!-- END:RECENT_CONTRIBUTORS -->
 
 ## ⚠️ Official Repository & Impersonation Warning


### PR DESCRIPTION
## Summary

- Removes the hardcoded v0.3.1 "What's New" and "Recent Contributors" sections from README.md
- Keeps the `<!-- BEGIN/END -->` marker comments so the `sync-readme` workflow repopulates them correctly on the next release