### PR TITLE
fix(web): display pairing code in dashboard

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,7 @@ import Pairing from './pages/Pairing';
 import { AuthProvider, useAuth } from './hooks/useAuth';
 import { DraftContext, useDraftStore } from './hooks/useDraft';
 import { setLocale, type Locale } from './lib/i18n';
+import { getAdminPairCode } from './lib/api';
 
 // Locale context
 interface LocaleContextType {
@@ -89,6 +90,26 @@ function PairingDialog({ onPair }: { onPair: (code: string) => Promise<void> }) 
   const [code, setCode] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [displayCode, setDisplayCode] = useState<string | null>(null);
+  const [codeLoading, setCodeLoading] = useState(true);
+
+  // Fetch the current pairing code from the admin endpoint (localhost only)
+  useEffect(() => {
+    let cancelled = false;
+    getAdminPairCode()
+      .then((data) => {
+        if (!cancelled && data.pairing_code) {
+          setDisplayCode(data.pairing_code);
+        }
+      })
+      .catch(() => {
+        // Admin endpoint not reachable (non-localhost) — user must check terminal
+      })
+      .finally(() => {
+        if (!cancelled) setCodeLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -120,8 +141,23 @@ function PairingDialog({ onPair }: { onPair: (code: string) => Promise<void> }) 
             style={{ boxShadow: '0 0 30px rgba(0,128,255,0.3)' }}
           />
           <h1 className="text-2xl font-bold text-gradient-blue mb-2">ZeroClaw</h1>
-          <p className="text-[#556080] text-sm">Enter the pairing code from your terminal</p>
+          {displayCode ? (
+            <p className="text-[#556080] text-sm">Your pairing code</p>
+          ) : (
+            <p className="text-[#556080] text-sm">Enter the pairing code from your terminal</p>
+          )}
         </div>
+
+        {/* Show the pairing code if available (localhost) */}
+        {!codeLoading && displayCode && (
+          <div className="mb-6 p-4 rounded-xl text-center" style={{ background: 'rgba(0,128,255,0.08)', border: '1px solid rgba(0,128,255,0.2)' }}>
+            <div className="text-4xl font-mono font-bold tracking-[0.4em] text-white py-2">
+              {displayCode}
+            </div>
+            <p className="text-[#556080] text-xs mt-2">Enter this code below or on another device</p>
+          </div>
+        )}
+
         <form onSubmit={handleSubmit}>
           <input
             type="text"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -93,6 +93,14 @@ export async function pair(code: string): Promise<{ token: string }> {
   return data;
 }
 
+export async function getAdminPairCode(): Promise<{ pairing_code: string | null; pairing_required: boolean }> {
+  const response = await fetch('/admin/paircode');
+  if (!response.ok) {
+    throw new Error(`Failed to fetch pairing code (${response.status})`);
+  }
+  return response.json() as Promise<{ pairing_code: string | null; pairing_required: boolean }>;
+}
+
 // ---------------------------------------------------------------------------
 // Public health (no auth required)
 // ---------------------------------------------------------------------------

--- a/web/src/pages/Pairing.tsx
+++ b/web/src/pages/Pairing.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { getAdminPairCode } from '../lib/api';
 
 interface Device {
   id: string;
@@ -32,6 +33,19 @@ export default function Pairing() {
       setLoading(false);
     }
   }, [token]);
+
+  // Fetch the current pairing code on mount (if one is active)
+  useEffect(() => {
+    getAdminPairCode()
+      .then((data) => {
+        if (data.pairing_code) {
+          setPairingCode(data.pairing_code);
+        }
+      })
+      .catch(() => {
+        // Admin endpoint not reachable — code will show after clicking "Pair New Device"
+      });
+  }, []);
 
   useEffect(() => {
     fetchDevices();


### PR DESCRIPTION
## Summary
- Fetch pairing code from `GET /admin/paircode` (localhost-only) and display it in the web UI
- Initial pairing dialog now shows the 6-digit code directly instead of requiring users to check the terminal
- Pairing management page (`/pairing`) also loads the current active code on mount
- Graceful fallback: if admin endpoint is unreachable (non-localhost), shows the original "check your terminal" prompt

## Risk
**Medium** — touches `src/gateway/` frontend (web dashboard), no Rust backend changes.

## Test plan
- [x] `cargo fmt` / `cargo clippy` / `cargo test` — all pass
- [x] `npm run build` — web frontend builds cleanly
- [ ] Manual: start gateway, open `/_app/`, verify pairing code is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)