### PR TITLE
fix: reset tool call dedup cache each iteration to prevent loops

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2370,9 +2370,10 @@ pub(crate) async fn run_tool_call_loop(
     };
 
     let turn_id = Uuid::new_v4().to_string();
-    let mut seen_tool_signatures: HashSet<(String, String)> = HashSet::new();
 
     for iteration in 0..max_iterations {
+        let mut seen_tool_signatures: HashSet<(String, String)> = HashSet::new();
+
         if cancellation_token
             .as_ref()
             .is_some_and(CancellationToken::is_cancelled)


### PR DESCRIPTION
## Summary

- Fixes #3798: "Agent falls into a vicious circle of self-correction"
- Moves the `seen_tool_signatures` HashSet initialization from outside to inside the `for iteration in 0..max_iterations` loop in `src/agent/loop_.rs`
- This ensures tool call deduplication is scoped per-iteration (within-turn) rather than persisting across iterations, which was causing legitimate repeated tool calls to be incorrectly skipped, triggering an infinite self-correction spiral

## Test plan

- [x] `cargo test` passes (4077 tests, 0 failures)
- [ ] Manual verification: agent no longer enters self-correction loops when making the same tool call across different iterations