### PR TITLE
fix(channel): clear persisted JSONL session on /new command

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1456,6 +1456,11 @@ async fn handle_runtime_command_if_needed(
         }
         ChannelRuntimeCommand::NewSession => {
             clear_sender_history(ctx, &sender_key);
+            if let Some(ref store) = ctx.session_store {
+                if let Err(e) = store.delete_session(&sender_key) {
+                    tracing::warn!("Failed to delete persisted session for {sender_key}: {e}");
+                }
+            }
             mark_sender_for_new_session(ctx, &sender_key);
             "Conversation history cleared. Starting fresh.".to_string()
         }

--- a/src/channels/session_store.rs
+++ b/src/channels/session_store.rs
@@ -110,6 +110,16 @@ impl SessionStore {
         Ok(())
     }
 
+    /// Delete a session's JSONL file. Returns `true` if the file existed.
+    pub fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
+        let path = self.session_path(session_key);
+        if !path.exists() {
+            return Ok(false);
+        }
+        std::fs::remove_file(&path)?;
+        Ok(true)
+    }
+
     /// List all session keys that have files on disk.
     pub fn list_sessions(&self) -> Vec<String> {
         let entries = match std::fs::read_dir(&self.sessions_dir) {
@@ -146,6 +156,10 @@ impl SessionBackend for SessionStore {
 
     fn compact(&self, session_key: &str) -> std::io::Result<()> {
         self.compact(session_key)
+    }
+
+    fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
+        self.delete_session(session_key)
     }
 }
 
@@ -307,5 +321,45 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].content, "hello");
         assert_eq!(messages[1].content, "world");
+    }
+
+    #[test]
+    fn delete_session_removes_jsonl_file() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+        let key = "delete_test";
+
+        store.append(key, &ChatMessage::user("hello")).unwrap();
+        assert_eq!(store.load(key).len(), 1);
+
+        let deleted = store.delete_session(key).unwrap();
+        assert!(deleted);
+        assert!(store.load(key).is_empty());
+        assert!(!store.session_path(key).exists());
+    }
+
+    #[test]
+    fn delete_session_nonexistent_returns_false() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+
+        let deleted = store.delete_session("nonexistent").unwrap();
+        assert!(!deleted);
+    }
+
+    #[test]
+    fn delete_session_via_trait() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+        let backend: &dyn SessionBackend = &store;
+
+        backend
+            .append("trait_delete", &ChatMessage::user("hello"))
+            .unwrap();
+        assert_eq!(backend.load("trait_delete").len(), 1);
+
+        let deleted = backend.delete_session("trait_delete").unwrap();
+        assert!(deleted);
+        assert!(backend.load("trait_delete").is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Add `delete_session()` method to JSONL `SessionStore` that removes the `.jsonl` file from disk
- Wire `delete_session()` into the `/new` command handler so both in-memory and persisted session state are cleared
- Add tests for `delete_session` (direct, nonexistent, via trait)

Previously, `/new` only cleared the in-memory `conversation_histories` HashMap but left the JSONL file intact. On daemon restart, stale history was rehydrated from disk, undoing the user's session reset. This caused context pollution from prior hallucinated tool-use text, degrading native tool calling reliability.

## Test plan

- [x] `delete_session_removes_jsonl_file` — verifies file is deleted and load returns empty
- [x] `delete_session_nonexistent_returns_false` — no error on missing session
- [x] `delete_session_via_trait` — works through `dyn SessionBackend`
- [x] All existing session_store tests continue to pass
- [x] `cargo clippy` clean

Closes #4009