### PR TITLE
feat(status): show service running state in `zeroclaw status`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1024,6 +1024,11 @@ async fn main() -> Result<()> {
             );
             println!("🛡️  Autonomy:      {:?}", config.autonomy.level);
             println!("⚙️  Runtime:       {}", config.runtime.kind);
+            if service::is_running() {
+                println!("🟢 Service:       running");
+            } else {
+                println!("🔴 Service:       stopped");
+            }
             let effective_memory_backend = memory::effective_memory_backend_name(
                 &config.memory.backend,
                 Some(&config.storage.provider.config),

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -89,6 +89,42 @@ fn windows_task_name() -> &'static str {
     WINDOWS_TASK_NAME
 }
 
+/// Returns whether the ZeroClaw daemon service is currently running.
+pub fn is_running() -> bool {
+    if cfg!(target_os = "macos") {
+        run_capture(Command::new("launchctl").arg("list"))
+            .map(|out| out.lines().any(|l| l.contains(SERVICE_LABEL)))
+            .unwrap_or(false)
+    } else if cfg!(target_os = "linux") {
+        is_running_linux()
+    } else if cfg!(target_os = "windows") {
+        run_capture(Command::new("schtasks").args([
+            "/Query",
+            "/TN",
+            WINDOWS_TASK_NAME,
+            "/FO",
+            "LIST",
+        ]))
+        .map(|out| out.contains("Running"))
+        .unwrap_or(false)
+    } else {
+        false
+    }
+}
+
+fn is_running_linux() -> bool {
+    // Try systemd first, then OpenRC — mirrors detect_init_system() order
+    if run_capture(Command::new("systemctl").args(["--user", "is-active", "zeroclaw.service"]))
+        .map(|out| out.trim() == "active")
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    run_capture(Command::new("rc-service").args(["zeroclaw", "status"]))
+        .map(|out| out.contains("started"))
+        .unwrap_or(false)
+}
+
 pub fn handle_command(
     command: &crate::ServiceCommands,
     config: &Config,


### PR DESCRIPTION
## Summary
- Adds a `🟢 running` / `🔴 stopped` service status line to `zeroclaw status` output
- Adds `pub fn is_running()` to `src/service/mod.rs` that checks the daemon state across macOS (launchctl), Linux (systemd + OpenRC), and Windows (schtasks)

## Test plan
- [ ] Run `zeroclaw status` with service running → verify `🟢 Service:       running`
- [ ] Run `zeroclaw status` with service stopped → verify `🔴 Service:       stopped`
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] `cargo test` passes