### PR TITLE
fix(packaging): add Node.js build dependency to Homebrew formula

### DIFF
--- a/.github/workflows/pub-homebrew-core.yml
+++ b/.github/workflows/pub-homebrew-core.yml
@@ -146,6 +146,12 @@ jobs:
           perl -0pi -e "s|^  sha256 \".*\"|  sha256 \"${tarball_sha}\"|m" "$formula_file"
           perl -0pi -e "s|^  license \".*\"|  license \"Apache-2.0 OR MIT\"|m" "$formula_file"
 
+          # Ensure Node.js build dependency is declared so that build.rs can
+          # run `npm ci && npm run build` to produce the web frontend assets.
+          if ! grep -q 'depends_on "node" => :build' "$formula_file"; then
+            perl -0pi -e 's|(  depends_on "rust" => :build\n)|\1  depends_on "node" => :build\n|m' "$formula_file"
+          fi
+
           git -C "$repo_dir" diff -- "$FORMULA_PATH" > "$tmp_repo/formula.diff"
           if [[ ! -s "$tmp_repo/formula.diff" ]]; then
             echo "::error::No formula changes generated. Nothing to publish."


### PR DESCRIPTION
## Summary

Fixes #3991

Homebrew-installed ZeroClaw shows "Web dashboard not available" because the formula doesn't declare Node.js as a build dependency. The `build.rs` script already detects npm and builds the web frontend automatically, but npm isn't available in the Homebrew build environment.

- Add `depends_on "node" => :build` to the Homebrew formula template in `pub-homebrew-core.yml`
- Uses idempotent insertion (checks if already present before adding)
- No changes needed to `build.rs` — it already handles npm detection and web build correctly

## Test plan

- [x] Formula patch inserts after `depends_on "rust" => :build`
- [x] Idempotent — won't duplicate if already present
- [x] `build.rs` confirmed to handle npm correctly (runs `npm ci`, `npm run build`, graceful fallback)
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)