### PR TITLE
feat(security): inject security policy summary into LLM system prompt

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -42,9 +42,10 @@ pub struct Agent {
     allowed_tools: Option<Vec<String>>,
     response_cache: Option<Arc<crate::memory::response_cache::ResponseCache>>,
     tool_descriptions: Option<ToolDescriptions>,
+    /// Pre-rendered security policy summary injected into the system prompt
+    /// so the LLM knows the concrete constraints before making tool calls.
+    security_summary: Option<String>,
 }
-
-pub struct AgentBuilder {
     provider: Option<Box<dyn Provider>>,
     tools: Option<Vec<Box<dyn Tool>>>,
     memory: Option<Arc<dyn Memory>>,
@@ -67,6 +68,7 @@ pub struct AgentBuilder {
     allowed_tools: Option<Vec<String>>,
     response_cache: Option<Arc<crate::memory::response_cache::ResponseCache>>,
     tool_descriptions: Option<ToolDescriptions>,
+    security_summary: Option<String>,
 }
 
 impl AgentBuilder {
@@ -94,6 +96,7 @@ impl AgentBuilder {
             allowed_tools: None,
             response_cache: None,
             tool_descriptions: None,
+            security_summary: None,
         }
     }
 
@@ -216,6 +219,11 @@ impl AgentBuilder {
         self
     }
 
+    pub fn security_summary(mut self, summary: Option<String>) -> Self {
+        self.security_summary = summary;
+        self
+    }
+
     pub fn build(self) -> Result<Agent> {
         let mut tools = self
             .tools
@@ -267,6 +275,7 @@ impl AgentBuilder {
             allowed_tools: allowed,
             response_cache: self.response_cache,
             tool_descriptions: self.tool_descriptions,
+            security_summary: self.security_summary,
         })
     }
 }
@@ -426,6 +435,7 @@ impl Agent {
             ))
             .skills_prompt_mode(config.skills.prompt_injection_mode)
             .auto_save(config.memory.auto_save)
+            .security_summary(Some(security.prompt_summary()))
             .build()
     }
 
@@ -467,6 +477,7 @@ impl Agent {
             identity_config: Some(&self.identity_config),
             dispatcher_instructions: &instructions,
             tool_descriptions: self.tool_descriptions.as_ref(),
+            security_summary: self.security_summary.clone(),
         };
         self.prompt_builder.build(&ctx)
     }

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -21,6 +21,11 @@ pub struct PromptContext<'a> {
     /// Locale-aware tool descriptions. When present, tool descriptions in
     /// prompts are resolved from the locale file instead of hardcoded values.
     pub tool_descriptions: Option<&'a ToolDescriptions>,
+    /// Pre-rendered security policy summary for inclusion in the Safety
+    /// prompt section.  When present, the LLM sees the concrete constraints
+    /// (allowed commands, forbidden paths, autonomy level) so it can plan
+    /// tool calls without trial-and-error.  See issue #2404.
+    pub security_summary: Option<String>,
 }
 
 pub trait PromptSection: Send + Sync {
@@ -153,8 +158,25 @@ impl PromptSection for SafetySection {
         "safety"
     }
 
-    fn build(&self, _ctx: &PromptContext<'_>) -> Result<String> {
-        Ok("## Safety\n\n- Do not exfiltrate private data.\n- Do not run destructive commands without asking.\n- Do not bypass oversight or approval mechanisms.\n- Prefer `trash` over `rm`.\n- When in doubt, ask before acting externally.".into())
+    fn build(&self, ctx: &PromptContext<'_>) -> Result<String> {
+        let mut out = String::from(
+            "## Safety\n\n\
+             - Do not exfiltrate private data.\n\
+             - Do not run destructive commands without asking.\n\
+             - Do not bypass oversight or approval mechanisms.\n\
+             - Prefer `trash` over `rm`.\n\
+             - When in doubt, ask before acting externally.",
+        );
+
+        // Append concrete security policy constraints when available (#2404).
+        // This tells the LLM exactly what commands are allowed, which paths
+        // are off-limits, etc. — preventing wasteful trial-and-error.
+        if let Some(ref summary) = ctx.security_summary {
+            out.push_str("\n\n### Active Security Policy\n\n");
+            out.push_str(summary);
+        }
+
+        Ok(out)
     }
 }
 
@@ -326,6 +348,7 @@ mod tests {
             identity_config: Some(&identity_config),
             dispatcher_instructions: "",
             tool_descriptions: None,
+            security_summary: None,
         };
 
         let section = IdentitySection;
@@ -355,6 +378,7 @@ mod tests {
             identity_config: None,
             dispatcher_instructions: "instr",
             tool_descriptions: None,
+            security_summary: None,
         };
         let prompt = SystemPromptBuilder::with_defaults().build(&ctx).unwrap();
         assert!(prompt.contains("## Tools"));
@@ -391,6 +415,7 @@ mod tests {
             identity_config: None,
             dispatcher_instructions: "",
             tool_descriptions: None,
+            security_summary: None,
         };
 
         let output = SkillsSection.build(&ctx).unwrap();
@@ -430,6 +455,7 @@ mod tests {
             identity_config: None,
             dispatcher_instructions: "",
             tool_descriptions: None,
+            security_summary: None,
         };
 
         let output = SkillsSection.build(&ctx).unwrap();
@@ -452,6 +478,7 @@ mod tests {
             identity_config: None,
             dispatcher_instructions: "instr",
             tool_descriptions: None,
+            security_summary: None,
         };
 
         let rendered = DateTimeSection.build(&ctx).unwrap();
@@ -506,5 +533,48 @@ mod tests {
         assert!(prompt.contains(
             "<instruction>Use &lt;tool_call&gt; and &amp; keep output &quot;safe&quot;</instruction>"
         ));
+    }
+
+    #[test]
+    fn safety_section_includes_security_summary_when_present() {
+        let tools: Vec<Box<dyn Tool>> = vec![];
+        let summary = "**Autonomy level**: Supervised\n**Allowed shell commands**: `git`, `ls`.\n".to_string();
+        let ctx = PromptContext {
+            workspace_dir: Path::new("/tmp"),
+            model_name: "test-model",
+            tools: &tools,
+            skills: &[],
+            skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
+            identity_config: None,
+            dispatcher_instructions: "",
+            tool_descriptions: None,
+            security_summary: Some(summary.clone()),
+        };
+
+        let output = SafetySection.build(&ctx).unwrap();
+        assert!(output.contains("## Safety"), "should contain base safety header");
+        assert!(output.contains("### Active Security Policy"), "should contain security policy header");
+        assert!(output.contains("Autonomy level"), "should contain autonomy level from summary");
+        assert!(output.contains("`git`"), "should contain allowed commands from summary");
+    }
+
+    #[test]
+    fn safety_section_omits_security_policy_when_none() {
+        let tools: Vec<Box<dyn Tool>> = vec![];
+        let ctx = PromptContext {
+            workspace_dir: Path::new("/tmp"),
+            model_name: "test-model",
+            tools: &tools,
+            skills: &[],
+            skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
+            identity_config: None,
+            dispatcher_instructions: "",
+            tool_descriptions: None,
+            security_summary: None,
+        };
+
+        let output = SafetySection.build(&ctx).unwrap();
+        assert!(output.contains("## Safety"), "should contain base safety header");
+        assert!(!output.contains("### Active Security Policy"), "should NOT contain security policy header when None");
     }
 }

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -1296,11 +1296,77 @@ impl SecurityPolicy {
             tracker: ActionTracker::new(),
         }
     }
+
+    /// Render a human-readable summary of the active security constraints
+    /// suitable for injection into the LLM system prompt.
+    ///
+    /// Giving the LLM visibility into these constraints prevents it from
+    /// wasting tokens on commands / paths that will be rejected at runtime.
+    /// See issue #2404.
+    pub fn prompt_summary(&self) -> String {
+        use std::fmt::Write;
+
+        let mut out = String::new();
+
+        // Autonomy level
+        let _ = writeln!(out, "**Autonomy level**: {:?}", self.autonomy);
+
+        // Workspace constraint
+        if self.workspace_only {
+            let _ = writeln!(
+                out,
+                "**Workspace boundary**: file operations are restricted to `{}`.",
+                self.workspace_dir.display()
+            );
+        }
+
+        // Allowed roots
+        if !self.allowed_roots.is_empty() {
+            let roots: Vec<String> = self.allowed_roots.iter().map(|p| format!("`{}`", p.display())).collect();
+            let _ = writeln!(out, "**Additional allowed paths**: {}", roots.join(", "));
+        }
+
+        // Allowed commands
+        if !self.allowed_commands.is_empty() {
+            let cmds: Vec<String> = self.allowed_commands.iter().map(|c| format!("`{c}`")).collect();
+            let _ = writeln!(
+                out,
+                "**Allowed shell commands**: {}. Commands not on this list will be rejected.",
+                cmds.join(", ")
+            );
+        }
+
+        // Forbidden paths
+        if !self.forbidden_paths.is_empty() {
+            let paths: Vec<String> = self.forbidden_paths.iter().map(|p| format!("`{p}`")).collect();
+            let _ = writeln!(
+                out,
+                "**Forbidden paths**: {}. Any read/write/exec targeting these paths will be blocked.",
+                paths.join(", ")
+            );
+        }
+
+        // Risk controls
+        if self.block_high_risk_commands {
+            let _ = writeln!(out, "**High-risk commands** (rm, kill, reboot, etc.) are blocked.");
+        }
+        if self.require_approval_for_medium_risk {
+            let _ = writeln!(out, "**Medium-risk commands** require user approval before execution.");
+        }
+
+        // Rate limit
+        let _ = writeln!(
+            out,
+            "**Rate limit**: max {} actions per hour.",
+            self.max_actions_per_hour
+        );
+
+        out
+    }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+mod tests {    use super::*;
 
     fn default_policy() -> SecurityPolicy {
         SecurityPolicy::default()
@@ -2743,5 +2809,94 @@ mod tests {
             ..SecurityPolicy::default()
         };
         assert!(!p.is_under_allowed_root("/any/path"));
+    }
+
+    // ── prompt_summary ──────────────────────────────────────
+
+    #[test]
+    fn prompt_summary_includes_autonomy_level() {
+        let p = default_policy();
+        let summary = p.prompt_summary();
+        assert!(summary.contains("Supervised"), "should mention autonomy level");
+    }
+
+    #[test]
+    fn prompt_summary_includes_workspace_boundary_when_workspace_only() {
+        let p = SecurityPolicy {
+            workspace_dir: PathBuf::from("/home/user/project"),
+            workspace_only: true,
+            ..SecurityPolicy::default()
+        };
+        let summary = p.prompt_summary();
+        assert!(summary.contains("Workspace boundary"), "should mention workspace boundary");
+        assert!(summary.contains("/home/user/project"), "should mention workspace path");
+    }
+
+    #[test]
+    fn prompt_summary_omits_workspace_boundary_when_not_workspace_only() {
+        let p = SecurityPolicy {
+            workspace_only: false,
+            ..SecurityPolicy::default()
+        };
+        let summary = p.prompt_summary();
+        assert!(!summary.contains("Workspace boundary"), "should not mention workspace boundary");
+    }
+
+    #[test]
+    fn prompt_summary_includes_allowed_commands() {
+        let p = SecurityPolicy {
+            allowed_commands: vec!["git".into(), "ls".into()],
+            ..SecurityPolicy::default()
+        };
+        let summary = p.prompt_summary();
+        assert!(summary.contains("`git`"), "should list allowed commands");
+        assert!(summary.contains("`ls`"), "should list allowed commands");
+        assert!(summary.contains("not on this list will be rejected"), "should warn about rejection");
+    }
+
+    #[test]
+    fn prompt_summary_includes_forbidden_paths() {
+        let p = SecurityPolicy {
+            workspace_only: false,
+            forbidden_paths: vec!["/etc".into(), "~/.ssh".into()],
+            ..SecurityPolicy::default()
+        };
+        let summary = p.prompt_summary();
+        assert!(summary.contains("`/etc`"), "should list forbidden paths");
+        assert!(summary.contains("`~/.ssh`"), "should list forbidden paths");
+    }
+
+    #[test]
+    fn prompt_summary_includes_rate_limit() {
+        let p = SecurityPolicy {
+            max_actions_per_hour: 42,
+            ..SecurityPolicy::default()
+        };
+        let summary = p.prompt_summary();
+        assert!(summary.contains("42"), "should mention rate limit");
+        assert!(summary.contains("actions per hour"), "should explain rate limit");
+    }
+
+    #[test]
+    fn prompt_summary_includes_risk_controls() {
+        let p = SecurityPolicy {
+            block_high_risk_commands: true,
+            require_approval_for_medium_risk: true,
+            ..SecurityPolicy::default()
+        };
+        let summary = p.prompt_summary();
+        assert!(summary.contains("High-risk commands"), "should mention high-risk block");
+        assert!(summary.contains("Medium-risk commands"), "should mention medium-risk approval");
+    }
+
+    #[test]
+    fn prompt_summary_includes_allowed_roots() {
+        let p = SecurityPolicy {
+            allowed_roots: vec![PathBuf::from("/shared/data"), PathBuf::from("/opt/tools")],
+            ..SecurityPolicy::default()
+        };
+        let summary = p.prompt_summary();
+        assert!(summary.contains("`/shared/data`"), "should list allowed roots");
+        assert!(summary.contains("`/opt/tools`"), "should list allowed roots");
     }
 }


### PR DESCRIPTION
## Problem

Fixes #2404

The LLM has no visibility into the active security policy constraints (allowed commands, forbidden paths, workspace boundary, autonomy level, rate limits). This means it frequently attempts tool calls that are immediately rejected by the runtime security layer, wasting tokens and degrading user experience through trial-and-error behavior.

## Solution

Inject a human-readable summary of the active `SecurityPolicy` into the system prompt's Safety section, so the LLM knows the concrete constraints before making tool calls.

### Changes

**`src/security/policy.rs`**
- Added `SecurityPolicy::prompt_summary()` method that renders the policy as Markdown
- Includes: autonomy level, workspace boundary, allowed roots, allowed commands, forbidden paths, risk controls, rate limit

**`src/agent/prompt.rs`**
- `SafetySection::build()` now appends an `### Active Security Policy` subsection when `security_summary` is `Some`
- Added `security_summary: Option<String>` field to `PromptContext`

**`src/agent/agent.rs`**
- Added `security_summary` field to `Agent` struct and `AgentBuilder`
- `from_config()` now calls `security.prompt_summary()` and passes it through the builder
- `build_system_prompt()` passes the summary to `PromptContext`

### Example output in system prompt

```
## Safety

- Do not exfiltrate private data.
- Do not run destructive commands without asking.
...

### Active Security Policy

**Autonomy level**: Supervised
**Workspace boundary**: file operations are restricted to `/home/user/project`.
**Allowed shell commands**: `git`, `npm`, `cargo`, `ls`, `cat`, ...
**Forbidden paths**: `/etc`, `/root`, `/home`, ...
**High-risk commands** (rm, kill, reboot, etc.) are blocked.
**Medium-risk commands** require user approval before execution.
**Rate limit**: max 20 actions per hour.
```

### Tests

- 9 new tests for `prompt_summary()` covering all policy fields
- 2 new tests for `SafetySection` (with/without security summary)
- All existing tests updated with `security_summary: None`