### PR TITLE
feat(memory): add scope metadata to mem0 and fix data persistence

### DIFF
--- a/deploy/mem0/mem0-server.py
+++ b/deploy/mem0/mem0-server.py
@@ -81,6 +81,7 @@ config = {
             "collection_name": MEM0_VECTOR_COLLECTION,
             "embedding_model_dims": MEM0_EMBEDDER_DIMS,
             "path": MEM0_VECTOR_PATH,
+            "on_disk": True,
         },
     },
     "custom_fact_extraction_prompt": CUSTOM_EXTRACTION_PROMPT,
@@ -164,7 +165,7 @@ def _parse_mem0_results(raw_results) -> list:
             "id": item.get("id", str(uuid.uuid4())),
             "memory": item.get("memory", item.get("text", "")),
             "created_at": item.get("created_at", datetime.now(timezone.utc).isoformat()),
-            "metadata_": item.get("metadata", {}),
+            "metadata": item.get("metadata", {}),
         })
     return items
 

--- a/docs/i18n/zh-CN/reference/api/config-reference.zh-CN.md
+++ b/docs/i18n/zh-CN/reference/api/config-reference.zh-CN.md
@@ -435,6 +435,10 @@ extraction_prompt = "用原始语言提取事实..."
 
 服务器部署脚本位于 `deploy/mem0/`。
 
+> **重要：** mem0 qdrant 向量存储**必须**在服务器脚本中配置 `on_disk: True`，否则每次重启数据都会被删除。部署脚本已默认包含此设置。
+
+自动保存频道消息时，mem0 条目会根据会话上下文自动获得 `scope` 元数据标签（`"personal"` 或 `"group"`）。Web UI 在有 scope 数据时会显示并支持筛选。
+
 ## `[[model_routes]]` 和 `[[embedding_routes]]`
 
 使用路由提示，以便集成可以在模型 ID 演变时保持稳定的名称。

--- a/docs/reference/api/config-reference.md
+++ b/docs/reference/api/config-reference.md
@@ -487,6 +487,10 @@ extraction_prompt = "Extract facts in the original language..."
 
 Server deployment scripts are in `deploy/mem0/`.
 
+> **Important:** The mem0 qdrant vector store **must** be configured with `on_disk: True` in the server script, otherwise data is deleted on every restart. The deploy script includes this by default.
+
+When auto-saving channel messages, mem0 entries automatically receive a `scope` metadata label (`"personal"` or `"group"`) derived from the session context. The web UI displays and filters by scope when available.
+
 ## `[[model_routes]]` and `[[embedding_routes]]`
 
 Use route hints so integrations can keep stable names while model IDs evolve.

--- a/docs/vi/config-reference.md
+++ b/docs/vi/config-reference.md
@@ -361,6 +361,10 @@ extraction_prompt = "Trích xuất sự kiện bằng ngôn ngữ gốc..."
 
 Script triển khai server nằm trong `deploy/mem0/`.
 
+> **Quan trọng:** Vector store qdrant của mem0 **phải** được cấu hình `on_disk: True` trong script server, nếu không dữ liệu sẽ bị xóa mỗi lần khởi động lại. Script deploy đã bao gồm cài đặt này mặc định.
+
+Khi tự động lưu tin nhắn kênh, các mục mem0 sẽ tự động nhận nhãn metadata `scope` (`"personal"` hoặc `"group"`) dựa trên ngữ cảnh phiên. Web UI hiển thị và lọc theo scope khi có dữ liệu.
+
 ## `[[model_routes]]` và `[[embedding_routes]]`
 
 Route hint giúp tên tích hợp ổn định khi model ID thay đổi.

--- a/src/agent/memory_loader.rs
+++ b/src/agent/memory_loader.rs
@@ -114,6 +114,7 @@ mod tests {
                 timestamp: "now".into(),
                 session_id: None,
                 score: None,
+                scope: None,
             }])
         }
 
@@ -220,6 +221,7 @@ mod tests {
                     timestamp: "now".into(),
                     session_id: None,
                     score: Some(0.95),
+                    scope: None,
                 },
                 MemoryEntry {
                     id: "2".into(),
@@ -229,6 +231,7 @@ mod tests {
                     timestamp: "now".into(),
                     session_id: None,
                     score: Some(0.9),
+                    scope: None,
                 },
             ]),
         };

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -6591,6 +6591,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 timestamp: "2026-02-20T00:00:00Z".to_string(),
                 session_id: None,
                 score: Some(0.9),
+                scope: None,
             }])
         }
 

--- a/src/memory/lucid.rs
+++ b/src/memory/lucid.rs
@@ -226,6 +226,7 @@ impl LucidMemory {
                 timestamp: now.clone(),
                 session_id: None,
                 score: Some((1.0 - rank as f64 * 0.05).max(0.1)),
+                scope: None,
             });
         }
 

--- a/src/memory/markdown.rs
+++ b/src/memory/markdown.rs
@@ -91,6 +91,7 @@ impl MarkdownMemory {
                     timestamp: filename.to_string(),
                     session_id: None,
                     score: None,
+                    scope: None,
                 }
             })
             .collect()

--- a/src/memory/mem0.rs
+++ b/src/memory/mem0.rs
@@ -44,6 +44,8 @@ struct Mem0Metadata<'a> {
     category: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     session_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scope: Option<&'a str>,
 }
 
 #[derive(Serialize)]
@@ -67,7 +69,7 @@ struct Mem0MemoryItem {
     memory: String,
     #[serde(default)]
     created_at: Option<serde_json::Value>,
-    #[serde(default, rename = "metadata_")]
+    #[serde(default, alias = "metadata_")]
     metadata: Option<Mem0ResponseMetadata>,
     #[serde(alias = "relevance_score", default)]
     score: Option<f64>,
@@ -81,6 +83,8 @@ struct Mem0ResponseMetadata {
     category: Option<String>,
     #[serde(default)]
     session_id: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -210,6 +214,7 @@ impl Mem0Memory {
             timestamp,
             session_id: meta.session_id,
             score: item.score,
+            scope: meta.scope,
         }
     }
 
@@ -330,6 +335,15 @@ impl Memory for Mem0Memory {
     ) -> anyhow::Result<()> {
         let cat_str = category.to_string();
         let effective_user = self.effective_user_id(session_id);
+        // Derive scope from session_id pattern:
+        // group identifiers contain "@g.us" or start with "group:"
+        let scope_label = session_id.map(|sid| {
+            if sid.contains("@g.us") || sid.starts_with("group:") {
+                "group"
+            } else {
+                "personal"
+            }
+        });
         let body = AddMemoryRequest {
             user_id: effective_user,
             text: content,
@@ -337,6 +351,7 @@ impl Memory for Mem0Memory {
                 key,
                 category: &cat_str,
                 session_id,
+                scope: scope_label,
             }),
             infer: self.infer,
             app: Some(&self.app_name),
@@ -524,6 +539,7 @@ mod tests {
                 key: Some("k1".into()),
                 category: Some("core".into()),
                 session_id: None,
+                scope: None,
             }),
             score: Some(0.95),
         };
@@ -578,6 +594,7 @@ mod tests {
                 key: Some("k".into()),
                 category: Some("project_notes".into()),
                 session_id: Some("s1".into()),
+                scope: None,
             }),
             score: None,
         };

--- a/src/memory/postgres.rs
+++ b/src/memory/postgres.rs
@@ -134,6 +134,7 @@ impl PostgresMemory {
             timestamp: timestamp.to_rfc3339(),
             session_id: row.get(5),
             score: row.try_get(6).ok(),
+            scope: None,
         })
     }
 }

--- a/src/memory/qdrant.rs
+++ b/src/memory/qdrant.rs
@@ -363,6 +363,7 @@ impl Memory for QdrantMemory {
                     timestamp: payload.timestamp,
                     session_id: payload.session_id,
                     score: Some(point.score),
+                    scope: None,
                 })
             })
             .collect();
@@ -419,6 +420,7 @@ impl Memory for QdrantMemory {
                 timestamp: payload.timestamp,
                 session_id: payload.session_id,
                 score: None,
+                scope: None,
             })
         });
 
@@ -496,6 +498,7 @@ impl Memory for QdrantMemory {
                     timestamp: payload.timestamp,
                     session_id: payload.session_id,
                     score: None,
+                    scope: None,
                 })
             })
             .collect();

--- a/src/memory/sqlite.rs
+++ b/src/memory/sqlite.rs
@@ -576,6 +576,7 @@ impl Memory for SqliteMemory {
                             timestamp: ts,
                             session_id: sid,
                             score: Some(f64::from(scored.final_score)),
+                            scope: None,
                         };
                         if let Some(filter_sid) = session_ref {
                             if entry.session_id.as_deref() != Some(filter_sid) {
@@ -632,6 +633,7 @@ impl Memory for SqliteMemory {
                             timestamp: row.get(4)?,
                             session_id: row.get(5)?,
                             score: Some(1.0),
+                            scope: None,
                         })
                     })?;
                     for row in rows {
@@ -671,6 +673,7 @@ impl Memory for SqliteMemory {
                     timestamp: row.get(4)?,
                     session_id: row.get(5)?,
                     score: None,
+                    scope: None,
                 })
             })?;
 
@@ -707,6 +710,7 @@ impl Memory for SqliteMemory {
                     timestamp: row.get(4)?,
                     session_id: row.get(5)?,
                     score: None,
+                    scope: None,
                 })
             };
 

--- a/src/memory/traits.rs
+++ b/src/memory/traits.rs
@@ -23,6 +23,8 @@ pub struct MemoryEntry {
     pub timestamp: String,
     pub session_id: Option<String>,
     pub score: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
 }
 
 impl std::fmt::Debug for MemoryEntry {
@@ -181,6 +183,7 @@ mod tests {
             timestamp: "2026-02-16T00:00:00Z".into(),
             session_id: Some("session-abc".into()),
             score: Some(0.98),
+            scope: Some("personal".into()),
         };
 
         let json = serde_json::to_string(&entry).unwrap();

--- a/web/src/pages/Memory.tsx
+++ b/web/src/pages/Memory.tsx
@@ -58,6 +58,14 @@ export default function Memory() {
   };
 
   const categories = Array.from(new Set(entries.map((e) => e.category))).sort();
+  const scopes = Array.from(new Set(entries.map((e) => e.scope).filter(Boolean) as string[])).sort();
+  const hasScopes = scopes.length > 0;
+
+  const [scopeFilter, setScopeFilter] = useState('');
+
+  const filteredEntries = scopeFilter
+    ? entries.filter((e) => e.scope === scopeFilter)
+    : entries;
 
   const handleAdd = async () => {
     if (!formKey.trim() || !formContent.trim()) {
@@ -112,7 +120,7 @@ export default function Memory() {
         <div className="flex items-center gap-2">
           <Brain className="h-5 w-5 text-[#0080ff]" />
           <h2 className="text-sm font-semibold text-white uppercase tracking-wider">
-            {t('memory.memory_title')} ({entries.length})
+            {t('memory.memory_title')} ({filteredEntries.length})
           </h2>
         </div>
         <button
@@ -152,6 +160,23 @@ export default function Memory() {
             ))}
           </select>
         </div>
+        {hasScopes && (
+          <div className="relative">
+            <Filter className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-[#334060]" />
+            <select
+              value={scopeFilter}
+              onChange={(e) => setScopeFilter(e.target.value)}
+              className="input-electric pl-10 pr-8 py-2.5 text-sm appearance-none cursor-pointer"
+            >
+              <option value="">All Scopes</option>
+              {scopes.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
         <button
           onClick={handleSearch}
           className="btn-electric px-4 py-2.5 text-sm"
@@ -269,12 +294,13 @@ export default function Memory() {
                 <th className="text-left">{t('memory.key')}</th>
                 <th className="text-left">{t('memory.content')}</th>
                 <th className="text-left">{t('memory.category')}</th>
+                {hasScopes && <th className="text-left">Scope</th>}
                 <th className="text-left">{t('memory.timestamp')}</th>
                 <th className="text-right">{t('common.actions')}</th>
               </tr>
             </thead>
             <tbody>
-              {entries.map((entry) => (
+              {filteredEntries.map((entry) => (
                 <tr key={entry.id}>
                   <td className="px-4 py-3 text-white font-medium font-mono text-xs">
                     {entry.key}
@@ -289,6 +315,17 @@ export default function Memory() {
                       {entry.category}
                     </span>
                   </td>
+                  {hasScopes && (
+                    <td className="px-4 py-3">
+                      {entry.scope ? (
+                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-semibold capitalize border ${entry.scope === 'group' ? 'border-[#3e1a3e] text-[#a888c8]' : 'border-[#1a3e2e] text-[#88a898]'}`} style={{ background: entry.scope === 'group' ? 'rgba(128,0,255,0.06)' : 'rgba(0,255,128,0.06)' }}>
+                          {entry.scope}
+                        </span>
+                      ) : (
+                        <span className="text-[#334060] text-xs">—</span>
+                      )}
+                    </td>
+                  )}
                   <td className="px-4 py-3 text-[#556080] text-xs whitespace-nowrap">
                     {formatDate(entry.timestamp)}
                   </td>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -73,6 +73,7 @@ export interface MemoryEntry {
   timestamp: string;
   session_id: string | null;
   score: number | null;
+  scope: string | null;
 }
 
 export interface CostSummary {


### PR DESCRIPTION
## Summary
- **Fix mem0 data loss on restart**: Add `on_disk: True` to qdrant vector_store config — without this, mem0 SDK's qdrant client deletes all data on every init
- **Fix metadata key mismatch**: Server returned `metadata_`, Rust expected `metadata`. Fixed both sides: server outputs `metadata`, Rust uses `alias` to accept both
- **Add `scope` metadata**: `MemoryEntry` gains `scope: Option<String>` across all backends. Mem0 `store()` auto-derives scope (`"personal"` / `"group"`) from session_id pattern
- **Web UI scope support**: Scope column (purple=group, green=personal) and filter dropdown, hidden when no scope data exists (non-mem0 backends)
- **Docs**: `on_disk` requirement warning + scope behavior documented (EN/zh-CN/VI)

## Changed files
- `deploy/mem0/mem0-server.py` — `on_disk: True` + `metadata_` → `metadata`
- `src/memory/traits.rs` — `scope: Option<String>` on `MemoryEntry`
- `src/memory/mem0.rs` — scope in metadata structs, scope derivation, `alias` for compat
- `src/memory/{sqlite,markdown,lucid,qdrant,postgres}.rs` — `scope: None`
- `src/agent/memory_loader.rs`, `src/channels/mod.rs` — `scope: None` in test fixtures
- `web/src/types/api.ts` — `scope` field
- `web/src/pages/Memory.tsx` — conditional scope column + filter
- `docs/reference/api/config-reference.md` + zh-CN + VI

## Test plan
- [x] `cargo check --features memory-mem0` passes
- [x] All memory tests pass
- [x] Manual: restart mem0 server, verify data persists
- [ ] Manual: send group + DM messages, verify scope labels in web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)