### PR TITLE
fix(config): add missing #[serde(default)] to Config struct fields

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -122,21 +122,26 @@ pub struct Config {
 
     /// Security subsystem configuration (`[security]`).
     #[serde(default)]
+    pub security: SecurityConfig,
+
     /// Backup tool configuration (`[backup]`).
+    #[serde(default)]
     pub backup: BackupConfig,
 
     /// Data retention and purge configuration (`[data_retention]`).
+    #[serde(default)]
     pub data_retention: DataRetentionConfig,
 
     /// Cloud transformation accelerator configuration (`[cloud_ops]`).
+    #[serde(default)]
     pub cloud_ops: CloudOpsConfig,
 
     /// Conversational AI agent builder configuration (`[conversational_ai]`).
+    #[serde(default)]
     pub conversational_ai: ConversationalAiConfig,
 
-    pub security: SecurityConfig,
-
     /// Managed cybersecurity service configuration (`[security_ops]`).
+    #[serde(default)]
     pub security_ops: SecurityOpsConfig,
 
     /// Runtime adapter configuration (`[runtime]`). Controls native vs Docker execution.


### PR DESCRIPTION
## Summary
- Adds missing `#[serde(default)]` to `data_retention`, `cloud_ops`, `conversational_ai`, and `security_ops` fields on the `Config` struct
- Fixes `security` field whose `#[serde(default)]` was accidentally consumed by the `backup` field's doc comment
- This was breaking **all PR CI runs** with `missing field 'data_retention'` deserialization errors in tests

## Root cause
Commits 8a61a283 (PR #3657) and 861dd3e2 (PR #3662) added new config struct fields without `#[serde(default)]`, causing test configs that don't include those sections to fail deserialization.

## Test plan
- [x] `cargo test config::schema::tests` — 196 passed, 0 failed
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean