### PR TITLE
fix(skills): support ClawHub registry URLs in skills install

### DIFF
--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -791,7 +791,44 @@ pub fn init_skills_dir(workspace_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// The ClawHub registry download API base URL.
+const CLAWHUB_DOWNLOAD_API: &str = "https://wry-manatee-359.convex.site/api/v1/download";
+
+/// Check if a source URL points to the ClawHub registry.
+fn is_clawhub_source(source: &str) -> bool {
+    let lower = source.to_ascii_lowercase();
+    lower.starts_with("https://clawhub.ai/") || lower.starts_with("http://clawhub.ai/")
+}
+
+/// Extract the skill slug from a ClawHub URL.
+///
+/// `https://clawhub.ai/steipete/summarize` → `"summarize"`
+/// `https://clawhub.ai/steipete/summarize/` → `"summarize"`
+fn clawhub_slug(source: &str) -> Option<&str> {
+    let rest = source
+        .strip_prefix("https://clawhub.ai/")
+        .or_else(|| source.strip_prefix("http://clawhub.ai/"))
+        .or_else(|| source.strip_prefix("https://CLAWHUB.AI/"))
+        .or_else(|| {
+            let lower = source.to_ascii_lowercase();
+            if lower.starts_with("https://clawhub.ai/") || lower.starts_with("http://clawhub.ai/") {
+                // Safe: the prefix length is fixed, works on the original source
+                let prefix_len = source.find("clawhub.ai/").unwrap() + "clawhub.ai/".len();
+                Some(&source[prefix_len..])
+            } else {
+                None
+            }
+        })?;
+    let rest = rest.trim_end_matches('/');
+    // Expected pattern: owner/skill-name — take the last segment
+    rest.rsplit('/').next().filter(|s| !s.is_empty())
+}
+
 fn is_git_source(source: &str) -> bool {
+    // ClawHub URLs look like https:// but are not git repos
+    if is_clawhub_source(source) {
+        return false;
+    }
     is_git_scheme_source(source, "https://")
         || is_git_scheme_source(source, "http://")
         || is_git_scheme_source(source, "ssh://")
@@ -1000,6 +1037,70 @@ fn install_git_skill_source(
     }
 }
 
+/// Download and install a skill from the ClawHub registry.
+///
+/// Fetches the skill ZIP from the ClawHub download API, extracts it into a
+/// subdirectory named after the slug, and runs the security audit.
+fn install_clawhub_skill_source(
+    source: &str,
+    skills_path: &Path,
+    allow_scripts: bool,
+) -> Result<(PathBuf, usize)> {
+    let slug = clawhub_slug(source).ok_or_else(|| {
+        anyhow::anyhow!("Could not extract skill name from ClawHub URL: {source}")
+    })?;
+
+    let url = format!("{CLAWHUB_DOWNLOAD_API}?slug={slug}");
+
+    // Download the ZIP to a temporary file
+    let response = reqwest::blocking::get(&url)
+        .with_context(|| format!("Failed to download skill from ClawHub: {url}"))?;
+
+    if !response.status().is_success() {
+        anyhow::bail!(
+            "ClawHub download failed (HTTP {}): {url}",
+            response.status()
+        );
+    }
+
+    let zip_bytes = response
+        .bytes()
+        .context("Failed to read ClawHub response body")?;
+
+    // Write ZIP to a temp file
+    let tmp_dir = tempfile::tempdir().context("Failed to create temp directory")?;
+    let zip_path = tmp_dir.path().join(format!("{slug}.zip"));
+    std::fs::write(&zip_path, &zip_bytes)
+        .with_context(|| format!("Failed to write temp zip: {}", zip_path.display()))?;
+
+    // Extract into the skills directory under the slug name
+    let dest = skills_path.join(slug);
+    std::fs::create_dir_all(&dest)
+        .with_context(|| format!("Failed to create skill directory: {}", dest.display()))?;
+
+    let output = std::process::Command::new("unzip")
+        .args(["-o", "-q"])
+        .arg(&zip_path)
+        .arg("-d")
+        .arg(&dest)
+        .output()
+        .context("Failed to run unzip — is it installed?")?;
+
+    if !output.status.success() {
+        let _ = std::fs::remove_dir_all(&dest);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("Failed to extract ClawHub skill archive: {stderr}");
+    }
+
+    match enforce_skill_security_audit(&dest, allow_scripts) {
+        Ok(report) => Ok((dest, report.files_scanned)),
+        Err(err) => {
+            let _ = std::fs::remove_dir_all(&dest);
+            Err(err)
+        }
+    }
+}
+
 /// Handle the `skills` CLI command
 #[allow(clippy::too_many_lines)]
 pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Config) -> Result<()> {
@@ -1087,29 +1188,22 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
             let skills_path = skills_dir(workspace_dir);
             std::fs::create_dir_all(&skills_path)?;
 
-            if is_git_source(&source) {
-                let (installed_dir, files_scanned) =
-                    install_git_skill_source(&source, &skills_path, config.skills.allow_scripts)
-                        .with_context(|| format!("failed to install git skill source: {source}"))?;
-                println!(
-                    "  {} Skill installed and audited: {} ({} files scanned)",
-                    console::style("✓").green().bold(),
-                    installed_dir.display(),
-                    files_scanned
-                );
+            let (installed_dir, files_scanned) = if is_clawhub_source(&source) {
+                install_clawhub_skill_source(&source, &skills_path, config.skills.allow_scripts)
+                    .with_context(|| format!("failed to install skill from ClawHub: {source}"))?
+            } else if is_git_source(&source) {
+                install_git_skill_source(&source, &skills_path, config.skills.allow_scripts)
+                    .with_context(|| format!("failed to install git skill source: {source}"))?
             } else {
-                let (dest, files_scanned) =
-                    install_local_skill_source(&source, &skills_path, config.skills.allow_scripts)
-                        .with_context(|| {
-                            format!("failed to install local skill source: {source}")
-                        })?;
-                println!(
-                    "  {} Skill installed and audited: {} ({} files scanned)",
-                    console::style("✓").green().bold(),
-                    dest.display(),
-                    files_scanned
-                );
-            }
+                install_local_skill_source(&source, &skills_path, config.skills.allow_scripts)
+                    .with_context(|| format!("failed to install local skill source: {source}"))?
+            };
+            println!(
+                "  {} Skill installed and audited: {} ({} files scanned)",
+                console::style("✓").green().bold(),
+                installed_dir.display(),
+                files_scanned
+            );
 
             println!("  Security audit completed successfully.");
             Ok(())
@@ -1574,6 +1668,56 @@ description = "Bare minimum"
                 !is_git_source(source),
                 "expected local/invalid source detection for '{source}'"
             );
+        }
+    }
+
+    #[test]
+    fn clawhub_source_detected_and_excluded_from_git() {
+        let clawhub_urls = [
+            "https://clawhub.ai/steipete/summarize",
+            "https://clawhub.ai/steipete/summarize/",
+            "http://clawhub.ai/user/skill",
+        ];
+
+        for url in clawhub_urls {
+            assert!(
+                is_clawhub_source(url),
+                "expected clawhub detection for '{url}'"
+            );
+            assert!(
+                !is_git_source(url),
+                "clawhub URL should NOT be detected as git source: '{url}'"
+            );
+        }
+    }
+
+    #[test]
+    fn clawhub_slug_extracts_skill_name() {
+        assert_eq!(
+            clawhub_slug("https://clawhub.ai/steipete/summarize"),
+            Some("summarize")
+        );
+        assert_eq!(
+            clawhub_slug("https://clawhub.ai/steipete/summarize/"),
+            Some("summarize")
+        );
+        assert_eq!(
+            clawhub_slug("http://clawhub.ai/user/my-skill"),
+            Some("my-skill")
+        );
+        assert_eq!(clawhub_slug("https://clawhub.ai/"), None);
+        assert_eq!(clawhub_slug("https://github.com/owner/repo"), None);
+    }
+
+    #[test]
+    fn non_clawhub_https_urls_still_detected_as_git() {
+        let git_urls = [
+            "https://github.com/some-org/some-skill.git",
+            "https://gitlab.com/owner/repo",
+        ];
+        for url in git_urls {
+            assert!(!is_clawhub_source(url));
+            assert!(is_git_source(url));
         }
     }
 


### PR DESCRIPTION
## Summary

- `zeroclaw skills install https://clawhub.ai/owner/skill` now works by downloading from the ClawHub registry API instead of attempting a git clone
- Adds ClawHub URL detection (`is_clawhub_source()`) that excludes clawhub.ai from git source classification
- Extracts the skill slug from the URL path and downloads the ZIP archive via the ClawHub download API
- Extracted skills are placed in the skills directory and run through the security audit, same as git-installed skills

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `src`
- Module labels: `skills`

## Change Metadata

- Change type: `fix`
- Primary scope: `skills`

## Linked Issue

- Closes #4022

## Validation Evidence (required)

```
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass
cargo test   # all pass
```

New tests:
- `clawhub_source_detected_and_excluded_from_git` — verifies clawhub.ai URLs are detected and excluded from git classification
- `clawhub_slug_extracts_skill_name` — verifies slug extraction from various URL formats
- `non_clawhub_https_urls_still_detected_as_git` — verifies github.com/gitlab.com URLs still work as git sources

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? Yes — HTTP GET to ClawHub download API (`wry-manatee-359.convex.site/api/v1/download`) when user explicitly runs `skills install` with a clawhub.ai URL
- Secrets/tokens handling changed? No
- File system access scope changed? No — downloads to existing skills directory, same as git install path

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`

## Compatibility / Migration

- Backward compatible? Yes — existing git/local install paths unchanged; this adds a new code path for clawhub.ai URLs only
- Config/env changes? No
- Migration needed? No

## Side Effects / Blast Radius (required)

- Affected subsystems: `zeroclaw skills install` command only
- Potential unintended effects: Requires `unzip` command on the system (standard on Linux/macOS)
- Guardrails: Security audit runs on extracted files before completing install

## Rollback Plan (required)

- Revert this PR; clawhub.ai URLs will revert to failing with "Git clone failed"

## Test plan

- [x] ClawHub URLs detected and excluded from git source detection
- [x] Slug extraction handles `owner/skill`, `owner/skill/`, edge cases
- [x] Non-clawhub HTTPS URLs still detected as git sources (no regression)
- [x] Full test suite passes
- [x] fmt + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)