### PR TITLE
fix(lint): Box::pin large futures in cron scheduler

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -53,7 +53,7 @@ pub async fn run(config: Config) -> Result<()> {
 
 pub async fn execute_job_now(config: &Config, job: &CronJob) -> (bool, String) {
     let security = SecurityPolicy::from_config(&config.autonomy, &config.workspace_dir);
-    execute_job_with_retry(config, &security, job).await
+    Box::pin(execute_job_with_retry(config, &security, job)).await
 }
 
 async fn execute_job_with_retry(
@@ -68,7 +68,7 @@ async fn execute_job_with_retry(
     for attempt in 0..=retries {
         let (success, output) = match job.job_type {
             JobType::Shell => run_job_command(config, security, job).await,
-            JobType::Agent => run_agent_job(config, security, job).await,
+            JobType::Agent => Box::pin(run_agent_job(config, security, job)).await,
         };
         last_output = output;
 
@@ -108,7 +108,7 @@ async fn process_due_jobs(
                 let security = Arc::clone(security);
                 let component = component.to_owned();
                 async move {
-                    execute_and_persist_job(&config, security.as_ref(), &job, &component).await
+                    Box::pin(execute_and_persist_job(&config, security.as_ref(), &job, &component)).await
                 }
             }),
         )
@@ -131,9 +131,9 @@ async fn execute_and_persist_job(
     warn_if_high_frequency_agent_job(job);
 
     let started_at = Utc::now();
-    let (success, output) = execute_job_with_retry(config, security, job).await;
+    let (success, output) = Box::pin(execute_job_with_retry(config, security, job)).await;
     let finished_at = Utc::now();
-    let success = persist_job_result(config, job, success, &output, started_at, finished_at).await;
+    let success = Box::pin(persist_job_result(config, job, success, &output, started_at, finished_at)).await;
 
     (job.id.clone(), success, output)
 }
@@ -744,7 +744,7 @@ mod tests {
         .unwrap();
         let job = test_job("sh ./retry-once.sh");
 
-        let (success, output) = execute_job_with_retry(&config, &security, &job).await;
+        let (success, output) = Box::pin(execute_job_with_retry(&config, &security, &job)).await;
         assert!(success);
         assert!(output.contains("recovered"));
     }
@@ -759,7 +759,7 @@ mod tests {
 
         let job = test_job("ls always_missing_for_retry_test");
 
-        let (success, output) = execute_job_with_retry(&config, &security, &job).await;
+        let (success, output) = Box::pin(execute_job_with_retry(&config, &security, &job)).await;
         assert!(!success);
         assert!(output.contains("always_missing_for_retry_test"));
     }

--- a/src/tools/cron_run.rs
+++ b/src/tools/cron_run.rs
@@ -116,7 +116,7 @@ impl Tool for CronRunTool {
         }
 
         let started_at = Utc::now();
-        let (success, output) = cron::scheduler::execute_job_now(&self.config, &job).await;
+        let (success, output) = Box::pin(cron::scheduler::execute_job_now(&self.config, &job)).await;
         let finished_at = Utc::now();
         let duration_ms = (finished_at - started_at).num_milliseconds();
         let status = if success { "ok" } else { "error" };


### PR DESCRIPTION
## Summary
- Wrap `execute_job_with_retry`, `execute_and_persist_job`, `persist_job_result`, `run_agent_job`, and `execute_job_now` calls with `Box::pin()` to satisfy `clippy::large_futures` lint (futures exceeding 16KB)
- Fixes CI lint failures across all open PRs that touch cron-related code

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes clean
- [x] All 98 cron-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)