### PR TITLE
fix(cron): persist allowed_tools for agent jobs

### DIFF
--- a/src/cron/mod.rs
+++ b/src/cron/mod.rs
@@ -156,6 +156,7 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
             expression,
             tz,
             agent,
+            allowed_tools,
             command,
         } => {
             let schedule = Schedule::Cron {
@@ -172,12 +173,20 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
                     None,
                     None,
                     false,
+                    if allowed_tools.is_empty() {
+                        None
+                    } else {
+                        Some(allowed_tools)
+                    },
                 )?;
                 println!("✅ Added agent cron job {}", job.id);
                 println!("  Expr  : {}", job.expression);
                 println!("  Next  : {}", job.next_run.to_rfc3339());
                 println!("  Prompt: {}", job.prompt.as_deref().unwrap_or_default());
             } else {
+                if !allowed_tools.is_empty() {
+                    bail!("--allowed-tool is only supported with --agent cron jobs");
+                }
                 let job = add_shell_job(config, None, schedule, &command)?;
                 println!("✅ Added cron job {}", job.id);
                 println!("  Expr: {}", job.expression);
@@ -186,7 +195,12 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
             }
             Ok(())
         }
-        crate::CronCommands::AddAt { at, agent, command } => {
+        crate::CronCommands::AddAt {
+            at,
+            agent,
+            allowed_tools,
+            command,
+        } => {
             let at = chrono::DateTime::parse_from_rfc3339(&at)
                 .map_err(|e| anyhow::anyhow!("Invalid RFC3339 timestamp for --at: {e}"))?
                 .with_timezone(&chrono::Utc);
@@ -201,11 +215,19 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
                     None,
                     None,
                     true,
+                    if allowed_tools.is_empty() {
+                        None
+                    } else {
+                        Some(allowed_tools)
+                    },
                 )?;
                 println!("✅ Added one-shot agent cron job {}", job.id);
                 println!("  At    : {}", job.next_run.to_rfc3339());
                 println!("  Prompt: {}", job.prompt.as_deref().unwrap_or_default());
             } else {
+                if !allowed_tools.is_empty() {
+                    bail!("--allowed-tool is only supported with --agent cron jobs");
+                }
                 let job = add_shell_job(config, None, schedule, &command)?;
                 println!("✅ Added one-shot cron job {}", job.id);
                 println!("  At  : {}", job.next_run.to_rfc3339());
@@ -216,6 +238,7 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
         crate::CronCommands::AddEvery {
             every_ms,
             agent,
+            allowed_tools,
             command,
         } => {
             let schedule = Schedule::Every { every_ms };
@@ -229,12 +252,20 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
                     None,
                     None,
                     false,
+                    if allowed_tools.is_empty() {
+                        None
+                    } else {
+                        Some(allowed_tools)
+                    },
                 )?;
                 println!("✅ Added interval agent cron job {}", job.id);
                 println!("  Every(ms): {every_ms}");
                 println!("  Next     : {}", job.next_run.to_rfc3339());
                 println!("  Prompt   : {}", job.prompt.as_deref().unwrap_or_default());
             } else {
+                if !allowed_tools.is_empty() {
+                    bail!("--allowed-tool is only supported with --agent cron jobs");
+                }
                 let job = add_shell_job(config, None, schedule, &command)?;
                 println!("✅ Added interval cron job {}", job.id);
                 println!("  Every(ms): {every_ms}");
@@ -246,6 +277,7 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
         crate::CronCommands::Once {
             delay,
             agent,
+            allowed_tools,
             command,
         } => {
             if agent {
@@ -261,11 +293,19 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
                     None,
                     None,
                     true,
+                    if allowed_tools.is_empty() {
+                        None
+                    } else {
+                        Some(allowed_tools)
+                    },
                 )?;
                 println!("✅ Added one-shot agent cron job {}", job.id);
                 println!("  At    : {}", job.next_run.to_rfc3339());
                 println!("  Prompt: {}", job.prompt.as_deref().unwrap_or_default());
             } else {
+                if !allowed_tools.is_empty() {
+                    bail!("--allowed-tool is only supported with --agent cron jobs");
+                }
                 let job = add_once(config, &delay, &command)?;
                 println!("✅ Added one-shot cron job {}", job.id);
                 println!("  At  : {}", job.next_run.to_rfc3339());
@@ -279,21 +319,37 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
             tz,
             command,
             name,
+            allowed_tools,
         } => {
-            if expression.is_none() && tz.is_none() && command.is_none() && name.is_none() {
-                bail!("At least one of --expression, --tz, --command, or --name must be provided");
+            if expression.is_none()
+                && tz.is_none()
+                && command.is_none()
+                && name.is_none()
+                && allowed_tools.is_empty()
+            {
+                bail!(
+                    "At least one of --expression, --tz, --command, --name, or --allowed-tool must be provided"
+                );
             }
+
+            let existing = if expression.is_some() || tz.is_some() || !allowed_tools.is_empty() {
+                Some(get_job(config, &id)?)
+            } else {
+                None
+            };
 
             // Merge expression/tz with the existing schedule so that
             // --tz alone updates the timezone and --expression alone
             // preserves the existing timezone.
             let schedule = if expression.is_some() || tz.is_some() {
-                let existing = get_job(config, &id)?;
-                let (existing_expr, existing_tz) = match existing.schedule {
+                let existing = existing
+                    .as_ref()
+                    .expect("existing job must be loaded when updating schedule");
+                let (existing_expr, existing_tz) = match &existing.schedule {
                     Schedule::Cron {
                         expr,
                         tz: existing_tz,
-                    } => (expr, existing_tz),
+                    } => (expr.clone(), existing_tz.clone()),
                     _ => bail!("Cannot update expression/tz on a non-cron schedule"),
                 };
                 Some(Schedule::Cron {
@@ -304,10 +360,24 @@ pub fn handle_command(command: crate::CronCommands, config: &Config) -> Result<(
                 None
             };
 
+            if !allowed_tools.is_empty() {
+                let existing = existing
+                    .as_ref()
+                    .expect("existing job must be loaded when updating allowed tools");
+                if existing.job_type != JobType::Agent {
+                    bail!("--allowed-tool is only supported for agent cron jobs");
+                }
+            }
+
             let patch = CronJobPatch {
                 schedule,
                 command,
                 name,
+                allowed_tools: if allowed_tools.is_empty() {
+                    None
+                } else {
+                    Some(allowed_tools)
+                },
                 ..CronJobPatch::default()
             };
 
@@ -430,6 +500,7 @@ mod tests {
                 tz: tz.map(Into::into),
                 command: command.map(Into::into),
                 name: name.map(Into::into),
+                allowed_tools: vec![],
             },
             config,
         )
@@ -778,6 +849,7 @@ mod tests {
                 expression: "*/15 * * * *".into(),
                 tz: None,
                 agent: true,
+                allowed_tools: vec![],
                 command: "Check server health: disk space, memory, CPU load".into(),
             },
             &config,
@@ -808,6 +880,7 @@ mod tests {
                 expression: "*/15 * * * *".into(),
                 tz: None,
                 agent: true,
+                allowed_tools: vec![],
                 command: "Check server health: disk space, memory, CPU load".into(),
             },
             &config,
@@ -820,6 +893,68 @@ mod tests {
     }
 
     #[test]
+    fn cli_agent_allowed_tools_persist() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        handle_command(
+            crate::CronCommands::Add {
+                expression: "*/15 * * * *".into(),
+                tz: None,
+                agent: true,
+                allowed_tools: vec!["file_read".into(), "web_search".into()],
+                command: "Check server health".into(),
+            },
+            &config,
+        )
+        .unwrap();
+
+        let jobs = list_jobs(&config).unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(
+            jobs[0].allowed_tools,
+            Some(vec!["file_read".into(), "web_search".into()])
+        );
+    }
+
+    #[test]
+    fn cli_update_agent_allowed_tools_persist() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+        let job = add_agent_job(
+            &config,
+            Some("agent".into()),
+            Schedule::Cron {
+                expr: "*/5 * * * *".into(),
+                tz: None,
+            },
+            "original prompt",
+            SessionTarget::Isolated,
+            None,
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+
+        handle_command(
+            crate::CronCommands::Update {
+                id: job.id.clone(),
+                expression: None,
+                tz: None,
+                command: None,
+                name: None,
+                allowed_tools: vec!["shell".into()],
+            },
+            &config,
+        )
+        .unwrap();
+
+        let updated = get_job(&config, &job.id).unwrap();
+        assert_eq!(updated.allowed_tools, Some(vec!["shell".into()]));
+    }
+
+    #[test]
     fn cli_without_agent_flag_defaults_to_shell_job() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(&tmp);
@@ -829,6 +964,7 @@ mod tests {
                 expression: "*/5 * * * *".into(),
                 tz: None,
                 agent: false,
+                allowed_tools: vec![],
                 command: "echo ok".into(),
             },
             &config,

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -965,6 +965,7 @@ mod tests {
             None,
             None,
             true,
+            None,
         )
         .unwrap();
         let started = Utc::now();
@@ -990,6 +991,7 @@ mod tests {
             None,
             None,
             true,
+            None,
         )
         .unwrap();
         let started = Utc::now();
@@ -1056,6 +1058,7 @@ mod tests {
                 best_effort: false,
             }),
             false,
+            None,
         )
         .unwrap();
         let started = Utc::now();
@@ -1094,6 +1097,7 @@ mod tests {
                 best_effort: true,
             }),
             false,
+            None,
         )
         .unwrap();
         let started = Utc::now();
@@ -1125,6 +1129,7 @@ mod tests {
             None,
             None,
             false,
+            None,
         )
         .unwrap();
         assert!(!job.delete_after_run);

--- a/src/cron/store.rs
+++ b/src/cron/store.rs
@@ -77,6 +77,7 @@ pub fn add_agent_job(
     model: Option<String>,
     delivery: Option<DeliveryConfig>,
     delete_after_run: bool,
+    allowed_tools: Option<Vec<String>>,
 ) -> Result<CronJob> {
     let now = Utc::now();
     validate_schedule(&schedule, now)?;
@@ -90,8 +91,8 @@ pub fn add_agent_job(
         conn.execute(
             "INSERT INTO cron_jobs (
                 id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                enabled, delivery, delete_after_run, created_at, next_run
-             ) VALUES (?1, ?2, '', ?3, 'agent', ?4, ?5, ?6, ?7, 1, ?8, ?9, ?10, ?11)",
+                enabled, delivery, delete_after_run, allowed_tools, created_at, next_run
+             ) VALUES (?1, ?2, '', ?3, 'agent', ?4, ?5, ?6, ?7, 1, ?8, ?9, ?10, ?11, ?12)",
             params![
                 id,
                 expression,
@@ -102,6 +103,7 @@ pub fn add_agent_job(
                 model,
                 serde_json::to_string(&delivery)?,
                 if delete_after_run { 1 } else { 0 },
+                encode_allowed_tools(allowed_tools.as_ref())?,
                 now.to_rfc3339(),
                 next_run.to_rfc3339(),
             ],
@@ -117,7 +119,8 @@ pub fn list_jobs(config: &Config) -> Result<Vec<CronJob>> {
     with_connection(config, |conn| {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output
+                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
+                    allowed_tools
              FROM cron_jobs ORDER BY next_run ASC",
         )?;
 
@@ -135,7 +138,8 @@ pub fn get_job(config: &Config, job_id: &str) -> Result<CronJob> {
     with_connection(config, |conn| {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output
+                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
+                    allowed_tools
              FROM cron_jobs WHERE id = ?1",
         )?;
 
@@ -168,7 +172,8 @@ pub fn due_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJob>> {
     with_connection(config, |conn| {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output
+                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
+                    allowed_tools
              FROM cron_jobs
              WHERE enabled = 1 AND next_run <= ?1
              ORDER BY next_run ASC
@@ -197,7 +202,7 @@ pub fn all_overdue_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJ
     with_connection(config, |conn| {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output
+                    enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output, allowed_tools
              FROM cron_jobs
              WHERE enabled = 1 AND next_run <= ?1
              ORDER BY next_run ASC",
@@ -250,6 +255,9 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
     if let Some(delete_after_run) = patch.delete_after_run {
         job.delete_after_run = delete_after_run;
     }
+    if let Some(allowed_tools) = patch.allowed_tools {
+        job.allowed_tools = Some(allowed_tools);
+    }
 
     if schedule_changed {
         job.next_run = next_run_for_schedule(&job.schedule, Utc::now())?;
@@ -260,8 +268,8 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
             "UPDATE cron_jobs
              SET expression = ?1, command = ?2, schedule = ?3, job_type = ?4, prompt = ?5, name = ?6,
                  session_target = ?7, model = ?8, enabled = ?9, delivery = ?10, delete_after_run = ?11,
-                 next_run = ?12
-             WHERE id = ?13",
+                 allowed_tools = ?12, next_run = ?13
+             WHERE id = ?14",
             params![
                 job.expression,
                 job.command,
@@ -274,6 +282,7 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
                 if job.enabled { 1 } else { 0 },
                 serde_json::to_string(&job.delivery)?,
                 if job.delete_after_run { 1 } else { 0 },
+                encode_allowed_tools(job.allowed_tools.as_ref())?,
                 job.next_run.to_rfc3339(),
                 job.id,
             ],
@@ -474,6 +483,7 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
     let next_run_raw: String = row.get(13)?;
     let last_run_raw: Option<String> = row.get(14)?;
     let created_at_raw: String = row.get(12)?;
+    let allowed_tools_raw: Option<String> = row.get(17)?;
 
     Ok(CronJob {
         id: row.get(0)?,
@@ -496,7 +506,8 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
         },
         last_status: row.get(15)?,
         last_output: row.get(16)?,
-        allowed_tools: None,
+        allowed_tools: decode_allowed_tools(allowed_tools_raw.as_deref())
+            .map_err(sql_conversion_error)?,
     })
 }
 
@@ -528,6 +539,25 @@ fn decode_delivery(delivery_raw: Option<&str>) -> Result<DeliveryConfig> {
         }
     }
     Ok(DeliveryConfig::default())
+}
+
+fn encode_allowed_tools(allowed_tools: Option<&Vec<String>>) -> Result<Option<String>> {
+    allowed_tools
+        .map(serde_json::to_string)
+        .transpose()
+        .context("Failed to serialize cron allowed_tools")
+}
+
+fn decode_allowed_tools(raw: Option<&str>) -> Result<Option<Vec<String>>> {
+    if let Some(raw) = raw {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            return serde_json::from_str(trimmed)
+                .map(Some)
+                .with_context(|| format!("Failed to parse cron allowed_tools JSON: {trimmed}"));
+        }
+    }
+    Ok(None)
 }
 
 fn add_column_if_missing(conn: &Connection, name: &str, sql_type: &str) -> Result<()> {
@@ -585,6 +615,7 @@ fn with_connection<T>(config: &Config, f: impl FnOnce(&Connection) -> Result<T>)
             enabled          INTEGER NOT NULL DEFAULT 1,
             delivery         TEXT,
             delete_after_run INTEGER NOT NULL DEFAULT 0,
+            allowed_tools    TEXT,
             created_at       TEXT NOT NULL,
             next_run         TEXT NOT NULL,
             last_run         TEXT,
@@ -618,6 +649,7 @@ fn with_connection<T>(config: &Config, f: impl FnOnce(&Connection) -> Result<T>)
     add_column_if_missing(&conn, "enabled", "INTEGER NOT NULL DEFAULT 1")?;
     add_column_if_missing(&conn, "delivery", "TEXT")?;
     add_column_if_missing(&conn, "delete_after_run", "INTEGER NOT NULL DEFAULT 0")?;
+    add_column_if_missing(&conn, "allowed_tools", "TEXT")?;
 
     f(&conn)
 }
@@ -770,6 +802,68 @@ mod tests {
         let far_future = Utc::now() + ChronoDuration::days(365);
         let overdue = all_overdue_jobs(&config, far_future).unwrap();
         assert!(overdue.is_empty());
+    }
+
+    #[test]
+    fn add_agent_job_persists_allowed_tools() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let job = add_agent_job(
+            &config,
+            Some("agent".into()),
+            Schedule::Every { every_ms: 60_000 },
+            "do work",
+            SessionTarget::Isolated,
+            None,
+            None,
+            false,
+            Some(vec!["file_read".into(), "web_search".into()]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            job.allowed_tools,
+            Some(vec!["file_read".into(), "web_search".into()])
+        );
+
+        let stored = get_job(&config, &job.id).unwrap();
+        assert_eq!(stored.allowed_tools, job.allowed_tools);
+    }
+
+    #[test]
+    fn update_job_persists_allowed_tools_patch() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let job = add_agent_job(
+            &config,
+            Some("agent".into()),
+            Schedule::Every { every_ms: 60_000 },
+            "do work",
+            SessionTarget::Isolated,
+            None,
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+
+        let updated = update_job(
+            &config,
+            &job.id,
+            CronJobPatch {
+                allowed_tools: Some(vec!["shell".into()]),
+                ..CronJobPatch::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(updated.allowed_tools, Some(vec!["shell".into()]));
+        assert_eq!(
+            get_job(&config, &job.id).unwrap().allowed_tools,
+            Some(vec!["shell".into()])
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,6 +299,9 @@ Examples:
         /// Treat the argument as an agent prompt instead of a shell command
         #[arg(long)]
         agent: bool,
+        /// Restrict agent cron jobs to the specified tool names (repeatable, agent-only)
+        #[arg(long = "allowed-tool")]
+        allowed_tools: Vec<String>,
         /// Command (shell) or prompt (agent) to run
         command: String,
     },
@@ -317,6 +320,9 @@ Examples:
         /// Treat the argument as an agent prompt instead of a shell command
         #[arg(long)]
         agent: bool,
+        /// Restrict agent cron jobs to the specified tool names (repeatable, agent-only)
+        #[arg(long = "allowed-tool")]
+        allowed_tools: Vec<String>,
         /// Command (shell) or prompt (agent) to run
         command: String,
     },
@@ -335,6 +341,9 @@ Examples:
         /// Treat the argument as an agent prompt instead of a shell command
         #[arg(long)]
         agent: bool,
+        /// Restrict agent cron jobs to the specified tool names (repeatable, agent-only)
+        #[arg(long = "allowed-tool")]
+        allowed_tools: Vec<String>,
         /// Command (shell) or prompt (agent) to run
         command: String,
     },
@@ -355,6 +364,9 @@ Examples:
         /// Treat the argument as an agent prompt instead of a shell command
         #[arg(long)]
         agent: bool,
+        /// Restrict agent cron jobs to the specified tool names (repeatable, agent-only)
+        #[arg(long = "allowed-tool")]
+        allowed_tools: Vec<String>,
         /// Command (shell) or prompt (agent) to run
         command: String,
     },
@@ -388,6 +400,9 @@ Examples:
         /// New job name
         #[arg(long)]
         name: Option<String>,
+        /// Replace the agent job allowlist with the specified tool names (repeatable)
+        #[arg(long = "allowed-tool")]
+        allowed_tools: Vec<String>,
     },
     /// Pause a scheduled task
     Pause {

--- a/src/tools/cron_add.rs
+++ b/src/tools/cron_add.rs
@@ -130,6 +130,11 @@ impl Tool for CronAddTool {
                     "type": "string",
                     "description": "Optional model override for agent jobs, e.g. 'x-ai/grok-4-1-fast'"
                 },
+                "allowed_tools": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional allowlist of tool names for agent jobs. When omitted, all tools remain available."
+                },
                 "delivery": {
                     "type": "object",
                     "description": "Optional delivery config to send job output to a channel after each run. When provided, all three of mode, channel, and to are expected.",
@@ -288,6 +293,19 @@ impl Tool for CronAddTool {
                     .get("model")
                     .and_then(serde_json::Value::as_str)
                     .map(str::to_string);
+                let allowed_tools = match args.get("allowed_tools") {
+                    Some(v) => match serde_json::from_value::<Vec<String>>(v.clone()) {
+                        Ok(v) => Some(v),
+                        Err(e) => {
+                            return Ok(ToolResult {
+                                success: false,
+                                output: String::new(),
+                                error: Some(format!("Invalid allowed_tools: {e}")),
+                            });
+                        }
+                    },
+                    None => None,
+                };
 
                 let delivery = match args.get("delivery") {
                     Some(v) => match serde_json::from_value::<DeliveryConfig>(v.clone()) {
@@ -316,6 +334,7 @@ impl Tool for CronAddTool {
                     model,
                     delivery,
                     delete_after_run,
+                    allowed_tools,
                 )
             }
         };
@@ -329,7 +348,8 @@ impl Tool for CronAddTool {
                     "job_type": job.job_type,
                     "schedule": job.schedule,
                     "next_run": job.next_run,
-                    "enabled": job.enabled
+                    "enabled": job.enabled,
+                    "allowed_tools": job.allowed_tools
                 }))?,
                 error: None,
             }),
@@ -610,6 +630,32 @@ mod tests {
             .error
             .unwrap_or_default()
             .contains("Missing 'prompt'"));
+    }
+
+    #[tokio::test]
+    async fn agent_job_persists_allowed_tools() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+
+        let result = tool
+            .execute(json!({
+                "schedule": { "kind": "cron", "expr": "*/5 * * * *" },
+                "job_type": "agent",
+                "prompt": "check status",
+                "allowed_tools": ["file_read", "web_search"]
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+
+        let jobs = cron::list_jobs(&cfg).unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(
+            jobs[0].allowed_tools,
+            Some(vec!["file_read".into(), "web_search".into()])
+        );
     }
 
     #[tokio::test]

--- a/src/tools/cron_update.rs
+++ b/src/tools/cron_update.rs
@@ -89,6 +89,11 @@ impl Tool for CronUpdateTool {
                             "type": "string",
                             "description": "Model override for agent jobs, e.g. 'x-ai/grok-4-1-fast'"
                         },
+                        "allowed_tools": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Optional replacement allowlist of tool names for agent jobs"
+                        },
                         "session_target": {
                             "type": "string",
                             "enum": ["isolated", "main"],
@@ -403,6 +408,7 @@ mod tests {
             "command",
             "prompt",
             "model",
+            "allowed_tools",
             "session_target",
             "delete_after_run",
             "schedule",
@@ -500,5 +506,41 @@ mod tests {
             .unwrap_or_default()
             .contains("Rate limit exceeded"));
         assert!(cron::get_job(&cfg, &job.id).unwrap().enabled);
+    }
+
+    #[tokio::test]
+    async fn updates_agent_allowed_tools() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let job = cron::add_agent_job(
+            &cfg,
+            None,
+            crate::cron::Schedule::Cron {
+                expr: "*/5 * * * *".into(),
+                tz: None,
+            },
+            "check status",
+            crate::cron::SessionTarget::Isolated,
+            None,
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+        let tool = CronUpdateTool::new(cfg.clone(), test_security(&cfg));
+
+        let result = tool
+            .execute(json!({
+                "job_id": job.id,
+                "patch": { "allowed_tools": ["file_read", "web_search"] }
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+        assert_eq!(
+            cron::get_job(&cfg, &job.id).unwrap().allowed_tools,
+            Some(vec!["file_read".into(), "web_search".into()])
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Persist `allowed_tools` in `cron_jobs` table, threading it through CLI add/update and `cron_add`/`cron_update` tool APIs
- Add regression coverage for store, tool, and CLI roundtrip paths
- Fixups over original PR #3929: add `allowed_tools` to `all_overdue_jobs` SELECT (merge gap with master), resolve merge conflicts

Closes #3920
Supersedes #3929

## Test plan
- [x] `cargo test --locked allowed_tools` — 14 tests pass
- [x] `cargo test --locked cron::` — 84 tests pass
- [x] `cargo clippy --locked --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean