### PR TITLE
fix: restore --interactive flag for onboard command (#3573)

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -155,11 +155,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          # Use ubuntu-22.04 for Linux builds to link against glibc 2.35,
+          # ensuring compatibility with Ubuntu 22.04+ (#3573).
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             artifact: zeroclaw
             ext: tar.gz
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             artifact: zeroclaw
             ext: tar.gz

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -156,11 +156,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          # Use ubuntu-22.04 for Linux builds to link against glibc 2.35,
+          # ensuring compatibility with Ubuntu 22.04+ (#3573).
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             artifact: zeroclaw
             ext: tar.gz
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: aarch64-unknown-linux-gnu
             artifact: zeroclaw
             ext: tar.gz

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,10 @@ struct Cli {
 enum Commands {
     /// Initialize your workspace and configuration
     Onboard {
+        /// Run the full interactive wizard (default is quick setup)
+        #[arg(long)]
+        interactive: bool,
+
         /// Overwrite existing config without confirmation
         #[arg(long)]
         force: bool,
@@ -170,7 +174,7 @@ enum Commands {
         #[arg(long)]
         channels_only: bool,
 
-        /// API key for provider configuration
+        /// API key (used in quick mode, ignored with --interactive)
         #[arg(long)]
         api_key: Option<String>,
 
@@ -723,6 +727,7 @@ async fn main() -> Result<()> {
     // Tokio runtime. To avoid "Cannot drop a runtime in a context where blocking is
     // not allowed", we run the wizard on a blocking thread via spawn_blocking.
     if let Commands::Onboard {
+        interactive,
         force,
         reinit,
         channels_only,
@@ -732,6 +737,7 @@ async fn main() -> Result<()> {
         memory,
     } = &cli.command
     {
+        let interactive = *interactive;
         let force = *force;
         let reinit = *reinit;
         let channels_only = *channels_only;
@@ -740,8 +746,14 @@ async fn main() -> Result<()> {
         let model = model.clone();
         let memory = memory.clone();
 
+        if interactive && channels_only {
+            bail!("Use either --interactive or --channels-only, not both");
+        }
         if reinit && channels_only {
             bail!("--reinit and --channels-only cannot be used together");
+        }
+        if reinit && !interactive {
+            bail!("--reinit requires --interactive mode");
         }
         if channels_only
             && (api_key.is_some() || provider.is_some() || model.is_some() || memory.is_some())
@@ -795,6 +807,8 @@ async fn main() -> Result<()> {
 
         let config = if channels_only {
             Box::pin(onboard::run_channels_repair_wizard()).await
+        } else if interactive {
+            Box::pin(onboard::run_wizard(force)).await
         } else {
             onboard::run_quick_setup(
                 api_key.as_deref(),

--- a/src/onboard/mod.rs
+++ b/src/onboard/mod.rs
@@ -4,7 +4,7 @@ pub mod wizard;
 #[allow(unused_imports)]
 pub use wizard::{
     run_channels_repair_wizard, run_models_list, run_models_refresh, run_models_refresh_all,
-    run_models_set, run_models_status, run_quick_setup,
+    run_models_set, run_models_status, run_quick_setup, run_wizard,
 };
 
 #[cfg(test)]
@@ -17,6 +17,7 @@ mod tests {
     fn wizard_functions_are_reexported() {
         assert_reexport_exists(run_channels_repair_wizard);
         assert_reexport_exists(run_quick_setup);
+        assert_reexport_exists(run_wizard);
         assert_reexport_exists(run_models_refresh);
         assert_reexport_exists(run_models_list);
         assert_reexport_exists(run_models_set);


### PR DESCRIPTION
## Summary

- Restores the `--interactive` flag for `zeroclaw onboard` that was removed in commit `46d4b13c`
- Re-exports `run_wizard` from `src/onboard/mod.rs` which was no longer accessible
- Fixes glibc compatibility for Ubuntu 22.04 by changing Linux CI build runners from `ubuntu-latest` (24.04, glibc 2.39) to `ubuntu-22.04` (glibc 2.35) in both release workflows

## Test plan

- [x] `cargo check` passes
- [x] All 115 tests pass
- [ ] Manual test: `zeroclaw onboard --interactive`
- [ ] Verify built binary runs on Ubuntu 22.04 (glibc 2.35)

Closes #3573