### PR TITLE
fix(provider): disable native tool calling for Venice

### DIFF
--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -186,6 +186,12 @@ impl OpenAiCompatibleProvider {
         }
     }
 
+    /// Disable native tool calling, forcing prompt-guided tool use instead.
+    pub fn without_native_tools(mut self) -> Self {
+        self.native_tool_calling = false;
+        self
+    }
+
     /// Override the HTTP request timeout for LLM API calls.
     pub fn with_timeout_secs(mut self, timeout_secs: u64) -> Self {
         self.timeout_secs = timeout_secs;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1160,9 +1160,12 @@ fn create_provider_with_url_and_options(
         "telnyx" => Ok(Box::new(telnyx::TelnyxProvider::new(key))),
 
         // ── OpenAI-compatible providers ──────────────────────
-        "venice" => Ok(compat(OpenAiCompatibleProvider::new(
-            "Venice", "https://api.venice.ai", key, AuthStyle::Bearer,
-        ))),
+        "venice" => Ok(compat(
+            OpenAiCompatibleProvider::new(
+                "Venice", "https://api.venice.ai", key, AuthStyle::Bearer,
+            )
+            .without_native_tools(),
+        )),
         "vercel" | "vercel-ai" => Ok(compat(OpenAiCompatibleProvider::new(
             "Vercel AI Gateway",
             VERCEL_AI_GATEWAY_BASE_URL,
@@ -2457,7 +2460,11 @@ mod tests {
 
     #[test]
     fn factory_venice() {
-        assert!(create_provider("venice", Some("vn-key")).is_ok());
+        let provider = create_provider("venice", Some("vn-key")).unwrap();
+        assert!(
+            !provider.capabilities().native_tool_calling,
+            "Venice should use prompt-guided tools, not native tool calling"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Disable native tool calling for the Venice provider, forcing prompt-guided tool use instead
- Add `without_native_tools()` builder method to `OpenAiCompatibleProvider` for providers that support system messages but not native function calling
- Update factory test to assert Venice has `native_tool_calling: false`

Venice's API accepts the OpenAI-compatible tool format in requests without returning an error, but models ignore the tool specs and hallucinate tool usage in prose instead of emitting structured tool call blocks. This made the agent unusable for any task requiring tool execution.

By disabling native tool calling, Venice falls back to prompt-guided tools (tool specs injected into the system prompt), which models handle reliably.

## Test plan

- [x] `factory_venice` test verifies `native_tool_calling` is `false`
- [x] `cargo check` clean
- [x] `cargo clippy` clean
- [ ] Manual test: `zeroclaw agent` with Venice provider, verify tool calls work via prompt-guided mode

Closes #4007