### PR TITLE
fix: prevent Python shebang false positive in skill audit

### DIFF
--- a/src/skills/audit.rs
+++ b/src/skills/audit.rs
@@ -408,14 +408,30 @@ fn has_shell_shebang(path: &Path) -> bool {
     let Ok(content) = fs::read(path) else {
         return false;
     };
-    let prefix = &content[..content.len().min(128)];
+    let prefix = &content[..content.len().min(512)]; // Read more to get full first line
     let shebang = String::from_utf8_lossy(prefix).to_ascii_lowercase();
-    shebang.starts_with("#!")
-        && (shebang.contains("sh")
-            || shebang.contains("bash")
-            || shebang.contains("zsh")
-            || shebang.contains("pwsh")
-            || shebang.contains("powershell"))
+    
+    // Extract just the first line (the shebang line)
+    let first_line = shebang.lines().next().unwrap_or("");
+    
+    if !first_line.starts_with("#!") {
+        return false;
+    }
+    
+    // If the shebang points to a Python interpreter, it's not a shell script
+    // This prevents false positives like Python files containing "refresh" (has "sh")
+    if first_line.contains("python") || first_line.contains("pypy") || first_line.contains("jython") {
+        return false;
+    }
+    
+    // Check for shell interpreters in the shebang line itself
+    first_line.contains("sh")
+        || first_line.contains("bash")
+        || first_line.contains("zsh")
+        || first_line.contains("ksh")
+        || first_line.contains("fish")
+        || first_line.contains("pwsh")
+        || first_line.contains("powershell")
 }
 
 fn extract_markdown_links(content: &str) -> Vec<String> {


### PR DESCRIPTION
## Summary

The skill security audit was incorrectly blocking Python files that contained text like 'refresh' because it did a broad substring match for 'sh' across the first 128 bytes.

## Changes

This fix:
- Extracts only the shebang line (first line) instead of checking the first 128 bytes
- Excludes Python interpreters (python, python3, pypy, jython) from shell script detection  
- Checks for shell interpreters only in the shebang line itself

## Fixes

Fixes: zeroclaw-labs/zeroclaw#3851