### PR TITLE
fix(approval): support wildcard * in auto_approve and always_ask

### DIFF
--- a/src/approval/mod.rs
+++ b/src/approval/mod.rs
@@ -122,7 +122,7 @@ impl ApprovalManager {
         }
 
         // always_ask overrides everything.
-        if self.always_ask.contains(tool_name) {
+        if self.always_ask.contains("*") || self.always_ask.contains(tool_name) {
             return true;
         }
 
@@ -136,7 +136,7 @@ impl ApprovalManager {
         }
 
         // auto_approve skips the prompt.
-        if self.auto_approve.contains(tool_name) {
+        if self.auto_approve.contains("*") || self.auto_approve.contains(tool_name) {
             return false;
         }
 

--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -108,6 +108,7 @@ fn is_context_window_exceeded(err: &anyhow::Error) -> bool {
         "token limit exceeded",
         "prompt is too long",
         "input is too long",
+        "prompt exceeds max length",
     ];
 
     hints.iter().any(|hint| lower.contains(hint))


### PR DESCRIPTION
## Summary
- `auto_approve = ["*"]` was doing exact string matching via `HashSet.contains()`, so only the literal string `"*"` matched — wildcards didn't work
- Users in supervised mode with `auto_approve = ["*"]` had every tool blocked, causing the agent to "hallucinate" executing commands without actually running them
- Same fix applied to `always_ask` wildcard handling
- Also adds "prompt exceeds max length" to context-window error detection (GLM error 1261)

Closes #4127

## Test plan
- [ ] CI passes
- [ ] With `auto_approve = ["*"]` in supervised mode, tools execute without approval prompt
- [ ] With `always_ask = ["*"]`, all tools require approval
- [ ] GLM "Prompt exceeds max length" error is now properly detected as context window exceeded