### PR TITLE
fix(transcription): honor configured default provider

### DIFF
--- a/src/channels/transcription.rs
+++ b/src/channels/transcription.rs
@@ -727,8 +727,41 @@ pub async fn transcribe_audio(
     // are reported before missing-key errors (preserves original behavior).
     validate_audio(&audio_data, file_name)?;
 
-    let groq = GroqProvider::from_config(config)?;
-    groq.transcribe(&audio_data, file_name).await
+    match config.default_provider.as_str() {
+        "groq" => {
+            let groq = GroqProvider::from_config(config)?;
+            groq.transcribe(&audio_data, file_name).await
+        }
+        "openai" => {
+            let openai_cfg = config.openai.as_ref().context(
+                "Default transcription provider 'openai' is not configured. Add [transcription.openai]",
+            )?;
+            let openai = OpenAiWhisperProvider::from_config(openai_cfg)?;
+            openai.transcribe(&audio_data, file_name).await
+        }
+        "deepgram" => {
+            let deepgram_cfg = config.deepgram.as_ref().context(
+                "Default transcription provider 'deepgram' is not configured. Add [transcription.deepgram]",
+            )?;
+            let deepgram = DeepgramProvider::from_config(deepgram_cfg)?;
+            deepgram.transcribe(&audio_data, file_name).await
+        }
+        "assemblyai" => {
+            let assemblyai_cfg = config.assemblyai.as_ref().context(
+                "Default transcription provider 'assemblyai' is not configured. Add [transcription.assemblyai]",
+            )?;
+            let assemblyai = AssemblyAiProvider::from_config(assemblyai_cfg)?;
+            assemblyai.transcribe(&audio_data, file_name).await
+        }
+        "google" => {
+            let google_cfg = config.google.as_ref().context(
+                "Default transcription provider 'google' is not configured. Add [transcription.google]",
+            )?;
+            let google = GoogleSttProvider::from_config(google_cfg)?;
+            google.transcribe(&audio_data, file_name).await
+        }
+        other => bail!("Unsupported transcription provider '{other}'"),
+    }
 }
 
 #[cfg(test)]
@@ -783,6 +816,25 @@ mod tests {
         assert!(
             err.to_string().contains("Unsupported audio format"),
             "expected unsupported-format error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn openai_default_provider_uses_openai_config() {
+        let data = vec![0u8; 100];
+        let mut config = TranscriptionConfig::default();
+        config.default_provider = "openai".to_string();
+        config.openai = Some(crate::config::OpenAiSttConfig {
+            api_key: None,
+            model: "gpt-4o-mini-transcribe".to_string(),
+        });
+
+        let err = transcribe_audio(data, "test.ogg", &config)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("[transcription.openai].api_key"),
+            "expected openai-specific missing-key error, got: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: Telegram and WhatsApp voice-message transcription still routed through the legacy `transcribe_audio()` helper, which always instantiated `GroqProvider` and ignored `transcription.default_provider`
- Why it matters: OpenAI and other configured STT providers could never be used from these channel paths, causing runtime failures even when `[transcription.openai]` was configured correctly
- What changed: `transcribe_audio()` now dispatches by `transcription.default_provider` across the supported STT backends and adds a focused regression test for the OpenAI path
- What did **not** change (scope boundary): No schema changes, no provider implementation changes, no channel UX changes, no local deployment config included

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `channel: telegram`, `channel: whatsapp_web`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: None

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes # N/A
- Related # N/A
- Depends on # N/A
- Supersedes # N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): No
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): No superseded PR in this change
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): Pass

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- `cargo fmt --all -- --check`: Pass
- `cargo test openai_default_provider_uses_openai_config --lib`: Pass
- `cargo test manager_default_provider_from_config --lib`: Pass
- Evidence provided (test/log/trace/screenshot/perf): focused unit-test output plus local runtime diagnosis showing the old Groq-only dispatch path
- If any command is intentionally skipped, explain why: `cargo clippy --all-targets -- -D warnings` and full `cargo test` were not run in this turn; focused regression coverage was used to validate the targeted bug fix before local release-fast rebuild/restart

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: No personal data or secrets added to repo changes
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: OpenAI default-provider path now returns the OpenAI-specific missing-key/config error rather than falling back to Groq; manager default-provider test still passes
- Edge cases checked: unsupported provider names still error explicitly; missing nested provider config produces provider-specific guidance
- What was not verified: full `cargo test`/`clippy` run and end-to-end Telegram voice-message transcription against a live OpenAI STT request in upstream CI context

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: voice-message transcription entrypoints used by Telegram and WhatsApp Web
- Potential unintended effects: provider-specific error strings may surface earlier for non-Groq defaults; additional providers now follow `default_provider` via the legacy helper path
- Guardrails/monitoring for early detection: focused unit tests; runtime logs already surface `Voice transcription failed` with provider-specific errors

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex terminal tools, local git, local systemd for repro only
- Workflow/plan summary (if any): reproduced runtime failure, traced it to the legacy wrapper, patched provider dispatch, added regression coverage, validated focused tests
- Verification focus: transcription routing for non-Groq defaults
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: revert commit `3d0872c1` or revert this PR
- Feature flags or config toggles (if any): None
- Observable failure symptoms: voice-message transcription regresses to provider misrouting or provider-specific configuration errors

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: legacy helper now contains provider dispatch logic parallel to `TranscriptionManager`
  - Mitigation: scope is limited to preserving current public helper behavior; regression test added for the OpenAI default-provider path
