### PR TITLE
fix(ci): decouple tweet from Docker push in release workflows

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -318,10 +318,13 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # ── Post-publish: only run after ALL artifacts are live ──────────────
+  # ── Post-publish: tweet after release + website are live ──────────────
+  # Docker is slow (multi-platform) and can be cancelled by concurrency;
+  # don't let it block the tweet.
   tweet:
     name: Tweet Release
-    needs: [version, publish, docker, redeploy-website]
+    needs: [version, publish, redeploy-website]
+    if: ${{ !cancelled() && needs.publish.result == 'success' }}
     uses: ./.github/workflows/tweet-release.yml
     with:
       release_tag: ${{ needs.version.outputs.tag }}

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -361,10 +361,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # ── Post-publish: only run after ALL artifacts are live ──────────────
+  # ── Post-publish: tweet after release + website are live ──────────────
+  # Docker push can be slow; don't let it block the tweet.
   tweet:
     name: Tweet Release
-    needs: [validate, publish, docker, redeploy-website]
+    needs: [validate, publish, redeploy-website]
+    if: ${{ !cancelled() && needs.publish.result == 'success' }}
     uses: ./.github/workflows/tweet-release.yml
     with:
       release_tag: ${{ needs.validate.outputs.tag }}


### PR DESCRIPTION
## Summary
- Remove Docker from the tweet job's `needs` in both `release-beta-on-push.yml` and `release-stable-manual.yml`
- Add `if: !cancelled() && needs.publish.result == 'success'` guard so tweet fires as long as the GitHub Release published successfully

## Root cause
The beta run had Docker cancelled by `cancel-in-progress: true` when a newer push triggered a new run. Since `tweet` depended on `docker`, it was skipped. The tweet announces the GitHub Release URL, not the Docker image, so Docker shouldn't gate it.

## Test plan
- [ ] Next beta release should tweet even if Docker is slow or cancelled
- [ ] Stable release tweet should fire after publish + website redeploy, independent of Docker