### PR TITLE
fix(qq): respond to WebSocket Ping frames to prevent timeout

### DIFF
--- a/src/channels/qq.rs
+++ b/src/channels/qq.rs
@@ -378,6 +378,12 @@ impl Channel for QQChannel {
                 msg = read.next() => {
                     let msg = match msg {
                         Some(Ok(Message::Text(t))) => t,
+                        Some(Ok(Message::Ping(payload))) => {
+                            if write.send(Message::Pong(payload)).await.is_err() {
+                                break;
+                            }
+                            continue;
+                        }
                         Some(Ok(Message::Close(_))) | None => break,
                         _ => continue,
                     };


### PR DESCRIPTION
## Summary
- Handle incoming `Message::Ping` frames in the QQ channel WebSocket loop by replying with `Message::Pong`
- Prevents the server from dropping the connection due to unanswered Ping frames

## Risk
Medium — behavioral change in `src/channels/qq.rs`, no security boundary impact.

## Test plan
- [*] Verify QQ bot maintains long-lived WebSocket connections without unexpected disconnects
- [*] Confirm heartbeat mechanism still works correctly alongside Ping/Pong handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)