### PR TITLE
ci(docker): add fork PR preview workflow

### DIFF
--- a/.github/workflows/pr-docker-preview.yml
+++ b/.github/workflows/pr-docker-preview.yml
@@ -1,0 +1,83 @@
+name: PR Docker Preview (Fork)
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: pr-docker-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker-preview:
+    name: Build and Push PR Image
+    if: ${{ github.repository_owner == 'f0rr0' && github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Derive image tags
+        id: vars
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch_slug="$(echo "${{ github.event.pull_request.head.ref }}" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+          if [ -z "${branch_slug}" ]; then
+            branch_slug="pr"
+          fi
+          branch_slug="${branch_slug:0:40}"
+          short_sha="$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-12)"
+          stable_tag="pr-${branch_slug}-${{ github.event.pull_request.number }}"
+          sha_tag="${stable_tag}-${short_sha}"
+          image="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          echo "image=${image}" >> "$GITHUB_OUTPUT"
+          echo "stable_tag=${stable_tag}" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=${sha_tag}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push PR image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.stable_tag }}
+            ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.sha_tag }}
+          platforms: linux/amd64
+          cache-from: type=gha,scope=pr-docker-preview-${{ github.event.pull_request.number }}
+          cache-to: type=gha,mode=max,scope=pr-docker-preview-${{ github.event.pull_request.number }}
+
+      - name: Publish pull commands
+        shell: bash
+        run: |
+          {
+            echo "### PR image pushed"
+            echo ""
+            echo "- \`${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.stable_tag }}\` (moves with new PR commits)"
+            echo "- \`${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.sha_tag }}\` (immutable commit pin)"
+            echo ""
+            echo "Pull command:"
+            echo "\`docker pull ${{ steps.vars.outputs.image }}:${{ steps.vars.outputs.stable_tag }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: fork branches do not have a dedicated PR preview image workflow.
- Why it matters: a published preview image makes it easier to validate branch-specific Docker builds from GHCR.
- What changed: adds `.github/workflows/pr-docker-preview.yml` to build and publish PR preview images for non-draft PRs opened from branches in `f0rr0/zeroclaw`.
- What did **not** change (scope boundary): no runtime, Dockerfile, or application-code changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `ci`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `ci: docker`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `auto-managed`
- If any auto-label is incorrect, note requested correction: `N/A`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `ci`

## Linked Issue

- Closes # `N/A`
- Related # `N/A`
- Depends on # (if stacked) `N/A`
- Supersedes # (if replacing older PR) `N/A`

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Integrated scope by source PR (what was materially carried forward): `N/A`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `N/A`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): `N/A`
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `N/A`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): manual workflow review for trigger, permission, tag derivation, and GHCR push path
- If any command is intentionally skipped, explain why: workflow-only PR; Rust build/test commands were not run because no Rust source or runtime behavior changed

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `Yes`
- New external network calls? (`Yes/No`): `Yes`
- Secrets/tokens handling changed? (`Yes/No`): `Yes`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: workflow requests `packages: write`, authenticates to GHCR with `GITHUB_TOKEN`, and pushes preview images only for non-draft PRs whose head repo matches `f0rr0/zeroclaw`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no user data or live secrets added
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N/A`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `N/A`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N/A`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N/A`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: `N/A`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: workflow trigger conditions, tag derivation, GHCR login path, and push tags produced by the workflow definition
- Edge cases checked: branch slug sanitization and stable-vs-sha tag naming
- What was not verified: live GitHub Actions execution on a fork PR

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `.github/workflows/pr-docker-preview.yml`, GHCR preview image publishing
- Potential unintended effects: GHCR preview tags can accumulate without cleanup
- Guardrails/monitoring for early detection: GitHub Actions run logs and GHCR package tags

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local git, gh CLI
- Workflow/plan summary (if any): split combined branch into isolated CI and Slack branches, then pushed each branch separately
- Verification focus: workflow correctness and separation of concerns
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed

## Rollback Plan (required)

- Fast rollback command/path: revert the PR or delete `.github/workflows/pr-docker-preview.yml`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: missing preview image tags in GHCR or failed workflow runs on PRs

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: the bootstrap PR itself will not run a brand-new `pull_request` workflow until the workflow exists on the base branch
- Mitigation: merge once, or add a separate bootstrap trigger such as `workflow_dispatch`/`push` in a follow-up
