### PR TITLE
Fix Docker builds failing due to .dockerignore conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # 1. Copy manifests to cache dependencies
 COPY Cargo.toml Cargo.lock ./
-COPY crates/robot-kit/Cargo.toml crates/robot-kit/Cargo.toml
+# Remove robot-kit from workspace members — it is excluded by .dockerignore
+# and is not needed for the Docker build (hardware-only crate).
+RUN sed -i 's/members = \[".", "crates\/robot-kit"\]/members = ["."]/' Cargo.toml
 # Create dummy targets declared in Cargo.toml so manifest parsing succeeds.
-RUN mkdir -p src benches crates/robot-kit/src \
+RUN mkdir -p src benches \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
-    && echo "fn main() {}" > benches/agent_benchmarks.rs \
-    && echo "pub fn placeholder() {}" > crates/robot-kit/src/lib.rs
+    && echo "fn main() {}" > benches/agent_benchmarks.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
@@ -38,13 +39,11 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     else \
       cargo build --release --locked; \
     fi
-RUN rm -rf src benches crates/robot-kit/src
+RUN rm -rf src benches
 
 # 2. Copy only build-relevant source paths (avoid cache-busting on docs/tests/scripts)
 COPY src/ src/
 COPY benches/ benches/
-COPY crates/ crates/
-COPY firmware/ firmware/
 COPY --from=web-builder /web/dist web/dist
 COPY *.rs .
 RUN touch src/main.rs

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -38,13 +38,14 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # 1. Copy manifests to cache dependencies
 COPY Cargo.toml Cargo.lock ./
-COPY crates/robot-kit/Cargo.toml crates/robot-kit/Cargo.toml
+# Remove robot-kit from workspace members — it is excluded by .dockerignore
+# and is not needed for the Docker build (hardware-only crate).
+RUN sed -i 's/members = \[".", "crates\/robot-kit"\]/members = ["."]/' Cargo.toml
 # Create dummy targets declared in Cargo.toml so manifest parsing succeeds.
-RUN mkdir -p src benches crates/robot-kit/src \
+RUN mkdir -p src benches \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
-    && echo "fn main() {}" > benches/agent_benchmarks.rs \
-    && echo "pub fn placeholder() {}" > crates/robot-kit/src/lib.rs
+    && echo "fn main() {}" > benches/agent_benchmarks.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
@@ -53,13 +54,11 @@ RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/regist
     else \
       cargo build --release --locked; \
     fi
-RUN rm -rf src benches crates/robot-kit/src
+RUN rm -rf src benches
 
 # 2. Copy only build-relevant source paths (avoid cache-busting on docs/tests/scripts)
 COPY src/ src/
 COPY benches/ benches/
-COPY crates/ crates/
-COPY firmware/ firmware/
 COPY --from=web-builder /web/dist web/dist
 RUN touch src/main.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \


### PR DESCRIPTION
## Summary
- Fixes #3836
- Removed COPY commands for `firmware/` and `crates/robot-kit/` from both `Dockerfile` and `Dockerfile.debian` since these paths are excluded by `.dockerignore`
- Added `sed` command to strip `crates/robot-kit` from workspace members in the copied `Cargo.toml` so Cargo doesn't try to resolve the missing member

## Test plan
- [ ] `docker build .` succeeds without COPY errors
- [ ] `docker build -f Dockerfile.debian .` succeeds
- [ ] Built image runs correctly (zeroclaw binary starts)
- [ ] CI/CD pipeline passes