### PR TITLE
fix(web): preserve provider runtime options in ws agent

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -331,13 +331,16 @@ impl Agent {
             .unwrap_or("anthropic/claude-sonnet-4-20250514")
             .to_string();
 
-        let provider: Box<dyn Provider> = providers::create_routed_provider(
+        let provider_runtime_options = providers::provider_runtime_options_from_config(config);
+
+        let provider: Box<dyn Provider> = providers::create_routed_provider_with_options(
             provider_name,
             config.api_key.as_deref(),
             config.api_url.as_deref(),
             &config.reliability,
             &config.model_routes,
             &model_name,
+            &provider_runtime_options,
         )?;
 
         let dispatcher_choice = config.agent.tool_dispatcher.as_str();
@@ -1004,6 +1007,92 @@ mod tests {
         assert_eq!(response, "classified");
         let seen = seen_models.lock();
         assert_eq!(seen.as_slice(), &["hint:fast".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn from_config_passes_extra_headers_to_custom_provider() {
+        use axum::{http::HeaderMap, routing::post, Json, Router};
+        use tempfile::TempDir;
+        use tokio::net::TcpListener;
+
+        let captured_headers: Arc<std::sync::Mutex<Option<HashMap<String, String>>>> =
+            Arc::new(std::sync::Mutex::new(None));
+        let captured_headers_clone = captured_headers.clone();
+
+        let app = Router::new().route(
+            "/chat/completions",
+            post(
+                move |headers: HeaderMap, Json(_body): Json<serde_json::Value>| {
+                    let captured_headers = captured_headers_clone.clone();
+                    async move {
+                        let collected = headers
+                            .iter()
+                            .filter_map(|(name, value)| {
+                                value
+                                    .to_str()
+                                    .ok()
+                                    .map(|value| (name.as_str().to_string(), value.to_string()))
+                            })
+                            .collect();
+                        *captured_headers.lock().unwrap() = Some(collected);
+                        Json(serde_json::json!({
+                            "choices": [{
+                                "message": {
+                                    "content": "hello from mock"
+                                }
+                            }]
+                        }))
+                    }
+                },
+            ),
+        );
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let tmp = TempDir::new().expect("temp dir");
+        let workspace_dir = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace_dir).unwrap();
+
+        let mut config = crate::config::Config::default();
+        config.workspace_dir = workspace_dir;
+        config.config_path = tmp.path().join("config.toml");
+        config.api_key = Some("test-key".to_string());
+        config.default_provider = Some(format!("custom:http://{addr}"));
+        config.default_model = Some("test-model".to_string());
+        config.memory.backend = "none".to_string();
+        config.memory.auto_save = false;
+        config.extra_headers.insert(
+            "User-Agent".to_string(),
+            "zeroclaw-web-test/1.0".to_string(),
+        );
+        config
+            .extra_headers
+            .insert("X-Title".to_string(), "zeroclaw-web".to_string());
+
+        let mut agent = Agent::from_config(&config).expect("agent from config");
+        let response = agent.turn("hello").await.expect("agent turn");
+
+        assert_eq!(response, "hello from mock");
+
+        let headers = captured_headers
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("captured headers");
+        assert_eq!(
+            headers.get("user-agent").map(String::as_str),
+            Some("zeroclaw-web-test/1.0")
+        );
+        assert_eq!(
+            headers.get("x-title").map(String::as_str),
+            Some("zeroclaw-web")
+        );
+
+        server_handle.abort();
     }
 
     #[test]

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -3209,17 +3209,7 @@ pub async fn run(
         .or(config.default_model.as_deref())
         .unwrap_or("anthropic/claude-sonnet-4");
 
-    let provider_runtime_options = providers::ProviderRuntimeOptions {
-        auth_profile_override: None,
-        provider_api_url: config.api_url.clone(),
-        zeroclaw_dir: config.config_path.parent().map(std::path::PathBuf::from),
-        secrets_encrypt: config.secrets.encrypt,
-        reasoning_enabled: config.runtime.reasoning_enabled,
-        reasoning_effort: config.runtime.reasoning_effort.clone(),
-        provider_timeout_secs: Some(config.provider_timeout_secs),
-        extra_headers: config.extra_headers.clone(),
-        api_path: config.api_path.clone(),
-    };
+    let provider_runtime_options = providers::provider_runtime_options_from_config(&config);
 
     let provider: Box<dyn Provider> = providers::create_routed_provider_with_options(
         provider_name,
@@ -3816,17 +3806,7 @@ pub async fn process_message(
         .default_model
         .clone()
         .unwrap_or_else(|| "anthropic/claude-sonnet-4-20250514".into());
-    let provider_runtime_options = providers::ProviderRuntimeOptions {
-        auth_profile_override: None,
-        provider_api_url: config.api_url.clone(),
-        zeroclaw_dir: config.config_path.parent().map(std::path::PathBuf::from),
-        secrets_encrypt: config.secrets.encrypt,
-        reasoning_enabled: config.runtime.reasoning_enabled,
-        reasoning_effort: config.runtime.reasoning_effort.clone(),
-        provider_timeout_secs: Some(config.provider_timeout_secs),
-        extra_headers: config.extra_headers.clone(),
-        api_path: config.api_path.clone(),
-    };
+    let provider_runtime_options = providers::provider_runtime_options_from_config(&config);
     let provider: Box<dyn Provider> = providers::create_routed_provider_with_options(
         provider_name,
         config.api_key.as_deref(),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -708,6 +708,22 @@ impl Default for ProviderRuntimeOptions {
     }
 }
 
+pub fn provider_runtime_options_from_config(
+    config: &crate::config::Config,
+) -> ProviderRuntimeOptions {
+    ProviderRuntimeOptions {
+        auth_profile_override: None,
+        provider_api_url: config.api_url.clone(),
+        zeroclaw_dir: config.config_path.parent().map(PathBuf::from),
+        secrets_encrypt: config.secrets.encrypt,
+        reasoning_enabled: config.runtime.reasoning_enabled,
+        reasoning_effort: config.runtime.reasoning_effort.clone(),
+        provider_timeout_secs: Some(config.provider_timeout_secs),
+        extra_headers: config.extra_headers.clone(),
+        api_path: config.api_path.clone(),
+    }
+}
+
 fn is_secret_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':')
 }


### PR DESCRIPTION
## Summary

- Extract shared `provider_runtime_options_from_config` helper to deduplicate runtime options construction
- Use helper in `Agent::from_config` (WebSocket path) so extra headers, timeout, API path, and reasoning effort are preserved
- Includes `reasoning_effort` field (added on master after original PR branch diverged)

Supersedes #3770 (resolves merge conflict with reasoning_effort addition).

## Test plan

- [x] `cargo check` passes
- [ ] CI lint, test, build all pass