### PR TITLE
fix: resolve ClawHub URLs to GitHub repos for skills install

### DIFF
--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -791,6 +791,26 @@ pub fn init_skills_dir(workspace_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Resolve ClawHub URLs to their backing GitHub repository.
+///
+/// ClawHub (`clawhub.ai`) is a skill discovery portal, not a Git host.
+/// Skills listed there are hosted on GitHub at the same `author/name` path.
+/// This function transparently rewrites ClawHub URLs so that `skills install`
+/// can clone them via the normal Git path.
+fn resolve_skill_source_url(source: &str) -> String {
+    let s = source.trim();
+    // Handle https://clawhub.ai/author/skill, http://…, and bare clawhub.ai/…
+    for prefix in &["https://clawhub.ai/", "http://clawhub.ai/", "clawhub.ai/"] {
+        if let Some(rest) = s.strip_prefix(prefix) {
+            let path = rest.trim_end_matches('/');
+            if !path.is_empty() {
+                return format!("https://github.com/{path}");
+            }
+        }
+    }
+    s.to_string()
+}
+
 fn is_git_source(source: &str) -> bool {
     is_git_scheme_source(source, "https://")
         || is_git_scheme_source(source, "http://")
@@ -1084,13 +1104,23 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
         crate::SkillCommands::Install { source } => {
             println!("Installing skill from: {source}");
 
+            // Resolve ClawHub URLs to their backing GitHub repository
+            let resolved_source = resolve_skill_source_url(&source);
+            if resolved_source != source {
+                println!(
+                    "  {} Resolved ClawHub URL to GitHub: {}",
+                    console::style("ℹ").blue().bold(),
+                    resolved_source
+                );
+            }
+
             let skills_path = skills_dir(workspace_dir);
             std::fs::create_dir_all(&skills_path)?;
 
-            if is_git_source(&source) {
+            if is_git_source(&resolved_source) {
                 let (installed_dir, files_scanned) =
-                    install_git_skill_source(&source, &skills_path, config.skills.allow_scripts)
-                        .with_context(|| format!("failed to install git skill source: {source}"))?;
+                    install_git_skill_source(&resolved_source, &skills_path, config.skills.allow_scripts)
+                        .with_context(|| format!("failed to install git skill source: {resolved_source}"))?;
                 println!(
                     "  {} Skill installed and audited: {} ({} files scanned)",
                     console::style("✓").green().bold(),
@@ -1099,9 +1129,9 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
                 );
             } else {
                 let (dest, files_scanned) =
-                    install_local_skill_source(&source, &skills_path, config.skills.allow_scripts)
+                    install_local_skill_source(&resolved_source, &skills_path, config.skills.allow_scripts)
                         .with_context(|| {
-                            format!("failed to install local skill source: {source}")
+                            format!("failed to install local skill source: {resolved_source}")
                         })?;
                 println!(
                     "  {} Skill installed and audited: {} ({} files scanned)",


### PR DESCRIPTION
## Summary

Fixes #4022

`zeroclaw skills install https://clawhub.ai/steipete/summarize` fails because the URL is passed directly to `git clone`. ClawHub (`clawhub.ai`) is a skill discovery portal — not a Git host. The actual skill repositories are hosted on GitHub.

## Changes

Added `resolve_skill_source_url()` in `src/skills/mod.rs` that transparently rewrites ClawHub URLs to their backing GitHub repository before the install flow:

```
https://clawhub.ai/author/skill  →  https://github.com/author/skill
http://clawhub.ai/author/skill   →  https://github.com/author/skill
clawhub.ai/author/skill          →  https://github.com/author/skill
```

Modified the `Install` command handler to:
1. Call `resolve_skill_source_url()` on the input source
2. Print an informational message when a ClawHub URL is resolved
3. Use the resolved URL for all subsequent operations (`is_git_source`, `install_git_skill_source`, etc.)

### Before
```
$ zeroclaw skills install https://clawhub.ai/steipete/summarize
Error: failed to install git skill source: https://clawhub.ai/steipete/summarize
  Git clone failed: fatal: repository 'https://clawhub.ai/steipete/summarize/' not found
```

### After
```
$ zeroclaw skills install https://clawhub.ai/steipete/summarize
Installing skill from: https://clawhub.ai/steipete/summarize
  ℹ Resolved ClawHub URL to GitHub: https://github.com/steipete/summarize
  ✓ Skill installed and audited: ...
```