### PR TITLE
fix(providers): bail immediately on unrecoverable context window overflow

### DIFF
--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -541,6 +541,25 @@ impl Provider for ReliableProvider {
                                     );
                                     continue; // Retry with truncated messages (counts as an attempt)
                                 }
+                                // Nothing to truncate (system prompt alone exceeds
+                                // the model's context window) — bail immediately
+                                // instead of wasting retry attempts.
+                                let error_detail = compact_error_detail(&e);
+                                push_failure(
+                                    &mut failures,
+                                    provider_name,
+                                    current_model,
+                                    attempt + 1,
+                                    self.max_retries + 1,
+                                    "non_retryable",
+                                    &error_detail,
+                                );
+                                anyhow::bail!(
+                                    "Request exceeds model context window and cannot be reduced further. \
+                                     Try using a model with a larger context window, reducing the number \
+                                     of tools/skills, or enabling compact_context in config. Attempts:\n{}",
+                                    failures.join("\n")
+                                );
                             }
 
                             let non_retryable_rate_limit = is_non_retryable_rate_limit(&e);
@@ -676,6 +695,25 @@ impl Provider for ReliableProvider {
                                     );
                                     continue; // Retry with truncated messages (counts as an attempt)
                                 }
+                                // Nothing to truncate (system prompt alone exceeds
+                                // the model's context window) — bail immediately
+                                // instead of wasting retry attempts.
+                                let error_detail = compact_error_detail(&e);
+                                push_failure(
+                                    &mut failures,
+                                    provider_name,
+                                    current_model,
+                                    attempt + 1,
+                                    self.max_retries + 1,
+                                    "non_retryable",
+                                    &error_detail,
+                                );
+                                anyhow::bail!(
+                                    "Request exceeds model context window and cannot be reduced further. \
+                                     Try using a model with a larger context window, reducing the number \
+                                     of tools/skills, or enabling compact_context in config. Attempts:\n{}",
+                                    failures.join("\n")
+                                );
                             }
 
                             let non_retryable_rate_limit = is_non_retryable_rate_limit(&e);
@@ -798,6 +836,25 @@ impl Provider for ReliableProvider {
                                     );
                                     continue; // Retry with truncated messages (counts as an attempt)
                                 }
+                                // Nothing to truncate (system prompt alone exceeds
+                                // the model's context window) — bail immediately
+                                // instead of wasting retry attempts.
+                                let error_detail = compact_error_detail(&e);
+                                push_failure(
+                                    &mut failures,
+                                    provider_name,
+                                    current_model,
+                                    attempt + 1,
+                                    self.max_retries + 1,
+                                    "non_retryable",
+                                    &error_detail,
+                                );
+                                anyhow::bail!(
+                                    "Request exceeds model context window and cannot be reduced further. \
+                                     Try using a model with a larger context window, reducing the number \
+                                     of tools/skills, or enabling compact_context in config. Attempts:\n{}",
+                                    failures.join("\n")
+                                );
                             }
 
                             let non_retryable_rate_limit = is_non_retryable_rate_limit(&e);
@@ -2211,6 +2268,44 @@ mod tests {
         assert_eq!(result, "recovered after truncation");
         // Should have been called twice: once with full messages, once with truncated
         assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn context_overflow_with_no_history_to_truncate_bails_immediately() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mock = ContextOverflowMock {
+            calls: Arc::clone(&calls),
+            fail_until_attempt: 999, // always fail
+            message_counts: parking_lot::Mutex::new(Vec::new()),
+        };
+
+        let provider = ReliableProvider::new(
+            vec![("local".into(), Box::new(mock) as Box<dyn Provider>)],
+            3,
+            1,
+        );
+
+        // Only system + one user message — nothing to truncate
+        let messages = vec![
+            ChatMessage::system("huge system prompt that exceeds context window"),
+            ChatMessage::user("hello"),
+        ];
+
+        let result = provider
+            .chat_with_history(&messages, "local-model", 0.0)
+            .await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("cannot be reduced further"),
+            "Should bail with actionable message, got: {err_msg}"
+        );
+        // Should only be called once — no useless retries
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "Should not retry when truncation is impossible"
+        );
     }
 
     // ── Tool schema error detection tests ───────────────────────────────


### PR DESCRIPTION
## Summary

- When a model's context window is exceeded and there is no conversation history to truncate (system prompt alone is too large), **bail immediately** with an actionable error message
- Previously, all 3 retry attempts were wasted making identical failing API calls
- Adds early exit in `chat_with_history`, `chat_with_tools`, and `chat` methods when `truncate_for_context` returns 0 dropped messages
- Error message now guides users: try a larger context model, reduce tools/skills, or enable `compact_context`

## Root Cause

The retry loop correctly detected context window errors as "retryable" (since truncation can fix them). But when truncation found nothing to drop (only system + 1 user message), it fell through to normal retry logic — retrying the same oversized request 3 times.

For DeepSeek (`deepseek-chat`, 131K context limit), even a `zeroclaw agent -m "hello"` sends 168K tokens in the system prompt (tool instructions + skills + bootstrap), far exceeding the limit.

## Changes

- `src/providers/reliable.rs`: Added early bail when `is_context_window_exceeded` is true but `truncate_for_context` returns 0, across all 3 chat methods
- Added test: `context_overflow_with_no_history_to_truncate_bails_immediately`

Fixes #4044

## Test plan

- [x] All 57 reliable provider tests pass (including new test)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] CI pipeline validates on PR