### PR TITLE
feat(cron): add Edit button and unified modal for updating cron jobs

### DIFF
--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -78,6 +78,14 @@ pub struct CronAddBody {
     pub delete_after_run: Option<bool>,
 }
 
+#[derive(Deserialize)]
+pub struct CronPatchBody {
+    pub name: Option<String>,
+    pub schedule: Option<String>,
+    pub command: Option<String>,
+    pub prompt: Option<String>,
+}
+
 // ── Handlers ────────────────────────────────────────────────────
 
 /// GET /api/status — system status overview
@@ -228,27 +236,7 @@ pub async fn handle_api_cron_list(
 
     let config = state.config.lock().clone();
     match crate::cron::list_jobs(&config) {
-        Ok(jobs) => {
-            let jobs_json: Vec<serde_json::Value> = jobs
-                .iter()
-                .map(|job| {
-                    serde_json::json!({
-                        "id": job.id,
-                        "name": job.name,
-                        "job_type": job.job_type,
-                        "command": job.command,
-                        "prompt": job.prompt,
-                        "schedule": job.schedule,
-                        "next_run": job.next_run.to_rfc3339(),
-                        "last_run": job.last_run.map(|t| t.to_rfc3339()),
-                        "last_status": job.last_status,
-                        "enabled": job.enabled,
-                        "delivery": job.delivery,
-                    })
-                })
-                .collect();
-            Json(serde_json::json!({"jobs": jobs_json})).into_response()
-        }
+        Ok(jobs) => Json(serde_json::json!({"jobs": jobs})).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": format!("Failed to list cron jobs: {e}")})),
@@ -344,20 +332,7 @@ pub async fn handle_api_cron_add(
     };
 
     match result {
-        Ok(job) => Json(serde_json::json!({
-            "status": "ok",
-            "job": {
-                "id": job.id,
-                "name": job.name,
-                "job_type": job.job_type,
-                "command": job.command,
-                "prompt": job.prompt,
-                "schedule": job.schedule,
-                "enabled": job.enabled,
-                "delivery": job.delivery,
-            }
-        }))
-        .into_response(),
+        Ok(job) => Json(serde_json::json!({"status": "ok", "job": job})).into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": format!("Failed to add cron job: {e}")})),
@@ -410,6 +385,66 @@ pub async fn handle_api_cron_runs(
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": format!("Failed to list cron runs: {e}")})),
+        )
+            .into_response(),
+    }
+}
+
+/// PATCH /api/cron/:id — update an existing cron job
+pub async fn handle_api_cron_patch(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(body): Json<CronPatchBody>,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let config = state.config.lock().clone();
+
+    // Build the schedule from the provided expression string (if any).
+    let schedule = match body.schedule {
+        Some(expr) if !expr.trim().is_empty() => Some(crate::cron::Schedule::Cron {
+            expr: expr.trim().to_string(),
+            tz: None,
+        }),
+        _ => None,
+    };
+
+    // Route the edited text to the correct field based on the job's stored type.
+    // The frontend sends a single textarea value; for agent jobs it is the prompt,
+    // for shell jobs it is the command.
+    let existing = match crate::cron::get_job(&config, &id) {
+        Ok(j) => j,
+        Err(e) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({"error": format!("Cron job not found: {e}")})),
+            )
+                .into_response();
+        }
+    };
+    let is_agent = matches!(existing.job_type, crate::cron::JobType::Agent);
+    let (patch_command, patch_prompt) = if is_agent {
+        (None, body.command.or(body.prompt))
+    } else {
+        (body.command.or(body.prompt), None)
+    };
+
+    let patch = crate::cron::CronJobPatch {
+        name: body.name,
+        schedule,
+        command: patch_command,
+        prompt: patch_prompt,
+        ..crate::cron::CronJobPatch::default()
+    };
+
+    match crate::cron::update_shell_job_with_approval(&config, &id, patch, false) {
+        Ok(job) => Json(serde_json::json!({"status": "ok", "job": job})).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Failed to update cron job: {e}")})),
         )
             .into_response(),
     }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -843,7 +843,10 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
             "/api/cron/settings",
             get(api::handle_api_cron_settings_get).patch(api::handle_api_cron_settings_patch),
         )
-        .route("/api/cron/{id}", delete(api::handle_api_cron_delete))
+        .route(
+            "/api/cron/{id}",
+            delete(api::handle_api_cron_delete).patch(api::handle_api_cron_patch),
+        )
         .route("/api/cron/{id}/runs", get(api::handle_api_cron_runs))
         .route("/api/integrations", get(api::handle_api_integrations))
         .route(

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -182,6 +182,19 @@ export function deleteCronJob(id: string): Promise<void> {
     method: 'DELETE',
   });
 }
+export function patchCronJob(
+  id: string,
+  patch: { name?: string; schedule?: string; command?: string },
+): Promise<CronJob> {
+  return apiFetch<CronJob | { status: string; job: CronJob }>(
+    `/api/cron/${encodeURIComponent(id)}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(patch),
+    },
+  ).then((data) => (typeof (data as { job?: CronJob }).job === 'object' ? (data as { job: CronJob }).job : (data as CronJob)));
+}
+
 
 export function getCronRuns(
   jobId: string,

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -113,6 +113,11 @@ const translations: Record<Locale, Record<string, string>> = {
     'cron.recent_runs': '最近运行',
     'cron.yes': '是',
     'cron.no': '否',
+    'cron.edit': '编辑',
+    'cron.edit_modal_title': '编辑 Cron 任务',
+    'cron.edit_error': '更新任务失败',
+    'cron.saving': '保存中...',
+    'cron.save': '保存',
 
     // Integrations
     'integrations.title': '集成',
@@ -415,6 +420,11 @@ const translations: Record<Locale, Record<string, string>> = {
     'cron.recent_runs': 'Recent Runs',
     'cron.yes': 'Yes',
     'cron.no': 'No',
+    'cron.edit': 'Edit',
+    'cron.edit_modal_title': 'Edit Cron Job',
+    'cron.edit_error': 'Failed to update job',
+    'cron.saving': 'Saving...',
+    'cron.save': 'Save',
 
     // Integrations
     'integrations.title': 'Integrations',
@@ -739,6 +749,11 @@ const translations: Record<Locale, Record<string, string>> = {
     'cron.recent_runs': 'Son Çalıştırmalar',
     'cron.yes': 'Evet',
     'cron.no': 'Hayır',
+    'cron.edit': 'Düzenle',
+    'cron.edit_modal_title': 'Cron Görevini Düzenle',
+    'cron.edit_error': 'Görev güncellenemedi',
+    'cron.saving': 'Kaydediliyor...',
+    'cron.save': 'Kaydet',
 
     // Integrations
     'integrations.title': 'Entegrasyonlar',

--- a/web/src/pages/Cron.tsx
+++ b/web/src/pages/Cron.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   ChevronRight,
   RefreshCw,
+  Pencil,
 } from 'lucide-react';
 import type { CronJob, CronRun } from '@/types/api';
 import {
@@ -19,6 +20,7 @@ import {
   getCronRuns,
   getCronSettings,
   patchCronSettings,
+  patchCronJob,
 } from '@/lib/api';
 import type { CronSettings } from '@/lib/api';
 import { t } from '@/lib/i18n';
@@ -148,18 +150,43 @@ export default function Cron() {
   const [jobs, setJobs] = useState<CronJob[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [showForm, setShowForm] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
   const [expandedJob, setExpandedJob] = useState<string | null>(null);
   const [settings, setSettings] = useState<CronSettings | null>(null);
   const [togglingCatchUp, setTogglingCatchUp] = useState(false);
 
-  // Form state
+  // Unified modal: null = closed, 'add' = adding, CronJob = editing
+  const [modalJob, setModalJob] = useState<CronJob | 'add' | null>(null);
+
+  // Shared form state for both add and edit
   const [formName, setFormName] = useState('');
   const [formSchedule, setFormSchedule] = useState('');
   const [formCommand, setFormCommand] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  const isEditing = modalJob !== null && modalJob !== 'add';
+
+  const openAddModal = () => {
+    setFormName('');
+    setFormSchedule('');
+    setFormCommand('');
+    setFormError(null);
+    setModalJob('add');
+  };
+
+  const openEditModal = (job: CronJob) => {
+    setFormName(job.name ?? '');
+    setFormSchedule(job.expression);
+    setFormCommand(job.prompt ?? job.command);
+    setFormError(null);
+    setModalJob(job);
+  };
+
+  const closeModal = () => {
+    setModalJob(null);
+    setFormError(null);
+  };
 
   const fetchJobs = () => {
     setLoading(true);
@@ -193,7 +220,7 @@ export default function Cron() {
     fetchSettings();
   }, []);
 
-  const handleAdd = async () => {
+  const handleSubmit = async () => {
     if (!formSchedule.trim() || !formCommand.trim()) {
       setFormError(t('cron.validation_error'));
       return;
@@ -201,18 +228,28 @@ export default function Cron() {
     setSubmitting(true);
     setFormError(null);
     try {
-      const job = await addCronJob({
-        name: formName.trim() || undefined,
-        schedule: formSchedule.trim(),
-        command: formCommand.trim(),
-      });
-      setJobs((prev) => [...prev, job]);
-      setShowForm(false);
-      setFormName('');
-      setFormSchedule('');
-      setFormCommand('');
+      if (isEditing) {
+        const updated = await patchCronJob((modalJob as CronJob).id, {
+          name: formName.trim() || undefined,
+          schedule: formSchedule.trim(),
+          command: formCommand.trim(),
+        });
+        setJobs((prev) => prev.map((j) => (j.id === updated.id ? updated : j)));
+      } else {
+        const job = await addCronJob({
+          name: formName.trim() || undefined,
+          schedule: formSchedule.trim(),
+          command: formCommand.trim(),
+        });
+        setJobs((prev) => [...prev, job]);
+      }
+      closeModal();
     } catch (err: unknown) {
-      setFormError(err instanceof Error ? err.message : t('cron.add_error'));
+      setFormError(
+        err instanceof Error
+          ? err.message
+          : t(isEditing ? 'cron.edit_error' : 'cron.add_error'),
+      );
     } finally {
       setSubmitting(false);
     }
@@ -272,7 +309,7 @@ export default function Cron() {
           </h2>
         </div>
         <button
-          onClick={() => setShowForm(true)}
+          onClick={openAddModal}
           className="btn-electric flex items-center gap-2 text-sm px-4 py-2"
         >
           <Plus className="h-4 w-4" />
@@ -311,17 +348,16 @@ export default function Cron() {
         </div>
       )}
 
-      {/* Add Job Form Modal */}
-      {showForm && (
+      {/* Unified Add / Edit Modal */}
+      {modalJob !== null && (
         <div className="fixed inset-0 modal-backdrop flex items-center justify-center z-50">
           <div className="glass-card p-6 w-full max-w-md mx-4 animate-fade-in-scale">
             <div className="flex items-center justify-between mb-4">
-              <h3 className="text-lg font-semibold text-white">{t('cron.add_modal_title')}</h3>
+              <h3 className="text-lg font-semibold text-white">
+                {isEditing ? t('cron.edit_modal_title') : t('cron.add_modal_title')}
+              </h3>
               <button
-                onClick={() => {
-                  setShowForm(false);
-                  setFormError(null);
-                }}
+                onClick={closeModal}
                 className="text-[#556080] hover:text-white transition-colors duration-300"
               >
                 <X className="h-5 w-5" />
@@ -363,32 +399,31 @@ export default function Cron() {
                 <label className="block text-xs font-semibold text-[#8892a8] mb-1.5 uppercase tracking-wider">
                   {t('cron.command_required')} <span className="text-[#ff4466]">*</span>
                 </label>
-                <input
-                  type="text"
+                <textarea
                   value={formCommand}
                   onChange={(e) => setFormCommand(e.target.value)}
                   placeholder="e.g. cleanup --older-than 7d"
-                  className="input-electric w-full px-3 py-2.5 text-sm"
+                  rows={4}
+                  className="input-electric w-full px-3 py-2.5 text-sm resize-y"
                 />
               </div>
             </div>
 
             <div className="flex justify-end gap-3 mt-6">
               <button
-                onClick={() => {
-                  setShowForm(false);
-                  setFormError(null);
-                }}
+                onClick={closeModal}
                 className="px-4 py-2 text-sm font-medium text-[#8892a8] hover:text-white border border-[#1a1a3e] rounded-xl hover:bg-[#0080ff08] transition-all duration-300"
               >
                 {t('cron.cancel')}
               </button>
               <button
-                onClick={handleAdd}
+                onClick={handleSubmit}
                 disabled={submitting}
                 className="btn-electric px-4 py-2 text-sm font-medium"
               >
-                {submitting ? t('cron.adding') : t('cron.add_job')}
+                {submitting
+                  ? t(isEditing ? 'cron.saving' : 'cron.adding')
+                  : t(isEditing ? 'cron.save' : 'cron.add_job')}
               </button>
             </div>
           </div>
@@ -441,7 +476,7 @@ export default function Cron() {
                       {job.name ?? '-'}
                     </td>
                     <td className="px-4 py-3 text-[#8892a8] font-mono text-xs max-w-[200px] truncate">
-                      {job.command}
+                      {job.prompt ?? job.command}
                     </td>
                     <td className="px-4 py-3 text-[#556080] text-xs">
                       {formatDate(job.next_run)}
@@ -467,30 +502,39 @@ export default function Cron() {
                       </span>
                     </td>
                     <td className="px-4 py-3 text-right">
-                      {confirmDelete === job.id ? (
-                        <div className="flex items-center justify-end gap-2 animate-fade-in">
-                          <span className="text-xs text-[#ff4466]">{t('cron.confirm_delete')}</span>
-                          <button
-                            onClick={() => handleDelete(job.id)}
-                            className="text-[#ff4466] hover:text-[#ff6680] text-xs font-medium"
-                          >
-                            {t('cron.yes')}
-                          </button>
-                          <button
-                            onClick={() => setConfirmDelete(null)}
-                            className="text-[#556080] hover:text-white text-xs font-medium"
-                          >
-                            {t('cron.no')}
-                          </button>
-                        </div>
-                      ) : (
+                      <div className="flex items-center justify-end gap-2">
                         <button
-                          onClick={() => setConfirmDelete(job.id)}
-                          className="text-[#334060] hover:text-[#ff4466] transition-all duration-300"
+                          onClick={() => openEditModal(job)}
+                          className="text-[#334060] hover:text-[#0080ff] transition-all duration-300"
+                          title={t('cron.edit')}
                         >
-                          <Trash2 className="h-4 w-4" />
+                          <Pencil className="h-4 w-4" />
                         </button>
-                      )}
+                        {confirmDelete === job.id ? (
+                          <div className="flex items-center justify-end gap-2 animate-fade-in">
+                            <span className="text-xs text-[#ff4466]">{t('cron.confirm_delete')}</span>
+                            <button
+                              onClick={() => handleDelete(job.id)}
+                              className="text-[#ff4466] hover:text-[#ff6680] text-xs font-medium"
+                            >
+                              {t('cron.yes')}
+                            </button>
+                            <button
+                              onClick={() => setConfirmDelete(null)}
+                              className="text-[#556080] hover:text-white text-xs font-medium"
+                            >
+                              {t('cron.no')}
+                            </button>
+                          </div>
+                        ) : (
+                          <button
+                            onClick={() => setConfirmDelete(job.id)}
+                            className="text-[#334060] hover:text-[#ff4466] transition-all duration-300"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        )}
+                      </div>
                     </td>
                   </tr>
                   {expandedJob === job.id && (

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -35,11 +35,19 @@ export interface ToolSpec {
 export interface CronJob {
   id: string;
   name: string | null;
+  expression: string;
   command: string;
+  prompt: string | null;
+  job_type: string;
+  schedule: unknown;
+  enabled: boolean;
+  delivery: unknown;
+  delete_after_run: boolean;
+  created_at: string;
   next_run: string;
   last_run: string | null;
   last_status: string | null;
-  enabled: boolean;
+  last_output: string | null;
 }
 
 export interface CronRun {


### PR DESCRIPTION
## Summary

- Adds a `PATCH /api/cron/{id}` backend endpoint for updating existing cron jobs
- Unifies the Add/Edit modal on the `/cron` web page — the Edit (pencil) button and Add button share one modal, pre-populated when editing
- Command/prompt field is now a resizable textarea
- API list/add/patch handlers serialize full `CronJob` struct via serde instead of hand-picking fields
- Handler detects stored job type and routes edited text to `command` (shell) or `prompt` (agent) in `CronJobPatch`
- i18n keys added for edit UI in en/zh/tr locales

## Supersedes
- #4123 by @WareWolf-MoonWall

## Integrated Scope
- From #4123: full implementation cherry-picked — backend PATCH endpoint, unified modal, i18n, type updates

## Attribution
- Co-authored-by trailer added for materially incorporated contributor: Yes

## Non-goals
- No changes to scheduling logic, security policy, or cron store format

## Risk and Rollback
- Risk: Low — additive API endpoint + UI enhancement to existing cron page
- Rollback: revert commit

## Test plan
- [ ] Verify PATCH endpoint updates cron jobs correctly
- [ ] Verify Edit modal pre-populates with existing job data
- [ ] Verify Add modal still works as before
- [ ] Verify agent jobs route text to prompt field, shell jobs to command field
- [ ] Verify i18n strings render in en/zh/tr

Co-authored-by: WareWolf-MoonWall <chris.hengge@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)