### PR TITLE
fix(cron): persist delivery for api-created cron jobs

### DIFF
--- a/src/cron/mod.rs
+++ b/src/cron/mod.rs
@@ -45,6 +45,39 @@ pub(crate) fn validate_shell_command_with_security(
         .map_err(|reason| anyhow!("blocked by security policy: {reason}"))
 }
 
+pub(crate) fn validate_delivery_config(delivery: Option<&DeliveryConfig>) -> Result<()> {
+    let Some(delivery) = delivery else {
+        return Ok(());
+    };
+
+    if delivery.mode.eq_ignore_ascii_case("none") {
+        return Ok(());
+    }
+    if !delivery.mode.eq_ignore_ascii_case("announce") {
+        bail!("unsupported delivery mode: {}", delivery.mode);
+    }
+
+    let channel = delivery.channel.as_deref().map(str::trim);
+    let Some(channel) = channel.filter(|value| !value.is_empty()) else {
+        bail!("delivery.channel is required for announce mode");
+    };
+    match channel.to_ascii_lowercase().as_str() {
+        "telegram" | "discord" | "slack" | "mattermost" | "signal" | "matrix" => {}
+        other => bail!("unsupported delivery channel: {other}"),
+    }
+
+    let has_target = delivery
+        .to
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
+    if !has_target {
+        bail!("delivery.to is required for announce mode");
+    }
+
+    Ok(())
+}
+
 /// Create a validated shell job, enforcing security policy before persistence.
 ///
 /// All entrypoints that create shell cron jobs should route through this
@@ -54,10 +87,12 @@ pub fn add_shell_job_with_approval(
     name: Option<String>,
     schedule: Schedule,
     command: &str,
+    delivery: Option<DeliveryConfig>,
     approved: bool,
 ) -> Result<CronJob> {
     validate_shell_command(config, command, approved)?;
-    store::add_shell_job(config, name, schedule, command)
+    validate_delivery_config(delivery.as_ref())?;
+    store::add_shell_job(config, name, schedule, command, delivery)
 }
 
 /// Update a shell job's command with security validation.
@@ -95,7 +130,7 @@ pub fn add_once_at_validated(
     approved: bool,
 ) -> Result<CronJob> {
     let schedule = Schedule::At { at };
-    add_shell_job_with_approval(config, None, schedule, command, approved)
+    add_shell_job_with_approval(config, None, schedule, command, None, approved)
 }
 
 // Convenience wrappers for CLI paths (default approved=false).
@@ -106,7 +141,7 @@ pub(crate) fn add_shell_job(
     schedule: Schedule,
     command: &str,
 ) -> Result<CronJob> {
-    add_shell_job_with_approval(config, name, schedule, command, false)
+    add_shell_job_with_approval(config, name, schedule, command, None, false)
 }
 
 pub(crate) fn add_job(config: &Config, expression: &str, command: &str) -> Result<CronJob> {
@@ -680,6 +715,7 @@ mod tests {
                 tz: None,
             },
             "touch cron-medium-risk",
+            None,
             true,
         );
         assert!(approved.is_ok(), "{approved:?}");
@@ -812,6 +848,7 @@ mod tests {
                 tz: None,
             },
             "curl https://example.com",
+            None,
             false,
         );
         assert!(result.is_err());

--- a/src/cron/store.rs
+++ b/src/cron/store.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::cron::{
-    next_run_for_schedule, schedule_cron_expression, validate_schedule, CronJob, CronJobPatch,
-    CronRun, DeliveryConfig, JobType, Schedule, SessionTarget,
+    next_run_for_schedule, schedule_cron_expression, validate_delivery_config, validate_schedule,
+    CronJob, CronJobPatch, CronRun, DeliveryConfig, JobType, Schedule, SessionTarget,
 };
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -24,7 +24,7 @@ pub fn add_job(config: &Config, expression: &str, command: &str) -> Result<CronJ
         expr: expression.to_string(),
         tz: None,
     };
-    add_shell_job(config, None, schedule, command)
+    add_shell_job(config, None, schedule, command, None)
 }
 
 pub fn add_shell_job(
@@ -32,13 +32,16 @@ pub fn add_shell_job(
     name: Option<String>,
     schedule: Schedule,
     command: &str,
+    delivery: Option<DeliveryConfig>,
 ) -> Result<CronJob> {
     let now = Utc::now();
     validate_schedule(&schedule, now)?;
+    validate_delivery_config(delivery.as_ref())?;
     let next_run = next_run_for_schedule(&schedule, now)?;
     let id = Uuid::new_v4().to_string();
     let expression = schedule_cron_expression(&schedule).unwrap_or_default();
     let schedule_json = serde_json::to_string(&schedule)?;
+    let delivery = delivery.unwrap_or_default();
 
     let delete_after_run = matches!(schedule, Schedule::At { .. });
 
@@ -54,7 +57,7 @@ pub fn add_shell_job(
                 command,
                 schedule_json,
                 name,
-                serde_json::to_string(&DeliveryConfig::default())?,
+                serde_json::to_string(&delivery)?,
                 if delete_after_run { 1 } else { 0 },
                 now.to_rfc3339(),
                 next_run.to_rfc3339(),
@@ -81,6 +84,7 @@ pub fn add_agent_job(
 ) -> Result<CronJob> {
     let now = Utc::now();
     validate_schedule(&schedule, now)?;
+    validate_delivery_config(delivery.as_ref())?;
     let next_run = next_run_for_schedule(&schedule, now)?;
     let id = Uuid::new_v4().to_string();
     let expression = schedule_cron_expression(&schedule).unwrap_or_default();
@@ -694,6 +698,7 @@ mod tests {
                 at: Utc::now() + ChronoDuration::minutes(10),
             },
             "echo once",
+            None,
         )
         .unwrap();
         assert!(one_shot.delete_after_run);
@@ -703,9 +708,96 @@ mod tests {
             None,
             Schedule::Every { every_ms: 60_000 },
             "echo recurring",
+            None,
         )
         .unwrap();
         assert!(!recurring.delete_after_run);
+    }
+
+    #[test]
+    fn add_shell_job_persists_delivery() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let job = add_shell_job(
+            &config,
+            Some("deliver-shell".into()),
+            Schedule::Cron {
+                expr: "*/5 * * * *".into(),
+                tz: None,
+            },
+            "echo delivered",
+            Some(DeliveryConfig {
+                mode: "announce".into(),
+                channel: Some("discord".into()),
+                to: Some("1234567890".into()),
+                best_effort: true,
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(job.delivery.mode, "announce");
+        assert_eq!(job.delivery.channel.as_deref(), Some("discord"));
+        assert_eq!(job.delivery.to.as_deref(), Some("1234567890"));
+
+        let stored = get_job(&config, &job.id).unwrap();
+        assert_eq!(stored.delivery.mode, "announce");
+        assert_eq!(stored.delivery.channel.as_deref(), Some("discord"));
+        assert_eq!(stored.delivery.to.as_deref(), Some("1234567890"));
+    }
+
+    #[test]
+    fn add_agent_job_rejects_invalid_announce_delivery() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let err = add_agent_job(
+            &config,
+            Some("deliver-agent".into()),
+            Schedule::Cron {
+                expr: "*/5 * * * *".into(),
+                tz: None,
+            },
+            "summarize logs",
+            SessionTarget::Isolated,
+            None,
+            Some(DeliveryConfig {
+                mode: "announce".into(),
+                channel: Some("discord".into()),
+                to: None,
+                best_effort: true,
+            }),
+            false,
+            None,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("delivery.to is required"));
+    }
+
+    #[test]
+    fn add_shell_job_rejects_invalid_delivery_mode() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let err = add_shell_job(
+            &config,
+            Some("deliver-shell".into()),
+            Schedule::Cron {
+                expr: "*/5 * * * *".into(),
+                tz: None,
+            },
+            "echo delivered",
+            Some(DeliveryConfig {
+                mode: "annouce".into(),
+                channel: Some("discord".into()),
+                to: Some("1234567890".into()),
+                best_effort: true,
+            }),
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("unsupported delivery mode"));
     }
 
     #[test]
@@ -1034,7 +1126,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let config = test_config(&tmp);
         let at = Utc::now() + ChronoDuration::minutes(10);
-        let job = add_shell_job(&config, None, Schedule::At { at }, "echo once").unwrap();
+        let job = add_shell_job(&config, None, Schedule::At { at }, "echo once", None).unwrap();
 
         reschedule_after_run(&config, &job, true, "done").unwrap();
 
@@ -1051,7 +1143,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let config = test_config(&tmp);
         let at = Utc::now() + ChronoDuration::minutes(10);
-        let job = add_shell_job(&config, None, Schedule::At { at }, "echo once").unwrap();
+        let job = add_shell_job(&config, None, Schedule::At { at }, "echo once", None).unwrap();
 
         reschedule_after_run(&config, &job, false, "failed").unwrap();
 

--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -68,7 +68,10 @@ pub struct CronRunsQuery {
 pub struct CronAddBody {
     pub name: Option<String>,
     pub schedule: String,
-    pub command: String,
+    pub command: Option<String>,
+    pub job_type: Option<String>,
+    pub prompt: Option<String>,
+    pub delivery: Option<crate::cron::DeliveryConfig>,
 }
 
 // ── Handlers ────────────────────────────────────────────────────
@@ -228,11 +231,14 @@ pub async fn handle_api_cron_list(
                     serde_json::json!({
                         "id": job.id,
                         "name": job.name,
+                        "job_type": job.job_type,
                         "command": job.command,
+                        "prompt": job.prompt,
                         "next_run": job.next_run.to_rfc3339(),
                         "last_run": job.last_run.map(|t| t.to_rfc3339()),
                         "last_status": job.last_status,
                         "enabled": job.enabled,
+                        "delivery": job.delivery,
                     })
                 })
                 .collect();
@@ -256,26 +262,83 @@ pub async fn handle_api_cron_add(
         return e.into_response();
     }
 
+    let CronAddBody {
+        name,
+        schedule,
+        command,
+        job_type,
+        prompt,
+        delivery,
+    } = body;
+
     let config = state.config.lock().clone();
     let schedule = crate::cron::Schedule::Cron {
-        expr: body.schedule,
+        expr: schedule,
         tz: None,
     };
+    if let Err(e) = crate::cron::validate_delivery_config(delivery.as_ref()) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": format!("Failed to add cron job: {e}")})),
+        )
+            .into_response();
+    }
 
-    match crate::cron::add_shell_job_with_approval(
-        &config,
-        body.name,
-        schedule,
-        &body.command,
-        false,
-    ) {
+    let result = match job_type.as_deref().unwrap_or("shell") {
+        "shell" => {
+            let Some(command) = command.as_deref().filter(|value| !value.trim().is_empty()) else {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"error": "Missing command for shell cron job"})),
+                )
+                    .into_response();
+            };
+
+            crate::cron::add_shell_job_with_approval(
+                &config, name, schedule, command, delivery, false,
+            )
+        }
+        "agent" => {
+            let Some(prompt) = prompt.as_deref().filter(|value| !value.trim().is_empty()) else {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"error": "Missing prompt for agent cron job"})),
+                )
+                    .into_response();
+            };
+
+            crate::cron::add_agent_job(
+                &config,
+                name,
+                schedule,
+                prompt,
+                crate::cron::SessionTarget::Isolated,
+                None,
+                delivery,
+                false,
+                None,
+            )
+        }
+        other => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": format!("Invalid job_type: {other}")})),
+            )
+                .into_response();
+        }
+    };
+
+    match result {
         Ok(job) => Json(serde_json::json!({
             "status": "ok",
             "job": {
                 "id": job.id,
                 "name": job.name,
+                "job_type": job.job_type,
                 "command": job.command,
+                "prompt": job.prompt,
                 "enabled": job.enabled,
+                "delivery": job.delivery,
             }
         }))
         .into_response(),
@@ -1208,6 +1271,125 @@ pub async fn handle_api_session_delete(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::gateway::{nodes, AppState, GatewayRateLimiter, IdempotencyStore};
+    use crate::memory::{Memory, MemoryCategory, MemoryEntry};
+    use crate::providers::Provider;
+    use crate::security::pairing::PairingGuard;
+    use async_trait::async_trait;
+    use axum::response::IntoResponse;
+    use http_body_util::BodyExt;
+    use parking_lot::Mutex;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    struct MockMemory;
+
+    #[async_trait]
+    impl Memory for MockMemory {
+        fn name(&self) -> &str {
+            "mock"
+        }
+
+        async fn store(
+            &self,
+            _key: &str,
+            _content: &str,
+            _category: MemoryCategory,
+            _session_id: Option<&str>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn recall(
+            &self,
+            _query: &str,
+            _limit: usize,
+            _session_id: Option<&str>,
+        ) -> anyhow::Result<Vec<MemoryEntry>> {
+            Ok(Vec::new())
+        }
+
+        async fn get(&self, _key: &str) -> anyhow::Result<Option<MemoryEntry>> {
+            Ok(None)
+        }
+
+        async fn list(
+            &self,
+            _category: Option<&MemoryCategory>,
+            _session_id: Option<&str>,
+        ) -> anyhow::Result<Vec<MemoryEntry>> {
+            Ok(Vec::new())
+        }
+
+        async fn forget(&self, _key: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+
+        async fn count(&self) -> anyhow::Result<usize> {
+            Ok(0)
+        }
+
+        async fn health_check(&self) -> bool {
+            true
+        }
+    }
+
+    struct MockProvider;
+
+    #[async_trait]
+    impl Provider for MockProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            Ok("ok".to_string())
+        }
+    }
+
+    fn test_state(config: crate::config::Config) -> AppState {
+        AppState {
+            config: Arc::new(Mutex::new(config)),
+            provider: Arc::new(MockProvider),
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: Arc::new(MockMemory),
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(GatewayRateLimiter::new(100, 100, 100)),
+            idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            linq: None,
+            linq_signing_secret: None,
+            nextcloud_talk: None,
+            nextcloud_talk_webhook_secret: None,
+            wati: None,
+            observer: Arc::new(crate::observability::NoopObserver),
+            tools_registry: Arc::new(Vec::new()),
+            cost_tracker: None,
+            event_tx: tokio::sync::broadcast::channel(16).0,
+            shutdown_tx: tokio::sync::watch::channel(false).0,
+            node_registry: Arc::new(nodes::NodeRegistry::new(16)),
+            session_backend: None,
+            device_registry: None,
+            pending_pairings: None,
+        }
+    }
+
+    async fn response_json(response: axum::response::Response) -> serde_json::Value {
+        let body = response
+            .into_body()
+            .collect()
+            .await
+            .expect("response body")
+            .to_bytes();
+        serde_json::from_slice(&body).expect("valid json response")
+    }
 
     #[test]
     fn masking_keeps_toml_valid_and_preserves_api_keys_type() {
@@ -1614,5 +1796,175 @@ mod tests {
             .embedding_routes
             .iter()
             .all(|route| route.api_key.as_deref() != Some(MASKED_SECRET)));
+    }
+
+    #[tokio::test]
+    async fn cron_api_shell_roundtrip_includes_delivery() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = crate::config::Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            ..crate::config::Config::default()
+        };
+        std::fs::create_dir_all(&config.workspace_dir).unwrap();
+        let state = test_state(config);
+
+        let add_response = handle_api_cron_add(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(
+                serde_json::from_value::<CronAddBody>(serde_json::json!({
+                    "name": "test-job",
+                    "schedule": "*/5 * * * *",
+                    "command": "echo hello",
+                    "delivery": {
+                        "mode": "announce",
+                        "channel": "discord",
+                        "to": "1234567890",
+                        "best_effort": true
+                    }
+                }))
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        let add_json = response_json(add_response).await;
+        assert_eq!(add_json["status"], "ok");
+        assert_eq!(add_json["job"]["delivery"]["mode"], "announce");
+        assert_eq!(add_json["job"]["delivery"]["channel"], "discord");
+        assert_eq!(add_json["job"]["delivery"]["to"], "1234567890");
+
+        let list_response = handle_api_cron_list(State(state), HeaderMap::new())
+            .await
+            .into_response();
+        let list_json = response_json(list_response).await;
+        let jobs = list_json["jobs"].as_array().expect("jobs array");
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0]["delivery"]["mode"], "announce");
+        assert_eq!(jobs[0]["delivery"]["channel"], "discord");
+        assert_eq!(jobs[0]["delivery"]["to"], "1234567890");
+    }
+
+    #[tokio::test]
+    async fn cron_api_accepts_agent_jobs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = crate::config::Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            ..crate::config::Config::default()
+        };
+        std::fs::create_dir_all(&config.workspace_dir).unwrap();
+        let state = test_state(config);
+
+        let response = handle_api_cron_add(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(
+                serde_json::from_value::<CronAddBody>(serde_json::json!({
+                    "name": "agent-job",
+                    "schedule": "*/5 * * * *",
+                    "job_type": "agent",
+                    "command": "ignored shell command",
+                    "prompt": "summarize the latest logs"
+                }))
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        let json = response_json(response).await;
+        assert_eq!(json["status"], "ok");
+
+        let config = state.config.lock().clone();
+        let jobs = crate::cron::list_jobs(&config).unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].job_type, crate::cron::JobType::Agent);
+        assert_eq!(jobs[0].prompt.as_deref(), Some("summarize the latest logs"));
+    }
+
+    #[tokio::test]
+    async fn cron_api_rejects_announce_delivery_without_target() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = crate::config::Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            ..crate::config::Config::default()
+        };
+        std::fs::create_dir_all(&config.workspace_dir).unwrap();
+        let state = test_state(config);
+
+        let response = handle_api_cron_add(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(
+                serde_json::from_value::<CronAddBody>(serde_json::json!({
+                    "name": "invalid-delivery-job",
+                    "schedule": "*/5 * * * *",
+                    "command": "echo hello",
+                    "delivery": {
+                        "mode": "announce",
+                        "channel": "discord"
+                    }
+                }))
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let json = response_json(response).await;
+        assert!(json["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("delivery.to is required"));
+
+        let config = state.config.lock().clone();
+        assert!(crate::cron::list_jobs(&config).unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cron_api_rejects_announce_delivery_with_unsupported_channel() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = crate::config::Config {
+            workspace_dir: tmp.path().join("workspace"),
+            config_path: tmp.path().join("config.toml"),
+            ..crate::config::Config::default()
+        };
+        std::fs::create_dir_all(&config.workspace_dir).unwrap();
+        let state = test_state(config);
+
+        let response = handle_api_cron_add(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(
+                serde_json::from_value::<CronAddBody>(serde_json::json!({
+                    "name": "invalid-delivery-job",
+                    "schedule": "*/5 * * * *",
+                    "command": "echo hello",
+                    "delivery": {
+                        "mode": "announce",
+                        "channel": "email",
+                        "to": "alerts@example.com"
+                    }
+                }))
+                .expect("body should deserialize"),
+            ),
+        )
+        .await
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let json = response_json(response).await;
+        assert!(json["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("unsupported delivery channel"));
+
+        let config = state.config.lock().clone();
+        assert!(crate::cron::list_jobs(&config).unwrap().is_empty());
     }
 }

--- a/src/tools/cron_add.rs
+++ b/src/tools/cron_add.rs
@@ -235,6 +235,19 @@ impl Tool for CronAddTool {
             .get("approved")
             .and_then(serde_json::Value::as_bool)
             .unwrap_or(false);
+        let delivery = match args.get("delivery") {
+            Some(v) => match serde_json::from_value::<DeliveryConfig>(v.clone()) {
+                Ok(cfg) => Some(cfg),
+                Err(e) => {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(format!("Invalid delivery config: {e}")),
+                    });
+                }
+            },
+            None => None,
+        };
 
         let result = match job_type {
             JobType::Shell => {
@@ -261,7 +274,14 @@ impl Tool for CronAddTool {
                     return Ok(blocked);
                 }
 
-                cron::add_shell_job_with_approval(&self.config, name, schedule, command, approved)
+                cron::add_shell_job_with_approval(
+                    &self.config,
+                    name,
+                    schedule,
+                    command,
+                    delivery,
+                    approved,
+                )
             }
             JobType::Agent => {
                 let prompt = match args.get("prompt").and_then(serde_json::Value::as_str) {
@@ -301,20 +321,6 @@ impl Tool for CronAddTool {
                                 success: false,
                                 output: String::new(),
                                 error: Some(format!("Invalid allowed_tools: {e}")),
-                            });
-                        }
-                    },
-                    None => None,
-                };
-
-                let delivery = match args.get("delivery") {
-                    Some(v) => match serde_json::from_value::<DeliveryConfig>(v.clone()) {
-                        Ok(cfg) => Some(cfg),
-                        Err(e) => {
-                            return Ok(ToolResult {
-                                success: false,
-                                output: String::new(),
-                                error: Some(format!("Invalid delivery config: {e}")),
                             });
                         }
                     },
@@ -404,6 +410,36 @@ mod tests {
 
         assert!(result.success, "{:?}", result.error);
         assert!(result.output.contains("next_run"));
+    }
+
+    #[tokio::test]
+    async fn shell_job_persists_delivery() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = test_config(&tmp).await;
+        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+        let result = tool
+            .execute(json!({
+                "schedule": { "kind": "cron", "expr": "*/5 * * * *" },
+                "job_type": "shell",
+                "command": "echo ok",
+                "delivery": {
+                    "mode": "announce",
+                    "channel": "discord",
+                    "to": "1234567890",
+                    "best_effort": true
+                }
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success, "{:?}", result.error);
+
+        let jobs = cron::list_jobs(&cfg).unwrap();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].delivery.mode, "announce");
+        assert_eq!(jobs[0].delivery.channel.as_deref(), Some("discord"));
+        assert_eq!(jobs[0].delivery.to.as_deref(), Some("1234567890"));
+        assert!(jobs[0].delivery.best_effort);
     }
 
     #[tokio::test]

--- a/src/tools/cron_run.rs
+++ b/src/tools/cron_run.rs
@@ -244,6 +244,7 @@ mod tests {
                 tz: None,
             },
             "touch cron-run-approval",
+            None,
             true,
         )
         .unwrap();

--- a/src/tools/schedule.rs
+++ b/src/tools/schedule.rs
@@ -315,6 +315,7 @@ impl ScheduleTool {
                     tz: None,
                 },
                 command,
+                None,
                 approved,
             ) {
                 Ok(job) => job,


### PR DESCRIPTION

## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: in `v0.5.2`, `/api/cron` ignored `job_type=agent`, treated API-created jobs as shell-oriented, and dropped `delivery` for API-created cron jobs.
- Why it matters: bots or integrations relying on `/api/cron` could register cron jobs that were accepted but did not preserve the requested job type or delivery behavior.
- What changed: threaded `delivery` through shell cron creation into persistence, extended `/api/cron` request/response handling for `job_type`, `prompt`, and `delivery`, and added add-time validation for supported delivery modes/channels and required announce targets.
- What did **not** change (scope boundary): this PR does not add new delivery backends, does not redesign scheduler delivery semantics

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto-managed
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `cron, gateway, tool, tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `tool: cron_add`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: if needed, please add `cron` + `gateway` and remove unrelated labels

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #4063
- Related #1866
- Depends on #N/A
- Supersedes #N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): no superseded PR
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
  - `cargo fmt --all -- --check` passed
  - `env CARGO_TARGET_DIR=/tmp/zeroclaw-target cargo test --lib add_shell_job_persists_delivery -- --nocapture` passed
  - `env CARGO_TARGET_DIR=/tmp/zeroclaw-target cargo test --lib add_agent_job_rejects_invalid_announce_delivery -- --nocapture` passed
  - `env CARGO_TARGET_DIR=/tmp/zeroclaw-target cargo test --lib add_shell_job_rejects_invalid_delivery_mode -- --nocapture` passed
  - `env CARGO_TARGET_DIR=/tmp/zeroclaw-target cargo test --lib shell_job_persists_delivery -- --nocapture` passed
  - `env CARGO_TARGET_DIR=/tmp/zeroclaw-target cargo test --lib cron_api_shell_roundtrip_includes_delivery -- --nocapture` passed
  - `env CARGO_TARGET_DIR=/tmp/zeroclaw-target cargo test --lib cron_api_accepts_agent_jobs -- --nocapture` passed
  - `env CARGO_TARGET_DIR=/tmp/zeroclaw-target cargo test --lib cron_api_rejects_announce_delivery_without_target -- --nocapture` passed
  - `env CARGO_TARGET_DIR=/tmp/zeroclaw-target cargo test --lib cron_api_rejects_announce_delivery_with_unsupported_channel -- --nocapture` passed
  - local release build succeeded: `env CARGO_TARGET_DIR=/tmp/zeroclaw-target cargo build --release`
  - manual bot-side verification with `v0.5.2` reproduced the API issue:
    - `job_type=agent` did not behave as requested through `/api/cron`
    - `delivery` did not round-trip through `/api/cron`
  - manual bot-side verification with the fixed release binary succeeded
  - full `env CARGO_TARGET_DIR=/tmp/zeroclaw-target cargo test -- --nocapture` still reports one unrelated existing failure: `providers::claude_code::tests::chat_with_history_multi_turn_without_system`
- If any command is intentionally skipped, explain why:
  - `cargo clippy --all-targets -- -D warnings` was not run in this pass due to time/iteration focus on reproducing and validating the cron fix plus local release verification.
  - plain `cargo test` on the default target dir was not used because WSL-on-NTFS linking was excessively slow; equivalent test runs were done with `CARGO_TARGET_DIR=/tmp/zeroclaw-target`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: tests and examples use neutral placeholders only
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `N.A.`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N.A.`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N.A.`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: no docs or user-facing wording docs were changed in this PR

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - shell cron delivery config is persisted
  - `/api/cron` shell + delivery round-trip works
  - `/api/cron` respects `job_type=agent` instead of treating the request as shell-oriented
  - malformed delivery mode is rejected at add time
  - `announce` without `to` is rejected at add time
  - unsupported announce channel is rejected at add time
  - local release binary worked in bot-side manual verification
  - `v0.5.2` behavior was manually reproduced through a bot/integration flow before testing the fix
- Edge cases checked:
  - invalid `delivery.mode`
  - invalid `delivery.channel`
  - missing `delivery.to` for `announce`
  - agent job creation path uses the same delivery validation as shell path
- What was not verified:
  - exhaustive end-to-end delivery on every supported backend
  - unrelated failing provider test in the full suite

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
  - cron persistence
  - `/api/cron` create/list handlers
  - cron tool shell create path
  - add-time delivery validation
- Potential unintended effects:
  - clients sending previously accepted malformed delivery payloads now get validation errors instead of deferred runtime failure
  - unsupported delivery channels are now rejected earlier
- Guardrails/monitoring for early detection:
  - added unit/API tests for valid/invalid delivery inputs
  - rollback is straightforward because scope is limited to cron create/list paths

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local shell, targeted test runs, release build verification support, code review iteration
- Workflow/plan summary (if any): inspect existing partial implementation, run targeted tests in WSL with Linux-side target dir, trim out-of-scope API changes, address review comments with minimal validation fixes, build and manually verify release binary
- Verification focus: persistence path, API contract, validation timing, and release-binary behavior
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path:
  - revert this PR / revert the merge commit
- Feature flags or config toggles (if any):
  - none
- Observable failure symptoms:
  - `/api/cron` rejects valid payloads unexpectedly
  - cron jobs lose `delivery` persistence again
  - API-created agent cron jobs regress to shell-oriented behavior

## Risks and Mitigations

List real risks in this PR (or write `None`).

None