### PR TITLE
fix(config): remove duplicate default_otp_challenge_max_attempts function

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -5491,10 +5491,6 @@ fn default_otp_gated_actions() -> Vec<String> {
     ]
 }
 
-fn default_otp_challenge_max_attempts() -> u32 {
-    3
-}
-
 impl Default for OtpConfig {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
## Summary
- Removes duplicate `default_otp_challenge_max_attempts()` function in `src/config/schema.rs`
- The duplication was introduced when #3921 was merged, causing compilation failures on all downstream branches

## Test plan
- [ ] `cargo check` compiles successfully
- [ ] All existing tests pass