### PR TITLE
feat(providers): close AiHubMix, SiliconFlow, and Codex OAuth gaps

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -862,6 +862,8 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "llamacpp" | "llama.cpp" => vec!["LLAMACPP_API_KEY"],
         "sglang" => vec!["SGLANG_API_KEY"],
         "vllm" => vec!["VLLM_API_KEY"],
+        "aihubmix" => vec!["AIHUBMIX_API_KEY"],
+        "siliconflow" | "silicon-flow" => vec!["SILICONFLOW_API_KEY"],
         "osaurus" => vec!["OSAURUS_API_KEY"],
         "telnyx" => vec!["TELNYX_API_KEY"],
         "azure_openai" | "azure-openai" | "azure" => vec!["AZURE_OPENAI_API_KEY"],
@@ -2615,6 +2617,44 @@ mod tests {
         let _guard = EnvGuard::set("VOLCENGINE_API_KEY", Some("volc-test-key"));
         let resolved = resolve_provider_credential("volcengine", None);
         assert_eq!(resolved, Some("volc-test-key".to_string()));
+    }
+
+    #[test]
+    fn resolve_provider_credential_aihubmix_env() {
+        let _env_lock = env_lock();
+        let _guard = EnvGuard::set("AIHUBMIX_API_KEY", Some("aihubmix-test-key"));
+        let resolved = resolve_provider_credential("aihubmix", None);
+        assert_eq!(resolved, Some("aihubmix-test-key".to_string()));
+    }
+
+    #[test]
+    fn resolve_provider_credential_siliconflow_env() {
+        let _env_lock = env_lock();
+        let _guard = EnvGuard::set("SILICONFLOW_API_KEY", Some("sf-test-key"));
+        let resolved = resolve_provider_credential("siliconflow", None);
+        assert_eq!(resolved, Some("sf-test-key".to_string()));
+    }
+
+    #[test]
+    fn factory_aihubmix() {
+        assert!(create_provider("aihubmix", Some("key")).is_ok());
+    }
+
+    #[test]
+    fn factory_siliconflow() {
+        assert!(create_provider("siliconflow", Some("key")).is_ok());
+        assert!(create_provider("silicon-flow", Some("key")).is_ok());
+    }
+
+    #[test]
+    fn factory_codex_oauth_aliases() {
+        let options = ProviderRuntimeOptions::default();
+        for alias in &["codex", "openai-codex", "openai_codex"] {
+            assert!(
+                create_provider_with_options(alias, None, &options).is_ok(),
+                "codex alias '{alias}' should produce a provider"
+            );
+        }
     }
 
     // ── Extended ecosystem ───────────────────────────────────


### PR DESCRIPTION
## Summary
- Added `AIHUBMIX_API_KEY` env var resolution for AiHubMix (Chinese aggregator gateway)
- Added `SILICONFLOW_API_KEY` env var resolution for SiliconFlow (Chinese router gateway)
- Added factory + credential resolution tests for AiHubMix, SiliconFlow, and Codex OAuth
- All provider aliases verified: `aihubmix`, `siliconflow`, `silicon-flow`, `codex`, `openai-codex`, `openai_codex`

Combined with #3725 (VolcEngine), this closes all 4 provider gaps from the competitive analysis.

## Test plan
- [ ] `resolve_provider_credential_aihubmix_env` passes
- [ ] `resolve_provider_credential_siliconflow_env` passes
- [ ] `factory_aihubmix`, `factory_siliconflow`, `factory_codex_oauth_aliases` pass
- [ ] CI green