### PR TITLE
fix(providers): clamp unsupported temperatures in Claude Code provider

### DIFF
--- a/src/providers/claude_code.rs
+++ b/src/providers/claude_code.rs
@@ -90,17 +90,31 @@ impl ClaudeCodeProvider {
             .any(|v| (temperature - v).abs() < TEMP_EPSILON)
     }
 
-    fn validate_temperature(temperature: f64) -> anyhow::Result<()> {
+    fn validate_temperature(temperature: f64) -> anyhow::Result<f64> {
         if !temperature.is_finite() {
             anyhow::bail!("Claude Code provider received non-finite temperature value");
         }
-        if !Self::supports_temperature(temperature) {
-            anyhow::bail!(
-                "temperature unsupported by Claude Code CLI: {temperature}. \
-                 Supported values: 0.7 or 1.0"
-            );
+        if Self::supports_temperature(temperature) {
+            return Ok(temperature);
         }
-        Ok(())
+        // Clamp to the nearest supported value — the CLI ignores temperature
+        // anyway, so a hard error just blocks callers like memory consolidation
+        // that legitimately request low temperatures.
+        let clamped = *CLAUDE_CODE_SUPPORTED_TEMPERATURES
+            .iter()
+            .min_by(|a, b| {
+                (temperature - **a)
+                    .abs()
+                    .partial_cmp(&(temperature - **b).abs())
+                    .unwrap()
+            })
+            .unwrap();
+        tracing::debug!(
+            requested = temperature,
+            clamped = clamped,
+            "Clamped unsupported temperature to nearest Claude Code CLI value"
+        );
+        Ok(clamped)
     }
 
     fn redact_stderr(stderr: &[u8]) -> String {
@@ -352,11 +366,18 @@ mod tests {
     }
 
     #[test]
-    fn validate_temperature_rejects_custom_value() {
-        let err = ClaudeCodeProvider::validate_temperature(0.2).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("temperature unsupported by Claude Code CLI"));
+    fn validate_temperature_clamps_custom_value() {
+        let clamped = ClaudeCodeProvider::validate_temperature(0.2).unwrap();
+        assert!((clamped - 0.7).abs() < 1e-9, "0.2 should clamp to 0.7");
+
+        let clamped = ClaudeCodeProvider::validate_temperature(0.9).unwrap();
+        assert!((clamped - 1.0).abs() < 1e-9, "0.9 should clamp to 1.0");
+    }
+
+    #[test]
+    fn validate_temperature_rejects_non_finite() {
+        assert!(ClaudeCodeProvider::validate_temperature(f64::NAN).is_err());
+        assert!(ClaudeCodeProvider::validate_temperature(f64::INFINITY).is_err());
     }
 
     #[tokio::test]
@@ -467,10 +488,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn chat_with_history_rejects_bad_temperature() {
+    async fn chat_with_history_clamps_bad_temperature() {
         let provider = echo_provider();
         let messages = vec![ChatMessage::user("test")];
         let result = provider.chat_with_history(&messages, "default", 0.5).await;
-        assert!(result.is_err());
+        assert!(
+            result.is_ok(),
+            "unsupported temperature should be clamped, not rejected"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- The Claude Code CLI only supports temperatures 0.7 and 1.0, but internal subsystems (memory consolidation at 0.1, context summarizer at 0.2) request lower values
- Previously the provider rejected these with a hard error, triggering retries and WARN-level log noise via `ReliableProvider`
- Now clamps to the nearest supported value with a debug-level log, since the CLI ignores temperature anyway

## Test plan
- [x] Existing unit tests updated and passing (`cargo test --lib providers::claude_code` — 14/14 pass)
- [ ] Manual: run `zeroclaw daemon` with `claude-code` provider and verify no temperature warnings on incoming messages
- [ ] Manual: trigger memory consolidation and verify it completes without retry warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)