### PR TITLE
fix(channel): add interruption_scope_id for thread-aware cancellation scoping

### DIFF
--- a/src/channels/bluesky.rs
+++ b/src/channels/bluesky.rs
@@ -251,6 +251,7 @@ impl BlueskyChannel {
             channel: "bluesky".to_string(),
             timestamp,
             thread_ts: Some(notif.uri.clone()),
+            interruption_scope_id: None,
         })
     }
 

--- a/src/channels/cli.rs
+++ b/src/channels/cli.rs
@@ -48,6 +48,7 @@ impl Channel for CliChannel {
                     .unwrap_or_default()
                     .as_secs(),
                 thread_ts: None,
+                interruption_scope_id: None,
             };
 
             if tx.send(msg).await.is_err() {
@@ -111,6 +112,7 @@ mod tests {
             channel: "cli".into(),
             timestamp: 1_234_567_890,
             thread_ts: None,
+            interruption_scope_id: None,
         };
         assert_eq!(msg.id, "test-id");
         assert_eq!(msg.sender, "user");
@@ -130,6 +132,7 @@ mod tests {
             channel: "ch".into(),
             timestamp: 0,
             thread_ts: None,
+            interruption_scope_id: None,
         };
         let cloned = msg.clone();
         assert_eq!(cloned.id, msg.id);

--- a/src/channels/dingtalk.rs
+++ b/src/channels/dingtalk.rs
@@ -275,6 +275,7 @@ impl Channel for DingTalkChannel {
                             .unwrap_or_default()
                             .as_secs(),
                         thread_ts: None,
+                        interruption_scope_id: None,
                     };
 
                     if tx.send(channel_msg).await.is_err() {

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -789,6 +789,7 @@ impl Channel for DiscordChannel {
                             .unwrap_or_default()
                             .as_secs(),
                         thread_ts: None,
+                        interruption_scope_id: None,
                     };
 
                     if tx.send(channel_msg).await.is_err() {

--- a/src/channels/email_channel.rs
+++ b/src/channels/email_channel.rs
@@ -467,6 +467,7 @@ impl EmailChannel {
                 channel: "email".to_string(),
                 timestamp: email.timestamp,
                 thread_ts: None,
+                interruption_scope_id: None,
             };
 
             if tx.send(msg).await.is_err() {

--- a/src/channels/imessage.rs
+++ b/src/channels/imessage.rs
@@ -294,6 +294,7 @@ end tell"#
                                 .unwrap_or_default()
                                 .as_secs(),
                             thread_ts: None,
+                            interruption_scope_id: None,
                         };
 
                         if tx.send(msg).await.is_err() {

--- a/src/channels/irc.rs
+++ b/src/channels/irc.rs
@@ -580,6 +580,7 @@ impl Channel for IrcChannel {
                             .unwrap_or_default()
                             .as_secs(),
                         thread_ts: None,
+                        interruption_scope_id: None,
                     };
 
                     if tx.send(channel_msg).await.is_err() {

--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -823,6 +823,7 @@ impl LarkChannel {
                             .unwrap_or_default()
                             .as_secs(),
                         thread_ts: None,
+                        interruption_scope_id: None,
                     };
 
                     tracing::debug!("Lark WS: message in {}", lark_msg.chat_id);
@@ -1120,6 +1121,7 @@ impl LarkChannel {
             channel: self.channel_name().to_string(),
             timestamp,
             thread_ts: None,
+            interruption_scope_id: None,
         });
 
         messages

--- a/src/channels/linq.rs
+++ b/src/channels/linq.rs
@@ -267,6 +267,7 @@ impl LinqChannel {
             channel: "linq".to_string(),
             timestamp,
             thread_ts: None,
+            interruption_scope_id: None,
         });
 
         messages

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -893,7 +893,8 @@ impl Channel for MatrixChannel {
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap_or_default()
                         .as_secs(),
-                    thread_ts,
+                    thread_ts: thread_ts.clone(),
+                    interruption_scope_id: thread_ts,
                 };
 
                 let _ = tx.send(msg).await;

--- a/src/channels/mattermost.rs
+++ b/src/channels/mattermost.rs
@@ -322,6 +322,7 @@ impl MattermostChannel {
             #[allow(clippy::cast_sign_loss)]
             timestamp: (create_at / 1000) as u64,
             thread_ts: None,
+            interruption_scope_id: None,
         })
     }
 }

--- a/src/channels/mochat.rs
+++ b/src/channels/mochat.rs
@@ -198,6 +198,7 @@ impl Channel for MochatChannel {
                                     .unwrap_or_default()
                                     .as_secs(),
                                 thread_ts: None,
+                                interruption_scope_id: None,
                             };
 
                             if tx.send(channel_msg).await.is_err() {

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -406,7 +406,13 @@ fn followup_thread_id(msg: &traits::ChannelMessage) -> Option<String> {
 }
 
 fn interruption_scope_key(msg: &traits::ChannelMessage) -> String {
-    format!("{}_{}_{}", msg.channel, msg.reply_target, msg.sender)
+    match &msg.interruption_scope_id {
+        Some(scope) => format!(
+            "{}_{}_{}_{}",
+            msg.channel, msg.reply_target, msg.sender, scope
+        ),
+        None => format!("{}_{}_{}", msg.channel, msg.reply_target, msg.sender),
+    }
 }
 
 /// Returns `true` when `content` is a `/stop` command (with optional `@botname` suffix).
@@ -5592,6 +5598,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "test-channel".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -5670,6 +5677,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -5762,6 +5770,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "test-channel".to_string(),
                 timestamp: 3,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -5839,6 +5848,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "test-channel".to_string(),
                 timestamp: 2,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -5926,6 +5936,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -6034,6 +6045,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 2,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -6123,6 +6135,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 3,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -6227,6 +6240,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 4,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -6316,6 +6330,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "test-channel".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -6395,6 +6410,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "test-channel".to_string(),
                 timestamp: 2,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -6584,6 +6600,7 @@ BTC is currently around $65,000 based on latest tool output."#
             channel: "test-channel".to_string(),
             timestamp: 1,
             thread_ts: None,
+            interruption_scope_id: None,
         })
         .await
         .unwrap();
@@ -6595,6 +6612,7 @@ BTC is currently around $65,000 based on latest tool output."#
             channel: "test-channel".to_string(),
             timestamp: 2,
             thread_ts: None,
+            interruption_scope_id: None,
         })
         .await
         .unwrap();
@@ -6683,6 +6701,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             })
             .await
             .unwrap();
@@ -6695,6 +6714,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 2,
                 thread_ts: None,
+                interruption_scope_id: None,
             })
             .await
             .unwrap();
@@ -6796,6 +6816,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "slack".to_string(),
                 timestamp: 1,
                 thread_ts: Some("1741234567.100001".to_string()),
+                interruption_scope_id: Some("1741234567.100001".to_string()),
             })
             .await
             .unwrap();
@@ -6808,6 +6829,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "slack".to_string(),
                 timestamp: 2,
                 thread_ts: Some("1741234567.100001".to_string()),
+                interruption_scope_id: Some("1741234567.100001".to_string()),
             })
             .await
             .unwrap();
@@ -6906,6 +6928,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             })
             .await
             .unwrap();
@@ -6918,6 +6941,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 2,
                 thread_ts: None,
+                interruption_scope_id: None,
             })
             .await
             .unwrap();
@@ -6998,6 +7022,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "test-channel".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -7075,6 +7100,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "test-channel".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -7596,6 +7622,7 @@ BTC is currently around $65,000 based on latest tool output."#
             channel: "slack".into(),
             timestamp: 1,
             thread_ts: None,
+            interruption_scope_id: None,
         };
 
         assert_eq!(conversation_memory_key(&msg), "slack_U123_msg_abc123");
@@ -7611,6 +7638,7 @@ BTC is currently around $65,000 based on latest tool output."#
             channel: "slack".into(),
             timestamp: 1,
             thread_ts: Some("1741234567.123456".into()),
+            interruption_scope_id: None,
         };
 
         assert_eq!(
@@ -7629,6 +7657,7 @@ BTC is currently around $65,000 based on latest tool output."#
             channel: "cli".into(),
             timestamp: 1,
             thread_ts: None,
+            interruption_scope_id: None,
         };
 
         assert_eq!(followup_thread_id(&msg).as_deref(), Some("msg_abc123"));
@@ -7644,6 +7673,7 @@ BTC is currently around $65,000 based on latest tool output."#
             channel: "slack".into(),
             timestamp: 1,
             thread_ts: None,
+            interruption_scope_id: None,
         };
         let msg2 = traits::ChannelMessage {
             id: "msg_2".into(),
@@ -7653,6 +7683,7 @@ BTC is currently around $65,000 based on latest tool output."#
             channel: "slack".into(),
             timestamp: 2,
             thread_ts: None,
+            interruption_scope_id: None,
         };
 
         assert_ne!(
@@ -7674,6 +7705,7 @@ BTC is currently around $65,000 based on latest tool output."#
             channel: "slack".into(),
             timestamp: 1,
             thread_ts: None,
+            interruption_scope_id: None,
         };
         let msg2 = traits::ChannelMessage {
             id: "msg_2".into(),
@@ -7683,6 +7715,7 @@ BTC is currently around $65,000 based on latest tool output."#
             channel: "slack".into(),
             timestamp: 2,
             thread_ts: None,
+            interruption_scope_id: None,
         };
 
         mem.store(
@@ -7828,6 +7861,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "test-channel".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -7843,6 +7877,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "test-channel".to_string(),
                 timestamp: 2,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -7955,6 +7990,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -7986,6 +8022,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 2,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -8023,6 +8060,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 3,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -8121,6 +8159,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "test-channel".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -8224,6 +8263,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 channel: "telegram".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -8793,6 +8833,7 @@ This is an example JSON object for profile settings."#;
                 channel: "test-channel".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -8876,6 +8917,7 @@ This is an example JSON object for profile settings."#;
                 channel: "test-channel".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -8891,6 +8933,7 @@ This is an example JSON object for profile settings."#;
                 channel: "test-channel".to_string(),
                 timestamp: 2,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -9034,6 +9077,7 @@ This is an example JSON object for profile settings."#;
                 channel: "telegram".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -9142,6 +9186,7 @@ This is an example JSON object for profile settings."#;
                 channel: "telegram".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -9242,6 +9287,7 @@ This is an example JSON object for profile settings."#;
                 channel: "telegram".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -9362,6 +9408,7 @@ This is an example JSON object for profile settings."#;
                 channel: "telegram".to_string(),
                 timestamp: 1,
                 thread_ts: None,
+                interruption_scope_id: None,
             },
             CancellationToken::new(),
         )
@@ -9499,5 +9546,152 @@ This is an example JSON object for profile settings."#;
             mattermost: false,
         };
         assert!(!cfg.enabled_for_channel("discord"));
+    }
+
+    // ── interruption_scope_key tests ──────────────────────────────────────
+
+    #[test]
+    fn interruption_scope_key_without_scope_id_is_three_component() {
+        let msg = traits::ChannelMessage {
+            id: "1".into(),
+            sender: "alice".into(),
+            reply_target: "room".into(),
+            content: "hi".into(),
+            channel: "matrix".into(),
+            timestamp: 0,
+            thread_ts: None,
+            interruption_scope_id: None,
+        };
+        assert_eq!(interruption_scope_key(&msg), "matrix_room_alice");
+    }
+
+    #[test]
+    fn interruption_scope_key_with_scope_id_is_four_component() {
+        let msg = traits::ChannelMessage {
+            id: "1".into(),
+            sender: "alice".into(),
+            reply_target: "room".into(),
+            content: "hi".into(),
+            channel: "matrix".into(),
+            timestamp: 0,
+            thread_ts: Some("$thread1".into()),
+            interruption_scope_id: Some("$thread1".into()),
+        };
+        assert_eq!(interruption_scope_key(&msg), "matrix_room_alice_$thread1");
+    }
+
+    #[test]
+    fn interruption_scope_key_thread_ts_alone_does_not_affect_key() {
+        // thread_ts used for reply anchoring should not bleed into scope key
+        let msg = traits::ChannelMessage {
+            id: "1".into(),
+            sender: "alice".into(),
+            reply_target: "C123".into(),
+            content: "hi".into(),
+            channel: "slack".into(),
+            timestamp: 0,
+            thread_ts: Some("1234567890.000100".into()), // Slack top-level fallback
+            interruption_scope_id: None,                 // but NOT a thread reply
+        };
+        assert_eq!(interruption_scope_key(&msg), "slack_C123_alice");
+    }
+
+    #[tokio::test]
+    async fn message_dispatch_different_threads_do_not_cancel_each_other() {
+        let channel_impl = Arc::new(SlackRecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::new(SlowProvider {
+                delay: Duration::from_millis(150),
+            }),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("test-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 10,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(HashMap::new())),
+            pending_new_sessions: Arc::new(Mutex::new(HashSet::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(crate::config::ReliabilityConfig::default()),
+            provider_runtime_options: providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            prompt_config: Arc::new(crate::config::Config::default()),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: InterruptOnNewMessageConfig {
+                telegram: false,
+                slack: true,
+                discord: false,
+                mattermost: false,
+            },
+            multimodal: crate::config::MultimodalConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Vec::new()),
+            autonomy_level: AutonomyLevel::default(),
+            tool_call_dedup_exempt: Arc::new(Vec::new()),
+            model_routes: Arc::new(Vec::new()),
+            query_classification: crate::config::QueryClassificationConfig::default(),
+            ack_reactions: true,
+            show_tool_calls: true,
+            session_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(
+                &crate::config::AutonomyConfig::default(),
+            )),
+            activated_tools: None,
+        });
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);
+        let send_task = tokio::spawn(async move {
+            // Two messages from same sender but in different Slack threads —
+            // they must NOT cancel each other.
+            tx.send(traits::ChannelMessage {
+                id: "1741234567.100001".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "C123".to_string(),
+                content: "thread-a question".to_string(),
+                channel: "slack".to_string(),
+                timestamp: 1,
+                thread_ts: Some("1741234567.100001".to_string()),
+                interruption_scope_id: Some("1741234567.100001".to_string()),
+            })
+            .await
+            .unwrap();
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            tx.send(traits::ChannelMessage {
+                id: "1741234567.200002".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "C123".to_string(),
+                content: "thread-b question".to_string(),
+                channel: "slack".to_string(),
+                timestamp: 2,
+                thread_ts: Some("1741234567.200002".to_string()),
+                interruption_scope_id: Some("1741234567.200002".to_string()),
+            })
+            .await
+            .unwrap();
+        });
+
+        run_message_dispatch_loop(rx, runtime_ctx, 4).await;
+        send_task.await.unwrap();
+
+        // Both tasks should have completed — different threads, no cancellation.
+        let sent_messages = channel_impl.sent_messages.lock().await;
+        assert_eq!(
+            sent_messages.len(),
+            2,
+            "both Slack thread messages should complete, got: {sent_messages:?}"
+        );
     }
 }

--- a/src/channels/nextcloud_talk.rs
+++ b/src/channels/nextcloud_talk.rs
@@ -193,6 +193,7 @@ impl NextcloudTalkChannel {
             channel: "nextcloud_talk".to_string(),
             timestamp: Self::now_unix_secs(),
             thread_ts: None,
+            interruption_scope_id: None,
         });
 
         messages
@@ -294,6 +295,7 @@ impl NextcloudTalkChannel {
             channel: "nextcloud_talk".to_string(),
             timestamp,
             thread_ts: None,
+            interruption_scope_id: None,
         });
 
         messages

--- a/src/channels/nostr.rs
+++ b/src/channels/nostr.rs
@@ -253,6 +253,7 @@ impl Channel for NostrChannel {
                             channel: "nostr".to_string(),
                             timestamp,
                             thread_ts: None,
+                            interruption_scope_id: None,
                         };
                         if tx.send(msg).await.is_err() {
                             tracing::info!("Nostr listener: message bus closed, stopping");

--- a/src/channels/notion.rs
+++ b/src/channels/notion.rs
@@ -360,6 +360,7 @@ impl Channel for NotionChannel {
                                 channel: "notion".into(),
                                 timestamp,
                                 thread_ts: None,
+                                interruption_scope_id: None,
                             })
                             .await
                             .is_err()

--- a/src/channels/qq.rs
+++ b/src/channels/qq.rs
@@ -465,6 +465,7 @@ impl Channel for QQChannel {
                                     .unwrap_or_default()
                                     .as_secs(),
                                 thread_ts: None,
+                                interruption_scope_id: None,
                             };
 
                             if tx.send(channel_msg).await.is_err() {
@@ -503,6 +504,7 @@ impl Channel for QQChannel {
                                     .unwrap_or_default()
                                     .as_secs(),
                                 thread_ts: None,
+                                interruption_scope_id: None,
                             };
 
                             if tx.send(channel_msg).await.is_err() {

--- a/src/channels/reddit.rs
+++ b/src/channels/reddit.rs
@@ -225,6 +225,7 @@ impl RedditChannel {
             channel: "reddit".to_string(),
             timestamp,
             thread_ts: item.parent_id.clone(),
+            interruption_scope_id: None,
         })
     }
 }

--- a/src/channels/signal.rs
+++ b/src/channels/signal.rs
@@ -266,6 +266,7 @@ impl SignalChannel {
             channel: "signal".to_string(),
             timestamp: timestamp / 1000, // millis → secs
             thread_ts: None,
+            interruption_scope_id: None,
         })
     }
 }

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -165,6 +165,23 @@ impl SlackChannel {
             .map(str::to_string)
     }
 
+    /// Returns the interruption scope identifier for a Slack message.
+    ///
+    /// Returns `Some(thread_ts)` only when the message is a genuine thread reply
+    /// (Slack's `thread_ts` field is present and differs from the message's own `ts`).
+    /// Returns `None` for top-level messages and thread parent messages (where
+    /// `thread_ts == ts`), placing them in the 3-component scope key
+    /// (`channel_reply_target_sender`).
+    ///
+    /// Intentional: top-level messages and threaded replies are separate conversational
+    /// scopes and should not cancel each other's in-flight tasks.
+    fn inbound_interruption_scope_id(msg: &serde_json::Value, ts: &str) -> Option<String> {
+        msg.get("thread_ts")
+            .and_then(|t| t.as_str())
+            .filter(|&t| t != ts)
+            .map(str::to_string)
+    }
+
     fn normalized_channel_id(input: Option<&str>) -> Option<String> {
         input
             .map(str::trim)
@@ -1792,6 +1809,7 @@ impl SlackChannel {
                         .unwrap_or_default()
                         .as_secs(),
                     thread_ts: Self::inbound_thread_ts(event, ts),
+                    interruption_scope_id: Self::inbound_interruption_scope_id(event, ts),
                 };
 
                 if tx.send(channel_msg).await.is_err() {
@@ -2356,6 +2374,7 @@ impl Channel for SlackChannel {
                                 .unwrap_or_default()
                                 .as_secs(),
                             thread_ts: Self::inbound_thread_ts(msg, ts),
+                            interruption_scope_id: Self::inbound_interruption_scope_id(msg, ts),
                         };
 
                         if tx.send(channel_msg).await.is_err() {
@@ -2440,6 +2459,7 @@ impl Channel for SlackChannel {
                             .unwrap_or_default()
                             .as_secs(),
                         thread_ts: Some(thread_ts.clone()),
+                        interruption_scope_id: Some(thread_ts.clone()),
                     };
 
                     if tx.send(channel_msg).await.is_err() {

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -1142,6 +1142,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 .unwrap_or_default()
                 .as_secs(),
             thread_ts: thread_id,
+            interruption_scope_id: None,
         })
     }
 
@@ -1264,6 +1265,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 .unwrap_or_default()
                 .as_secs(),
             thread_ts: thread_id,
+            interruption_scope_id: None,
         })
     }
 
@@ -1425,6 +1427,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
                 .unwrap_or_default()
                 .as_secs(),
             thread_ts: thread_id,
+            interruption_scope_id: None,
         })
     }
 

--- a/src/channels/traits.rs
+++ b/src/channels/traits.rs
@@ -12,6 +12,11 @@ pub struct ChannelMessage {
     /// Platform thread identifier (e.g. Slack `ts`, Discord thread ID).
     /// When set, replies should be posted as threaded responses.
     pub thread_ts: Option<String>,
+    /// Thread scope identifier for interruption/cancellation grouping.
+    /// Distinct from `thread_ts` (reply anchor): this is `Some` only when the message
+    /// is genuinely inside a reply thread and should be isolated from other threads.
+    /// `None` means top-level — scope is sender+channel only.
+    pub interruption_scope_id: Option<String>,
 }
 
 /// Message to send through a channel
@@ -182,6 +187,7 @@ mod tests {
                 channel: "dummy".into(),
                 timestamp: 123,
                 thread_ts: None,
+                interruption_scope_id: None,
             })
             .await
             .map_err(|e| anyhow::anyhow!(e.to_string()))
@@ -198,6 +204,7 @@ mod tests {
             channel: "dummy".into(),
             timestamp: 999,
             thread_ts: None,
+            interruption_scope_id: None,
         };
 
         let cloned = message.clone();

--- a/src/channels/twitter.rs
+++ b/src/channels/twitter.rs
@@ -288,6 +288,7 @@ impl Channel for TwitterChannel {
                                     .get("conversation_id")
                                     .and_then(|c| c.as_str())
                                     .map(|s| s.to_string()),
+                                interruption_scope_id: None,
                             };
 
                             if tx.send(channel_msg).await.is_err() {

--- a/src/channels/wati.rs
+++ b/src/channels/wati.rs
@@ -163,6 +163,7 @@ impl WatiChannel {
             channel: "wati".to_string(),
             timestamp,
             thread_ts: None,
+            interruption_scope_id: None,
         });
 
         messages

--- a/src/channels/webhook.rs
+++ b/src/channels/webhook.rs
@@ -237,6 +237,7 @@ impl Channel for WebhookChannel {
                 channel: "webhook".to_string(),
                 timestamp,
                 thread_ts: payload.thread_id,
+                interruption_scope_id: None,
             };
 
             if state.tx.send(msg).await.is_err() {

--- a/src/channels/whatsapp.rs
+++ b/src/channels/whatsapp.rs
@@ -142,6 +142,7 @@ impl WhatsAppChannel {
                         channel: "whatsapp".to_string(),
                         timestamp,
                         thread_ts: None,
+                        interruption_scope_id: None,
                     });
                 }
             }

--- a/src/channels/whatsapp_web.rs
+++ b/src/channels/whatsapp_web.rs
@@ -741,6 +741,7 @@ impl Channel for WhatsAppWebChannel {
                                         content,
                                         timestamp: chrono::Utc::now().timestamp() as u64,
                                         thread_ts: None,
+                                        interruption_scope_id: None,
                                     })
                                     .await
                                 {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -2173,6 +2173,7 @@ mod tests {
             channel: "whatsapp".into(),
             timestamp: 1,
             thread_ts: None,
+            interruption_scope_id: None,
         };
 
         let key = whatsapp_memory_key(&msg);

--- a/tests/integration/channel_matrix.rs
+++ b/tests/integration/channel_matrix.rs
@@ -124,6 +124,7 @@ impl Channel for MatrixTestChannel {
             channel: self.channel_name.clone(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         })
         .await
         .map_err(|e| anyhow::anyhow!(e.to_string()))
@@ -564,6 +565,7 @@ fn channel_message_thread_ts_preserved_on_clone() {
         channel: "slack".into(),
         timestamp: 1700000000,
         thread_ts: Some("1700000000.000001".into()),
+        interruption_scope_id: None,
     };
 
     let cloned = msg.clone();
@@ -580,6 +582,7 @@ fn channel_message_none_thread_ts_preserved() {
         channel: "telegram".into(),
         timestamp: 1700000000,
         thread_ts: None,
+        interruption_scope_id: None,
     };
 
     assert!(msg.clone().thread_ts.is_none());
@@ -633,6 +636,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "telegram".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "discord" => ChannelMessage {
             id: "dc_1".into(),
@@ -642,6 +646,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "discord".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "slack" => ChannelMessage {
             id: "sl_1".into(),
@@ -651,6 +656,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "slack".into(),
             timestamp: 1700000000,
             thread_ts: Some("1700000000.000001".into()),
+            interruption_scope_id: None,
         },
         "imessage" => ChannelMessage {
             id: "im_1".into(),
@@ -660,6 +666,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "imessage".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "irc" => ChannelMessage {
             id: "irc_1".into(),
@@ -669,6 +676,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "irc".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "email" => ChannelMessage {
             id: "email_1".into(),
@@ -678,6 +686,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "email".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "signal" => ChannelMessage {
             id: "sig_1".into(),
@@ -687,6 +696,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "signal".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "mattermost" => ChannelMessage {
             id: "mm_1".into(),
@@ -696,6 +706,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "mattermost".into(),
             timestamp: 1700000000,
             thread_ts: Some("root_msg_id".into()),
+            interruption_scope_id: None,
         },
         "whatsapp" => ChannelMessage {
             id: "wa_1".into(),
@@ -705,6 +716,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "whatsapp".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "nextcloud_talk" => ChannelMessage {
             id: "nc_1".into(),
@@ -714,6 +726,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "nextcloud_talk".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "wecom" => ChannelMessage {
             id: "wc_1".into(),
@@ -723,6 +736,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "wecom".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "dingtalk" => ChannelMessage {
             id: "dt_1".into(),
@@ -732,6 +746,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "dingtalk".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "qq" => ChannelMessage {
             id: "qq_1".into(),
@@ -741,6 +756,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "qq".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "linq" => ChannelMessage {
             id: "lq_1".into(),
@@ -750,6 +766,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "linq".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "wati" => ChannelMessage {
             id: "wt_1".into(),
@@ -759,6 +776,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "wati".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         "cli" => ChannelMessage {
             id: "cli_1".into(),
@@ -768,6 +786,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             channel: "cli".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         },
         _ => panic!("Unknown platform: {platform}"),
     }
@@ -1068,6 +1087,7 @@ fn channel_message_zero_timestamp() {
         channel: "ch".into(),
         timestamp: 0,
         thread_ts: None,
+        interruption_scope_id: None,
     };
     assert_eq!(msg.timestamp, 0);
 }
@@ -1082,6 +1102,7 @@ fn channel_message_max_timestamp() {
         channel: "ch".into(),
         timestamp: u64::MAX,
         thread_ts: None,
+        interruption_scope_id: None,
     };
     assert_eq!(msg.timestamp, u64::MAX);
 }

--- a/tests/integration/channel_routing.rs
+++ b/tests/integration/channel_routing.rs
@@ -25,6 +25,7 @@ fn channel_message_sender_field_holds_platform_user_id() {
         channel: "telegram".into(),
         timestamp: 1700000000,
         thread_ts: None,
+        interruption_scope_id: None,
     };
 
     assert_eq!(msg.sender, "123456789");
@@ -47,6 +48,7 @@ fn channel_message_reply_target_distinct_from_sender() {
         channel: "discord".into(),
         timestamp: 1700000000,
         thread_ts: None,
+        interruption_scope_id: None,
     };
 
     assert_ne!(
@@ -67,6 +69,7 @@ fn channel_message_fields_not_swapped() {
         channel: "test".into(),
         timestamp: 1700000000,
         thread_ts: None,
+        interruption_scope_id: None,
     };
 
     assert_eq!(
@@ -93,6 +96,7 @@ fn channel_message_preserves_all_fields_on_clone() {
         channel: "test_channel".into(),
         timestamp: 1700000001,
         thread_ts: None,
+        interruption_scope_id: None,
     };
 
     let cloned = original.clone();
@@ -186,6 +190,7 @@ impl Channel for CapturingChannel {
             channel: "capturing".into(),
             timestamp: 1700000000,
             thread_ts: None,
+            interruption_scope_id: None,
         })
         .await
         .map_err(|e| anyhow::anyhow!(e.to_string()))


### PR DESCRIPTION
## Summary
- Add `interruption_scope_id: Option<String>` to `ChannelMessage` for thread-aware cancellation
- `interruption_scope_key` produces 4-component key when scope is Some, 3-component when None
- Slack: top-level/parent messages get None, genuine thread replies (thread_ts != ts) get Some(thread_ts)
- Matrix: thread_ts used as interruption_scope_id
- All other ~28 channels set None (preserving existing behavior)

Supersedes #3900. Depends on #3891.

## Test plan
- [x] `cargo test --locked interruption_scope` — 6 tests pass
- [x] `cargo test --locked channel` — 1,890 tests pass
- [x] `cargo test --locked dispatch` — 60 tests pass
- [x] `cargo clippy --locked --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean