### PR TITLE
fix: enable vision support for llamacpp provider

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1320,11 +1320,12 @@ fn create_provider_with_url_and_options(
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
                 .unwrap_or("llama.cpp");
-            Ok(compat(OpenAiCompatibleProvider::new(
+            Ok(compat(OpenAiCompatibleProvider::new_with_vision(
                 "llama.cpp",
                 base_url,
                 Some(llama_cpp_key),
                 AuthStyle::Bearer,
+                true,
             )))
         }
         "sglang" => {


### PR DESCRIPTION
## Summary
- Enable vision support for the llamacpp provider by switching from `OpenAiCompatibleProvider::new()` to `OpenAiCompatibleProvider::new_with_vision()` with `supports_vision: true`
- This fixes image transfers from Telegram failing when using the llamacpp provider

## Root Cause
The llamacpp provider was instantiated with `OpenAiCompatibleProvider::new()` which defaults `supports_vision` to `false`. Other providers (e.g., custom HTTP) use `new_with_vision(..., true)` and handle images correctly.

## Test plan
- [ ] Verify llamacpp provider can receive and process images from Telegram
- [ ] Verify no regression in text-only conversations via llamacpp
- [ ] `cargo clippy` and `cargo fmt` pass cleanly

Fixes #3802