### PR TITLE
Fix undocumented conversational_ai section in default config

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -137,7 +137,12 @@ pub struct Config {
     pub cloud_ops: CloudOpsConfig,
 
     /// Conversational AI agent builder configuration (`[conversational_ai]`).
-    #[serde(default)]
+    ///
+    /// Experimental / future feature — not yet wired into the agent runtime.
+    /// Omitted from generated config files when disabled (the default).
+    /// Existing configs that already contain this section will continue to
+    /// deserialize correctly thanks to `#[serde(default)]`.
+    #[serde(default, skip_serializing_if = "ConversationalAiConfig::is_disabled")]
     pub conversational_ai: ConversationalAiConfig,
 
     /// Managed cybersecurity service configuration (`[security_ops]`).
@@ -5903,6 +5908,17 @@ pub struct ConversationalAiConfig {
     /// Optional tool name for RAG-based knowledge base lookup during conversations.
     #[serde(default)]
     pub knowledge_base_tool: Option<String>,
+}
+
+impl ConversationalAiConfig {
+    /// Returns `true` when the feature is disabled (the default).
+    ///
+    /// Used by `#[serde(skip_serializing_if)]` to omit the entire
+    /// `[conversational_ai]` section from newly-generated config files,
+    /// avoiding user confusion over an undocumented / experimental section.
+    pub fn is_disabled(&self) -> bool {
+        !self.enabled
+    }
 }
 
 impl Default for ConversationalAiConfig {


### PR DESCRIPTION
## Summary
- Fixes #3958
- Added `#[serde(skip_serializing_if)]` to omit the experimental `[conversational_ai]` section from generated config when disabled (the default)
- Existing configs with the section continue to work via `#[serde(default)]`
- Added doc comments explaining the feature is experimental

## Test plan
- [ ] Fresh install no longer generates `[conversational_ai]` section in config.toml
- [ ] Existing configs with the section still parse correctly
- [ ] Setting `conversational_ai.enabled = true` makes the section appear in serialized output