### PR TITLE
fix: only tweet for stable releases, not beta builds

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -314,12 +314,3 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # ── Post-publish: only run after ALL artifacts are live ──────────────
-  tweet:
-    name: Tweet Release
-    needs: [version, publish, docker, redeploy-website]
-    uses: ./.github/workflows/tweet-release.yml
-    with:
-      release_tag: ${{ needs.version.outputs.tag }}
-      release_url: https://github.com/zeroclaw-labs/zeroclaw/releases/tag/${{ needs.version.outputs.tag }}
-    secrets: inherit

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
     inputs:
       release_tag:
-        description: "Release tag (e.g. v0.3.0 or v0.3.0-beta.42)"
+        description: "Stable release tag (e.g. v0.3.0)"
         required: true
         type: string
       release_url:
@@ -53,9 +53,10 @@ jobs:
             exit 0
           fi
 
-          # Find the PREVIOUS release tag (including betas) to check for new features
+          # Find the previous STABLE release tag (exclude betas) to check for new features
           PREV_TAG=$(git tag --sort=-creatordate \
             | grep -v "^${RELEASE_TAG}$" \
+            | grep -vE '\-beta\.' \
             | head -1 || echo "")
 
           if [ -z "$PREV_TAG" ]; then
@@ -89,53 +90,37 @@ jobs:
           if [ -n "$MANUAL_TEXT" ]; then
             TWEET="$MANUAL_TEXT"
           else
-            # For features: diff against the PREVIOUS release (including betas)
-            # This prevents duplicate feature lists across consecutive betas
-            PREV_RELEASE=$(git tag --sort=-creatordate \
-              | grep -v "^${RELEASE_TAG}$" \
-              | head -1 || echo "")
-
-            # For contributors: diff against the last STABLE release
-            # This captures everyone across the full release cycle
+            # Diff against the last STABLE release (exclude betas) to capture
+            # ALL features accumulated across the full beta cycle
             PREV_STABLE=$(git tag --sort=-creatordate \
               | grep -v "^${RELEASE_TAG}$" \
               | grep -vE '\-beta\.' \
               | head -1 || echo "")
 
-            FEAT_RANGE="${PREV_RELEASE:+${PREV_RELEASE}..}${RELEASE_TAG}"
-            CONTRIB_RANGE="${PREV_STABLE:+${PREV_STABLE}..}${RELEASE_TAG}"
+            RANGE="${PREV_STABLE:+${PREV_STABLE}..}${RELEASE_TAG}"
 
-            # Extract NEW features only since the last release
-            FEATURES=$(git log "$FEAT_RANGE" --pretty=format:"%s" --no-merges \
+            # Extract ALL features since the last stable release
+            FEATURES=$(git log "$RANGE" --pretty=format:"%s" --no-merges \
               | grep -iE '^feat(\(|:)' \
               | sed 's/^feat(\([^)]*\)): /\1: /' \
               | sed 's/^feat: //' \
               | sed 's/ (#[0-9]*)$//' \
-              | sort -uf \
-              | head -4 \
-              | while IFS= read -r line; do echo "🚀 ${line}"; done || true)
-
-            if [ -z "$FEATURES" ]; then
-              FEATURES="🚀 Incremental improvements and polish"
-            fi
-
-            # Count ALL contributors across the full release cycle
-            GIT_AUTHORS=$(git log "$CONTRIB_RANGE" --pretty=format:"%an" --no-merges | sort -uf || true)
-            CO_AUTHORS=$(git log "$CONTRIB_RANGE" --pretty=format:"%b" --no-merges \
-              | grep -ioE 'Co-Authored-By: *[^<]+' \
-              | sed 's/Co-Authored-By: *//i' \
-              | sed 's/ *$//' \
               | sort -uf || true)
 
-            TOTAL_COUNT=$(printf "%s\n%s" "$GIT_AUTHORS" "$CO_AUTHORS" \
-              | sort -uf \
-              | grep -v '^$' \
-              | grep -viE '\[bot\]$|^dependabot|^github-actions|^copilot|^ZeroClaw Bot|^ZeroClaw Runner|^ZeroClaw Agent|^blacksmith' \
-              | grep -c . || echo "0")
+            FEAT_COUNT=$(echo "$FEATURES" | grep -c . || echo "0")
 
-            # Build tweet — new features, contributor count, hashtags
-            TWEET=$(printf "🦀 ZeroClaw %s\n\n%s\n\n🙌 %s contributors\n\n%s\n\n#zeroclaw #rust #ai #opensource" \
-              "$RELEASE_TAG" "$FEATURES" "$TOTAL_COUNT" "$RELEASE_URL")
+            # Format top features with rocket emoji (limit to 6 for tweet space)
+            FEAT_LIST=$(echo "$FEATURES" \
+              | head -6 \
+              | while IFS= read -r line; do echo "🚀 ${line}"; done || true)
+
+            if [ -z "$FEAT_LIST" ]; then
+              FEAT_LIST="🚀 Incremental improvements and polish"
+            fi
+
+            # Build tweet — feature-focused style
+            TWEET=$(printf "🦀 ZeroClaw %s\n\n%s\n\nZero overhead. Zero compromise. 100%% Rust.\n\n#zeroclaw #rust #ai #opensource" \
+              "$RELEASE_TAG" "$FEAT_LIST")
           fi
 
           # X/Twitter counts any URL as 23 chars (t.co shortening).


### PR DESCRIPTION
## Summary

- **Remove tweet job from beta workflow** — beta pushes to master no longer trigger X posts
- **Use stable-to-stable diff for features** — stable release tweets now show ALL accumulated features across the full beta cycle (instead of just features since the last beta)
- **Update tweet format** — feature-focused style matching the desired format: version header, feature list with rocket emojis, Rust tagline, hashtags

### Before (beta tweets going out on every push to master)
```
🦀 ZeroClaw v0.3.0-beta.178

🚀 some minor change

🙌 3 contributors

https://github.com/...

#zeroclaw #rust #ai #opensource
```

### After (only stable releases, all features shown)
```
🦀 ZeroClaw v0.3.0

🚀 feature one
🚀 feature two
🚀 feature three
...

Zero overhead. Zero compromise. 100% Rust.

#zeroclaw #rust #ai #opensource
```

## Test plan
- [ ] Verify beta workflow no longer has tweet job
- [ ] Trigger a test stable release and confirm tweet includes full feature set since last stable
- [ ] Confirm manual `workflow_dispatch` tweets still work