### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9164,7 +9164,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump `zeroclawlabs` version from 0.5.0 → 0.5.1
- Regenerated `Cargo.lock`

### Release highlights
- Autonomy enforcement in gateway and channel paths (#3952)
- `conversational_ai` startup warning for unimplemented config (#3958)
- Heartbeat default interval 30→5min (#3938)
- Provider timeout and error handling improvements (#3973, #3978)
- Docker/CI postgres and Lark feature fixes (#3971, #3933)
- Tool path resolution fix (#3937)
- OTP config fix (#3936)
- README: Instagram badge + banner image (#3979)

## Test plan
- [x] `cargo check` builds as `v0.5.1`
- [x] Lock file regenerated cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)