### PR TITLE
feat(gateway): persist WS chat sessions across restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7945,7 +7945,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"

--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -278,6 +278,25 @@ impl Agent {
         self.memory_session_id = session_id;
     }
 
+    /// Hydrate the agent with prior chat messages (e.g. from a session backend).
+    ///
+    /// Ensures a system prompt is prepended if history is empty, then appends all
+    /// non-system messages from the seed. System messages in the seed are skipped
+    /// to avoid duplicating the system prompt.
+    pub fn seed_history(&mut self, messages: &[ChatMessage]) {
+        if self.history.is_empty() {
+            if let Ok(sys) = self.build_system_prompt() {
+                self.history
+                    .push(ConversationMessage::Chat(ChatMessage::system(sys)));
+            }
+        }
+        for msg in messages {
+            if msg.role != "system" {
+                self.history.push(ConversationMessage::Chat(msg.clone()));
+            }
+        }
+    }
+
     pub fn from_config(config: &Config) -> Result<Self> {
         let observer: Arc<dyn Observer> =
             Arc::from(observability::create_observer(&config.observability));
@@ -1068,5 +1087,51 @@ mod tests {
             agent.tool_specs.is_empty(),
             "No tools should match a non-existent allowlist entry"
         );
+    }
+
+    #[test]
+    fn seed_history_prepends_system_and_skips_system_from_seed() {
+        let provider = Box::new(MockProvider {
+            responses: Mutex::new(vec![]),
+        });
+
+        let memory_cfg = crate::config::MemoryConfig {
+            backend: "none".into(),
+            ..crate::config::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            crate::memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let seed = vec![
+            ChatMessage::system("old system prompt"),
+            ChatMessage::user("hello"),
+            ChatMessage::assistant("hi there"),
+        ];
+        agent.seed_history(&seed);
+
+        let history = agent.history();
+        // First message should be a freshly built system prompt (not the seed one)
+        assert!(matches!(&history[0], ConversationMessage::Chat(m) if m.role == "system"));
+        // System message from seed should be skipped, so next is user
+        assert!(
+            matches!(&history[1], ConversationMessage::Chat(m) if m.role == "user" && m.content == "hello")
+        );
+        assert!(
+            matches!(&history[2], ConversationMessage::Chat(m) if m.role == "assistant" && m.content == "hi there")
+        );
+        assert_eq!(history.len(), 3);
     }
 }

--- a/src/channels/session_backend.rs
+++ b/src/channels/session_backend.rs
@@ -76,6 +76,11 @@ pub trait SessionBackend: Send + Sync {
     fn search(&self, _query: &SessionQuery) -> Vec<SessionMetadata> {
         Vec::new()
     }
+
+    /// Delete all messages for a session. Returns `true` if the session existed.
+    fn delete_session(&self, _session_key: &str) -> std::io::Result<bool> {
+        Ok(false)
+    }
 }
 
 #[cfg(test)]

--- a/src/channels/session_sqlite.rs
+++ b/src/channels/session_sqlite.rs
@@ -288,6 +288,39 @@ impl SessionBackend for SqliteSessionBackend {
         Ok(count)
     }
 
+    fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
+        let conn = self.conn.lock();
+
+        // Check if session exists
+        let exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM session_metadata WHERE session_key = ?1",
+                params![session_key],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
+
+        if !exists {
+            return Ok(false);
+        }
+
+        // Delete messages (FTS5 trigger handles sessions_fts cleanup)
+        conn.execute(
+            "DELETE FROM sessions WHERE session_key = ?1",
+            params![session_key],
+        )
+        .map_err(std::io::Error::other)?;
+
+        // Delete metadata
+        conn.execute(
+            "DELETE FROM session_metadata WHERE session_key = ?1",
+            params![session_key],
+        )
+        .map_err(std::io::Error::other)?;
+
+        Ok(true)
+    }
+
     fn search(&self, query: &SessionQuery) -> Vec<SessionMetadata> {
         let Some(keyword) = &query.keyword else {
             return self.list_sessions_with_metadata();
@@ -471,6 +504,28 @@ mod tests {
         let sessions = backend.list_sessions();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0], "new_session");
+    }
+
+    #[test]
+    fn delete_session_removes_all_data() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        backend.append("s1", &ChatMessage::user("hello")).unwrap();
+        backend.append("s1", &ChatMessage::assistant("hi")).unwrap();
+        backend.append("s2", &ChatMessage::user("other")).unwrap();
+
+        assert!(backend.delete_session("s1").unwrap());
+        assert!(backend.load("s1").is_empty());
+        assert_eq!(backend.list_sessions().len(), 1);
+        assert_eq!(backend.list_sessions()[0], "s2");
+    }
+
+    #[test]
+    fn delete_session_returns_false_for_missing() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+        assert!(!backend.delete_session("nonexistent").unwrap());
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1437,6 +1437,7 @@ impl Default for PeripheralBoardConfig {
 ///
 /// Controls the HTTP gateway for webhook and pairing endpoints.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct GatewayConfig {
     /// Gateway port (default: 42617)
     #[serde(default = "default_gateway_port")]
@@ -1478,6 +1479,14 @@ pub struct GatewayConfig {
     /// Maximum distinct idempotency keys retained in memory.
     #[serde(default = "default_gateway_idempotency_max_keys")]
     pub idempotency_max_keys: usize,
+
+    /// Persist gateway WebSocket chat sessions to SQLite. Default: true.
+    #[serde(default = "default_true")]
+    pub session_persistence: bool,
+
+    /// Auto-archive stale gateway sessions older than N hours. 0 = disabled. Default: 0.
+    #[serde(default)]
+    pub session_ttl_hours: u32,
 }
 
 fn default_gateway_port() -> u16 {
@@ -1530,6 +1539,8 @@ impl Default for GatewayConfig {
             rate_limit_max_keys: default_gateway_rate_limit_max_keys(),
             idempotency_ttl_secs: default_idempotency_ttl_secs(),
             idempotency_max_keys: default_gateway_idempotency_max_keys(),
+            session_persistence: true,
+            session_ttl_hours: 0,
         }
     }
 }
@@ -9388,10 +9399,14 @@ channel_id = "C123"
             rate_limit_max_keys: 2048,
             idempotency_ttl_secs: 600,
             idempotency_max_keys: 4096,
+            session_persistence: true,
+            session_ttl_hours: 0,
         };
         let toml_str = toml::to_string(&g).unwrap();
         let parsed: GatewayConfig = toml::from_str(&toml_str).unwrap();
         assert!(parsed.require_pairing);
+        assert!(parsed.session_persistence);
+        assert_eq!(parsed.session_ttl_hours, 0);
         assert!(!parsed.allow_public_bind);
         assert_eq!(parsed.paired_tokens, vec!["zc_test_token"]);
         assert_eq!(parsed.pair_rate_limit_per_minute, 12);

--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -1076,6 +1076,76 @@ fn hydrate_config_for_save(
     incoming
 }
 
+// ── Session API handlers ─────────────────────────────────────────
+
+/// GET /api/sessions — list gateway sessions
+pub async fn handle_api_sessions_list(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let Some(ref backend) = state.session_backend else {
+        return Json(serde_json::json!({
+            "sessions": [],
+            "message": "Session persistence is disabled"
+        }))
+        .into_response();
+    };
+
+    let all_metadata = backend.list_sessions_with_metadata();
+    let gw_sessions: Vec<serde_json::Value> = all_metadata
+        .into_iter()
+        .filter_map(|meta| {
+            let session_id = meta.key.strip_prefix("gw_")?;
+            Some(serde_json::json!({
+                "session_id": session_id,
+                "created_at": meta.created_at.to_rfc3339(),
+                "last_activity": meta.last_activity.to_rfc3339(),
+                "message_count": meta.message_count,
+            }))
+        })
+        .collect();
+
+    Json(serde_json::json!({ "sessions": gw_sessions })).into_response()
+}
+
+/// DELETE /api/sessions/{id} — delete a gateway session
+pub async fn handle_api_session_delete(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let Some(ref backend) = state.session_backend else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Session persistence is disabled"})),
+        )
+            .into_response();
+    };
+
+    let session_key = format!("gw_{id}");
+    match backend.delete_session(&session_key) {
+        Ok(true) => Json(serde_json::json!({"deleted": true, "session_id": id})).into_response(),
+        Ok(false) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Session not found"})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Failed to delete session: {e}")})),
+        )
+            .into_response(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -14,7 +14,8 @@ pub mod static_files;
 pub mod ws;
 
 use crate::channels::{
-    Channel, LinqChannel, NextcloudTalkChannel, SendMessage, WatiChannel, WhatsAppChannel,
+    session_backend::SessionBackend, session_sqlite::SqliteSessionBackend, Channel, LinqChannel,
+    NextcloudTalkChannel, SendMessage, WatiChannel, WhatsAppChannel,
 };
 use crate::config::Config;
 use crate::cost::CostTracker;
@@ -331,6 +332,8 @@ pub struct AppState {
     pub shutdown_tx: tokio::sync::watch::Sender<bool>,
     /// Registry of dynamically connected nodes
     pub node_registry: Arc<nodes::NodeRegistry>,
+    /// Session backend for persisting gateway WS chat sessions
+    pub session_backend: Option<Arc<dyn SessionBackend>>,
 }
 
 /// Run the HTTP gateway using axum with proper HTTP/1.1 compliance.
@@ -554,6 +557,29 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
             })
             .map(Arc::from);
 
+    // ── Session persistence for WS chat ─────────────────────
+    let session_backend: Option<Arc<dyn SessionBackend>> = if config.gateway.session_persistence {
+        match SqliteSessionBackend::new(&config.workspace_dir) {
+            Ok(b) => {
+                tracing::info!("Gateway session persistence enabled (SQLite)");
+                if config.gateway.session_ttl_hours > 0 {
+                    if let Ok(cleaned) = b.cleanup_stale(config.gateway.session_ttl_hours) {
+                        if cleaned > 0 {
+                            tracing::info!("Cleaned up {cleaned} stale gateway sessions");
+                        }
+                    }
+                }
+                Some(Arc::new(b))
+            }
+            Err(e) => {
+                tracing::warn!("Session persistence disabled: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     // ── Pairing guard ──────────────────────────────────────
     let pairing = Arc::new(PairingGuard::new(
         config.gateway.require_pairing,
@@ -681,6 +707,7 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         event_tx,
         shutdown_tx,
         node_registry,
+        session_backend,
     };
 
     // Config PUT needs larger body limit (1MB)
@@ -728,6 +755,8 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         .route("/api/cost", get(api::handle_api_cost))
         .route("/api/cli-tools", get(api::handle_api_cli_tools))
         .route("/api/health", get(api::handle_api_health))
+        .route("/api/sessions", get(api::handle_api_sessions_list))
+        .route("/api/sessions/{id}", delete(api::handle_api_session_delete))
         // ── SSE event stream ──
         .route("/api/events", get(sse::handle_sse_events))
         // ── WebSocket agent chat ──
@@ -1830,6 +1859,7 @@ mod tests {
             event_tx: tokio::sync::broadcast::channel(16).0,
             shutdown_tx: tokio::sync::watch::channel(false).0,
             node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            session_backend: None,
         };
 
         let response = handle_metrics(State(state)).await.into_response();
@@ -1882,6 +1912,7 @@ mod tests {
             event_tx: tokio::sync::broadcast::channel(16).0,
             shutdown_tx: tokio::sync::watch::channel(false).0,
             node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            session_backend: None,
         };
 
         let response = handle_metrics(State(state)).await.into_response();
@@ -2258,6 +2289,7 @@ mod tests {
             event_tx: tokio::sync::broadcast::channel(16).0,
             shutdown_tx: tokio::sync::watch::channel(false).0,
             node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            session_backend: None,
         };
 
         let mut headers = HeaderMap::new();
@@ -2324,6 +2356,7 @@ mod tests {
             event_tx: tokio::sync::broadcast::channel(16).0,
             shutdown_tx: tokio::sync::watch::channel(false).0,
             node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            session_backend: None,
         };
 
         let headers = HeaderMap::new();
@@ -2402,6 +2435,7 @@ mod tests {
             event_tx: tokio::sync::broadcast::channel(16).0,
             shutdown_tx: tokio::sync::watch::channel(false).0,
             node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            session_backend: None,
         };
 
         let response = handle_webhook(
@@ -2452,6 +2486,7 @@ mod tests {
             event_tx: tokio::sync::broadcast::channel(16).0,
             shutdown_tx: tokio::sync::watch::channel(false).0,
             node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            session_backend: None,
         };
 
         let mut headers = HeaderMap::new();
@@ -2507,6 +2542,7 @@ mod tests {
             event_tx: tokio::sync::broadcast::channel(16).0,
             shutdown_tx: tokio::sync::watch::channel(false).0,
             node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            session_backend: None,
         };
 
         let mut headers = HeaderMap::new();
@@ -2567,6 +2603,7 @@ mod tests {
             event_tx: tokio::sync::broadcast::channel(16).0,
             shutdown_tx: tokio::sync::watch::channel(false).0,
             node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            session_backend: None,
         };
 
         let response = Box::pin(handle_nextcloud_talk_webhook(
@@ -2623,6 +2660,7 @@ mod tests {
             event_tx: tokio::sync::broadcast::channel(16).0,
             shutdown_tx: tokio::sync::watch::channel(false).0,
             node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            session_backend: None,
         };
 
         let mut headers = HeaderMap::new();

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -111,13 +111,20 @@ pub async fn handle_ws_chat(
         ws
     };
 
-    let session_id = params.session_id.clone();
+    let session_id = params.session_id;
     ws.on_upgrade(move |socket| handle_socket(socket, state, session_id))
         .into_response()
 }
 
+/// Gateway session key prefix to avoid collisions with channel sessions.
+const GW_SESSION_PREFIX: &str = "gw_";
+
 async fn handle_socket(socket: WebSocket, state: AppState, session_id: Option<String>) {
     let (mut sender, mut receiver) = socket.split();
+
+    // Resolve session ID: use provided or generate a new UUID
+    let session_id = session_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    let session_key = format!("{GW_SESSION_PREFIX}{session_id}");
 
     // Build a persistent Agent for this connection so history is maintained across turns.
     let config = state.config.lock().clone();
@@ -129,7 +136,30 @@ async fn handle_socket(socket: WebSocket, state: AppState, session_id: Option<St
             return;
         }
     };
-    agent.set_memory_session_id(session_id.clone());
+    agent.set_memory_session_id(Some(session_id.clone()));
+
+    // Hydrate agent from persisted session (if available)
+    let mut resumed = false;
+    let mut message_count: usize = 0;
+    if let Some(ref backend) = state.session_backend {
+        let messages = backend.load(&session_key);
+        if !messages.is_empty() {
+            message_count = messages.len();
+            agent.seed_history(&messages);
+            resumed = true;
+        }
+    }
+
+    // Send session_start message to client
+    let session_start = serde_json::json!({
+        "type": "session_start",
+        "session_id": session_id,
+        "resumed": resumed,
+        "message_count": message_count,
+    });
+    let _ = sender
+        .send(Message::Text(session_start.to_string().into()))
+        .await;
 
     while let Some(msg) = receiver.next().await {
         let msg = match msg {
@@ -158,6 +188,12 @@ async fn handle_socket(socket: WebSocket, state: AppState, session_id: Option<St
             continue;
         }
 
+        // Persist user message
+        if let Some(ref backend) = state.session_backend {
+            let user_msg = crate::providers::ChatMessage::user(&content);
+            let _ = backend.append(&session_key, &user_msg);
+        }
+
         // Process message with the LLM provider
         let provider_label = state
             .config
@@ -176,6 +212,12 @@ async fn handle_socket(socket: WebSocket, state: AppState, session_id: Option<St
         // Multi-turn chat via persistent Agent (history is maintained across turns)
         match agent.turn(&content).await {
             Ok(response) => {
+                // Persist assistant response
+                if let Some(ref backend) = state.session_backend {
+                    let assistant_msg = crate::providers::ChatMessage::assistant(&response);
+                    let _ = backend.append(&session_key, &assistant_msg);
+                }
+
                 // Send the full response as a done message
                 let done = serde_json::json!({
                     "type": "done",


### PR DESCRIPTION
## Summary
- Wire existing `SessionBackend` (SQLite) into the gateway WS handler so chat sessions persist across restarts, macOS sleep/wake, and client reconnections
- Add `session_persistence` and `session_ttl_hours` config fields to `GatewayConfig`
- Add REST endpoints (`GET /api/sessions`, `DELETE /api/sessions/{id}`) for session management
- Bump version to `0.5.0`

## Changes
| File | Change | Risk |
|------|--------|------|
| `src/channels/session_backend.rs` | Add `delete_session()` default method | Low |
| `src/channels/session_sqlite.rs` | Implement `delete_session()` + 2 tests | Low |
| `src/config/schema.rs` | Add 2 fields to `GatewayConfig` | Low |
| `src/agent/agent.rs` | Add `seed_history()` method + test | Medium |
| `src/gateway/mod.rs` | Add `session_backend` to AppState, init, routes | Medium |
| `src/gateway/ws.rs` | Session resolve, hydrate, persist per turn | High |
| `src/gateway/api.rs` | 2 REST handlers for session list/delete | Medium |
| `Cargo.toml` | Version bump `0.4.3` → `0.5.0` | Low |

## WS Protocol (backward-compatible)
New server-initiated message after upgrade:
```json
{"type":"session_start","session_id":"abc-123","resumed":true,"message_count":14}
```
Old clients that don't handle `session_start` simply ignore it. Clients that want persistence store the `session_id` and pass it on reconnect via `?session_id=abc-123`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — all pass including 3 new tests
- [ ] Manual: connect via WS, send messages, disconnect, reconnect with same `session_id` → history restored
- [ ] Manual: kill gateway, restart, reconnect → history restored
- [ ] Manual: `GET /api/sessions` → session listed; `DELETE /api/sessions/{id}` → removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)