### PR TITLE
fix(ci): skip release and publish workflows on forks

### DIFF
--- a/.github/workflows/publish-crates-auto.yml
+++ b/.github/workflows/publish-crates-auto.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   detect-version-change:
     name: Detect Version Bump
+    if: github.repository == 'zeroclaw-labs/zeroclaw'
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.check.outputs.changed }}

--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   version:
     name: Resolve Version
+    if: github.repository == 'zeroclaw-labs/zeroclaw'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.ver.outputs.version }}
@@ -40,6 +41,7 @@ jobs:
 
   release-notes:
     name: Generate Release Notes
+    if: github.repository == 'zeroclaw-labs/zeroclaw'
     runs-on: ubuntu-latest
     outputs:
       notes: ${{ steps.notes.outputs.body }}
@@ -130,6 +132,7 @@ jobs:
 
   web:
     name: Build Web Dashboard
+    if: github.repository == 'zeroclaw-labs/zeroclaw'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
## Summary

- Adds `if: github.repository == 'zeroclaw-labs/zeroclaw'` guard to root jobs in `release-beta-on-push.yml` and `publish-crates-auto.yml`
- When a fork (e.g. `WareWolf-MoonWall/zeroclaw`) syncs with upstream, GitHub attributes the push to the fork owner — this was causing confusing email notifications and failed workflow runs due to missing secrets
- Downstream jobs automatically skip when root jobs are skipped, so no changes needed there

## Context

WareWolf was getting notified about commits and workflow failures they didn't make. The root cause: GitHub's fork sync operation attributes the push event to the fork owner, not the original commit author. This triggered `release-beta-on-push` under WareWolf's identity, which then failed (missing `RELEASE_TOKEN`, `WEBSITE_REPO_PAT` secrets).

## Test plan

- [ ] Verify `release-beta-on-push` still triggers normally on pushes to `zeroclaw-labs/zeroclaw:master`
- [ ] Verify the workflow is skipped when a fork syncs with upstream
- [ ] Verify `publish-crates-auto` behaves the same way