### PR TITLE
fix(ci): make crates.io publish idempotent across all workflows

### DIFF
--- a/.github/workflows/publish-crates-auto.yml
+++ b/.github/workflows/publish-crates-auto.yml
@@ -103,9 +103,20 @@ jobs:
         run: rm -rf web/node_modules web/src web/package.json web/package-lock.json web/tsconfig*.json web/vite.config.ts web/index.html
 
       - name: Publish to crates.io
-        run: cargo publish --locked --allow-dirty --no-verify
+        shell: bash
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          VERSION: ${{ needs.detect-version-change.outputs.version }}
+        run: |
+          # Publish to crates.io; treat "already exists" as success
+          # (manual publish or stable workflow may have already published)
+          OUTPUT=$(cargo publish --locked --allow-dirty --no-verify 2>&1) && exit 0
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q 'already exists'; then
+            echo "::notice::zeroclawlabs@${VERSION} already on crates.io — skipping"
+            exit 0
+          fi
+          exit 1
 
       - name: Verify published
         shell: bash

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -75,6 +75,16 @@ jobs:
 
       - name: Publish to crates.io
         if: "!inputs.dry_run"
-        run: cargo publish --locked --allow-dirty --no-verify
+        shell: bash
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          # Publish to crates.io; treat "already exists" as success
+          OUTPUT=$(cargo publish --locked --allow-dirty --no-verify 2>&1) && exit 0
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q 'already exists'; then
+            echo "::notice::zeroclawlabs@${VERSION} already on crates.io — skipping"
+            exit 0
+          fi
+          exit 1


### PR DESCRIPTION
## Summary
- `publish-crates-auto.yml`: wrap `cargo publish` with "already exists" guard so the job succeeds when the version was already published (e.g., by a manual run or stable release workflow)
- `publish-crates.yml`: same idempotent guard for the manual workflow

## Root cause
The auto-sync workflow detected a version bump and passed the HTTP registry check (crates.io API may return 404 briefly after publish), then `cargo publish` failed with "already exists" exit code 101. The stable release workflow already had this fix; the auto-sync and manual workflows did not.

## Test plan
- [ ] Trigger `publish-crates.yml` manually for an already-published version — should succeed with notice
- [ ] Next version bump should publish cleanly via auto-sync