### PR TITLE
Fix route-specific api_key dropped in Channel mode

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -227,6 +227,10 @@ fn channel_message_timeout_budget_secs(
 struct ChannelRouteSelection {
     provider: String,
     model: String,
+    /// Route-specific API key override. When set, this takes precedence over
+    /// the global `api_key` in [`ChannelRuntimeContext`] when creating the
+    /// provider for this route.
+    api_key: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -904,6 +908,7 @@ fn default_route_selection(ctx: &ChannelRuntimeContext) -> ChannelRouteSelection
     ChannelRouteSelection {
         provider: defaults.default_provider,
         model: defaults.model,
+        api_key: None,
     }
 }
 
@@ -1122,21 +1127,43 @@ fn load_cached_model_preview(workspace_dir: &Path, provider_name: &str) -> Vec<S
         .unwrap_or_default()
 }
 
+/// Build a cache key that includes the provider name and, when a
+/// route-specific API key is supplied, a hash of that key. This prevents
+/// cache poisoning when multiple routes target the same provider with
+/// different credentials.
+fn provider_cache_key(provider_name: &str, route_api_key: Option<&str>) -> String {
+    match route_api_key {
+        Some(key) => {
+            use std::hash::{Hash, Hasher};
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            key.hash(&mut hasher);
+            format!("{provider_name}@{:x}", hasher.finish())
+        }
+        None => provider_name.to_string(),
+    }
+}
+
 async fn get_or_create_provider(
     ctx: &ChannelRuntimeContext,
     provider_name: &str,
+    route_api_key: Option<&str>,
 ) -> anyhow::Result<Arc<dyn Provider>> {
+    let cache_key = provider_cache_key(provider_name, route_api_key);
+
     if let Some(existing) = ctx
         .provider_cache
         .lock()
         .unwrap_or_else(|e| e.into_inner())
-        .get(provider_name)
+        .get(&cache_key)
         .cloned()
     {
         return Ok(existing);
     }
 
-    if provider_name == ctx.default_provider.as_str() {
+    // Only return the pre-built default provider when there is no
+    // route-specific credential override — otherwise the default was
+    // created with the global key and would be wrong.
+    if route_api_key.is_none() && provider_name == ctx.default_provider.as_str() {
         return Ok(Arc::clone(&ctx.provider));
     }
 
@@ -1147,9 +1174,14 @@ async fn get_or_create_provider(
         None
     };
 
+    // Prefer route-specific credential; fall back to the global key.
+    let effective_api_key = route_api_key
+        .map(ToString::to_string)
+        .or_else(|| ctx.api_key.clone());
+
     let provider = create_resilient_provider_nonblocking(
         provider_name,
-        ctx.api_key.clone(),
+        effective_api_key,
         api_url.map(ToString::to_string),
         ctx.reliability.as_ref().clone(),
         ctx.provider_runtime_options.clone(),
@@ -1163,7 +1195,7 @@ async fn get_or_create_provider(
 
     let mut cache = ctx.provider_cache.lock().unwrap_or_else(|e| e.into_inner());
     let cached = cache
-        .entry(provider_name.to_string())
+        .entry(cache_key)
         .or_insert_with(|| Arc::clone(&provider));
     Ok(Arc::clone(cached))
 }
@@ -1279,25 +1311,27 @@ async fn handle_runtime_command_if_needed(
         ChannelRuntimeCommand::ShowProviders => build_providers_help_response(&current),
         ChannelRuntimeCommand::SetProvider(raw_provider) => {
             match resolve_provider_alias(&raw_provider) {
-                Some(provider_name) => match get_or_create_provider(ctx, &provider_name).await {
-                    Ok(_) => {
-                        if provider_name != current.provider {
-                            current.provider = provider_name.clone();
-                            set_route_selection(ctx, &sender_key, current.clone());
-                        }
+                Some(provider_name) => {
+                    match get_or_create_provider(ctx, &provider_name, None).await {
+                        Ok(_) => {
+                            if provider_name != current.provider {
+                                current.provider = provider_name.clone();
+                                set_route_selection(ctx, &sender_key, current.clone());
+                            }
 
-                        format!(
+                            format!(
                             "Provider switched to `{provider_name}` for this sender session. Current model is `{}`.\nUse `/model <model-id>` to set a provider-compatible model.",
                             current.model
                         )
-                    }
-                    Err(err) => {
-                        let safe_err = providers::sanitize_api_error(&err.to_string());
-                        format!(
+                        }
+                        Err(err) => {
+                            let safe_err = providers::sanitize_api_error(&err.to_string());
+                            format!(
                             "Failed to initialize provider `{provider_name}`. Route unchanged.\nDetails: {safe_err}"
                         )
+                        }
                     }
-                },
+                }
                 None => format!(
                     "Unknown provider `{raw_provider}`. Use `/models` to list valid providers."
                 ),
@@ -1317,6 +1351,7 @@ async fn handle_runtime_command_if_needed(
                 }) {
                     current.provider = route.provider.clone();
                     current.model = route.model.clone();
+                    current.api_key = route.api_key.clone();
                 } else {
                     current.model = model.clone();
                 }
@@ -1922,12 +1957,19 @@ async fn process_channel_message(
             route = ChannelRouteSelection {
                 provider: matched_route.provider.clone(),
                 model: matched_route.model.clone(),
+                api_key: matched_route.api_key.clone(),
             };
         }
     }
 
     let runtime_defaults = runtime_defaults_snapshot(ctx.as_ref());
-    let active_provider = match get_or_create_provider(ctx.as_ref(), &route.provider).await {
+    let active_provider = match get_or_create_provider(
+        ctx.as_ref(),
+        &route.provider,
+        route.api_key.as_deref(),
+    )
+    .await
+    {
         Ok(provider) => provider,
         Err(err) => {
             let safe_err = providers::sanitize_api_error(&err.to_string());
@@ -5602,6 +5644,7 @@ BTC is currently around $65,000 based on latest tool output."#
             ChannelRouteSelection {
                 provider: "openrouter".to_string(),
                 model: "route-model".to_string(),
+                api_key: None,
             },
         );
 


### PR DESCRIPTION
## Summary
- Fixes #3838
- Added `api_key` field to `ChannelRouteSelection` so route-specific credentials are preserved
- Updated `get_or_create_provider` to accept and use route-specific `api_key` over the global key
- Fixed cache poisoning: provider cache key now includes a hash of the api_key to prevent credential collisions between routes sharing the same provider name

## Test plan
- [ ] Configure `[[model_routes]]` with a route-specific `api_key` for a `custom:` provider
- [ ] Trigger classification via keyword match in Channel mode — verify the route's `api_key` is used (no 401)
- [ ] Verify `/model` command also respects route-specific keys
- [ ] Verify different routes with different api_keys don't share cached providers
- [ ] All existing tests pass (4068 tests)