### PR TITLE
style: cargo fmt Box::pin calls in cron scheduler

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -101,18 +101,21 @@ async fn process_due_jobs(
     crate::health::mark_component_ok(component);
 
     let max_concurrent = config.scheduler.max_concurrent.max(1);
-    let mut in_flight =
-        stream::iter(
-            jobs.into_iter().map(|job| {
-                let config = config.clone();
-                let security = Arc::clone(security);
-                let component = component.to_owned();
-                async move {
-                    Box::pin(execute_and_persist_job(&config, security.as_ref(), &job, &component)).await
-                }
-            }),
-        )
-        .buffer_unordered(max_concurrent);
+    let mut in_flight = stream::iter(jobs.into_iter().map(|job| {
+        let config = config.clone();
+        let security = Arc::clone(security);
+        let component = component.to_owned();
+        async move {
+            Box::pin(execute_and_persist_job(
+                &config,
+                security.as_ref(),
+                &job,
+                &component,
+            ))
+            .await
+        }
+    }))
+    .buffer_unordered(max_concurrent);
 
     while let Some((job_id, success, output)) = in_flight.next().await {
         if !success {
@@ -133,7 +136,15 @@ async fn execute_and_persist_job(
     let started_at = Utc::now();
     let (success, output) = Box::pin(execute_job_with_retry(config, security, job)).await;
     let finished_at = Utc::now();
-    let success = Box::pin(persist_job_result(config, job, success, &output, started_at, finished_at)).await;
+    let success = Box::pin(persist_job_result(
+        config,
+        job,
+        success,
+        &output,
+        started_at,
+        finished_at,
+    ))
+    .await;
 
     (job.id.clone(), success, output)
 }

--- a/src/tools/cron_run.rs
+++ b/src/tools/cron_run.rs
@@ -116,7 +116,8 @@ impl Tool for CronRunTool {
         }
 
         let started_at = Utc::now();
-        let (success, output) = Box::pin(cron::scheduler::execute_job_now(&self.config, &job)).await;
+        let (success, output) =
+            Box::pin(cron::scheduler::execute_job_now(&self.config, &job)).await;
         let finished_at = Utc::now();
         let duration_ms = (finished_at - started_at).num_milliseconds();
         let status = if success { "ok" } else { "error" };


### PR DESCRIPTION
## Summary
- Run `cargo fmt` on the Box::pin changes from #3666 to fix formatting lint failures

## Test plan
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)