### PR TITLE
fix(web): add clipboard fallback for HTTP contexts

### DIFF
--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -172,11 +172,41 @@ export default function AgentChat() {
   };
 
   const handleCopy = useCallback((msgId: string, content: string) => {
-    navigator.clipboard.writeText(content).then(() => {
+    const onSuccess = () => {
       setCopiedId(msgId);
       setTimeout(() => setCopiedId((prev) => (prev === msgId ? null : prev)), 2000);
-    });
+    };
+
+    if (navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(content).then(onSuccess).catch(() => {
+        // Fallback for insecure contexts (HTTP)
+        fallbackCopy(content) && onSuccess();
+      });
+    } else {
+      fallbackCopy(content) && onSuccess();
+    }
   }, []);
+
+  /**
+   * Fallback copy using a temporary textarea for HTTP contexts
+   * where navigator.clipboard is unavailable.
+   */
+  function fallbackCopy(text: string): boolean {
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      document.execCommand('copy');
+      return true;
+    } catch {
+      return false;
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
 
   return (
     <div className="flex flex-col h-[calc(100vh-3.5rem)]">


### PR DESCRIPTION
## Summary

- Add fallback copy mechanism using `document.execCommand('copy')` for HTTP contexts where `navigator.clipboard` is unavailable
- Add proper `.catch()` error handling on the clipboard promise (was silently swallowing failures)
- Check for `navigator.clipboard?.writeText` existence before calling

The web dashboard copy button silently failed when served over HTTP (the default gateway mode) because the Clipboard API requires a secure context (HTTPS). Users saw no feedback when clicking copy.

## Test plan

- [ ] Verify copy works over HTTP (local gateway default)
- [ ] Verify copy works over HTTPS
- [ ] Verify visual feedback (checkmark icon) appears after successful copy
- [x] Web dashboard builds cleanly (`npm run build`)

Closes #4008