### PR TITLE
feat(cron): add Edit button and unified modal for updating cron jobs

### DIFF
--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -78,6 +78,14 @@ pub struct CronAddBody {
     pub delete_after_run: Option<bool>,
 }
 
+#[derive(Deserialize)]
+pub struct CronPatchBody {
+    pub name: Option<String>,
+    pub schedule: Option<String>,
+    pub command: Option<String>,
+    pub prompt: Option<String>,
+}
+
 // ── Handlers ────────────────────────────────────────────────────
 
 /// GET /api/status — system status overview
@@ -228,27 +236,7 @@ pub async fn handle_api_cron_list(
 
     let config = state.config.lock().clone();
     match crate::cron::list_jobs(&config) {
-        Ok(jobs) => {
-            let jobs_json: Vec<serde_json::Value> = jobs
-                .iter()
-                .map(|job| {
-                    serde_json::json!({
-                        "id": job.id,
-                        "name": job.name,
-                        "job_type": job.job_type,
-                        "command": job.command,
-                        "prompt": job.prompt,
-                        "schedule": job.schedule,
-                        "next_run": job.next_run.to_rfc3339(),
-                        "last_run": job.last_run.map(|t| t.to_rfc3339()),
-                        "last_status": job.last_status,
-                        "enabled": job.enabled,
-                        "delivery": job.delivery,
-                    })
-                })
-                .collect();
-            Json(serde_json::json!({"jobs": jobs_json})).into_response()
-        }
+        Ok(jobs) => Json(serde_json::json!({"jobs": jobs})).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": format!("Failed to list cron jobs: {e}")})),
@@ -344,20 +332,7 @@ pub async fn handle_api_cron_add(
     };
 
     match result {
-        Ok(job) => Json(serde_json::json!({
-            "status": "ok",
-            "job": {
-                "id": job.id,
-                "name": job.name,
-                "job_type": job.job_type,
-                "command": job.command,
-                "prompt": job.prompt,
-                "schedule": job.schedule,
-                "enabled": job.enabled,
-                "delivery": job.delivery,
-            }
-        }))
-        .into_response(),
+        Ok(job) => Json(serde_json::json!({"status": "ok", "job": job})).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": format!("Failed to add cron job: {e}")})),
@@ -410,6 +385,66 @@ pub async fn handle_api_cron_runs(
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": format!("Failed to list cron runs: {e}")})),
+        )
+            .into_response(),
+    }
+}
+
+/// PATCH /api/cron/:id — update an existing cron job
+pub async fn handle_api_cron_patch(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(body): Json<CronPatchBody>,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let config = state.config.lock().clone();
+
+    // Build the schedule from the provided expression string (if any).
+    let schedule = match body.schedule {
+        Some(expr) if !expr.trim().is_empty() => Some(crate::cron::Schedule::Cron {
+            expr: expr.trim().to_string(),
+            tz: None,
+        }),
+        _ => None,
+    };
+
+    // Route the edited text to the correct field based on the job's stored type.
+    // The frontend sends a single textarea value; for agent jobs it is the prompt,
+    // for shell jobs it is the command.
+    let existing = match crate::cron::get_job(&config, &id) {
+        Ok(j) => j,
+        Err(e) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": format!("Cron job not found: {e}")})),
+            )
+                .into_response();
+        }
+    };
+    let is_agent = matches!(existing.job_type, crate::cron::JobType::Agent);
+    let (patch_command, patch_prompt) = if is_agent {
+        (None, body.command.or(body.prompt))
+    } else {
+        (body.command.or(body.prompt), None)
+    };
+
+    let patch = crate::cron::CronJobPatch {
+        name: body.name,
+        schedule,
+        command: patch_command,
+        prompt: patch_prompt,
+        ..crate::cron::CronJobPatch::default()
+    };
+
+    match crate::cron::update_shell_job_with_approval(&config, &id, patch, false) {
+        Ok(job) => Json(serde_json::json!({"status": "ok", "job": job})).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Failed to update cron job: {e}")})),
         )
             .into_response(),
     }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -783,7 +783,10 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
             "/api/cron/settings",
             get(api::handle_api_cron_settings_get).patch(api::handle_api_cron_settings_patch),
         )
-        .route("/api/cron/{id}", delete(api::handle_api_cron_delete))
+        .route(
+            "/api/cron/{id}",
+            delete(api::handle_api_cron_delete).patch(api::handle_api_cron_patch),
+        )
         .route("/api/cron/{id}/runs", get(api::handle_api_cron_runs))
         .route("/api/integrations", get(api::handle_api_integrations))
         .route(

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -182,6 +182,19 @@ export function deleteCronJob(id: string): Promise<void> {
     method: 'DELETE',
   });
 }
+export function patchCronJob(
+  id: string,
+  patch: { name?: string; schedule?: string; command?: string },
+): Promise<CronJob> {
+  return apiFetch<CronJob | { status: string; job: CronJob }>(
+    `/api/cron/${encodeURIComponent(id)}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(patch),
+    },
+  ).then((data) => (typeof (data as { job?: CronJob }).job === 'object' ? (data as { job: CronJob }).job : (data as CronJob)));
+}
+
 
 export function getCronRuns(
   jobId: string,

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -113,6 +113,11 @@ const translations: Record<Locale, Record<string, string>> = {
     'cron.recent_runs': '最近运行',
     'cron.yes': '是',
     'cron.no': '否',
+    'cron.edit': '编辑',
+    'cron.edit_modal_title': '编辑 Cron 任务',
+    'cron.edit_error': '更新任务失败',
+    'cron.saving': '保存中...',
+    'cron.save': '保存',
 
     // Integrations
     'integrations.title': '集成',
@@ -415,6 +420,11 @@ const translations: Record<Locale, Record<string, string>> = {
     'cron.recent_runs': 'Recent Runs',
     'cron.yes': 'Yes',
     'cron.no': 'No',
+    'cron.edit': 'Edit',
+    'cron.edit_modal_title': 'Edit Cron Job',
+    'cron.edit_error': 'Failed to update job',
+    'cron.saving': 'Saving...',
+    'cron.save': 'Save',
 
     // Integrations
     'integrations.title': 'Integrations',
@@ -739,6 +749,11 @@ const translations: Record<Locale, Record<string, string>> = {
     'cron.recent_runs': 'Son Çalıştırmalar',
     'cron.yes': 'Evet',
     'cron.no': 'Hayır',
+    'cron.edit': 'Düzenle',
+    'cron.edit_modal_title': 'Cron Görevini Düzenle',
+    'cron.edit_error': 'Görev güncellenemedi',
+    'cron.saving': 'Kaydediliyor...',
+    'cron.save': 'Kaydet',
 
     // Integrations
     'integrations.title': 'Entegrasyonlar',

--- a/web/src/pages/Cron.tsx
+++ b/web/src/pages/Cron.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   ChevronRight,
   RefreshCw,
+  Pencil,
 } from 'lucide-react';
 import type { CronJob, CronRun } from '@/types/api';
 import {
@@ -19,6 +20,7 @@ import {
   getCronRuns,
   getCronSettings,
   patchCronSettings,
+  patchCronJob,
 } from '@/lib/api';
 import type { CronSettings } from '@/lib/api';
 import { t } from '@/lib/i18n';
@@ -148,18 +150,43 @@ export default function Cron() {
   const [jobs, setJobs] = useState<CronJob[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [showForm, setShowForm] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [expandedJob, setExpandedJob] = useState<string | null>(null);
   const [settings, setSettings] = useState<CronSettings | null>(null);
   const [togglingCatchUp, setTogglingCatchUp] = useState(false);
 
-  // Form state
+  // Unified modal: null = closed, 'add' = adding, CronJob = editing
+  const [modalJob, setModalJob] = useState<CronJob | 'add' | null>(null);
+
+  // Shared form state for both add and edit
   const [formName, setFormName] = useState('');
   const [formSchedule, setFormSchedule] = useState('');
   const [formCommand, setFormCommand] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  const isEditing = modalJob !== null && modalJob !== 'add';
+
+  const openAddModal = () => {
+    setFormName('');
+    setFormSchedule('');
+    setFormCommand('');
+    setFormError(null);
+    setModalJob('add');
+  };
+
+  const openEditModal = (job: CronJob) => {
+    setFormName(job.name ?? '');
+    setFormSchedule(job.expression);
+    setFormCommand(job.prompt ?? job.command);
+    setFormError(null);
+    setModalJob(job);
+  };
+
+  const closeModal = () => {
+    setModalJob(null);
+    setFormError(null);
+  };
 
   const fetchJobs = () => {
     setLoading(true);
@@ -193,7 +220,7 @@ export default function Cron() {
     fetchSettings();
   }, []);
 
-  const handleAdd = async () => {
+  const handleSubmit = async () => {
     if (!formSchedule.trim() || !formCommand.trim()) {
       setFormError(t('cron.validation_error'));
       return;
@@ -201,18 +228,28 @@ export default function Cron() {
     setSubmitting(true);
     setFormError(null);
     try {
-      const job = await addCronJob({
-        name: formName.trim() || undefined,
-        schedule: formSchedule.trim(),
-        command: formCommand.trim(),
-      });
-      setJobs((prev) => [...prev, job]);
-      setShowForm(false);
-      setFormName('');
-      setFormSchedule('');
-      setFormCommand('');
+      if (isEditing) {
+        const updated = await patchCronJob((modalJob as CronJob).id, {
+          name: formName.trim() || undefined,
+          schedule: formSchedule.trim(),
+          command: formCommand.trim(),
+        });
+        setJobs((prev) => prev.map((j) => (j.id === updated.id ? updated : j)));
+      } else {
+        const job = await addCronJob({
+          name: formName.trim() || undefined,
+          schedule: formSchedule.trim(),
+          command: formCommand.trim(),
+        });
+        setJobs((prev) => [...prev, job]);
+      }
+      closeModal();
     } catch (err: unknown) {
-      setFormError(err instanceof Error ? err.message : t('cron.add_error'));
+      setFormError(
+        err instanceof Error
+          ? err.message
+          : t(isEditing ? 'cron.edit_error' : 'cron.add_error'),
+      );
     } finally {
       setSubmitting(false);
     }
@@ -272,7 +309,7 @@ export default function Cron() {
           </h2>
         </div>
         <button
-          onClick={() => setShowForm(true)}
+          onClick={openAddModal}
           className="btn-electric flex items-center gap-2 text-sm px-4 py-2"
         >
           <Plus className="h-4 w-4" />
@@ -311,17 +348,16 @@ export default function Cron() {
         </div>
       )}
 
-      {/* Add Job Form Modal */}
-      {showForm && (
+      {/* Unified Add / Edit Modal */}
+      {modalJob !== null && (
         <div className="fixed inset-0 modal-backdrop flex items-center justify-center z-50">
           <div className="glass-card p-6 w-full max-w-md mx-4 animate-fade-in-scale">
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-white">{t('cron.add_modal_title')}</h3>
+              <h3 className="text-lg font-semibold text-white">
+                {isEditing ? t('cron.edit_modal_title') : t('cron.add_modal_title')}
+              </h3>
               <button
-                onClick={() => {
-                  setShowForm(false);
-                  setFormError(null);
-                }}
+                onClick={closeModal}
                 className="text-[#556080] hover:text-white transition-colors duration-300"
               >
                 <X className="h-5 w-5" />
@@ -363,32 +399,31 @@ export default function Cron() {
                 <label className="block text-xs font-semibold text-[#8892a8] mb-1.5 uppercase tracking-wider">
                   {t('cron.command_required')} <span className="text-[#ff4466]">*</span>
                 </label>
-                <input
-                  type="text"
+                <textarea
                   value={formCommand}
                   onChange={(e) => setFormCommand(e.target.value)}
                   placeholder="e.g. cleanup --older-than 7d"
-                  className="input-electric w-full px-3 py-2.5 text-sm"
+                  rows={4}
+                  className="input-electric w-full px-3 py-2.5 text-sm resize-y"
                 />
               </div>
             </div>
 
             <div className="flex justify-end gap-3 mt-6">
               <button
-                onClick={() => {
-                  setShowForm(false);
-                  setFormError(null);
-                }}
+                onClick={closeModal}
                 className="px-4 py-2 text-sm font-medium text-[#8892a8] hover:text-white border border-[#1a1a3e] rounded-xl hover:bg-[#0080ff08] transition-all duration-300"
               >
                 {t('cron.cancel')}
               </button>
               <button
-                onClick={handleAdd}
+                onClick={handleSubmit}
                 disabled={submitting}
                 className="btn-electric px-4 py-2 text-sm font-medium"
               >
-                {submitting ? t('cron.adding') : t('cron.add_job')}
+                {submitting
+                  ? t(isEditing ? 'cron.saving' : 'cron.adding')
+                  : t(isEditing ? 'cron.save' : 'cron.add_job')}
               </button>
             </div>
           </div>
@@ -441,7 +476,7 @@ export default function Cron() {
                       {job.name ?? '-'}
                     </td>
                     <td className="px-4 py-3 text-[#8892a8] font-mono text-xs max-w-[200px] truncate">
-                      {job.command}
+                      {job.prompt ?? job.command}
                     </td>
                     <td className="px-4 py-3 text-[#556080] text-xs">
                       {formatDate(job.next_run)}
@@ -467,30 +502,39 @@ export default function Cron() {
                       </span>
                     </td>
                     <td className="px-4 py-3 text-right">
-                      {confirmDelete === job.id ? (
-                        <div className="flex items-center justify-end gap-2 animate-fade-in">
-                          <span className="text-xs text-[#ff4466]">{t('cron.confirm_delete')}</span>
-                          <button
-                            onClick={() => handleDelete(job.id)}
-                            className="text-[#ff4466] hover:text-[#ff6680] text-xs font-medium"
-                          >
-                            {t('cron.yes')}
-                          </button>
-                          <button
-                            onClick={() => setConfirmDelete(null)}
-                            className="text-[#556080] hover:text-white text-xs font-medium"
-                          >
-                            {t('cron.no')}
-                          </button>
-                        </div>
-                      ) : (
+                      <div className="flex items-center justify-end gap-2">
                         <button
-                          onClick={() => setConfirmDelete(job.id)}
-                          className="text-[#334060] hover:text-[#ff4466] transition-all duration-300"
+                          onClick={() => openEditModal(job)}
+                          className="text-[#334060] hover:text-[#0080ff] transition-all duration-300"
+                          title={t('cron.edit')}
                         >
-                          <Trash2 className="h-4 w-4" />
+                          <Pencil className="h-4 w-4" />
                         </button>
-                      )}
+                        {confirmDelete === job.id ? (
+                          <div className="flex items-center justify-end gap-2 animate-fade-in">
+                            <span className="text-xs text-[#ff4466]">{t('cron.confirm_delete')}</span>
+                            <button
+                              onClick={() => handleDelete(job.id)}
+                              className="text-[#ff4466] hover:text-[#ff6680] text-xs font-medium"
+                            >
+                              {t('cron.yes')}
+                            </button>
+                            <button
+                              onClick={() => setConfirmDelete(null)}
+                              className="text-[#556080] hover:text-white text-xs font-medium"
+                            >
+                              {t('cron.no')}
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            onClick={() => setConfirmDelete(job.id)}
+                            className="text-[#334060] hover:text-[#ff4466] transition-all duration-300"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        )}
+                      </div>
                     </td>
                   </tr>
                   {expandedJob === job.id && (

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -35,11 +35,19 @@ export interface ToolSpec {
 export interface CronJob {
   id: string;
   name: string | null;
+  expression: string;
   command: string;
+  prompt: string | null;
+  job_type: string;
+  schedule: unknown;
+  enabled: boolean;
+  delivery: unknown;
+  delete_after_run: boolean;
+  created_at: string;
   next_run: string;
   last_run: string | null;
   last_status: string | null;
-  enabled: boolean;
+  last_output: string | null;
 }
 
 export interface CronRun {


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The `/cron` dashboard page had no way to edit an existing scheduled job — users had to delete and recreate jobs to change them, or use the CLI.
- Why it matters: Live cron jobs (including agent jobs with long prompts) could not be updated from the web UI.
- What changed: Added a unified Add/Edit modal on the `/cron` page with a `PATCH /api/cron/{id}` backend endpoint. The Add button and new Edit (pencil) button both open the same modal — pre-populated when editing. The command/prompt field is a resizable textarea. The handler detects the job's stored type and routes the edited text to either `command` (shell jobs) or `prompt` (agent jobs) in `CronJobPatch`. The API list/add/patch handlers now serialize the full `CronJob` struct via serde instead of hand-picking fields, so the frontend always has the same data the CLI sees.
- What did **not** change: Job scheduling logic, security policy enforcement (`approved=false` is preserved), run history, the catch-up toggle, delete flow, or any other page.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: M`
- Scope labels: `cron`, `gateway`
- Module labels: `cron: dashboard`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `runtime`

## Linked Issue

- Closes: N/A
- Related: N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A — no superseded PRs.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
# Result: clean, no diff

cargo test --lib gateway::api
# Result: 7 passed; 0 failed; 0 ignored

cd web && npx tsc -b --noEmit
# Result: clean, no type errors
```

- `cargo clippy --all-targets -- -D warnings`: skipped — SIGKILL (OOM) during full compilation on this machine; `cargo check` and `cargo fmt` pass clean, all existing gateway::api tests pass.
- Feature verified manually end-to-end against a live daemon with 4 active agent cron jobs: edit modal pre-populates all three fields correctly, saving updates the table row in-place.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

The `PATCH /api/cron/{id}` handler requires bearer token auth (same as all other `/api/*` routes) and calls `update_shell_job_with_approval(..., approved=false)`, preserving the existing security policy gate.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No personal data introduced. Tests and examples use neutral project-scoped strings.
- Neutral wording confirmation: All user-facing strings go through the i18n system with keys only.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

The API response for `GET /api/cron` and `POST /api/cron` now serializes the full `CronJob` struct. All previously returned fields are still present; additional fields are now included. Existing clients that ignore unknown JSON fields are unaffected.

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? Yes
- 5 new keys added to all 3 runtime locales (`en`, `zh`, `tr`): `cron.edit`, `cron.edit_modal_title`, `cron.edit_error`, `cron.saving`, `cron.save`
- `ja`, `ru`, `fr`, `vi` locale docs updated? No — these locales are not present in `web/src/lib/i18n.ts`; the runtime i18n module only covers `en`, `zh`, `tr`. No docs locale navigation was changed.

## Human Verification (required)

- Verified scenarios:
  - Clicking Edit on a live agent job opens the modal pre-populated with name, cron expression, and full prompt text
  - Saving calls `PATCH /api/cron/{id}` and updates the table row in-place without a page reload
  - Add Job button still works correctly using the same modal in add mode
  - Closing via ✕ or Cancel resets state cleanly
  - Resizable textarea handles long prompts (300+ characters) without horizontal scrolling
  - Command column in the table shows `prompt ?? command` so agent job content is visible
- Edge cases checked:
  - Empty schedule or command shows validation error without calling the API
  - Backend 404 on missing job ID returns error surfaced in the modal
- What was not verified: Edit flow for shell jobs with delivery config (no such jobs in test environment); `allowed_tools` and `model` fields are intentionally not exposed in the modal

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `/cron` dashboard page, `GET /api/cron`, `POST /api/cron` response shape (additional fields now included)
- Potential unintended effects: Clients consuming `GET /api/cron` or `POST /api/cron` that are strict about unknown JSON fields may see new keys. Standard JSON parsers ignore unknown fields so this is safe in practice.
- Guardrails/monitoring for early detection: Existing gateway API tests cover the cron add/list paths.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Sonnet 4.6 via Zed editor agent panel
- Workflow summary: Explored existing cron handler patterns → added `PATCH` handler → unified two-modal design into one → switched hand-rolled JSON serialization to direct serde struct serialization → added `textarea` for long content → fixed agent/shell job routing so `prompt` vs `command` is set correctly based on stored job type
- Verification focus: Matching the data shape the CLI exposes (`zeroclaw cron list`) so the web UI has full fidelity with the same backend store
- Confirmation: naming + architecture boundaries followed per `AGENTS.md` + `CONTRIBUTING.md`

## Rollback Plan (required)

- Fast rollback command/path: Remove `cron-edit-modal.patch` from `~/.zeroclaw/patches/` and re-run `update_zeropaw.sh`; or revert this PR
- Feature flags or config toggles: None
- Observable failure symptoms: `PATCH /api/cron/{id}` returns 404 or 500; modal displays error inline; no data loss possible

## Risks and Mitigations

- Risk: `allowed_tools` and `model` fields on agent jobs are not exposed in the edit modal.
  - Mitigation: Intentional scope boundary for this PR — those fields are passed through unchanged. A follow-up can add them if needed.