### PR TITLE
feat(provider): upgrade claude-code provider to full agent mode

### DIFF
--- a/src/providers/claude_code.rs
+++ b/src/providers/claude_code.rs
@@ -47,12 +47,10 @@ const DEFAULT_CLAUDE_CODE_BINARY: &str = "claude";
 /// Model name used to signal "use the provider's own default model".
 const DEFAULT_MODEL_MARKER: &str = "default";
 /// Claude Code requests are bounded to avoid hung subprocesses.
-const CLAUDE_CODE_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+/// Set higher than typical API timeouts to accommodate multi-turn tool loops.
+const CLAUDE_CODE_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 /// Avoid leaking oversized stderr payloads.
 const MAX_CLAUDE_CODE_STDERR_CHARS: usize = 512;
-/// The CLI does not support sampling controls; allow only baseline defaults.
-const CLAUDE_CODE_SUPPORTED_TEMPERATURES: [f64; 2] = [0.7, 1.0];
-const TEMP_EPSILON: f64 = 1e-9;
 
 /// Provider that invokes the Claude Code CLI as a subprocess.
 ///
@@ -84,37 +82,11 @@ impl ClaudeCodeProvider {
         !trimmed.is_empty() && trimmed != DEFAULT_MODEL_MARKER
     }
 
-    fn supports_temperature(temperature: f64) -> bool {
-        CLAUDE_CODE_SUPPORTED_TEMPERATURES
-            .iter()
-            .any(|v| (temperature - v).abs() < TEMP_EPSILON)
-    }
-
-    fn validate_temperature(temperature: f64) -> anyhow::Result<f64> {
+    fn validate_temperature(temperature: f64) -> anyhow::Result<()> {
         if !temperature.is_finite() {
             anyhow::bail!("Claude Code provider received non-finite temperature value");
         }
-        if Self::supports_temperature(temperature) {
-            return Ok(temperature);
-        }
-        // Clamp to the nearest supported value — the CLI ignores temperature
-        // anyway, so a hard error just blocks callers like memory consolidation
-        // that legitimately request low temperatures.
-        let clamped = *CLAUDE_CODE_SUPPORTED_TEMPERATURES
-            .iter()
-            .min_by(|a, b| {
-                (temperature - **a)
-                    .abs()
-                    .partial_cmp(&(temperature - **b).abs())
-                    .unwrap()
-            })
-            .unwrap();
-        tracing::debug!(
-            requested = temperature,
-            clamped = clamped,
-            "Clamped unsupported temperature to nearest Claude Code CLI value"
-        );
-        Ok(clamped)
+        Ok(())
     }
 
     fn redact_stderr(stderr: &[u8]) -> String {
@@ -130,14 +102,37 @@ impl ClaudeCodeProvider {
         format!("{clipped}...")
     }
 
-    /// Invoke the claude binary with the given prompt and optional model.
-    /// Returns the trimmed stdout output as the assistant response.
-    async fn invoke_cli(&self, message: &str, model: &str) -> anyhow::Result<String> {
+    /// Invoke the claude binary with the given prompt, optional model, and optional
+    /// system prompt override. Returns the trimmed stdout output as the assistant
+    /// response.
+    ///
+    /// When `agent_mode` is true, enables `--dangerously-skip-permissions` so
+    /// Claude Code can execute its built-in tools (Bash, Read, Edit, WebSearch,
+    /// etc.) autonomously.  The response is extracted from the JSON `result`
+    /// field when possible, falling back to raw stdout.
+    async fn invoke_cli(
+        &self,
+        message: &str,
+        model: &str,
+        system_prompt: Option<&str>,
+        agent_mode: bool,
+    ) -> anyhow::Result<(String, Option<TokenUsage>)> {
         let mut cmd = Command::new(&self.binary_path);
         cmd.arg("--print");
 
+        if agent_mode {
+            cmd.arg("--dangerously-skip-permissions");
+            cmd.arg("--output-format").arg("json");
+        }
+
         if Self::should_forward_model(model) {
             cmd.arg("--model").arg(model);
+        }
+
+        if let Some(sp) = system_prompt {
+            if !sp.is_empty() {
+                cmd.arg("--append-system-prompt").arg(sp);
+            }
         }
 
         // Read prompt from stdin to avoid exposing sensitive content in process args.
@@ -189,10 +184,29 @@ impl ClaudeCodeProvider {
             );
         }
 
-        let text = String::from_utf8(output.stdout)
+        let raw = String::from_utf8(output.stdout)
             .map_err(|err| anyhow::anyhow!("Claude Code produced non-UTF-8 output: {err}"))?;
 
-        Ok(text.trim().to_string())
+        if agent_mode {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw) {
+                let text = json
+                    .get("result")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .trim()
+                    .to_string();
+
+                let usage = json.get("usage").map(|u| TokenUsage {
+                    input_tokens: u.get("input_tokens").and_then(|v| v.as_u64()),
+                    output_tokens: u.get("output_tokens").and_then(|v| v.as_u64()),
+                    cached_input_tokens: u.get("cache_read_input_tokens").and_then(|v| v.as_u64()),
+                });
+
+                return Ok((text, usage));
+            }
+        }
+
+        Ok((raw.trim().to_string(), None))
     }
 }
 
@@ -213,14 +227,8 @@ impl Provider for ClaudeCodeProvider {
     ) -> anyhow::Result<String> {
         Self::validate_temperature(temperature)?;
 
-        let full_message = match system_prompt {
-            Some(system) if !system.is_empty() => {
-                format!("{system}\n\n{message}")
-            }
-            _ => message.to_string(),
-        };
-
-        self.invoke_cli(&full_message, model).await
+        let (text, _usage) = self.invoke_cli(message, model, system_prompt, true).await?;
+        Ok(text)
     }
 
     async fn chat_with_history(
@@ -231,44 +239,31 @@ impl Provider for ClaudeCodeProvider {
     ) -> anyhow::Result<String> {
         Self::validate_temperature(temperature)?;
 
-        // Separate system prompt from conversation messages.
         let system = messages
             .iter()
             .find(|m| m.role == "system")
             .map(|m| m.content.as_str());
 
-        // Build conversation turns (skip system messages).
         let turns: Vec<&ChatMessage> = messages.iter().filter(|m| m.role != "system").collect();
 
-        // If there's only one user message, use the simple path.
-        if turns.len() <= 1 {
-            let last_user = turns.first().map(|m| m.content.as_str()).unwrap_or("");
-            let full_message = match system {
-                Some(s) if !s.is_empty() => format!("{s}\n\n{last_user}"),
-                _ => last_user.to_string(),
-            };
-            return self.invoke_cli(&full_message, model).await;
-        }
-
-        // Format multi-turn conversation into a single prompt.
-        let mut parts = Vec::new();
-        if let Some(s) = system {
-            if !s.is_empty() {
-                parts.push(format!("[system]\n{s}"));
+        let user_message = if turns.len() <= 1 {
+            turns.first().map(|m| m.content.clone()).unwrap_or_default()
+        } else {
+            let mut parts = Vec::new();
+            for msg in &turns {
+                let label = match msg.role.as_str() {
+                    "user" => "[user]",
+                    "assistant" => "[assistant]",
+                    other => other,
+                };
+                parts.push(format!("{label}\n{}", msg.content));
             }
-        }
-        for msg in &turns {
-            let label = match msg.role.as_str() {
-                "user" => "[user]",
-                "assistant" => "[assistant]",
-                other => other,
-            };
-            parts.push(format!("{label}\n{}", msg.content));
-        }
-        parts.push("[assistant]".to_string());
+            parts.push("[assistant]".to_string());
+            parts.join("\n\n")
+        };
 
-        let full_message = parts.join("\n\n");
-        self.invoke_cli(&full_message, model).await
+        let (text, _usage) = self.invoke_cli(&user_message, model, system, true).await?;
+        Ok(text)
     }
 
     async fn chat(
@@ -277,14 +272,42 @@ impl Provider for ClaudeCodeProvider {
         model: &str,
         temperature: f64,
     ) -> anyhow::Result<ChatResponse> {
-        let text = self
-            .chat_with_history(request.messages, model, temperature)
-            .await?;
+        Self::validate_temperature(temperature)?;
+
+        let system = request
+            .messages
+            .iter()
+            .find(|m| m.role == "system")
+            .map(|m| m.content.as_str());
+
+        let turns: Vec<&ChatMessage> = request
+            .messages
+            .iter()
+            .filter(|m| m.role != "system")
+            .collect();
+
+        let user_message = if turns.len() <= 1 {
+            turns.first().map(|m| m.content.clone()).unwrap_or_default()
+        } else {
+            let mut parts = Vec::new();
+            for msg in &turns {
+                let label = match msg.role.as_str() {
+                    "user" => "[user]",
+                    "assistant" => "[assistant]",
+                    other => other,
+                };
+                parts.push(format!("{label}\n{}", msg.content));
+            }
+            parts.push("[assistant]".to_string());
+            parts.join("\n\n")
+        };
+
+        let (text, usage) = self.invoke_cli(&user_message, model, system, true).await?;
 
         Ok(ChatResponse {
             text: Some(text),
             tool_calls: Vec::new(),
-            usage: Some(TokenUsage::default()),
+            usage: Some(usage.unwrap_or_default()),
             reasoning_content: None,
         })
     }
@@ -361,18 +384,11 @@ mod tests {
     }
 
     #[test]
-    fn validate_temperature_allows_defaults() {
+    fn validate_temperature_allows_any_finite_value() {
+        assert!(ClaudeCodeProvider::validate_temperature(0.1).is_ok());
         assert!(ClaudeCodeProvider::validate_temperature(0.7).is_ok());
         assert!(ClaudeCodeProvider::validate_temperature(1.0).is_ok());
-    }
-
-    #[test]
-    fn validate_temperature_clamps_custom_value() {
-        let clamped = ClaudeCodeProvider::validate_temperature(0.2).unwrap();
-        assert!((clamped - 0.7).abs() < 1e-9, "0.2 should clamp to 0.7");
-
-        let clamped = ClaudeCodeProvider::validate_temperature(0.9).unwrap();
-        assert!((clamped - 1.0).abs() < 1e-9, "0.9 should clamp to 1.0");
+        assert!(ClaudeCodeProvider::validate_temperature(1.5).is_ok());
     }
 
     #[test]
@@ -386,7 +402,7 @@ mod tests {
         let provider = ClaudeCodeProvider {
             binary_path: PathBuf::from("/nonexistent/path/to/claude"),
         };
-        let result = provider.invoke_cli("hello", "default").await;
+        let result = provider.invoke_cli("hello", "default", None, false).await;
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -450,7 +466,9 @@ mod tests {
             .chat_with_history(&messages, "default", 1.0)
             .await
             .unwrap();
-        assert_eq!(result, "You are helpful.\n\nhello");
+        // System prompt is passed via --append-system-prompt flag (not in stdin),
+        // so the echo script only sees the user message.
+        assert_eq!(result, "hello");
     }
 
     #[tokio::test]
@@ -466,7 +484,8 @@ mod tests {
             .chat_with_history(&messages, "default", 1.0)
             .await
             .unwrap();
-        assert!(result.contains("[system]\nBe concise."));
+        // System prompt is passed via --append-system-prompt flag, not in stdin.
+        assert!(!result.contains("[system]"));
         assert!(result.contains("[user]\nWhat is 2+2?"));
         assert!(result.contains("[assistant]\n4"));
         assert!(result.contains("[user]\nAnd 3+3?"));
@@ -492,13 +511,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn chat_with_history_clamps_bad_temperature() {
+    async fn chat_with_history_rejects_non_finite_temperature() {
         let provider = echo_provider();
         let messages = vec![ChatMessage::user("test")];
-        let result = provider.chat_with_history(&messages, "default", 0.5).await;
-        assert!(
-            result.is_ok(),
-            "unsupported temperature should be clamped, not rejected"
-        );
+        let result = provider
+            .chat_with_history(&messages, "default", f64::NAN)
+            .await;
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

- Upgrades the `claude-code` CLI provider from a basic text pipe to a full agent-capable provider
- Enables `--dangerously-skip-permissions` for autonomous tool use (Bash, Read, Edit, WebSearch, etc.)
- Passes system prompt via `--append-system-prompt` for proper context separation
- Uses `--output-format json` for structured responses with token usage tracking
- Increases timeout from 120s → 300s for multi-turn tool loops

## Motivation

Since March 17, 2026, Anthropic enforces client fingerprinting on OAuth subscription tokens (`sk-ant-oat01-*`), rejecting direct API calls from non-Claude-Code clients with HTTP 400. This affects all users authenticating via Claude subscription (Pro/Max) rather than console API keys.

**Before this change:** the `claude-code` provider was a minimal text-only passthrough — no tool use, no structured output, no system prompt support. Users falling back to it lost all agent capabilities.

**After this change:** `claude-code` is a production-viable provider that delegates the full agent loop to Claude Code's CLI, which handles its own OAuth authentication and tool execution. Users get Opus 4.6 with full tool calling through their existing subscription.

### Evidence

Direct API calls with OAuth tokens fail for all non-Haiku models:
```
$ curl -s api.anthropic.com/v1/messages -H "Authorization: Bearer sk-ant-oat01-..." \
    -H "anthropic-beta: oauth-2025-04-20" ...
→ 400 {"type":"error","error":{"type":"invalid_request_error","message":"Error"}}
```

The same token works through Claude Code CLI:
```
$ claude -p "say hello" --model claude-opus-4-6 --output-format json
→ {"type":"result","subtype":"success","result":"Hello!","usage":{...}}
```

The upgraded provider passes through Claude Code's auth:
```
$ zeroclaw agent --provider claude-code --message "what files are in /tmp? list 3"
→ Here are 3 files in /tmp: ...  (3 turns — tool use working)
```

### Live Telegram proof (Opus 4.6 via claude-code provider)

```
Mar 18 20:38:34 zeroclaw:   💬 [telegram] from guitaripod: what's the weather in Helsinki right now?
Mar 18 20:38:34 zeroclaw:   ⏳ Processing message...
Mar 18 20:38:58 zeroclaw:   🤖 Reply (23346ms): Right now in Helsinki it's around 0°C (32°F), partly sunny with cloudy spell...
```

Full agent loop: Telegram → ZeroClaw daemon → Claude Code CLI (Opus 4.6) → WebSearch tool → reply in 23s.

Related issues:
- [anomalyco/opencode#17910](https://github.com/anomalyco/opencode/issues/17910) — OAuth + API breakage since 2026-03-17
- [Anthropic clarifies ban on third-party OAuth](https://www.theregister.com/2026/02/20/anthropic_clarifies_ban_third_party_claude_access/)

## Test plan

- [x] All existing `claude_code` unit tests pass (13/13)
- [x] Integration test: `zeroclaw agent --message` with tool-requiring prompts returns correct results
- [x] JSON parsing fallback: non-JSON responses (e.g. from echo test script) handled gracefully
- [x] Token usage correctly extracted from JSON envelope
- [x] Live Telegram channel test: weather query → Opus 4.6 web search → reply delivered