### PR TITLE
ci: restore Homebrew and add Scoop/AUR package manager workflows

### DIFF
--- a/.github/workflows/pub-aur.yml
+++ b/.github/workflows/pub-aur.yml
@@ -1,0 +1,155 @@
+name: Pub AUR Package
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag (vX.Y.Z)"
+        required: true
+        type: string
+      dry_run:
+        description: "Generate PKGBUILD only (no push)"
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: aur-publish-${{ github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish-aur:
+    name: Update AUR Package
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      DRY_RUN: ${{ inputs.dry_run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate and compute metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release_tag must be vX.Y.Z format."
+            exit 1
+          fi
+
+          version="${RELEASE_TAG#v}"
+          tarball_url="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${RELEASE_TAG}.tar.gz"
+          tarball_sha="$(curl -fsSL "$tarball_url" | sha256sum | awk '{print $1}')"
+
+          if [[ -z "$tarball_sha" ]]; then
+            echo "::error::Could not compute SHA256 for source tarball."
+            exit 1
+          fi
+
+          {
+            echo "version=$version"
+            echo "tarball_url=$tarball_url"
+            echo "tarball_sha=$tarball_sha"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### AUR Package Metadata"
+            echo "- version: \`${version}\`"
+            echo "- tarball_url: \`${tarball_url}\`"
+            echo "- tarball_sha: \`${tarball_sha}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Generate PKGBUILD
+        id: pkgbuild
+        shell: bash
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          TARBALL_SHA: ${{ steps.meta.outputs.tarball_sha }}
+        run: |
+          set -euo pipefail
+
+          pkgbuild_file="$(mktemp)"
+          sed -e "s/^pkgver=.*/pkgver=${VERSION}/" \
+              -e "s/^sha256sums=.*/sha256sums=('${TARBALL_SHA}')/" \
+              dist/aur/PKGBUILD > "$pkgbuild_file"
+
+          echo "pkgbuild_file=$pkgbuild_file" >> "$GITHUB_OUTPUT"
+
+          echo "### Generated PKGBUILD" >> "$GITHUB_STEP_SUMMARY"
+          echo '```bash' >> "$GITHUB_STEP_SUMMARY"
+          cat "$pkgbuild_file" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Generate .SRCINFO
+        id: srcinfo
+        shell: bash
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          TARBALL_SHA: ${{ steps.meta.outputs.tarball_sha }}
+        run: |
+          set -euo pipefail
+
+          srcinfo_file="$(mktemp)"
+          sed -e "s/pkgver = .*/pkgver = ${VERSION}/" \
+              -e "s/sha256sums = .*/sha256sums = ${TARBALL_SHA}/" \
+              -e "s|zeroclaw-[0-9.]*.tar.gz|zeroclaw-${VERSION}.tar.gz|g" \
+              -e "s|/v[0-9.]*\.tar\.gz|/v${VERSION}.tar.gz|g" \
+              dist/aur/.SRCINFO > "$srcinfo_file"
+
+          echo "srcinfo_file=$srcinfo_file" >> "$GITHUB_OUTPUT"
+
+      - name: Push to AUR
+        if: inputs.dry_run == false
+        shell: bash
+        env:
+          AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
+          PKGBUILD_FILE: ${{ steps.pkgbuild.outputs.pkgbuild_file }}
+          SRCINFO_FILE: ${{ steps.srcinfo.outputs.srcinfo_file }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${AUR_SSH_KEY}" ]]; then
+            echo "::error::Secret AUR_SSH_KEY is required for non-dry-run."
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          echo "$AUR_SSH_KEY" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          cat >> ~/.ssh/config <<SSH_CONFIG
+          Host aur.archlinux.org
+            IdentityFile ~/.ssh/aur
+            User aur
+            StrictHostKeyChecking accept-new
+          SSH_CONFIG
+
+          tmp_dir="$(mktemp -d)"
+          git clone ssh://aur@aur.archlinux.org/zeroclaw.git "$tmp_dir/aur"
+
+          cp "$PKGBUILD_FILE" "$tmp_dir/aur/PKGBUILD"
+          cp "$SRCINFO_FILE" "$tmp_dir/aur/.SRCINFO"
+
+          cd "$tmp_dir/aur"
+          git config user.name "zeroclaw-bot"
+          git config user.email "bot@zeroclaw.dev"
+          git add PKGBUILD .SRCINFO
+          git commit -m "zeroclaw ${VERSION}"
+          git push origin HEAD
+
+          echo "AUR package updated to ${VERSION}"
+
+      - name: Summary
+        shell: bash
+        run: |
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "Dry run complete: PKGBUILD generated, no push performed."
+          else
+            echo "Publish complete: AUR package pushed."
+          fi

--- a/.github/workflows/pub-homebrew-core.yml
+++ b/.github/workflows/pub-homebrew-core.yml
@@ -1,0 +1,206 @@
+name: Pub Homebrew Core
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag to publish (vX.Y.Z)"
+        required: true
+        type: string
+      dry_run:
+        description: "Patch formula only (no push/PR)"
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: homebrew-core-${{ github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish-homebrew-core:
+    name: Publish Homebrew Core PR
+    runs-on: ubuntu-latest
+    env:
+      UPSTREAM_REPO: Homebrew/homebrew-core
+      FORMULA_PATH: Formula/z/zeroclaw.rb
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      DRY_RUN: ${{ inputs.dry_run }}
+      BOT_FORK_REPO: ${{ vars.HOMEBREW_CORE_BOT_FORK_REPO }}
+      BOT_EMAIL: ${{ vars.HOMEBREW_CORE_BOT_EMAIL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate release tag and version alignment
+        id: release_meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          semver_pattern='^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'
+          if [[ ! "$RELEASE_TAG" =~ $semver_pattern ]]; then
+            echo "::error::release_tag must match semver-like format (vX.Y.Z[-suffix])."
+            exit 1
+          fi
+
+          if ! git rev-parse "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            git fetch --tags origin
+          fi
+
+          tag_version="${RELEASE_TAG#v}"
+          cargo_version="$(git show "${RELEASE_TAG}:Cargo.toml" \
+            | sed -n 's/^version = "\([^"]*\)"/\1/p' | head -n1)"
+          if [[ -z "$cargo_version" ]]; then
+            echo "::error::Unable to read Cargo.toml version from tag ${RELEASE_TAG}."
+            exit 1
+          fi
+          if [[ "$cargo_version" != "$tag_version" ]]; then
+            echo "::error::Tag ${RELEASE_TAG} does not match Cargo.toml version (${cargo_version})."
+            exit 1
+          fi
+
+          tarball_url="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${RELEASE_TAG}.tar.gz"
+          tarball_sha="$(curl -fsSL "$tarball_url" | sha256sum | awk '{print $1}')"
+
+          {
+            echo "tag_version=$tag_version"
+            echo "tarball_url=$tarball_url"
+            echo "tarball_sha=$tarball_sha"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Release Metadata"
+            echo "- release_tag: \`${RELEASE_TAG}\`"
+            echo "- cargo_version: \`${cargo_version}\`"
+            echo "- tarball_sha256: \`${tarball_sha}\`"
+            echo "- dry_run: ${DRY_RUN}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Patch Homebrew formula
+        id: patch_formula
+        shell: bash
+        env:
+          HOMEBREW_CORE_BOT_TOKEN: ${{ secrets.HOMEBREW_UPSTREAM_PR_TOKEN || secrets.HOMEBREW_CORE_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_UPSTREAM_PR_TOKEN || secrets.HOMEBREW_CORE_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          tmp_repo="$(mktemp -d)"
+          echo "tmp_repo=$tmp_repo" >> "$GITHUB_OUTPUT"
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            git clone --depth=1 "https://github.com/${UPSTREAM_REPO}.git" "$tmp_repo/homebrew-core"
+          else
+            if [[ -z "${BOT_FORK_REPO}" ]]; then
+              echo "::error::Repository variable HOMEBREW_CORE_BOT_FORK_REPO is required when dry_run=false."
+              exit 1
+            fi
+            if [[ -z "${HOMEBREW_CORE_BOT_TOKEN}" ]]; then
+              echo "::error::Repository secret HOMEBREW_CORE_BOT_TOKEN is required when dry_run=false."
+              exit 1
+            fi
+            if [[ "$BOT_FORK_REPO" != */* ]]; then
+              echo "::error::HOMEBREW_CORE_BOT_FORK_REPO must be in owner/repo format."
+              exit 1
+            fi
+            if ! gh api "repos/${BOT_FORK_REPO}" >/dev/null 2>&1; then
+              echo "::error::HOMEBREW_CORE_BOT_TOKEN cannot access ${BOT_FORK_REPO}."
+              exit 1
+            fi
+            gh repo clone "${BOT_FORK_REPO}" "$tmp_repo/homebrew-core" -- --depth=1
+          fi
+
+          repo_dir="$tmp_repo/homebrew-core"
+          formula_file="$repo_dir/$FORMULA_PATH"
+          if [[ ! -f "$formula_file" ]]; then
+            echo "::error::Formula file not found: $FORMULA_PATH"
+            exit 1
+          fi
+
+          if [[ "$DRY_RUN" == "false" ]]; then
+            if git -C "$repo_dir" remote get-url upstream >/dev/null 2>&1; then
+              git -C "$repo_dir" remote set-url upstream "https://github.com/${UPSTREAM_REPO}.git"
+            else
+              git -C "$repo_dir" remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
+            fi
+            if git -C "$repo_dir" ls-remote --exit-code --heads upstream main >/dev/null 2>&1; then
+              upstream_ref="main"
+            else
+              upstream_ref="master"
+            fi
+            git -C "$repo_dir" fetch --depth=1 upstream "$upstream_ref"
+            branch_name="zeroclaw-${RELEASE_TAG}-${GITHUB_RUN_ID}"
+            git -C "$repo_dir" checkout -B "$branch_name" "upstream/$upstream_ref"
+            echo "branch_name=$branch_name" >> "$GITHUB_OUTPUT"
+          fi
+
+          tarball_url="$(grep 'tarball_url=' "$GITHUB_OUTPUT" | head -1 | cut -d= -f2-)"
+          tarball_sha="$(grep 'tarball_sha=' "$GITHUB_OUTPUT" | head -1 | cut -d= -f2-)"
+
+          perl -0pi -e "s|^  url \".*\"|  url \"${tarball_url}\"|m" "$formula_file"
+          perl -0pi -e "s|^  sha256 \".*\"|  sha256 \"${tarball_sha}\"|m" "$formula_file"
+          perl -0pi -e "s|^  license \".*\"|  license \"Apache-2.0 OR MIT\"|m" "$formula_file"
+
+          git -C "$repo_dir" diff -- "$FORMULA_PATH" > "$tmp_repo/formula.diff"
+          if [[ ! -s "$tmp_repo/formula.diff" ]]; then
+            echo "::error::No formula changes generated. Nothing to publish."
+            exit 1
+          fi
+
+          {
+            echo "### Formula Diff"
+            echo '```diff'
+            cat "$tmp_repo/formula.diff"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Push branch and open Homebrew PR
+        if: inputs.dry_run == false
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_UPSTREAM_PR_TOKEN || secrets.HOMEBREW_CORE_BOT_TOKEN }}
+          TMP_REPO: ${{ steps.patch_formula.outputs.tmp_repo }}
+          BRANCH_NAME: ${{ steps.patch_formula.outputs.branch_name }}
+          TAG_VERSION: ${{ steps.release_meta.outputs.tag_version }}
+          TARBALL_URL: ${{ steps.release_meta.outputs.tarball_url }}
+          TARBALL_SHA: ${{ steps.release_meta.outputs.tarball_sha }}
+        run: |
+          set -euo pipefail
+
+          repo_dir="${TMP_REPO}/homebrew-core"
+          fork_owner="${BOT_FORK_REPO%%/*}"
+          bot_email="${BOT_EMAIL:-${fork_owner}@users.noreply.github.com}"
+
+          git -C "$repo_dir" config user.name "$fork_owner"
+          git -C "$repo_dir" config user.email "$bot_email"
+          git -C "$repo_dir" add "$FORMULA_PATH"
+          git -C "$repo_dir" commit -m "zeroclaw ${TAG_VERSION}"
+          gh auth setup-git
+          git -C "$repo_dir" push --set-upstream origin "$BRANCH_NAME"
+
+          pr_body="Automated formula bump from ZeroClaw release workflow.
+
+          - Release tag: ${RELEASE_TAG}
+          - Source tarball: ${TARBALL_URL}
+          - Source sha256: ${TARBALL_SHA}"
+
+          gh pr create \
+            --repo "$UPSTREAM_REPO" \
+            --base main \
+            --head "${fork_owner}:${BRANCH_NAME}" \
+            --title "zeroclaw ${TAG_VERSION}" \
+            --body "$pr_body"
+
+      - name: Summary
+        shell: bash
+        run: |
+          if [[ "$DRY_RUN" == "true" ]]; then
+            echo "Dry run complete: formula diff generated, no push/PR performed."
+          else
+            echo "Publish complete: branch pushed and PR opened from bot fork."
+          fi

--- a/.github/workflows/pub-scoop.yml
+++ b/.github/workflows/pub-scoop.yml
@@ -1,0 +1,151 @@
+name: Pub Scoop Manifest
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Existing release tag (vX.Y.Z)"
+        required: true
+        type: string
+      dry_run:
+        description: "Generate manifest only (no push)"
+        required: false
+        default: true
+        type: boolean
+
+concurrency:
+  group: scoop-publish-${{ github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish-scoop:
+    name: Update Scoop Manifest
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      DRY_RUN: ${{ inputs.dry_run }}
+      SCOOP_BUCKET_REPO: ${{ vars.SCOOP_BUCKET_REPO }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate and compute metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::release_tag must be vX.Y.Z format."
+            exit 1
+          fi
+
+          version="${RELEASE_TAG#v}"
+          zip_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/zeroclaw-x86_64-pc-windows-msvc.zip"
+          sums_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/SHA256SUMS"
+
+          sha256="$(curl -fsSL "$sums_url" | grep 'zeroclaw-x86_64-pc-windows-msvc.zip' | awk '{print $1}')"
+
+          if [[ -z "$sha256" ]]; then
+            echo "::error::Could not find Windows binary hash in SHA256SUMS for ${RELEASE_TAG}."
+            exit 1
+          fi
+
+          {
+            echo "version=$version"
+            echo "zip_url=$zip_url"
+            echo "sha256=$sha256"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Scoop Manifest Metadata"
+            echo "- version: \`${version}\`"
+            echo "- zip_url: \`${zip_url}\`"
+            echo "- sha256: \`${sha256}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Generate manifest
+        id: manifest
+        shell: bash
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          ZIP_URL: ${{ steps.meta.outputs.zip_url }}
+          SHA256: ${{ steps.meta.outputs.sha256 }}
+        run: |
+          set -euo pipefail
+
+          manifest_file="$(mktemp)"
+          cat > "$manifest_file" <<MANIFEST
+          {
+              "version": "${VERSION}",
+              "description": "Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.",
+              "homepage": "https://github.com/zeroclaw-labs/zeroclaw",
+              "license": "MIT|Apache-2.0",
+              "architecture": {
+                  "64bit": {
+                      "url": "${ZIP_URL}",
+                      "hash": "${SHA256}",
+                      "bin": "zeroclaw.exe"
+                  }
+              },
+              "checkver": {
+                  "github": "https://github.com/zeroclaw-labs/zeroclaw"
+              },
+              "autoupdate": {
+                  "architecture": {
+                      "64bit": {
+                          "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v\$version/zeroclaw-x86_64-pc-windows-msvc.zip"
+                      }
+                  },
+                  "hash": {
+                      "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v\$version/SHA256SUMS",
+                      "regex": "([a-f0-9]{64})\\\\s+zeroclaw-x86_64-pc-windows-msvc\\\\.zip"
+                  }
+              }
+          }
+          MANIFEST
+
+          jq '.' "$manifest_file" > "${manifest_file}.formatted"
+          mv "${manifest_file}.formatted" "$manifest_file"
+
+          echo "manifest_file=$manifest_file" >> "$GITHUB_OUTPUT"
+
+          echo "### Generated Manifest" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat "$manifest_file" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Push to Scoop bucket
+        if: inputs.dry_run == false
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          MANIFEST_FILE: ${{ steps.manifest.outputs.manifest_file }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${SCOOP_BUCKET_REPO}" ]]; then
+            echo "::error::Repository variable SCOOP_BUCKET_REPO is required (e.g. zeroclaw-labs/scoop-zeroclaw)."
+            exit 1
+          fi
+
+          tmp_dir="$(mktemp -d)"
+          gh repo clone "${SCOOP_BUCKET_REPO}" "$tmp_dir/bucket" -- --depth=1
+
+          mkdir -p "$tmp_dir/bucket/bucket"
+          cp "$MANIFEST_FILE" "$tmp_dir/bucket/bucket/zeroclaw.json"
+
+          cd "$tmp_dir/bucket"
+          git config user.name "zeroclaw-bot"
+          git config user.email "bot@zeroclaw.dev"
+          git add bucket/zeroclaw.json
+          git commit -m "zeroclaw ${VERSION}"
+          gh auth setup-git
+          git push origin HEAD
+
+          echo "Scoop manifest updated to ${VERSION}"

--- a/dist/aur/.SRCINFO
+++ b/dist/aur/.SRCINFO
@@ -1,0 +1,16 @@
+pkgbase = zeroclaw
+	pkgdesc = Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.
+	pkgver = 0.4.0
+	pkgrel = 1
+	url = https://github.com/zeroclaw-labs/zeroclaw
+	arch = x86_64
+	license = MIT
+	license = Apache-2.0
+	makedepends = cargo
+	makedepends = git
+	depends = gcc-libs
+	depends = openssl
+	source = zeroclaw-0.4.0.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.4.0.tar.gz
+	sha256sums = SKIP
+
+pkgname = zeroclaw

--- a/dist/aur/PKGBUILD
+++ b/dist/aur/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: zeroclaw-labs <bot@zeroclaw.dev>
+pkgname=zeroclaw
+pkgver=0.4.0
+pkgrel=1
+pkgdesc="Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant."
+arch=('x86_64')
+url="https://github.com/zeroclaw-labs/zeroclaw"
+license=('MIT' 'Apache-2.0')
+depends=('gcc-libs' 'openssl')
+makedepends=('cargo' 'git')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('SKIP')
+
+prepare() {
+  cd "${pkgname}-${pkgver}"
+  export RUSTUP_TOOLCHAIN=stable
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "${pkgname}-${pkgver}"
+  export RUSTUP_TOOLCHAIN=stable
+  export CARGO_TARGET_DIR=target
+  cargo build --frozen --release --profile dist
+}
+
+package() {
+  cd "${pkgname}-${pkgver}"
+  install -Dm0755 -t "${pkgdir}/usr/bin/" "target/dist/zeroclaw"
+  install -Dm0644 LICENSE-MIT "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE-MIT"
+  install -Dm0644 LICENSE-APACHE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE-APACHE"
+}

--- a/dist/scoop/zeroclaw.json
+++ b/dist/scoop/zeroclaw.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.4.0",
+    "description": "Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.",
+    "homepage": "https://github.com/zeroclaw-labs/zeroclaw",
+    "license": "MIT|Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.4.0/zeroclaw-x86_64-pc-windows-msvc.zip",
+            "hash": "",
+            "bin": "zeroclaw.exe"
+        }
+    },
+    "checkver": {
+        "github": "https://github.com/zeroclaw-labs/zeroclaw"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v$version/zeroclaw-x86_64-pc-windows-msvc.zip"
+            }
+        },
+        "hash": {
+            "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v$version/SHA256SUMS",
+            "regex": "([a-f0-9]{64})\\s+zeroclaw-x86_64-pc-windows-msvc\\.zip"
+        }
+    }
+}

--- a/docs/contributing/ci-map.md
+++ b/docs/contributing/ci-map.md
@@ -37,6 +37,12 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - `.github/workflows/pub-homebrew-core.yml` (`Pub Homebrew Core`)
     - Purpose: manual, bot-owned Homebrew core formula bump PR flow for tagged releases
     - Guardrail: release tag must match `Cargo.toml` version
+- `.github/workflows/pub-scoop.yml` (`Pub Scoop Manifest`)
+    - Purpose: manual Scoop bucket manifest update for Windows distribution
+    - Guardrail: release tag must be `vX.Y.Z` format; Windows binary hash extracted from `SHA256SUMS`
+- `.github/workflows/pub-aur.yml` (`Pub AUR Package`)
+    - Purpose: manual AUR PKGBUILD push for Arch Linux distribution
+    - Guardrail: release tag must be `vX.Y.Z` format; source tarball SHA256 computed at publish time
 - `.github/workflows/pr-label-policy-check.yml` (`Label Policy Sanity`)
     - Purpose: validate shared contributor-tier policy in `.github/label-policy.json` and ensure label workflows consume that policy
 - `.github/workflows/test-rust-build.yml` (`Rust Reusable Job`)
@@ -75,6 +81,8 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - `Docker`: tag push (`v*`) for publish, matching PRs to `master` for smoke build, manual dispatch for smoke only
 - `Release`: tag push (`v*`), weekly schedule (verification-only), manual dispatch (verification or publish)
 - `Pub Homebrew Core`: manual dispatch only
+- `Pub Scoop Manifest`: manual dispatch only
+- `Pub AUR Package`: manual dispatch only
 - `Security Audit`: push to `master`, PRs to `master`, weekly schedule
 - `Sec Vorpal Reviewdog`: manual dispatch only
 - `Workflow Sanity`: PR/push when `.github/workflows/**`, `.github/*.yml`, or `.github/*.yaml` change
@@ -92,12 +100,14 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 2. Docker failures on PRs: inspect `.github/workflows/pub-docker-img.yml` `pr-smoke` job.
 3. Release failures (tag/manual/scheduled): inspect `.github/workflows/pub-release.yml` and the `prepare` job outputs.
 4. Homebrew formula publish failures: inspect `.github/workflows/pub-homebrew-core.yml` summary output and bot token/fork variables.
-5. Security failures: inspect `.github/workflows/sec-audit.yml` and `deny.toml`.
-6. Workflow syntax/lint failures: inspect `.github/workflows/workflow-sanity.yml`.
-7. PR intake failures: inspect `.github/workflows/pr-intake-checks.yml` sticky comment and run logs.
-8. Label policy parity failures: inspect `.github/workflows/pr-label-policy-check.yml`.
-9. Docs failures in CI: inspect `docs-quality` job logs in `.github/workflows/ci-run.yml`.
-10. Strict delta lint failures in CI: inspect `lint-strict-delta` job logs and compare with `BASE_SHA` diff scope.
+5. Scoop manifest publish failures: inspect `.github/workflows/pub-scoop.yml` summary output and `SCOOP_BUCKET_REPO`/`SCOOP_BUCKET_TOKEN` settings.
+6. AUR package publish failures: inspect `.github/workflows/pub-aur.yml` summary output and `AUR_SSH_KEY` secret.
+7. Security failures: inspect `.github/workflows/sec-audit.yml` and `deny.toml`.
+8. Workflow syntax/lint failures: inspect `.github/workflows/workflow-sanity.yml`.
+9. PR intake failures: inspect `.github/workflows/pr-intake-checks.yml` sticky comment and run logs.
+10. Label policy parity failures: inspect `.github/workflows/pr-label-policy-check.yml`.
+11. Docs failures in CI: inspect `docs-quality` job logs in `.github/workflows/ci-run.yml`.
+12. Strict delta lint failures in CI: inspect `lint-strict-delta` job logs and compare with `BASE_SHA` diff scope.
 
 ## Maintenance Rules
 

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -23,6 +23,8 @@ Release automation lives in:
 
 - `.github/workflows/pub-release.yml`
 - `.github/workflows/pub-homebrew-core.yml` (manual Homebrew formula PR, bot-owned)
+- `.github/workflows/pub-scoop.yml` (manual Scoop bucket manifest update)
+- `.github/workflows/pub-aur.yml` (manual AUR PKGBUILD push)
 
 Modes:
 
@@ -114,6 +116,41 @@ Workflow guardrails:
 - formula source URL and SHA256 are updated from the tagged tarball
 - formula license is normalized to `Apache-2.0 OR MIT`
 - PR is opened from the bot fork into `Homebrew/homebrew-core:master`
+
+### 7) Publish Scoop manifest (Windows)
+
+Run `Pub Scoop Manifest` manually:
+
+- `release_tag`: `vX.Y.Z`
+- `dry_run`: `true` first, then `false`
+
+Required repository settings for non-dry-run:
+
+- secret: `SCOOP_BUCKET_TOKEN` (PAT with push access to the bucket repo)
+- variable: `SCOOP_BUCKET_REPO` (for example `zeroclaw-labs/scoop-zeroclaw`)
+
+Workflow guardrails:
+
+- release tag must be `vX.Y.Z` format
+- Windows binary SHA256 extracted from `SHA256SUMS` release asset
+- manifest pushed to `bucket/zeroclaw.json` in the Scoop bucket repo
+
+### 8) Publish AUR package (Arch Linux)
+
+Run `Pub AUR Package` manually:
+
+- `release_tag`: `vX.Y.Z`
+- `dry_run`: `true` first, then `false`
+
+Required repository settings for non-dry-run:
+
+- secret: `AUR_SSH_KEY` (SSH private key registered with AUR)
+
+Workflow guardrails:
+
+- release tag must be `vX.Y.Z` format
+- source tarball SHA256 computed from the tagged release
+- PKGBUILD and .SRCINFO pushed to AUR `zeroclaw` package
 
 ## Emergency / Recovery Path
 


### PR DESCRIPTION
## Summary
- Restore `pub-homebrew-core.yml` workflow (was removed in Feb 2026)
- Add Scoop manifest template (`dist/scoop/zeroclaw.json`) and `pub-scoop.yml` workflow for Windows distribution
- Add AUR PKGBUILD template (`dist/aur/`) and `pub-aur.yml` workflow for Arch Linux distribution
- Update `ci-map.md` and `release-process.md` with all three package manager workflows

## Required secrets/variables for non-dry-run
- **Homebrew**: `HOMEBREW_CORE_BOT_TOKEN` secret, `HOMEBREW_CORE_BOT_FORK_REPO` variable
- **Scoop**: `SCOOP_BUCKET_TOKEN` secret, `SCOOP_BUCKET_REPO` variable
- **AUR**: `AUR_SSH_KEY` secret

## Test plan
- [x] All workflows use `dry_run: true` by default (safe to test)
- [x] All `${{ }}` expressions are in `env:` blocks, not `run:` blocks (injection-safe)
- [ ] Trigger each workflow in dry-run mode to verify manifest/PKGBUILD generation
- [ ] Verify Homebrew dry-run produces correct formula diff
- [ ] Verify Scoop dry-run produces valid JSON manifest
- [ ] Verify AUR dry-run produces valid PKGBUILD