### PR TITLE
feat(gateway): make request timeout configurable via env var

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -50,8 +50,21 @@ use uuid::Uuid;
 
 /// Maximum request body size (64KB) — prevents memory exhaustion
 pub const MAX_BODY_SIZE: usize = 65_536;
-/// Request timeout (30s) — prevents slow-loris attacks
+/// Default request timeout (30s) — prevents slow-loris attacks.
 pub const REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// Read gateway request timeout from `ZEROCLAW_GATEWAY_TIMEOUT_SECS` env var
+/// at runtime, falling back to [`REQUEST_TIMEOUT_SECS`].
+///
+/// Agentic workloads with tool use (web search, MCP tools, sub-agent
+/// delegation) regularly exceed 30 seconds. This allows operators to
+/// increase the timeout without recompiling.
+pub fn gateway_request_timeout_secs() -> u64 {
+    std::env::var("ZEROCLAW_GATEWAY_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(REQUEST_TIMEOUT_SECS)
+}
 /// Sliding window used by gateway rate limiting.
 pub const RATE_LIMIT_WINDOW_SECS: u64 = 60;
 /// Fallback max distinct client keys tracked in gateway rate limiter.
@@ -821,7 +834,7 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         .layer(RequestBodyLimitLayer::new(MAX_BODY_SIZE))
         .layer(TimeoutLayer::with_status_code(
             StatusCode::REQUEST_TIMEOUT,
-            Duration::from_secs(REQUEST_TIMEOUT_SECS),
+            Duration::from_secs(gateway_request_timeout_secs()),
         ))
         // ── SPA fallback: non-API GET requests serve index.html ──
         .fallback(get(static_files::handle_spa_fallback));
@@ -1850,8 +1863,15 @@ mod tests {
     }
 
     #[test]
-    fn security_timeout_is_30_seconds() {
+    fn security_timeout_default_is_30_seconds() {
         assert_eq!(REQUEST_TIMEOUT_SECS, 30);
+    }
+
+    #[test]
+    fn gateway_timeout_falls_back_to_default() {
+        // When env var is not set, should return the default constant
+        std::env::remove_var("ZEROCLAW_GATEWAY_TIMEOUT_SECS");
+        assert_eq!(gateway_request_timeout_secs(), 30);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `ZEROCLAW_GATEWAY_TIMEOUT_SECS` environment variable to override the hardcoded 30-second gateway HTTP request timeout at runtime
- Default remains 30s for backward compatibility

## Problem

The gateway HTTP layer timeout is hardcoded at 30 seconds. When LLM requests involve tool use (e.g., web_search, MCP tools), responses frequently exceed 30 seconds, causing HTTP 408 timeouts at the gateway layer — even though `provider_timeout_secs` (default 120s) allows longer LLM calls.

This is especially problematic for:
- Agentic workflows with multiple tool calls (60-180s typical)
- Cron-triggered briefings that use web search + data APIs
- Sub-agent delegation with chained tool calls

Note: `provider_timeout_secs` controls the LLM provider HTTP timeout, while `REQUEST_TIMEOUT_SECS` controls the gateway-to-client layer. These are separate concerns — a long-running LLM call succeeds at the provider level but the gateway drops the client connection at 30s.

## Solution

Add a `gateway_request_timeout_secs()` function that reads from `ZEROCLAW_GATEWAY_TIMEOUT_SECS` env var at runtime, falling back to the 30s default constant.

```bash
# Example: allow 3-minute gateway timeout for agentic workloads
export ZEROCLAW_GATEWAY_TIMEOUT_SECS=180
```

## Test plan

- [x] Default (no env var) remains 30s
- [x] Custom value is respected when `ZEROCLAW_GATEWAY_TIMEOUT_SECS` is set
- [x] Invalid env var values fall back to default gracefully
- [ ] Run existing gateway unit tests

🤖 Generated with Claude Code (claude-opus-4-6)