### PR TITLE
fix(security): validate command before rate-limiting in cron once

### DIFF
--- a/src/tools/schedule.rs
+++ b/src/tools/schedule.rs
@@ -88,9 +88,6 @@ impl Tool for ScheduleTool {
                 self.handle_get(id)
             }
             "create" | "add" | "once" => {
-                if let Some(blocked) = self.enforce_mutation_allowed(action) {
-                    return Ok(blocked);
-                }
                 let approved = args
                     .get("approved")
                     .and_then(serde_json::Value::as_bool)
@@ -299,6 +296,12 @@ impl ScheduleTool {
                     });
                 }
             }
+        }
+
+        // Enforce rate-limiting AFTER command/args validation so that invalid
+        // requests do not consume the action budget.  (Fixes #3699)
+        if let Some(blocked) = self.enforce_mutation_allowed(action) {
+            return Ok(blocked);
         }
 
         // All job creation routes through validated cron helpers, which enforce


### PR DESCRIPTION
Closes #3699

## Summary
- `cron once` was calling `enforce_mutation_allowed()` before command validation, consuming rate-limited actions even for blocked commands
- Moved rate-limit check into `handle_create_like()` after validation, matching `cron_add.rs` pattern

## Test plan
- [ ] `cron once` with blocked command no longer consumes rate-limited action
- [ ] `cron once` with valid command still works
- [ ] CI green