### PR TITLE
fix(ci): harden AUR SSH key setup and add diagnostics

### DIFF
--- a/.github/workflows/pub-aur.yml
+++ b/.github/workflows/pub-aur.yml
@@ -134,15 +134,27 @@ jobs:
             exit 1
           fi
 
+          # Set up SSH key — normalize line endings and ensure trailing newline
           mkdir -p ~/.ssh
-          echo "$AUR_SSH_KEY" > ~/.ssh/aur
+          chmod 700 ~/.ssh
+          printf '%s\n' "$AUR_SSH_KEY" | tr -d '\r' > ~/.ssh/aur
           chmod 600 ~/.ssh/aur
-          cat >> ~/.ssh/config <<SSH_CONFIG
+
+          cat > ~/.ssh/config <<'SSH_CONFIG'
           Host aur.archlinux.org
             IdentityFile ~/.ssh/aur
             User aur
             StrictHostKeyChecking accept-new
           SSH_CONFIG
+          chmod 600 ~/.ssh/config
+
+          # Verify key is valid and print fingerprint for debugging
+          echo "::group::SSH key diagnostics"
+          ssh-keygen -l -f ~/.ssh/aur || { echo "::error::AUR_SSH_KEY is not a valid SSH private key"; exit 1; }
+          echo "::endgroup::"
+
+          # Test SSH connectivity before attempting clone
+          ssh -T -o BatchMode=yes -o ConnectTimeout=10 aur@aur.archlinux.org 2>&1 || true
 
           tmp_dir="$(mktemp -d)"
           git clone ssh://aur@aur.archlinux.org/zeroclaw.git "$tmp_dir/aur"


### PR DESCRIPTION
## Summary
- AUR publish fails with `Permission denied (publickey)` during stable release
- Likely cause: key formatting issues (Windows line endings from GitHub secrets UI) or missing public key registration on AUR

## Changes
- Normalize line endings (`tr -d '\r'`) when writing SSH key file
- Set correct permissions: `~/.ssh` (700), `~/.ssh/config` (600), key (600)
- Validate key with `ssh-keygen -l` before attempting clone
- Add SSH connectivity test (`ssh -T`) for clearer error diagnostics

## Test plan
- [x] Workflow syntax validated
- [ ] After merge: re-run `pub-aur.yml` with `release_tag=v0.5.1` to verify
- [ ] If SSH still fails: the public key needs to be re-registered on https://aur.archlinux.org account settings

## Note
If the SSH key diagnostics show a valid fingerprint but AUR still rejects it, the corresponding **public key** needs to be added to the AUR account at https://aur.archlinux.org/account → SSH Public Key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)