### PR TITLE
chore: bump version to 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9179,7 +9179,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"

--- a/dist/scoop/zeroclaw.json
+++ b/dist/scoop/zeroclaw.json
@@ -1,11 +1,11 @@
 {
-    "version": "0.4.3",
+    "version": "0.5.2",
     "description": "Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.",
     "homepage": "https://github.com/zeroclaw-labs/zeroclaw",
     "license": "MIT|Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.4.3/zeroclaw-x86_64-pc-windows-msvc.zip",
+            "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.5.2/zeroclaw-x86_64-pc-windows-msvc.zip",
             "hash": "",
             "bin": "zeroclaw.exe"
         }


### PR DESCRIPTION
## Summary

- Bump ZeroClaw version from 0.5.1 to 0.5.2
- Update Cargo.toml, Cargo.lock, and Scoop manifest (`dist/scoop/zeroclaw.json`)

## Test plan

- [ ] `cargo build --release` succeeds
- [ ] `zeroclaw --version` shows `0.5.2`
- [ ] Scoop manifest URL points to correct release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)