### PR TITLE
fix(web): anchor memory table to viewport with dual scrollbars

### DIFF
--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -7,17 +7,17 @@ export default function Layout() {
   const { pathname } = useLocation();
 
   return (
-    <div className="min-h-screen text-white" style={{ background: 'linear-gradient(135deg, #050510 0%, #080818 50%, #050510 100%)' }}>
+    <div className="h-screen flex overflow-hidden text-white" style={{ background: 'linear-gradient(135deg, #050510 0%, #080818 50%, #050510 100%)' }}>
       {/* Fixed sidebar */}
       <Sidebar />
 
       {/* Main area offset by sidebar width (240px / w-60) */}
-      <div className="ml-60 flex flex-col min-h-screen">
+      <div className="ml-60 flex flex-col flex-1 min-w-0 h-screen">
         <Header />
 
         {/* Page content — ErrorBoundary keyed by pathname so the nav shell
             survives a page crash and the boundary resets on route change */}
-        <main className="flex-1 overflow-y-auto">
+        <main className="flex-1 overflow-y-auto min-h-0">
           <ErrorBoundary key={pathname}>
             <Outlet />
           </ErrorBoundary>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -301,6 +301,12 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.05em;
   padding: 0.75rem 1rem;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  /* Match glass-card background so rows do not bleed through on scroll */
+  background: linear-gradient(135deg, rgba(13, 13, 32, 0.95), rgba(5, 5, 16, 0.90));
+  backdrop-filter: blur(8px);
 }
 
 .table-electric tbody tr {

--- a/web/src/pages/Memory.tsx
+++ b/web/src/pages/Memory.tsx
@@ -106,7 +106,7 @@ export default function Memory() {
   }
 
   return (
-    <div className="p-6 space-y-6 animate-fade-in">
+    <div className="flex flex-col h-full p-6 gap-6 animate-fade-in overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -262,7 +262,7 @@ export default function Memory() {
           <p className="text-[#556080]">{t('memory.empty')}</p>
         </div>
       ) : (
-        <div className="glass-card overflow-x-auto">
+        <div className="glass-card flex-1 min-h-0 overflow-auto">
           <table className="table-electric">
             <thead>
               <tr>


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The `/memory` data grid grew unboundedly with table rows, pushing the horizontal scrollbar to the very bottom of a tall page where it was hard or impossible to reach without scrolling all the way down first.
- Why it matters: With even a modest number of memory entries, the horizontal scrollbar becomes practically unreachable, making wide columns (long keys, long content) inaccessible. The UX expectation for a data grid is that both scroll axes are always visible and reachable — like a bounded iframe.
- What changed: Three targeted, minimal edits to `Layout.tsx`, `Memory.tsx`, and `index.css` that anchor the memory table to the available viewport height and expose both scrollbars at all times.
- What did **not** change: No logic, API calls, state management, routing, other pages, Rust backend, or any other frontend page was modified. The layout shell change (`Layout.tsx`) is structurally safe — `h-screen` + `overflow-hidden` on the root with `min-h-0` on `<main>` is the canonical flex-column viewport-fill pattern and does not affect any other page's scroll behaviour since all other pages fit within the viewport naturally.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `memory`
- Module labels: `memory: web-ui`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `docs` — web dashboard UI only, no runtime changes

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A — this PR does not supersede any existing PR.

## Validation Evidence (required)

This PR touches only `web/src/` files. No Rust source was modified.

```bash
cargo fmt --all -- --check   # not applicable — no Rust changes
cargo clippy --all-targets -- -D warnings  # not applicable — no Rust changes
cargo test                   # not applicable — no Rust changes
```

- `npm run build` completed successfully in `web/` with no errors or warnings.
- Patch applied cleanly to master via `git apply --check` before committing.
- Manually verified in-browser on a live ZeroClaw instance with a populated SQLite memory backend (50+ entries): both vertical and horizontal scrollbars are visible and reachable without any page-level scrolling. Column headers remain pinned during vertical scroll.
- Evidence provided: manual browser verification (screenshot available on request).
- Rust validation intentionally skipped: no `.rs` files were modified; the embedded `web/dist/` asset is the only artifact produced by this change after `npm run build`.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No test data, fixtures, or user-identifiable content introduced.
- Neutral wording confirmation: All wording is system/component-focused; no personal or identity-specific language used.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No — no user-facing strings were added, removed, or modified. All existing `t('memory.*')` keys are preserved verbatim.

## Human Verification (required)

- Verified scenarios:
  - `/memory` page with 50+ entries: table fills viewport, vertical scrollbar visible and functional at right edge of card, horizontal scrollbar visible and functional at bottom edge of card — no page-level scroll required to reach either.
  - Column headers remain sticky and visible when scrolling vertically through a long list.
  - Empty state (zero entries) renders correctly — the centered empty-state card is unaffected.
  - Loading spinner renders correctly while fetch is in-flight.
  - Add Memory modal opens, submits, and closes correctly.
  - Delete confirmation inline flow works correctly.
  - Search and category filter controls remain fully accessible above the table.
  - All other dashboard pages (`/`, `/agent`, `/tools`, `/cron`, `/cost`, `/logs`, `/doctor`, `/config`, `/integrations`) render and scroll normally — the `Layout.tsx` change did not introduce regressions.
- Edge cases checked:
  - Very long key names: table auto-sizing behaviour unchanged (browser `table-layout: auto` still governs column widths).
  - Narrow viewport / smaller window: table card scrolls both axes correctly within the reduced space.
- What was not verified: mobile/touch viewport behaviour (ZeroClaw dashboard is a desktop-first tool).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `/memory` dashboard page only (primary). `Layout.tsx` shell change is shared but behaviorally inert for all other pages.
- Potential unintended effects: Any future page that relies on the page itself growing taller than the viewport (rather than scrolling within `<main>`) would need `overflow-y: visible` or equivalent — but no current page does this.
- Guardrails/monitoring for early detection: Visual regression is immediately obvious on page load; no silent failure mode.

## Agent Collaboration Notes (recommended)

- Agent tools used: Zed AI (Claude Sonnet) for patch authorship and review.
- Workflow/plan summary: Identified root cause (missing `min-h-0` on flex child + unbounded `overflow-x-auto` wrapper), applied minimal three-line surgical fix, generated clean patch verified with `git apply --check`, tested locally before committing.
- Verification focus: Confirmed no other pages were affected by the `Layout.tsx` shell change; confirmed sticky `thead` background matches `glass-card` so rows don't visually bleed through on scroll.
- Confirmation: naming + architecture boundaries followed per `CLAUDE.md`.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>` — the commit is a single atomic change to three files; revert is clean with no cascade.
- Feature flags or config toggles: None — pure CSS/JSX layout change.
- Observable failure symptoms: If regressed, the `/memory` page would revert to unbounded vertical growth with the horizontal scrollbar buried at the bottom of the page. No data loss or API impact possible.

## Risks and Mitigations

- Risk: The `h-screen` + `overflow-hidden` change to `Layout.tsx` is shared across all pages. If a future page needs to grow beyond the viewport height it would need to opt out.
  - Mitigation: All current pages either fit within the viewport or scroll within `<main>` via `overflow-y-auto`, which is exactly the intended pattern. The change enforces correct flex-column viewport containment that was already the design intent of the shell.