### PR TITLE
fix(test): eliminate race condition in claude_code provider tests

### DIFF
--- a/src/providers/claude_code.rs
+++ b/src/providers/claude_code.rs
@@ -376,31 +376,36 @@ mod tests {
     /// Helper: create a provider that uses a shell script echoing stdin back.
     /// The script ignores CLI flags (`--print`, `--model`, `-`) and just cats stdin.
     ///
-    /// Uses `OnceLock` to write the script file exactly once, avoiding
-    /// "Text file busy" (ETXTBSY) races when parallel tests try to
-    /// overwrite a script that another test is currently executing.
+    /// Creates a unique temp file per invocation to avoid race conditions when
+    /// tests run in parallel. Each test gets its own script file, eliminating
+    /// "Text file busy" (ETXTBSY) and "Broken pipe" (EPIPE) errors.
     fn echo_provider() -> ClaudeCodeProvider {
-        use std::sync::OnceLock;
+        use std::io::Write;
 
-        static SCRIPT_PATH: OnceLock<PathBuf> = OnceLock::new();
-        let script = SCRIPT_PATH.get_or_init(|| {
-            use std::io::Write;
-            let dir = std::env::temp_dir().join("zeroclaw_test_claude_code");
-            std::fs::create_dir_all(&dir).unwrap();
-            let path = dir.join("fake_claude.sh");
-            let mut f = std::fs::File::create(&path).unwrap();
-            writeln!(f, "#!/bin/sh\ncat /dev/stdin").unwrap();
-            drop(f);
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
-            }
-            path
-        });
-        ClaudeCodeProvider {
-            binary_path: script.clone(),
+        let dir = std::env::temp_dir().join("zeroclaw_test_claude_code");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Use thread ID + high-resolution timestamp for uniqueness
+        let thread_id = std::thread::current().id();
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = dir.join(format!("fake_claude_{:?}_{}.sh", thread_id, nanos));
+
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "#!/bin/sh\nexec cat /dev/stdin").unwrap();
+        // Force sync to disk before marking executable
+        f.sync_all().unwrap();
+        drop(f);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
+
+        ClaudeCodeProvider { binary_path: path }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The `claude_code` provider tests have a race condition causing intermittent CI failures when tests run in parallel
- Why it matters: Blocks unrelated PRs and wastes CI resources with random test failures
- What changed: Replaced shared temp file with unique per-invocation temp files to eliminate all parallelization races
- What did **not** change: Test assertions, provider implementation, or any production code

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `Testing`
- Module labels: `provider: claude-code`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `test`

## Linked Issue

- Fixes #3902

## Root Cause

The `echo_provider()` test helper used `OnceLock` to create a single shared temp script at `/tmp/zeroclaw_test_claude_code/fake_claude.sh`. While this avoided recreating the file, parallel test execution caused:

1. **ETXTBSY (errno 26)**: "Text file busy" when multiple tests tried to execute the script simultaneously
2. **EPIPE (errno 32)**: "Broken pipe" when the script process terminated unexpectedly during stdin writes

These failures were non-deterministic and blocked PRs #3891 and #3895.

## Solution

Replace the shared file with unique temp files per `echo_provider()` invocation:
- Use thread ID + nanosecond timestamp for uniqueness
- Add `f.sync_all()` to ensure file is fully written before chmod
- Use `exec cat` instead of `cat` to avoid extra shell process

Each test now gets its own isolated script, eliminating all race conditions.

## Validation Evidence (required)

Local testing with high parallelism (5 runs × 20 threads):

```bash
cargo test providers::claude_code::tests --locked -- --test-threads=20
```

All 5 runs passed consistently:
```
test result: ok. 13 passed; 0 failed; 0 ignored
```

Standard pre-push checks also passed:
```bash
cargo fmt --all -- --check    # clean
cargo clippy --all-targets -- -D warnings  # clean
cargo test                     # all tests pass
```

## Impact

- Unblocks affected PRs (#3891, #3895)
- Prevents future random test failures in CI
- No production code changes, test-only fix