### PR TITLE
fix(providers): exempt tool schema errors from non-retryable classification

### DIFF
--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -2217,9 +2217,8 @@ mod tests {
 
     #[test]
     fn tool_schema_error_detects_groq_validation_failure() {
-        let err = anyhow::anyhow!(
-            r#"Groq API error (400 Bad Request): {"error":{"message":"tool call validation failed: attempted to call tool 'memory_recall' which was not in request"}}"#
-        );
+        let msg = r#"Groq API error (400 Bad Request): {"error":{"message":"tool call validation failed: attempted to call tool 'memory_recall' which was not in request"}}"#;
+        let err = anyhow::anyhow!("{}", msg);
         assert!(is_tool_schema_error(&err));
     }
 
@@ -2253,9 +2252,8 @@ mod tests {
     #[test]
     fn non_retryable_returns_false_for_tool_schema_400() {
         // A 400 error with tool schema validation text should NOT be non-retryable.
-        let err = anyhow::anyhow!(
-            r#"400 Bad Request: tool call validation failed: attempted to call tool 'x' which was not in request"#
-        );
+        let msg = "400 Bad Request: tool call validation failed: attempted to call tool 'x' which was not in request";
+        let err = anyhow::anyhow!("{}", msg);
         assert!(!is_non_retryable(&err));
     }
 


### PR DESCRIPTION
## Summary

Fixes #3757

When using the Groq provider, a 400 error with "tool call validation failed" was classified as non-retryable by `reliable.rs::is_non_retryable()`. This prevented the provider's built-in fallback in `compatible.rs::is_native_tool_schema_unsupported()` from ever executing, making the agent completely unusable with Groq.

- Add `is_tool_schema_error()` helper that detects tool schema validation keywords ("tool call validation failed", "was not in request", "not found in tool list", "invalid_tool_call")
- Exempt these errors from non-retryable classification so the provider's prompt-guided fallback can execute
- 7 unit tests covering detection, negative cases, and interaction with `is_non_retryable`

## Test plan

- [x] `is_tool_schema_error` detects Groq-style "tool call validation failed" errors
- [x] `is_tool_schema_error` detects individual keywords
- [x] `is_tool_schema_error` ignores unrelated errors
- [x] `is_non_retryable` returns `false` for tool schema 400 errors
- [x] `is_non_retryable` still returns `true` for other 400 errors
- [x] `cargo check` passes
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)