### PR TITLE
fix(slack): respect thread_replies config for session context

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3225,6 +3225,7 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                     Vec::new(),
                     sl.allowed_users.clone(),
                 )
+                .with_thread_replies(sl.thread_replies.unwrap_or(true))
                 .with_workspace_dir(config.workspace_dir.clone()),
             ))
         }
@@ -3318,6 +3319,7 @@ fn collect_configured_channels(
                     Vec::new(),
                     sl.allowed_users.clone(),
                 )
+                .with_thread_replies(sl.thread_replies.unwrap_or(true))
                 .with_group_reply_policy(sl.mention_only, Vec::new())
                 .with_workspace_dir(config.workspace_dir.clone()),
             ),

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -26,6 +26,7 @@ pub struct SlackChannel {
     channel_ids: Vec<String>,
     allowed_users: Vec<String>,
     mention_only: bool,
+    thread_replies: bool,
     group_reply_allowed_sender_ids: Vec<String>,
     user_display_name_cache: Mutex<HashMap<String, CachedSlackDisplayName>>,
     workspace_dir: Option<PathBuf>,
@@ -76,6 +77,7 @@ impl SlackChannel {
             channel_ids,
             allowed_users,
             mention_only: false,
+            thread_replies: true,
             group_reply_allowed_sender_ids: Vec::new(),
             user_display_name_cache: Mutex::new(HashMap::new()),
             workspace_dir: None,
@@ -91,6 +93,14 @@ impl SlackChannel {
         self.mention_only = mention_only;
         self.group_reply_allowed_sender_ids =
             Self::normalize_group_reply_allowed_sender_ids(allowed_sender_ids);
+        self
+    }
+
+    /// Configure whether replies are threaded on the original message.
+    /// When `false`, replies go to the channel root and inbound `thread_ts` is
+    /// cleared so that sessions are scoped per-channel instead of per-thread.
+    pub fn with_thread_replies(mut self, enabled: bool) -> Self {
+        self.thread_replies = enabled;
         self
     }
 
@@ -147,6 +157,16 @@ impl SlackChannel {
             .and_then(|t| t.as_str())
             .or(if ts.is_empty() { None } else { Some(ts) })
             .map(str::to_string)
+    }
+
+    /// Like `inbound_thread_ts`, but returns `None` when `thread_replies` is
+    /// disabled so that the session is scoped per-channel instead of per-thread.
+    fn resolve_inbound_thread_ts(&self, msg: &serde_json::Value, ts: &str) -> Option<String> {
+        if self.thread_replies {
+            Self::inbound_thread_ts(msg, ts)
+        } else {
+            None
+        }
     }
 
     fn normalized_channel_id(input: Option<&str>) -> Option<String> {
@@ -1775,7 +1795,7 @@ impl SlackChannel {
                         .duration_since(std::time::UNIX_EPOCH)
                         .unwrap_or_default()
                         .as_secs(),
-                    thread_ts: Self::inbound_thread_ts(event, ts),
+                    thread_ts: self.resolve_inbound_thread_ts(event, ts),
                 };
 
                 if tx.send(channel_msg).await.is_err() {
@@ -2149,8 +2169,10 @@ impl Channel for SlackChannel {
             "text": message.content
         });
 
-        if let Some(ref ts) = message.thread_ts {
-            body["thread_ts"] = serde_json::json!(ts);
+        if self.thread_replies {
+            if let Some(ref ts) = message.thread_ts {
+                body["thread_ts"] = serde_json::json!(ts);
+            }
         }
 
         let resp = self
@@ -2339,7 +2361,7 @@ impl Channel for SlackChannel {
                                 .duration_since(std::time::UNIX_EPOCH)
                                 .unwrap_or_default()
                                 .as_secs(),
-                            thread_ts: Self::inbound_thread_ts(msg, ts),
+                            thread_ts: self.resolve_inbound_thread_ts(msg, ts),
                         };
 
                         if tx.send(channel_msg).await.is_err() {
@@ -2423,7 +2445,11 @@ impl Channel for SlackChannel {
                             .duration_since(std::time::UNIX_EPOCH)
                             .unwrap_or_default()
                             .as_secs(),
-                        thread_ts: Some(thread_ts.clone()),
+                        thread_ts: if self.thread_replies {
+                            Some(thread_ts.clone())
+                        } else {
+                            None
+                        },
                     };
 
                     if tx.send(channel_msg).await.is_err() {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4572,6 +4572,11 @@ pub struct SlackConfig {
     /// Direct messages remain allowed.
     #[serde(default)]
     pub mention_only: bool,
+    /// When true (default) or omitted, replies thread on the original message.
+    /// When false, replies go to the channel root and sessions are scoped per-channel
+    /// rather than per-thread.
+    #[serde(default)]
+    pub thread_replies: Option<bool>,
 }
 
 impl ChannelConfig for SlackConfig {

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -3911,6 +3911,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     allowed_users,
                     interrupt_on_new_message: false,
                     mention_only: false,
+                    thread_replies: None,
                 });
             }
             ChannelMenuChoice::IMessage => {


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: When `thread_replies` is disabled, Slack channel replies still force threading and session history is scoped by thread, causing context loss.
- What changed: Added `thread_replies: Option<bool>` to `SlackConfig`; `send()` conditionally omits `thread_ts`; `conversation_history_key()` scopes by channel-only when threading is disabled.
- What did **not** change: Default behavior (`thread_replies: true`) is unchanged. Other channel implementations are untouched.

### Change Metadata
- Change type: `bug`
- Primary scope: `channel`
- Risk: `medium`
- Closes #4052

### Validation Evidence
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ✅

### Compatibility
- Backward compatible: Yes (`thread_replies` defaults to `true`)
- Config/env changes: New optional `thread_replies` field in Slack config
- Migration needed: No

### Rollback Plan
- `git revert <commit-sha>`
- Or set `thread_replies: true` to restore original behavior