### PR TITLE
feat(heartbeat): 5-min default interval + conversation pruning

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4045,7 +4045,8 @@ pub struct ClassificationRule {
 pub struct HeartbeatConfig {
     /// Enable periodic heartbeat pings. Default: `false`.
     pub enabled: bool,
-    /// Interval in minutes between heartbeat pings. Default: `30`.
+    /// Interval in minutes between heartbeat pings. Default: `5`.
+    #[serde(default = "default_heartbeat_interval")]
     pub interval_minutes: u32,
     /// Enable two-phase heartbeat: Phase 1 asks LLM whether to run, Phase 2
     /// executes only when the LLM decides there is work to do. Saves API cost
@@ -4089,6 +4090,10 @@ pub struct HeartbeatConfig {
     pub max_run_history: u32,
 }
 
+fn default_heartbeat_interval() -> u32 {
+    5
+}
+
 fn default_two_phase() -> bool {
     true
 }
@@ -4109,7 +4114,7 @@ impl Default for HeartbeatConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            interval_minutes: 30,
+            interval_minutes: default_heartbeat_interval(),
             two_phase: true,
             message: None,
             target: None,
@@ -8323,7 +8328,7 @@ mod tests {
     async fn heartbeat_config_default() {
         let h = HeartbeatConfig::default();
         assert!(!h.enabled);
-        assert_eq!(h.interval_minutes, 30);
+        assert_eq!(h.interval_minutes, 5);
         assert!(h.message.is_none());
         assert!(h.target.is_none());
         assert!(h.to.is_none());

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -315,7 +315,10 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
 
         // ── Phase 1: LLM decision (two-phase mode) ──────────────
         let tasks_to_run = if two_phase {
-            let decision_prompt = HeartbeatEngine::build_decision_prompt(&tasks);
+            let decision_prompt = format!(
+                "[Heartbeat Task | decision] {}",
+                HeartbeatEngine::build_decision_prompt(&tasks),
+            );
             match Box::pin(crate::agent::run(
                 config.clone(),
                 Some(decision_prompt),

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -101,6 +101,7 @@ pub fn should_skip_autosave_content(content: &str) -> bool {
 
     let lowered = normalized.to_ascii_lowercase();
     lowered.starts_with("[cron:")
+        || lowered.starts_with("[heartbeat task")
         || lowered.starts_with("[distilled_")
         || lowered.contains("distilled_index_sig:")
 }
@@ -470,6 +471,12 @@ mod tests {
         assert!(should_skip_autosave_content("[cron:auto] patrol check"));
         assert!(should_skip_autosave_content(
             "[DISTILLED_MEMORY_CHUNK 1/2] DISTILLED_INDEX_SIG:abc123"
+        ));
+        assert!(should_skip_autosave_content(
+            "[Heartbeat Task | decision] Should I run tasks?"
+        ));
+        assert!(should_skip_autosave_content(
+            "[Heartbeat Task | high] Execute scheduled patrol"
         ));
         assert!(!should_skip_autosave_content(
             "User prefers concise answers."


### PR DESCRIPTION
## Summary
- Lower default `interval_minutes` from 30 → 5 to match renewable partial wake-lock cadence (cheap with `two_phase: true` default)
- Add `[heartbeat task` prefix to memory auto-save skip filter so heartbeat prompts don't pollute persistent context
- Wrap Phase 1 decision prompt with `[Heartbeat Task | decision]` prefix so it's caught by the same filter (Phase 2 already had the prefix)

## Changes
| File | What |
|------|------|
| `src/config/schema.rs` | `default_heartbeat_interval()` → 5, serde default attr, updated doc + Default impl + test |
| `src/memory/mod.rs` | Added `[heartbeat task` to skip filter + 2 test assertions |
| `src/daemon/mod.rs` | Wrapped Phase 1 decision prompt with `[Heartbeat Task \| decision]` prefix |

## Risk
Medium — heartbeat subsystem only. Users with `heartbeat.enabled = true` who omit `interval_minutes` will tick every 5min instead of 30min, but `two_phase: true` (default) makes idle ticks cheap (one short LLM call returning "skip").

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — no warnings
- [x] `cargo test` — all pass
- [x] `cargo build --release` — compiles
- [ ] CI/CD passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)