### PR TITLE
fix(docker): default CMD to `daemon` instead of `gateway`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,7 +116,7 @@ EXPOSE 42617
 HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=10s \
     CMD ["zeroclaw", "status", "--format=exit-code"]
 ENTRYPOINT ["zeroclaw"]
-CMD ["gateway"]
+CMD ["daemon"]
 
 # ── Stage 3: Production Runtime (Distroless) ─────────────────
 FROM gcr.io/distroless/cc-debian13:nonroot@sha256:84fcd3c223b144b0cb6edc5ecc75641819842a9679a3a58fd6294bec47532bf7 AS release
@@ -142,4 +142,4 @@ EXPOSE 42617
 HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=10s \
     CMD ["zeroclaw", "status", "--format=exit-code"]
 ENTRYPOINT ["zeroclaw"]
-CMD ["gateway"]
+CMD ["daemon"]

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -122,4 +122,4 @@ EXPOSE 42617
 HEALTHCHECK --interval=60s --timeout=10s --retries=3 --start-period=10s \
     CMD ["zeroclaw", "status", "--format=exit-code"]
 ENTRYPOINT ["zeroclaw"]
-CMD ["gateway"]
+CMD ["daemon"]


### PR DESCRIPTION
## Summary
- Change default Docker CMD from `gateway` to `daemon` in both `Dockerfile` and `Dockerfile.debian`
- `gateway` only starts the HTTP/WebSocket server — channel listeners (Matrix, Telegram, Discord, etc.) are never spawned
- `daemon` starts the full runtime: gateway + channels + heartbeat + scheduler
- Users who configure channels in `config.toml` and run the default image get no response because the channel sync loops never start

## Test plan
- [ ] Build image and run with default CMD — verify channels start (`docker logs` should show channel listener output)
- [ ] Verify gateway is still accessible at the configured port
- [ ] Confirm `docker run <image> gateway` still works for gateway-only mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)