### PR TITLE
chore: gitignore stale target-* build cache dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/target-*/
 firmware/*/target
 web/dist/
 *.db


### PR DESCRIPTION
## Summary
- Adds `/target-*/` to `.gitignore` to prevent alternative Cargo build directories (e.g. `target-ms365`, `target-pr`, `target-master2`) from being tracked
- These directories are created when building with custom `CARGO_TARGET_DIR` paths and contain only compiled artifacts

## Test plan
- [ ] Verify `.gitignore` correctly ignores `target-*` directories
- [ ] Confirm no functional code is affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)