### PR TITLE
fix: exclude name field from Mistral tool_calls (#3572)

### DIFF
--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -512,7 +512,11 @@ struct ToolCall {
     arguments: Option<String>,
 
     // Compatibility: DeepSeek sometimes wraps arguments differently
-    #[serde(rename = "parameters", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "parameters",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     parameters: Option<serde_json::Value>,
 }
 


### PR DESCRIPTION
## Summary

- Fixes tool invocation failure when using Mistral as provider (422 Unprocessable Entity)
- Root cause: `ToolCall` struct compatibility fields (`name`, `arguments`, `parameters`) were serialized as `null` when `None`, but Mistral's API strictly rejects extra fields
- Added `skip_serializing_if = "Option::is_none"` to omit these fields from the JSON payload when not set

## Test plan

- [x] `cargo check` passes
- [x] All 92 compatible provider unit tests pass
- [ ] Manual test with Mistral provider: `zeroclaw agent -m "list all files in my workspace"`

Closes #3572