### PR TITLE
fix(docker): default CMD to daemon instead of gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,7 @@ WORKDIR /zeroclaw-data
 USER 65534:65534
 EXPOSE 42617
 ENTRYPOINT ["zeroclaw"]
-CMD ["gateway"]
+CMD ["daemon"]
 
 # ── Stage 3: Production Runtime (Distroless) ─────────────────
 FROM gcr.io/distroless/cc-debian13:nonroot@sha256:84fcd3c223b144b0cb6edc5ecc75641819842a9679a3a58fd6294bec47532bf7 AS release
@@ -127,4 +127,4 @@ WORKDIR /zeroclaw-data
 USER 65534:65534
 EXPOSE 42617
 ENTRYPOINT ["zeroclaw"]
-CMD ["gateway"]
+CMD ["daemon"]


### PR DESCRIPTION
## Summary
- Change default Docker CMD from gateway to daemon in both dev and release stages\n- gateway only starts the HTTP/WebSocket server — channel listeners (Matrix, Telegram, Discord, etc.) are never spawned\n- daemon starts the full runtime: gateway + channels + heartbeat + scheduler\n- Users who configure channels in config.toml and run the default image get no response because the channel sync loops never start\n\n## Test plan\n- [ ] Build image and run with default CMD — verify channels start (docker logs should show channel listener output)\n- [ ] Verify gateway is still accessible at the configured port\n- [ ] Confirm docker run <image> gateway still works for gateway-only mode\n\nCloses #3893