### PR TITLE
Fix GHCR image: add memory-postgres feature to Docker/CI builds

### DIFF
--- a/.github/workflows/cross-platform-build-manual.yml
+++ b/.github/workflows/cross-platform-build-manual.yml
@@ -74,4 +74,4 @@ jobs:
           if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
             export "${{ matrix.linker_env }}=${{ matrix.linker }}"
           fi
-          cargo build --release --locked --features channel-matrix --target ${{ matrix.target }}
+          cargo build --release --locked --features channel-matrix,memory-postgres --target ${{ matrix.target }}

--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -213,7 +213,7 @@ jobs:
           if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
             export "${{ matrix.linker_env }}=${{ matrix.linker }}"
           fi
-          cargo build --release --locked --features channel-matrix --target ${{ matrix.target }}
+          cargo build --release --locked --features channel-matrix,memory-postgres --target ${{ matrix.target }}
 
       - name: Package (Unix)
         if: runner.os != 'Windows'
@@ -346,7 +346,7 @@ jobs:
           context: docker-ctx
           push: true
           build-args: |
-            ZEROCLAW_CARGO_FEATURES=channel-matrix
+            ZEROCLAW_CARGO_FEATURES=channel-matrix,memory-postgres
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.version.outputs.tag }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:beta

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -214,7 +214,7 @@ jobs:
           if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
             export "${{ matrix.linker_env }}=${{ matrix.linker }}"
           fi
-          cargo build --release --locked --features channel-matrix --target ${{ matrix.target }}
+          cargo build --release --locked --features channel-matrix,memory-postgres --target ${{ matrix.target }}
 
       - name: Package (Unix)
         if: runner.os != 'Windows'
@@ -389,7 +389,7 @@ jobs:
           context: docker-ctx
           push: true
           build-args: |
-            ZEROCLAW_CARGO_FEATURES=channel-matrix
+            ZEROCLAW_CARGO_FEATURES=channel-matrix,memory-postgres
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.validate.outputs.tag }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN npm run build
 FROM rust:1.94-slim@sha256:da9dab7a6b8dd428e71718402e97207bb3e54167d37b5708616050b1e8f60ed6 AS builder
 
 WORKDIR /app
-ARG ZEROCLAW_CARGO_FEATURES=""
+ARG ZEROCLAW_CARGO_FEATURES="memory-postgres"
 
 # Install build dependencies
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -27,7 +27,7 @@ RUN npm run build
 FROM rust:1.94-bookworm AS builder
 
 WORKDIR /app
-ARG ZEROCLAW_CARGO_FEATURES=""
+ARG ZEROCLAW_CARGO_FEATURES="memory-postgres"
 
 # Install build dependencies
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## Summary
- Fixes #3946
- Added `memory-postgres` to default cargo features in `Dockerfile` and `Dockerfile.debian`
- Added `memory-postgres` to all CI release workflows (beta, stable, cross-platform)
- Official GHCR images will now support postgres memory backend out of the box

## Test plan
- [ ] `docker build .` includes memory-postgres feature
- [ ] `docker build -f Dockerfile.debian .` includes memory-postgres feature
- [ ] Container starts successfully with `ZEROCLAW_STORAGE_PROVIDER=postgres`
- [ ] CI release builds include the feature