### PR TITLE
chore: bump version to 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9179,7 +9179,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"

--- a/dist/aur/.SRCINFO
+++ b/dist/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = zeroclaw
 	pkgdesc = Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.
-	pkgver = 0.4.3
+	pkgver = 0.5.3
 	pkgrel = 1
 	url = https://github.com/zeroclaw-labs/zeroclaw
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = zeroclaw
 	makedepends = git
 	depends = gcc-libs
 	depends = openssl
-	source = zeroclaw-0.4.3.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.4.3.tar.gz
+	source = zeroclaw-0.5.3.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.5.3.tar.gz
 	sha256sums = SKIP
 
 pkgname = zeroclaw

--- a/dist/aur/PKGBUILD
+++ b/dist/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: zeroclaw-labs <bot@zeroclaw.dev>
 pkgname=zeroclaw
-pkgver=0.4.3
+pkgver=0.5.3
 pkgrel=1
 pkgdesc="Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant."
 arch=('x86_64')

--- a/dist/scoop/zeroclaw.json
+++ b/dist/scoop/zeroclaw.json
@@ -1,11 +1,11 @@
 {
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.",
     "homepage": "https://github.com/zeroclaw-labs/zeroclaw",
     "license": "MIT|Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.5.2/zeroclaw-x86_64-pc-windows-msvc.zip",
+            "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.5.3/zeroclaw-x86_64-pc-windows-msvc.zip",
             "hash": "",
             "bin": "zeroclaw.exe"
         }


### PR DESCRIPTION
Version bump across Cargo.toml, Scoop, AUR manifests.