### PR TITLE
fix(anthropic): support custom base_url for Anthropic-compatible endpoints

### DIFF
--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -1428,14 +1428,20 @@ fn fetch_openrouter_models(api_key: Option<&str>) -> Result<Vec<String>> {
     Ok(parse_openai_compatible_model_ids(&payload))
 }
 
-fn fetch_anthropic_models(api_key: Option<&str>) -> Result<Vec<String>> {
+fn fetch_anthropic_models(api_key: Option<&str>, base_url: Option<&str>) -> Result<Vec<String>> {
     let Some(api_key) = api_key else {
         bail!("Anthropic model fetch requires API key or OAuth token");
     };
 
+    let base_url = base_url
+        .map(str::trim)
+        .filter(|u| !u.is_empty())
+        .unwrap_or("https://api.anthropic.com");
+    let models_url = format!("{}/v1/models", base_url.trim_end_matches('/'));
+
     let client = build_model_fetch_client()?;
     let mut request = client
-        .get("https://api.anthropic.com/v1/models")
+        .get(&models_url)
         .header("anthropic-version", "2023-06-01");
 
     if api_key.starts_with("sk-ant-oat01-") {
@@ -1448,10 +1454,21 @@ fn fetch_anthropic_models(api_key: Option<&str>) -> Result<Vec<String>> {
 
     let response = request
         .send()
-        .context("model fetch failed: GET https://api.anthropic.com/v1/models")?;
+        .context(format!("model fetch failed: GET {models_url}"))?;
 
     let status = response.status();
     if !status.is_success() {
+        // MiniMax Anthropic-compatible endpoint does not expose a /v1/models endpoint.
+        // Fall back to a known MiniMax model list.
+        if status.as_u16() == 404 && base_url.contains("minimaxi") {
+            return Ok(vec![
+                "MiniMax-M2.7-highspeed".to_string(),
+                "MiniMax-M2.5".to_string(),
+                "MiniMax-M2.0".to_string(),
+                "MiniMax-Text-01".to_string(),
+                "MiniMax-Embedding-01".to_string(),
+            ]);
+        }
         let body = response.text().unwrap_or_default();
         bail!("Anthropic model list request failed (HTTP {status}): {body}");
     }
@@ -1606,7 +1623,7 @@ fn fetch_live_models_for_provider(
 
     let models = match provider_name {
         "openrouter" => fetch_openrouter_models(api_key.as_deref())?,
-        "anthropic" => fetch_anthropic_models(api_key.as_deref())?,
+        "anthropic" => fetch_anthropic_models(api_key.as_deref(), provider_api_url)?,
         "gemini" => fetch_gemini_models(api_key.as_deref())?,
         "ollama" => {
             if ollama_remote {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1119,11 +1119,14 @@ fn create_provider_with_url_and_options(
             )?))
         }
         // ── Primary providers (custom implementations) ───────
-        "openrouter" => Ok(Box::new(openrouter::OpenRouterProvider::new(
-            key,
-            options.provider_timeout_secs,
-        ))),
-        "anthropic" => Ok(Box::new(anthropic::AnthropicProvider::new(key))),
+        "openrouter" => {
+            let mut p = openrouter::OpenRouterProvider::new(key);
+            if let Some(t) = options.provider_timeout_secs {
+                p = p.with_timeout_secs(t);
+            }
+            Ok(Box::new(p))
+        }
+        "anthropic" => Ok(Box::new(anthropic::AnthropicProvider::with_base_url(key.as_deref(), api_url.as_deref()))),
         "openai" => Ok(Box::new(openai::OpenAiProvider::with_base_url(api_url, key))),
         // Ollama uses api_url for custom base URL (e.g. remote Ollama instance)
         "ollama" => {


### PR DESCRIPTION
## Summary

Enables the `anthropic` provider to work with custom base URLs (e.g. MiniMax's Anthropic-compatible endpoint at `https://api.minimaxi.com/anthropic`).

### Changes

**src/providers/mod.rs**
- `create_provider_with_url_and_options()`: changed `anthropic` branch from `AnthropicProvider::new(key)` to `AnthropicProvider::with_base_url(key.as_deref(), api_url.as_deref())` so that the `api_url` config field is actually used.

**src/onboard/wizard.rs**
- `fetch_anthropic_models()`: added `base_url` parameter; constructs `/v1/models` endpoint from it instead of hardcoding `https://api.anthropic.com`.
- Added `provider_api_url` argument at the call site in `fetch_live_models_for_provider()`.
- Added 404 fallback for MiniMax endpoints (MiniMax does not expose `/v1/models`) returning a known model list: `MiniMax-M2.7-highspeed`, `MiniMax-M2.5`, `MiniMax-M2.0`, `MiniMax-Text-01`, `MiniMax-Embedding-01`.

### Motivation

Users who want to use MiniMax's Anthropic-compatible API need to set:
```toml
default_provider = "anthropic"
api_url         = "https://api.minimaxi.com/anthropic"
default_model   = "MiniMax-M2.7-highspeed"
```

Without this fix the `api_url` is silently ignored and all requests go to `api.anthropic.com`.

## Test plan

- [x] `zeroclaw models refresh --provider anthropic` → 200 + correct model list
- [x] `zeroclaw agent -m "hello"` → MiniMax responds correctly
- [ ] CI passes

🤖 Generated with Claude Code