### PR TITLE
chore: add .wrangler/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ lcov.info
 
 # IDE's stuff
 .idea
+
+# Wrangler cache
+.wrangler/


### PR DESCRIPTION
## Summary

- Adds `.wrangler/` to `.gitignore` to prevent Wrangler cache from being tracked
- Removed local stale files (feature_parity_matrix.py, feature_parity_30day_matrix.xlsx, README.md.tmp)

## Test plan

- [x] Low risk — gitignore-only change
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)