### PR TITLE
fix(ci): decouple tweet from crates.io in stable release

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -307,13 +307,16 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           VERSION: ${{ inputs.version }}
         run: |
-          # Skip if this version is already on crates.io (auto-sync may have published it)
+          # Publish to crates.io; treat "already exists" as success
+          # (auto-publish workflow may have already published this version)
           CRATE_NAME=$(sed -n 's/^name = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
-          if curl -sfL "https://crates.io/api/v1/crates/${CRATE_NAME}/${VERSION}" | grep -q '"version"'; then
-            echo "::notice::${CRATE_NAME}@${VERSION} already published on crates.io — skipping"
-          else
-            cargo publish --locked --allow-dirty --no-verify
+          OUTPUT=$(cargo publish --locked --allow-dirty --no-verify 2>&1) && exit 0
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q 'already exists'; then
+            echo "::notice::${CRATE_NAME}@${VERSION} already on crates.io — skipping"
+            exit 0
           fi
+          exit 1
 
   redeploy-website:
     name: Trigger Website Redeploy
@@ -361,7 +364,7 @@ jobs:
   # ── Post-publish: only run after ALL artifacts are live ──────────────
   tweet:
     name: Tweet Release
-    needs: [validate, publish, docker, crates-io, redeploy-website]
+    needs: [validate, publish, docker, redeploy-website]
     uses: ./.github/workflows/tweet-release.yml
     with:
       release_tag: ${{ needs.validate.outputs.tag }}


### PR DESCRIPTION
## Summary

- **Tweet no longer blocked by crates.io**: Drops `crates-io` from the tweet job's `needs` so the release announcement fires once GitHub release + Docker + website are live — matching how the beta workflow already works
- **Fix crates.io duplicate handling**: The previous `curl` pre-check used a URL that didn't match the actual crate index, so `cargo publish` would hit "already exists" and fail the whole job. Now we just run `cargo publish` and gracefully treat "already exists" as success

This is what caused the `v0.4.0` tweet to be skipped — crates.io was already published by the auto-sync workflow, the check didn't detect it, and the job failed on the duplicate.

## Test plan

- [ ] CI passes
- [ ] Next stable release tweets without waiting on crates.io
- [ ] If crate is already published, job succeeds with a notice instead of failing