### PR TITLE
fix: use resolve_tool_path for consistent absolute/relative path handling

### DIFF
--- a/src/tools/file_edit.rs
+++ b/src/tools/file_edit.rs
@@ -103,7 +103,7 @@ impl Tool for FileEditTool {
             });
         }
 
-        let full_path = self.security.workspace_dir.join(path);
+        let full_path = self.security.resolve_tool_path(path);
 
         // ── 5. Canonicalize parent ─────────────────────────────────
         let Some(parent) = full_path.parent() else {

--- a/src/tools/file_write.rs
+++ b/src/tools/file_write.rs
@@ -78,7 +78,7 @@ impl Tool for FileWriteTool {
             });
         }
 
-        let full_path = self.security.workspace_dir.join(path);
+        let full_path = self.security.resolve_tool_path(path);
 
         let Some(parent) = full_path.parent() else {
             return Ok(ToolResult {

--- a/src/tools/pdf_read.rs
+++ b/src/tools/pdf_read.rs
@@ -100,7 +100,7 @@ impl Tool for PdfReadTool {
             });
         }
 
-        let full_path = self.security.workspace_dir.join(path);
+        let full_path = self.security.resolve_tool_path(path);
 
         let resolved_path = match tokio::fs::canonicalize(&full_path).await {
             Ok(p) => p,


### PR DESCRIPTION
file_write, file_edit, and pdf_read tools now use resolve_tool_path() instead of workspace_dir.join() to properly handle both absolute and relative paths consistently with file_read.

Fixes #3774