### PR TITLE
fix(config): make new config sections backward compatible

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -126,17 +126,23 @@ pub struct Config {
     pub backup: BackupConfig,
 
     /// Data retention and purge configuration (`[data_retention]`).
+    #[serde(default)]
     pub data_retention: DataRetentionConfig,
 
     /// Cloud transformation accelerator configuration (`[cloud_ops]`).
+    #[serde(default)]
     pub cloud_ops: CloudOpsConfig,
 
     /// Conversational AI agent builder configuration (`[conversational_ai]`).
+    #[serde(default)]
     pub conversational_ai: ConversationalAiConfig,
 
+    /// Security subsystem configuration (`[security]`).
+    #[serde(default)]
     pub security: SecurityConfig,
 
     /// Managed cybersecurity service configuration (`[security_ops]`).
+    #[serde(default)]
     pub security_ops: SecurityOpsConfig,
 
     /// Runtime adapter configuration (`[runtime]`). Controls native vs Docker execution.


### PR DESCRIPTION
## Summary

Fixes #3684 - Upgrade to v0.3.4 breaks daemon startup with `TOML parse error: missing field '...'`

## Problem

Users upgrading from previous versions experience daemon crashes because new config sections added in v0.3.4 require explicit TOML entries:
- `data_retention`
- `cloud_ops`
- `conversational_ai`
- `security`
- `security_ops`

Each missing field is discovered incrementally via trial-and-error, blocking workflow entirely.

## Root Cause

These config sections have `Default` implementations but lacked `#[serde(default)]` on their `Config` struct fields. This makes them **required** in TOML even though all their sub-fields have defaults.

## Fix

Add `#[serde(default)]` to each affected field so old `config.toml` files continue to work without manual section additions.

## Test Plan

- [x] Code compiles (Rust with serde)
- [ ] Run `zeroclaw daemon` with old config.toml (no new sections)
- [ ] Verify no "missing field" errors
- [ ] Confirm default values are applied

## Impact

- **Users affected**: Anyone upgrading from a previous version
- **Frequency**: 100% reproducible on upgrade
- **Severity**: S1 - workflow blocked (daemon unusable)

## Checklist

- [x] Code follows project conventions
- [x] Commit message follows conventional commits
- [x] References issue #3684