### PR TITLE
feat(ci): add ARM cross-compilation targets for SBCs

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -177,6 +177,15 @@ jobs:
             cross_compiler: gcc-arm-linux-gnueabihf
             linker_env: CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER
             linker: arm-linux-gnueabihf-gcc
+            skip_prometheus: true
+          - os: ubuntu-22.04
+            target: arm-unknown-linux-gnueabihf
+            artifact: zeroclaw
+            ext: tar.gz
+            cross_compiler: gcc-arm-linux-gnueabihf
+            linker_env: CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER
+            linker: arm-linux-gnueabihf-gcc
+            skip_prometheus: true
           - os: macos-14
             target: aarch64-apple-darwin
             artifact: zeroclaw
@@ -222,7 +231,11 @@ jobs:
           if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
             export "${{ matrix.linker_env }}=${{ matrix.linker }}"
           fi
-          cargo build --release --locked --features "${{ env.RELEASE_CARGO_FEATURES }}" --target ${{ matrix.target }}
+          if [ "${{ matrix.skip_prometheus || 'false' }}" = "true" ]; then
+            cargo build --release --locked --no-default-features --features "${{ env.RELEASE_CARGO_FEATURES }},channel-nostr,skill-creation" --target ${{ matrix.target }}
+          else
+            cargo build --release --locked --features "${{ env.RELEASE_CARGO_FEATURES }}" --target ${{ matrix.target }}
+          fi
 
       - name: Package (Unix)
         if: runner.os != 'Windows'

--- a/install.sh
+++ b/install.sh
@@ -212,8 +212,11 @@ detect_release_target() {
         echo "aarch64-unknown-linux-gnu"
       fi
       ;;
-    Linux:armv7l|Linux:armv6l)
+    Linux:armv7l)
       echo "armv7-unknown-linux-gnueabihf"
+      ;;
+    Linux:armv6l)
+      echo "arm-unknown-linux-gnueabihf"
       ;;
     Darwin:x86_64)
       echo "x86_64-apple-darwin"


### PR DESCRIPTION
## Summary
- Adds `arm-unknown-linux-gnueabihf` (ARMv6, RPi Zero) and `armv7-unknown-linux-gnueabihf` (ARMv7, Orange Pi) targets to release build matrix
- Adds `skip_prometheus` flag to disable `observability-prometheus` on 32-bit targets (requires `AtomicU64`)
- Updates `install.sh` to map `armv6l` to the correct ARM binary

Supersedes #4030
Closes #3848

## Test plan
- [ ] Verify CI workflow syntax is valid
- [ ] Verify ARM targets build in release workflow
- [ ] Verify install.sh correctly detects ARM architectures