### PR TITLE
feat(web): responsive mobile sidebar with hamburger toggle

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { useLocation } from 'react-router-dom';
-import { LogOut } from 'lucide-react';
+import { LogOut, Menu } from 'lucide-react';
 import { t } from '@/lib/i18n';
 import { useLocaleContext } from '@/App';
 import { useAuth } from '@/hooks/useAuth';
@@ -17,7 +17,11 @@ const routeTitles: Record<string, string> = {
   '/doctor': 'nav.doctor',
 };
 
-export default function Header() {
+interface HeaderProps {
+  onMenuToggle: () => void;
+}
+
+export default function Header({ onMenuToggle }: HeaderProps) {
   const location = useLocation();
   const { logout } = useAuth();
   const { locale, setAppLocale } = useLocaleContext();
@@ -33,8 +37,20 @@ export default function Header() {
 
   return (
     <header className="h-14 flex items-center justify-between px-6 border-b border-[#1a1a3e]/40 animate-fade-in" style={{ background: 'linear-gradient(90deg, rgba(8,8,24,0.9), rgba(5,5,16,0.9))', backdropFilter: 'blur(12px)' }}>
-      {/* Page title */}
-      <h1 className="text-lg font-semibold text-white tracking-tight">{pageTitle}</h1>
+      <div className="flex items-center gap-3">
+        {/* Hamburger — visible only on mobile */}
+        <button
+          type="button"
+          onClick={onMenuToggle}
+          className="md:hidden p-1.5 -ml-1.5 rounded-lg text-[#8892a8] hover:text-white hover:bg-[#0080ff10] transition-colors duration-200"
+          aria-label="Open menu"
+        >
+          <Menu className="h-5 w-5" />
+        </button>
+
+        {/* Page title */}
+        <h1 className="text-lg font-semibold text-white tracking-tight">{pageTitle}</h1>
+      </div>
 
       {/* Right-side controls */}
       <div className="flex items-center gap-3">
@@ -54,7 +70,7 @@ export default function Header() {
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs text-[#8892a8] hover:text-[#ff4466] hover:bg-[#ff446610] transition-all duration-300"
         >
           <LogOut className="h-3.5 w-3.5" />
-          <span>{t('auth.logout')}</span>
+          <span className="hidden sm:inline">{t('auth.logout')}</span>
         </button>
       </div>
     </header>

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import Sidebar from '@/components/layout/Sidebar';
 import Header from '@/components/layout/Header';
@@ -5,15 +6,21 @@ import { ErrorBoundary } from '@/App';
 
 export default function Layout() {
   const { pathname } = useLocation();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  // Close sidebar on route change (mobile navigation)
+  useEffect(() => {
+    setSidebarOpen(false);
+  }, [pathname]);
 
   return (
     <div className="min-h-screen text-white" style={{ background: 'linear-gradient(135deg, #050510 0%, #080818 50%, #050510 100%)' }}>
       {/* Fixed sidebar */}
-      <Sidebar />
+      <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
-      {/* Main area offset by sidebar width (240px / w-60) */}
-      <div className="ml-60 flex flex-col min-h-screen">
-        <Header />
+      {/* Main area offset by sidebar width on desktop, full-width on mobile */}
+      <div className="md:ml-60 ml-0 flex flex-col min-h-screen">
+        <Header onMenuToggle={() => setSidebarOpen(true)} />
 
         {/* Page content — ErrorBoundary keyed by pathname so the nav shell
             survives a page crash and the boundary resets on route change */}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -26,61 +26,89 @@ const navItems = [
   { to: '/doctor', icon: Stethoscope, labelKey: 'nav.doctor' },
 ];
 
-export default function Sidebar() {
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function Sidebar({ open, onClose }: SidebarProps) {
   return (
-    <aside className="fixed top-0 left-0 h-screen w-60 flex flex-col" style={{ background: 'linear-gradient(180deg, #080818 0%, #050510 100%)' }}>
-      {/* Glow line on right edge */}
-      <div className="sidebar-glow-line" />
-
-      {/* Logo / Title */}
-      <div className="flex items-center gap-3 px-4 py-4 border-b border-[#1a1a3e]/50">
-        <img
-          src="/_app/zeroclaw-trans.png"
-          alt="ZeroClaw"
-          className="h-10 w-10 rounded-xl object-cover animate-pulse-glow"
+    <>
+      {/* Backdrop — mobile only, visible when sidebar is open */}
+      {open && (
+        <div
+          className="md:hidden fixed inset-0 z-40 bg-black/60 backdrop-blur-sm transition-opacity"
+          onClick={onClose}
+          onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}
+          role="button"
+          tabIndex={-1}
+          aria-label="Close menu"
         />
-        <span className="text-lg font-bold text-gradient-blue tracking-wide">
-          ZeroClaw
-        </span>
-      </div>
+      )}
 
-      {/* Navigation */}
-      <nav className="flex-1 overflow-y-auto py-4 px-3 space-y-1">
-        {navItems.map(({ to, icon: Icon, labelKey }, idx) => (
-          <NavLink
-            key={to}
-            to={to}
-            end={to === '/'}
-            className={({ isActive }) =>
-              [
-                'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-300 animate-slide-in-left group',
-                isActive
-                  ? 'text-white shadow-[0_0_15px_rgba(0,128,255,0.2)]'
-                  : 'text-[#556080] hover:text-white hover:bg-[#0080ff08]',
-              ].join(' ')
-            }
-            style={({ isActive }) => ({
-              animationDelay: `${idx * 40}ms`,
-              ...(isActive ? { background: 'linear-gradient(135deg, rgba(0,128,255,0.15), rgba(0,128,255,0.05))' } : {}),
-            })}
-          >
-            {({ isActive }) => (
-              <>
-                <Icon className={`h-5 w-5 flex-shrink-0 transition-colors duration-300 ${isActive ? 'text-[#0080ff]' : 'group-hover:text-[#0080ff80]'}`} />
-                <span>{t(labelKey)}</span>
-                {isActive && (
-                  <div className="ml-auto h-1.5 w-1.5 rounded-full bg-[#0080ff] glow-dot" />
-                )}
-              </>
-            )}
-          </NavLink>
-        ))}
-      </nav>
+      <aside
+        className={[
+          'fixed top-0 left-0 h-screen w-60 flex flex-col z-50',
+          // Mobile: slide in/out with transition
+          'max-md:-translate-x-full max-md:transition-transform max-md:duration-200 max-md:ease-out',
+          open ? 'max-md:translate-x-0' : '',
+        ].join(' ')}
+        style={{ background: 'linear-gradient(180deg, #080818 0%, #050510 100%)' }}
+      >
+        {/* Glow line on right edge */}
+        <div className="sidebar-glow-line" />
 
-      {/* Footer */}
-      <div className="px-5 py-4 border-t border-[#1a1a3e]/50">
-        <p className="text-[10px] text-[#334060] tracking-wider uppercase">ZeroClaw Runtime</p>
-      </div>
-    </aside>
+        {/* Logo / Title */}
+        <div className="flex items-center gap-3 px-4 py-4 border-b border-[#1a1a3e]/50">
+          <img
+            src="/_app/zeroclaw-trans.png"
+            alt="ZeroClaw"
+            className="h-10 w-10 rounded-xl object-cover animate-pulse-glow"
+          />
+          <span className="text-lg font-bold text-gradient-blue tracking-wide">
+            ZeroClaw
+          </span>
+        </div>
+
+        {/* Navigation */}
+        <nav className="flex-1 overflow-y-auto py-4 px-3 space-y-1">
+          {navItems.map(({ to, icon: Icon, labelKey }, idx) => (
+            <NavLink
+              key={to}
+              to={to}
+              end={to === '/'}
+              onClick={onClose}
+              className={({ isActive }) =>
+                [
+                  'flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-medium transition-all duration-300 animate-slide-in-left group',
+                  isActive
+                    ? 'text-white shadow-[0_0_15px_rgba(0,128,255,0.2)]'
+                    : 'text-[#556080] hover:text-white hover:bg-[#0080ff08]',
+                ].join(' ')
+              }
+              style={({ isActive }) => ({
+                animationDelay: `${idx * 40}ms`,
+                ...(isActive ? { background: 'linear-gradient(135deg, rgba(0,128,255,0.15), rgba(0,128,255,0.05))' } : {}),
+              })}
+            >
+              {({ isActive }) => (
+                <>
+                  <Icon className={`h-5 w-5 flex-shrink-0 transition-colors duration-300 ${isActive ? 'text-[#0080ff]' : 'group-hover:text-[#0080ff80]'}`} />
+                  <span>{t(labelKey)}</span>
+                  {isActive && (
+                    <div className="ml-auto h-1.5 w-1.5 rounded-full bg-[#0080ff] glow-dot" />
+                  )}
+                </>
+              )}
+            </NavLink>
+          ))}
+        </nav>
+
+        {/* Footer */}
+        <div className="px-5 py-4 border-t border-[#1a1a3e]/50">
+          <p className="text-[10px] text-[#334060] tracking-wider uppercase">ZeroClaw Runtime</p>
+        </div>
+      </aside>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The web dashboard sidebar is fixed at 240px and always visible, making it unusable on mobile devices — it consumes ~60% of the screen width, leaving dashboard content squished and barely readable.
- Why it matters: ZeroClaw is increasingly used as a Home Assistant addon where users access the dashboard from phones and tablets.
- What changed: On viewports below 768px (`md`), the sidebar is hidden off-screen and replaced by a hamburger button in the header. Tapping it slides the sidebar in as an overlay drawer with a backdrop. Tapping the backdrop or navigating closes it.
- What did **not** change (scope boundary): Desktop layout is completely unchanged — no visual diff on screens >= 768px. No new dependencies, no new components, no state management beyond a single `useState`.

## Screenshots

<!-- TODO: add mobile before/after screenshots -->
Before:
<img width="33%" height="33%" alt="image" src="https://github.com/user-attachments/assets/fde25421-dfb3-4814-b04f-106ef8a3e2a7" />  <img width="33%" height="33%" alt="image" src="https://github.com/user-attachments/assets/b4f2d0ea-d36d-4b0d-b099-57044583a967" />

After:
<img width="30%" height="30%" alt="image" src="https://github.com/user-attachments/assets/0b9aa4ab-76c0-4a59-ab6b-8684e108d1d4" /> <img width="30%" height="30%" alt="image" src="https://github.com/user-attachments/assets/02dc8fa1-2d40-4cb4-9ceb-38cdb65eb2ad" /> <img width="30%" height="30%" alt="image" src="https://github.com/user-attachments/assets/8a9550c4-70b1-4126-9218-b546ab2a6e58" />



## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `gateway`
- Module labels: `gateway: web-dashboard`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `gateway`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Validation Evidence (required)

No Rust changes — only 3 TypeScript/TSX files in `web/src/components/layout/`.

```bash
cd web && npm run build   # tsc -b && vite build — passes clean
```

Cargo checks not applicable (no `.rs` changes).

- Evidence provided: `npm run build` passes (TypeScript type check + Vite production build)
- If any command is intentionally skipped, explain why: `cargo fmt/clippy/test` skipped — no Rust source changes

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: No identity-like wording introduced

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (no user-facing text changes — hamburger is icon-only, existing i18n labels unchanged)

## Human Verification (required)

- Verified scenarios: Desktop >= 768px unchanged, mobile < 768px sidebar hidden + hamburger visible, overlay opens/closes on tap, nav click closes sidebar, backdrop click closes sidebar
- Edge cases checked: Rapid open/close toggling, route change auto-closes, sidebar scroll on small screens with many nav items
- What **was** verified: Tablet landscape (768px-1024px boundary)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Web dashboard layout only (3 components: Layout, Header, Sidebar)
- Potential unintended effects: None — desktop path is unchanged, mobile path is additive
- Guardrails/monitoring for early detection: Visual regression on dashboard load

## Rollback Plan (required)

- Fast rollback command/path: Revert single commit
- Feature flags or config toggles: None needed — CSS-only behavior gated by `md:` breakpoint
- Observable failure symptoms: Sidebar not appearing on desktop, or hamburger not working on mobile

## Risks and Mitigations

- Risk: Tailwind `max-md:` prefix may behave differently across Tailwind versions
  - Mitigation: Tested with Tailwind CSS 4.0 (project's current version), `max-md:` is stable syntax