### PR TITLE
docs: add OpenClaw migration commands to all translated READMEs

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -370,6 +370,10 @@ zeroclaw pairing rotate      # تدوير سر الاقتران الحالي
 zeroclaw tunnel start        # بدء نفق إلى البرنامج الخفي المحلي
 zeroclaw tunnel stop         # إيقاف النفق النشط
 
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
+
 # التشخيص
 zeroclaw doctor              # تشغيل فحوصات صحة النظام
 zeroclaw version             # عرض الإصدار ومعلومات البناء

--- a/README.bn.md
+++ b/README.bn.md
@@ -105,6 +105,10 @@ cargo build --release
 
 # চালান
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### Docker দিয়ে

--- a/README.cs.md
+++ b/README.cs.md
@@ -370,6 +370,10 @@ zeroclaw pairing rotate      # Rotuje existující párovací tajemství
 zeroclaw tunnel start        # Spouští tunnel k lokálnímu daemon
 zeroclaw tunnel stop         # Zastavuje aktivní tunnel
 
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
+
 # Diagnostika
 zeroclaw doctor              # Spouští kontroly zdraví systému
 zeroclaw version             # Zobrazuje verzi a build informace

--- a/README.da.md
+++ b/README.da.md
@@ -105,6 +105,10 @@ cargo build --release
 
 # Kør
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### Med Docker

--- a/README.de.md
+++ b/README.de.md
@@ -374,6 +374,10 @@ zeroclaw pairing rotate      # Rotiert das bestehende Pairing-Geheimnis
 zeroclaw tunnel start        # Startet einen Tunnel zum lokalen Daemon
 zeroclaw tunnel stop         # Stoppt den aktiven Tunnel
 
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
+
 # Diagnose
 zeroclaw doctor              # Führt System-Gesundheitsprüfungen durch
 zeroclaw version             # Zeigt Version und Build-Informationen

--- a/README.el.md
+++ b/README.el.md
@@ -104,6 +104,10 @@ cargo build --release
 
 # Εκτέλεση
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### Με Docker

--- a/README.es.md
+++ b/README.es.md
@@ -370,6 +370,10 @@ zeroclaw pairing rotate      # Rota el secreto de emparejamiento existente
 zeroclaw tunnel start        # Inicia un tunnel hacia el daemon local
 zeroclaw tunnel stop         # Detiene el tunnel activo
 
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
+
 # Diagnóstico
 zeroclaw doctor              # Ejecuta verificaciones de salud del sistema
 zeroclaw version             # Muestra versión e información de build

--- a/README.fi.md
+++ b/README.fi.md
@@ -105,6 +105,10 @@ cargo build --release
 
 # Aja
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### Dockerilla

--- a/README.fr.md
+++ b/README.fr.md
@@ -368,6 +368,10 @@ zeroclaw pairing rotate      # Fait tourner le secret de pairing existant
 zeroclaw tunnel start        # Démarre un tunnel vers le daemon local
 zeroclaw tunnel stop         # Arrête le tunnel actif
 
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
+
 # Diagnostic
 zeroclaw doctor              # Exécute les vérifications de santé du système
 zeroclaw version             # Affiche la version et les informations de build

--- a/README.he.md
+++ b/README.he.md
@@ -111,6 +111,10 @@ cargo build --release
 
 # הפעל
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### עם Docker

--- a/README.hi.md
+++ b/README.hi.md
@@ -105,6 +105,10 @@ cargo build --release
 
 # चलाएं
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### Docker के साथ

--- a/README.hu.md
+++ b/README.hu.md
@@ -105,6 +105,10 @@ cargo build --release
 
 # Futtatás
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### Docker-rel

--- a/README.id.md
+++ b/README.id.md
@@ -105,6 +105,10 @@ cargo build --release
 
 # Jalankan
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### Dengan Docker

--- a/README.it.md
+++ b/README.it.md
@@ -370,6 +370,10 @@ zeroclaw pairing rotate      # Ruota il segreto di pairing esistente
 zeroclaw tunnel start        # Avvia un tunnel verso il daemon locale
 zeroclaw tunnel stop         # Ferma il tunnel attivo
 
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
+
 # Diagnostica
 zeroclaw doctor              # Esegue controlli di salute del sistema
 zeroclaw version             # Mostra versione e informazioni di build

--- a/README.ja.md
+++ b/README.ja.md
@@ -185,6 +185,10 @@ zeroclaw agent -m "Hello, ZeroClaw!"
 zeroclaw gateway
 
 zeroclaw daemon
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ## Subscription Auth（OpenAI Codex / Claude Code）

--- a/README.ko.md
+++ b/README.ko.md
@@ -370,6 +370,10 @@ zeroclaw pairing rotate      # 기존 페어링 시크릿 교체
 zeroclaw tunnel start        # 로컬 데몬으로 터널 시작
 zeroclaw tunnel stop         # 활성 터널 중지
 
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
+
 # 진단
 zeroclaw doctor              # 시스템 상태 검사 실행
 zeroclaw version             # 버전 및 빌드 정보 표시

--- a/README.nb.md
+++ b/README.nb.md
@@ -105,6 +105,10 @@ cargo build --release
 
 # Kjør
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### Med Docker

--- a/README.nl.md
+++ b/README.nl.md
@@ -370,6 +370,10 @@ zeroclaw pairing rotate      # Roteert het bestaande pairing geheim
 zeroclaw tunnel start        # Start een tunnel naar de lokale daemon
 zeroclaw tunnel stop         # Stopt de actieve tunnel
 
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
+
 # Diagnostiek
 zeroclaw doctor              # Voert systeem gezondheidscontroles uit
 zeroclaw version             # Toont versie en build informatie

--- a/README.pl.md
+++ b/README.pl.md
@@ -370,6 +370,10 @@ zeroclaw pairing rotate      # Rotuje istniejący sekret parowania
 zeroclaw tunnel start        # Uruchamia tunnel do lokalnego daemon
 zeroclaw tunnel stop         # Zatrzymuje aktywny tunnel
 
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
+
 # Diagnostyka
 zeroclaw doctor              # Uruchamia sprawdzenia zdrowia systemu
 zeroclaw version             # Pokazuje wersję i informacje o build

--- a/README.pt.md
+++ b/README.pt.md
@@ -370,6 +370,10 @@ zeroclaw pairing rotate      # Rotaciona o segredo de emparelhamento existente
 zeroclaw tunnel start        # Inicia um tunnel para o daemon local
 zeroclaw tunnel stop         # Para o tunnel ativo
 
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
+
 # Diagnóstico
 zeroclaw doctor              # Executa verificações de saúde do sistema
 zeroclaw version             # Mostra versão e informações de build

--- a/README.ro.md
+++ b/README.ro.md
@@ -105,6 +105,10 @@ cargo build --release
 
 # Rulează
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### Cu Docker

--- a/README.ru.md
+++ b/README.ru.md
@@ -185,6 +185,10 @@ zeroclaw agent -m "Hello, ZeroClaw!"
 zeroclaw gateway
 
 zeroclaw daemon
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ## Subscription Auth (OpenAI Codex / Claude Code)

--- a/README.sv.md
+++ b/README.sv.md
@@ -105,6 +105,10 @@ cargo build --release
 
 # Kör
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### Med Docker

--- a/README.th.md
+++ b/README.th.md
@@ -105,6 +105,10 @@ cargo build --release
 
 # Run
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### ด้วย Docker

--- a/README.tl.md
+++ b/README.tl.md
@@ -370,6 +370,10 @@ zeroclaw pairing rotate      # Nag-rotate ng existing pairing secret
 zeroclaw tunnel start        # Nagse-start ng tunnel sa local daemon
 zeroclaw tunnel stop         # Naghihinto sa active tunnel
 
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
+
 # Diagnostics
 zeroclaw doctor              # Nagpapatakbo ng system health checks
 zeroclaw version             # Nagpapakita ng version at build info

--- a/README.tr.md
+++ b/README.tr.md
@@ -370,6 +370,10 @@ zeroclaw pairing rotate      # Mevcut eşleştirme sırrını döndürür
 zeroclaw tunnel start        # Yerel arka plan programına bir tünel başlatır
 zeroclaw tunnel stop         # Aktif tüneli durdurur
 
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
+
 # Teşhis
 zeroclaw doctor              # Sistem sağlık kontrollerini çalıştırır
 zeroclaw version             # Sürüm ve derleme bilgilerini gösterir

--- a/README.uk.md
+++ b/README.uk.md
@@ -105,6 +105,10 @@ cargo build --release
 
 # Запустіть
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### З Docker

--- a/README.ur.md
+++ b/README.ur.md
@@ -111,6 +111,10 @@ cargo build --release
 
 # چلائیں
 cargo run --release
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ### Docker کے ساتھ

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -190,6 +190,10 @@ zeroclaw gateway
 
 # 启动长期运行模式
 zeroclaw daemon
+
+# Migrate from OpenClaw
+zeroclaw migrate openclaw --dry-run
+zeroclaw migrate openclaw
 ```
 
 ## Subscription Auth（OpenAI Codex / Claude Code）


### PR DESCRIPTION
## Summary
Added the OpenClaw migration commands to all 29 translated README files that were missing them:

```bash
# Migrate from OpenClaw
zeroclaw migrate openclaw --dry-run
zeroclaw migrate openclaw
```

All 31 READMEs (main + 30 translations) now include the migrate section.

## Test plan
- [x] Docs-only change
- [x] All 31 READMEs confirmed to contain `migrate openclaw`

🤖 Generated with [Claude Code](https://claude.com/claude-code)