### PR TITLE
feat(providers): add DeepMyst as OpenAI-compatible provider

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -909,6 +909,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         "ovhcloud" | "ovh" => vec!["OVH_AI_ENDPOINTS_ACCESS_TOKEN"],
         "astrai" => vec!["ASTRAI_API_KEY"],
         "avian" => vec!["AVIAN_API_KEY"],
+        "deepmyst" | "deep-myst" => vec!["DEEPMYST_API_KEY"],
         "llamacpp" | "llama.cpp" => vec!["LLAMACPP_API_KEY"],
         "sglang" => vec!["SGLANG_API_KEY"],
         "vllm" => vec!["VLLM_API_KEY"],
@@ -1498,6 +1499,9 @@ fn create_provider_with_url_and_options(
         ))),
         "avian" => Ok(compat(OpenAiCompatibleProvider::new(
             "Avian", "https://api.avian.io/v1", key, AuthStyle::Bearer,
+        ))),
+        "deepmyst" | "deep-myst" => Ok(compat(OpenAiCompatibleProvider::new(
+            "DeepMyst", "https://api.deepmyst.com/v1", key, AuthStyle::Bearer,
         ))),
 
         // ── Cloud AI endpoints ───────────────────────────────
@@ -2870,6 +2874,20 @@ mod tests {
     #[test]
     fn factory_avian() {
         assert!(create_provider("avian", Some("sk-avian-test")).is_ok());
+    }
+
+    #[test]
+    fn factory_deepmyst() {
+        assert!(create_provider("deepmyst", Some("key")).is_ok());
+        assert!(create_provider("deep-myst", Some("key")).is_ok());
+    }
+
+    #[test]
+    fn resolve_provider_credential_deepmyst_env() {
+        let _env_lock = env_lock();
+        let _guard = EnvGuard::set("DEEPMYST_API_KEY", Some("dm-test-key"));
+        let resolved = resolve_provider_credential("deepmyst", None);
+        assert_eq!(resolved, Some("dm-test-key".to_string()));
     }
 
     // ── Custom / BYOP provider ─────────────────────────────


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: DeepMyst, an LLM middleware/routing service with OpenAI-compatible API, is not available as a provider
- Why it matters: Users who use DeepMyst for intelligent model routing and token optimization cannot configure it natively
- What changed: Registered DeepMyst as an OpenAI-compatible provider with Bearer auth, `DEEPMYST_API_KEY` env var, and aliases `deepmyst` / `deep-myst`
- What did **not** change (scope boundary): No new files, no config schema changes, no changes to existing providers or shared code

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `provider`
- Module labels: `provider: deepmyst`
- Contributor tier label: N/A (first contribution)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `provider`

## Linked Issue

- Closes # N/A
- Related # N/A
- Depends on # N/A
- Supersedes # N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check     # ✅ pass
cargo clippy --all-targets -- -D warnings  # ✅ pass
cargo test factory_deepmyst    # ✅ pass
cargo test resolve_provider_credential_deepmyst  # ✅ pass
```

- Evidence provided: end-to-end tested with `gpt-5.2` and `gpt-5.2-optimize` models via DeepMyst API (multiple turns, different task types: math, creative writing, translation, technical explanation)
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (opt-in via user selecting `deepmyst` provider)
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No personal data in changes
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — new optional `DEEPMYST_API_KEY` env var (additive only)
- Migration needed? No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: single-message mode with `gpt-5.2` and `gpt-5.2-optimize` models, multiple turns with different prompt types
- Edge cases checked: invalid model name returns proper DeepMyst API error, credential env var resolution
- What was not verified: streaming mode (DeepMyst may or may not support it; falls back gracefully)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Provider factory only
- Potential unintended effects: None — purely additive match arm
- Guardrails/monitoring for early detection: Existing provider factory tests cover regression

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (Opus 4.6)
- Workflow/plan summary: Explored provider trait system, identified OpenAI-compatible pattern, implemented minimal registration, verified with live API
- Verification focus: Factory wiring, credential resolution, end-to-end API calls
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>`
- Feature flags or config toggles (if any): None needed — provider is only activated when user explicitly selects `deepmyst`
- Observable failure symptoms: `create_provider("deepmyst", ...)` returns error

## Risks and Mitigations

- Risk: None — additive-only change to a single file following established pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)