### PR TITLE
fix(tool): include descriptions in deferred MCP tools system prompt

### DIFF
--- a/src/tools/mcp_deferred.rs
+++ b/src/tools/mcp_deferred.rs
@@ -251,6 +251,8 @@ pub fn build_deferred_tools_section(deferred: &DeferredMcpToolSet) -> String {
     out.push_str("<available-deferred-tools>\n");
     for stub in &deferred.stubs {
         out.push_str(&stub.prefixed_name);
+        out.push_str(" - ");
+        out.push_str(&stub.description);
         out.push('\n');
     }
     out.push_str("</available-deferred-tools>\n");
@@ -421,8 +423,8 @@ mod tests {
         };
         let section = build_deferred_tools_section(&set);
         assert!(section.contains("<available-deferred-tools>"));
-        assert!(section.contains("fs__read_file"));
-        assert!(section.contains("git__status"));
+        assert!(section.contains("fs__read_file - Read a file"));
+        assert!(section.contains("git__status - Git status"));
         assert!(section.contains("</available-deferred-tools>"));
     }
 


### PR DESCRIPTION
## Summary

Supersedes #3846 (resolved conflicts with master, applied remaining improvement)

Master already had the `tool_search` activation instructions from a prior merge, but was missing tool descriptions alongside names in the deferred tools listing. This adds descriptions so the LLM can better identify which tool to activate.

- Add tool descriptions next to names in `build_deferred_tools_section()`
- Update test to verify descriptions are included

Original author: @mark-linyb

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --all -- --check` clean
- [x] 12/12 `mcp_deferred` unit tests pass
- [x] No conflicts with master