### PR TITLE
fix: normalize OpenAI Codex responses input payloads

### DIFF
--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -43,11 +43,20 @@ struct ResponsesRequest {
 #[derive(Debug, Serialize)]
 struct ResponsesInput {
     role: String,
-    content: Vec<ResponsesInputContent>,
+    content: ResponsesInputContent,
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    kind: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
-struct ResponsesInputContent {
+#[serde(untagged)]
+enum ResponsesInputContent {
+    Text(String),
+    Parts(Vec<ResponsesInputPart>),
+}
+
+#[derive(Debug, Serialize)]
+struct ResponsesInputPart {
     #[serde(rename = "type")]
     kind: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -113,6 +122,36 @@ impl OpenAiCodexProvider {
                 .build()
                 .unwrap_or_else(|_| Client::new()),
         })
+    }
+}
+
+impl ResponsesInput {
+    fn user_text(content: String) -> Self {
+        Self {
+            role: "user".to_string(),
+            content: ResponsesInputContent::Text(content),
+            kind: None,
+        }
+    }
+
+    fn user_parts(parts: Vec<ResponsesInputPart>) -> Self {
+        Self {
+            role: "user".to_string(),
+            content: ResponsesInputContent::Parts(parts),
+            kind: Some("message".to_string()),
+        }
+    }
+
+    fn assistant_output_text(content: String) -> Self {
+        Self {
+            role: "assistant".to_string(),
+            content: ResponsesInputContent::Parts(vec![ResponsesInputPart {
+                kind: "output_text".to_string(),
+                text: Some(content),
+                image_url: None,
+            }]),
+            kind: Some("message".to_string()),
+        }
     }
 }
 
@@ -220,11 +259,16 @@ fn build_responses_input(messages: &[ChatMessage]) -> (String, Vec<ResponsesInpu
             "user" => {
                 let (cleaned_text, image_refs) = multimodal::parse_image_markers(&msg.content);
 
+                if image_refs.is_empty() {
+                    input.push(ResponsesInput::user_text(cleaned_text));
+                    continue;
+                }
+
                 let mut content_items = Vec::new();
 
                 // Add text if present
                 if !cleaned_text.trim().is_empty() {
-                    content_items.push(ResponsesInputContent {
+                    content_items.push(ResponsesInputPart {
                         kind: "input_text".to_string(),
                         text: Some(cleaned_text),
                         image_url: None,
@@ -233,7 +277,7 @@ fn build_responses_input(messages: &[ChatMessage]) -> (String, Vec<ResponsesInpu
 
                 // Add images
                 for image_ref in image_refs {
-                    content_items.push(ResponsesInputContent {
+                    content_items.push(ResponsesInputPart {
                         kind: "input_image".to_string(),
                         text: None,
                         image_url: Some(image_ref),
@@ -242,27 +286,17 @@ fn build_responses_input(messages: &[ChatMessage]) -> (String, Vec<ResponsesInpu
 
                 // If no content at all, add empty text
                 if content_items.is_empty() {
-                    content_items.push(ResponsesInputContent {
+                    content_items.push(ResponsesInputPart {
                         kind: "input_text".to_string(),
                         text: Some(String::new()),
                         image_url: None,
                     });
                 }
 
-                input.push(ResponsesInput {
-                    role: "user".to_string(),
-                    content: content_items,
-                });
+                input.push(ResponsesInput::user_parts(content_items));
             }
             "assistant" => {
-                input.push(ResponsesInput {
-                    role: "assistant".to_string(),
-                    content: vec![ResponsesInputContent {
-                        kind: "output_text".to_string(),
-                        text: Some(msg.content.clone()),
-                        image_url: None,
-                    }],
-                });
+                input.push(ResponsesInput::assistant_output_text(msg.content.clone()));
             }
             _ => {}
         }
@@ -1044,11 +1078,14 @@ data: [DONE]
             .map(|item| serde_json::to_value(item).unwrap())
             .collect();
         assert_eq!(json[0]["role"], "user");
-        assert_eq!(json[0]["content"][0]["type"], "input_text");
+        assert!(json[0].get("type").is_none());
+        assert_eq!(json[0]["content"], "Hi");
         assert_eq!(json[1]["role"], "assistant");
+        assert_eq!(json[1]["type"], "message");
         assert_eq!(json[1]["content"][0]["type"], "output_text");
         assert_eq!(json[2]["role"], "user");
-        assert_eq!(json[2]["content"][0]["type"], "input_text");
+        assert!(json[2].get("type").is_none());
+        assert_eq!(json[2]["content"], "Thanks");
     }
 
     #[test]
@@ -1060,6 +1097,9 @@ data: [DONE]
         let (instructions, input) = build_responses_input(&messages);
         assert_eq!(instructions, DEFAULT_CODEX_INSTRUCTIONS);
         assert_eq!(input.len(), 1);
+        let json = serde_json::to_value(&input[0]).unwrap();
+        assert!(json.get("type").is_none());
+        assert_eq!(json["content"], "Hello");
     }
 
     #[test]
@@ -1079,6 +1119,8 @@ data: [DONE]
         assert_eq!(input.len(), 1);
         let json = serde_json::to_value(&input[0]).unwrap();
         assert_eq!(json["role"], "user");
+        assert!(json.get("type").is_none());
+        assert_eq!(json["content"], "Go");
     }
 
     #[test]
@@ -1089,14 +1131,11 @@ data: [DONE]
         let (_, input) = build_responses_input(&messages);
 
         assert_eq!(input.len(), 1);
-        assert_eq!(input[0].role, "user");
-        assert_eq!(input[0].content.len(), 2);
-
-        let json: Vec<Value> = input[0]
-            .content
-            .iter()
-            .map(|item| serde_json::to_value(item).unwrap())
-            .collect();
+        let item = serde_json::to_value(&input[0]).unwrap();
+        assert_eq!(item["role"], "user");
+        assert_eq!(item["type"], "message");
+        let json = item["content"].as_array().unwrap();
+        assert_eq!(json.len(), 2);
 
         // First content = text
         assert_eq!(json[0]["type"], "input_text");
@@ -1113,11 +1152,9 @@ data: [DONE]
         let (_, input) = build_responses_input(&messages);
 
         assert_eq!(input.len(), 1);
-        assert_eq!(input[0].content.len(), 1);
-
-        let json = serde_json::to_value(&input[0].content[0]).unwrap();
-        assert_eq!(json["type"], "input_text");
-        assert_eq!(json["text"], "Hello without images");
+        let item = serde_json::to_value(&input[0]).unwrap();
+        assert!(item.get("type").is_none());
+        assert_eq!(item["content"], "Hello without images");
     }
 
     #[test]
@@ -1128,13 +1165,9 @@ data: [DONE]
         let (_, input) = build_responses_input(&messages);
 
         assert_eq!(input.len(), 1);
-        assert_eq!(input[0].content.len(), 3); // text + 2 images
-
-        let json: Vec<Value> = input[0]
-            .content
-            .iter()
-            .map(|item| serde_json::to_value(item).unwrap())
-            .collect();
+        let item = serde_json::to_value(&input[0]).unwrap();
+        let json = item["content"].as_array().unwrap();
+        assert_eq!(json.len(), 3); // text + 2 images
 
         assert_eq!(json[0]["type"], "input_text");
         assert_eq!(json[1]["type"], "input_image");


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: the `openai-codex` provider was emitting a mixed Responses API payload shape that triggered `400 Bad Request` with `Cannot determine type of 'item'` for Codex-backed turns.
- Why it matters: Codex-configured agents fail even after auth succeeds, so provider routing appears broken when the real issue is request serialization.
- What changed: normalized `src/providers/openai_codex.rs` input serialization so plain user text emits string content, multimodal user turns emit typed message parts, and assistant history emits typed output text parts.
- What did **not** change (scope boundary): no gateway/channel/delegate/runtime reload behavior changes; no auth flow changes; no config schema changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S` requested
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `provider`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `provider: openai-codex`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: please label as `risk: medium`, `provider`, `provider: openai-codex`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `provider`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N.A.
- Integrated scope by source PR (what was materially carried forward): N.A.
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N.A.
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N.A.
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N.A.

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo test build_responses_input --lib --offline
cargo test decode_utf8_stream_chunks_handles_multibyte_split_across_chunks --lib --offline
```

- Evidence provided (test/log/trace/screenshot/perf): local unit-test output for the affected serializer paths and stream decoder path.
- If any command is intentionally skipped, explain why: `cargo clippy --all-targets -- -D warnings` and full `cargo test` were skipped for this draft because this PR is scoped to one provider file and the immediate goal is to validate/fix the Codex payload shape before running the heavier full-repo gates.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N.A.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no secrets or user data added; examples use synthetic content only.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N.A.

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N.A.
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N.A.
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N.A.
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: provider-internal change only.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: plain text user messages, assistant history messages, multimodal user messages with image markers, and UTF-8 stream chunk decoding tests all pass.
- Edge cases checked: text-only user turns now serialize without an ambiguous item `type`; multimodal turns still emit typed parts.
- What was not verified: live end-to-end Codex API calls after this patch are not yet included in this draft.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `openai-codex` provider request serialization only.
- Potential unintended effects: if the Codex backend expects a different historical-assistant item shape than assumed here, some conversation-history paths may still need follow-up.
- Guardrails/monitoring for early detection: targeted unit tests cover the serializer branches touched in this patch.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local shell, git, targeted cargo tests.
- Workflow/plan summary (if any): isolated the Codex serialization change from the config-reload branch, replayed only the provider patch on a fresh branch from `master`, and validated the changed serializer paths.
- Verification focus: request payload shape for Codex Responses API inputs.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert commit `584d802` or close the PR without merge.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: Codex-backed agents continue returning `400 Bad Request` with `Cannot determine type of 'item'`.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: the patched payload shape may fix plain text turns but still miss a live Codex edge case not covered by the existing unit tests.
  - Mitigation: PR is opened as draft; follow-up should include a live Codex smoke test before merge.
