### PR TITLE
fix(anthropic): always apply cache_control to system prompts

### DIFF
--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -1059,12 +1059,8 @@ mod tests {
                 role: "user".to_string(),
                 content: "Hello".to_string(),
             },
-            ChatMessage {
-                role: "assistant".to_string(),
-                content: "Hi".to_string(),
-            },
         ];
-        // Only 2 non-system messages
+        // Only 1 non-system message — should not cache
         assert!(!AnthropicProvider::should_cache_conversation(&messages));
     }
 
@@ -1074,8 +1070,8 @@ mod tests {
             role: "system".to_string(),
             content: "System prompt".to_string(),
         }];
-        // Add 5 non-system messages
-        for i in 0..5 {
+        // Add 3 non-system messages
+        for i in 0..3 {
             messages.push(ChatMessage {
                 role: if i % 2 == 0 { "user" } else { "assistant" }.to_string(),
                 content: format!("Message {i}"),
@@ -1086,21 +1082,24 @@ mod tests {
 
     #[test]
     fn should_cache_conversation_boundary() {
-        let mut messages = vec![];
-        // Add exactly 4 non-system messages
-        for i in 0..4 {
-            messages.push(ChatMessage {
-                role: if i % 2 == 0 { "user" } else { "assistant" }.to_string(),
-                content: format!("Message {i}"),
-            });
-        }
+        let messages = vec![ChatMessage {
+            role: "user".to_string(),
+            content: "Hello".to_string(),
+        }];
+        // Exactly 1 non-system message — should not cache
         assert!(!AnthropicProvider::should_cache_conversation(&messages));
 
-        // Add one more to cross boundary
-        messages.push(ChatMessage {
-            role: "user".to_string(),
-            content: "One more".to_string(),
-        });
+        // Add one more to cross boundary (>1)
+        let messages = vec![
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Hello".to_string(),
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "Hi".to_string(),
+            },
+        ];
         assert!(AnthropicProvider::should_cache_conversation(&messages));
     }
 
@@ -1213,7 +1212,7 @@ mod tests {
     }
 
     #[test]
-    fn convert_messages_small_system_prompt() {
+    fn convert_messages_small_system_prompt_uses_blocks_with_cache() {
         let messages = vec![ChatMessage {
             role: "system".to_string(),
             content: "Short system prompt".to_string(),
@@ -1222,10 +1221,17 @@ mod tests {
         let (system_prompt, _) = AnthropicProvider::convert_messages(&messages);
 
         match system_prompt.unwrap() {
-            SystemPrompt::String(s) => {
-                assert_eq!(s, "Short system prompt");
+            SystemPrompt::Blocks(blocks) => {
+                assert_eq!(blocks.len(), 1);
+                assert_eq!(blocks[0].text, "Short system prompt");
+                assert!(
+                    blocks[0].cache_control.is_some(),
+                    "Small system prompts should have cache_control"
+                );
             }
-            SystemPrompt::Blocks(_) => panic!("Expected String variant for small prompt"),
+            SystemPrompt::String(_) => {
+                panic!("Expected Blocks variant with cache_control for small prompt")
+            }
         }
     }
 
@@ -1250,12 +1256,16 @@ mod tests {
     }
 
     #[test]
-    fn backward_compatibility_native_chat_request() {
-        // Test that requests without cache_control serialize identically to old format
+    fn native_chat_request_with_blocks_system() {
+        // System prompts now always use Blocks format with cache_control
         let req = NativeChatRequest {
             model: "claude-3-opus".to_string(),
             max_tokens: 4096,
-            system: Some(SystemPrompt::String("System".to_string())),
+            system: Some(SystemPrompt::Blocks(vec![SystemBlock {
+                block_type: "text".to_string(),
+                text: "System".to_string(),
+                cache_control: Some(CacheControl::ephemeral()),
+            }])),
             messages: vec![NativeMessage {
                 role: "user".to_string(),
                 content: vec![NativeContentOut::Text {
@@ -1268,8 +1278,11 @@ mod tests {
         };
 
         let json = serde_json::to_string(&req).unwrap();
-        assert!(!json.contains("cache_control"));
-        assert!(json.contains(r#""system":"System""#));
+        assert!(json.contains("System"));
+        assert!(
+            json.contains(r#""cache_control":{"type":"ephemeral"}"#),
+            "System prompt should include cache_control"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #3977

Anthropic prompt caching showed 0% cache hit rate because system prompts under 3KB were sent as plain strings (`SystemPrompt::String`) which cannot carry `cache_control` headers. The Anthropic API requires `cache_control: {"type": "ephemeral"}` on content blocks for caching to activate.

- Always use `SystemPrompt::Blocks` format with `cache_control: ephemeral` regardless of system prompt size
- Lower conversation caching threshold from >4 to >1 non-system messages (cache after first exchange)
- Update tests for new behavior and thresholds

## Test plan

- [x] Small system prompts now get `cache_control` headers
- [x] Conversation caching activates after 2 messages instead of 5
- [x] All 56 anthropic tests pass
- [x] `cargo check` passes
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)