### PR TITLE
feat(channel): add Slack Assistants API status indicators

### DIFF
--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -30,6 +30,8 @@ pub struct SlackChannel {
     group_reply_allowed_sender_ids: Vec<String>,
     user_display_name_cache: Mutex<HashMap<String, CachedSlackDisplayName>>,
     workspace_dir: Option<PathBuf>,
+    /// Maps channel_id -> thread_ts for active assistant threads (used for status indicators).
+    active_assistant_thread: Mutex<HashMap<String, String>>,
 }
 
 const SLACK_HISTORY_MAX_RETRIES: u32 = 3;
@@ -118,6 +120,7 @@ impl SlackChannel {
             group_reply_allowed_sender_ids: Vec::new(),
             user_display_name_cache: Mutex::new(HashMap::new()),
             workspace_dir: None,
+            active_assistant_thread: Mutex::new(HashMap::new()),
         }
     }
 
@@ -1784,7 +1787,34 @@ impl SlackChannel {
                 else {
                     continue;
                 };
-                if event.get("type").and_then(|v| v.as_str()) != Some("message") {
+                let event_type = event
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default();
+
+                // Track assistant thread context for Assistants API status indicators.
+                if event_type == "assistant_thread_started"
+                    || event_type == "assistant_thread_context_changed"
+                {
+                    if let Some(thread) = event.get("assistant_thread") {
+                        let ch = thread
+                            .get("channel_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default();
+                        let tts = thread
+                            .get("thread_ts")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default();
+                        if !ch.is_empty() && !tts.is_empty() {
+                            if let Ok(mut map) = self.active_assistant_thread.lock() {
+                                map.insert(ch.to_string(), tts.to_string());
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                if event_type != "message" {
                     continue;
                 }
                 let subtype = event.get("subtype").and_then(|v| v.as_str());
@@ -1863,6 +1893,13 @@ impl SlackChannel {
                     },
                     interruption_scope_id: Self::inbound_interruption_scope_id(event, ts),
                 };
+
+                // Track thread context so start_typing can set assistant status.
+                if let Some(ref tts) = channel_msg.thread_ts {
+                    if let Ok(mut map) = self.active_assistant_thread.lock() {
+                        map.insert(channel_id.clone(), tts.clone());
+                    }
+                }
 
                 if tx.send(channel_msg).await.is_err() {
                     return Ok(());
@@ -2638,6 +2675,49 @@ impl Channel for SlackChannel {
             true
         };
         Self::evaluate_health(bot_ok, socket_mode_enabled, socket_mode_ok)
+    }
+
+    async fn start_typing(&self, recipient: &str) -> anyhow::Result<()> {
+        let thread_ts = {
+            let map = self
+                .active_assistant_thread
+                .lock()
+                .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+            match map.get(recipient) {
+                Some(ts) => ts.clone(),
+                None => return Ok(()),
+            }
+        };
+
+        let body = serde_json::json!({
+            "channel_id": recipient,
+            "thread_ts": thread_ts,
+            "status": "is thinking...",
+        });
+
+        // Gracefully ignore errors — non-assistant contexts will return errors.
+        if let Ok(resp) = self
+            .http_client()
+            .post("https://slack.com/api/assistant.threads.setStatus")
+            .bearer_auth(&self.bot_token)
+            .json(&body)
+            .send()
+            .await
+        {
+            if !resp.status().is_success() {
+                tracing::debug!(
+                    "assistant.threads.setStatus returned {}; ignoring",
+                    resp.status()
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn stop_typing(&self, _recipient: &str) -> anyhow::Result<()> {
+        // Status auto-clears when the bot sends a message via chat.postMessage.
+        Ok(())
     }
 }
 
@@ -3548,5 +3628,40 @@ mod tests {
         let key1 = super::super::conversation_history_key(&msg1);
         let key2 = super::super::conversation_history_key(&msg2);
         assert_ne!(key1, key2, "session key should differ per thread");
+    }
+
+    #[tokio::test]
+    async fn start_typing_requires_thread_context() {
+        let ch = SlackChannel::new("xoxb-fake".into(), None, None, vec![], vec![]);
+        // No thread_ts tracked for "C999" — start_typing should be a no-op (Ok).
+        let result = ch.start_typing("C999").await;
+        assert!(
+            result.is_ok(),
+            "start_typing should succeed as no-op without thread context"
+        );
+    }
+
+    #[test]
+    fn assistant_thread_tracking() {
+        let ch = SlackChannel::new("xoxb-fake".into(), None, None, vec![], vec![]);
+
+        // Initially empty.
+        {
+            let map = ch.active_assistant_thread.lock().unwrap();
+            assert!(map.is_empty());
+        }
+
+        // Simulate storing a thread_ts (as listen_socket_mode would).
+        {
+            let mut map = ch.active_assistant_thread.lock().unwrap();
+            map.insert("C123".to_string(), "1741234567.000100".to_string());
+        }
+
+        // Verify retrieval.
+        {
+            let map = ch.active_assistant_thread.lock().unwrap();
+            assert_eq!(map.get("C123"), Some(&"1741234567.000100".to_string()),);
+            assert_eq!(map.get("C999"), None);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Slack channel has no typing/status indicator — users see no feedback while the bot processes messages.
- Why it matters: Slack's Assistants API provides native `assistant.threads.setStatus` for animated status indicators in DM threads, improving perceived responsiveness.
- What changed: Implemented `start_typing`/`stop_typing` for Slack using the Assistants API. Tracks thread context from `assistant_thread_started`/`assistant_thread_context_changed` events and inbound messages, then sets "is thinking..." status during processing.
- What did **not** change (scope boundary): No trait or orchestration changes. No changes to other channels. `stop_typing` is a no-op since status auto-clears on `chat.postMessage`.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels: `channel`
- Module labels: `channel: slack`
- Contributor tier label: `auto-managed/read-only`
- If any auto-label is incorrect, note requested correction: `None`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

- N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check  # pass
cargo test --lib channels::slack::tests  # 82 passed
```

- Evidence provided: Unit tests for `start_typing_requires_thread_context` and `assistant_thread_tracking`. Manual testing confirmed API calls succeed (`ok: true`) with status indicators visible in Slack assistant DM threads.
- If any command is intentionally skipped, explain why: `cargo clippy` not run (no new warnings expected — only new code follows existing patterns).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `Yes` — calls `assistant.threads.setStatus` Slack API endpoint using the existing bot token.
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: Uses the same `bot_token` already used for `chat.postMessage`. Errors are gracefully ignored (non-assistant contexts return errors silently).

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: No user data is sent — only static status text ("is thinking...") and thread identifiers already known to Slack.
- Neutral wording confirmation: `Yes`

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`

## Human Verification (required)

- Verified scenarios: Sent messages in Slack channel threads — API calls succeed, status indicators appear in assistant DM threads.
- Edge cases checked: No thread context tracked → `start_typing` is a no-op. Non-assistant contexts → API errors silently ignored.
- What was not verified: Slack workspaces without Agents & AI Apps feature enabled.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Slack channel typing indicator only.
- Potential unintended effects: Additional HTTP calls to Slack API during processing (one per typing refresh interval). Gracefully ignored if they fail.
- Guardrails/monitoring for early detection: Debug-level logging on non-200 responses from `setStatus`.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Claude Code
- Workflow/plan summary (if any): Planned in plan mode, implemented iteratively with manual Slack testing.
- Verification focus: API response validation, no-op behavior without thread context.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles (if any): `None`
- Observable failure symptoms: Missing typing indicators in Slack DM threads (graceful degradation — no functional impact).

## Risks and Mitigations

- Risk: `assistant.threads.setStatus` adds an extra API call per typing refresh cycle.
  - Mitigation: Errors are silently ignored, and the call only fires when thread context is tracked. No impact on message delivery.