### PR TITLE
fix(ci): ensure tweet posts for stable releases and fix beta concurrency

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -5,8 +5,8 @@ on:
     branches: [master]
 
 concurrency:
-  group: release
-  cancel-in-progress: false
+  group: release-beta
+  cancel-in-progress: true
 
 permissions:
   contents: write

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -53,7 +53,15 @@ jobs:
             exit 0
           fi
 
-          # Find the PREVIOUS release tag (including betas) to check for new features
+          # Stable releases (no -beta suffix) always tweet — they represent
+          # the full release cycle, so skipping them loses visibility.
+          if [[ ! "$RELEASE_TAG" =~ -beta\. ]]; then
+            echo "Stable release ${RELEASE_TAG} — always tweet"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # For betas: find the PREVIOUS release tag to check for new features
           PREV_TAG=$(git tag --sort=-creatordate \
             | grep -v "^${RELEASE_TAG}$" \
             | head -1 || echo "")
@@ -63,15 +71,15 @@ jobs:
             exit 0
           fi
 
-          # Count new feat() commits since the previous release
-          NEW_FEATS=$(git log "${PREV_TAG}..${RELEASE_TAG}" --pretty=format:"%s" --no-merges \
-            | grep -ciE '^feat(\(|:)' || echo "0")
+          # Count new feat() OR fix() commits since the previous release
+          NEW_CHANGES=$(git log "${PREV_TAG}..${RELEASE_TAG}" --pretty=format:"%s" --no-merges \
+            | grep -ciE '^(feat|fix)(\(|:)' || echo "0")
 
-          if [ "$NEW_FEATS" -eq 0 ]; then
-            echo "No new features since ${PREV_TAG} — skipping tweet"
+          if [ "$NEW_CHANGES" -eq 0 ]; then
+            echo "No new features or fixes since ${PREV_TAG} — skipping tweet"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            echo "${NEW_FEATS} new feature(s) since ${PREV_TAG} — tweeting"
+            echo "${NEW_CHANGES} new change(s) since ${PREV_TAG} — tweeting"
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary
- **Tweet workflow**: stable releases (no `-beta` suffix) now always tweet — previously they were skipped if no `feat()` commits existed between the previous and current tag, causing missed announcements
- **Tweet workflow**: beta tweet gate now also counts `fix()` commits, not just `feat()`, reducing silent skips
- **Beta release**: changed concurrency from `cancel-in-progress: false` to `true` — rapid merges were queuing beta runs that then got stuck/cancelled, preventing website redeploy and tweet from firing

## Root cause
The stable release on 2026-03-16 completed all publish steps (GitHub Release, Docker, website redeploy) but the tweet was skipped because the feature-check gate found 0 `feat()` commits between the previous and current tag. The beta releases were being cancelled because the `release` concurrency group with `cancel-in-progress: false` caused queued runs to pile up and get cancelled.

## Test plan
- [ ] Trigger `tweet-release.yml` manually with a stable tag — should not skip
- [ ] Verify beta release fires on next master push with `cancel-in-progress: true`