### PR TITLE
feat(security): add capability-based tool access control

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -37,6 +37,7 @@ pub struct Agent {
     classification_config: crate::config::QueryClassificationConfig,
     available_hints: Vec<String>,
     route_model_by_hint: HashMap<String, String>,
+    allowed_tools: Option<Vec<String>>,
 }
 
 pub struct AgentBuilder {
@@ -58,6 +59,7 @@ pub struct AgentBuilder {
     classification_config: Option<crate::config::QueryClassificationConfig>,
     available_hints: Option<Vec<String>>,
     route_model_by_hint: Option<HashMap<String, String>>,
+    allowed_tools: Option<Vec<String>>,
 }
 
 impl AgentBuilder {
@@ -81,6 +83,7 @@ impl AgentBuilder {
             classification_config: None,
             available_hints: None,
             route_model_by_hint: None,
+            allowed_tools: None,
         }
     }
 
@@ -180,10 +183,19 @@ impl AgentBuilder {
         self
     }
 
+    pub fn allowed_tools(mut self, allowed_tools: Option<Vec<String>>) -> Self {
+        self.allowed_tools = allowed_tools;
+        self
+    }
+
     pub fn build(self) -> Result<Agent> {
-        let tools = self
+        let mut tools = self
             .tools
             .ok_or_else(|| anyhow::anyhow!("tools are required"))?;
+        let allowed = self.allowed_tools.clone();
+        if let Some(ref allow_list) = allowed {
+            tools.retain(|t| allow_list.iter().any(|name| name == t.name()));
+        }
         let tool_specs = tools.iter().map(|tool| tool.spec()).collect();
 
         Ok(Agent {
@@ -223,6 +235,7 @@ impl AgentBuilder {
             classification_config: self.classification_config.unwrap_or_default(),
             available_hints: self.available_hints.unwrap_or_default(),
             route_model_by_hint: self.route_model_by_hint.unwrap_or_default(),
+            allowed_tools: allowed,
         })
     }
 }
@@ -891,5 +904,69 @@ mod tests {
         assert_eq!(response, "classified");
         let seen = seen_models.lock();
         assert_eq!(seen.as_slice(), &["hint:fast".to_string()]);
+    }
+
+    #[test]
+    fn builder_allowed_tools_none_keeps_all_tools() {
+        let provider = Box::new(MockProvider {
+            responses: Mutex::new(vec![]),
+        });
+
+        let memory_cfg = crate::config::MemoryConfig {
+            backend: "none".into(),
+            ..crate::config::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            crate::memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .allowed_tools(None)
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        assert_eq!(agent.tool_specs.len(), 1);
+        assert_eq!(agent.tool_specs[0].name, "echo");
+    }
+
+    #[test]
+    fn builder_allowed_tools_some_filters_tools() {
+        let provider = Box::new(MockProvider {
+            responses: Mutex::new(vec![]),
+        });
+
+        let memory_cfg = crate::config::MemoryConfig {
+            backend: "none".into(),
+            ..crate::config::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            crate::memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .allowed_tools(Some(vec!["nonexistent".to_string()]))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        assert!(
+            agent.tool_specs.is_empty(),
+            "No tools should match a non-existent allowlist entry"
+        );
     }
 }

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -93,6 +93,24 @@ pub(crate) fn filter_tool_specs_for_turn(
         .collect()
 }
 
+/// Filters a tool spec list by an optional capability allowlist.
+///
+/// When `allowed` is `None`, all specs pass through unchanged.
+/// When `allowed` is `Some(list)`, only specs whose name appears in the list
+/// are retained. Unknown names in the allowlist are silently ignored.
+pub(crate) fn filter_by_allowed_tools(
+    specs: Vec<crate::tools::ToolSpec>,
+    allowed: Option<&[String]>,
+) -> Vec<crate::tools::ToolSpec> {
+    match allowed {
+        None => specs,
+        Some(list) => specs
+            .into_iter()
+            .filter(|spec| list.iter().any(|name| name == &spec.name))
+            .collect(),
+    }
+}
+
 /// Computes the list of MCP tool names that should be excluded for a given turn
 /// based on `tool_filter_groups` and the user message.
 ///
@@ -2994,6 +3012,7 @@ pub async fn run(
     peripheral_overrides: Vec<String>,
     interactive: bool,
     session_state_file: Option<PathBuf>,
+    allowed_tools: Option<Vec<String>>,
 ) -> Result<String> {
     // ── Wire up agnostic subsystems ──────────────────────────────
     let base_observer = observability::create_observer(&config.observability);
@@ -3053,6 +3072,19 @@ pub async fn run(
     if !peripheral_tools.is_empty() {
         tracing::info!(count = peripheral_tools.len(), "Peripheral tools added");
         tools_registry.extend(peripheral_tools);
+    }
+
+    // ── Capability-based tool access control ─────────────────────
+    // When `allowed_tools` is `Some(list)`, restrict the tool registry to only
+    // those tools whose name appears in the list. Unknown names are silently
+    // ignored. When `None`, all tools remain available (backward compatible).
+    if let Some(ref allow_list) = allowed_tools {
+        tools_registry.retain(|t| allow_list.iter().any(|name| name == t.name()));
+        tracing::info!(
+            allowed = allow_list.len(),
+            retained = tools_registry.len(),
+            "Applied capability-based tool access filter"
+        );
     }
 
     // ── Wire MCP tools (non-fatal) — CLI path ────────────────────
@@ -3874,7 +3906,7 @@ mod tests {
     use std::time::Duration;
 
     #[test]
-    fn test_scrub_credentials() {
+    fn scrub_credentials_redacts_bearer_token() {
         let input = "API_KEY=sk-1234567890abcdef; token: 1234567890; password=\"secret123456\"";
         let scrubbed = scrub_credentials(input);
         assert!(scrubbed.contains("API_KEY=sk-1*[REDACTED]"));
@@ -3885,7 +3917,7 @@ mod tests {
     }
 
     #[test]
-    fn test_scrub_credentials_json() {
+    fn scrub_credentials_redacts_json_api_key() {
         let input = r#"{"api_key": "sk-1234567890", "other": "public"}"#;
         let scrubbed = scrub_credentials(input);
         assert!(scrubbed.contains("\"api_key\": \"sk-1*[REDACTED]\""));
@@ -6640,5 +6672,56 @@ Let me check the result."#;
         );
 
         assert_eq!(result, "I could not execute that command.");
+    }
+
+    // ── filter_by_allowed_tools tests ─────────────────────────────────────
+
+    #[test]
+    fn filter_by_allowed_tools_none_passes_all() {
+        let specs = vec![
+            make_spec("shell"),
+            make_spec("memory_store"),
+            make_spec("file_read"),
+        ];
+        let result = filter_by_allowed_tools(specs, None);
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn filter_by_allowed_tools_some_restricts_to_listed() {
+        let specs = vec![
+            make_spec("shell"),
+            make_spec("memory_store"),
+            make_spec("file_read"),
+        ];
+        let allowed = vec!["shell".to_string(), "memory_store".to_string()];
+        let result = filter_by_allowed_tools(specs, Some(&allowed));
+        let names: Vec<&str> = result.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names.len(), 2);
+        assert!(names.contains(&"shell"));
+        assert!(names.contains(&"memory_store"));
+        assert!(!names.contains(&"file_read"));
+    }
+
+    #[test]
+    fn filter_by_allowed_tools_unknown_names_silently_ignored() {
+        let specs = vec![make_spec("shell"), make_spec("file_read")];
+        let allowed = vec![
+            "shell".to_string(),
+            "nonexistent_tool".to_string(),
+            "another_missing".to_string(),
+        ];
+        let result = filter_by_allowed_tools(specs, Some(&allowed));
+        let names: Vec<&str> = result.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names.len(), 1);
+        assert!(names.contains(&"shell"));
+    }
+
+    #[test]
+    fn filter_by_allowed_tools_empty_list_excludes_all() {
+        let specs = vec![make_spec("shell"), make_spec("file_read")];
+        let allowed: Vec<String> = vec![];
+        let result = filter_by_allowed_tools(specs, Some(&allowed));
+        assert!(result.is_empty());
     }
 }

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -7875,6 +7875,9 @@ This is an example JSON object for profile settings."#;
             ack_reactions: true,
             show_tool_calls: true,
             session_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -7974,6 +7977,9 @@ This is an example JSON object for profile settings."#;
             ack_reactions: true,
             show_tool_calls: true,
             session_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -8065,6 +8071,9 @@ This is an example JSON object for profile settings."#;
             ack_reactions: true,
             show_tool_calls: true,
             session_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(
@@ -8176,6 +8185,9 @@ This is an example JSON object for profile settings."#;
             ack_reactions: true,
             show_tool_calls: true,
             session_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(
+                &crate::config::AutonomyConfig::default(),
+            )),
         });
 
         process_channel_message(

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -179,6 +179,7 @@ async fn run_agent_job(
                 vec![],
                 false,
                 None,
+                job.allowed_tools.clone(),
             )
             .await
         }
@@ -557,6 +558,7 @@ mod tests {
             enabled: true,
             delivery: DeliveryConfig::default(),
             delete_after_run: false,
+            allowed_tools: None,
             created_at: Utc::now(),
             next_run: Utc::now(),
             last_run: None,

--- a/src/cron/store.rs
+++ b/src/cron/store.rs
@@ -453,6 +453,7 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
         },
         last_status: row.get(15)?,
         last_output: row.get(16)?,
+        allowed_tools: None,
     })
 }
 

--- a/src/cron/types.rs
+++ b/src/cron/types.rs
@@ -115,6 +115,11 @@ pub struct CronJob {
     pub enabled: bool,
     pub delivery: DeliveryConfig,
     pub delete_after_run: bool,
+    /// Optional allowlist of tool names this cron job may use.
+    /// When `Some(list)`, only tools whose name is in the list are available.
+    /// When `None`, all tools are available (backward compatible default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<Vec<String>>,
     pub created_at: DateTime<Utc>,
     pub next_run: DateTime<Utc>,
     pub last_run: Option<DateTime<Utc>>,
@@ -144,6 +149,7 @@ pub struct CronJobPatch {
     pub model: Option<String>,
     pub session_target: Option<SessionTarget>,
     pub delete_after_run: Option<bool>,
+    pub allowed_tools: Option<Vec<String>>,
 }
 
 #[cfg(test)]

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -254,6 +254,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
                 vec![],
                 false,
                 None,
+                None,
             )
             .await
             {
@@ -295,6 +296,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
                 temp,
                 vec![],
                 false,
+                None,
                 None,
             )
             .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -889,6 +889,7 @@ async fn main() -> Result<()> {
                 peripheral,
                 true,
                 session_state_file,
+                None,
             )
             .await
             .map(|_| ())


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: No mechanism to restrict which tools are available to specific agent invocations (cron jobs, heartbeat tasks, CLI runs)
- Why it matters: Enables fine-grained capability control for least-privilege tool access
- What changed: Added `allowed_tools: Option<Vec<String>>` parameter to `agent::run()`, `AgentBuilder`, `CronJob`, filtering tools at both the registry and builder level
- What did **not** change: No changes to tool trait interfaces, security policy, or MCP tool handling

Supersedes #3602 — rebased on latest master to resolve merge conflicts.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `agent`, `cron`, `daemon`, `security`
- Module labels: `agent: agent`, `agent: loop`, `cron: types`, `cron: scheduler`, `cron: store`, `daemon: mod`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `security`

## Linked Issue

- Supersedes #3602

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors: #3602 by @rareba
- Integrated scope by source PR: All changes from #3602 carried forward (capability-based tool filtering in agent builder, run function, cron jobs, daemon heartbeat, and associated tests)
- `Co-authored-by` trailers added for materially incorporated contributors? Yes
- Trailer format check: Pass

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # Pass (no output)
cargo clippy --all-targets -- -D warnings   # Pass (clean)
cargo test   # Pass: 3529 passed; 0 failed; 2 ignored
```

- Evidence provided: All three validation commands passed
- If any command is intentionally skipped: N/A

## Security Impact (required)

- New permissions/capabilities? Yes — new capability-based tool restriction mechanism
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`: This feature restricts tool access (reduces attack surface). When `allowed_tools` is `None`, behavior is identical to before (backward compatible). When set, only listed tools are available, enforcing least-privilege.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes — `allowed_tools` defaults to `None` everywhere, preserving existing behavior
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: All existing tests pass; new tests verify filtering with None (pass-through), Some (restriction), empty list (exclude all), and unknown names (silently ignored)
- Edge cases checked: Empty allowlist excludes all tools; unknown tool names in allowlist are silently ignored
- What was not verified: End-to-end integration with a running agent instance

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `agent::run`, `AgentBuilder`, cron scheduler, daemon heartbeat worker
- Potential unintended effects: None — all call sites pass `None` by default
- Guardrails/monitoring for early detection: `tracing::info` log emitted when filter is applied

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Fetched PR diff, created branch from master, applied changes resolving conflicts, validated with fmt/clippy/test
- Verification focus: Merge conflict resolution, all tests passing
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: Revert commit
- Feature flags or config toggles: `allowed_tools: None` disables the feature (default)
- Observable failure symptoms: Tools unexpectedly unavailable when allowlist is misconfigured

## Risks and Mitigations

- Risk: Misconfigured allowlist could accidentally restrict all tools
  - Mitigation: `None` default preserves existing behavior; `tracing::info` log shows retained count