### PR TITLE
fix(tools): use resolve_tool_path for consistent path resolution

### DIFF
--- a/src/tools/file_edit.rs
+++ b/src/tools/file_edit.rs
@@ -103,7 +103,7 @@ impl Tool for FileEditTool {
             });
         }
 
-        let full_path = self.security.workspace_dir.join(path);
+        let full_path = self.security.resolve_tool_path(path);
 
         // ── 5. Canonicalize parent ─────────────────────────────────
         let Some(parent) = full_path.parent() else {
@@ -662,6 +662,46 @@ mod tests {
             .as_deref()
             .unwrap_or("")
             .contains("Failed to read file"));
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
+    async fn file_edit_absolute_path_in_workspace() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_edit_abs_path");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        // Canonicalize so the workspace dir matches resolved paths on macOS (/private/var/…)
+        let dir = tokio::fs::canonicalize(&dir).await.unwrap();
+
+        tokio::fs::write(dir.join("target.txt"), "old content")
+            .await
+            .unwrap();
+
+        let tool = FileEditTool::new(test_security(dir.clone()));
+
+        // Pass an absolute path that is within the workspace
+        let abs_path = dir.join("target.txt");
+        let result = tool
+            .execute(json!({
+                "path": abs_path.to_string_lossy().to_string(),
+                "old_string": "old content",
+                "new_string": "new content"
+            }))
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "editing via absolute workspace path should succeed, error: {:?}",
+            result.error
+        );
+
+        let content = tokio::fs::read_to_string(dir.join("target.txt"))
+            .await
+            .unwrap();
+        assert_eq!(content, "new content");
 
         let _ = tokio::fs::remove_dir_all(&dir).await;
     }

--- a/src/tools/file_write.rs
+++ b/src/tools/file_write.rs
@@ -78,7 +78,7 @@ impl Tool for FileWriteTool {
             });
         }
 
-        let full_path = self.security.workspace_dir.join(path);
+        let full_path = self.security.resolve_tool_path(path);
 
         let Some(parent) = full_path.parent() else {
             return Ok(ToolResult {
@@ -448,6 +448,40 @@ mod tests {
         assert_eq!(content, "original", "original file must not be modified");
 
         let _ = tokio::fs::remove_dir_all(&root).await;
+    }
+
+    #[tokio::test]
+    async fn file_write_absolute_path_in_workspace() {
+        let dir = std::env::temp_dir().join("zeroclaw_test_file_write_abs_path");
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        // Canonicalize so the workspace dir matches resolved paths on macOS (/private/var/…)
+        let dir = tokio::fs::canonicalize(&dir).await.unwrap();
+
+        let tool = FileWriteTool::new(test_security(dir.clone()));
+
+        // Pass an absolute path that is within the workspace
+        let abs_path = dir.join("abs_test.txt");
+        let result = tool
+            .execute(
+                json!({"path": abs_path.to_string_lossy().to_string(), "content": "absolute!"}),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "writing via absolute workspace path should succeed, error: {:?}",
+            result.error
+        );
+
+        let content = tokio::fs::read_to_string(dir.join("abs_test.txt"))
+            .await
+            .unwrap();
+        assert_eq!(content, "absolute!");
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
     }
 
     #[tokio::test]

--- a/src/tools/pdf_read.rs
+++ b/src/tools/pdf_read.rs
@@ -100,7 +100,7 @@ impl Tool for PdfReadTool {
             });
         }
 
-        let full_path = self.security.workspace_dir.join(path);
+        let full_path = self.security.resolve_tool_path(path);
 
         let resolved_path = match tokio::fs::canonicalize(&full_path).await {
             Ok(p) => p,


### PR DESCRIPTION
## Summary

Fixes #3774

- Replace `self.security.workspace_dir.join(path)` with `self.security.resolve_tool_path(path)` in `file_write`, `file_edit`, and `pdf_read` tools
- This ensures absolute paths are passed through unchanged instead of being incorrectly joined with the workspace directory (e.g. `/workspace//absolute/path`)
- `file_read` already used the correct pattern — this brings the other file tools in line

## Test plan

- [x] Added unit tests for `file_write` with absolute path resolution
- [x] Added unit tests for `file_edit` with absolute path resolution
- [x] Verified `pdf_read` uses `resolve_tool_path`
- [x] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)