### PR TITLE
fix(lint): Box::pin agent::run calls for large_futures

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -181,7 +181,7 @@ async fn run_agent_job(
 
     let run_result = match job.session_target {
         SessionTarget::Main | SessionTarget::Isolated => {
-            crate::agent::run(
+            Box::pin(crate::agent::run(
                 config.clone(),
                 Some(prefixed_prompt),
                 None,
@@ -191,7 +191,7 @@ async fn run_agent_job(
                 false,
                 None,
                 job.allowed_tools.clone(),
-            )
+            ))
             .await
         }
     };

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -245,7 +245,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
         // ── Phase 1: LLM decision (two-phase mode) ──────────────
         let tasks_to_run = if two_phase {
             let decision_prompt = HeartbeatEngine::build_decision_prompt(&tasks);
-            match crate::agent::run(
+            match Box::pin(crate::agent::run(
                 config.clone(),
                 Some(decision_prompt),
                 None,
@@ -255,7 +255,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
                 false,
                 None,
                 None,
-            )
+            ))
             .await
             {
                 Ok(response) => {
@@ -288,7 +288,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
         for task in &tasks_to_run {
             let prompt = format!("[Heartbeat Task | {}] {}", task.priority, task.text);
             let temp = config.default_temperature;
-            match crate::agent::run(
+            match Box::pin(crate::agent::run(
                 config.clone(),
                 Some(prompt),
                 None,
@@ -298,7 +298,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
                 false,
                 None,
                 None,
-            )
+            ))
             .await
             {
                 Ok(output) => {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -2492,11 +2492,11 @@ mod tests {
             node_registry: Arc::new(nodes::NodeRegistry::new(16)),
         };
 
-        let response = handle_nextcloud_talk_webhook(
+        let response = Box::pin(handle_nextcloud_talk_webhook(
             State(state),
             HeaderMap::new(),
             Bytes::from_static(br#"{"type":"message"}"#),
-        )
+        ))
         .await
         .into_response();
 
@@ -2558,9 +2558,13 @@ mod tests {
             HeaderValue::from_str(invalid_signature).unwrap(),
         );
 
-        let response = handle_nextcloud_talk_webhook(State(state), headers, Bytes::from(body))
-            .await
-            .into_response();
+        let response = Box::pin(handle_nextcloud_talk_webhook(
+            State(state),
+            headers,
+            Bytes::from(body),
+        ))
+        .await
+        .into_response();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
         assert_eq!(provider_impl.calls.load(Ordering::SeqCst), 0);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -880,7 +880,7 @@ async fn main() -> Result<()> {
         } => {
             let final_temperature = temperature.unwrap_or(config.default_temperature);
 
-            agent::run(
+            Box::pin(agent::run(
                 config,
                 message,
                 provider,
@@ -890,7 +890,7 @@ async fn main() -> Result<()> {
                 true,
                 session_state_file,
                 None,
-            )
+            ))
             .await
             .map(|_| ())
         }


### PR DESCRIPTION
## Summary
- Wrap all `crate::agent::run()` calls with `Box::pin()` in scheduler, daemon, gateway tests, and main.rs
- Fixes clippy::large_futures lint errors introduced by recent merges (#3648, #3651, #3659)

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes clean
- [x] `cargo fmt --all -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)