### PR TITLE
chore: bump version to v0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7945,7 +7945,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump version from `0.3.2` → `0.3.3` following the merge of #3574 (token-based compaction, persistent sessions, and LLM consolidation)

## Risk tier

**Low risk** — version bump only (`Cargo.toml` + `Cargo.lock`).

## Test plan

- [x] `Cargo.toml` version updated to `0.3.3`
- [x] `Cargo.lock` regenerated with matching version
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)