### PR TITLE
fix(config): remove duplicate default_otp_challenge_max_attempts function

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -5491,10 +5491,6 @@ fn default_otp_gated_actions() -> Vec<String> {
     ]
 }
 
-fn default_otp_challenge_max_attempts() -> u32 {
-    3
-}
-
 impl Default for OtpConfig {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
## Summary
- Removes duplicate `default_otp_challenge_max_attempts()` function definition in `src/config/schema.rs` (lines 5494-5496)
- PR #3921 accidentally introduced a second copy of this function, causing `E0428` compilation failure on master
- This was the root cause of the CI failures on the mem0 PR (#3965) merge commit

## Test plan
- [ ] CI passes (clippy, tests, builds) — this was the only compilation error blocking master