### PR TITLE
fix(web/cron): contain table scroll within viewport

### DIFF
--- a/web/src/pages/Cron.tsx
+++ b/web/src/pages/Cron.tsx
@@ -293,7 +293,7 @@ export default function Cron() {
   }
 
   return (
-    <div className="p-6 space-y-6 animate-fade-in">
+    <div className="flex flex-col h-full p-6 gap-6 animate-fade-in overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -415,7 +415,7 @@ export default function Cron() {
           <p style={{ color: 'var(--pc-text-muted)' }}>{t('cron.empty')}</p>
         </div>
       ) : (
-        <div className="card overflow-x-auto rounded-2xl">
+        <div className="card overflow-auto rounded-2xl flex-1 min-h-0">
           <table className="table-electric">
             <thead>
               <tr>


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The `/cron` page root used a plain block-flow container with no height constraint, causing the jobs table to grow taller than the viewport and the entire page to scroll.
- Why it matters: Header, Add Job button, and catch-up toggle scroll out of view with the table, making the page difficult to use with many jobs. Inconsistent with the `/memory` page which already constrains its table correctly.
- What changed: Page root class changed to `flex flex-col h-full` pattern; table wrapper gains `flex-1 min-h-0 overflow-auto` so it fills remaining height and scrolls both axes internally.
- What did **not** change: Job CRUD logic, modal, catch-up toggle, run history panel, API calls, `table-electric` CSS (thead `position: sticky` already works correctly once the container is constrained).

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `cron`
- Module labels: N/A
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `multi` (web/cron page layout)

## Linked Issue

- Closes #4183

## Supersede Attribution (required when `Supersedes #` is used)

N/A — no superseded PRs.

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check   # skipped — no Rust files changed
cargo clippy --all-targets   # skipped — no Rust files changed
cargo test                   # skipped — no Rust files changed
cd web && npm run build      # ✓ built in 2.36s, 1620 modules transformed, no errors
```

- Evidence provided: frontend build output confirms zero errors
- Rust suite skipped: only `web/src/pages/Cron.tsx` was modified; no Rust source touched

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A — layout-only change, no data handling
- Neutral wording confirmation: No user-facing wording changed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No — no user-facing wording changed, layout classes only

## Human Verification (required)

- Verified scenarios: page root class and table wrapper class are the only two changed lines; diff is 2 insertions 2 deletions against master
- Edge cases checked: empty job list (empty state card is above the flex-1 table wrapper, unaffected); modal (fixed-position overlay, unaffected); catch-up toggle (above the table in flow, implicitly flex-shrink-0)
- What was not verified: live browser rendering with a large job list (owner will validate locally via patch)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `/cron` page layout only
- Potential unintended effects: None — `table-electric` thead already has `position: sticky`, pins correctly inside the new scrolling container with no CSS change needed
- Guardrails/monitoring: visual regression only; no runtime behaviour changed

## Agent Collaboration Notes (recommended)

- Agent tools used: Zed AI (Claude Sonnet)
- Workflow/plan summary: read backlog → filed upstream issue #4183 → restored master file → applied two-line surgical patch via sed → npm build validation → format-patch → git apply --check dry-run → owner approval → push + PR
- Verification focus: confirmed patch touches exactly 2 lines, no reformatting or unrelated changes mixed in
- Confirmation: naming + architecture boundaries followed per AGENTS.md and CONTRIBUTING.md

## Rollback Plan (required)

- Fast rollback: revert the two class changes in `web/src/pages/Cron.tsx` — no config, no migration, no backend change
- Feature flags or config toggles: none
- Observable failure symptoms: page scrolls as a whole again instead of table scrolling within its card

## Risks and Mitigations

None — layout-only change with no logic, API, or security impact.