### PR TITLE
fix(docker): purge stale fingerprints before build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,9 @@ RUN touch src/main.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
+    rm -rf target/release/.fingerprint/zeroclawlabs-* \
+           target/release/deps/zeroclawlabs-* \
+           target/release/incremental/zeroclawlabs-* && \
     cargo build --release --locked && \
     cp target/release/zeroclaw /app/zeroclaw && \
     strip /app/zeroclaw


### PR DESCRIPTION
## Summary
- Fixes Docker multi-arch build failure caused by stale BuildKit cache artifacts
- Clears zeroclawlabs-specific `.fingerprint`, `deps`, and `incremental` artifacts before cargo build
- Preserves dependency caches for fast rebuilds while ensuring the main crate recompiles cleanly

## Problem
The `--mount=type=cache,id=zeroclaw-target` persists compilation artifacts across source tree changes. When imports change (e.g., new CLI subcommands added), stale `.d` dep-info files cause `E0432` (unresolved imports) and `E0282` (type inference) errors.

## Test plan
- [ ] CI passes
- [ ] After merge, re-trigger stable release to verify Docker build succeeds