### PR TITLE
fix(channel): prevent vision error from poisoning conversation history

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2361,16 +2361,23 @@ pub(crate) async fn run_tool_call_loop(
             return Err(ToolLoopCancelled.into());
         }
 
-        let image_marker_count = multimodal::count_image_markers(history);
-        if image_marker_count > 0 && !provider.supports_vision() {
-            return Err(ProviderCapabilityError {
-                provider: provider_name.to_string(),
-                capability: "vision".to_string(),
-                message: format!(
-                    "received {image_marker_count} image marker(s), but this provider does not support vision input"
-                ),
+        if !provider.supports_vision() {
+            // Strip stale image markers from all historical turns except the
+            // latest user message. This prevents persisted [IMAGE:] markers
+            // (e.g. reloaded from a JSONL session store after a daemon restart)
+            // from permanently poisoning the conversation for non-vision providers.
+            multimodal::strip_image_markers_from_history(history);
+            let image_marker_count = multimodal::count_image_markers(history);
+            if image_marker_count > 0 {
+                return Err(ProviderCapabilityError {
+                    provider: provider_name.to_string(),
+                    capability: "vision".to_string(),
+                    message: format!(
+                        "received {image_marker_count} image marker(s), but this provider does not support vision input"
+                    ),
+                }
+                .into());
             }
-            .into());
         }
 
         let prepared_messages =

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1016,6 +1016,15 @@ fn rollback_orphan_user_turn(
     if turns.is_empty() {
         histories.remove(sender_key);
     }
+
+    // Mirror the in-memory rollback in the JSONL session store so the orphan
+    // turn does not survive a daemon restart via session hydration.
+    if let Some(ref store) = ctx.session_store {
+        if let Err(e) = store.rollback_last(sender_key) {
+            tracing::warn!("Failed to rollback session store entry for {sender_key}: {e}");
+        }
+    }
+
     true
 }
 
@@ -4364,6 +4373,87 @@ mod tests {
         assert_eq!(turns.len(), 2);
         assert_eq!(turns[0].content, "first");
         assert_eq!(turns[1].content, "ok");
+    }
+
+    #[test]
+    fn rollback_orphan_user_turn_removes_from_session_store() {
+        use crate::channels::session_store::SessionStore;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        let store = Arc::new(SessionStore::new(tmp.path()).unwrap());
+
+        let sender = "telegram_zeroclaw_user".to_string();
+
+        // Pre-populate the JSONL store with two turns.
+        store.append(&sender, &ChatMessage::user("hello")).unwrap();
+        store
+            .append(&sender, &ChatMessage::user("pending"))
+            .unwrap();
+
+        let mut histories = HashMap::new();
+        histories.insert(
+            sender.clone(),
+            vec![ChatMessage::user("hello"), ChatMessage::user("pending")],
+        );
+
+        let ctx = ChannelRuntimeContext {
+            channels_by_name: Arc::new(HashMap::new()),
+            provider: Arc::new(DummyProvider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("system".to_string()),
+            model: Arc::new("test-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 5,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(histories)),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            interrupt_on_new_message: InterruptOnNewMessageConfig {
+                telegram: false,
+                slack: false,
+            },
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            provider_runtime_options: providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(tmp.path().to_path_buf()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            non_cli_excluded_tools: Arc::new(Vec::new()),
+            tool_call_dedup_exempt: Arc::new(Vec::new()),
+            model_routes: Arc::new(Vec::new()),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            ack_reactions: true,
+            show_tool_calls: true,
+            session_store: Some(store.clone()),
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(
+                &crate::config::AutonomyConfig::default(),
+            )),
+        };
+
+        let rolled_back = rollback_orphan_user_turn(&ctx, &sender, "pending");
+        assert!(rolled_back);
+
+        // In-memory history should only have "hello" remaining.
+        let locked = ctx
+            .conversation_histories
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let turns = locked.get(&sender).expect("history should remain");
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].content, "hello");
+        drop(locked);
+
+        // JSONL store should also only have "hello" remaining.
+        let persisted = store.load(&sender);
+        assert_eq!(persisted.len(), 1);
+        assert_eq!(persisted[0].content, "hello");
     }
 
     struct DummyProvider;

--- a/src/channels/session_store.rs
+++ b/src/channels/session_store.rs
@@ -78,6 +78,33 @@ impl SessionStore {
         Ok(())
     }
 
+    /// Remove the last entry from the session JSONL file.
+    ///
+    /// Returns `Ok(true)` if an entry was removed, `Ok(false)` if the session
+    /// file does not exist or is already empty.  Used to roll back an orphan
+    /// user turn that was persisted before an LLM call that subsequently failed
+    /// (e.g. a `ProviderCapabilityError` for vision on a non-vision provider).
+    pub fn rollback_last(&self, session_key: &str) -> std::io::Result<bool> {
+        let path = self.session_path(session_key);
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(e) => return Err(e),
+        };
+        let mut lines: Vec<&str> = content.lines().collect();
+        if lines.is_empty() {
+            return Ok(false);
+        }
+        lines.pop();
+        let new_content = if lines.is_empty() {
+            String::new()
+        } else {
+            format!("{}\n", lines.join("\n"))
+        };
+        std::fs::write(&path, new_content)?;
+        Ok(true)
+    }
+
     /// List all session keys that have files on disk.
     pub fn list_sessions(&self) -> Vec<String> {
         let entries = match std::fs::read_dir(&self.sessions_dir) {
@@ -196,5 +223,80 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].content, "hello");
         assert_eq!(messages[1].content, "world");
+    }
+
+    #[test]
+    fn rollback_last_removes_final_entry() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+        let key = "rollback_test";
+
+        store.append(key, &ChatMessage::user("msg1")).unwrap();
+        store.append(key, &ChatMessage::assistant("reply")).unwrap();
+        store.append(key, &ChatMessage::user("msg2")).unwrap();
+
+        let removed = store.rollback_last(key).unwrap();
+        assert!(removed);
+
+        let messages = store.load(key);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].content, "msg1");
+        assert_eq!(messages[1].content, "reply");
+    }
+
+    #[test]
+    fn rollback_last_on_single_entry_leaves_empty_file() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+        let key = "rollback_single";
+
+        store.append(key, &ChatMessage::user("only")).unwrap();
+
+        let removed = store.rollback_last(key).unwrap();
+        assert!(removed);
+
+        let messages = store.load(key);
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn rollback_last_on_nonexistent_session_returns_false() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+
+        let result = store.rollback_last("does_not_exist").unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn rollback_last_on_empty_file_returns_false() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+        let key = "empty_session";
+
+        // Create an empty file manually
+        let path = store.session_path(key);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "").unwrap();
+
+        let result = store.rollback_last(key).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn rollback_last_is_idempotent_on_subsequent_calls() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+        let key = "rollback_idempotent";
+
+        store.append(key, &ChatMessage::user("msg1")).unwrap();
+        store.append(key, &ChatMessage::user("msg2")).unwrap();
+
+        assert!(store.rollback_last(key).unwrap());
+        assert!(store.rollback_last(key).unwrap());
+        assert!(!store.rollback_last(key).unwrap());
+
+        let messages = store.load(key);
+        assert!(messages.is_empty());
     }
 }

--- a/src/multimodal.rs
+++ b/src/multimodal.rs
@@ -97,6 +97,24 @@ pub fn contains_image_markers(messages: &[ChatMessage]) -> bool {
     count_image_markers(messages) > 0
 }
 
+/// Strip `[IMAGE:...]` markers from all user messages **except** the latest one.
+///
+/// When a non-vision provider encounters stale image markers left in historical
+/// turns (e.g. reloaded from a persisted JSONL session), this function removes
+/// them so the vision capability check only fires for the current request.
+pub fn strip_image_markers_from_history(messages: &mut [ChatMessage]) {
+    let last_user_idx = messages.iter().rposition(|m| m.role == "user");
+    for (i, msg) in messages.iter_mut().enumerate() {
+        if msg.role != "user" || Some(i) == last_user_idx {
+            continue;
+        }
+        let (cleaned, refs) = parse_image_markers(&msg.content);
+        if !refs.is_empty() {
+            msg.content = cleaned;
+        }
+    }
+}
+
 pub fn extract_ollama_image_payload(image_ref: &str) -> Option<String> {
     if image_ref.starts_with("data:") {
         let comma_idx = image_ref.find(',')?;
@@ -565,5 +583,66 @@ mod tests {
         let payload = extract_ollama_image_payload("data:image/png;base64,abcd==")
             .expect("payload should be extracted");
         assert_eq!(payload, "abcd==");
+    }
+
+    #[test]
+    fn strip_image_markers_from_history_cleans_old_preserves_latest() {
+        let mut history = vec![
+            ChatMessage::user("first message [IMAGE:/tmp/old.png]"),
+            ChatMessage::assistant("I saw your image"),
+            ChatMessage::user("second message [IMAGE:/tmp/current.png]"),
+        ];
+
+        strip_image_markers_from_history(&mut history);
+
+        assert_eq!(history[0].content, "first message");
+        assert_eq!(history[1].content, "I saw your image");
+        assert_eq!(
+            history[2].content,
+            "second message [IMAGE:/tmp/current.png]"
+        );
+    }
+
+    #[test]
+    fn strip_image_markers_from_history_no_user_messages_is_noop() {
+        let mut history = vec![
+            ChatMessage::assistant("hello"),
+            ChatMessage::assistant("world"),
+        ];
+        let original = history.clone();
+
+        strip_image_markers_from_history(&mut history);
+
+        assert_eq!(history[0].content, original[0].content);
+        assert_eq!(history[1].content, original[1].content);
+    }
+
+    #[test]
+    fn strip_image_markers_from_history_single_user_message_preserved() {
+        let mut history = vec![ChatMessage::user("only message [IMAGE:/tmp/a.png]")];
+
+        strip_image_markers_from_history(&mut history);
+
+        assert_eq!(
+            history[0].content, "only message [IMAGE:/tmp/a.png]",
+            "sole user message must not be stripped"
+        );
+    }
+
+    #[test]
+    fn strip_image_markers_from_history_multiple_old_markers_all_cleaned() {
+        let mut history = vec![
+            ChatMessage::user("msg1 [IMAGE:/tmp/a.png]"),
+            ChatMessage::assistant("ok"),
+            ChatMessage::user("msg2 [IMAGE:/tmp/b.png]"),
+            ChatMessage::assistant("ok"),
+            ChatMessage::user("latest text only"),
+        ];
+
+        strip_image_markers_from_history(&mut history);
+
+        assert_eq!(history[0].content, "msg1");
+        assert_eq!(history[2].content, "msg2");
+        assert_eq!(history[4].content, "latest text only");
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: When a user sends an image to a non-vision provider via Telegram, the `[IMAGE:]` marker is stored in the JSONL session store before the LLM call. `rollback_orphan_user_turn()` removes it from in-memory history on `ProviderCapabilityError` but leaves it in the JSONL file. On daemon restart, session hydration reloads the marker, causing every subsequent message (including plain text) to fail with the same vision error permanently.
- Why it matters: Any user who accidentally sends an image to a non-vision provider has their conversation permanently poisoned — they must manually delete the session JSONL file to recover.
- What changed: Two-pronged fix — (A) strip stale image markers from historical turns before the vision check so only the current request can trigger the error; (B) extend `rollback_orphan_user_turn()` to also roll back the JSONL session store entry, keeping disk and memory in sync.
- What did **not** change: Vision behavior for vision-capable providers is completely unchanged. The error message for current-turn vision failures is unchanged. No config schema or API surface changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): XS
- Scope labels: `channel`, `agent`
- Module labels: `channel: telegram`
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #3674 
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A — this is an original fix, not superseding another PR.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings  # pass (pre-existing warnings in src/config/schema.rs unrelated to this PR)
cargo test strip_image_markers  # 4/4 pass
cargo test rollback             # 7/7 pass (5 session_store + 1 integration + 1 existing regression)
```

- All 11 new/modified tests pass
- Existing test `rollback_orphan_user_turn_removes_only_latest_matching_user_turn` still passes unchanged
- Pre-existing clippy warning `unused import: tempfile::TempDir` in `src/config/schema.rs` exists on master and is unrelated to this PR

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No — `rollback_last()` only writes to the existing sessions directory that `append()` already writes to

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: test fixtures use neutral labels (`zeroclaw_user`, `msg1`, `hello`, `pending`)
- Neutral wording confirmation: yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No — no user-facing wording changes; the error message text is unchanged

## Human Verification (required)

- Verified scenarios: strip logic preserves latest user message, cleans all older messages; rollback_last removes exactly the final JSONL line and returns false on missing/empty files; rollback_orphan_user_turn with a live SessionStore removes from both in-memory and JSONL
- Edge cases checked: single user message in history (not stripped), empty session file, non-existent session file, idempotent rollback
- What was not verified: live end-to-end test with a real Telegram bot and MiniMax provider (no credentials available in test environment)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: channel message handling, session persistence, agent loop vision check
- Potential unintended effects: `strip_image_markers_from_history()` mutates history in-place on the non-vision path; for vision providers the function is never called so there is no change
- Guardrails/monitoring for early detection: existing observer events on `LlmRequest` will continue to surface any unexpected errors

## Agent Collaboration Notes (recommended)

- Agent tools used: Cursor AI (code generation and test authorship)
- Workflow/plan summary: analyzed root cause via code trace → implemented two-pronged fix → ran targeted tests → validated no regressions
- Verification focus: both prongs independently verifiable via unit tests; integration test covers the combined end-to-end rollback path
- Confirmation: naming and architecture boundaries followed per `AGENTS.md` and `CONTRIBUTING.md`

## Rollback Plan (required)

- Fast rollback command/path: `git revert 39ab207` — reverts all four file changes atomically
- Feature flags or config toggles: none
- Observable failure symptoms: vision errors reappearing on text-only messages after daemon restart; `[IMAGE:]` markers visible in `sessions/*.jsonl` files after a failed vision request

## Risks and Mitigations

- Risk: `strip_image_markers_from_history()` is called once per loop iteration on non-vision providers. For very long histories this is O(n) string scanning per turn.
  - Mitigation: the function short-circuits immediately if no markers are found (the common case for most messages); the overhead is negligible compared to network I/O for the LLM call.
- Risk: `rollback_last()` uses a read-modify-write pattern on the JSONL file, which is not atomic.
  - Mitigation: this matches the existing risk profile of `append()` (also not atomic). Rollback is a best-effort operation — a warn log is emitted on failure, and the in-memory state is always authoritative.
