### PR TITLE
fix(docker): remove firmware/ COPY and drop crates/robot-kit from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -65,9 +65,8 @@ LICENSE
 coverage
 lcov.info
 
-# Firmware and hardware crates (not needed for Docker runtime)
+# Firmware (not a Cargo workspace member, not needed for Docker runtime)
 firmware/
-crates/robot-kit/
 
 # Application and script directories (not needed for Docker runtime)
 apps/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ RUN rm -rf src benches crates/robot-kit/src
 COPY src/ src/
 COPY benches/ benches/
 COPY crates/ crates/
-COPY firmware/ firmware/
 COPY --from=web-builder /web/dist web/dist
 COPY *.rs .
 RUN touch src/main.rs

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -59,7 +59,6 @@ RUN rm -rf src benches crates/robot-kit/src
 COPY src/ src/
 COPY benches/ benches/
 COPY crates/ crates/
-COPY firmware/ firmware/
 COPY --from=web-builder /web/dist web/dist
 RUN touch src/main.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Two conflicts between `.dockerignore` and the Dockerfiles caused `docker build .` to fail with COPY errors 100% of the time. `crates/robot-kit/` was excluded from the build context but `COPY crates/robot-kit/Cargo.toml` ran in the manifest-caching step; separately, `COPY firmware/ firmware/` ran in the source-copy step but `firmware/` is (correctly) excluded by `.dockerignore`.
- Why it matters: Anyone attempting to build a Docker image from source gets a hard failure before Rust even starts compiling. Severity is S1 — workflow completely blocked.
- What changed: Removed `crates/robot-kit/` from `.dockerignore` (it is a Cargo workspace member and must be in the build context); removed `COPY firmware/ firmware/` from both `Dockerfile` and `Dockerfile.debian` (firmware is not a workspace member, not needed at compile time, and is correctly excluded by `.dockerignore`).
- What did **not** change: No Rust source, no config schema, no runtime behaviour, no CI workflow files. `firmware/` remains excluded from the image. `crates/robot-kit/` source is still excluded at the `rm -rf` step inside the Dockerfile; only `Cargo.toml` is needed for the manifest-caching pre-build.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS` (4 lines deleted, 1 line edited — 5 non-doc lines net)
- Scope labels: `ci`
- Module labels: `tool: docker`
- Contributor tier label: auto-managed/read-only
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `ci`

## Linked Issue

- Closes #3836

## Supersede Attribution (required when `Supersedes #` is used)

N/A — no superseded PRs.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # PASS
cargo clippy --all-targets -- -D warnings   # PASS (2m 35s, zero warnings in owned code)
cargo test   # SKIPPED — see note below
```

- `cargo fmt`: pass
- `cargo clippy`: pass — finished cleanly, zero diagnostic errors in owned code
- `cargo test`: OOM-killed at link step on this 7.5 GiB machine (swap exhausted). The patch touches **zero Rust source files** (only `.dockerignore`, `Dockerfile`, `Dockerfile.debian`), so the test suite is not a meaningful gate for correctness here. The fix was manually verified against the exact COPY error reported in the issue by inspecting the Dockerfile layer order and `.dockerignore` rules.
- Evidence: clippy clean exit logged above; fmt exit 0.
- If any command is intentionally skipped, explain why: `cargo test` OOM-killed due to insufficient RAM on this dev machine — not a code regression, patch contains no Rust changes.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: no user data, no identifiers, no PII in any changed file
- Neutral wording confirmation: all wording is project-native

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No — no docs or user-facing wording changed.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Traced the Dockerfile layer order step-by-step against the `.dockerignore` rule set. Confirmed `crates/robot-kit/` appears in `workspace.members` in `Cargo.toml` (so it must be in context for manifest-caching). Confirmed `firmware/` is not a workspace member and is not referenced anywhere the compiler needs it.
- Edge cases checked: Verified that removing `COPY firmware/ firmware/` does not break subsequent Dockerfile steps — no later layer references `firmware/` as an input.
- What was not verified: Actual end-to-end `docker build` on a machine with sufficient RAM/bandwidth to pull base images.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Docker image builds only.
- Potential unintended effects: None — `firmware/` content is not compiled into the binary; `robot-kit/src` is still deleted by the `RUN rm -rf` step inside the builder before source is copied, preserving the intent of the original structure.
- Guardrails/monitoring for early detection: The existing CI Docker build job (if enabled) will catch any regression.

## Agent Collaboration Notes (recommended)

- Agent tools used: Zed AI assistant (Claude Sonnet 4.6) for issue triage, root cause analysis, patch authoring, and PR drafting.
- Workflow/plan summary: Read triage log → fetched open issues → selected #3836 → read full Dockerfile + .dockerignore → identified two independent root causes → applied minimal patch (3 files, 5 lines net) → ran fmt/clippy → opened PR.
- Verification focus: Dockerfile layer ordering and `.dockerignore` exclusion semantics; workspace membership of `crates/robot-kit`.
- Confirmation: naming + architecture boundaries followed per `CLAUDE.md`.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 23c2b15c` — restores all three files atomically.
- Feature flags or config toggles: None.
- Observable failure symptoms: `ERROR [builder N/18] COPY crates/robot-kit/Cargo.toml` or `ERROR [builder N/18] COPY firmware/ firmware/` in `docker build` output.

## Risks and Mitigations

- Risk: Removing `COPY firmware/ firmware/` could silently break a future Dockerfile that re-adds a firmware compilation step without updating `.dockerignore`.
  - Mitigation: The `.dockerignore` entry for `firmware/` remains and will produce a clear COPY error immediately if that path is re-added to a Dockerfile, making the conflict visible rather than silent.
