### PR TITLE
fix(install): detect un-accepted Xcode license + bump to v0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9203,7 +9203,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "aardvark-sys",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"

--- a/dist/aur/.SRCINFO
+++ b/dist/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = zeroclaw
 	pkgdesc = Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.
-	pkgver = 0.5.4
+	pkgver = 0.5.5
 	pkgrel = 1
 	url = https://github.com/zeroclaw-labs/zeroclaw
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = zeroclaw
 	makedepends = git
 	depends = gcc-libs
 	depends = openssl
-	source = zeroclaw-0.5.4.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.5.4.tar.gz
+	source = zeroclaw-0.5.5.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.5.5.tar.gz
 	sha256sums = SKIP
 
 pkgname = zeroclaw

--- a/dist/aur/PKGBUILD
+++ b/dist/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: zeroclaw-labs <bot@zeroclaw.dev>
 pkgname=zeroclaw
-pkgver=0.5.4
+pkgver=0.5.5
 pkgrel=1
 pkgdesc="Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant."
 arch=('x86_64')

--- a/dist/scoop/zeroclaw.json
+++ b/dist/scoop/zeroclaw.json
@@ -1,11 +1,11 @@
 {
-    "version": "0.5.4",
+    "version": "0.5.5",
     "description": "Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.",
     "homepage": "https://github.com/zeroclaw-labs/zeroclaw",
     "license": "MIT|Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.5.4/zeroclaw-x86_64-pc-windows-msvc.zip",
+            "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.5.5/zeroclaw-x86_64-pc-windows-msvc.zip",
             "hash": "",
             "bin": "zeroclaw.exe"
         }

--- a/install.sh
+++ b/install.sh
@@ -568,6 +568,13 @@ then re-run bootstrap.
 MSG
         exit 0
       fi
+      # Detect un-accepted Xcode/CLT license (causes `cc` to exit 69).
+      if ! /usr/bin/xcrun --show-sdk-path >/dev/null 2>&1; then
+        warn "Xcode license has not been accepted. Run:"
+        warn "  sudo xcodebuild -license accept"
+        warn "then re-run this installer."
+        exit 1
+      fi
       if ! have_cmd git; then
         warn "git is not available. Install git (e.g., Homebrew) and re-run bootstrap."
       fi


### PR DESCRIPTION
## Summary

- Adds an `xcrun --show-sdk-path` check after verifying Xcode CLT is installed
- When the Xcode/CLT license hasn't been accepted, `cc` exits with code 69 and the build fails with cryptic linker errors
- Now surfaces a clear message: `sudo xcodebuild -license accept`
- Bumps version to v0.5.5 across all distribution manifests (Cargo.toml, Cargo.lock, AUR PKGBUILD/.SRCINFO, Scoop JSON)

## Risk and Rollback

- Risk: Low — pre-flight check + version bump
- Rollback: revert commit

## Test plan

- [ ] On macOS with accepted license: installer proceeds normally
- [ ] On macOS with un-accepted license: installer exits with clear instructions
- [ ] Version shows 0.5.5 in all manifests