### PR TITLE
ci: auto-sync Scoop and AUR on stable release

### DIFF
--- a/.github/workflows/pub-aur.yml
+++ b/.github/workflows/pub-aur.yml
@@ -1,6 +1,20 @@
 name: Pub AUR Package
 
 on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Existing release tag (vX.Y.Z)"
+        required: true
+        type: string
+      dry_run:
+        description: "Generate PKGBUILD only (no push)"
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      AUR_SSH_KEY:
+        required: false
   workflow_dispatch:
     inputs:
       release_tag:

--- a/.github/workflows/pub-scoop.yml
+++ b/.github/workflows/pub-scoop.yml
@@ -1,6 +1,20 @@
 name: Pub Scoop Manifest
 
 on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Existing release tag (vX.Y.Z)"
+        required: true
+        type: string
+      dry_run:
+        description: "Generate manifest only (no push)"
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      SCOOP_BUCKET_TOKEN:
+        required: false
   workflow_dispatch:
     inputs:
       release_tag:

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -361,6 +361,27 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # ── Post-publish: package manager auto-sync ─────────────────────────
+  scoop:
+    name: Update Scoop Manifest
+    needs: [validate, publish]
+    if: ${{ !cancelled() && needs.publish.result == 'success' }}
+    uses: ./.github/workflows/pub-scoop.yml
+    with:
+      release_tag: ${{ needs.validate.outputs.tag }}
+      dry_run: false
+    secrets: inherit
+
+  aur:
+    name: Update AUR Package
+    needs: [validate, publish]
+    if: ${{ !cancelled() && needs.publish.result == 'success' }}
+    uses: ./.github/workflows/pub-aur.yml
+    with:
+      release_tag: ${{ needs.validate.outputs.tag }}
+      dry_run: false
+    secrets: inherit
+
   # ── Post-publish: tweet after release + website are live ──────────────
   # Docker push can be slow; don't let it block the tweet.
   tweet:

--- a/docs/contributing/ci-map.md
+++ b/docs/contributing/ci-map.md
@@ -38,10 +38,10 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
     - Purpose: manual, bot-owned Homebrew core formula bump PR flow for tagged releases
     - Guardrail: release tag must match `Cargo.toml` version
 - `.github/workflows/pub-scoop.yml` (`Pub Scoop Manifest`)
-    - Purpose: manual Scoop bucket manifest update for Windows distribution
+    - Purpose: Scoop bucket manifest update for Windows; auto-called by stable release, also manual dispatch
     - Guardrail: release tag must be `vX.Y.Z` format; Windows binary hash extracted from `SHA256SUMS`
 - `.github/workflows/pub-aur.yml` (`Pub AUR Package`)
-    - Purpose: manual AUR PKGBUILD push for Arch Linux distribution
+    - Purpose: AUR PKGBUILD push for Arch Linux; auto-called by stable release, also manual dispatch
     - Guardrail: release tag must be `vX.Y.Z` format; source tarball SHA256 computed at publish time
 - `.github/workflows/pr-label-policy-check.yml` (`Label Policy Sanity`)
     - Purpose: validate shared contributor-tier policy in `.github/label-policy.json` and ensure label workflows consume that policy
@@ -81,8 +81,8 @@ Merge-blocking checks should stay small and deterministic. Optional checks are u
 - `Docker`: tag push (`v*`) for publish, matching PRs to `master` for smoke build, manual dispatch for smoke only
 - `Release`: tag push (`v*`), weekly schedule (verification-only), manual dispatch (verification or publish)
 - `Pub Homebrew Core`: manual dispatch only
-- `Pub Scoop Manifest`: manual dispatch only
-- `Pub AUR Package`: manual dispatch only
+- `Pub Scoop Manifest`: auto-called by stable release, also manual dispatch
+- `Pub AUR Package`: auto-called by stable release, also manual dispatch
 - `Security Audit`: push to `master`, PRs to `master`, weekly schedule
 - `Sec Vorpal Reviewdog`: manual dispatch only
 - `Workflow Sanity`: PR/push when `.github/workflows/**`, `.github/*.yml`, or `.github/*.yaml` change


### PR DESCRIPTION
## Summary

- Add `workflow_call` triggers to `pub-scoop.yml` and `pub-aur.yml` so the stable release workflow can invoke them automatically
- Wire `scoop` and `aur` jobs into `release-stable-manual.yml` as post-publish steps (parallel with tweet), gated on publish success
- Update `ci-map.md` trigger docs to reflect auto-called behavior

## Changes

| File | Change |
|------|--------|
| `.github/workflows/pub-scoop.yml` | Add `workflow_call` trigger with `SCOOP_BUCKET_TOKEN` secret |
| `.github/workflows/pub-aur.yml` | Add `workflow_call` trigger with `AUR_SSH_KEY` secret |
| `.github/workflows/release-stable-manual.yml` | Add `scoop` and `aur` post-publish jobs |
| `docs/contributing/ci-map.md` | Update descriptions and trigger map |

## Prerequisites

These secrets/variables must be configured in GitHub repo settings:
- `SCOOP_BUCKET_REPO` (repo variable) — e.g. `zeroclaw-labs/scoop-zeroclaw` ✅
- `SCOOP_BUCKET_TOKEN` (secret) — PAT with repo scope for bucket pushes ✅
- `AUR_SSH_KEY` (secret) — ed25519 private key for AUR git pushes ✅

## Test plan

- [ ] CI passes on this PR (workflow syntax validation)
- [ ] Manual dry-run dispatch of `pub-scoop.yml` succeeds
- [ ] Manual dry-run dispatch of `pub-aur.yml` succeeds
- [ ] Next stable release auto-triggers both package manager syncs