### PR TITLE
feat(channel): add /stop command to cancel in-flight tasks

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -399,6 +399,18 @@ fn interruption_scope_key(msg: &traits::ChannelMessage) -> String {
     format!("{}_{}_{}", msg.channel, msg.reply_target, msg.sender)
 }
 
+/// Returns `true` when `content` is a `/stop` command (with optional `@botname` suffix).
+/// Not gated on channel type — all non-CLI channels support `/stop`.
+fn is_stop_command(content: &str) -> bool {
+    let trimmed = content.trim();
+    if !trimmed.starts_with('/') {
+        return false;
+    }
+    let cmd = trimmed.split_whitespace().next().unwrap_or("");
+    let base = cmd.split('@').next().unwrap_or(cmd);
+    base.eq_ignore_ascii_case("/stop")
+}
+
 /// Strip tool-call XML tags from outgoing messages.
 ///
 /// LLM responses may contain `<function_calls>`, `<function_call>`,
@@ -2658,6 +2670,49 @@ async fn run_message_dispatch_loop(
     let task_sequence = Arc::new(AtomicU32::new(1));
 
     while let Some(msg) = rx.recv().await {
+        // Fast path: /stop cancels the in-flight task for this sender scope without
+        // spawning a worker or registering a new task. Handled here — before semaphore
+        // acquisition — so the target task is still in the store and is never replaced.
+        if msg.channel != "cli" && is_stop_command(&msg.content) {
+            let scope_key = interruption_scope_key(&msg);
+            let previous = {
+                let mut active = in_flight_by_sender.lock().await;
+                active.remove(&scope_key)
+            };
+            let reply = if let Some(state) = previous {
+                state.cancellation.cancel();
+                "Stop signal sent.".to_string()
+            } else {
+                "No in-flight task for this sender scope.".to_string()
+            };
+            let channel = ctx
+                .channels_by_name
+                .get(&msg.channel)
+                .or_else(|| {
+                    // Multi-room channels use "name:qualifier" format (e.g. "matrix:!roomId");
+                    // fall back to base channel name for routing.
+                    msg.channel
+                        .split_once(':')
+                        .and_then(|(base, _)| ctx.channels_by_name.get(base))
+                })
+                .cloned();
+            if let Some(channel) = channel {
+                let reply_target = msg.reply_target.clone();
+                let thread_ts = msg.thread_ts.clone();
+                tokio::spawn(async move {
+                    let _ = channel
+                        .send(&SendMessage::new(reply, &reply_target).in_thread(thread_ts))
+                        .await;
+                });
+            } else {
+                tracing::warn!(
+                    channel = %msg.channel,
+                    "stop command: no registered channel found for reply"
+                );
+            }
+            continue;
+        }
+
         let permit = match Arc::clone(&semaphore).acquire_owned().await {
             Ok(permit) => permit,
             Err(_) => break,
@@ -2676,7 +2731,12 @@ async fn run_message_dispatch_loop(
             let completion = Arc::new(InFlightTaskCompletion::new());
             let task_id = task_sequence.fetch_add(1, Ordering::Relaxed) as u64;
 
-            if interrupt_enabled {
+            // Register all non-CLI tasks in the in-flight store so /stop can reach them.
+            // This is a deliberate broadening from the previous behaviour where only
+            // interrupt_enabled (Telegram/Slack) channels registered tasks.
+            let register_in_flight = msg.channel != "cli";
+
+            if register_in_flight {
                 let previous = {
                     let mut active = in_flight.lock().await;
                     active.insert(
@@ -2689,20 +2749,22 @@ async fn run_message_dispatch_loop(
                     )
                 };
 
-                if let Some(previous) = previous {
-                    tracing::info!(
-                        channel = %msg.channel,
-                        sender = %msg.sender,
-                        "Interrupting previous in-flight request for sender"
-                    );
-                    previous.cancellation.cancel();
-                    previous.completion.wait().await;
+                if interrupt_enabled {
+                    if let Some(previous) = previous {
+                        tracing::info!(
+                            channel = %msg.channel,
+                            sender = %msg.sender,
+                            "Interrupting previous in-flight request for sender"
+                        );
+                        previous.cancellation.cancel();
+                        previous.completion.wait().await;
+                    }
                 }
             }
 
             process_channel_message(worker_ctx, msg, cancellation_token).await;
 
-            if interrupt_enabled {
+            if register_in_flight {
                 let mut active = in_flight.lock().await;
                 if active
                     .get(&sender_scope_key)
@@ -8672,5 +8734,48 @@ This is an example JSON object for profile settings."#;
             Ok(channel) => assert_eq!(channel.name(), "telegram"),
             Err(e) => panic!("should succeed when telegram is configured: {e}"),
         }
+    }
+
+    // ── is_stop_command tests ─────────────────────────────────────────────
+
+    #[test]
+    fn is_stop_command_matches_bare_slash_stop() {
+        assert!(is_stop_command("/stop"));
+    }
+
+    #[test]
+    fn is_stop_command_matches_with_leading_trailing_whitespace() {
+        assert!(is_stop_command("  /stop  "));
+    }
+
+    #[test]
+    fn is_stop_command_is_case_insensitive() {
+        assert!(is_stop_command("/STOP"));
+        assert!(is_stop_command("/Stop"));
+    }
+
+    #[test]
+    fn is_stop_command_matches_with_bot_suffix() {
+        assert!(is_stop_command("/stop@zeroclaw_bot"));
+    }
+
+    #[test]
+    fn is_stop_command_rejects_other_slash_commands() {
+        assert!(!is_stop_command("/new"));
+        assert!(!is_stop_command("/model gpt-4"));
+        assert!(!is_stop_command("/models"));
+    }
+
+    #[test]
+    fn is_stop_command_rejects_plain_text() {
+        assert!(!is_stop_command("stop"));
+        assert!(!is_stop_command("please stop"));
+        assert!(!is_stop_command(""));
+    }
+
+    #[test]
+    fn is_stop_command_rejects_stop_as_substring() {
+        assert!(!is_stop_command("/stopwatch"));
+        assert!(!is_stop_command("/stop-all"));
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: No explicit cancellation mechanism exists for users on non-CLI channels whose agent is mid-task (#2401 ); the only prior approach (#2855) had a race condition where the `/stop` handler cancelled itself rather than the in-flight task
- Why it matters: Clients on Matrix, Telegram, Slack, Discord, etc. cannot stop a runaway or misdirected task without disconnecting
- What changed: Added `/stop` slash command intercepted before semaphore acquisition; separated `register_in_flight` from `interrupt_enabled` so all non-CLI tasks are reachable
- What did **not** change: Auto-cancel-on-new-message behavior (still gated on `interrupt_enabled` for Telegram/Slack only); CLI behavior; any channel implementation file

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `channel`
- Module labels: `channel: dispatch`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Supersedes #2855

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors: `#2855 by @theredspoon`
- Integrated scope by source PR: Problem statement and `/stop` command concept; the race condition in #2855 is the root cause this PR resolves with a different implementation approach
- `Co-authored-by` trailers added for materially incorporated contributors? No
- If `No`, explain why: Same author; no external code carried forward
- Trailer format check: N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check    # clean
cargo clippy --all-targets -- -D warnings  # clean
cargo test --locked            # 4077 passed, 0 failed
```

- Evidence provided: Local test run, pre-push hook passed
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: None — no user data handled
- Neutral wording confirmation: Pass

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No — no user-facing doc changes in this PR

## Human Verification (required)

- Verified scenarios: `/stop` fires cancellation token for in-flight Slack and Matrix tasks in local testing; "No in-flight task" reply returns correctly when no task is running; CLI channel correctly excluded
- Edge cases checked: `/stop` with `@botname` suffix; case-insensitive input; `/stop` arriving after task completes (no crash)
- What was not verified: Live production channel end-to-end (requires deployed instance)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Async dispatch loop in `src/channels/mod.rs` — all non-CLI channels
- Potential unintended effects: None — scope key includes `sender`, so Bob's `/stop` in the same room produces a different key than Alice's in-flight task and cannot cancel it
- Guardrails/monitoring for early detection: Existing observer hooks record task cancellations; `ToolLoopCancelled` return value is observable in logs

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (claude-sonnet-4-6)
- Workflow/plan summary: Scoped from gap analysis → implement → TDD → review cycle → push
- Verification focus: Race condition elimination vs #2855; correct store key construction
- Confirmation: naming + architecture boundaries followed per AGENTS.md + CONTRIBUTING.md

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>` — single commit
- Feature flags or config toggles: None — `/stop` is always available on non-CLI channels; no opt-out config
- Observable failure symptoms: `/stop` messages processed as normal agent input rather than cancellation signals

## Risks and Mitigations

- Risk: `/stop` fast path runs before semaphore acquisition — if `in_flight_by_sender` lookup has a bug, it silently sends "No in-flight task" rather than crashing
  - Mitigation: The `remove` operation is atomic under the mutex; the reply is sent via `tokio::spawn` so it cannot block the dispatch loop