### PR TITLE
fix(ci): use pre-built binaries for Debian Docker image

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -330,6 +330,7 @@ jobs:
             > docker-ctx/zeroclaw-data/.zeroclaw/config.toml
 
           cp Dockerfile.ci docker-ctx/Dockerfile
+          cp Dockerfile.debian.ci docker-ctx/Dockerfile.debian
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -354,14 +355,12 @@ jobs:
       - name: Build and push Debian compatibility image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          context: .
-          file: Dockerfile.debian
+          context: docker-ctx
+          file: docker-ctx/Dockerfile.debian
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.version.outputs.tag }}-debian
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:beta-debian
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   # Tweet removed — only stable releases should tweet (see tweet-release.yml).

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -373,6 +373,7 @@ jobs:
             > docker-ctx/zeroclaw-data/.zeroclaw/config.toml
 
           cp Dockerfile.ci docker-ctx/Dockerfile
+          cp Dockerfile.debian.ci docker-ctx/Dockerfile.debian
 
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -397,15 +398,13 @@ jobs:
       - name: Build and push Debian compatibility image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          context: .
-          file: Dockerfile.debian
+          context: docker-ctx
+          file: docker-ctx/Dockerfile.debian
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.validate.outputs.tag }}-debian
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:debian
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   # ── Post-publish: package manager auto-sync ─────────────────────────
   scoop:

--- a/Dockerfile.debian.ci
+++ b/Dockerfile.debian.ci
@@ -1,0 +1,34 @@
+# Dockerfile.debian.ci — CI/release Debian image using pre-built binaries.
+# Mirrors Dockerfile.ci but uses debian:bookworm-slim with shell tools
+# so the agent can use shell-based tools (pwd, ls, git, curl, etc.).
+# Used by release workflows to skip ~60 min QEMU cross-compilation.
+
+# ── Runtime (Debian with shell) ────────────────────────────────
+FROM debian:bookworm-slim
+
+ARG TARGETARCH
+
+# Install essential tools for agent shell operations
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the pre-built binary for this platform (amd64 or arm64)
+COPY bin/${TARGETARCH}/zeroclaw /usr/local/bin/zeroclaw
+
+# Runtime directory structure and default config
+COPY --chown=65534:65534 zeroclaw-data/ /zeroclaw-data/
+
+ENV LANG=C.UTF-8
+ENV ZEROCLAW_WORKSPACE=/zeroclaw-data/workspace
+ENV HOME=/zeroclaw-data
+ENV ZEROCLAW_GATEWAY_PORT=42617
+
+WORKDIR /zeroclaw-data
+USER 65534:65534
+EXPOSE 42617
+ENTRYPOINT ["zeroclaw"]
+CMD ["gateway"]


### PR DESCRIPTION
## Summary
- The Debian compatibility Docker image (`*-debian` tags) was building from source with QEMU cross-compilation for ARM64, which is too slow for the 15-min timeout and was getting cancelled by the `cancel-in-progress` concurrency group
- Switch to using the same pre-built binaries as the distroless image, just with `debian:bookworm-slim` as the runtime base

## Changes
| File | Change | Risk |
|------|--------|------|
| `Dockerfile.debian.ci` | New file — mirrors `Dockerfile.ci` with Debian runtime + shell tools | Low |
| `.github/workflows/release-beta-on-push.yml` | Use `docker-ctx` context + `Dockerfile.debian` for Debian image | Low |
| `.github/workflows/release-stable-manual.yml` | Same fix for stable releases | Low |

## Root cause
The `Build and push Debian compatibility image` step used `context: .` with `Dockerfile.debian` which triggers a full Rust build inside Docker with QEMU for ARM64. This takes 30+ minutes and was getting cancelled by either the 15-min job timeout or the `cancel-in-progress: true` concurrency rule when a new push arrived.

## Test plan
- [x] `Dockerfile.debian.ci` syntax validated
- [ ] Merge and verify beta release pipeline completes with both `:beta` and `:beta-debian` tags pushed to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)