### PR TITLE
fix(telegram): respect ack_reactions configuration for telegram channel

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3194,7 +3194,11 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 )
                 .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
                 .with_transcription(config.transcription.clone())
-                .with_workspace_dir(config.workspace_dir.clone()),
+                .with_workspace_dir(config.workspace_dir.clone())
+                .with_ack_reactions(
+                    tg.ack_reactions
+                        .unwrap_or(config.channels_config.ack_reactions),
+                ),
             ))
         }
         "discord" => {
@@ -3289,7 +3293,11 @@ fn collect_configured_channels(
                 )
                 .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
                 .with_transcription(config.transcription.clone())
-                .with_workspace_dir(config.workspace_dir.clone()),
+                .with_workspace_dir(config.workspace_dir.clone())
+                .with_ack_reactions(
+                    tg.ack_reactions
+                        .unwrap_or(config.channels_config.ack_reactions),
+                ),
             ),
         });
     }
@@ -8624,6 +8632,8 @@ This is an example JSON object for profile settings."#;
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
+
+            ack_reactions: None,
         });
         match build_channel_by_id(&config, "telegram") {
             Ok(channel) => assert_eq!(channel.name(), "telegram"),

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -332,6 +332,7 @@ pub struct TelegramChannel {
     transcription: Option<crate::config::TranscriptionConfig>,
     voice_transcriptions: Mutex<std::collections::HashMap<String, String>>,
     workspace_dir: Option<std::path::PathBuf>,
+    ack_reactions: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -370,12 +371,19 @@ impl TelegramChannel {
             transcription: None,
             voice_transcriptions: Mutex::new(std::collections::HashMap::new()),
             workspace_dir: None,
+            ack_reactions: true,
         }
     }
 
     /// Configure workspace directory for saving downloaded attachments.
     pub fn with_workspace_dir(mut self, dir: std::path::PathBuf) -> Self {
         self.workspace_dir = Some(dir);
+        self
+    }
+
+    /// Configure whether to send acknowledgement reactions.
+    pub fn with_ack_reactions(mut self, ack_reactions: bool) -> Self {
+        self.ack_reactions = ack_reactions;
         self
     }
 
@@ -428,6 +436,9 @@ impl TelegramChannel {
     }
 
     fn try_add_ack_reaction_nonblocking(&self, chat_id: String, message_id: i64) {
+        if !self.ack_reactions {
+            return;
+        }
         let client = self.http_client();
         let url = self.api_url("setMessageReaction");
         let emoji = random_telegram_ack_reaction().to_string();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -55,6 +55,8 @@ mod tests {
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
+
+            ack_reactions: None,
         };
 
         let discord = DiscordConfig {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4511,6 +4511,10 @@ pub struct TelegramConfig {
     /// Direct messages are always processed.
     #[serde(default)]
     pub mention_only: bool,
+    /// Whether to send acknowledgement reactions (👀, ✅, ⚠️).
+    /// If omitted, falls back to the top-level `channels_config.ack_reactions`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ack_reactions: Option<bool>,
 }
 
 impl ChannelConfig for TelegramConfig {
@@ -8360,6 +8364,8 @@ default_temperature = 0.7
                     draft_update_interval_ms: default_draft_update_interval_ms(),
                     interrupt_on_new_message: false,
                     mention_only: false,
+
+                    ack_reactions: None,
                 }),
                 discord: None,
                 slack: None,
@@ -8942,6 +8948,8 @@ tool_dispatcher = "xml"
             draft_update_interval_ms: 500,
             interrupt_on_new_message: true,
             mention_only: false,
+
+            ack_reactions: None,
         };
         let json = serde_json::to_string(&tc).unwrap();
         let parsed: TelegramConfig = serde_json::from_str(&json).unwrap();
@@ -11256,6 +11264,8 @@ require_otp_to_resume = true
             draft_update_interval_ms: default_draft_update_interval_ms(),
             interrupt_on_new_message: false,
             mention_only: false,
+
+            ack_reactions: None,
         });
 
         // Save (triggers encryption)

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -642,6 +642,8 @@ mod tests {
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
+
+            ack_reactions: None,
         });
         assert!(has_supervised_channels(&config));
     }
@@ -755,6 +757,8 @@ mod tests {
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
+
+            ack_reactions: None,
         });
 
         let target = resolve_heartbeat_delivery(&config).unwrap();
@@ -771,6 +775,8 @@ mod tests {
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
+
+            ack_reactions: None,
         });
 
         let target = resolve_heartbeat_delivery(&config).unwrap();

--- a/src/integrations/registry.rs
+++ b/src/integrations/registry.rs
@@ -840,6 +840,8 @@ mod tests {
             draft_update_interval_ms: 1000,
             interrupt_on_new_message: false,
             mention_only: false,
+
+            ack_reactions: None,
         });
         let entries = all_integrations();
         let tg = entries.iter().find(|e| e.name == "Telegram").unwrap();

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -3683,6 +3683,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     draft_update_interval_ms: 1000,
                     interrupt_on_new_message: false,
                     mention_only: false,
+                    ack_reactions: None,
                 });
             }
             ChannelMenuChoice::Discord => {


### PR DESCRIPTION
Closes #3834

![Screenshot_20260317_233252_Nagram X.jpg](https://github.com/user-attachments/assets/e2c26d14-1853-4591-8bf7-d9236786908e)



### Description
This PR fixes an issue where the `ack_reactions` setting was either silently ignored or threw an "unknown config key" warning when applied to the Telegram channel.

### Changes Made
- Added `ack_reactions: Option<bool>` to `TelegramConfig` in `src/config/schema.rs` to allow users to override the global setting specifically for Telegram, while avoiding the "Unknown config key ignored" warning.
- Updated `try_add_ack_reaction_nonblocking` in `src/channels/telegram.rs` to check the `ack_reactions` flag and exit early if it is disabled.
- Modified `build_channel_by_id` and `collect_configured_channels` in `src/channels/mod.rs` to correctly pass the configuration value (falling back to the global `channels_config.ack_reactions` if the Telegram-specific one is omitted) into `TelegramChannel::new()`.
- Updated `src/onboard/wizard.rs` to reflect the new struct field.