### PR TITLE
fix(daemon): ignore SIGHUP to survive terminal/SSH session closes

### DIFF
--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -8,7 +8,7 @@ use tokio::time::Duration;
 
 const STATUS_FLUSH_SECONDS: u64 = 5;
 
-/// Wait for shutdown signal (SIGINT or SIGTERM)
+/// Wait for shutdown signal (SIGINT, SIGTERM, or ignore SIGHUP)
 async fn wait_for_shutdown_signal() -> Result<()> {
     #[cfg(unix)]
     {
@@ -16,13 +16,26 @@ async fn wait_for_shutdown_signal() -> Result<()> {
 
         let mut sigint = signal(SignalKind::interrupt())?;
         let mut sigterm = signal(SignalKind::terminate())?;
+        // Ignore SIGHUP to allow daemon to survive terminal/SSH session closes.
+        // When a terminal closes, SIGHUP is sent to the process group.
+        // By ignoring it, the daemon continues running in the background.
+        let mut sighup = signal(SignalKind::hangup())?;
 
-        tokio::select! {
-            _ = sigint.recv() => {
-                tracing::info!("Received SIGINT, shutting down...");
-            }
-            _ = sigterm.recv() => {
-                tracing::info!("Received SIGTERM, shutting down...");
+        loop {
+            tokio::select! {
+                _ = sigint.recv() => {
+                    tracing::info!("Received SIGINT, shutting down...");
+                    return Ok(());
+                }
+                _ = sigterm.recv() => {
+                    tracing::info!("Received SIGTERM, shutting down...");
+                    return Ok(());
+                }
+                _ = sighup.recv() => {
+                    // Ignore SIGHUP - daemon should continue running
+                    tracing::debug!("Received SIGHUP, ignoring...");
+                    // Continue loop to keep waiting for shutdown signals
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add SIGHUP signal handler to wait_for_shutdown_signal()
- Use loop to continuously ignore SIGHUP rather than exiting on first match
- Daemon now continues running in background after terminal/SSH disconnect

## Fix

This addresses the logic issue mentioned in PR review: the original code matched SIGHUP in tokio::select! then fell through to shutdown instead of looping to continue ignoring it.

Fixes #3688