### PR TITLE
feat(providers): add AiHubMix Chinese aggregator env var and tests

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -860,6 +860,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "llamacpp" | "llama.cpp" => vec!["LLAMACPP_API_KEY"],
         "sglang" => vec!["SGLANG_API_KEY"],
         "vllm" => vec!["VLLM_API_KEY"],
+        "aihubmix" => vec!["AIHUBMIX_API_KEY"],
         "osaurus" => vec!["OSAURUS_API_KEY"],
         "telnyx" => vec!["TELNYX_API_KEY"],
         "azure_openai" | "azure-openai" | "azure" => vec!["AZURE_OPENAI_API_KEY"],
@@ -2605,6 +2606,19 @@ mod tests {
         let _guard = EnvGuard::set("OSAURUS_API_KEY", Some("osaurus-test-key"));
         let resolved = resolve_provider_credential("osaurus", None);
         assert_eq!(resolved, Some("osaurus-test-key".to_string()));
+    }
+
+    #[test]
+    fn resolve_provider_credential_aihubmix_env() {
+        let _env_lock = env_lock();
+        let _guard = EnvGuard::set("AIHUBMIX_API_KEY", Some("aihubmix-test-key"));
+        let resolved = resolve_provider_credential("aihubmix", None);
+        assert_eq!(resolved, Some("aihubmix-test-key".to_string()));
+    }
+
+    #[test]
+    fn factory_aihubmix() {
+        assert!(create_provider("aihubmix", Some("key")).is_ok());
     }
 
     // ── Extended ecosystem ───────────────────────────────────


### PR DESCRIPTION
## Summary
- Added `AIHUBMIX_API_KEY` env var resolution for the AiHubMix provider
- Added factory test and credential resolution test

Closes the AiHubMix provider gap (Chinese aggregator gateway).