### PR TITLE
fix(install): clean stale build cache on upgrade

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1218,6 +1218,12 @@ if [[ -n "$TARGET_VERSION" ]]; then
   step_dot "Installing ZeroClaw v${TARGET_VERSION}"
 fi
 if [[ "$SKIP_BUILD" == false ]]; then
+  # Clean stale build artifacts on upgrade to prevent bindgen/build-script
+  # cache mismatches (e.g. libsqlite3-sys bindgen.rs not found).
+  if [[ "$INSTALL_MODE" == "upgrade" && -d "$WORK_DIR/target/release/build" ]]; then
+    step_dot "Cleaning stale build cache (upgrade detected)"
+    cargo clean --release 2>/dev/null || true
+  fi
   step_dot "Building release binary"
   cargo build --release --locked
   step_ok "Release binary built"

--- a/src/providers/claude_code.rs
+++ b/src/providers/claude_code.rs
@@ -387,7 +387,7 @@ mod tests {
             use std::io::Write;
             let dir = std::env::temp_dir().join("zeroclaw_test_claude_code");
             std::fs::create_dir_all(&dir).unwrap();
-            let path = dir.join("fake_claude.sh");
+            let path = dir.join(format!("fake_claude_{}.sh", std::process::id()));
             let mut f = std::fs::File::create(&path).unwrap();
             writeln!(f, "#!/bin/sh\ncat /dev/stdin").unwrap();
             drop(f);


### PR DESCRIPTION
## Summary
- Clean stale `target/release/build/` artifacts when upgrading an existing ZeroClaw installation
- Fixes `libsqlite3-sys` bindgen.rs build failure caused by stale cached build-script outputs
- Only triggers on upgrade path (existing install detected), fresh installs are unaffected

## Root Cause
When the install script runs `cargo build --release --locked` in an existing workspace, stale build-script outputs from previous versions can cause compilation failures. The `libsqlite3-sys` crate generates `bindgen.rs` via a build script, and if the cached output directory path changes between versions, the build fails with "No such file or directory".

## Risk
**Low** — adds a `cargo clean --release` only on upgrade path before building. Fresh installs are not affected.

## Test plan
- [x] `bash -n install.sh` — syntax check passes
- [x] `cargo clean --release && cargo build --release --locked` — builds cleanly
- [ ] Manual: run `curl -fsSL .../install.sh | bash` over existing installation

🤖 Generated with [Claude Code](https://claude.com/claude-code)