### PR TITLE
chore: bump version to v0.5.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9203,7 +9203,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "aardvark-sys",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"

--- a/dist/aur/.SRCINFO
+++ b/dist/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = zeroclaw
 	pkgdesc = Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.
-	pkgver = 0.5.5
+	pkgver = 0.5.6
 	pkgrel = 1
 	url = https://github.com/zeroclaw-labs/zeroclaw
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = zeroclaw
 	makedepends = git
 	depends = gcc-libs
 	depends = openssl
-	source = zeroclaw-0.5.5.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.5.5.tar.gz
+	source = zeroclaw-0.5.6.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.5.6.tar.gz
 	sha256sums = SKIP
 
 pkgname = zeroclaw

--- a/dist/aur/PKGBUILD
+++ b/dist/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: zeroclaw-labs <bot@zeroclaw.dev>
 pkgname=zeroclaw
-pkgver=0.5.5
+pkgver=0.5.6
 pkgrel=1
 pkgdesc="Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant."
 arch=('x86_64')

--- a/dist/scoop/zeroclaw.json
+++ b/dist/scoop/zeroclaw.json
@@ -1,11 +1,11 @@
 {
-    "version": "0.5.5",
+    "version": "0.5.6",
     "description": "Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.",
     "homepage": "https://github.com/zeroclaw-labs/zeroclaw",
     "license": "MIT|Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.5.5/zeroclaw-x86_64-pc-windows-msvc.zip",
+            "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.5.6/zeroclaw-x86_64-pc-windows-msvc.zip",
             "hash": "",
             "bin": "zeroclaw.exe"
         }


### PR DESCRIPTION
## Summary
- Bump version from 0.5.5 to 0.5.6 across all distribution manifests
- Captures post-0.5.5 fixes: install script Xcode auto-accept, flaky subprocess test, aardvark-sys publish

## Files updated
- `Cargo.toml` / `Cargo.lock`
- `dist/aur/PKGBUILD` + `.SRCINFO`
- `dist/scoop/zeroclaw.json`

## Test plan
- [ ] CI passes
- [ ] After merge, auto-publish to crates.io triggers