### PR TITLE
fix(config): prevent test suite from clobbering active_workspace.toml

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6620,7 +6620,7 @@ async fn persist_active_workspace_config_dir_in(
         );
     }
 
-    sync_directory(&default_config_dir).await?;
+    sync_directory(default_config_dir).await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): master
- Problem: `cargo test` overwrites `~/.zeroclaw/active_workspace.toml` with a stale temp-directory path, breaking subsequent `zeroclaw` commands.
- Why it matters: Any developer running `cargo test` or `git push` (via pre-push hook) has their active workspace config silently corrupted.
- What changed: Refactored `persist_active_workspace_config_dir()` to accept the default config directory as an explicit parameter. Removed `#[cfg(not(test))]` gate on temp-directory guard. Updated three tests to use the new inner function directly.
- What did **not** change (scope boundary): No changes to production behavior, config loading, or workspace resolution logic. The public API (`persist_active_workspace_config_dir`) is unchanged.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `config`, `tests`
- Module labels: `config: schema`
- Contributor tier label: N/A (first contribution)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `config`

## Linked Issue

- Closes #4117

## Validation Evidence (required)

\`\`\`bash
cargo fmt --all -- --check   # PASS
cargo clippy --all-targets -- -D warnings   # PASS
cargo test   # PASS (4,513 tests)
\`\`\`

- Evidence provided: All 4 active_workspace tests pass. Full suite passes. ~/.zeroclaw/active_workspace.toml survives cargo test unchanged.
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No PII in code or tests
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: (1) `cargo test -- active_workspace` passes 4/4, (2) full test suite 4,513 pass, (3) `~/.zeroclaw/active_workspace.toml` retains correct content after test run
- Edge cases checked: Test where both config_dir and default_dir are temp (write succeeds). Test where config_dir is temp and default_dir is real (write blocked).
- What was not verified: macOS symlink canonicalization (macOS /var -> /private/var) -- existing `is_temp_directory` handles this already.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `persist_active_workspace_config_dir` and three test functions in `config::schema::tests`
- Potential unintended effects: None -- the public API is unchanged, only the internal implementation and test callers changed
- Guardrails/monitoring for early detection: The temp-directory guard now runs unconditionally, so any regression would surface as a warning log

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Root-caused via git blame + test analysis, refactored to eliminate hidden global state dependency
- Verification focus: Test isolation, marker file survival across test runs
- Confirmation: naming + architecture boundaries followed (AGENTS.md + CONTRIBUTING.md): Yes

## Rollback Plan (required)

- Fast rollback command/path: Revert commit, re-add `#[cfg(not(test))]` gate
- Feature flags or config toggles: None
- Observable failure symptoms: Tests that manipulate HOME would clobber active_workspace.toml again

## Risks and Mitigations

- Risk: The flaky `openai_codex::resolve_responses_url` test (observed once during push) suggests other tests also have env var isolation issues
  - Mitigation: Out of scope for this PR, but same class of bug -- process-wide env var manipulation in parallel tests