### PR TITLE
feat(theme): add theme switch support 

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,20 @@ import { AuthProvider, useAuth } from './hooks/useAuth';
 import { DraftContext, useDraftStore } from './hooks/useDraft';
 import { setLocale, type Locale } from './lib/i18n';
 
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
 // Locale context
 interface LocaleContextType {
   locale: string;
@@ -103,23 +117,21 @@ function PairingDialog({ onPair }: { onPair: (code: string) => Promise<void> }) 
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center" style={{ background: 'radial-gradient(ellipse at center, #0a0a20 0%, #050510 70%)' }}>
-      {/* Ambient glow */}
-      <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] rounded-full opacity-20 pointer-events-none" style={{ background: 'radial-gradient(circle, #0080ff 0%, transparent 70%)' }} />
+    <div className="min-h-screen flex items-center justify-center page-background">
+      <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] h-[500px] rounded-full opacity-20 pointer-events-none" style={{ background: 'radial-gradient(circle, var(--color-accent-blue) 0%, transparent 70%)' }} />
 
       <div className="relative glass-card p-8 w-full max-w-md animate-fade-in-scale">
-        {/* Top glow accent */}
-        <div className="absolute -top-px left-1/4 right-1/4 h-px" style={{ background: 'linear-gradient(90deg, transparent, #0080ff, transparent)' }} />
+        <div className="absolute -top-px left-1/4 right-1/4 h-px" style={{ background: 'linear-gradient(90deg, transparent, var(--color-accent-blue), transparent)' }} />
 
         <div className="text-center mb-8">
           <img
             src="/_app/logo.png"
             alt="ZeroClaw"
             className="h-20 w-20 rounded-2xl object-cover mx-auto mb-4 animate-float"
-            style={{ boxShadow: '0 0 30px rgba(0,128,255,0.3)' }}
+            style={{ boxShadow: '0 0 30px var(--color-glow-blue)' }}
           />
           <h1 className="text-2xl font-bold text-gradient-blue mb-2">ZeroClaw</h1>
-          <p className="text-[#556080] text-sm">Enter the pairing code from your terminal</p>
+          <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>Enter the pairing code from your terminal</p>
         </div>
         <form onSubmit={handleSubmit}>
           <input
@@ -132,7 +144,7 @@ function PairingDialog({ onPair }: { onPair: (code: string) => Promise<void> }) 
             autoFocus
           />
           {error && (
-            <p className="text-[#ff4466] text-sm mb-4 text-center animate-fade-in" aria-live="polite">{error}</p>
+            <p className="text-sm mb-4 text-center animate-fade-in" style={{ color: 'var(--color-status-error)' }}>{error}</p>
           )}
           <button
             type="submit"
@@ -155,12 +167,35 @@ function PairingDialog({ onPair }: { onPair: (code: string) => Promise<void> }) 
 function AppContent() {
   const { isAuthenticated, requiresPairing, loading, pair, logout } = useAuth();
   const [locale, setLocaleState] = useState('tr');
+  const [theme, setTheme] = useState<Theme>('light');
   const draftStore = useDraftStore();
 
   const setAppLocale = (newLocale: string) => {
     setLocaleState(newLocale);
     setLocale(newLocale as Locale);
   };
+
+  const toggleTheme = () => {
+    const newTheme = theme === 'light' ? 'dark' : 'light';
+    setTheme(newTheme);
+    document.documentElement.setAttribute('data-theme', newTheme);
+    localStorage.setItem('theme', newTheme);
+  };
+
+  // Load theme from localStorage on mount
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme') as Theme | null;
+    if (savedTheme) {
+      setTheme(savedTheme);
+      document.documentElement.setAttribute('data-theme', savedTheme);
+    } else {
+      // Check system preference
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const defaultTheme = prefersDark ? 'dark' : 'light';
+      setTheme(defaultTheme);
+      document.documentElement.setAttribute('data-theme', defaultTheme);
+    }
+  }, []);
 
   // Listen for 401 events to force logout
   useEffect(() => {
@@ -173,10 +208,10 @@ function AppContent() {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center" style={{ background: 'radial-gradient(ellipse at center, #0a0a20 0%, #050510 70%)' }}>
+      <div className="min-h-screen flex items-center justify-center page-background">
         <div className="flex flex-col items-center gap-4 animate-fade-in">
-          <div className="h-10 w-10 border-2 border-[#0080ff30] border-t-[#0080ff] rounded-full animate-spin" />
-          <p className="text-[#556080] text-sm">Connecting...</p>
+          <div className="h-10 w-10 border-2 rounded-full animate-spin" style={{ borderColor: 'var(--color-glow-blue)', borderTopColor: 'var(--color-accent-blue)' }} />
+          <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>Connecting...</p>
         </div>
       </div>
     );
@@ -187,25 +222,27 @@ function AppContent() {
   }
 
   return (
-    <DraftContext.Provider value={draftStore}>
-      <LocaleContext.Provider value={{ locale, setAppLocale }}>
-        <Routes>
-          <Route element={<Layout />}>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/agent" element={<AgentChat />} />
-            <Route path="/tools" element={<Tools />} />
-            <Route path="/cron" element={<Cron />} />
-            <Route path="/integrations" element={<Integrations />} />
-            <Route path="/memory" element={<Memory />} />
-            <Route path="/config" element={<Config />} />
-            <Route path="/cost" element={<Cost />} />
-            <Route path="/logs" element={<Logs />} />
-            <Route path="/doctor" element={<Doctor />} />
-            <Route path="*" element={<Navigate to="/" replace />} />
-          </Route>
-        </Routes>
-      </LocaleContext.Provider>
-    </DraftContext.Provider>
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      <DraftContext.Provider value={draftStore}>
+        <LocaleContext.Provider value={{ locale, setAppLocale }}>
+          <Routes>
+            <Route element={<Layout />}>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/agent" element={<AgentChat />} />
+              <Route path="/tools" element={<Tools />} />
+              <Route path="/cron" element={<Cron />} />
+              <Route path="/integrations" element={<Integrations />} />
+              <Route path="/memory" element={<Memory />} />
+              <Route path="/config" element={<Config />} />
+              <Route path="/cost" element={<Cost />} />
+              <Route path="/logs" element={<Logs />} />
+              <Route path="/doctor" element={<Doctor />} />
+              <Route path="*" element={<Navigate to="/" replace />} />
+            </Route>
+          </Routes>
+        </LocaleContext.Provider>
+      </DraftContext.Provider>
+    </ThemeContext.Provider>
   );
 }
 

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,8 +1,9 @@
 import { useLocation } from 'react-router-dom';
-import { LogOut } from 'lucide-react';
+import { LogOut, Sun, Moon } from 'lucide-react';
 import { t } from '@/lib/i18n';
 import { useLocaleContext } from '@/App';
 import { useAuth } from '@/hooks/useAuth';
+import { useTheme } from '@/App';
 
 const routeTitles: Record<string, string> = {
   '/': 'nav.dashboard',
@@ -21,6 +22,7 @@ export default function Header() {
   const location = useLocation();
   const { logout } = useAuth();
   const { locale, setAppLocale } = useLocaleContext();
+  const { theme, toggleTheme } = useTheme();
 
   const titleKey = routeTitles[location.pathname] ?? 'nav.dashboard';
   const pageTitle = t(titleKey);
@@ -30,26 +32,37 @@ export default function Header() {
   };
 
   return (
-    <header className="h-14 flex items-center justify-between px-6 border-b border-[#1a1a3e]/40 animate-fade-in" style={{ background: 'linear-gradient(90deg, rgba(8,8,24,0.9), rgba(5,5,16,0.9))', backdropFilter: 'blur(12px)' }}>
-      {/* Page title */}
-      <h1 className="text-lg font-semibold text-white tracking-tight">{pageTitle}</h1>
+    <header className="h-14 flex items-center justify-between px-6 header animate-fade-in">
+      <h1 className="text-lg font-semibold tracking-tight">{pageTitle}</h1>
 
-      {/* Right-side controls */}
       <div className="flex items-center gap-3">
-        {/* Language switcher */}
+        <button
+          type="button"
+          onClick={toggleTheme}
+          className="theme-toggle"
+          title={theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'}
+        >
+          {theme === 'light' ? <Moon className="h-4 w-4" /> : <Sun className="h-4 w-4" />}
+        </button>
+
         <button
           type="button"
           onClick={toggleLanguage}
-          className="px-3 py-1 rounded-lg text-xs font-semibold border border-[#1a1a3e] text-[#8892a8] hover:text-white hover:border-[#0080ff40] hover:bg-[#0080ff10] transition-all duration-300"
+          className="px-3 py-1.5 rounded-lg text-xs font-semibold border transition-all duration-300"
+          style={{ 
+            borderColor: 'var(--color-border-default)', 
+            color: 'var(--color-text-secondary)',
+            backgroundColor: 'var(--color-bg-secondary)'
+          }}
         >
           {locale === 'en' ? 'EN' : 'TR'}
         </button>
 
-        {/* Logout */}
         <button
           type="button"
           onClick={logout}
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs text-[#8892a8] hover:text-[#ff4466] hover:bg-[#ff446610] transition-all duration-300"
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs transition-all duration-300"
+          style={{ color: 'var(--color-text-secondary)' }}
         >
           <LogOut className="h-3.5 w-3.5" />
           <span>{t('auth.logout')}</span>

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -7,11 +7,9 @@ export default function Layout() {
   const { pathname } = useLocation();
 
   return (
-    <div className="min-h-screen text-white" style={{ background: 'linear-gradient(135deg, #050510 0%, #080818 50%, #050510 100%)' }}>
-      {/* Fixed sidebar */}
+    <div className="min-h-screen page-background">
       <Sidebar />
 
-      {/* Main area offset by sidebar width (240px / w-60) */}
       <div className="ml-60 flex flex-col min-h-screen">
         <Header />
 

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -28,12 +28,10 @@ const navItems = [
 
 export default function Sidebar() {
   return (
-    <aside className="fixed top-0 left-0 h-screen w-60 flex flex-col" style={{ background: 'linear-gradient(180deg, #080818 0%, #050510 100%)' }}>
-      {/* Glow line on right edge */}
+    <aside className="fixed top-0 left-0 h-screen w-60 flex flex-col sidebar">
       <div className="sidebar-glow-line" />
 
-      {/* Logo / Title */}
-      <div className="flex items-center gap-3 px-4 py-4 border-b border-[#1a1a3e]/50">
+      <div className="flex items-center gap-3 px-4 py-4 border-b" style={{ borderColor: 'var(--color-border-default)' }}>
         <img
           src="/_app/logo.png"
           alt="ZeroClaw"
@@ -44,7 +42,6 @@ export default function Sidebar() {
         </span>
       </div>
 
-      {/* Navigation */}
       <nav className="flex-1 overflow-y-auto py-4 px-3 space-y-1">
         {navItems.map(({ to, icon: Icon, labelKey }, idx) => (
           <NavLink
@@ -55,21 +52,21 @@ export default function Sidebar() {
               [
                 'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-300 animate-slide-in-left group',
                 isActive
-                  ? 'text-white shadow-[0_0_15px_rgba(0,128,255,0.2)]'
-                  : 'text-[#556080] hover:text-white hover:bg-[#0080ff08]',
+                  ? 'sidebar-nav-item active'
+                  : 'sidebar-nav-item',
               ].join(' ')
             }
             style={({ isActive }) => ({
               animationDelay: `${idx * 40}ms`,
-              ...(isActive ? { background: 'linear-gradient(135deg, rgba(0,128,255,0.15), rgba(0,128,255,0.05))' } : {}),
+              ...(isActive ? { background: 'var(--color-glow-blue)' } : {}),
             })}
           >
             {({ isActive }) => (
               <>
-                <Icon className={`h-5 w-5 flex-shrink-0 transition-colors duration-300 ${isActive ? 'text-[#0080ff]' : 'group-hover:text-[#0080ff80]'}`} />
+                <Icon className={`h-5 w-5 flex-shrink-0 transition-colors duration-300`} style={{ color: isActive ? 'var(--color-accent-blue)' : 'inherit' }} />
                 <span>{t(labelKey)}</span>
                 {isActive && (
-                  <div className="ml-auto h-1.5 w-1.5 rounded-full bg-[#0080ff] glow-dot" />
+                  <div className="ml-auto h-1.5 w-1.5 rounded-full" style={{ backgroundColor: 'var(--color-accent-blue)' }} />
                 )}
               </>
             )}
@@ -77,9 +74,8 @@ export default function Sidebar() {
         ))}
       </nav>
 
-      {/* Footer */}
-      <div className="px-5 py-4 border-t border-[#1a1a3e]/50">
-        <p className="text-[10px] text-[#334060] tracking-wider uppercase">ZeroClaw Runtime</p>
+      <div className="px-5 py-4 border-t" style={{ borderColor: 'var(--color-border-default)' }}>
+        <p className="text-xs tracking-wider uppercase" style={{ color: 'var(--color-text-muted)' }}>ZeroClaw Runtime</p>
       </div>
     </aside>
   );

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,16 +1,60 @@
 @import "tailwindcss";
 
-/*
- * ZeroClaw Electric Blue Theme
- * Dark-mode with electric blue accents, glassmorphism, and animations.
- */
-
 @theme {
+  /* Light theme (default) */
+  --color-bg-primary: #f8fafc;
+  --color-bg-secondary: #f1f5f9;
+  --color-bg-card: #ffffff;
+  --color-bg-card-hover: #f8fafc;
+  --color-bg-input: #ffffff;
+  --color-bg-sidebar: #ffffff;
+  --color-bg-header: #ffffff;
+
+  --color-border-default: #e2e8f0;
+  --color-border-subtle: #f1f5f9;
+
+  --color-accent-blue: #3b82f6;
+  --color-accent-blue-hover: #2563eb;
+  --color-accent-cyan: #06b6d4;
+  --color-accent-green: #10b981;
+  --color-accent-green-hover: #059669;
+
+  --color-text-primary: #0f172a;
+  --color-text-secondary: #64748b;
+  --color-text-muted: #94a3b8;
+
+  --color-status-success: #10b981;
+  --color-status-warning: #f59e0b;
+  --color-status-error: #ef4444;
+  --color-status-info: #3b82f6;
+
+  --color-glow-blue: #3b82f620;
+  --color-glow-cyan: #06b6d410;
+  
+  --color-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --color-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --color-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+
+  /* Translucent backgrounds — use these instead of bg + opacity on container */
+  --color-bg-blue-subtle: rgba(59, 130, 246, 0.08);
+  --color-bg-green-subtle: rgba(16, 185, 129, 0.08);
+  --color-bg-purple-subtle: rgba(168, 85, 247, 0.08);
+  --color-bg-orange-subtle: rgba(255, 136, 0, 0.08);
+  --color-bg-warning-subtle: rgba(245, 158, 11, 0.08);
+  --color-bg-error-subtle: rgba(239, 68, 68, 0.08);
+  --color-bg-success-subtle: rgba(16, 185, 129, 0.08);
+  --color-bg-muted-subtle: rgba(100, 116, 139, 0.08);
+}
+
+/* Dark theme */
+[data-theme="dark"] {
   --color-bg-primary: #050510;
   --color-bg-secondary: #0a0a1a;
   --color-bg-card: #0d0d20;
   --color-bg-card-hover: #141430;
   --color-bg-input: #0a0a18;
+  --color-bg-sidebar: linear-gradient(180deg, #080818 0%, #050510 100%);
+  --color-bg-header: linear-gradient(90deg, rgba(8,8,24,0.9), rgba(5,5,16,0.9));
 
   --color-border-default: #1a1a3e;
   --color-border-subtle: #12122a;
@@ -32,11 +76,24 @@
 
   --color-glow-blue: #0080ff40;
   --color-glow-cyan: #00d4ff30;
+  
+  --color-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
+  --color-shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.3), 0 2px 4px -2px rgb(0 0 0 / 0.3);
+  --color-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.3), 0 4px 6px -4px rgb(0 0 0 / 0.3);
+
+  /* Translucent backgrounds — dark mode versions */
+  --color-bg-blue-subtle: rgba(0, 128, 255, 0.12);
+  --color-bg-green-subtle: rgba(0, 230, 138, 0.12);
+  --color-bg-purple-subtle: rgba(168, 85, 247, 0.12);
+  --color-bg-orange-subtle: rgba(255, 136, 0, 0.12);
+  --color-bg-warning-subtle: rgba(255, 170, 0, 0.12);
+  --color-bg-error-subtle: rgba(255, 68, 102, 0.12);
+  --color-bg-success-subtle: rgba(0, 230, 138, 0.12);
+  --color-bg-muted-subtle: rgba(85, 96, 128, 0.15);
 }
 
-/* Base styles */
 html {
-  color-scheme: dark;
+  color-scheme: light dark;
 }
 
 body {
@@ -50,13 +107,13 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 #root {
   min-height: 100vh;
 }
 
-/* Scrollbar styling */
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;
@@ -67,29 +124,28 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #1a1a3e;
+  background: var(--color-border-default);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #0080ff60;
+  background: var(--color-accent-blue);
 }
 
 /* Card utility */
 .card {
-  background: linear-gradient(135deg, rgba(13, 13, 32, 0.8), rgba(10, 10, 26, 0.6));
-  border: 1px solid rgba(0, 128, 255, 0.1);
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border-default);
   border-radius: 1rem;
-  backdrop-filter: blur(12px);
+  box-shadow: var(--color-shadow-sm);
   transition: all 0.3s ease;
 }
 
 .card:hover {
-  border-color: rgba(0, 128, 255, 0.25);
-  box-shadow: 0 0 20px rgba(0, 128, 255, 0.08);
+  border-color: var(--color-accent-blue);
+  box-shadow: var(--color-shadow-md);
 }
 
-/* Focus ring utility */
 *:focus-visible {
   outline: 2px solid var(--color-accent-blue);
   outline-offset: 2px;
@@ -123,8 +179,8 @@ body {
 }
 
 @keyframes pulse-glow {
-  0%, 100% { box-shadow: 0 0 8px rgba(0, 128, 255, 0.3); }
-  50% { box-shadow: 0 0 20px rgba(0, 128, 255, 0.6); }
+  0%, 100% { box-shadow: 0 0 8px var(--color-glow-blue); }
+  50% { box-shadow: 0 0 20px var(--color-glow-blue); }
 }
 
 @keyframes shimmer {
@@ -181,7 +237,7 @@ body {
   animation: float 3s ease-in-out infinite;
 }
 
-/* Stagger delays for grid children */
+/* Stagger delays */
 .stagger-children > *:nth-child(1) { animation-delay: 0ms; }
 .stagger-children > *:nth-child(2) { animation-delay: 60ms; }
 .stagger-children > *:nth-child(3) { animation-delay: 120ms; }
@@ -195,34 +251,31 @@ body {
 
 /* Glass card */
 .glass-card {
-  background: linear-gradient(135deg, rgba(13, 13, 32, 0.7), rgba(5, 5, 16, 0.5));
-  border: 1px solid rgba(0, 128, 255, 0.12);
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border-default);
   border-radius: 1rem;
-  backdrop-filter: blur(16px);
+  box-shadow: var(--color-shadow-sm);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .glass-card:hover {
-  border-color: rgba(0, 128, 255, 0.3);
-  box-shadow: 0 4px 30px rgba(0, 128, 255, 0.1), 0 0 0 1px rgba(0, 128, 255, 0.05);
+  border-color: var(--color-accent-blue);
+  box-shadow: var(--color-shadow-md);
   transform: translateY(-1px);
 }
 
-/* Electric button */
+/* Button styles */
 .btn-electric {
-  background: linear-gradient(135deg, #0080ff, #0066cc);
+  background: linear-gradient(135deg, var(--color-accent-blue), var(--color-accent-blue-hover));
   color: white;
   border: none;
   border-radius: 0.75rem;
   font-weight: 500;
   transition: all 0.3s ease;
-  position: relative;
-  overflow: hidden;
 }
 
 .btn-electric:hover:not(:disabled) {
-  background: linear-gradient(135deg, #0090ff, #0070dd);
-  box-shadow: 0 0 20px rgba(0, 128, 255, 0.4);
+  box-shadow: 0 0 20px var(--color-glow-blue);
   transform: translateY(-1px);
 }
 
@@ -237,7 +290,7 @@ body {
 
 /* Gradient text */
 .text-gradient-blue {
-  background: linear-gradient(135deg, #0080ff, #00d4ff);
+  background: linear-gradient(135deg, var(--color-accent-blue), var(--color-accent-cyan));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
@@ -248,10 +301,10 @@ body {
   box-shadow: 0 0 6px currentColor;
 }
 
-/* Electric input */
+/* Input styles */
 .input-electric {
-  background: rgba(10, 10, 26, 0.8);
-  border: 1px solid rgba(0, 128, 255, 0.15);
+  background: var(--color-bg-input);
+  border: 1px solid var(--color-border-default);
   border-radius: 0.75rem;
   color: var(--color-text-primary);
   transition: all 0.3s ease;
@@ -259,15 +312,15 @@ body {
 
 .input-electric:focus {
   outline: none;
-  border-color: rgba(0, 128, 255, 0.5);
-  box-shadow: 0 0 0 3px rgba(0, 128, 255, 0.15), 0 0 20px rgba(0, 128, 255, 0.1);
+  border-color: var(--color-accent-blue);
+  box-shadow: 0 0 0 3px var(--color-glow-blue), 0 0 20px var(--color-glow-blue);
 }
 
 .input-electric::placeholder {
   color: var(--color-text-muted);
 }
 
-/* Progress bar animation */
+/* Progress bar */
 .progress-bar-animated {
   position: relative;
   overflow: hidden;
@@ -291,7 +344,7 @@ body {
 }
 
 .table-electric thead tr {
-  border-bottom: 1px solid rgba(0, 128, 255, 0.1);
+  border-bottom: 1px solid var(--color-border-default);
 }
 
 .table-electric thead th {
@@ -304,17 +357,17 @@ body {
 }
 
 .table-electric tbody tr {
-  border-bottom: 1px solid rgba(26, 26, 62, 0.5);
+  border-bottom: 1px solid var(--color-border-subtle);
   transition: all 0.2s ease;
 }
 
 .table-electric tbody tr:hover {
-  background: rgba(0, 128, 255, 0.04);
+  background: var(--color-glow-blue);
 }
 
 /* Modal backdrop */
 .modal-backdrop {
-  background: rgba(5, 5, 16, 0.8);
+  background: rgba(0, 0, 0, 0.5);
   backdrop-filter: blur(8px);
 }
 
@@ -325,5 +378,81 @@ body {
   top: 0;
   bottom: 0;
   width: 1px;
-  background: linear-gradient(180deg, transparent, rgba(0, 128, 255, 0.3), transparent);
+  background: linear-gradient(180deg, transparent, var(--color-glow-blue), transparent);
 }
+
+/* Theme toggle button */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 0.5rem;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border-default);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.theme-toggle:hover {
+  background: var(--color-bg-card);
+  color: var(--color-accent-blue);
+  border-color: var(--color-accent-blue);
+}
+
+/* Sidebar styles */
+.sidebar {
+  background: var(--color-bg-sidebar);
+  border-right: 1px solid var(--color-border-default);
+}
+
+.sidebar-nav-item {
+  color: var(--color-text-secondary);
+  transition: all 0.2s ease;
+}
+
+.sidebar-nav-item:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-secondary);
+}
+
+.sidebar-nav-item.active {
+  color: var(--color-accent-blue);
+  background: var(--color-glow-blue);
+}
+
+/* Header styles */
+.header {
+  background: var(--color-bg-header);
+  border-bottom: 1px solid var(--color-border-default);
+}
+
+/* Page background */
+.page-background {
+  background: var(--color-bg-primary);
+}
+
+/* Status colors */
+.status-success { color: var(--color-status-success); }
+.status-warning { color: var(--color-status-warning); }
+.status-error { color: var(--color-status-error); }
+.status-info { color: var(--color-status-info); }
+
+.bg-status-success { background-color: var(--color-status-success); }
+.bg-status-warning { background-color: var(--color-status-warning); }
+.bg-status-error { background-color: var(--color-status-error); }
+.bg-status-info { background-color: var(--color-status-info); }
+
+/* Border colors */
+.border-status-success { border-color: var(--color-status-success); }
+.border-status-warning { border-color: var(--color-status-warning); }
+.border-status-error { border-color: var(--color-status-error); }
+.border-status-info { border-color: var(--color-status-info); }
+
+/* Background colors with opacity */
+.bg-success-10 { background-color: var(--color-status-success); opacity: 0.1; }
+.bg-warning-10 { background-color: var(--color-status-warning); opacity: 0.1; }
+.bg-error-10 { background-color: var(--color-status-error); opacity: 0.1; }
+.bg-info-10 { background-color: var(--color-status-info); opacity: 0.1; }

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -28,7 +28,6 @@ export default function AgentChat() {
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const pendingContentRef = useRef('');
 
-  // Persist draft to in-memory store so it survives route changes
   useEffect(() => {
     saveDraft(input);
   }, [input, saveDraft]);
@@ -179,23 +178,21 @@ export default function AgentChat() {
 
   return (
     <div className="flex flex-col h-[calc(100vh-3.5rem)]">
-      {/* Connection status bar */}
       {error && (
-        <div className="px-4 py-2 bg-[#ff446615] border-b border-[#ff446630] flex items-center gap-2 text-sm text-[#ff6680] animate-fade-in">
+        <div className="px-4 py-2 border-b flex items-center gap-2 text-sm animate-fade-in" style={{ backgroundColor: 'var(--color-status-error)', opacity: 0.1, borderColor: 'var(--color-status-error)', color: 'var(--color-status-error)' }}>
           <AlertCircle className="h-4 w-4 flex-shrink-0" />
           {error}
         </div>
       )}
 
-      {/* Messages area */}
       <div className="flex-1 overflow-y-auto p-4 space-y-4">
         {messages.length === 0 && (
-          <div className="flex flex-col items-center justify-center h-full text-[#334060] animate-fade-in">
-            <div className="h-16 w-16 rounded-2xl flex items-center justify-center mb-4 animate-float" style={{ background: 'linear-gradient(135deg, #0080ff15, #0080ff08)' }}>
-              <Bot className="h-8 w-8 text-[#0080ff]" />
+          <div className="flex flex-col items-center justify-center h-full animate-fade-in" style={{ color: 'var(--color-text-muted)' }}>
+            <div className="h-16 w-16 rounded-2xl flex items-center justify-center mb-4 animate-float" style={{ background: 'linear-gradient(135deg, var(--color-accent-blue), var(--color-accent-cyan))', opacity: 0.1 }}>
+              <Bot className="h-8 w-8" style={{ color: 'var(--color-accent-blue)' }} />
             </div>
-            <p className="text-lg font-semibold text-white mb-1">ZeroClaw Agent</p>
-            <p className="text-sm text-[#556080]">Send a message to start the conversation</p>
+            <p className="text-lg font-semibold mb-1" style={{ color: 'var(--color-text-primary)' }}>ZeroClaw Agent</p>
+            <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>Send a message to start the conversation</p>
           </div>
         )}
 
@@ -208,21 +205,17 @@ export default function AgentChat() {
             style={{ animationDelay: `${Math.min(idx * 30, 200)}ms` }}
           >
             <div
-              className={`flex-shrink-0 w-8 h-8 rounded-xl flex items-center justify-center ${
-                msg.role === 'user'
-                  ? ''
-                  : ''
-              }`}
+              className="flex-shrink-0 w-8 h-8 rounded-xl flex items-center justify-center"
               style={{
                 background: msg.role === 'user'
-                  ? 'linear-gradient(135deg, #0080ff, #0060cc)'
-                  : 'linear-gradient(135deg, #1a1a3e, #12122a)'
+                  ? 'linear-gradient(135deg, var(--color-accent-blue), var(--color-accent-blue-hover))'
+                  : 'var(--color-bg-secondary)'
               }}
             >
               {msg.role === 'user' ? (
                 <User className="h-4 w-4 text-white" />
               ) : (
-                <Bot className="h-4 w-4 text-[#0080ff]" />
+                <Bot className="h-4 w-4" style={{ color: 'var(--color-accent-blue)' }} />
               )}
             </div>
             <div className="relative max-w-[75%]">
@@ -230,19 +223,19 @@ export default function AgentChat() {
                 className={`rounded-2xl px-4 py-3 ${
                   msg.role === 'user'
                     ? 'text-white'
-                    : 'text-[#e8edf5] border border-[#1a1a3e]'
+                    : ''
                 }`}
                 style={{
                   background: msg.role === 'user'
-                    ? 'linear-gradient(135deg, #0080ff, #0066cc)'
-                    : 'linear-gradient(135deg, rgba(13,13,32,0.8), rgba(10,10,26,0.6))'
+                    ? 'linear-gradient(135deg, var(--color-accent-blue), var(--color-accent-blue-hover))'
+                    : 'var(--color-bg-card)',
+                  border: msg.role === 'agent' ? '1px solid var(--color-border-default)' : 'none'
                 }}
               >
-                <p className="text-sm whitespace-pre-wrap break-words">{msg.content}</p>
+                <p className="text-sm whitespace-pre-wrap break-words" style={{ color: msg.role === 'user' ? 'white' : 'var(--color-text-primary)' }}>{msg.content}</p>
                 <p
-                  className={`text-[10px] mt-1.5 ${
-                    msg.role === 'user' ? 'text-white/50' : 'text-[#334060]'
-                  }`}
+                  className="text-xs mt-1.5"
+                  style={{ color: msg.role === 'user' ? 'rgba(255,255,255,0.5)' : 'var(--color-text-muted)' }}
                 >
                   {msg.timestamp.toLocaleTimeString()}
                 </p>
@@ -250,10 +243,11 @@ export default function AgentChat() {
               <button
                 onClick={() => handleCopy(msg.id, msg.content)}
                 aria-label="Copy message"
-                className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-all duration-300 p-1.5 rounded-lg bg-[#0a0a18] border border-[#1a1a3e] text-[#556080] hover:text-white hover:border-[#0080ff40]"
+                className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-all duration-300 p-1.5 rounded-lg border hover:opacity-80"
+                style={{ backgroundColor: 'var(--color-bg-input)', borderColor: 'var(--color-border-default)', color: 'var(--color-text-muted)' }}
               >
                 {copiedId === msg.id ? (
-                  <Check className="h-3 w-3 text-[#00e68a]" />
+                  <Check className="h-3 w-3" style={{ color: 'var(--color-status-success)' }} />
                 ) : (
                   <Copy className="h-3 w-3" />
                 )}
@@ -264,14 +258,14 @@ export default function AgentChat() {
 
         {typing && (
           <div className="flex items-start gap-3 animate-fade-in">
-            <div className="flex-shrink-0 w-8 h-8 rounded-xl flex items-center justify-center" style={{ background: 'linear-gradient(135deg, #1a1a3e, #12122a)' }}>
-              <Bot className="h-4 w-4 text-[#0080ff]" />
+            <div className="flex-shrink-0 w-8 h-8 rounded-xl flex items-center justify-center" style={{ background: 'var(--color-bg-secondary)' }}>
+              <Bot className="h-4 w-4" style={{ color: 'var(--color-accent-blue)' }} />
             </div>
-            <div className="rounded-2xl px-4 py-3 border border-[#1a1a3e]" style={{ background: 'linear-gradient(135deg, rgba(13,13,32,0.8), rgba(10,10,26,0.6))' }}>
+            <div className="rounded-2xl px-4 py-3 border" style={{ background: 'var(--color-bg-card)', borderColor: 'var(--color-border-default)' }}>
               <div className="flex items-center gap-1.5">
-                <span className="w-1.5 h-1.5 bg-[#0080ff] rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-                <span className="w-1.5 h-1.5 bg-[#0080ff] rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-                <span className="w-1.5 h-1.5 bg-[#0080ff] rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+                <span className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ backgroundColor: 'var(--color-accent-blue)', animationDelay: '0ms' }} />
+                <span className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ backgroundColor: 'var(--color-accent-blue)', animationDelay: '150ms' }} />
+                <span className="w-1.5 h-1.5 rounded-full animate-bounce" style={{ backgroundColor: 'var(--color-accent-blue)', animationDelay: '300ms' }} />
               </div>
             </div>
           </div>
@@ -280,8 +274,7 @@ export default function AgentChat() {
         <div ref={messagesEndRef} />
       </div>
 
-      {/* Input area */}
-      <div className="border-t border-[#1a1a3e]/40 p-4" style={{ background: 'linear-gradient(180deg, rgba(8,8,24,0.9), rgba(5,5,16,0.95))' }}>
+      <div className="border-t p-4" style={{ borderColor: 'var(--color-border-default)', backgroundColor: 'var(--color-bg-header)' }}>
         <div className="flex items-end gap-3 max-w-4xl mx-auto">
           <div className="flex-1">
             <textarea
@@ -306,11 +299,10 @@ export default function AgentChat() {
         </div>
         <div className="flex items-center justify-center mt-2 gap-2">
           <span
-            className={`inline-block h-1.5 w-1.5 rounded-full glow-dot ${
-              connected ? 'text-[#00e68a] bg-[#00e68a]' : 'text-[#ff4466] bg-[#ff4466]'
-            }`}
+            className="inline-block h-1.5 w-1.5 rounded-full"
+            style={{ backgroundColor: connected ? 'var(--color-status-success)' : 'var(--color-status-error)' }}
           />
-          <span className="text-[10px] text-[#334060]">
+          <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
             {connected ? 'Connected' : 'Disconnected'}
           </span>
         </div>

--- a/web/src/pages/Config.tsx
+++ b/web/src/pages/Config.tsx
@@ -1,12 +1,6 @@
-import { useState, useEffect } from 'react';
-import {
-  Settings,
-  Save,
-  CheckCircle,
-  AlertTriangle,
-  ShieldAlert,
-} from 'lucide-react';
-import { getConfig, putConfig } from '@/lib/api';
+import { useEffect, useState } from 'react'
+import { AlertTriangle, CheckCircle, Save, Settings, ShieldAlert, } from 'lucide-react'
+import { getConfig, putConfig } from '@/lib/api'
 
 export default function Config() {
   const [config, setConfig] = useState('');
@@ -38,7 +32,6 @@ export default function Config() {
     }
   };
 
-  // Auto-dismiss success after 4 seconds
   useEffect(() => {
     if (!success) return;
     const timer = setTimeout(() => setSuccess(null), 4000);
@@ -48,18 +41,17 @@ export default function Config() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="h-8 w-8 border-2 border-[#0080ff30] border-t-[#0080ff] rounded-full animate-spin" />
+        <div className="h-8 w-8 border-2 rounded-full animate-spin" style={{ borderColor: 'var(--color-glow-blue)', borderTopColor: 'var(--color-accent-blue)' }} />
       </div>
     );
   }
 
   return (
     <div className="p-6 space-y-6 animate-fade-in">
-      {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Settings className="h-5 w-5 text-[#0080ff]" />
-          <h2 className="text-sm font-semibold text-white uppercase tracking-wider">Configuration</h2>
+          <Settings className="h-5 w-5" style={{ color: 'var(--color-accent-blue)' }} />
+          <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>Configuration</h2>
         </div>
         <button
           onClick={handleSave}
@@ -71,43 +63,39 @@ export default function Config() {
         </button>
       </div>
 
-      {/* Sensitive fields note */}
-      <div className="flex items-start gap-3 rounded-xl p-4 border border-[#ffaa0020]" style={{ background: 'rgba(255,170,0,0.05)' }}>
-        <ShieldAlert className="h-5 w-5 text-[#ffaa00] flex-shrink-0 mt-0.5" />
+      <div className="flex items-start gap-3 rounded-xl p-4 border" style={{ borderColor: 'var(--color-status-warning)', backgroundColor: 'var(--color-bg-warning-subtle)' }}>
+        <ShieldAlert className="h-5 w-5 flex-shrink-0 mt-0.5" style={{ color: 'var(--color-status-warning)' }} />
         <div>
-          <p className="text-sm text-[#ffaa00] font-medium">
+          <p className="text-sm font-medium" style={{ color: 'var(--color-status-warning)' }}>
             Sensitive fields are masked
           </p>
-          <p className="text-sm text-[#ffaa0080] mt-0.5">
+          <p className="text-sm mt-0.5" style={{ color: 'var(--color-status-warning)', opacity: 0.8 }}>
             API keys, tokens, and passwords are hidden for security. To update a
             masked field, replace the entire masked value with your new value.
           </p>
         </div>
       </div>
 
-      {/* Success message */}
       {success && (
-        <div className="flex items-center gap-2 rounded-xl p-3 border border-[#00e68a30] animate-fade-in" style={{ background: 'rgba(0,230,138,0.06)' }}>
-          <CheckCircle className="h-4 w-4 text-[#00e68a] flex-shrink-0" />
-          <span className="text-sm text-[#00e68a]">{success}</span>
+        <div className="flex items-center gap-2 rounded-xl p-3 border animate-fade-in" style={{ borderColor: 'var(--color-status-success)', backgroundColor: 'var(--color-bg-success-subtle)' }}>
+          <CheckCircle className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-status-success)' }} />
+          <span className="text-sm" style={{ color: 'var(--color-status-success)' }}>{success}</span>
         </div>
       )}
 
-      {/* Error message */}
       {error && (
-        <div className="flex items-center gap-2 rounded-xl p-3 border border-[#ff446630] animate-fade-in" style={{ background: 'rgba(255,68,102,0.06)' }}>
-          <AlertTriangle className="h-4 w-4 text-[#ff4466] flex-shrink-0" />
-          <span className="text-sm text-[#ff6680]">{error}</span>
+        <div className="flex items-center gap-2 rounded-xl p-3 border animate-fade-in" style={{ borderColor: 'var(--color-status-error)', backgroundColor: 'var(--color-bg-error-subtle)' }}>
+          <AlertTriangle className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-status-error)' }} />
+          <span className="text-sm" style={{ color: 'var(--color-status-error)' }}>{error}</span>
         </div>
       )}
 
-      {/* Config Editor */}
       <div className="glass-card overflow-hidden">
-        <div className="flex items-center justify-between px-4 py-2.5 border-b border-[#1a1a3e]" style={{ background: 'rgba(0,128,255,0.03)' }}>
-          <span className="text-[10px] text-[#334060] font-semibold uppercase tracking-wider">
+        <div className="flex items-center justify-between px-4 py-2.5 border-b" style={{ borderColor: 'var(--color-border-default)', backgroundColor: 'var(--color-bg-secondary)' }}>
+          <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-muted)' }}>
             TOML Configuration
           </span>
-          <span className="text-[10px] text-[#334060]">
+          <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
             {config.split('\n').length} lines
           </span>
         </div>
@@ -115,8 +103,13 @@ export default function Config() {
           value={config}
           onChange={(e) => setConfig(e.target.value)}
           spellCheck={false}
-          className="w-full min-h-[500px] text-[#8892a8] font-mono text-sm p-4 resize-y focus:outline-none focus:ring-2 focus:ring-[#0080ff40] focus:ring-inset"
-          style={{ background: 'rgba(5,5,16,0.8)', tabSize: 4 }}
+          className="w-full min-h-[500px] font-mono text-sm p-4 resize-y focus:outline-none"
+          style={{ 
+            backgroundColor: 'var(--color-bg-primary)', 
+            color: 'var(--color-text-secondary)',
+            borderColor: 'var(--color-accent-blue)',
+            outline: 'none'
+          }}
         />
       </div>
     </div>

--- a/web/src/pages/Cost.tsx
+++ b/web/src/pages/Cost.tsx
@@ -1,12 +1,7 @@
-import { useState, useEffect } from 'react';
-import {
-  DollarSign,
-  TrendingUp,
-  Hash,
-  Layers,
-} from 'lucide-react';
-import type { CostSummary } from '@/types/api';
-import { getCost } from '@/lib/api';
+import { useEffect, useState } from 'react'
+import { DollarSign, Hash, Layers, TrendingUp, } from 'lucide-react'
+import type { CostSummary } from '@/types/api'
+import { getCost } from '@/lib/api'
 
 function formatUSD(value: number): string {
   return `$${value.toFixed(4)}`;
@@ -27,7 +22,7 @@ export default function Cost() {
   if (error) {
     return (
       <div className="p-6 animate-fade-in">
-        <div className="rounded-xl bg-[#ff446615] border border-[#ff446630] p-4 text-[#ff6680]">
+        <div className="rounded-xl p-4" style={{ backgroundColor: 'var(--color-bg-error-subtle)', border: '1px solid var(--color-status-error)', color: 'var(--color-status-error)' }}>
           Failed to load cost data: {error}
         </div>
       </div>
@@ -37,7 +32,7 @@ export default function Cost() {
   if (loading || !cost) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="h-8 w-8 border-2 border-[#0080ff30] border-t-[#0080ff] rounded-full animate-spin" />
+        <div className="h-8 w-8 border-2 rounded-full animate-spin" style={{ borderColor: 'var(--color-glow-blue)', borderTopColor: 'var(--color-accent-blue)' }} />
       </div>
     );
   }
@@ -46,29 +41,27 @@ export default function Cost() {
 
   return (
     <div className="p-6 space-y-6 animate-fade-in">
-      {/* Summary Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 stagger-children">
         {[
-          { icon: DollarSign, color: '#0080ff', bg: '#0080ff15', label: 'Session Cost', value: formatUSD(cost.session_cost_usd) },
-          { icon: TrendingUp, color: '#00e68a', bg: '#00e68a15', label: 'Daily Cost', value: formatUSD(cost.daily_cost_usd) },
-          { icon: Layers, color: '#a855f7', bg: '#a855f715', label: 'Monthly Cost', value: formatUSD(cost.monthly_cost_usd) },
-          { icon: Hash, color: '#ff8800', bg: '#ff880015', label: 'Total Requests', value: cost.request_count.toLocaleString() },
+          { icon: DollarSign, color: 'var(--color-accent-blue)', bg: 'var(--color-bg-blue-subtle)', label: 'Session Cost', value: formatUSD(cost.session_cost_usd) },
+          { icon: TrendingUp, color: 'var(--color-status-success)', bg: 'var(--color-bg-green-subtle)', label: 'Daily Cost', value: formatUSD(cost.daily_cost_usd) },
+          { icon: Layers, color: '#a855f7', bg: 'var(--color-bg-purple-subtle)', label: 'Monthly Cost', value: formatUSD(cost.monthly_cost_usd) },
+          { icon: Hash, color: '#ff8800', bg: 'var(--color-bg-orange-subtle)', label: 'Total Requests', value: cost.request_count.toLocaleString() },
         ].map(({ icon: Icon, color, bg, label, value }) => (
           <div key={label} className="glass-card p-5 animate-slide-in-up">
             <div className="flex items-center gap-3 mb-3">
-              <div className="p-2 rounded-xl" style={{ background: bg }}>
+              <div className="p-2 rounded-xl" style={{ backgroundColor: bg }}>
                 <Icon className="h-5 w-5" style={{ color }} />
               </div>
-              <span className="text-xs text-[#556080] uppercase tracking-wider font-medium">{label}</span>
+              <span className="text-xs uppercase tracking-wider font-medium" style={{ color: 'var(--color-text-muted)' }}>{label}</span>
             </div>
-            <p className="text-2xl font-bold text-white font-mono">{value}</p>
+            <p className="text-2xl font-bold font-mono" style={{ color: 'var(--color-text-primary)' }}>{value}</p>
           </div>
         ))}
       </div>
 
-      {/* Token Statistics */}
       <div className="glass-card p-5 animate-slide-in-up" style={{ animationDelay: '200ms' }}>
-        <h3 className="text-sm font-semibold text-white mb-4 uppercase tracking-wider">
+        <h3 className="text-sm font-semibold mb-4 uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>
           Token Statistics
         </h3>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
@@ -77,23 +70,22 @@ export default function Cost() {
             { label: 'Avg Tokens / Request', value: cost.request_count > 0 ? Math.round(cost.total_tokens / cost.request_count).toLocaleString() : '0' },
             { label: 'Cost per 1K Tokens', value: cost.total_tokens > 0 ? formatUSD((cost.monthly_cost_usd / cost.total_tokens) * 1000) : '$0.0000' },
           ].map(({ label, value }) => (
-            <div key={label} className="rounded-xl p-4" style={{ background: 'rgba(0,128,255,0.04)', border: '1px solid rgba(0,128,255,0.08)' }}>
-              <p className="text-xs text-[#556080] uppercase tracking-wider">{label}</p>
-              <p className="text-xl font-bold text-white mt-1 font-mono">{value}</p>
+            <div key={label} className="rounded-xl p-4" style={{ backgroundColor: 'var(--color-bg-blue-subtle)', border: '1px solid var(--color-border-default)' }}>
+              <p className="text-xs uppercase tracking-wider" style={{ color: 'var(--color-text-muted)' }}>{label}</p>
+              <p className="text-xl font-bold mt-1 font-mono" style={{ color: 'var(--color-text-primary)' }}>{value}</p>
             </div>
           ))}
         </div>
       </div>
 
-      {/* Model Breakdown Table */}
       <div className="glass-card overflow-hidden animate-slide-in-up" style={{ animationDelay: '300ms' }}>
-        <div className="px-5 py-4 border-b border-[#1a1a3e]">
-          <h3 className="text-sm font-semibold text-white uppercase tracking-wider">
+        <div className="px-5 py-4 border-b" style={{ borderColor: 'var(--color-border-default)' }}>
+          <h3 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>
             Model Breakdown
           </h3>
         </div>
         {models.length === 0 ? (
-          <div className="p-8 text-center text-[#334060]">
+          <div className="p-8 text-center" style={{ color: 'var(--color-text-muted)' }}>
             No model data available.
           </div>
         ) : (
@@ -118,27 +110,27 @@ export default function Cost() {
                         : 0;
                     return (
                       <tr key={m.model}>
-                        <td className="px-5 py-3 text-white font-medium text-sm">
+                        <td className="px-5 py-3 font-medium text-sm" style={{ color: 'var(--color-text-primary)' }}>
                           {m.model}
                         </td>
-                        <td className="px-5 py-3 text-[#8892a8] text-right font-mono text-sm">
+                        <td className="px-5 py-3 text-right font-mono text-sm" style={{ color: 'var(--color-text-secondary)' }}>
                           {formatUSD(m.cost_usd)}
                         </td>
-                        <td className="px-5 py-3 text-[#8892a8] text-right text-sm">
+                        <td className="px-5 py-3 text-right text-sm" style={{ color: 'var(--color-text-secondary)' }}>
                           {m.total_tokens.toLocaleString()}
                         </td>
-                        <td className="px-5 py-3 text-[#8892a8] text-right text-sm">
+                        <td className="px-5 py-3 text-right text-sm" style={{ color: 'var(--color-text-secondary)' }}>
                           {m.request_count.toLocaleString()}
                         </td>
                         <td className="px-5 py-3">
                           <div className="flex items-center gap-2">
-                            <div className="w-20 h-1.5 bg-[#0a0a18] rounded-full overflow-hidden">
+                            <div className="w-20 h-1.5 rounded-full overflow-hidden" style={{ backgroundColor: 'var(--color-bg-input)' }}>
                               <div
                                 className="h-full rounded-full progress-bar-animated transition-all duration-700"
-                                style={{ width: `${Math.max(share, 2)}%`, background: '#0080ff' }}
+                                style={{ width: `${Math.max(share, 2)}%`, background: 'var(--color-accent-blue)' }}
                               />
                             </div>
-                            <span className="text-xs text-[#556080] w-10 text-right font-mono">
+                            <span className="text-xs w-10 text-right font-mono" style={{ color: 'var(--color-text-muted)' }}>
                               {share.toFixed(1)}%
                             </span>
                           </div>

--- a/web/src/pages/Cron.tsx
+++ b/web/src/pages/Cron.tsx
@@ -48,8 +48,8 @@ function RunHistoryPanel({ jobId }: { jobId: string }) {
 
   if (loading) {
     return (
-      <div className="flex items-center gap-2 px-4 py-3 text-[#556080] text-xs">
-        <div className="animate-spin rounded-full h-4 w-4 border border-[#0080ff30] border-t-[#0080ff]" />
+      <div className="flex items-center gap-2 px-4 py-3 text-xs" style={{ color: 'var(--color-text-muted)' }}>
+        <div className="animate-spin rounded-full h-4 w-4 border" style={{ borderColor: 'var(--color-glow-blue)', borderTopColor: 'var(--color-accent-blue)' }} />
         Loading run history...
       </div>
     );
@@ -59,12 +59,13 @@ function RunHistoryPanel({ jobId }: { jobId: string }) {
     return (
       <div className="px-4 py-3">
         <div className="flex items-center justify-between">
-          <span className="text-xs text-[#ff6680]">
+          <span className="text-xs" style={{ color: 'var(--color-status-error)' }}>
             Failed to load run history: {error}
           </span>
           <button
             onClick={fetchRuns}
-            className="text-[#556080] hover:text-white transition-colors duration-300"
+            className="hover:opacity-80 transition-colors duration-300"
+            style={{ color: 'var(--color-text-muted)' }}
           >
             <RefreshCw className="h-3.5 w-3.5" />
           </button>
@@ -76,10 +77,11 @@ function RunHistoryPanel({ jobId }: { jobId: string }) {
   if (runs.length === 0) {
     return (
       <div className="px-4 py-3 flex items-center justify-between">
-        <span className="text-xs text-[#334060]">No runs recorded yet.</span>
+        <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>No runs recorded yet.</span>
         <button
           onClick={fetchRuns}
-          className="text-[#556080] hover:text-white transition-colors duration-300"
+          className="hover:opacity-80 transition-colors duration-300"
+          style={{ color: 'var(--color-text-muted)' }}
         >
           <RefreshCw className="h-3.5 w-3.5" />
         </button>
@@ -90,13 +92,14 @@ function RunHistoryPanel({ jobId }: { jobId: string }) {
   return (
     <div className="px-4 py-3">
       <div className="flex items-center justify-between mb-2">
-        <span className="text-xs font-medium text-[#8892a8]">
+        <span className="text-xs font-medium" style={{ color: 'var(--color-text-secondary)' }}>
           Recent Runs ({runs.length})
         </span>
         <button
           onClick={fetchRuns}
-          className="text-[#556080] hover:text-white transition-colors duration-300"
+          className="hover:opacity-80 transition-colors duration-300"
           title="Refresh runs"
+          style={{ color: 'var(--color-text-muted)' }}
         >
           <RefreshCw className="h-3.5 w-3.5" />
         </button>
@@ -105,26 +108,27 @@ function RunHistoryPanel({ jobId }: { jobId: string }) {
         {runs.map((run) => (
           <div
             key={run.id}
-            className="bg-[#0a0a2060] rounded-lg px-3 py-2 text-xs border border-[#1a1a3e]/30"
+            className="rounded-lg px-3 py-2 text-xs border"
+            style={{ backgroundColor: 'var(--color-bg-secondary)', opacity: 0.5, borderColor: 'var(--color-border-subtle)' }}
           >
             <div className="flex items-center justify-between mb-1">
               <div className="flex items-center gap-2">
                 {run.status === 'ok' ? (
-                  <CheckCircle className="h-3.5 w-3.5 text-[#00e68a]" />
+                  <CheckCircle className="h-3.5 w-3.5" style={{ color: 'var(--color-status-success)' }} />
                 ) : (
-                  <XCircle className="h-3.5 w-3.5 text-[#ff4466]" />
+                  <XCircle className="h-3.5 w-3.5" style={{ color: 'var(--color-status-error)' }} />
                 )}
-                <span className="text-[#8892a8] capitalize">{run.status}</span>
+                <span className="capitalize" style={{ color: 'var(--color-text-secondary)' }}>{run.status}</span>
               </div>
-              <span className="text-[#556080]">
+              <span style={{ color: 'var(--color-text-muted)' }}>
                 {formatDuration(run.duration_ms)}
               </span>
             </div>
-            <div className="flex items-center gap-3 text-[#556080]">
+            <div className="flex items-center gap-3" style={{ color: 'var(--color-text-muted)' }}>
               <span>{formatDate(run.started_at)}</span>
             </div>
             {run.output && (
-              <pre className="mt-1.5 bg-[#050510]/70 rounded p-2 text-[#8892a8] text-xs overflow-x-auto max-h-24 whitespace-pre-wrap break-words">
+              <pre className="mt-1.5 rounded p-2 text-xs overflow-x-auto max-h-24 whitespace-pre-wrap break-words" style={{ backgroundColor: 'var(--color-bg-primary)', color: 'var(--color-text-secondary)' }}>
                 {run.output}
               </pre>
             )}
@@ -143,7 +147,6 @@ export default function Cron() {
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [expandedJob, setExpandedJob] = useState<string | null>(null);
 
-  // Form state
   const [formName, setFormName] = useState('');
   const [formSchedule, setFormSchedule] = useState('');
   const [formCommand, setFormCommand] = useState('');
@@ -203,19 +206,19 @@ export default function Cron() {
     switch (status.toLowerCase()) {
       case 'ok':
       case 'success':
-        return <CheckCircle className="h-4 w-4 text-[#00e68a]" />;
+        return <CheckCircle className="h-4 w-4" style={{ color: 'var(--color-status-success)' }} />;
       case 'error':
       case 'failed':
-        return <XCircle className="h-4 w-4 text-[#ff4466]" />;
+        return <XCircle className="h-4 w-4" style={{ color: 'var(--color-status-error)' }} />;
       default:
-        return <AlertCircle className="h-4 w-4 text-[#ffaa00]" />;
+        return <AlertCircle className="h-4 w-4" style={{ color: 'var(--color-status-warning)' }} />;
     }
   };
 
   if (error) {
     return (
       <div className="p-6 animate-fade-in">
-        <div className="rounded-xl bg-[#ff446615] border border-[#ff446630] p-4 text-[#ff6680]">
+        <div className="rounded-xl p-4" style={{ backgroundColor: 'var(--color-status-error)', opacity: 0.1, border: '1px solid var(--color-status-error)', color: 'var(--color-status-error)' }}>
           Failed to load cron jobs: {error}
         </div>
       </div>
@@ -225,18 +228,17 @@ export default function Cron() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="h-8 w-8 border-2 border-[#0080ff30] border-t-[#0080ff] rounded-full animate-spin" />
+        <div className="h-8 w-8 border-2 rounded-full animate-spin" style={{ borderColor: 'var(--color-glow-blue)', borderTopColor: 'var(--color-accent-blue)' }} />
       </div>
     );
   }
 
   return (
     <div className="p-6 space-y-6 animate-fade-in">
-      {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Clock className="h-5 w-5 text-[#0080ff]" />
-          <h2 className="text-sm font-semibold text-white uppercase tracking-wider">
+          <Clock className="h-5 w-5" style={{ color: 'var(--color-accent-blue)' }} />
+          <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>
             Scheduled Tasks ({jobs.length})
           </h2>
         </div>
@@ -249,32 +251,32 @@ export default function Cron() {
         </button>
       </div>
 
-      {/* Add Job Form Modal */}
       {showForm && (
         <div className="fixed inset-0 modal-backdrop flex items-center justify-center z-50">
           <div className="glass-card p-6 w-full max-w-md mx-4 animate-fade-in-scale">
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-white">Add Cron Job</h3>
+              <h3 className="text-lg font-semibold" style={{ color: 'var(--color-text-primary)' }}>Add Cron Job</h3>
               <button
                 onClick={() => {
                   setShowForm(false);
                   setFormError(null);
                 }}
-                className="text-[#556080] hover:text-white transition-colors duration-300"
+                className="hover:opacity-80 transition-colors duration-300"
+                style={{ color: 'var(--color-text-muted)' }}
               >
                 <X className="h-5 w-5" />
               </button>
             </div>
 
             {formError && (
-              <div className="mb-4 rounded-xl bg-[#ff446615] border border-[#ff446630] p-3 text-sm text-[#ff6680] animate-fade-in">
+              <div className="mb-4 rounded-xl p-3 text-sm animate-fade-in" style={{ backgroundColor: 'var(--color-status-error)', opacity: 0.1, border: '1px solid var(--color-status-error)', color: 'var(--color-status-error)' }}>
                 {formError}
               </div>
             )}
 
             <div className="space-y-4">
               <div>
-                <label className="block text-xs font-semibold text-[#8892a8] mb-1.5 uppercase tracking-wider">
+                <label className="block text-xs font-semibold mb-1.5 uppercase tracking-wider" style={{ color: 'var(--color-text-secondary)' }}>
                   Name (optional)
                 </label>
                 <input
@@ -286,8 +288,8 @@ export default function Cron() {
                 />
               </div>
               <div>
-                <label className="block text-xs font-semibold text-[#8892a8] mb-1.5 uppercase tracking-wider">
-                  Schedule <span className="text-[#ff4466]">*</span>
+                <label className="block text-xs font-semibold mb-1.5 uppercase tracking-wider" style={{ color: 'var(--color-text-secondary)' }}>
+                  Schedule <span style={{ color: 'var(--color-status-error)' }}>*</span>
                 </label>
                 <input
                   type="text"
@@ -298,8 +300,8 @@ export default function Cron() {
                 />
               </div>
               <div>
-                <label className="block text-xs font-semibold text-[#8892a8] mb-1.5 uppercase tracking-wider">
-                  Command <span className="text-[#ff4466]">*</span>
+                <label className="block text-xs font-semibold mb-1.5 uppercase tracking-wider" style={{ color: 'var(--color-text-secondary)' }}>
+                  Command <span style={{ color: 'var(--color-status-error)' }}>*</span>
                 </label>
                 <input
                   type="text"
@@ -317,7 +319,13 @@ export default function Cron() {
                   setShowForm(false);
                   setFormError(null);
                 }}
-                className="px-4 py-2 text-sm font-medium text-[#8892a8] hover:text-white border border-[#1a1a3e] rounded-xl hover:bg-[#0080ff08] transition-all duration-300"
+                className="px-4 py-2 text-sm font-medium border rounded-xl transition-all duration-300 hover:opacity-80"
+                style={{ 
+                  color: 'var(--color-text-secondary)', 
+                  borderColor: 'var(--color-border-default)',
+                  backgroundColor: 'var(--color-accent-blue)',
+                  opacity: 0.05
+                }}
               >
                 Cancel
               </button>
@@ -333,11 +341,10 @@ export default function Cron() {
         </div>
       )}
 
-      {/* Jobs Table */}
       {jobs.length === 0 ? (
         <div className="glass-card p-8 text-center">
-          <Clock className="h-10 w-10 text-[#1a1a3e] mx-auto mb-3" />
-          <p className="text-[#556080]">No scheduled tasks configured.</p>
+          <Clock className="h-10 w-10 mx-auto mb-3" style={{ color: 'var(--color-border-default)' }} />
+          <p style={{ color: 'var(--color-text-muted)' }}>No scheduled tasks configured.</p>
         </div>
       ) : (
         <div className="glass-card overflow-x-auto">
@@ -357,14 +364,15 @@ export default function Cron() {
               {jobs.map((job) => (
                 <React.Fragment key={job.id}>
                   <tr>
-                    <td className="px-4 py-3 text-[#556080] font-mono text-xs">
+                    <td className="px-4 py-3 font-mono text-xs" style={{ color: 'var(--color-text-muted)' }}>
                       <button
                         onClick={() =>
                           setExpandedJob((prev) =>
                             prev === job.id ? null : job.id,
                           )
                         }
-                        className="flex items-center gap-1 text-[#556080] hover:text-white transition-colors duration-300"
+                        className="flex items-center gap-1 hover:opacity-80 transition-colors duration-300"
+                        style={{ color: 'var(--color-text-muted)' }}
                         title="Toggle run history"
                       >
                         {expandedJob === job.id ? (
@@ -375,31 +383,32 @@ export default function Cron() {
                         {job.id.slice(0, 8)}
                       </button>
                     </td>
-                    <td className="px-4 py-3 text-white font-medium text-sm">
+                    <td className="px-4 py-3 font-medium text-sm" style={{ color: 'var(--color-text-primary)' }}>
                       {job.name ?? '-'}
                     </td>
-                    <td className="px-4 py-3 text-[#8892a8] font-mono text-xs max-w-[200px] truncate">
+                    <td className="px-4 py-3 font-mono text-xs max-w-[200px] truncate" style={{ color: 'var(--color-text-secondary)' }}>
                       {job.command}
                     </td>
-                    <td className="px-4 py-3 text-[#556080] text-xs">
+                    <td className="px-4 py-3 text-xs" style={{ color: 'var(--color-text-muted)' }}>
                       {formatDate(job.next_run)}
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-1.5">
                         {statusIcon(job.last_status)}
-                        <span className="text-[#8892a8] text-xs capitalize">
+                        <span className="text-xs capitalize" style={{ color: 'var(--color-text-secondary)' }}>
                           {job.last_status ?? '-'}
                         </span>
                       </div>
                     </td>
                     <td className="px-4 py-3">
                       <span
-                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-semibold border ${
-                          job.enabled
-                            ? 'text-[#00e68a] border-[#00e68a30]'
-                            : 'text-[#334060] border-[#1a1a3e]'
-                        }`}
-                        style={{ background: job.enabled ? 'rgba(0,230,138,0.06)' : 'rgba(26,26,62,0.3)' }}
+                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold border"
+                        style={{ 
+                          color: job.enabled ? 'var(--color-status-success)' : 'var(--color-text-muted)',
+                          borderColor: job.enabled ? 'var(--color-status-success)' : 'var(--color-border-default)',
+                          backgroundColor: job.enabled ? 'var(--color-status-success)' : 'transparent',
+                          opacity: job.enabled ? 0.1 : 1
+                        }}
                       >
                         {job.enabled ? 'Enabled' : 'Disabled'}
                       </span>
@@ -407,16 +416,18 @@ export default function Cron() {
                     <td className="px-4 py-3 text-right">
                       {confirmDelete === job.id ? (
                         <div className="flex items-center justify-end gap-2 animate-fade-in">
-                          <span className="text-xs text-[#ff4466]">Delete?</span>
+                          <span className="text-xs" style={{ color: 'var(--color-status-error)' }}>Delete?</span>
                           <button
                             onClick={() => handleDelete(job.id)}
-                            className="text-[#ff4466] hover:text-[#ff6680] text-xs font-medium"
+                            className="text-xs font-medium hover:opacity-80"
+                            style={{ color: 'var(--color-status-error)' }}
                           >
                             Yes
                           </button>
                           <button
                             onClick={() => setConfirmDelete(null)}
-                            className="text-[#556080] hover:text-white text-xs font-medium"
+                            className="text-xs font-medium hover:opacity-80"
+                            style={{ color: 'var(--color-text-muted)' }}
                           >
                             No
                           </button>
@@ -424,7 +435,8 @@ export default function Cron() {
                       ) : (
                         <button
                           onClick={() => setConfirmDelete(job.id)}
-                          className="text-[#334060] hover:text-[#ff4466] transition-all duration-300"
+                          className="hover:opacity-80 transition-all duration-300"
+                          style={{ color: 'var(--color-text-muted)' }}
                         >
                           <Trash2 className="h-4 w-4" />
                         </button>
@@ -432,7 +444,7 @@ export default function Cron() {
                     </td>
                   </tr>
                   {expandedJob === job.id && (
-                    <tr className="bg-[#0a0a2080]">
+                    <tr>
                       <td colSpan={7}>
                         <RunHistoryPanel jobId={job.id} />
                       </td>

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,15 +1,7 @@
-import { useState, useEffect } from 'react';
-import {
-  Cpu,
-  Clock,
-  Globe,
-  Database,
-  Activity,
-  DollarSign,
-  Radio,
-} from 'lucide-react';
-import type { StatusResponse, CostSummary } from '@/types/api';
-import { getStatus, getCost } from '@/lib/api';
+import { useEffect, useState } from 'react'
+import { Activity, Clock, Cpu, Database, DollarSign, Globe, Radio, } from 'lucide-react'
+import type { CostSummary, StatusResponse } from '@/types/api'
+import { getCost, getStatus } from '@/lib/api'
 
 function formatUptime(seconds: number): string {
   const d = Math.floor(seconds / 86400);
@@ -28,13 +20,13 @@ function healthColor(status: string): string {
   switch (status.toLowerCase()) {
     case 'ok':
     case 'healthy':
-      return 'bg-[#00e68a]';
+      return 'var(--color-status-success)';
     case 'warn':
     case 'warning':
     case 'degraded':
-      return 'bg-[#ffaa00]';
+      return 'var(--color-status-warning)';
     default:
-      return 'bg-[#ff4466]';
+      return 'var(--color-status-error)';
   }
 }
 
@@ -42,13 +34,13 @@ function healthBorder(status: string): string {
   switch (status.toLowerCase()) {
     case 'ok':
     case 'healthy':
-      return 'border-[#00e68a30]';
+      return 'var(--color-status-success)';
     case 'warn':
     case 'warning':
     case 'degraded':
-      return 'border-[#ffaa0030]';
+      return 'var(--color-status-warning)';
     default:
-      return 'border-[#ff446630]';
+      return 'var(--color-status-error)';
   }
 }
 
@@ -69,7 +61,7 @@ export default function Dashboard() {
   if (error) {
     return (
       <div className="p-6 animate-fade-in">
-        <div className="rounded-xl bg-[#ff446615] border border-[#ff446630] p-4 text-[#ff6680]">
+        <div className="rounded-xl p-4" style={{ backgroundColor: 'var(--color-bg-error-subtle)', border: '1px solid var(--color-status-error)', color: 'var(--color-status-error)' }}>
           Failed to load dashboard: {error}
         </div>
       </div>
@@ -79,7 +71,7 @@ export default function Dashboard() {
   if (!status || !cost) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="h-8 w-8 border-2 border-[#0080ff30] border-t-[#0080ff] rounded-full animate-spin" />
+        <div className="h-8 w-8 border-2 rounded-full animate-spin" style={{ borderColor: 'var(--color-glow-blue)', borderTopColor: 'var(--color-accent-blue)' }} />
       </div>
     );
   }
@@ -88,46 +80,44 @@ export default function Dashboard() {
 
   return (
     <div className="p-6 space-y-6 animate-fade-in">
-      {/* Status Cards Grid */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 stagger-children">
         {[
-          { icon: Cpu, color: '#0080ff', bg: '#0080ff15', label: 'Provider / Model', value: status.provider ?? 'Unknown', sub: status.model },
-          { icon: Clock, color: '#00e68a', bg: '#00e68a15', label: 'Uptime', value: formatUptime(status.uptime_seconds), sub: 'Since last restart' },
-          { icon: Globe, color: '#a855f7', bg: '#a855f715', label: 'Gateway Port', value: `:${status.gateway_port}`, sub: `Locale: ${status.locale}` },
-          { icon: Database, color: '#ff8800', bg: '#ff880015', label: 'Memory Backend', value: status.memory_backend, sub: `Paired: ${status.paired ? 'Yes' : 'No'}` },
+          { icon: Cpu, color: 'var(--color-accent-blue)', bg: 'var(--color-bg-blue-subtle)', label: 'Provider / Model', value: status.provider ?? 'Unknown', sub: status.model },
+          { icon: Clock, color: 'var(--color-status-success)', bg: 'var(--color-bg-green-subtle)', label: 'Uptime', value: formatUptime(status.uptime_seconds), sub: 'Since last restart' },
+          { icon: Globe, color: '#a855f7', bg: 'var(--color-bg-purple-subtle)', label: 'Gateway Port', value: `:${status.gateway_port}`, sub: `Locale: ${status.locale}` },
+          { icon: Database, color: '#ff8800', bg: 'var(--color-bg-orange-subtle)', label: 'Memory Backend', value: status.memory_backend, sub: `Paired: ${status.paired ? 'Yes' : 'No'}` },
         ].map(({ icon: Icon, color, bg, label, value, sub }) => (
           <div key={label} className="glass-card p-5 animate-slide-in-up">
             <div className="flex items-center gap-3 mb-3">
-              <div className="p-2 rounded-xl" style={{ background: bg }}>
+              <div className="p-2 rounded-xl" style={{ backgroundColor: bg }}>
                 <Icon className="h-5 w-5" style={{ color }} />
               </div>
-              <span className="text-xs text-[#556080] uppercase tracking-wider font-medium">{label}</span>
+              <span className="text-xs uppercase tracking-wider font-medium" style={{ color: 'var(--color-text-muted)' }}>{label}</span>
             </div>
-            <p className="text-lg font-semibold text-white truncate capitalize">{value}</p>
-            <p className="text-sm text-[#556080] truncate">{sub}</p>
+            <p className="text-lg font-semibold truncate capitalize" style={{ color: 'var(--color-text-primary)' }}>{value}</p>
+            <p className="text-sm truncate" style={{ color: 'var(--color-text-muted)' }}>{sub}</p>
           </div>
         ))}
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 stagger-children">
-        {/* Cost Widget */}
         <div className="glass-card p-5 animate-slide-in-up">
           <div className="flex items-center gap-2 mb-5">
-            <DollarSign className="h-5 w-5 text-[#0080ff]" />
-            <h2 className="text-sm font-semibold text-white uppercase tracking-wider">Cost Overview</h2>
+            <DollarSign className="h-5 w-5" style={{ color: 'var(--color-accent-blue)' }} />
+            <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>Cost Overview</h2>
           </div>
           <div className="space-y-4">
             {[
-              { label: 'Session', value: cost.session_cost_usd, color: '#0080ff' },
-              { label: 'Daily', value: cost.daily_cost_usd, color: '#00e68a' },
+              { label: 'Session', value: cost.session_cost_usd, color: 'var(--color-accent-blue)' },
+              { label: 'Daily', value: cost.daily_cost_usd, color: 'var(--color-status-success)' },
               { label: 'Monthly', value: cost.monthly_cost_usd, color: '#a855f7' },
             ].map(({ label, value, color }) => (
               <div key={label}>
                 <div className="flex justify-between text-sm mb-1.5">
-                  <span className="text-[#556080]">{label}</span>
-                  <span className="text-white font-medium font-mono">{formatUSD(value)}</span>
+                  <span style={{ color: 'var(--color-text-muted)' }}>{label}</span>
+                  <span className="font-mono font-medium" style={{ color: 'var(--color-text-primary)' }}>{formatUSD(value)}</span>
                 </div>
-                <div className="w-full h-1.5 bg-[#0a0a18] rounded-full overflow-hidden">
+                <div className="w-full h-1.5 rounded-full overflow-hidden" style={{ backgroundColor: 'var(--color-bg-input)' }}>
                   <div
                     className="h-full rounded-full progress-bar-animated transition-all duration-700 ease-out"
                     style={{ width: `${Math.max((value / maxCost) * 100, 2)}%`, background: color }}
@@ -136,40 +126,38 @@ export default function Dashboard() {
               </div>
             ))}
           </div>
-          <div className="mt-5 pt-4 border-t border-[#1a1a3e]/50 flex justify-between text-sm">
-            <span className="text-[#556080]">Total Tokens</span>
-            <span className="text-white font-mono">{cost.total_tokens.toLocaleString()}</span>
+          <div className="mt-5 pt-4 border-t flex justify-between text-sm" style={{ borderColor: 'var(--color-border-default)' }}>
+            <span style={{ color: 'var(--color-text-muted)' }}>Total Tokens</span>
+            <span className="font-mono" style={{ color: 'var(--color-text-primary)' }}>{cost.total_tokens.toLocaleString()}</span>
           </div>
           <div className="flex justify-between text-sm mt-1">
-            <span className="text-[#556080]">Requests</span>
-            <span className="text-white font-mono">{cost.request_count.toLocaleString()}</span>
+            <span style={{ color: 'var(--color-text-muted)' }}>Requests</span>
+            <span className="font-mono" style={{ color: 'var(--color-text-primary)' }}>{cost.request_count.toLocaleString()}</span>
           </div>
         </div>
 
-        {/* Active Channels */}
         <div className="glass-card p-5 animate-slide-in-up">
           <div className="flex items-center gap-2 mb-5">
-            <Radio className="h-5 w-5 text-[#0080ff]" />
-            <h2 className="text-sm font-semibold text-white uppercase tracking-wider">Active Channels</h2>
+            <Radio className="h-5 w-5" style={{ color: 'var(--color-accent-blue)' }} />
+            <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>Active Channels</h2>
           </div>
           <div className="space-y-2">
             {Object.entries(status.channels).length === 0 ? (
-              <p className="text-sm text-[#334060]">No channels configured</p>
+              <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>No channels configured</p>
             ) : (
               Object.entries(status.channels).map(([name, active]) => (
                 <div
                   key={name}
-                  className="flex items-center justify-between py-2.5 px-3 rounded-xl transition-all duration-300 hover:bg-[#0080ff08]"
-                  style={{ background: 'rgba(10, 10, 26, 0.5)' }}
+                  className="flex items-center justify-between py-2.5 px-3 rounded-xl transition-all duration-300 hover:opacity-80"
+                  style={{ background: 'var(--color-bg-secondary)' }}
                 >
-                  <span className="text-sm text-white capitalize font-medium">{name}</span>
+                  <span className="text-sm font-medium capitalize" style={{ color: 'var(--color-text-primary)' }}>{name}</span>
                   <div className="flex items-center gap-2">
                     <span
-                      className={`inline-block h-2 w-2 rounded-full glow-dot ${
-                        active ? 'text-[#00e68a] bg-[#00e68a]' : 'text-[#334060] bg-[#334060]'
-                      }`}
+                      className="inline-block h-2 w-2 rounded-full"
+                      style={{ backgroundColor: active ? 'var(--color-status-success)' : 'var(--color-text-muted)' }}
                     />
-                    <span className="text-xs text-[#556080]">
+                    <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
                       {active ? 'Active' : 'Inactive'}
                     </span>
                   </div>
@@ -179,31 +167,33 @@ export default function Dashboard() {
           </div>
         </div>
 
-        {/* Health Grid */}
         <div className="glass-card p-5 animate-slide-in-up">
           <div className="flex items-center gap-2 mb-5">
-            <Activity className="h-5 w-5 text-[#0080ff]" />
-            <h2 className="text-sm font-semibold text-white uppercase tracking-wider">Component Health</h2>
+            <Activity className="h-5 w-5" style={{ color: 'var(--color-accent-blue)' }} />
+            <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>Component Health</h2>
           </div>
           <div className="grid grid-cols-2 gap-3">
             {Object.entries(status.health.components).length === 0 ? (
-              <p className="text-sm text-[#334060] col-span-2">No components reporting</p>
+              <p className="text-sm col-span-2" style={{ color: 'var(--color-text-muted)' }}>No components reporting</p>
             ) : (
               Object.entries(status.health.components).map(([name, comp]) => (
                 <div
                   key={name}
-                  className={`rounded-xl p-3 border ${healthBorder(comp.status)} transition-all duration-300 hover:scale-[1.02]`}
-                  style={{ background: 'rgba(10, 10, 26, 0.5)' }}
+                  className="rounded-xl p-3 border transition-all duration-300 hover:scale-[1.02]"
+                  style={{ 
+                    background: 'var(--color-bg-secondary)', 
+                    borderColor: healthBorder(comp.status)
+                  }}
                 >
                   <div className="flex items-center gap-2 mb-1">
-                    <span className={`inline-block h-2 w-2 rounded-full ${healthColor(comp.status)} glow-dot`} />
-                    <span className="text-sm font-medium text-white capitalize truncate">
+                    <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: healthColor(comp.status) }} />
+                    <span className="text-sm font-medium truncate capitalize" style={{ color: 'var(--color-text-primary)' }}>
                       {name}
                     </span>
                   </div>
-                  <p className="text-xs text-[#556080] capitalize">{comp.status}</p>
+                  <p className="text-xs capitalize" style={{ color: 'var(--color-text-muted)' }}>{comp.status}</p>
                   {comp.restart_count > 0 && (
-                    <p className="text-xs text-[#ffaa00] mt-1">
+                    <p className="text-xs mt-1" style={{ color: 'var(--color-status-warning)' }}>
                       Restarts: {comp.restart_count}
                     </p>
                   )}

--- a/web/src/pages/Doctor.tsx
+++ b/web/src/pages/Doctor.tsx
@@ -13,33 +13,33 @@ import { runDoctor } from '@/lib/api';
 function severityIcon(severity: DiagResult['severity']) {
   switch (severity) {
     case 'ok':
-      return <CheckCircle className="h-4 w-4 text-[#00e68a] flex-shrink-0" />;
+      return <CheckCircle className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-status-success)' }} />;
     case 'warn':
-      return <AlertTriangle className="h-4 w-4 text-[#ffaa00] flex-shrink-0" />;
+      return <AlertTriangle className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-status-warning)' }} />;
     case 'error':
-      return <XCircle className="h-4 w-4 text-[#ff4466] flex-shrink-0" />;
+      return <XCircle className="h-4 w-4 flex-shrink-0" style={{ color: 'var(--color-status-error)' }} />;
   }
 }
 
 function severityBorder(severity: DiagResult['severity']): string {
   switch (severity) {
     case 'ok':
-      return 'border-[#00e68a20]';
+      return 'var(--color-status-success)';
     case 'warn':
-      return 'border-[#ffaa0020]';
+      return 'var(--color-status-warning)';
     case 'error':
-      return 'border-[#ff446620]';
+      return 'var(--color-status-error)';
   }
 }
 
 function severityBg(severity: DiagResult['severity']): string {
   switch (severity) {
     case 'ok':
-      return 'rgba(0,230,138,0.04)';
+      return 'var(--color-status-success)';
     case 'warn':
-      return 'rgba(255,170,0,0.04)';
+      return 'var(--color-status-warning)';
     case 'error':
-      return 'rgba(255,68,102,0.04)';
+      return 'var(--color-status-error)';
   }
 }
 
@@ -76,11 +76,10 @@ export default function Doctor() {
 
   return (
     <div className="p-6 space-y-6 animate-fade-in">
-      {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Stethoscope className="h-5 w-5 text-[#0080ff]" />
-          <h2 className="text-sm font-semibold text-white uppercase tracking-wider">Diagnostics</h2>
+          <Stethoscope className="h-5 w-5" style={{ color: 'var(--color-accent-blue)' }} />
+          <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>Diagnostics</h2>
         </div>
         <button
           onClick={handleRun}
@@ -101,93 +100,91 @@ export default function Doctor() {
         </button>
       </div>
 
-      {/* Error */}
       {error && (
-        <div className="rounded-xl bg-[#ff446615] border border-[#ff446630] p-4 text-[#ff6680] animate-fade-in">
+        <div className="rounded-xl p-4 animate-fade-in" style={{ backgroundColor: 'var(--color-status-error)', opacity: 0.1, border: '1px solid var(--color-status-error)', color: 'var(--color-status-error)' }}>
           {error}
         </div>
       )}
 
-      {/* Loading spinner */}
       {loading && (
         <div className="flex flex-col items-center justify-center py-16 animate-fade-in">
-          <div className="h-12 w-12 border-2 border-[#0080ff30] border-t-[#0080ff] rounded-full animate-spin mb-4" />
-          <p className="text-[#8892a8]">Running diagnostics...</p>
-          <p className="text-sm text-[#334060] mt-1">
+          <div className="h-12 w-12 border-2 rounded-full animate-spin mb-4" style={{ borderColor: 'var(--color-glow-blue)', borderTopColor: 'var(--color-accent-blue)' }} />
+          <p style={{ color: 'var(--color-text-secondary)' }}>Running diagnostics...</p>
+          <p className="text-sm mt-1" style={{ color: 'var(--color-text-muted)' }}>
             This may take a few seconds.
           </p>
         </div>
       )}
 
-      {/* Results */}
       {results && !loading && (
         <>
-          {/* Summary Bar */}
           <div className="glass-card flex items-center gap-4 p-4 animate-slide-in-up">
             <div className="flex items-center gap-2">
-              <CheckCircle className="h-5 w-5 text-[#00e68a]" />
-              <span className="text-sm text-white font-medium">
-                {okCount} <span className="text-[#556080] font-normal">ok</span>
+              <CheckCircle className="h-5 w-5" style={{ color: 'var(--color-status-success)' }} />
+              <span className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
+                {okCount} <span style={{ color: 'var(--color-text-muted)', fontWeight: 'normal' }}>ok</span>
               </span>
             </div>
-            <div className="w-px h-5 bg-[#1a1a3e]" />
+            <div className="w-px h-5" style={{ backgroundColor: 'var(--color-border-default)' }} />
             <div className="flex items-center gap-2">
-              <AlertTriangle className="h-5 w-5 text-[#ffaa00]" />
-              <span className="text-sm text-white font-medium">
-                {warnCount}{' '}
-                <span className="text-[#556080] font-normal">
+              <AlertTriangle className="h-5 w-5" style={{ color: 'var(--color-status-warning)' }} />
+              <span className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
+                {warnCount}
+                <span style={{ color: 'var(--color-text-muted)', fontWeight: 'normal' }}>
                   warning{warnCount !== 1 ? 's' : ''}
                 </span>
               </span>
             </div>
-            <div className="w-px h-5 bg-[#1a1a3e]" />
+            <div className="w-px h-5" style={{ backgroundColor: 'var(--color-border-default)' }} />
             <div className="flex items-center gap-2">
-              <XCircle className="h-5 w-5 text-[#ff4466]" />
-              <span className="text-sm text-white font-medium">
-                {errorCount}{' '}
-                <span className="text-[#556080] font-normal">
+              <XCircle className="h-5 w-5" style={{ color: 'var(--color-status-error)' }} />
+              <span className="text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>
+                {errorCount}
+                <span style={{ color: 'var(--color-text-muted)', fontWeight: 'normal' }}>
                   error{errorCount !== 1 ? 's' : ''}
                 </span>
               </span>
             </div>
 
-            {/* Overall indicator */}
             <div className="ml-auto">
               {errorCount > 0 ? (
-                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-semibold border text-[#ff4466] border-[#ff446630]" style={{ background: 'rgba(255,68,102,0.06)' }}>
+                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold border" style={{ color: 'var(--color-status-error)', borderColor: 'var(--color-status-error)', backgroundColor: 'var(--color-status-error)', opacity: 0.06 }}>
                   Issues Found
                 </span>
               ) : warnCount > 0 ? (
-                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-semibold border text-[#ffaa00] border-[#ffaa0030]" style={{ background: 'rgba(255,170,0,0.06)' }}>
+                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold border" style={{ color: 'var(--color-status-warning)', borderColor: 'var(--color-status-warning)', backgroundColor: 'var(--color-status-warning)', opacity: 0.06 }}>
                   Warnings
                 </span>
               ) : (
-                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[10px] font-semibold border text-[#00e68a] border-[#00e68a30]" style={{ background: 'rgba(0,230,138,0.06)' }}>
+                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-semibold border" style={{ color: 'var(--color-status-success)', borderColor: 'var(--color-status-success)', backgroundColor: 'var(--color-status-success)', opacity: 0.06 }}>
                   All Clear
                 </span>
               )}
             </div>
           </div>
 
-          {/* Grouped Results */}
           {Object.entries(grouped)
             .sort(([a], [b]) => a.localeCompare(b))
             .map(([category, items], catIdx) => (
               <div key={category} className="animate-slide-in-up" style={{ animationDelay: `${(catIdx + 1) * 100}ms` }}>
-                <h3 className="text-[10px] font-semibold text-[#334060] uppercase tracking-wider mb-3 capitalize">
+                <h3 className="text-xs font-semibold uppercase tracking-wider mb-3 capitalize" style={{ color: 'var(--color-text-muted)' }}>
                   {category}
                 </h3>
                 <div className="space-y-2 stagger-children">
                   {items.map((result, idx) => (
                     <div
                       key={`${category}-${idx}`}
-                      className={`flex items-start gap-3 rounded-xl border p-3 transition-all duration-300 hover:translate-x-1 ${severityBorder(result.severity)} animate-slide-in-left`}
-                      style={{ background: severityBg(result.severity) }}
+                      className="flex items-start gap-3 rounded-xl border p-3 transition-all duration-300 hover:translate-x-1 animate-slide-in-left"
+                      style={{ 
+                        backgroundColor: severityBg(result.severity), 
+                        opacity: 0.04,
+                        borderColor: severityBorder(result.severity)
+                      }}
                     >
                       {severityIcon(result.severity)}
                       <div className="min-w-0">
-                        <p className="text-sm text-white">{result.message}</p>
-                        <p className="text-[10px] text-[#334060] mt-0.5 capitalize uppercase tracking-wider">
+                        <p className="text-sm" style={{ color: 'var(--color-text-primary)' }}>{result.message}</p>
+                        <p className="text-xs mt-0.5 capitalize uppercase tracking-wider" style={{ color: 'var(--color-text-muted)' }}>
                           {result.severity}
                         </p>
                       </div>
@@ -199,14 +196,13 @@ export default function Doctor() {
         </>
       )}
 
-      {/* Empty state */}
       {!results && !loading && !error && (
-        <div className="flex flex-col items-center justify-center py-16 text-[#334060] animate-fade-in">
-          <div className="h-16 w-16 rounded-2xl flex items-center justify-center mb-4 animate-float" style={{ background: 'linear-gradient(135deg, #0080ff15, #0080ff08)' }}>
-            <Stethoscope className="h-8 w-8 text-[#0080ff]" />
+        <div className="flex flex-col items-center justify-center py-16 animate-fade-in" style={{ color: 'var(--color-text-muted)' }}>
+          <div className="h-16 w-16 rounded-2xl flex items-center justify-center mb-4 animate-float" style={{ background: 'linear-gradient(135deg, var(--color-accent-blue), var(--color-accent-cyan))', opacity: 0.1 }}>
+            <Stethoscope className="h-8 w-8" style={{ color: 'var(--color-accent-blue)' }} />
           </div>
-          <p className="text-lg font-semibold text-white mb-1">System Diagnostics</p>
-          <p className="text-sm text-[#556080]">
+          <p className="text-lg font-semibold mb-1" style={{ color: 'var(--color-text-primary)' }}>System Diagnostics</p>
+          <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>
             Click "Run Diagnostics" to check your ZeroClaw installation.
           </p>
         </div>

--- a/web/src/pages/Integrations.tsx
+++ b/web/src/pages/Integrations.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect } from 'react';
-import { Puzzle, Check, Zap, Clock } from 'lucide-react';
-import type { Integration } from '@/types/api';
-import { getIntegrations } from '@/lib/api';
+import { useEffect, useState } from 'react'
+import { Check, Clock, Puzzle, Zap } from 'lucide-react'
+import type { Integration } from '@/types/api'
+import { getIntegrations } from '@/lib/api'
 
 function statusBadge(status: Integration['status']) {
   switch (status) {
@@ -9,22 +9,25 @@ function statusBadge(status: Integration['status']) {
       return {
         icon: Check,
         label: 'Active',
-        classes: 'text-[#00e68a] border-[#00e68a30]',
-        bg: 'rgba(0,230,138,0.06)',
+        color: 'var(--color-status-success)',
+        borderColor: 'var(--color-status-success)',
+        bg: 'var(--color-bg-success-subtle)',
       };
     case 'Available':
       return {
         icon: Zap,
         label: 'Available',
-        classes: 'text-[#0080ff] border-[#0080ff30]',
-        bg: 'rgba(0,128,255,0.06)',
+        color: 'var(--color-accent-blue)',
+        borderColor: 'var(--color-accent-blue)',
+        bg: 'var(--color-bg-blue-subtle)',
       };
     case 'ComingSoon':
       return {
         icon: Clock,
         label: 'Coming Soon',
-        classes: 'text-[#556080] border-[#1a1a3e]',
-        bg: 'rgba(26,26,62,0.3)',
+        color: 'var(--color-text-muted)',
+        borderColor: 'var(--color-border-default)',
+        bg: 'var(--color-bg-muted-subtle)',
       };
   }
 }
@@ -52,7 +55,6 @@ export default function Integrations() {
       ? integrations
       : integrations.filter((i) => i.category === activeCategory);
 
-  // Group by category for display
   const grouped = filtered.reduce<Record<string, Integration[]>>((acc, item) => {
     const key = item.category;
     if (!acc[key]) acc[key] = [];
@@ -63,7 +65,7 @@ export default function Integrations() {
   if (error) {
     return (
       <div className="p-6 animate-fade-in">
-        <div className="rounded-xl bg-[#ff446615] border border-[#ff446630] p-4 text-[#ff6680]">
+        <div className="rounded-xl p-4" style={{ backgroundColor: 'var(--color-bg-error-subtle)', border: '1px solid var(--color-status-error)', color: 'var(--color-status-error)' }}>
           Failed to load integrations: {error}
         </div>
       </div>
@@ -73,51 +75,47 @@ export default function Integrations() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="h-8 w-8 border-2 border-[#0080ff30] border-t-[#0080ff] rounded-full animate-spin" />
+        <div className="h-8 w-8 border-2 rounded-full animate-spin" style={{ borderColor: 'var(--color-glow-blue)', borderTopColor: 'var(--color-accent-blue)' }} />
       </div>
     );
   }
 
   return (
     <div className="p-6 space-y-6 animate-fade-in">
-      {/* Header */}
       <div className="flex items-center gap-2">
-        <Puzzle className="h-5 w-5 text-[#0080ff]" />
-        <h2 className="text-sm font-semibold text-white uppercase tracking-wider">
+        <Puzzle className="h-5 w-5" style={{ color: 'var(--color-accent-blue)' }} />
+        <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>
           Integrations ({integrations.length})
         </h2>
       </div>
 
-      {/* Category Filter Tabs */}
       <div className="flex flex-wrap gap-2">
         {categories.map((cat) => (
           <button
             key={cat}
             onClick={() => setActiveCategory(cat)}
-            className={`px-3.5 py-1.5 rounded-xl text-xs font-semibold transition-all duration-300 capitalize ${
-              activeCategory === cat
-                ? 'text-white shadow-[0_0_15px_rgba(0,128,255,0.2)]'
-                : 'text-[#556080] border border-[#1a1a3e] hover:text-white hover:border-[#0080ff40]'
-            }`}
-            style={activeCategory === cat ? { background: 'linear-gradient(135deg, #0080ff, #0066cc)' } : {}}
+            className="px-3.5 py-1.5 rounded-xl text-xs font-semibold transition-all duration-300 capitalize"
+            style={activeCategory === cat ? 
+              { background: 'linear-gradient(135deg, var(--color-accent-blue), var(--color-accent-blue-hover))', color: 'white', boxShadow: '0 0 15px var(--color-glow-blue)' } : 
+              { color: 'var(--color-text-muted)', border: '1px solid var(--color-border-default)' }
+            }
           >
             {cat}
           </button>
         ))}
       </div>
 
-      {/* Grouped Integration Cards */}
       {Object.keys(grouped).length === 0 ? (
         <div className="glass-card p-8 text-center">
-          <Puzzle className="h-10 w-10 text-[#1a1a3e] mx-auto mb-3" />
-          <p className="text-[#556080]">No integrations found.</p>
+          <Puzzle className="h-10 w-10 mx-auto mb-3" style={{ color: 'var(--color-border-default)' }} />
+          <p style={{ color: 'var(--color-text-muted)' }}>No integrations found.</p>
         </div>
       ) : (
         Object.entries(grouped)
           .sort(([a], [b]) => a.localeCompare(b))
           .map(([category, items]) => (
             <div key={category}>
-              <h3 className="text-[10px] font-semibold text-[#334060] uppercase tracking-wider mb-3 capitalize">
+              <h3 className="text-xs font-semibold uppercase tracking-wider mb-3 capitalize" style={{ color: 'var(--color-text-muted)' }}>
                 {category}
               </h3>
               <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 stagger-children">
@@ -131,16 +129,20 @@ export default function Integrations() {
                     >
                       <div className="flex items-start justify-between gap-3">
                         <div className="min-w-0">
-                          <h4 className="text-sm font-semibold text-white truncate">
+                          <h4 className="text-sm font-semibold truncate" style={{ color: 'var(--color-text-primary)' }}>
                             {integration.name}
                           </h4>
-                          <p className="text-sm text-[#556080] mt-1 line-clamp-2">
+                          <p className="text-sm mt-1 line-clamp-2" style={{ color: 'var(--color-text-muted)' }}>
                             {integration.description}
                           </p>
                         </div>
                         <span
-                          className={`flex-shrink-0 inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[10px] font-semibold border ${badge.classes}`}
-                          style={{ background: badge.bg }}
+                          className="flex-shrink-0 inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold border"
+                          style={{ 
+                            color: badge.color, 
+                            borderColor: badge.borderColor, 
+                            backgroundColor: badge.bg,
+                          }}
                         >
                           <BadgeIcon className="h-3 w-3" />
                           {badge.label}

--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -14,24 +14,24 @@ function formatTimestamp(ts?: string): string {
   return new Date(ts).toLocaleTimeString();
 }
 
-function eventTypeBadgeColor(type: string): { classes: string; bg: string } {
+function eventTypeBadgeColor(type: string): { color: string; bg: string; border: string } {
   switch (type.toLowerCase()) {
     case 'error':
-      return { classes: 'text-[#ff4466] border-[#ff446630]', bg: 'rgba(255,68,102,0.06)' };
+      return { color: 'var(--color-status-error)', bg: 'var(--color-status-error)', border: 'var(--color-status-error)' };
     case 'warn':
     case 'warning':
-      return { classes: 'text-[#ffaa00] border-[#ffaa0030]', bg: 'rgba(255,170,0,0.06)' };
+      return { color: 'var(--color-status-warning)', bg: 'var(--color-status-warning)', border: 'var(--color-status-warning)' };
     case 'tool_call':
     case 'tool_result':
-      return { classes: 'text-[#a855f7] border-[#a855f730]', bg: 'rgba(168,85,247,0.06)' };
+      return { color: '#a855f7', bg: '#a855f7', border: '#a855f7' };
     case 'message':
     case 'chat':
-      return { classes: 'text-[#0080ff] border-[#0080ff30]', bg: 'rgba(0,128,255,0.06)' };
+      return { color: 'var(--color-accent-blue)', bg: 'var(--color-accent-blue)', border: 'var(--color-accent-blue)' };
     case 'health':
     case 'status':
-      return { classes: 'text-[#00e68a] border-[#00e68a30]', bg: 'rgba(0,230,138,0.06)' };
+      return { color: 'var(--color-status-success)', bg: 'var(--color-status-success)', border: 'var(--color-status-success)' };
     default:
-      return { classes: 'text-[#556080] border-[#1a1a3e]', bg: 'rgba(26,26,62,0.3)' };
+      return { color: 'var(--color-text-muted)', bg: 'var(--color-text-muted)', border: 'var(--color-border-default)' };
   }
 }
 
@@ -52,7 +52,6 @@ export default function Logs() {
   const pausedRef = useRef(false);
   const entryIdRef = useRef(0);
 
-  // Keep pausedRef in sync
   useEffect(() => {
     pausedRef.current = paused;
   }, [paused]);
@@ -89,14 +88,12 @@ export default function Logs() {
     };
   }, []);
 
-  // Auto-scroll to bottom
   useEffect(() => {
     if (autoScroll && containerRef.current) {
       containerRef.current.scrollTop = containerRef.current.scrollHeight;
     }
   }, [entries, autoScroll]);
 
-  // Detect user scroll to toggle auto-scroll
   const handleScroll = useCallback(() => {
     if (!containerRef.current) return;
     const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
@@ -132,39 +129,33 @@ export default function Logs() {
 
   return (
     <div className="flex flex-col h-[calc(100vh-3.5rem)]">
-      {/* Toolbar */}
-      <div className="flex items-center justify-between px-6 py-3 border-b border-[#1a1a3e]/40 animate-fade-in" style={{ background: 'linear-gradient(90deg, rgba(8,8,24,0.9), rgba(5,5,16,0.9))' }}>
+      <div className="flex items-center justify-between px-6 py-3 border-b animate-fade-in" style={{ borderColor: 'var(--color-border-default)', backgroundColor: 'var(--color-bg-header)' }}>
         <div className="flex items-center gap-3">
-          <Activity className="h-5 w-5 text-[#0080ff]" />
-          <h2 className="text-sm font-semibold text-white uppercase tracking-wider">Live Logs</h2>
+          <Activity className="h-5 w-5" style={{ color: 'var(--color-accent-blue)' }} />
+          <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>Live Logs</h2>
           <div className="flex items-center gap-2 ml-2">
             <span
-              className={`inline-block h-1.5 w-1.5 rounded-full glow-dot ${
-                connected ? 'text-[#00e68a] bg-[#00e68a]' : 'text-[#ff4466] bg-[#ff4466]'
-              }`}
+              className="inline-block h-1.5 w-1.5 rounded-full"
+              style={{ backgroundColor: connected ? 'var(--color-status-success)' : 'var(--color-status-error)' }}
             />
-            <span className="text-[10px] text-[#334060]">
+            <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
               {connected ? 'Connected' : 'Disconnected'}
             </span>
           </div>
-          <span className="text-[10px] text-[#334060] ml-2 font-mono">
+          <span className="text-xs ml-2 font-mono" style={{ color: 'var(--color-text-muted)' }}>
             {filteredEntries.length} events
           </span>
         </div>
 
         <div className="flex items-center gap-2">
-          {/* Pause/Resume */}
           <button
             onClick={() => setPaused(!paused)}
-            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-semibold transition-all duration-300 ${
-              paused
-                ? 'text-white shadow-[0_0_15px_rgba(0,230,138,0.2)]'
-                : 'text-white shadow-[0_0_15px_rgba(255,170,0,0.2)]'
-            }`}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-semibold transition-all duration-300"
             style={{
               background: paused
-                ? 'linear-gradient(135deg, #00e68a, #00cc7a)'
-                : 'linear-gradient(135deg, #ffaa00, #ee9900)'
+                ? 'linear-gradient(135deg, var(--color-status-success), var(--color-status-success-hover, #00cc7a))'
+                : 'linear-gradient(135deg, var(--color-status-warning), #ee9900)',
+              color: 'white'
             }}
           >
             {paused ? (
@@ -178,7 +169,6 @@ export default function Logs() {
             )}
           </button>
 
-          {/* Jump to Bottom */}
           {!autoScroll && (
             <button
               onClick={jumpToBottom}
@@ -191,11 +181,10 @@ export default function Logs() {
         </div>
       </div>
 
-      {/* Event type filters */}
       {allTypes.length > 0 && (
-        <div className="flex items-center gap-2 px-6 py-2 border-b border-[#1a1a3e]/30 overflow-x-auto" style={{ background: 'rgba(5,5,16,0.6)' }}>
-          <Filter className="h-3.5 w-3.5 text-[#334060] flex-shrink-0" />
-          <span className="text-[10px] text-[#334060] flex-shrink-0 uppercase tracking-wider">Filter:</span>
+        <div className="flex items-center gap-2 px-6 py-2 border-b overflow-x-auto" style={{ borderColor: 'var(--color-border-subtle)', backgroundColor: 'var(--color-bg-primary)', opacity: 0.6 }}>
+          <Filter className="h-3.5 w-3.5 flex-shrink-0" style={{ color: 'var(--color-text-muted)' }} />
+          <span className="text-xs flex-shrink-0 uppercase tracking-wider" style={{ color: 'var(--color-text-muted)' }}>Filter:</span>
           {allTypes.map((type) => (
             <label
               key={type}
@@ -205,15 +194,21 @@ export default function Logs() {
                 type="checkbox"
                 checked={typeFilters.has(type)}
                 onChange={() => toggleTypeFilter(type)}
-                className="rounded bg-[#0a0a18] border-[#1a1a3e] text-[#0080ff] focus:ring-[#0080ff] focus:ring-offset-0 h-3 w-3"
+                className="rounded h-3 w-3"
+                style={{ 
+                  backgroundColor: 'var(--color-bg-input)', 
+                  borderColor: 'var(--color-border-default)', 
+                  accentColor: 'var(--color-accent-blue)' 
+                }}
               />
-              <span className="text-[10px] text-[#556080] capitalize">{type}</span>
+              <span className="text-xs capitalize" style={{ color: 'var(--color-text-muted)' }}>{type}</span>
             </label>
           ))}
           {typeFilters.size > 0 && (
             <button
               onClick={() => setTypeFilters(new Set())}
-              className="text-[10px] text-[#0080ff] hover:text-[#00d4ff] flex-shrink-0 ml-1 transition-colors"
+              className="text-xs flex-shrink-0 ml-1 transition-colors"
+              style={{ color: 'var(--color-accent-blue)' }}
             >
               Clear
             </button>
@@ -221,15 +216,14 @@ export default function Logs() {
         </div>
       )}
 
-      {/* Log entries */}
       <div
         ref={containerRef}
         onScroll={handleScroll}
         className="flex-1 overflow-y-auto p-4 space-y-1.5"
       >
         {filteredEntries.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full text-[#334060] animate-fade-in">
-            <Activity className="h-10 w-10 text-[#1a1a3e] mb-3" />
+          <div className="flex flex-col items-center justify-center h-full animate-fade-in" style={{ color: 'var(--color-text-muted)' }}>
+            <Activity className="h-10 w-10 mb-3" style={{ color: 'var(--color-border-default)' }} />
             <p className="text-sm">
               {paused
                 ? 'Log streaming is paused.'
@@ -255,19 +249,24 @@ export default function Logs() {
             return (
               <div
                 key={entry.id}
-                className="glass-card rounded-lg p-3 hover:border-[#0080ff20] transition-all duration-200"
+                className="glass-card rounded-lg p-3 hover:border-[var(--color-accent-blue)] transition-all duration-200"
               >
                 <div className="flex items-start gap-3">
-                  <span className="text-[10px] text-[#334060] font-mono whitespace-nowrap mt-0.5">
+                  <span className="text-xs font-mono whitespace-nowrap mt-0.5" style={{ color: 'var(--color-text-muted)' }}>
                     {formatTimestamp(event.timestamp)}
                   </span>
                   <span
-                    className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-semibold border capitalize flex-shrink-0 ${badge.classes}`}
-                    style={{ background: badge.bg }}
+                    className="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold border capitalize flex-shrink-0"
+                    style={{ 
+                      color: badge.color, 
+                      backgroundColor: badge.bg, 
+                      opacity: 0.15,
+                      borderColor: badge.border
+                    }}
                   >
                     {event.type}
                   </span>
-                  <p className="text-sm text-[#8892a8] break-all min-w-0">
+                  <p className="text-sm break-all min-w-0" style={{ color: 'var(--color-text-secondary)' }}>
                     {typeof detail === 'string' ? detail : JSON.stringify(detail)}
                   </p>
                 </div>

--- a/web/src/pages/Memory.tsx
+++ b/web/src/pages/Memory.tsx
@@ -1,14 +1,7 @@
-import { useState, useEffect } from 'react';
-import {
-  Brain,
-  Search,
-  Plus,
-  Trash2,
-  X,
-  Filter,
-} from 'lucide-react';
-import type { MemoryEntry } from '@/types/api';
-import { getMemory, storeMemory, deleteMemory } from '@/lib/api';
+import { useEffect, useState } from 'react'
+import { Brain, Filter, Plus, Search, Trash2, X, } from 'lucide-react'
+import type { MemoryEntry } from '@/types/api'
+import { deleteMemory, getMemory, storeMemory } from '@/lib/api'
 
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text;
@@ -29,7 +22,6 @@ export default function Memory() {
   const [showForm, setShowForm] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
 
-  // Form state
   const [formKey, setFormKey] = useState('');
   const [formContent, setFormContent] = useState('');
   const [formCategory, setFormCategory] = useState('');
@@ -97,7 +89,7 @@ export default function Memory() {
   if (error && entries.length === 0) {
     return (
       <div className="p-6 animate-fade-in">
-        <div className="rounded-xl bg-[#ff446615] border border-[#ff446630] p-4 text-[#ff6680]">
+        <div className="rounded-xl p-4" style={{ backgroundColor: 'var(--color-bg-error-subtle)', border: '1px solid var(--color-status-error)', color: 'var(--color-status-error)' }}>
           Failed to load memory: {error}
         </div>
       </div>
@@ -106,11 +98,10 @@ export default function Memory() {
 
   return (
     <div className="p-6 space-y-6 animate-fade-in">
-      {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Brain className="h-5 w-5 text-[#0080ff]" />
-          <h2 className="text-sm font-semibold text-white uppercase tracking-wider">
+          <Brain className="h-5 w-5" style={{ color: 'var(--color-accent-blue)' }} />
+          <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>
             Memory ({entries.length})
           </h2>
         </div>
@@ -123,10 +114,9 @@ export default function Memory() {
         </button>
       </div>
 
-      {/* Search and Filter */}
       <div className="flex flex-col sm:flex-row gap-3">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[#334060]" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4" style={{ color: 'var(--color-text-muted)' }} />
           <input
             type="text"
             value={search}
@@ -137,7 +127,7 @@ export default function Memory() {
           />
         </div>
         <div className="relative">
-          <Filter className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[#334060]" />
+          <Filter className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4" style={{ color: 'var(--color-text-muted)' }} />
           <select
             value={categoryFilter}
             onChange={(e) => setCategoryFilter(e.target.value)}
@@ -159,40 +149,39 @@ export default function Memory() {
         </button>
       </div>
 
-      {/* Error banner (non-fatal) */}
       {error && (
-        <div className="rounded-xl bg-[#ff446615] border border-[#ff446630] p-3 text-sm text-[#ff6680] animate-fade-in">
+        <div className="rounded-xl p-3 text-sm animate-fade-in" style={{ backgroundColor: 'var(--color-bg-error-subtle)', border: '1px solid var(--color-status-error)', color: 'var(--color-status-error)' }}>
           {error}
         </div>
       )}
 
-      {/* Add Memory Form Modal */}
       {showForm && (
         <div className="fixed inset-0 modal-backdrop flex items-center justify-center z-50">
           <div className="glass-card p-6 w-full max-w-md mx-4 animate-fade-in-scale">
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-white">Add Memory</h3>
+              <h3 className="text-lg font-semibold" style={{ color: 'var(--color-text-primary)' }}>Add Memory</h3>
               <button
                 onClick={() => {
                   setShowForm(false);
                   setFormError(null);
                 }}
-                className="text-[#556080] hover:text-white transition-colors duration-300"
+                className="hover:opacity-80 transition-colors duration-300"
+                style={{ color: 'var(--color-text-muted)' }}
               >
                 <X className="h-5 w-5" />
               </button>
             </div>
 
             {formError && (
-              <div className="mb-4 rounded-xl bg-[#ff446615] border border-[#ff446630] p-3 text-sm text-[#ff6680] animate-fade-in">
+              <div className="mb-4 rounded-xl p-3 text-sm animate-fade-in" style={{ backgroundColor: 'var(--color-bg-error-subtle)', border: '1px solid var(--color-status-error)', color: 'var(--color-status-error)' }}>
                 {formError}
               </div>
             )}
 
             <div className="space-y-4">
               <div>
-                <label className="block text-xs font-semibold text-[#8892a8] mb-1.5 uppercase tracking-wider">
-                  Key <span className="text-[#ff4466]">*</span>
+                <label className="block text-xs font-semibold mb-1.5 uppercase tracking-wider" style={{ color: 'var(--color-text-secondary)' }}>
+                  Key <span style={{ color: 'var(--color-status-error)' }}>*</span>
                 </label>
                 <input
                   type="text"
@@ -203,8 +192,8 @@ export default function Memory() {
                 />
               </div>
               <div>
-                <label className="block text-xs font-semibold text-[#8892a8] mb-1.5 uppercase tracking-wider">
-                  Content <span className="text-[#ff4466]">*</span>
+                <label className="block text-xs font-semibold mb-1.5 uppercase tracking-wider" style={{ color: 'var(--color-text-secondary)' }}>
+                  Content <span style={{ color: 'var(--color-status-error)' }}>*</span>
                 </label>
                 <textarea
                   value={formContent}
@@ -215,7 +204,7 @@ export default function Memory() {
                 />
               </div>
               <div>
-                <label className="block text-xs font-semibold text-[#8892a8] mb-1.5 uppercase tracking-wider">
+                <label className="block text-xs font-semibold mb-1.5 uppercase tracking-wider" style={{ color: 'var(--color-text-secondary)' }}>
                   Category (optional)
                 </label>
                 <input
@@ -234,7 +223,12 @@ export default function Memory() {
                   setShowForm(false);
                   setFormError(null);
                 }}
-                className="px-4 py-2 text-sm font-medium text-[#8892a8] hover:text-white border border-[#1a1a3e] rounded-xl hover:bg-[#0080ff08] transition-all duration-300"
+                className="px-4 py-2 text-sm font-medium border rounded-xl transition-all duration-300 hover:opacity-80"
+                style={{ 
+                  color: 'var(--color-text-secondary)', 
+                  borderColor: 'var(--color-border-default)',
+                  backgroundColor: 'var(--color-bg-secondary)',
+                }}
               >
                 Cancel
               </button>
@@ -250,15 +244,14 @@ export default function Memory() {
         </div>
       )}
 
-      {/* Memory Table */}
       {loading ? (
         <div className="flex items-center justify-center h-32">
-          <div className="h-8 w-8 border-2 border-[#0080ff30] border-t-[#0080ff] rounded-full animate-spin" />
+          <div className="h-8 w-8 border-2 rounded-full animate-spin" style={{ borderColor: 'var(--color-glow-blue)', borderTopColor: 'var(--color-accent-blue)' }} />
         </div>
       ) : entries.length === 0 ? (
         <div className="glass-card p-8 text-center">
-          <Brain className="h-10 w-10 text-[#1a1a3e] mx-auto mb-3" />
-          <p className="text-[#556080]">No memory entries found.</p>
+          <Brain className="h-10 w-10 mx-auto mb-3" style={{ color: 'var(--color-border-default)' }} />
+          <p style={{ color: 'var(--color-text-muted)' }}>No memory entries found.</p>
         </div>
       ) : (
         <div className="glass-card overflow-x-auto">
@@ -275,35 +268,37 @@ export default function Memory() {
             <tbody>
               {entries.map((entry) => (
                 <tr key={entry.id}>
-                  <td className="px-4 py-3 text-white font-medium font-mono text-xs">
+                  <td className="px-4 py-3 font-medium font-mono text-xs" style={{ color: 'var(--color-text-primary)' }}>
                     {entry.key}
                   </td>
-                  <td className="px-4 py-3 text-[#8892a8] max-w-[300px] text-sm">
+                  <td className="px-4 py-3 max-w-[300px] text-sm" style={{ color: 'var(--color-text-secondary)' }}>
                     <span title={entry.content}>
                       {truncate(entry.content, 80)}
                     </span>
                   </td>
                   <td className="px-4 py-3">
-                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-semibold capitalize border border-[#1a1a3e] text-[#8892a8]" style={{ background: 'rgba(0,128,255,0.06)' }}>
+                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold capitalize border" style={{ borderColor: 'var(--color-border-default)', color: 'var(--color-text-secondary)', backgroundColor: 'var(--color-bg-blue-subtle)' }}>
                       {entry.category}
                     </span>
                   </td>
-                  <td className="px-4 py-3 text-[#556080] text-xs whitespace-nowrap">
+                  <td className="px-4 py-3 text-xs whitespace-nowrap" style={{ color: 'var(--color-text-muted)' }}>
                     {formatDate(entry.timestamp)}
                   </td>
                   <td className="px-4 py-3 text-right">
                     {confirmDelete === entry.key ? (
                       <div className="flex items-center justify-end gap-2 animate-fade-in">
-                        <span className="text-xs text-[#ff4466]">Delete?</span>
+                        <span className="text-xs" style={{ color: 'var(--color-status-error)' }}>Delete?</span>
                         <button
                           onClick={() => handleDelete(entry.key)}
-                          className="text-[#ff4466] hover:text-[#ff6680] text-xs font-medium"
+                          className="text-xs font-medium hover:opacity-80"
+                          style={{ color: 'var(--color-status-error)' }}
                         >
                           Yes
                         </button>
                         <button
                           onClick={() => setConfirmDelete(null)}
-                          className="text-[#556080] hover:text-white text-xs font-medium"
+                          className="text-xs font-medium hover:opacity-80"
+                          style={{ color: 'var(--color-text-muted)' }}
                         >
                           No
                         </button>
@@ -311,7 +306,8 @@ export default function Memory() {
                     ) : (
                       <button
                         onClick={() => setConfirmDelete(entry.key)}
-                        className="text-[#334060] hover:text-[#ff4466] transition-all duration-300"
+                        className="hover:opacity-80 transition-all duration-300"
+                        style={{ color: 'var(--color-text-muted)' }}
                       >
                         <Trash2 className="h-4 w-4" />
                       </button>

--- a/web/src/pages/Tools.tsx
+++ b/web/src/pages/Tools.tsx
@@ -43,7 +43,7 @@ export default function Tools() {
   if (error) {
     return (
       <div className="p-6 animate-fade-in">
-        <div className="rounded-xl bg-[#ff446615] border border-[#ff446630] p-4 text-[#ff6680]">
+        <div className="rounded-xl p-4" style={{ backgroundColor: 'var(--color-status-error)', opacity: 0.1, border: '1px solid var(--color-status-error)', color: 'var(--color-status-error)' }}>
           Failed to load tools: {error}
         </div>
       </div>
@@ -53,16 +53,15 @@ export default function Tools() {
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
-        <div className="h-8 w-8 border-2 border-[#0080ff30] border-t-[#0080ff] rounded-full animate-spin" />
+        <div className="h-8 w-8 border-2 rounded-full animate-spin" style={{ borderColor: 'var(--color-glow-blue)', borderTopColor: 'var(--color-accent-blue)' }} />
       </div>
     );
   }
 
   return (
     <div className="p-6 space-y-6 animate-fade-in">
-      {/* Search */}
       <div className="relative max-w-md">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[#334060]" />
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4" style={{ color: 'var(--color-text-muted)' }} />
         <input
           type="text"
           value={search}
@@ -72,17 +71,16 @@ export default function Tools() {
         />
       </div>
 
-      {/* Agent Tools Grid */}
       <div>
         <div className="flex items-center gap-2 mb-4">
-          <Wrench className="h-5 w-5 text-[#0080ff]" />
-          <h2 className="text-sm font-semibold text-white uppercase tracking-wider">
+          <Wrench className="h-5 w-5" style={{ color: 'var(--color-accent-blue)' }} />
+          <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>
             Agent Tools ({filtered.length})
           </h2>
         </div>
 
         {filtered.length === 0 ? (
-          <p className="text-sm text-[#334060]">No tools match your search.</p>
+          <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>No tools match your search.</p>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 stagger-children">
             {filtered.map((tool) => {
@@ -96,32 +94,32 @@ export default function Tools() {
                     onClick={() =>
                       setExpandedTool(isExpanded ? null : tool.name)
                     }
-                    className="w-full text-left p-4 hover:bg-[#0080ff08] transition-all duration-300"
+                    className="w-full text-left p-4 transition-all duration-300 hover:opacity-80"
                   >
                     <div className="flex items-start justify-between gap-2">
                       <div className="flex items-center gap-2 min-w-0">
-                        <Package className="h-4 w-4 text-[#0080ff] flex-shrink-0 mt-0.5" />
-                        <h3 className="text-sm font-semibold text-white truncate">
+                        <Package className="h-4 w-4 flex-shrink-0 mt-0.5" style={{ color: 'var(--color-accent-blue)' }} />
+                        <h3 className="text-sm font-semibold truncate" style={{ color: 'var(--color-text-primary)' }}>
                           {tool.name}
                         </h3>
                       </div>
                       {isExpanded ? (
-                        <ChevronDown className="h-4 w-4 text-[#0080ff] flex-shrink-0 transition-transform" />
+                        <ChevronDown className="h-4 w-4 flex-shrink-0 transition-transform" style={{ color: 'var(--color-accent-blue)' }} />
                       ) : (
-                        <ChevronRight className="h-4 w-4 text-[#334060] flex-shrink-0 transition-transform" />
+                        <ChevronRight className="h-4 w-4 flex-shrink-0 transition-transform" style={{ color: 'var(--color-text-muted)' }} />
                       )}
                     </div>
-                    <p className="text-sm text-[#556080] mt-2 line-clamp-2">
+                    <p className="text-sm mt-2 line-clamp-2" style={{ color: 'var(--color-text-muted)' }}>
                       {tool.description}
                     </p>
                   </button>
 
                   {isExpanded && tool.parameters && (
-                    <div className="border-t border-[#1a1a3e] p-4 animate-fade-in">
-                      <p className="text-[10px] text-[#334060] mb-2 font-semibold uppercase tracking-wider">
+                    <div className="border-t p-4 animate-fade-in" style={{ borderColor: 'var(--color-border-default)' }}>
+                      <p className="text-xs font-semibold uppercase tracking-wider mb-2" style={{ color: 'var(--color-text-muted)' }}>
                         Parameter Schema
                       </p>
-                      <pre className="text-xs text-[#8892a8] rounded-xl p-3 overflow-x-auto max-h-64 overflow-y-auto" style={{ background: 'rgba(5,5,16,0.8)' }}>
+                      <pre className="text-xs rounded-xl p-3 overflow-x-auto max-h-64 overflow-y-auto" style={{ backgroundColor: 'var(--color-bg-primary)', color: 'var(--color-text-secondary)' }}>
                         {JSON.stringify(tool.parameters, null, 2)}
                       </pre>
                     </div>
@@ -133,12 +131,11 @@ export default function Tools() {
         )}
       </div>
 
-      {/* CLI Tools Section */}
       {filteredCli.length > 0 && (
         <div className="animate-slide-in-up" style={{ animationDelay: '200ms' }}>
           <div className="flex items-center gap-2 mb-4">
-            <Terminal className="h-5 w-5 text-[#00e68a]" />
-            <h2 className="text-sm font-semibold text-white uppercase tracking-wider">
+            <Terminal className="h-5 w-5" style={{ color: 'var(--color-status-success)' }} />
+            <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--color-text-primary)' }}>
               CLI Tools ({filteredCli.length})
             </h2>
           </div>
@@ -156,17 +153,17 @@ export default function Tools() {
               <tbody>
                 {filteredCli.map((tool) => (
                   <tr key={tool.name}>
-                    <td className="px-4 py-3 text-white font-medium text-sm">
+                    <td className="px-4 py-3 font-medium text-sm" style={{ color: 'var(--color-text-primary)' }}>
                       {tool.name}
                     </td>
-                    <td className="px-4 py-3 text-[#556080] font-mono text-xs truncate max-w-[200px]">
+                    <td className="px-4 py-3 font-mono text-xs truncate max-w-[200px]" style={{ color: 'var(--color-text-muted)' }}>
                       {tool.path}
                     </td>
-                    <td className="px-4 py-3 text-[#556080] text-sm">
+                    <td className="px-4 py-3 text-sm" style={{ color: 'var(--color-text-muted)' }}>
                       {tool.version ?? '-'}
                     </td>
                     <td className="px-4 py-3">
-                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-semibold capitalize border border-[#1a1a3e] text-[#8892a8]" style={{ background: 'rgba(0,128,255,0.06)' }}>
+                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-semibold capitalize border" style={{ borderColor: 'var(--color-border-default)', color: 'var(--color-text-secondary)', backgroundColor: 'var(--color-accent-blue)', opacity: 0.1 }}>
                         {tool.category}
                       </span>
                     </td>


### PR DESCRIPTION
Introduce a ThemeContext and useTheme hook with persistent theme (localStorage + system preference) and data-theme attribute. Replace many hard-coded colors and gradients with CSS custom properties and centralized light/dark variable sets in index.css, add utility classes (page-background, sidebar, header, theme-toggle, etc.), and update components (App, Header, Layout, Sidebar, AgentChat, Config, Cost, Cron, etc.) to use the new theme variables and simplified class styles. Also add a theme toggle in the header, adjust loading/connection/status UI to use status/color vars, and tidy various UI bits (shadows, focus styles, animations) for consistent theming and maintainability.