### PR TITLE
fix(ci): scope rust-cache in stable release workflow

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -190,6 +190,8 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         if: runner.os != 'Windows'
+        with:
+          prefix-key: ${{ matrix.os }}-${{ matrix.target }}
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- Same glibc cache mismatch fix applied to the **stable** release workflow
- Without this, triggering a stable v0.4.0 release would fail on `aarch64-unknown-linux-gnu` with `GLIBC_2.39 not found`
- Adds `prefix-key: ${{ matrix.os }}-${{ matrix.target }}` to isolate caches by runner image

## Test plan

- [ ] CI passes on this PR
- [ ] Stable release workflow dispatch succeeds after merge