### PR TITLE
fix(tools): implement per-task cancellation for background delegate in #4159

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -9275,7 +9275,6 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
     use std::sync::{Arc, Mutex as StdMutex};
-    #[cfg(unix)]
     use tempfile::TempDir;
     use tokio::sync::{Mutex, MutexGuard};
     use tokio::test;
@@ -13671,12 +13670,12 @@ require_otp_to_resume = true
     async fn ensure_bootstrap_files_creates_missing_files() {
         let tmp = TempDir::new().unwrap();
         let ws = tmp.path().join("workspace");
-        tokio::fs::create_dir_all(&ws).await.unwrap();
+        let _: () = tokio::fs::create_dir_all(&ws).await.unwrap();
 
         ensure_bootstrap_files(&ws).await.unwrap();
 
-        let soul = tokio::fs::read_to_string(ws.join("SOUL.md")).await.unwrap();
-        let identity = tokio::fs::read_to_string(ws.join("IDENTITY.md"))
+        let soul: String = tokio::fs::read_to_string(ws.join("SOUL.md")).await.unwrap();
+        let identity: String = tokio::fs::read_to_string(ws.join("IDENTITY.md"))
             .await
             .unwrap();
         assert!(soul.contains("SOUL.md"));
@@ -13687,21 +13686,21 @@ require_otp_to_resume = true
     async fn ensure_bootstrap_files_does_not_overwrite_existing() {
         let tmp = TempDir::new().unwrap();
         let ws = tmp.path().join("workspace");
-        tokio::fs::create_dir_all(&ws).await.unwrap();
+        let _: () = tokio::fs::create_dir_all(&ws).await.unwrap();
 
         let custom = "# My custom SOUL";
-        tokio::fs::write(ws.join("SOUL.md"), custom).await.unwrap();
+        let _: () = tokio::fs::write(ws.join("SOUL.md"), custom).await.unwrap();
 
         ensure_bootstrap_files(&ws).await.unwrap();
 
-        let soul = tokio::fs::read_to_string(ws.join("SOUL.md")).await.unwrap();
+        let soul: String = tokio::fs::read_to_string(ws.join("SOUL.md")).await.unwrap();
         assert_eq!(
             soul, custom,
             "ensure_bootstrap_files must not overwrite existing files"
         );
 
         // IDENTITY.md should still be created since it was missing
-        let identity = tokio::fs::read_to_string(ws.join("IDENTITY.md"))
+        let identity: String = tokio::fs::read_to_string(ws.join("IDENTITY.md"))
             .await
             .unwrap();
         assert!(identity.contains("IDENTITY.md"));

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -13,11 +13,44 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+/// Serializable result of a background delegate task.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BackgroundDelegateResult {
+    pub task_id: String,
+    pub agent: String,
+    pub status: BackgroundTaskStatus,
+    pub output: Option<String>,
+    pub error: Option<String>,
+    pub started_at: String,
+    pub finished_at: Option<String>,
+}
+
+/// Status of a background delegate task.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum BackgroundTaskStatus {
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
 
 /// Tool that delegates a subtask to a named agent with a different
 /// provider/model configuration. Enables multi-agent workflows where
 /// a primary agent can hand off specialized work (research, coding,
 /// summarization) to purpose-built sub-agents.
+///
+/// Supports three execution modes:
+/// - **Synchronous** (default): blocks until the sub-agent completes.
+/// - **Background** (`background: true`): spawns the sub-agent in a tokio
+///   task and returns a `task_id` immediately.
+/// - **Parallel** (`parallel: [...]`): runs multiple agents concurrently
+///   and returns all results.
+///
+/// Background results are persisted to `workspace/delegate_results/{task_id}.json`
+/// and can be retrieved via `action: "check_result"`.
 pub struct DelegateTool {
     agents: Arc<HashMap<String, DelegateAgentConfig>>,
     security: Arc<SecurityPolicy>,
@@ -35,6 +68,8 @@ pub struct DelegateTool {
     delegate_config: DelegateToolConfig,
     /// Workspace directory inherited from the root agent context.
     workspace_dir: PathBuf,
+    /// Cancellation token for cascade control of background tasks.
+    cancellation_token: CancellationToken,
 }
 
 impl DelegateTool {
@@ -67,6 +102,7 @@ impl DelegateTool {
             multimodal_config: crate::config::MultimodalConfig::default(),
             delegate_config: DelegateToolConfig::default(),
             workspace_dir: PathBuf::new(),
+            cancellation_token: CancellationToken::new(),
         }
     }
 
@@ -105,6 +141,7 @@ impl DelegateTool {
             multimodal_config: crate::config::MultimodalConfig::default(),
             delegate_config: DelegateToolConfig::default(),
             workspace_dir: PathBuf::new(),
+            cancellation_token: CancellationToken::new(),
         }
     }
 
@@ -137,6 +174,23 @@ impl DelegateTool {
         self.workspace_dir = workspace_dir;
         self
     }
+
+    /// Attach a cancellation token for cascade control of background tasks.
+    /// When the token is cancelled, all background sub-agents are aborted.
+    pub fn with_cancellation_token(mut self, token: CancellationToken) -> Self {
+        self.cancellation_token = token;
+        self
+    }
+
+    /// Return the cancellation token for external cascade control.
+    pub fn cancellation_token(&self) -> &CancellationToken {
+        &self.cancellation_token
+    }
+
+    /// Directory where background delegate results are stored.
+    fn results_dir(&self) -> PathBuf {
+        self.workspace_dir.join("delegate_results")
+    }
 }
 
 #[async_trait]
@@ -148,7 +202,10 @@ impl Tool for DelegateTool {
     fn description(&self) -> &str {
         "Delegate a subtask to a specialized agent. Use when: a task benefits from a different model \
          (e.g. fast summarization, deep reasoning, code generation). The sub-agent runs a single \
-         prompt by default; with agentic=true it can iterate with a filtered tool-call loop."
+         prompt by default; with agentic=true it can iterate with a filtered tool-call loop. \
+         Supports background execution (returns a task_id immediately) and parallel execution \
+         (runs multiple agents concurrently). Use action='check_result' with a task_id to \
+         retrieve background results."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -157,6 +214,14 @@ impl Tool for DelegateTool {
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["delegate", "check_result", "list_results", "cancel_task"],
+                    "description": "Action to perform. Default: 'delegate'. Use 'check_result' to \
+                                    retrieve a background task result, 'list_results' to list all \
+                                    background tasks, 'cancel_task' to cancel a running background task.",
+                    "default": "delegate"
+                },
                 "agent": {
                     "type": "string",
                     "minLength": 1,
@@ -177,13 +242,59 @@ impl Tool for DelegateTool {
                 "context": {
                     "type": "string",
                     "description": "Optional context to prepend (e.g. relevant code, prior findings)"
+                },
+                "background": {
+                    "type": "boolean",
+                    "description": "When true, the sub-agent runs in a background tokio task and \
+                                    returns a task_id immediately. Results are stored to \
+                                    workspace/delegate_results/{task_id}.json.",
+                    "default": false
+                },
+                "parallel": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Array of agent names to run concurrently with the same prompt. \
+                                    Returns all results when all agents complete. Cannot be combined \
+                                    with 'background'."
+                },
+                "task_id": {
+                    "type": "string",
+                    "description": "Task ID for check_result/cancel_task actions (returned by \
+                                    background delegation)."
                 }
             },
-            "required": ["agent", "prompt"]
+            "required": []
         })
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        let action = args
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or("delegate");
+
+        match action {
+            "check_result" => return self.handle_check_result(&args).await,
+            "list_results" => return self.handle_list_results().await,
+            "cancel_task" => return self.handle_cancel_task(&args).await,
+            "delegate" => {} // fall through to delegation logic
+            other => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!(
+                        "Unknown action '{other}'. Use delegate/check_result/list_results/cancel_task."
+                    )),
+                });
+            }
+        }
+
+        // --- Parallel mode ---
+        if let Some(parallel_agents) = args.get("parallel").and_then(|v| v.as_array()) {
+            return self.execute_parallel(parallel_agents, &args).await;
+        }
+
+        // --- Single-agent delegation (synchronous or background) ---
         let agent_name = args
             .get("agent")
             .and_then(|v| v.as_str())
@@ -212,6 +323,28 @@ impl Tool for DelegateTool {
             });
         }
 
+        let background = args
+            .get("background")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        if background {
+            return self.execute_background(agent_name, prompt, &args).await;
+        }
+
+        // --- Synchronous delegation (original path) ---
+        self.execute_sync(agent_name, prompt, &args).await
+    }
+}
+
+impl DelegateTool {
+    /// Original synchronous delegation path (extracted for reuse).
+    async fn execute_sync(
+        &self,
+        agent_name: &str,
+        prompt: &str,
+        args: &serde_json::Value,
+    ) -> anyhow::Result<ToolResult> {
         let context = args
             .get("context")
             .and_then(|v| v.as_str())
@@ -372,6 +505,460 @@ impl Tool for DelegateTool {
 }
 
 impl DelegateTool {
+    // ── Background Execution ────────────────────────────────────────
+
+    /// Spawn a sub-agent in a background tokio task. Returns a task_id immediately.
+    /// The result is persisted to `workspace/delegate_results/{task_id}.json`.
+    async fn execute_background(
+        &self,
+        agent_name: &str,
+        prompt: &str,
+        args: &serde_json::Value,
+    ) -> anyhow::Result<ToolResult> {
+        // Validate agent exists and check depth/security before spawning
+        let agent_config = match self.agents.get(agent_name) {
+            Some(cfg) => cfg.clone(),
+            None => {
+                let available: Vec<&str> =
+                    self.agents.keys().map(|s: &String| s.as_str()).collect();
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!(
+                        "Unknown agent '{agent_name}'. Available agents: {}",
+                        if available.is_empty() {
+                            "(none configured)".to_string()
+                        } else {
+                            available.join(", ")
+                        }
+                    )),
+                });
+            }
+        };
+
+        if self.depth >= agent_config.max_depth {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Delegation depth limit reached ({depth}/{max}).",
+                    depth = self.depth,
+                    max = agent_config.max_depth
+                )),
+            });
+        }
+
+        if let Err(error) = self
+            .security
+            .enforce_tool_operation(ToolOperation::Act, "delegate")
+        {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(error),
+            });
+        }
+
+        let task_id = uuid::Uuid::new_v4().to_string();
+        let results_dir = self.results_dir();
+        tokio::fs::create_dir_all(&results_dir).await?;
+
+        let context = args
+            .get("context")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .unwrap_or("");
+        let full_prompt = if context.is_empty() {
+            prompt.to_string()
+        } else {
+            format!("[Context]\n{context}\n\n[Task]\n{prompt}")
+        };
+
+        let started_at = chrono::Utc::now().to_rfc3339();
+        let agent_name_owned = agent_name.to_string();
+
+        // Write initial "running" status
+        let initial_result = BackgroundDelegateResult {
+            task_id: task_id.clone(),
+            agent: agent_name_owned.clone(),
+            status: BackgroundTaskStatus::Running,
+            output: None,
+            error: None,
+            started_at: started_at.clone(),
+            finished_at: None,
+        };
+        let result_path = results_dir.join(format!("{task_id}.json"));
+        let json_bytes = serde_json::to_vec_pretty(&initial_result)?;
+        tokio::fs::write(&result_path, &json_bytes).await?;
+
+        // Clone everything needed for the spawned task
+        let agents = Arc::clone(&self.agents);
+        let security = Arc::clone(&self.security);
+        let fallback_credential = self.fallback_credential.clone();
+        let provider_runtime_options = self.provider_runtime_options.clone();
+        let depth = self.depth;
+        let parent_tools = Arc::clone(&self.parent_tools);
+        let multimodal_config = self.multimodal_config.clone();
+        let delegate_config = self.delegate_config.clone();
+        let workspace_dir = self.workspace_dir.clone();
+        let child_token = self.cancellation_token.child_token();
+        let task_id_clone = task_id.clone();
+
+        tokio::spawn(async move {
+            // Build an inner DelegateTool for the spawned context
+            let inner = DelegateTool {
+                agents,
+                security,
+                fallback_credential,
+                provider_runtime_options,
+                depth,
+                parent_tools,
+                multimodal_config,
+                delegate_config,
+                workspace_dir: workspace_dir.clone(),
+                cancellation_token: child_token.clone(),
+            };
+
+            let args_inner = json!({
+                "agent": agent_name_owned,
+                "prompt": full_prompt,
+            });
+
+            // Race the delegation against cancellation
+            let outcome = tokio::select! {
+                () = child_token.cancelled() => {
+                    Err("Cancelled by parent session".to_string())
+                }
+                result = Box::pin(inner.execute_sync(&agent_name_owned, &full_prompt, &args_inner)) => {
+                    match result {
+                        Ok(tool_result) => {
+                            if tool_result.success {
+                                Ok(tool_result.output)
+                            } else {
+                                Err(tool_result.error.unwrap_or_else(|| "Unknown error".into()))
+                            }
+                        }
+                        Err(e) => Err(e.to_string()),
+                    }
+                }
+            };
+
+            let finished_at = chrono::Utc::now().to_rfc3339();
+            let final_result = match outcome {
+                Ok(output) => BackgroundDelegateResult {
+                    task_id: task_id_clone.clone(),
+                    agent: agent_name_owned,
+                    status: BackgroundTaskStatus::Completed,
+                    output: Some(output),
+                    error: None,
+                    started_at,
+                    finished_at: Some(finished_at),
+                },
+                Err(err) => {
+                    let status = if err.contains("Cancelled") {
+                        BackgroundTaskStatus::Cancelled
+                    } else {
+                        BackgroundTaskStatus::Failed
+                    };
+                    BackgroundDelegateResult {
+                        task_id: task_id_clone.clone(),
+                        agent: agent_name_owned,
+                        status,
+                        output: None,
+                        error: Some(err),
+                        started_at,
+                        finished_at: Some(finished_at),
+                    }
+                }
+            };
+
+            let result_path = results_dir.join(format!("{}.json", task_id_clone));
+            if let Ok(bytes) = serde_json::to_vec_pretty(&final_result) {
+                let _ = tokio::fs::write(&result_path, &bytes).await;
+            }
+        });
+
+        Ok(ToolResult {
+            success: true,
+            output: format!(
+                "Background task started for agent '{agent_name}'.\n\
+                 task_id: {task_id}\n\
+                 Use action='check_result' with task_id='{task_id}' to retrieve the result."
+            ),
+            error: None,
+        })
+    }
+
+    // ── Parallel Execution ──────────────────────────────────────────
+
+    /// Run multiple agents concurrently with the same prompt.
+    async fn execute_parallel(
+        &self,
+        parallel_agents: &[serde_json::Value],
+        args: &serde_json::Value,
+    ) -> anyhow::Result<ToolResult> {
+        let prompt = args
+            .get("prompt")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .ok_or_else(|| anyhow::anyhow!("Missing 'prompt' parameter for parallel execution"))?;
+
+        if prompt.is_empty() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("'prompt' parameter must not be empty".into()),
+            });
+        }
+
+        let agent_names: Vec<String> = parallel_agents
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.trim().to_string()))
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if agent_names.is_empty() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("'parallel' array must contain at least one agent name".into()),
+            });
+        }
+
+        // Validate all agents exist before starting any
+        for name in &agent_names {
+            if !self.agents.contains_key(name) {
+                let available: Vec<&str> =
+                    self.agents.keys().map(|s: &String| s.as_str()).collect();
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!(
+                        "Unknown agent '{name}' in parallel list. Available: {}",
+                        if available.is_empty() {
+                            "(none configured)".to_string()
+                        } else {
+                            available.join(", ")
+                        }
+                    )),
+                });
+            }
+        }
+
+        // Spawn all agents concurrently
+        let mut handles = Vec::with_capacity(agent_names.len());
+        for agent_name in &agent_names {
+            let agents = Arc::clone(&self.agents);
+            let security = Arc::clone(&self.security);
+            let fallback_credential = self.fallback_credential.clone();
+            let provider_runtime_options = self.provider_runtime_options.clone();
+            let depth = self.depth;
+            let parent_tools = Arc::clone(&self.parent_tools);
+            let multimodal_config = self.multimodal_config.clone();
+            let delegate_config = self.delegate_config.clone();
+            let workspace_dir = self.workspace_dir.clone();
+            let cancellation_token = self.cancellation_token.child_token();
+            let agent_name = agent_name.clone();
+            let prompt = prompt.to_string();
+            let args_clone = args.clone();
+
+            handles.push(tokio::spawn(async move {
+                let inner = DelegateTool {
+                    agents,
+                    security,
+                    fallback_credential,
+                    provider_runtime_options,
+                    depth,
+                    parent_tools,
+                    multimodal_config,
+                    delegate_config,
+                    workspace_dir,
+                    cancellation_token,
+                };
+                let result = Box::pin(inner.execute_sync(&agent_name, &prompt, &args_clone)).await;
+                (agent_name, result)
+            }));
+        }
+
+        // Collect all results
+        let mut outputs = Vec::with_capacity(handles.len());
+        let mut all_success = true;
+
+        for handle in handles {
+            match handle.await {
+                Ok((agent_name, Ok(tool_result))) => {
+                    if !tool_result.success {
+                        all_success = false;
+                    }
+                    outputs.push(format!(
+                        "--- {agent_name} (success={}) ---\n{}{}",
+                        tool_result.success,
+                        tool_result.output,
+                        tool_result
+                            .error
+                            .map(|e| format!("\nError: {e}"))
+                            .unwrap_or_default()
+                    ));
+                }
+                Ok((agent_name, Err(e))) => {
+                    all_success = false;
+                    outputs.push(format!("--- {agent_name} (success=false) ---\nError: {e}"));
+                }
+                Err(e) => {
+                    all_success = false;
+                    outputs.push(format!("--- [join error] ---\n{e}"));
+                }
+            }
+        }
+
+        Ok(ToolResult {
+            success: all_success,
+            output: format!(
+                "[Parallel delegation: {} agents]\n\n{}",
+                agent_names.len(),
+                outputs.join("\n\n")
+            ),
+            error: if all_success {
+                None
+            } else {
+                Some("One or more parallel agents failed".into())
+            },
+        })
+    }
+
+    // ── Result Retrieval ────────────────────────────────────────────
+
+    /// Retrieve the result of a background delegate task by task_id.
+    async fn handle_check_result(&self, args: &serde_json::Value) -> anyhow::Result<ToolResult> {
+        let task_id = args
+            .get("task_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("Missing 'task_id' parameter for check_result"))?;
+
+        let result_path = self.results_dir().join(format!("{task_id}.json"));
+        if !result_path.exists() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("No result found for task_id '{task_id}'")),
+            });
+        }
+
+        let content = tokio::fs::read_to_string(&result_path).await?;
+        let result: BackgroundDelegateResult = serde_json::from_str(&content)?;
+
+        Ok(ToolResult {
+            success: result.status == BackgroundTaskStatus::Completed,
+            output: serde_json::to_string_pretty(&result)?,
+            error: if result.status == BackgroundTaskStatus::Completed {
+                None
+            } else {
+                result.error
+            },
+        })
+    }
+
+    /// List all background delegate task results.
+    async fn handle_list_results(&self) -> anyhow::Result<ToolResult> {
+        let results_dir = self.results_dir();
+        if !results_dir.exists() {
+            return Ok(ToolResult {
+                success: true,
+                output: "No background delegate results found.".into(),
+                error: None,
+            });
+        }
+
+        let mut entries = tokio::fs::read_dir(&results_dir).await?;
+        let mut results = Vec::new();
+
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("json") {
+                if let Ok(content) = tokio::fs::read_to_string(&path).await {
+                    if let Ok(result) = serde_json::from_str::<BackgroundDelegateResult>(&content) {
+                        results.push(json!({
+                            "task_id": result.task_id,
+                            "agent": result.agent,
+                            "status": result.status,
+                            "started_at": result.started_at,
+                            "finished_at": result.finished_at,
+                        }));
+                    }
+                }
+            }
+        }
+
+        if results.is_empty() {
+            return Ok(ToolResult {
+                success: true,
+                output: "No background delegate results found.".into(),
+                error: None,
+            });
+        }
+
+        Ok(ToolResult {
+            success: true,
+            output: serde_json::to_string_pretty(&results)?,
+            error: None,
+        })
+    }
+
+    /// Cancel a running background task by task_id.
+    async fn handle_cancel_task(&self, args: &serde_json::Value) -> anyhow::Result<ToolResult> {
+        let task_id = args
+            .get("task_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("Missing 'task_id' parameter for cancel_task"))?;
+
+        let result_path = self.results_dir().join(format!("{task_id}.json"));
+        if !result_path.exists() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("No task found for task_id '{task_id}'")),
+            });
+        }
+
+        // Read current status
+        let content = tokio::fs::read_to_string(&result_path).await?;
+        let mut result: BackgroundDelegateResult = serde_json::from_str(&content)?;
+
+        if result.status != BackgroundTaskStatus::Running {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Task '{task_id}' is not running (status: {:?})",
+                    result.status
+                )),
+            });
+        }
+
+        // Cancel via the parent token — this will cascade to all child tokens
+        // Note: individual task cancellation uses the shared parent token, which
+        // cancels all background tasks. For per-task cancellation, each background
+        // task uses a child token, and the parent token cancels all.
+        // We update the result file to reflect the cancellation request.
+        result.status = BackgroundTaskStatus::Cancelled;
+        result.error = Some("Cancelled by user request".into());
+        result.finished_at = Some(chrono::Utc::now().to_rfc3339());
+        let bytes = serde_json::to_vec_pretty(&result)?;
+        tokio::fs::write(&result_path, &bytes).await?;
+
+        Ok(ToolResult {
+            success: true,
+            output: format!("Task '{task_id}' cancellation requested."),
+            error: None,
+        })
+    }
+
+    /// Cancel all background tasks (cascade control).
+    /// Call this when the parent session ends.
+    pub fn cancel_all_background_tasks(&self) {
+        self.cancellation_token.cancel();
+    }
+
     /// Build an enriched system prompt for a sub-agent by composing structured
     /// operational sections (tools, skills, workspace, datetime, shell policy)
     /// with the operator-configured `system_prompt` string.
@@ -829,9 +1416,13 @@ mod tests {
         assert!(schema["properties"]["agent"].is_object());
         assert!(schema["properties"]["prompt"].is_object());
         assert!(schema["properties"]["context"].is_object());
+        assert!(schema["properties"]["background"].is_object());
+        assert!(schema["properties"]["parallel"].is_object());
+        assert!(schema["properties"]["action"].is_object());
+        assert!(schema["properties"]["task_id"].is_object());
+        // required is empty because different actions need different params
         let required = schema["required"].as_array().unwrap();
-        assert!(required.contains(&json!("agent")));
-        assert!(required.contains(&json!("prompt")));
+        assert!(required.is_empty());
         assert_eq!(schema["additionalProperties"], json!(false));
         assert_eq!(schema["properties"]["agent"]["minLength"], json!(1));
         assert_eq!(schema["properties"]["prompt"]["minLength"], json!(1));
@@ -1817,5 +2408,391 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    // ── Background and Parallel execution tests ─────────────────────
+
+    #[tokio::test]
+    async fn background_delegation_returns_task_id() {
+        let workspace = std::env::temp_dir().join(format!(
+            "zeroclaw_delegate_bg_test_{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let tool = DelegateTool::new(sample_agents(), None, test_security())
+            .with_workspace_dir(workspace.clone());
+        let result = tool
+            .execute(json!({
+                "agent": "researcher",
+                "prompt": "test background",
+                "background": true
+            }))
+            .await
+            .unwrap();
+
+        // The agent will fail at provider level (ollama not running),
+        // but the background task should be spawned and return a task_id.
+        assert!(result.success);
+        assert!(result.output.contains("task_id:"));
+        assert!(result.output.contains("Background task started"));
+
+        // Wait a moment for the background task to write its result
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // The results directory should exist
+        assert!(workspace.join("delegate_results").exists());
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[tokio::test]
+    async fn background_unknown_agent_rejected() {
+        let workspace = std::env::temp_dir().join(format!(
+            "zeroclaw_delegate_bg_unknown_{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let tool = DelegateTool::new(sample_agents(), None, test_security())
+            .with_workspace_dir(workspace.clone());
+        let result = tool
+            .execute(json!({
+                "agent": "nonexistent",
+                "prompt": "test",
+                "background": true
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("Unknown agent"));
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[tokio::test]
+    async fn check_result_missing_task_id() {
+        let workspace = std::env::temp_dir().join(format!(
+            "zeroclaw_delegate_check_noid_{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let tool = DelegateTool::new(sample_agents(), None, test_security())
+            .with_workspace_dir(workspace.clone());
+        let result = tool.execute(json!({"action": "check_result"})).await;
+
+        assert!(result.is_err());
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[tokio::test]
+    async fn check_result_nonexistent_task() {
+        let workspace = std::env::temp_dir().join(format!(
+            "zeroclaw_delegate_check_miss_{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let tool = DelegateTool::new(sample_agents(), None, test_security())
+            .with_workspace_dir(workspace.clone());
+        let result = tool
+            .execute(json!({
+                "action": "check_result",
+                "task_id": "nonexistent-id"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("No result found"));
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[tokio::test]
+    async fn list_results_empty() {
+        let workspace = std::env::temp_dir().join(format!(
+            "zeroclaw_delegate_list_empty_{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let tool = DelegateTool::new(sample_agents(), None, test_security())
+            .with_workspace_dir(workspace.clone());
+        let result = tool
+            .execute(json!({"action": "list_results"}))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+        assert!(result.output.contains("No background delegate results"));
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[tokio::test]
+    async fn parallel_empty_list_rejected() {
+        let tool = DelegateTool::new(sample_agents(), None, test_security());
+        let result = tool
+            .execute(json!({
+                "parallel": [],
+                "prompt": "test"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("at least one agent"));
+    }
+
+    #[tokio::test]
+    async fn parallel_unknown_agent_rejected() {
+        let tool = DelegateTool::new(sample_agents(), None, test_security());
+        let result = tool
+            .execute(json!({
+                "parallel": ["researcher", "nonexistent"],
+                "prompt": "test"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("Unknown agent"));
+    }
+
+    #[tokio::test]
+    async fn parallel_missing_prompt_rejected() {
+        let tool = DelegateTool::new(sample_agents(), None, test_security());
+        let result = tool
+            .execute(json!({
+                "parallel": ["researcher"]
+            }))
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn unknown_action_rejected() {
+        let tool = DelegateTool::new(sample_agents(), None, test_security());
+        let result = tool
+            .execute(json!({"action": "invalid_action"}))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("Unknown action"));
+    }
+
+    #[tokio::test]
+    async fn cancel_task_nonexistent() {
+        let workspace = std::env::temp_dir().join(format!(
+            "zeroclaw_delegate_cancel_miss_{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let tool = DelegateTool::new(sample_agents(), None, test_security())
+            .with_workspace_dir(workspace.clone());
+        let result = tool
+            .execute(json!({
+                "action": "cancel_task",
+                "task_id": "nonexistent-id"
+            }))
+            .await
+            .unwrap();
+
+        assert!(!result.success);
+        assert!(result.error.unwrap().contains("No task found"));
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn cancellation_token_accessor() {
+        let tool = DelegateTool::new(sample_agents(), None, test_security());
+        let token = tool.cancellation_token();
+        assert!(!token.is_cancelled());
+
+        tool.cancel_all_background_tasks();
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn with_cancellation_token_replaces_default() {
+        let custom_token = CancellationToken::new();
+        let tool = DelegateTool::new(sample_agents(), None, test_security())
+            .with_cancellation_token(custom_token.clone());
+
+        assert!(!tool.cancellation_token().is_cancelled());
+        custom_token.cancel();
+        assert!(tool.cancellation_token().is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn background_task_result_persisted_to_disk() {
+        let workspace = std::env::temp_dir().join(format!(
+            "zeroclaw_delegate_bg_persist_{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let tool = DelegateTool::new(sample_agents(), None, test_security())
+            .with_workspace_dir(workspace.clone());
+
+        let result = tool
+            .execute(json!({
+                "agent": "researcher",
+                "prompt": "persistence test",
+                "background": true
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.success);
+
+        // Extract task_id from output
+        let task_id = result
+            .output
+            .lines()
+            .find(|l| l.starts_with("task_id:"))
+            .unwrap()
+            .trim_start_matches("task_id: ")
+            .trim();
+
+        // Wait for the background task to finish
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Check that the result file exists
+        let result_path = workspace
+            .join("delegate_results")
+            .join(format!("{task_id}.json"));
+        assert!(
+            result_path.exists(),
+            "Result file should exist at {result_path:?}"
+        );
+
+        // Read and parse the result
+        let content = std::fs::read_to_string(&result_path).unwrap();
+        let bg_result: BackgroundDelegateResult = serde_json::from_str(&content).unwrap();
+        assert_eq!(bg_result.task_id, task_id);
+        assert_eq!(bg_result.agent, "researcher");
+        // The task will have failed because ollama isn't running, but it should be persisted
+        assert!(
+            bg_result.status == BackgroundTaskStatus::Completed
+                || bg_result.status == BackgroundTaskStatus::Failed
+        );
+        assert!(bg_result.finished_at.is_some());
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[tokio::test]
+    async fn check_result_retrieves_persisted_background_result() {
+        let workspace = std::env::temp_dir().join(format!(
+            "zeroclaw_delegate_check_retrieve_{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let tool = DelegateTool::new(sample_agents(), None, test_security())
+            .with_workspace_dir(workspace.clone());
+
+        // Start background task
+        let result = tool
+            .execute(json!({
+                "agent": "researcher",
+                "prompt": "retrieval test",
+                "background": true
+            }))
+            .await
+            .unwrap();
+
+        let task_id = result
+            .output
+            .lines()
+            .find(|l| l.starts_with("task_id:"))
+            .unwrap()
+            .trim_start_matches("task_id: ")
+            .trim()
+            .to_string();
+
+        // Wait for background task
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // Check result
+        let check = tool
+            .execute(json!({
+                "action": "check_result",
+                "task_id": task_id
+            }))
+            .await
+            .unwrap();
+
+        // The output should contain the serialized result
+        assert!(check.output.contains(&task_id));
+        assert!(check.output.contains("researcher"));
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[tokio::test]
+    async fn list_results_includes_background_tasks() {
+        let workspace = std::env::temp_dir().join(format!(
+            "zeroclaw_delegate_list_tasks_{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let tool = DelegateTool::new(sample_agents(), None, test_security())
+            .with_workspace_dir(workspace.clone());
+
+        // Start a background task
+        let result = tool
+            .execute(json!({
+                "agent": "researcher",
+                "prompt": "list test",
+                "background": true
+            }))
+            .await
+            .unwrap();
+        assert!(result.success);
+
+        // Wait for task to complete
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // List results
+        let list = tool
+            .execute(json!({"action": "list_results"}))
+            .await
+            .unwrap();
+
+        assert!(list.success);
+        assert!(list.output.contains("researcher"));
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[tokio::test]
+    async fn default_action_is_delegate() {
+        // Calling without action should behave like "delegate"
+        let tool = DelegateTool::new(sample_agents(), None, test_security());
+        let result = tool
+            .execute(json!({"agent": "researcher", "prompt": "test"}))
+            .await
+            .unwrap();
+        // Should proceed to delegation (will fail at provider since ollama isn't running)
+        // but should NOT fail with "Unknown action" error
+        assert!(
+            result.error.is_none()
+                || !result
+                    .error
+                    .as_deref()
+                    .unwrap_or("")
+                    .contains("Unknown action")
+        );
     }
 }

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -70,6 +70,8 @@ pub struct DelegateTool {
     workspace_dir: PathBuf,
     /// Cancellation token for cascade control of background tasks.
     cancellation_token: CancellationToken,
+    /// Per-task cancellation tokens for individual background task cancellation.
+    task_tokens: Arc<RwLock<HashMap<String, CancellationToken>>>,
 }
 
 impl DelegateTool {
@@ -103,6 +105,7 @@ impl DelegateTool {
             delegate_config: DelegateToolConfig::default(),
             workspace_dir: PathBuf::new(),
             cancellation_token: CancellationToken::new(),
+            task_tokens: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -142,6 +145,7 @@ impl DelegateTool {
             delegate_config: DelegateToolConfig::default(),
             workspace_dir: PathBuf::new(),
             cancellation_token: CancellationToken::new(),
+            task_tokens: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -604,6 +608,12 @@ impl DelegateTool {
         let child_token = self.cancellation_token.child_token();
         let task_id_clone = task_id.clone();
 
+        // Store the per-task token so cancel_task can cancel this specific task.
+        self.task_tokens
+            .write()
+            .insert(task_id.clone(), child_token.clone());
+        let task_tokens = Arc::clone(&self.task_tokens);
+
         tokio::spawn(async move {
             // Build an inner DelegateTool for the spawned context
             let inner = DelegateTool {
@@ -617,6 +627,7 @@ impl DelegateTool {
                 delegate_config,
                 workspace_dir: workspace_dir.clone(),
                 cancellation_token: child_token.clone(),
+                task_tokens: Arc::new(RwLock::new(HashMap::new())),
             };
 
             let args_inner = json!({
@@ -676,6 +687,9 @@ impl DelegateTool {
             if let Ok(bytes) = serde_json::to_vec_pretty(&final_result) {
                 let _ = tokio::fs::write(&result_path, &bytes).await;
             }
+
+            // Remove the per-task token now that the task has finished.
+            task_tokens.write().remove(&task_id_clone);
         });
 
         Ok(ToolResult {
@@ -774,6 +788,7 @@ impl DelegateTool {
                     delegate_config,
                     workspace_dir,
                     cancellation_token,
+                    task_tokens: Arc::new(RwLock::new(HashMap::new())),
                 };
                 let result = Box::pin(inner.execute_sync(&agent_name, &prompt, &args_clone)).await;
                 (agent_name, result)
@@ -935,11 +950,16 @@ impl DelegateTool {
             });
         }
 
-        // Cancel via the parent token — this will cascade to all child tokens
-        // Note: individual task cancellation uses the shared parent token, which
-        // cancels all background tasks. For per-task cancellation, each background
-        // task uses a child token, and the parent token cancels all.
-        // We update the result file to reflect the cancellation request.
+        // Cancel via the per-task token so only this specific task is cancelled.
+        // The spawned task races against child_token.cancelled() in tokio::select!,
+        // so signalling the token will cause it to exit with a "Cancelled" error
+        // and persist the final status itself.
+        if let Some(token) = self.task_tokens.write().remove(task_id) {
+            token.cancel();
+        }
+
+        // Also update the result file immediately so a subsequent check_result
+        // reflects the cancellation even before the spawned task re-writes.
         result.status = BackgroundTaskStatus::Cancelled;
         result.error = Some("Cancelled by user request".into());
         result.finished_at = Some(chrono::Utc::now().to_rfc3339());

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -106,6 +106,9 @@ pub use cron_runs::CronRunsTool;
 pub use cron_update::CronUpdateTool;
 pub use data_management::DataManagementTool;
 pub use delegate::DelegateTool;
+// Re-exported for downstream consumers of background delegation results.
+#[allow(unused_imports)]
+pub use delegate::{BackgroundDelegateResult, BackgroundTaskStatus};
 pub use file_edit::FileEditTool;
 pub use file_read::FileReadTool;
 pub use file_write::FileWriteTool;


### PR DESCRIPTION
## Summary
- Fixes a significant bug in PR #4159 (`feat/parallel-delegate`) where `cancel_task` only updated the JSON result file but never actually cancelled the running tokio task
- The `CancellationToken` was shared across ALL background tasks with no per-task mechanism
- Added `task_tokens: Arc<RwLock<HashMap<String, CancellationToken>>>` to `DelegateTool` for per-task cancellation
- Each spawned background task now stores its child token keyed by `task_id`, and `handle_cancel_task` retrieves and cancels the correct token
- Includes all original #4159 changes: background mode, parallel mode, check_result/list_results/cancel_task actions

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --lib -- -D warnings` passes
- [x] 58 delegate tests pass (`cargo test --lib tools::delegate`)
- [x] 234 config schema tests pass (1 pre-existing failure unrelated to this PR)