### PR TITLE
fix(agent): force sequential execution when tool_search is in batch

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2425,6 +2425,14 @@ fn should_execute_tools_in_parallel(
         return false;
     }
 
+    // tool_search activates deferred MCP tools into ActivatedToolSet.
+    // Running tool_search in parallel with the tools it activates causes a
+    // race condition where the tool lookup happens before activation completes.
+    // Force sequential execution whenever tool_search is in the batch.
+    if tool_calls.iter().any(|call| call.name == "tool_search") {
+        return false;
+    }
+
     if let Some(mgr) = approval {
         if tool_calls.iter().any(|call| mgr.needs_approval(&call.name)) {
             // Approval-gated calls must keep sequential handling so the caller can


### PR DESCRIPTION
## Summary

- Fix race condition where `tool_search` activates deferred MCP tools into `ActivatedToolSet`, but parallel execution causes tool lookups to happen before activation completes
- Force sequential execution in `should_execute_tools_in_parallel` whenever `tool_search` is present in the tool call batch

## Problem

When the LLM emits `tool_search` alongside other tool calls in the same batch, `execute_tools_parallel` runs them concurrently. Since `tool_search` activates deferred MCP tools at runtime, the other tools may attempt to resolve activated tool names before the activation has completed, resulting in "Unknown tool" errors.

## Solution

Add a check in `should_execute_tools_in_parallel()` that returns `false` when any call in the batch is `tool_search`. This is a minimal, targeted fix — sequential execution only applies to batches containing `tool_search`, preserving parallel execution for all other cases.

```rust
if tool_calls.iter().any(|call| call.name == "tool_search") {
    return false;
}
```

## Test plan

- [x] Verify `tool_search` + activated tool calls in same batch resolve correctly
- [x] Verify parallel execution still works for non-tool_search batches
- [ ] Run existing `should_execute_tools_in_parallel` unit tests

🤖 Generated with Claude Code (claude-opus-4-6)