### PR TITLE
fix(channels): surface visible warning when whatsapp-web feature is missing

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3235,6 +3235,8 @@ fn collect_configured_channels(
                 #[cfg(not(feature = "whatsapp-web"))]
                 {
                     tracing::warn!("WhatsApp Web backend requires 'whatsapp-web' feature. Enable with: cargo build --features whatsapp-web");
+                    eprintln!("  ⚠ WhatsApp Web is configured but the 'whatsapp-web' feature is not compiled in.");
+                    eprintln!("    Rebuild with: cargo build --features whatsapp-web");
                 }
             }
             _ => {

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -4147,6 +4147,23 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     .interact()?;
 
                 if mode_idx == 0 {
+                    // Compile-time check: warn early if the feature is not enabled.
+                    #[cfg(not(feature = "whatsapp-web"))]
+                    {
+                        println!();
+                        println!(
+                            "  {} {}",
+                            style("⚠").yellow().bold(),
+                            style("The 'whatsapp-web' feature is not compiled in. WhatsApp Web will not work at runtime.").yellow()
+                        );
+                        println!(
+                            "  {} Rebuild with: {}",
+                            style("→").dim(),
+                            style("cargo build --features whatsapp-web").white().bold()
+                        );
+                        println!();
+                    }
+
                     println!("  {}", style("Mode: WhatsApp Web").dim());
                     print_bullet("1. Build with --features whatsapp-web");
                     print_bullet(


### PR DESCRIPTION
## Summary

- The WhatsApp Web QR code was not shown during `zeroclaw onboard --channels-only` because the wizard allowed configuring WhatsApp Web mode even when the binary was built without the `whatsapp-web` feature flag
- At runtime, `collect_configured_channels` silently skipped the WhatsApp Web channel with only a `tracing::warn!` that most users never see
- Added a compile-time `#[cfg(not(feature = "whatsapp-web"))]` warning in the onboarding wizard so users are told immediately during setup
- Added `eprintln!` in `collect_configured_channels` so the missing-feature warning is visible in the terminal at startup

Supersedes #3622

## Test plan

- [ ] Build without `--features whatsapp-web`, run `zeroclaw onboard --channels-only`, select WhatsApp Web mode — verify visible warning is printed
- [ ] Build without `--features whatsapp-web`, launch channels with WhatsApp Web configured — verify terminal shows missing feature message
- [ ] Build with `--features whatsapp-web`, run the same flow — verify no spurious warnings and QR code displays correctly
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo check` passes

Closes #3577