### PR TITLE
fix(cron): add qq to supported delivery channel whitelist

### DIFF
--- a/src/cron/mod.rs
+++ b/src/cron/mod.rs
@@ -62,7 +62,7 @@ pub(crate) fn validate_delivery_config(delivery: Option<&DeliveryConfig>) -> Res
         bail!("delivery.channel is required for announce mode");
     };
     match channel.to_ascii_lowercase().as_str() {
-        "telegram" | "discord" | "slack" | "mattermost" | "signal" | "matrix" => {}
+        "telegram" | "discord" | "slack" | "mattermost" | "signal" | "matrix" | "qq" => {}
         other => bail!("unsupported delivery channel: {other}"),
     }
 


### PR DESCRIPTION
The channel validation in `validate_announce_delivery` was missing `qq`, causing API-created cron jobs with QQ delivery to be rejected.

## Summary  

  - Base branch target: master                                                                             
  - Problem: Commit 8bb61fe (fix(cron): persist delivery for api-created cron jobs #4087) introduced a
  channel whitelist in validate_announce_delivery but omitted qq, causing QQ delivery cron jobs to be      
  rejected with "unsupported delivery channel"                                                           
  - Why it matters: QQ was already registered as a cron delivery channel in scheduler.rs and cron_add.rs   
  (merged via #4095), but the new validation gate blocks it before reaching that code                      
  - What changed: Added "qq" to the supported channel match arm in src/cron/mod.rs:65
  - What did not change (scope boundary): No changes to scheduler delivery logic, tool descriptions, or any
   other module                                                                                            
                                                                                                           
  Label Snapshot (required)                                                                                
                  
  - Risk label: risk: low                                                                                  
  - Size label: size: XS
  - Scope labels: cron                                                                                     
  - Module labels: cron: store                                                                             
  - Contributor tier label: N/A
  - If any auto-label is incorrect: N/A                                                                    
                                                                                                           
  Change Metadata                                                                                          
                                                                                                           
  - Change type: bug                                                                                       
  - Primary scope: channel
                                                                                                           
  Linked Issue    
                                                                                                           
  - Closes #                                                                                               
  - Related #4087, #4095
  - Depends on #                                                                                           
  - Supersedes #                                                                                           
                                                                                                           
  Supersede Attribution                                                                                    
                  
  N/A

  Validation Evidence

  cargo fmt --all -- --check   # pass                                                                      
  cargo clippy --all-targets -- -D warnings   # pass                                                       
  cargo test --lib -- channels::qq   # 39 passed                                                           
                                                                                                           
  - Evidence provided: CI commands above, manual verification that validate_announce_delivery accepts "qq" 
  after the fix                                                                                            
  - If any command is intentionally skipped: N/A                                                           
                  
  Security Impact (required)

  - New permissions/capabilities? No                                                                       
  - New external network calls? No
  - Secrets/tokens handling changed? No                                                                    
  - File system access scope changed? No

  Privacy and Data Hygiene (required)                                                                      
   
  - Data-hygiene status: pass                                                                              
  - Redaction/anonymization notes: N/A
  - Neutral wording confirmation: Yes                                                                      
                  
  Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No                                                                                   
                                                                                                           
  i18n Follow-Through                                                                                      
                                                                                                           
  - i18n follow-through triggered? No                                                                      
                  
  Human Verification (required)                                                                            
   
  - Verified scenarios: QQ cron delivery was rejected before fix, accepted after                           
  - Edge cases checked: Other channels in whitelist remain unaffected
  - What was not verified: End-to-end cron delivery to QQ (config-dependent)                               
                                                                                                           
  Side Effects / Blast Radius (required)                                                                   
                                                                                                           
  - Affected subsystems/workflows: Cron job creation via API with channel: "qq"                            
  - Potential unintended effects: None — additive one-word change to existing match arm
  - Guardrails/monitoring for early detection: Existing test                                               
  cron_api_rejects_announce_delivery_with_unsupported_channel validates rejection of truly unsupported     
  channels                                                                                                 
                                                                                                           
  Agent Collaboration Notes (recommended)

  - Agent tools used: Claude Code                                                                          
  - Workflow/plan summary: Identified missing qq in whitelist introduced by #4087, one-line fix
  - Verification focus: Whitelist completeness against registered delivery channels                        
  - Confirmation: naming + architecture boundaries followed                                                
                                                                                                           
  Rollback Plan (required)                                                                                 
                                                                                                           
  - Fast rollback: git revert <commit-sha>                                                                 
  - Feature flags or config toggles: None
  - Observable failure symptoms: API returns 400 "unsupported delivery channel: qq" when creating QQ cron  
  jobs                                                                                                     
   
  Risks and Mitigations                                                                                    
                  
  None.           
