### PR TITLE
fix(onboard): make tmux paste safe for text prompts

### DIFF
--- a/src/cli_input.rs
+++ b/src/cli_input.rs
@@ -1,0 +1,152 @@
+use anyhow::{bail, Result};
+use std::io::{BufRead, Write};
+
+#[derive(Debug, Clone, Default)]
+pub struct Input {
+    prompt: String,
+    default: Option<String>,
+    allow_empty: bool,
+}
+
+impl Input {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            prompt: String::new(),
+            default: None,
+            allow_empty: false,
+        }
+    }
+
+    #[must_use]
+    pub fn with_prompt<S: Into<String>>(mut self, prompt: S) -> Self {
+        self.prompt = prompt.into();
+        self
+    }
+
+    #[must_use]
+    pub fn allow_empty(mut self, val: bool) -> Self {
+        self.allow_empty = val;
+        self
+    }
+
+    #[must_use]
+    pub fn default<S: Into<String>>(mut self, value: S) -> Self {
+        self.default = Some(value.into());
+        self
+    }
+
+    pub fn interact_text(self) -> Result<String> {
+        let stdin = std::io::stdin();
+        let stdout = std::io::stdout();
+        self.interact_text_with_io(stdin.lock(), stdout.lock())
+    }
+
+    fn interact_text_with_io<R: BufRead, W: Write>(
+        self,
+        mut reader: R,
+        mut writer: W,
+    ) -> Result<String> {
+        loop {
+            write!(writer, "{}", self.render_prompt())?;
+            writer.flush()?;
+
+            let mut line = String::new();
+            let bytes_read = reader.read_line(&mut line)?;
+            if bytes_read == 0 {
+                bail!("No input received from stdin");
+            }
+
+            let trimmed = trim_trailing_line_ending(&line);
+            if trimmed.is_empty() {
+                if let Some(default) = &self.default {
+                    return Ok(default.clone());
+                }
+                if self.allow_empty {
+                    return Ok(String::new());
+                }
+                writeln!(writer, "Input cannot be empty.")?;
+                continue;
+            }
+
+            return Ok(trimmed.to_string());
+        }
+    }
+
+    fn render_prompt(&self) -> String {
+        match &self.default {
+            Some(default) => format!("{} [{}]: ", self.prompt, default),
+            None => format!("{}: ", self.prompt),
+        }
+    }
+}
+
+fn trim_trailing_line_ending(input: &str) -> &str {
+    input.trim_end_matches(['\n', '\r'])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{trim_trailing_line_ending, Input};
+    use anyhow::Result;
+    use std::io::Cursor;
+
+    #[test]
+    fn trim_trailing_line_ending_strips_newlines() {
+        assert_eq!(trim_trailing_line_ending("value\n"), "value");
+        assert_eq!(trim_trailing_line_ending("value\r\n"), "value");
+        assert_eq!(trim_trailing_line_ending("value\r"), "value");
+        assert_eq!(trim_trailing_line_ending("value"), "value");
+    }
+
+    #[test]
+    fn interact_text_returns_typed_value_without_newline() -> Result<()> {
+        let input = Input::new().with_prompt("Prompt");
+        let mut output = Vec::new();
+
+        let value = input.interact_text_with_io(Cursor::new(b"typed-value\n"), &mut output)?;
+
+        assert_eq!(value, "typed-value");
+        assert_eq!(String::from_utf8(output)?, "Prompt: ");
+        Ok(())
+    }
+
+    #[test]
+    fn interact_text_returns_default_for_blank_input() -> Result<()> {
+        let input = Input::new().with_prompt("Prompt").default("fallback");
+        let mut output = Vec::new();
+
+        let value = input.interact_text_with_io(Cursor::new(b"\n"), &mut output)?;
+
+        assert_eq!(value, "fallback");
+        assert_eq!(String::from_utf8(output)?, "Prompt [fallback]: ");
+        Ok(())
+    }
+
+    #[test]
+    fn interact_text_allows_empty_when_requested() -> Result<()> {
+        let input = Input::new().with_prompt("Prompt").allow_empty(true);
+        let mut output = Vec::new();
+
+        let value = input.interact_text_with_io(Cursor::new(b"\n"), &mut output)?;
+
+        assert_eq!(value, "");
+        assert_eq!(String::from_utf8(output)?, "Prompt: ");
+        Ok(())
+    }
+
+    #[test]
+    fn interact_text_reprompts_when_empty_is_not_allowed() -> Result<()> {
+        let input = Input::new().with_prompt("Prompt");
+        let mut output = Vec::new();
+
+        let value = input.interact_text_with_io(Cursor::new(b"\nsecond-try\n"), &mut output)?;
+
+        assert_eq!(value, "second-try");
+        assert_eq!(
+            String::from_utf8(output)?,
+            "Prompt: Input cannot be empty.\nPrompt: "
+        );
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod agent;
 pub(crate) mod approval;
 pub(crate) mod auth;
 pub mod channels;
+pub(crate) mod cli_input;
 pub mod commands;
 pub mod config;
 pub(crate) mod cost;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@
 
 use anyhow::{bail, Context, Result};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
-use dialoguer::{Input, Password};
+use dialoguer::Password;
 use serde::{Deserialize, Serialize};
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
@@ -75,6 +75,7 @@ mod agent;
 mod approval;
 mod auth;
 mod channels;
+mod cli_input;
 mod commands;
 mod rag {
     pub use zeroclaw::rag::*;
@@ -1805,7 +1806,9 @@ fn read_auth_input(prompt: &str) -> Result<String> {
 }
 
 fn read_plain_input(prompt: &str) -> Result<String> {
-    let input: String = Input::new().with_prompt(prompt).interact_text()?;
+    let input: String = cli_input::Input::new()
+        .with_prompt(prompt)
+        .interact_text()?;
     Ok(input.trim().to_string())
 }
 

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -1,3 +1,4 @@
+use crate::cli_input::Input;
 #[cfg(feature = "channel-nostr")]
 use crate::config::schema::{default_nostr_relays, NostrConfig};
 use crate::config::schema::{
@@ -20,7 +21,7 @@ use crate::providers::{
 };
 use anyhow::{bail, Context, Result};
 use console::style;
-use dialoguer::{Confirm, Input, Select};
+use dialoguer::{Confirm, Select};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -2391,7 +2392,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
 
         let model: String = Input::new()
             .with_prompt("  Model name (e.g. llama3, gpt-4o, mistral)")
-            .default("default".into())
+            .default("default")
             .interact_text()?;
 
         let provider_name = format!("custom:{base_url}");
@@ -2427,7 +2428,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
         if use_remote_ollama {
             let raw_url: String = Input::new()
                 .with_prompt("  Remote Ollama endpoint URL")
-                .default("https://ollama.com".into())
+                .default("https://ollama.com")
                 .interact_text()?;
 
             let normalized_url = normalize_ollama_endpoint_url(&raw_url);
@@ -2474,7 +2475,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
     } else if matches!(provider_name, "llamacpp" | "llama.cpp") {
         let raw_url: String = Input::new()
             .with_prompt("  llama.cpp server endpoint URL")
-            .default("http://localhost:8080/v1".into())
+            .default("http://localhost:8080/v1")
             .interact_text()?;
 
         let normalized_url = raw_url.trim().trim_end_matches('/').to_string();
@@ -2505,7 +2506,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
     } else if provider_name == "sglang" {
         let raw_url: String = Input::new()
             .with_prompt("  SGLang server endpoint URL")
-            .default("http://localhost:30000/v1".into())
+            .default("http://localhost:30000/v1")
             .interact_text()?;
 
         let normalized_url = raw_url.trim().trim_end_matches('/').to_string();
@@ -2536,7 +2537,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
     } else if provider_name == "vllm" {
         let raw_url: String = Input::new()
             .with_prompt("  vLLM server endpoint URL")
-            .default("http://localhost:8000/v1".into())
+            .default("http://localhost:8000/v1")
             .interact_text()?;
 
         let normalized_url = raw_url.trim().trim_end_matches('/').to_string();
@@ -2567,7 +2568,7 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
     } else if provider_name == "osaurus" {
         let raw_url: String = Input::new()
             .with_prompt("  Osaurus server endpoint URL")
-            .default("http://localhost:1337/v1".into())
+            .default("http://localhost:1337/v1")
             .interact_text()?;
 
         let normalized_url = raw_url.trim().trim_end_matches('/').to_string();
@@ -3255,7 +3256,7 @@ fn setup_hardware() -> Result<HardwareConfig> {
             // User chose serial but no device discovered — ask for manual path
             let manual_port: String = Input::new()
                 .with_prompt("  Serial port path (e.g. /dev/ttyUSB0)")
-                .default("/dev/ttyUSB0".into())
+                .default("/dev/ttyUSB0")
                 .interact_text()?;
             hw_config.serial_port = Some(manual_port);
         }
@@ -3281,7 +3282,7 @@ fn setup_hardware() -> Result<HardwareConfig> {
             4 => {
                 let custom: String = Input::new()
                     .with_prompt("  Custom baud rate")
-                    .default("115200".into())
+                    .default("115200")
                     .interact_text()?;
                 custom.parse::<u32>().unwrap_or(115_200)
             }
@@ -3295,7 +3296,7 @@ fn setup_hardware() -> Result<HardwareConfig> {
     {
         let target: String = Input::new()
             .with_prompt("  Target MCU chip (e.g. STM32F411CEUx, nRF52840_xxAA)")
-            .default("STM32F411CEUx".into())
+            .default("STM32F411CEUx")
             .interact_text()?;
         hw_config.probe_target = Some(target);
     }
@@ -3355,7 +3356,7 @@ fn setup_project_context() -> Result<ProjectContext> {
 
     let user_name: String = Input::new()
         .with_prompt("  Your name")
-        .default("User".into())
+        .default("User")
         .interact_text()?;
 
     let tz_options = vec![
@@ -3379,7 +3380,7 @@ fn setup_project_context() -> Result<ProjectContext> {
     let timezone = if tz_idx == tz_options.len() - 1 {
         Input::new()
             .with_prompt("  Enter timezone (e.g. America/New_York)")
-            .default("UTC".into())
+            .default("UTC")
             .interact_text()?
     } else {
         // Extract the short label before the parenthetical
@@ -3393,7 +3394,7 @@ fn setup_project_context() -> Result<ProjectContext> {
 
     let agent_name: String = Input::new()
         .with_prompt("  Agent name")
-        .default("ZeroClaw".into())
+        .default("ZeroClaw")
         .interact_text()?;
 
     let style_options = vec![
@@ -3422,7 +3423,7 @@ fn setup_project_context() -> Result<ProjectContext> {
         _ => Input::new()
             .with_prompt("  Custom communication style")
             .default(
-                "Be warm, natural, and clear. Use occasional relevant emojis (1-2 max) and avoid robotic phrasing.".into(),
+                "Be warm, natural, and clear. Use occasional relevant emojis (1-2 max) and avoid robotic phrasing.",
             )
             .interact_text()?,
     };
@@ -4046,7 +4047,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
 
                 let contacts_str: String = Input::new()
                     .with_prompt("  Allowed contacts (comma-separated phone/email, or * for all)")
-                    .default("*".into())
+                    .default("*")
                     .interact_text()?;
 
                 let allowed_contacts = if contacts_str.trim() == "*" {
@@ -4159,7 +4160,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
 
                 let users_str: String = Input::new()
                     .with_prompt("  Allowed users (comma-separated @user:server, or * for all)")
-                    .default("*".into())
+                    .default("*")
                     .interact_text()?;
 
                 let allowed_users = if users_str.trim() == "*" {
@@ -4193,7 +4194,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
 
                 let http_url: String = Input::new()
                     .with_prompt("  signal-cli HTTP URL")
-                    .default("http://127.0.0.1:8686".into())
+                    .default("http://127.0.0.1:8686")
                     .interact_text()?;
 
                 if http_url.trim().is_empty() {
@@ -4240,7 +4241,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     .with_prompt(
                         "  Allowed sender numbers (comma-separated +1234567890, or * for all)",
                     )
-                    .default("*".into())
+                    .default("*")
                     .interact_text()?;
 
                 let allowed_from = if allowed_from_raw.trim() == "*" {
@@ -4317,7 +4318,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
 
                     let session_path: String = Input::new()
                         .with_prompt("  Session database path")
-                        .default("~/.zeroclaw/state/whatsapp-web/session.db".into())
+                        .default("~/.zeroclaw/state/whatsapp-web/session.db")
                         .interact_text()?;
 
                     if session_path.trim().is_empty() {
@@ -4347,7 +4348,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                         .with_prompt(
                             "  Allowed phone numbers (comma-separated +1234567890, or * for all)",
                         )
-                        .default("*".into())
+                        .default("*")
                         .interact_text()?;
 
                     let allowed_numbers = if users_str.trim() == "*" {
@@ -4407,7 +4408,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
 
                 let verify_token: String = Input::new()
                     .with_prompt("  Webhook verify token (create your own)")
-                    .default("zeroclaw-whatsapp-verify".into())
+                    .default("zeroclaw-whatsapp-verify")
                     .interact_text()?;
 
                 // Test connection (run entirely in separate thread — Response must be used/dropped there)
@@ -4450,7 +4451,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     .with_prompt(
                         "  Allowed phone numbers (comma-separated +1234567890, or * for all)",
                     )
-                    .default("*".into())
+                    .default("*")
                     .interact_text()?;
 
                 let allowed_numbers = if users_str.trim() == "*" {
@@ -4537,7 +4538,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     .with_prompt(
                         "  Allowed sender numbers (comma-separated +1234567890, or * for all)",
                     )
-                    .default("*".into())
+                    .default("*")
                     .interact_text()?;
 
                 let allowed_senders = if users_str.trim() == "*" {
@@ -4585,7 +4586,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
 
                 let port_str: String = Input::new()
                     .with_prompt("  Port")
-                    .default("6697".into())
+                    .default("6697")
                     .interact_text()?;
 
                 let port: u16 = match port_str.trim().parse() {
@@ -4712,7 +4713,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
 
                 let port: String = Input::new()
                     .with_prompt("  Port")
-                    .default("8080".into())
+                    .default("8080")
                     .interact_text()?;
 
                 let secret: String = Input::new()
@@ -4779,7 +4780,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
 
                 let allowed_users_raw: String = Input::new()
                     .with_prompt("  Allowed Nextcloud actor IDs (comma-separated, or * for all)")
-                    .default("*".into())
+                    .default("*")
                     .interact_text()?;
 
                 let allowed_users = if allowed_users_raw.trim() == "*" {
@@ -5103,7 +5104,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                 let port = if receive_mode == LarkReceiveMode::Webhook {
                     let p: String = Input::new()
                         .with_prompt("  Webhook Port")
-                        .default("8080".into())
+                        .default("8080")
                         .interact_text()?;
                     Some(p.parse().unwrap_or(8080))
                 } else {

--- a/tests/manual/tmux/onboard_wrapper.sh
+++ b/tests/manual/tmux/onboard_wrapper.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+config_dir="$1"
+bin_path="$2"
+
+env ZEROCLAW_CONFIG_DIR="$config_dir" "$bin_path" onboard
+status=$?
+printf '\nEXIT_STATUS=%s\n' "$status"
+sleep 5

--- a/tests/manual/tmux/test_onboard_provider_input_paths.sh
+++ b/tests/manual/tmux/test_onboard_provider_input_paths.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+BIN_PATH="${1:-$ROOT_DIR/target/debug/zeroclaw}"
+TMP_ROOT="/tmp/zeroclaw-tmux-onboard-$$"
+
+cleanup() {
+  tmux kill-session -t "zc_full_$$_custom" >/dev/null 2>&1 || true
+  tmux kill-session -t "zc_update_$$_synthetic" >/dev/null 2>&1 || true
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "tmux is required for this regression test" >&2
+  exit 1
+fi
+
+if [[ ! -x "$BIN_PATH" ]]; then
+  echo "Building zeroclaw..."
+  cargo build --bin zeroclaw >/dev/null
+fi
+
+mkdir -p "$TMP_ROOT"
+
+start_onboard_session() {
+  local session="$1"
+  local config_dir="$2"
+  tmux kill-session -t "$session" >/dev/null 2>&1 || true
+  tmux new-session -d -x 240 -y 60 -s "$session" \
+    "bash \"$ROOT_DIR/tests/manual/tmux/onboard_wrapper.sh\" \"$config_dir\" \"$BIN_PATH\""
+  sleep 1
+}
+
+paste_value() {
+  local session="$1"
+  local buffer_name="$2"
+  local value="$3"
+  tmux set-buffer -b "$buffer_name" "$value"
+  tmux paste-buffer -t "$session":0.0 -b "$buffer_name" -p
+}
+
+send_enter() {
+  local session="$1"
+  tmux send-keys -t "$session":0.0 Enter
+}
+
+send_key() {
+  local session="$1"
+  local key="$2"
+  tmux send-keys -t "$session":0.0 "$key"
+}
+
+capture_recent() {
+  local session="$1"
+  tmux capture-pane -p -S -80 -t "$session":0.0
+}
+
+assert_prompt_value_exact() {
+  local session="$1"
+  local prompt="$2"
+  local value="$3"
+  local label="$4"
+  local line
+
+  line="$(
+    capture_recent "$session" |
+      awk -v prompt="$prompt" 'index($0, prompt) { line = $0 } END { if (line != "") print line; else exit 1 }'
+  )"
+
+  local actual="${line#*"$prompt"}"
+  if [[ "$actual" != "$value" ]]; then
+    echo "Unexpected tmux paste rendering for $label" >&2
+    echo "Prompt: $prompt" >&2
+    echo "Expected: $value" >&2
+    echo "Actual line: $line" >&2
+    exit 1
+  fi
+}
+
+run_full_custom_provider_flow() {
+  local root="$TMP_ROOT/full"
+  local config_dir="$root/config"
+  local workspace_path="$root/ws"
+  local session="zc_full_$$_custom"
+  local base_url="https://e.invalid/v1"
+  local api_key="sk-full-a1b2"
+  local model="full-model-a1"
+
+  mkdir -p "$root"
+  start_onboard_session "$session" "$config_dir"
+
+  send_key "$session" n
+  sleep 1
+
+  paste_value "$session" zc_full_workspace "$workspace_path"
+  sleep 1
+  assert_prompt_value_exact "$session" "  Enter workspace path: " "$workspace_path" "custom workspace path"
+  send_enter "$session"
+  sleep 1
+
+  for _ in 1 2 3 4 5; do
+    send_key "$session" Down
+  done
+  send_enter "$session"
+  sleep 1
+
+  paste_value "$session" zc_full_base_url "$base_url"
+  sleep 1
+  assert_prompt_value_exact \
+    "$session" \
+    "  API base URL (e.g. http://localhost:1234 or https://my-api.com): " \
+    "$base_url" \
+    "custom provider base URL"
+  send_enter "$session"
+  sleep 1
+
+  paste_value "$session" zc_full_api_key "$api_key"
+  sleep 1
+  assert_prompt_value_exact \
+    "$session" \
+    "  API key (or Enter to skip if not needed): " \
+    "$api_key" \
+    "custom provider API key"
+  send_enter "$session"
+  sleep 1
+
+  paste_value "$session" zc_full_model "$model"
+  sleep 1
+  assert_prompt_value_exact \
+    "$session" \
+    "  Model name (e.g. llama3, gpt-4o, mistral) [default]: " \
+    "$model" \
+    "custom provider model"
+  send_enter "$session"
+  sleep 1
+}
+
+run_update_custom_model_flow() {
+  local root="$TMP_ROOT/update"
+  local config_dir="$root/config"
+  local session="zc_update_$$_synthetic"
+  local api_key="sk-synth-a1b2"
+  local model="synthetic-manual-a1"
+
+  mkdir -p "$root"
+
+  env ZEROCLAW_CONFIG_DIR="$config_dir" \
+    "$BIN_PATH" onboard --provider openrouter --api-key seed-key --model openai/gpt-5-mini --force >/dev/null
+
+  start_onboard_session "$session" "$config_dir"
+
+  send_enter "$session"
+  sleep 1
+  send_enter "$session"
+  sleep 1
+
+  for _ in 1 2 3; do
+    send_key "$session" Down
+  done
+  send_enter "$session"
+  sleep 1
+
+  for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14; do
+    send_key "$session" Down
+  done
+  send_enter "$session"
+  sleep 1
+
+  paste_value "$session" zc_update_api_key "$api_key"
+  sleep 1
+  assert_prompt_value_exact \
+    "$session" \
+    "  Paste your API key (or press Enter to skip): " \
+    "$api_key" \
+    "provider-only API key"
+  send_enter "$session"
+  sleep 1
+
+  send_key "$session" Down
+  send_enter "$session"
+  sleep 1
+
+  paste_value "$session" zc_update_model "$model"
+  sleep 1
+  assert_prompt_value_exact \
+    "$session" \
+    "  Enter custom model ID [anthropic/claude-sonnet-4.6]: " \
+    "$model" \
+    "custom model ID"
+  send_enter "$session"
+  sleep 1
+}
+
+run_full_custom_provider_flow
+run_update_custom_model_flow
+
+echo "tmux onboarding provider input paths passed"


### PR DESCRIPTION
## Summary
- replace onboarding/plain text prompts with a paste-friendly stdin line reader
- add tmux regression coverage for the two real onboarding modes and their reachable text-entry fields
- keep select/confirm/password handling unchanged

## Problem
On the latest upstream `master` (`34f0b38e4213b7a7ff953559513d44c83ab02166`, dated March 20, 2026), pasting into onboarding text fields inside tmux could render repeated/garbled input. I reproduced this in real tmux sessions on the upstream code path, including:
- full onboarding -> custom workspace path -> custom provider base URL/API key/model
- existing config -> provider-only update -> provider API key / custom model path

## What Changed
- added an internal `cli_input::Input` helper that reads whole lines from stdin, trims trailing line endings, supports defaults/allow-empty, and avoids dialoguer raw-mode text input for these prompts
- switched onboarding wizard text prompts and `read_plain_input()` to that helper
- added focused unit tests for newline trimming, defaults, allow-empty, and reprompt behavior
- added a real tmux regression script covering:
  - full onboarding with custom workspace + custom provider text fields
  - provider-only update with API key + custom model text fields

## Validation
- `~/.cargo/bin/cargo fmt --all`
- `~/.cargo/bin/cargo build --bin zeroclaw`
- `~/.cargo/bin/cargo test cli_input -- --nocapture`
- `bash tests/manual/tmux/test_onboard_provider_input_paths.sh`

## Risk and Rollback
- Risk: low to medium; this changes only plain text prompt handling for onboarding/plain CLI input, while leaving select/confirm/password paths untouched
- Rollback: revert commit `539e8a2b2ce7bd3cfe8d7bc76c4df31cd1e7127a`
