### PR TITLE
feat(ci): add armv7-unknown-linux-gnueabihf release target

### DIFF
--- a/.github/workflows/cross-platform-build-manual.yml
+++ b/.github/workflows/cross-platform-build-manual.yml
@@ -44,6 +44,11 @@ jobs:
             cross_compiler: gcc-aarch64-linux-gnu
             linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
             linker: aarch64-linux-gnu-gcc
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            cross_compiler: gcc-arm-linux-gnueabihf
+            linker_env: CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER
+            linker: arm-linux-gnueabihf-gcc
           - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: windows-latest

--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -169,6 +169,13 @@ jobs:
             cross_compiler: gcc-aarch64-linux-gnu
             linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
             linker: aarch64-linux-gnu-gcc
+          - os: ubuntu-22.04
+            target: armv7-unknown-linux-gnueabihf
+            artifact: zeroclaw
+            ext: tar.gz
+            cross_compiler: gcc-arm-linux-gnueabihf
+            linker_env: CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER
+            linker: arm-linux-gnueabihf-gcc
           - os: macos-14
             target: aarch64-apple-darwin
             artifact: zeroclaw

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -170,6 +170,13 @@ jobs:
             cross_compiler: gcc-aarch64-linux-gnu
             linker_env: CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER
             linker: aarch64-linux-gnu-gcc
+          - os: ubuntu-22.04
+            target: armv7-unknown-linux-gnueabihf
+            artifact: zeroclaw
+            ext: tar.gz
+            cross_compiler: gcc-arm-linux-gnueabihf
+            linker_env: CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER
+            linker: arm-linux-gnueabihf-gcc
           - os: macos-14
             target: aarch64-apple-darwin
             artifact: zeroclaw


### PR DESCRIPTION
## Summary

- Adds `armv7-unknown-linux-gnueabihf` (32-bit ARM hard-float) to the release build matrix in all three workflows:
  - `release-stable-manual.yml` (stable releases)
  - `release-beta-on-push.yml` (beta releases on push to master)
  - `cross-platform-build-manual.yml` (manual cross-platform builds)
- Uses `gcc-arm-linux-gnueabihf` cross-compiler on `ubuntu-22.04` for glibc 2.35 compatibility
- `install.sh` already maps `armv7l`/`armv6l` → `armv7-unknown-linux-gnueabihf`, so no install script changes needed

This enables Raspberry Pi and similar ARMv7 device users to install zeroclaw directly via the install script.

Closes #3759

## Test plan

- [x] Workflow YAML syntax is valid (mirrors existing aarch64-unknown-linux-gnu pattern)
- [x] `install.sh` already handles armv7l/armv6l arch detection (line 215-216)
- [ ] CI pipeline validates on PR (no build step runs on PRs — only lint/test)
- [ ] First beta release after merge will produce the armv7 binary