### PR TITLE
fix(ci): scope rust-cache by OS image in release beta

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -189,6 +189,8 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         if: runner.os != 'Windows'
+        with:
+          prefix-key: ${{ matrix.os }}-${{ matrix.target }}
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- **Root cause**: The `aarch64-unknown-linux-gnu` release build runs on `ubuntu-22.04` (glibc 2.35), but `Swatinem/rust-cache` was restoring cached build-script binaries compiled on `ubuntu-latest` (Ubuntu 24.04, glibc 2.39). Both runners report `runner.os` as `Linux`, so the default cache keys collide across workflows.
- **Symptom**: `GLIBC_2.39 not found` when running the `libc` build script during the aarch64-linux-gnu cargo build.
- **Fix**: Add `prefix-key: ${{ matrix.os }}-${{ matrix.target }}` to the `rust-cache` step so each matrix entry gets its own isolated cache, preventing cross-image glibc mismatches.

## Test plan

- [ ] Verify the `aarch64-unknown-linux-gnu` build job passes in CI on this PR
- [ ] Confirm other build targets (x86_64-linux, macOS, Android, Windows) are unaffected
- [ ] Next push to `master` should produce a successful Release Beta run