### PR TITLE
Fix cron_add tool schedule parsing for stringified JSON

### DIFF
--- a/src/cron/mod.rs
+++ b/src/cron/mod.rs
@@ -17,7 +17,10 @@ pub use store::{
     add_agent_job, due_jobs, get_job, list_jobs, list_runs, record_last_run, record_run,
     remove_job, reschedule_after_run, update_job,
 };
-pub use types::{CronJob, CronJobPatch, CronRun, DeliveryConfig, JobType, Schedule, SessionTarget};
+pub use types::{
+    deserialize_maybe_stringified, CronJob, CronJobPatch, CronRun, DeliveryConfig, JobType,
+    Schedule, SessionTarget,
+};
 
 /// Validate a shell command against the full security policy (allowlist + risk gate).
 ///

--- a/src/cron/types.rs
+++ b/src/cron/types.rs
@@ -1,6 +1,32 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+/// Try to deserialize a `serde_json::Value` as `T`.  If the value is a JSON
+/// string that looks like an object (i.e. the LLM double-serialized it), parse
+/// the inner string first and then deserialize the resulting object.  This
+/// provides backward-compatible handling for both `Value::Object` and
+/// `Value::String` representations.
+pub fn deserialize_maybe_stringified<T: serde::de::DeserializeOwned>(
+    v: &serde_json::Value,
+) -> Result<T, serde_json::Error> {
+    // Fast path: value is already the right shape (object, array, etc.)
+    match serde_json::from_value::<T>(v.clone()) {
+        Ok(parsed) => Ok(parsed),
+        Err(first_err) => {
+            // If it's a string, try parsing the string as JSON first.
+            if let Some(s) = v.as_str() {
+                let s = s.trim();
+                if s.starts_with('{') || s.starts_with('[') {
+                    if let Ok(inner) = serde_json::from_str::<serde_json::Value>(s) {
+                        return serde_json::from_value::<T>(inner);
+                    }
+                }
+            }
+            Err(first_err)
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum JobType {
@@ -154,7 +180,46 @@ pub struct CronJobPatch {
 
 #[cfg(test)]
 mod tests {
-    use super::JobType;
+    use super::*;
+
+    #[test]
+    fn deserialize_schedule_from_object() {
+        let val = serde_json::json!({"kind": "cron", "expr": "*/5 * * * *"});
+        let sched = deserialize_maybe_stringified::<Schedule>(&val).unwrap();
+        assert!(matches!(sched, Schedule::Cron { ref expr, .. } if expr == "*/5 * * * *"));
+    }
+
+    #[test]
+    fn deserialize_schedule_from_string() {
+        let val = serde_json::Value::String(r#"{"kind":"cron","expr":"*/5 * * * *"}"#.to_string());
+        let sched = deserialize_maybe_stringified::<Schedule>(&val).unwrap();
+        assert!(matches!(sched, Schedule::Cron { ref expr, .. } if expr == "*/5 * * * *"));
+    }
+
+    #[test]
+    fn deserialize_schedule_string_with_tz() {
+        let val = serde_json::Value::String(
+            r#"{"kind":"cron","expr":"*/30 9-15 * * 1-5","tz":"Asia/Shanghai"}"#.to_string(),
+        );
+        let sched = deserialize_maybe_stringified::<Schedule>(&val).unwrap();
+        match sched {
+            Schedule::Cron { tz, .. } => assert_eq!(tz.as_deref(), Some("Asia/Shanghai")),
+            _ => panic!("expected Cron variant"),
+        }
+    }
+
+    #[test]
+    fn deserialize_every_from_string() {
+        let val = serde_json::Value::String(r#"{"kind":"every","every_ms":60000}"#.to_string());
+        let sched = deserialize_maybe_stringified::<Schedule>(&val).unwrap();
+        assert!(matches!(sched, Schedule::Every { every_ms: 60000 }));
+    }
+
+    #[test]
+    fn deserialize_invalid_string_returns_error() {
+        let val = serde_json::Value::String("not json at all".to_string());
+        assert!(deserialize_maybe_stringified::<Schedule>(&val).is_err());
+    }
 
     #[test]
     fn job_type_try_from_accepts_known_values_case_insensitive() {

--- a/src/tools/cron_add.rs
+++ b/src/tools/cron_add.rs
@@ -1,6 +1,8 @@
 use super::traits::{Tool, ToolResult};
 use crate::config::Config;
-use crate::cron::{self, DeliveryConfig, JobType, Schedule, SessionTarget};
+use crate::cron::{
+    self, deserialize_maybe_stringified, DeliveryConfig, JobType, Schedule, SessionTarget,
+};
 use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use serde_json::json;
@@ -176,7 +178,7 @@ impl Tool for CronAddTool {
         }
 
         let schedule = match args.get("schedule") {
-            Some(v) => match serde_json::from_value::<Schedule>(v.clone()) {
+            Some(v) => match deserialize_maybe_stringified::<Schedule>(v) {
                 Ok(schedule) => schedule,
                 Err(e) => {
                     return Ok(ToolResult {
@@ -509,6 +511,63 @@ mod tests {
             .await
             .unwrap();
         assert!(approved.success, "{:?}", approved.error);
+    }
+
+    #[tokio::test]
+    async fn accepts_schedule_passed_as_json_string() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+
+        // Simulate the LLM double-serializing the schedule: the value arrives
+        // as a JSON string containing a JSON object, rather than an object.
+        let result = tool
+            .execute(json!({
+                "schedule": r#"{"kind":"cron","expr":"*/5 * * * *"}"#,
+                "job_type": "shell",
+                "command": "echo string-schedule"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+        assert!(result.output.contains("next_run"));
+    }
+
+    #[tokio::test]
+    async fn accepts_stringified_interval_schedule() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+
+        let result = tool
+            .execute(json!({
+                "schedule": r#"{"kind":"every","every_ms":60000}"#,
+                "job_type": "shell",
+                "command": "echo interval"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+    }
+
+    #[tokio::test]
+    async fn accepts_stringified_schedule_with_timezone() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+
+        let result = tool
+            .execute(json!({
+                "schedule": r#"{"kind":"cron","expr":"*/30 9-15 * * 1-5","tz":"Asia/Shanghai"}"#,
+                "job_type": "shell",
+                "command": "echo tz-test"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{:?}", result.error);
     }
 
     #[tokio::test]

--- a/src/tools/cron_update.rs
+++ b/src/tools/cron_update.rs
@@ -1,6 +1,6 @@
 use super::traits::{Tool, ToolResult};
 use crate::config::Config;
-use crate::cron::{self, CronJobPatch};
+use crate::cron::{self, deserialize_maybe_stringified, CronJobPatch};
 use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use serde_json::json;
@@ -202,7 +202,7 @@ impl Tool for CronUpdateTool {
             }
         };
 
-        let patch = match serde_json::from_value::<CronJobPatch>(patch_val) {
+        let patch = match deserialize_maybe_stringified::<CronJobPatch>(&patch_val) {
             Ok(patch) => patch,
             Err(e) => {
                 return Ok(ToolResult {


### PR DESCRIPTION
## Summary
- Fixes #3860
- Added `deserialize_maybe_stringified()` helper that handles both proper JSON objects and double-serialized JSON strings for the `Schedule` enum
- Applied the fix to both `cron_add` and `cron_update` tool handlers
- Added unit tests for cron/interval/timezone variants and integration tests for string-vs-object inputs

## Test plan
- [ ] `cron_add` with schedule as JSON object works
- [ ] `cron_add` with schedule as stringified JSON works (the bug case)
- [ ] Both cron and interval schedule types work
- [ ] Timezone parameter is respected
- [ ] `cron_update` also handles stringified patches
- [ ] All existing tests pass