### PR TITLE
fix(tools): include tool_search instruction in deferred tools prompt

### DIFF
--- a/src/tools/mcp_deferred.rs
+++ b/src/tools/mcp_deferred.rs
@@ -233,12 +233,22 @@ impl Default for ActivatedToolSet {
 
 /// Build the `<available-deferred-tools>` section for the system prompt.
 /// Lists only tool names so the LLM knows what is available without
-/// consuming context window on full schemas.
+/// consuming context window on full schemas. Includes an instruction
+/// block that tells the LLM to call `tool_search` to activate them.
 pub fn build_deferred_tools_section(deferred: &DeferredMcpToolSet) -> String {
     if deferred.is_empty() {
         return String::new();
     }
-    let mut out = String::from("<available-deferred-tools>\n");
+    let mut out = String::new();
+    out.push_str("## Deferred Tools\n\n");
+    out.push_str(
+        "The tools listed below are available but NOT yet loaded. \
+         To use any of them you MUST first call the `tool_search` tool \
+         to fetch their full schemas. Use `\"select:name1,name2\"` for \
+         exact tools or keywords to search. Once activated, the tools \
+         become callable for the rest of the conversation.\n\n",
+    );
+    out.push_str("<available-deferred-tools>\n");
     for stub in &deferred.stubs {
         out.push_str(&stub.prefixed_name);
         out.push('\n');
@@ -417,6 +427,55 @@ mod tests {
     }
 
     #[test]
+    fn build_deferred_section_includes_tool_search_instruction() {
+        let stubs = vec![make_stub("fs__read_file", "Read a file")];
+        let set = DeferredMcpToolSet {
+            stubs,
+            registry: std::sync::Arc::new(
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(McpRegistry::connect_all(&[]))
+                    .unwrap(),
+            ),
+        };
+        let section = build_deferred_tools_section(&set);
+        assert!(
+            section.contains("tool_search"),
+            "deferred section must instruct the LLM to use tool_search"
+        );
+        assert!(
+            section.contains("## Deferred Tools"),
+            "deferred section must include a heading"
+        );
+    }
+
+    #[test]
+    fn build_deferred_section_multiple_servers() {
+        let stubs = vec![
+            make_stub("server_a__list", "List items"),
+            make_stub("server_a__create", "Create item"),
+            make_stub("server_b__query", "Query records"),
+        ];
+        let set = DeferredMcpToolSet {
+            stubs,
+            registry: std::sync::Arc::new(
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(McpRegistry::connect_all(&[]))
+                    .unwrap(),
+            ),
+        };
+        let section = build_deferred_tools_section(&set);
+        assert!(section.contains("server_a__list"));
+        assert!(section.contains("server_a__create"));
+        assert!(section.contains("server_b__query"));
+        assert!(
+            section.contains("tool_search"),
+            "section must mention tool_search for multi-server setups"
+        );
+    }
+
+    #[test]
     fn keyword_search_ranks_by_hits() {
         let stubs = vec![
             make_stub("fs__read_file", "Read a file from disk"),
@@ -456,5 +515,36 @@ mod tests {
         };
         assert!(set.get_by_name("a__one").is_some());
         assert!(set.get_by_name("nonexistent").is_none());
+    }
+
+    #[test]
+    fn search_across_multiple_servers() {
+        let stubs = vec![
+            make_stub("server_a__read_file", "Read a file from disk"),
+            make_stub("server_b__read_config", "Read configuration from database"),
+        ];
+        let set = DeferredMcpToolSet {
+            stubs,
+            registry: std::sync::Arc::new(
+                tokio::runtime::Runtime::new()
+                    .unwrap()
+                    .block_on(McpRegistry::connect_all(&[]))
+                    .unwrap(),
+            ),
+        };
+
+        // "read" should match stubs from both servers
+        let results = set.search("read", 10);
+        assert_eq!(results.len(), 2);
+
+        // "file" should match only server_a
+        let results = set.search("file", 10);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].prefixed_name, "server_a__read_file");
+
+        // "config database" should rank server_b highest (2 hits)
+        let results = set.search("config database", 10);
+        assert!(!results.is_empty());
+        assert_eq!(results[0].prefixed_name, "server_b__read_config");
     }
 }

--- a/src/tools/tool_search.rs
+++ b/src/tools/tool_search.rs
@@ -281,4 +281,88 @@ mod tests {
         // Tool should now be activated
         assert!(activated.lock().unwrap().is_activated("fs__read"));
     }
+
+    /// Verify tool_search works with stubs from multiple MCP servers,
+    /// simulating a daemon-mode setup where several servers are deferred.
+    #[tokio::test]
+    async fn multiple_servers_stubs_all_searchable() {
+        let activated = Arc::new(Mutex::new(ActivatedToolSet::new()));
+        let stubs = vec![
+            make_stub("server_a__list_files", "List files on server A"),
+            make_stub("server_a__read_file", "Read file on server A"),
+            make_stub("server_b__query_db", "Query database on server B"),
+            make_stub("server_b__insert_row", "Insert row on server B"),
+        ];
+        let tool = ToolSearchTool::new(make_deferred_set(stubs).await, Arc::clone(&activated));
+
+        // Search should find tools across both servers
+        let result = tool
+            .execute(serde_json::json!({"query": "file"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("server_a__list_files"));
+        assert!(result.output.contains("server_a__read_file"));
+
+        // Server B tools should also be searchable
+        let result = tool
+            .execute(serde_json::json!({"query": "database query"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("server_b__query_db"));
+    }
+
+    /// Verify select mode activates tools and they stay activated across calls,
+    /// matching the daemon-mode pattern where a single ActivatedToolSet persists.
+    #[tokio::test]
+    async fn select_activates_and_persists_across_calls() {
+        let activated = Arc::new(Mutex::new(ActivatedToolSet::new()));
+        let stubs = vec![
+            make_stub("srv__tool_a", "Tool A"),
+            make_stub("srv__tool_b", "Tool B"),
+        ];
+        let tool = ToolSearchTool::new(make_deferred_set(stubs).await, Arc::clone(&activated));
+
+        // Activate tool_a
+        let result = tool
+            .execute(serde_json::json!({"query": "select:srv__tool_a"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(activated.lock().unwrap().is_activated("srv__tool_a"));
+        assert!(!activated.lock().unwrap().is_activated("srv__tool_b"));
+
+        // Activate tool_b in a separate call
+        let result = tool
+            .execute(serde_json::json!({"query": "select:srv__tool_b"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+
+        // Both should remain activated
+        let guard = activated.lock().unwrap();
+        assert!(guard.is_activated("srv__tool_a"));
+        assert!(guard.is_activated("srv__tool_b"));
+        assert_eq!(guard.tool_specs().len(), 2);
+    }
+
+    /// Verify re-activating an already-activated tool does not duplicate it.
+    #[tokio::test]
+    async fn reactivation_is_idempotent() {
+        let activated = Arc::new(Mutex::new(ActivatedToolSet::new()));
+        let tool = ToolSearchTool::new(
+            make_deferred_set(vec![make_stub("srv__tool", "A tool")]).await,
+            Arc::clone(&activated),
+        );
+
+        tool.execute(serde_json::json!({"query": "select:srv__tool"}))
+            .await
+            .unwrap();
+        tool.execute(serde_json::json!({"query": "select:srv__tool"}))
+            .await
+            .unwrap();
+
+        assert_eq!(activated.lock().unwrap().tool_specs().len(), 1);
+    }
 }


### PR DESCRIPTION
## Summary
- Add explicit `tool_search` usage instructions to the `<available-deferred-tools>` system prompt section
- In daemon/Telegram mode, the LLM now knows it must call `tool_search` to activate deferred MCP tools before using them
- The instruction is included for all modes (CLI, daemon, Telegram) since the same codepath is shared

## Test plan
- [x] Instruction presence in deferred tools section
- [x] Multiple-server deferred section formatting
- [x] Cross-server keyword search ranking
- [x] Multi-server tool_search activation
- [x] Activation persistence across calls
- [x] Idempotent re-activation

Closes #3826