### PR TITLE
fix(approval): auto-approve read-only tools in non-interactive mode

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -5500,10 +5500,6 @@ fn default_otp_gated_actions() -> Vec<String> {
     ]
 }
 
-fn default_otp_challenge_max_attempts() -> u32 {
-    3
-}
-
 impl Default for OtpConfig {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
## Summary
- Add read-only tools (web_search_tool, web_fetch, calculator, glob_search, content_search, image_info) to the default auto_approve list
- These tools have no side effects and were being silently denied in channel mode (Telegram, Slack, etc.)
- Root cause: non-interactive ApprovalManager auto-denies any tool not in auto_approve when autonomy level is not "full"

## Test plan
- [ ] Verify web_search_tool works in channel mode without setting autonomy to full
- [ ] Verify existing auto_approve behavior for file_read and memory_recall unchanged
- [ ] Verify tools requiring approval (shell, file_write, etc.) still require it

Closes #4083