### PR TITLE
fix(skills): preserve TOML [[tools]] in Compact prompt injection mode

### DIFF
--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -445,7 +445,7 @@ mod tests {
     }
 
     #[test]
-    fn skills_section_compact_mode_omits_instructions_and_tools() {
+    fn skills_section_compact_mode_omits_instructions_but_keeps_tools() {
         let tools: Vec<Box<dyn Tool>> = vec![];
         let skills = vec![crate::skills::Skill {
             name: "deploy".into(),
@@ -482,7 +482,10 @@ mod tests {
         assert!(output.contains("<location>skills/deploy/SKILL.md</location>"));
         assert!(output.contains("read_skill(name)"));
         assert!(!output.contains("<instruction>Run smoke tests before deploy.</instruction>"));
-        assert!(!output.contains("<tools>"));
+        // Compact mode should still include tools so the LLM knows about them
+        assert!(output.contains("<tools>"));
+        assert!(output.contains("<name>release_checklist</name>"));
+        assert!(output.contains("<kind>shell</kind>"));
     }
 
     #[test]

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -7323,7 +7323,7 @@ BTC is currently around $65,000 based on latest tool output."#
     }
 
     #[test]
-    fn prompt_skills_compact_mode_omits_instructions_and_tools() {
+    fn prompt_skills_compact_mode_omits_instructions_but_keeps_tools() {
         let ws = make_workspace();
         let skills = vec![crate::skills::Skill {
             name: "code-review".into(),
@@ -7361,7 +7361,10 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(!prompt.contains("<instructions>"));
         assert!(!prompt
             .contains("<instruction>Always run cargo test before final response.</instruction>"));
-        assert!(!prompt.contains("<tools>"));
+        // Compact mode should still include tools so the LLM knows about them
+        assert!(prompt.contains("<tools>"));
+        assert!(prompt.contains("<name>lint</name>"));
+        assert!(prompt.contains("<kind>shell</kind>"));
     }
 
     #[test]

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -714,26 +714,29 @@ pub fn skills_to_prompt_with_mode(
         );
         write_xml_text_element(&mut prompt, 4, "location", &location);
 
-        if matches!(mode, crate::config::SkillsPromptInjectionMode::Full) {
-            if !skill.prompts.is_empty() {
-                let _ = writeln!(prompt, "    <instructions>");
-                for instruction in &skill.prompts {
-                    write_xml_text_element(&mut prompt, 6, "instruction", instruction);
-                }
-                let _ = writeln!(prompt, "    </instructions>");
+        // In Full mode, inline both instructions and tools.
+        // In Compact mode, skip instructions (loaded on demand) but keep tools
+        // so the LLM knows which skill tools are available.
+        if matches!(mode, crate::config::SkillsPromptInjectionMode::Full)
+            && !skill.prompts.is_empty()
+        {
+            let _ = writeln!(prompt, "    <instructions>");
+            for instruction in &skill.prompts {
+                write_xml_text_element(&mut prompt, 6, "instruction", instruction);
             }
+            let _ = writeln!(prompt, "    </instructions>");
+        }
 
-            if !skill.tools.is_empty() {
-                let _ = writeln!(prompt, "    <tools>");
-                for tool in &skill.tools {
-                    let _ = writeln!(prompt, "      <tool>");
-                    write_xml_text_element(&mut prompt, 8, "name", &tool.name);
-                    write_xml_text_element(&mut prompt, 8, "description", &tool.description);
-                    write_xml_text_element(&mut prompt, 8, "kind", &tool.kind);
-                    let _ = writeln!(prompt, "      </tool>");
-                }
-                let _ = writeln!(prompt, "    </tools>");
+        if !skill.tools.is_empty() {
+            let _ = writeln!(prompt, "    <tools>");
+            for tool in &skill.tools {
+                let _ = writeln!(prompt, "      <tool>");
+                write_xml_text_element(&mut prompt, 8, "name", &tool.name);
+                write_xml_text_element(&mut prompt, 8, "description", &tool.description);
+                write_xml_text_element(&mut prompt, 8, "kind", &tool.kind);
+                let _ = writeln!(prompt, "      </tool>");
             }
+            let _ = writeln!(prompt, "    </tools>");
         }
 
         let _ = writeln!(prompt, "  </skill>");
@@ -1286,7 +1289,7 @@ command = "echo hello"
     }
 
     #[test]
-    fn skills_to_prompt_compact_mode_omits_instructions_and_tools() {
+    fn skills_to_prompt_compact_mode_omits_instructions_but_keeps_tools() {
         let skills = vec![Skill {
             name: "test".to_string(),
             description: "A test".to_string(),
@@ -1316,7 +1319,10 @@ command = "echo hello"
         assert!(prompt.contains("read_skill(name)"));
         assert!(!prompt.contains("<instructions>"));
         assert!(!prompt.contains("<instruction>Do the thing.</instruction>"));
-        assert!(!prompt.contains("<tools>"));
+        // Compact mode should still include tools so the LLM knows about them
+        assert!(prompt.contains("<tools>"));
+        assert!(prompt.contains("<name>run</name>"));
+        assert!(prompt.contains("<kind>shell</kind>"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes a bug where Compact (`MetadataOnly`) prompt injection mode omitted TOML `[[tools]]` from the system prompt, making them invisible to the LLM.
- Compact mode now skips only `<instructions>` (loaded on demand via `read_skill(name)`) while still inlining `<tools>` so the LLM knows which skill tools are available.
- No backend changes, no new dependencies, no config changes.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `src`
- Module labels: `skills`

## Change Metadata

- Change type: `fix`
- Primary scope: `skills`

## Linked Issue

- Closes #3702

## Validation Evidence (required)

```
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass
cargo test   # all pass
```

Specifically validated:
- `skills::tests::skills_to_prompt_compact_mode_omits_instructions_but_keeps_tools`
- `agent::prompt::tests::skills_section_compact_mode_omits_instructions_but_keeps_tools`
- `channels::tests::prompt_skills_compact_mode_omits_instructions_but_keeps_tools`
- `tools::tests::all_tools_includes_read_skill_in_compact_mode`

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`

## Compatibility / Migration

- Backward compatible? Yes — Compact mode now includes more information (tools) than before; no existing behavior is removed.
- Config/env changes? No
- Migration needed? No

## Side Effects / Blast Radius (required)

- Affected subsystems: System prompt generation in Compact mode only
- Potential unintended effects: Slight increase in prompt token usage in Compact mode (tool metadata). This is intentional — tools are separate from instructions and their small token cost is justified by enabling structured tool calling.

## Rollback Plan (required)

- Revert this PR to restore previous Compact mode behavior (tools omitted).

## Test plan

- [x] Compact mode includes `<tools>` section in system prompt
- [x] Compact mode still omits `<instructions>` section
- [x] Full mode behavior unchanged (includes both tools and instructions)
- [x] clippy, fmt, full test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)