### PR TITLE
fix(channels): wire model_switch callback into channel inference path

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -89,7 +89,10 @@ pub use whatsapp::WhatsAppChannel;
 #[cfg(feature = "whatsapp-web")]
 pub use whatsapp_web::WhatsAppWebChannel;
 
-use crate::agent::loop_::{build_tool_instructions, run_tool_call_loop, scrub_credentials};
+use crate::agent::loop_::{
+    build_tool_instructions, clear_model_switch_request, get_model_switch_state,
+    is_model_switch_requested, run_tool_call_loop, scrub_credentials,
+};
 use crate::approval::ApprovalManager;
 use crate::config::Config;
 use crate::identity;
@@ -2081,7 +2084,7 @@ async fn process_channel_message(
     }
 
     let runtime_defaults = runtime_defaults_snapshot(ctx.as_ref());
-    let active_provider = match get_or_create_provider(
+    let mut active_provider = match get_or_create_provider(
         ctx.as_ref(),
         &route.provider,
         route.api_key.as_deref(),
@@ -2391,45 +2394,92 @@ async fn process_channel_message(
         Cancelled,
     }
 
+    let model_switch_callback = get_model_switch_state();
     let timeout_budget_secs =
         channel_message_timeout_budget_secs(ctx.message_timeout_secs, ctx.max_tool_iterations);
     let llm_call_start = Instant::now();
     #[allow(clippy::cast_possible_truncation)]
     let elapsed_before_llm_ms = started_at.elapsed().as_millis() as u64;
     tracing::info!(elapsed_before_llm_ms, "⏱ Starting LLM call");
-    let llm_result = tokio::select! {
-        () = cancellation_token.cancelled() => LlmExecutionResult::Cancelled,
-        result = tokio::time::timeout(
-            Duration::from_secs(timeout_budget_secs),
-            run_tool_call_loop(
-                active_provider.as_ref(),
-                &mut history,
-                ctx.tools_registry.as_ref(),
-                notify_observer.as_ref() as &dyn Observer,
-                route.provider.as_str(),
-                route.model.as_str(),
-                runtime_defaults.temperature,
-                true,
-                Some(&*ctx.approval_manager),
-                msg.channel.as_str(),
-                Some(msg.reply_target.as_str()),
-                &ctx.multimodal,
-                ctx.max_tool_iterations,
-                Some(cancellation_token.clone()),
-                delta_tx,
-                ctx.hooks.as_deref(),
-                if msg.channel == "cli"
-                    || ctx.autonomy_level == AutonomyLevel::Full
+    let llm_result = loop {
+        let loop_result = tokio::select! {
+            () = cancellation_token.cancelled() => LlmExecutionResult::Cancelled,
+            result = tokio::time::timeout(
+                Duration::from_secs(timeout_budget_secs),
+                run_tool_call_loop(
+                    active_provider.as_ref(),
+                    &mut history,
+                    ctx.tools_registry.as_ref(),
+                    notify_observer.as_ref() as &dyn Observer,
+                    route.provider.as_str(),
+                    route.model.as_str(),
+                    runtime_defaults.temperature,
+                    true,
+                    Some(&*ctx.approval_manager),
+                    msg.channel.as_str(),
+                    Some(msg.reply_target.as_str()),
+                    &ctx.multimodal,
+                    ctx.max_tool_iterations,
+                    Some(cancellation_token.clone()),
+                    delta_tx.clone(),
+                    ctx.hooks.as_deref(),
+                    if msg.channel == "cli"
+                        || ctx.autonomy_level == AutonomyLevel::Full
+                    {
+                        &[]
+                    } else {
+                        ctx.non_cli_excluded_tools.as_ref()
+                    },
+                    ctx.tool_call_dedup_exempt.as_ref(),
+                    ctx.activated_tools.as_ref(),
+                    Some(model_switch_callback.clone()),
+                ),
+            ) => LlmExecutionResult::Completed(result),
+        };
+
+        // Handle model switch: re-create the provider and retry
+        if let LlmExecutionResult::Completed(Ok(Err(ref e))) = loop_result {
+            if let Some((new_provider, new_model)) = is_model_switch_requested(e) {
+                tracing::info!(
+                    "Model switch requested, switching from {} {} to {} {}",
+                    route.provider,
+                    route.model,
+                    new_provider,
+                    new_model
+                );
+
+                match create_resilient_provider_nonblocking(
+                    &new_provider,
+                    ctx.api_key.clone(),
+                    ctx.api_url.clone(),
+                    ctx.reliability.as_ref().clone(),
+                    ctx.provider_runtime_options.clone(),
+                )
+                .await
                 {
-                    &[]
-                } else {
-                    ctx.non_cli_excluded_tools.as_ref()
-                },
-                ctx.tool_call_dedup_exempt.as_ref(),
-                ctx.activated_tools.as_ref(),
-                None,
-            ),
-        ) => LlmExecutionResult::Completed(result),
+                    Ok(new_prov) => {
+                        active_provider = Arc::from(new_prov);
+                        route.provider = new_provider;
+                        route.model = new_model;
+                        clear_model_switch_request();
+
+                        ctx.observer.record_event(&ObserverEvent::AgentStart {
+                            provider: route.provider.clone(),
+                            model: route.model.clone(),
+                        });
+
+                        continue;
+                    }
+                    Err(err) => {
+                        tracing::error!("Failed to create provider after model switch: {err}");
+                        clear_model_switch_request();
+                        // Fall through with the original error
+                    }
+                }
+            }
+        }
+
+        break loop_result;
     };
 
     if let Some(handle) = draft_updater {


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The channel path in `src/channels/mod.rs` passes `None` as the `model_switch_callback` to `run_tool_call_loop()`, so model switching via the `model_switch` tool is silently ignored in channel mode.
- Why it matters: Users in channel mode (Telegram, Discord, Slack, etc.) cannot switch models at runtime, despite the tool appearing available.
- What changed: Wired `model_switch_callback` into the channel's `run_tool_call_loop` call and added retry logic to handle `ModelSwitchRequested` errors by re-creating the provider with the new model.
- What did **not** change: CLI path, tool implementation, provider construction logic.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `channel`, `agent`
- Module labels: `channel: all`
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #4107

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # Pass
cargo check                  # Pass (no Rust errors; linker errors due to local Xcode license issue, unrelated)
```

- Evidence provided: `cargo fmt` and `cargo check` pass with no Rust compilation errors or warnings.
- If any command is intentionally skipped, explain why: `cargo clippy` and `cargo test` skipped due to local Xcode license issue preventing linking. The change is straightforward wiring that mirrors the existing CLI pattern.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Code review against CLI path pattern; confirmed same callback/error-handling flow.
- Edge cases checked: Provider creation failure after model switch (logs error, clears request, falls through with original error).
- What was not verified: Runtime integration test in channel mode (requires running instance).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Channel message processing path only.
- Potential unintended effects: None expected; the retry loop only activates when model_switch tool is explicitly invoked.
- Guardrails/monitoring for early detection: Existing tracing logs for model switch events.

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None
- Observable failure symptoms: Model switch tool returning success but model not actually changing in channel mode (pre-fix behavior).

## Risks and Mitigations

- Risk: Provider creation failure during model switch could leave the conversation in a partially broken state.
  - Mitigation: On failure, the global switch request is cleared and the original error propagates, matching existing error handling patterns.