### PR TITLE
fix(install): always check Xcode license on macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1182,6 +1182,21 @@ else
     install_system_deps
   fi
 
+  # Always check Xcode/CLT license on macOS, regardless of --install-system-deps.
+  # An un-accepted license causes `cc` to exit 69, breaking all Rust builds.
+  if [[ "$OS_NAME" == "Darwin" ]]; then
+    _xcode_test_file="$(mktemp /tmp/zeroclaw-xcode-check.XXXXXX.c)"
+    printf 'int main(){return 0;}\n' > "$_xcode_test_file"
+    if ! cc -x c "$_xcode_test_file" -o /dev/null 2>/dev/null; then
+      rm -f "$_xcode_test_file"
+      error "The C compiler failed (Xcode/CLT license not accepted)."
+      error "Run:  sudo xcodebuild -license accept"
+      error "then re-run this installer."
+      exit 1
+    fi
+    rm -f "$_xcode_test_file"
+  fi
+
   if [[ "$INSTALL_RUST" == true ]]; then
     install_rust_toolchain
   fi


### PR DESCRIPTION
## Summary
- The Xcode license test-compile from #4151 was inside `install_system_deps()`, which only runs with `--install-system-deps`. On macOS default installs, this was never called
- Moved the check into the unconditional main flow so it always fires on Darwin
- Tested locally on a machine with un-accepted Xcode license — installer now exits immediately with a clear remediation message

## Before
```
✓ System dependencies satisfied
...
error[E0463]: can't find crate for `std`
  = note: cc exited with signal: 69
```

## After
```
✗ The C compiler failed (Xcode/CLT license not accepted).
✗ Run:  sudo xcodebuild -license accept
✗ then re-run this installer.
```

## Test plan
- [x] `bash -n install.sh` passes
- [x] On macOS with un-accepted license: installer exits early with clear error
- [ ] On macOS with accepted license: installer proceeds normally
- [ ] CI passes