### PR TITLE
fix(web/config): fill viewport and add TOML syntax highlighting

### DIFF
--- a/web/src/pages/Config.tsx
+++ b/web/src/pages/Config.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import {
   Settings,
   Save,
@@ -9,12 +9,107 @@ import {
 import { getConfig, putConfig } from '@/lib/api';
 import { t } from '@/lib/i18n';
 
+
+// ---------------------------------------------------------------------------
+// Lightweight zero-dependency TOML syntax highlighter.
+// Produces an HTML string. The <pre> overlay sits behind the <textarea> so
+// the textarea remains the editable surface; the pre just provides colour.
+// ---------------------------------------------------------------------------
+function highlightToml(raw: string): string {
+  const lines = raw.split('\n');
+  const result: string[] = [];
+
+  for (const line of lines) {
+    const escaped = line
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+
+    // Section header  [section] or [[array]]
+    if (/^\s*\[/.test(escaped)) {
+      result.push(`<span style="color:#67e8f9;font-weight:600">${escaped}</span>`);
+      continue;
+    }
+
+    // Comment line
+    if (/^\s*#/.test(escaped)) {
+      result.push(`<span style="color:#52525b;font-style:italic">${escaped}</span>`);
+      continue;
+    }
+
+    // Key = value line
+    const kvMatch = escaped.match(/^(\s*)([A-Za-z0-9_\-.]+)(\s*=\s*)(.*)$/);
+    if (kvMatch) {
+      const [, indent, key, eq, rawValue] = kvMatch;
+      const value = colorValue(rawValue ?? '');
+      result.push(
+        `${indent}<span style="color:#a78bfa">${key}</span>`
+        + `<span style="color:#71717a">${eq}</span>${value}`
+      );
+      continue;
+    }
+
+    result.push(escaped);
+  }
+
+  return result.join('\n') + '\n';
+}
+
+function colorValue(v: string): string {
+  const trimmed = v.trim();
+  const commentIdx = findUnquotedHash(trimmed);
+  if (commentIdx !== -1) {
+    const valueCore = trimmed.slice(0, commentIdx).trimEnd();
+    const comment = `<span style="color:#52525b;font-style:italic">${trimmed.slice(commentIdx)}</span>`;
+    const leading = v.slice(0, v.indexOf(trimmed));
+    return leading + colorScalar(valueCore) + ' ' + comment;
+  }
+  return colorScalar(v);
+}
+
+function findUnquotedHash(s: string): number {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (c === "'" && !inDouble) inSingle = !inSingle;
+    else if (c === '"' && !inSingle) inDouble = !inDouble;
+    else if (c === '#' && !inSingle && !inDouble) return i;
+  }
+  return -1;
+}
+
+function colorScalar(v: string): string {
+  const t = v.trim();
+  if (t === 'true' || t === 'false')
+    return `<span style="color:#34d399">${v}</span>`;
+  if (/^-?\d[\d_]*(\.[\d_]*)?([eE][+-]?\d+)?$/.test(t))
+    return `<span style="color:#fbbf24">${v}</span>`;
+  if (t.startsWith('"') || t.startsWith("'"))
+    return `<span style="color:#86efac">${v}</span>`;
+  if (t.startsWith('[') || t.startsWith('{'))
+    return `<span style="color:#e2e8f0">${v}</span>`;
+  if (/^\d{4}-\d{2}-\d{2}/.test(t))
+    return `<span style="color:#fb923c">${v}</span>`;
+  return v;
+}
+
 export default function Config() {
   const [config, setConfig] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const preRef = useRef<HTMLPreElement>(null);
+
+  const syncScroll = useCallback(() => {
+    if (preRef.current && textareaRef.current) {
+      preRef.current.scrollTop = textareaRef.current.scrollTop;
+      preRef.current.scrollLeft = textareaRef.current.scrollLeft;
+    }
+  }, []);
 
   useEffect(() => {
     getConfig()
@@ -53,7 +148,7 @@ export default function Config() {
   }
 
   return (
-    <div className="p-6 space-y-6 animate-fade-in">
+    <div className="flex flex-col h-full p-6 gap-6 animate-fade-in overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -95,7 +190,7 @@ export default function Config() {
       )}
 
       {/* Config Editor */}
-      <div className="card overflow-hidden rounded-2xl">
+      <div className="card overflow-hidden rounded-2xl flex flex-col flex-1 min-h-0">
         <div className="flex items-center justify-between px-4 py-2.5 border-b" style={{ borderColor: 'var(--pc-border)', background: 'var(--pc-accent-glow)' }}>
           <span className="text-[10px] font-semibold uppercase tracking-wider" style={{ color: 'var(--pc-text-muted)' }}>
             {t('config.toml_label')}
@@ -104,13 +199,34 @@ export default function Config() {
             {config.split('\n').length} {t('config.lines')}
           </span>
         </div>
-        <textarea
-          value={config}
-          onChange={(e) => setConfig(e.target.value)}
-          spellCheck={false}
-          className="w-full min-h-[500px] text-sm p-4 resize-y focus:outline-none font-mono"
-          style={{ background: 'var(--pc-bg-base)', color: 'var(--pc-text-secondary)', tabSize: 4 }}
-        />
+        <div className="relative flex-1 min-h-0 overflow-hidden">
+          <pre
+            ref={preRef}
+            aria-hidden="true"
+            className="absolute inset-0 text-sm p-4 font-mono overflow-auto whitespace-pre pointer-events-none m-0"
+            style={{ background: 'var(--pc-bg-base)', tabSize: 4 }}
+            dangerouslySetInnerHTML={{ __html: highlightToml(config) }}
+          />
+          <textarea
+            ref={textareaRef}
+            value={config}
+            onChange={(e) => setConfig(e.target.value)}
+            onScroll={syncScroll}
+            onKeyDown={(e) => {
+              if (e.key === 'Tab') {
+                e.preventDefault();
+                const el = e.currentTarget;
+                const start = el.selectionStart;
+                const end = el.selectionEnd;
+                setConfig(config.slice(0, start) + '  ' + config.slice(end));
+                requestAnimationFrame(() => { el.selectionStart = el.selectionEnd = start + 2; });
+              }
+            }}
+            spellCheck={false}
+            className="absolute inset-0 w-full h-full text-sm p-4 resize-none focus:outline-none font-mono caret-white"
+            style={{ background: 'transparent', color: 'transparent', tabSize: 4 }}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The `/config` page root had no height constraint and the textarea used `min-h-[500px] resize-y`, causing dual independent scrollbars and the header/Save button scrolling out of view. The editor rendered TOML as plain unstyled text with no visual structure.
- Why it matters: The config file is the primary way users tune daemon behaviour — sections, keys, value types, and comments being visually indistinguishable makes it error-prone to edit. The layout inconsistency is also jarring next to `/memory` and `/cron` which already constrain their scroll correctly.
- What changed: Page root adopts the `flex flex-col h-full` pattern. Editor card becomes `flex-1 min-h-0`. Plain textarea replaced with a zero-dependency layered `<pre>` overlay that syntax-highlights TOML (sections, keys, strings, booleans, numbers, datetimes, comments) while keeping the textarea as the editable surface. Tab key inserts two spaces. Scroll is synced between overlay and textarea.
- What did **not** change: save/load API calls, validation logic, sensitive field masking behaviour, no new npm dependencies added.

## Label Snapshot (required)

- Risk label: `risk: low-medium`
- Size label: `size: S`
- Scope labels: `config`
- Module labels: N/A
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `multi` (web/config page layout + editor rendering)

## Linked Issue

- Closes #4195

## Supersede Attribution (required when `Supersedes #` is used)

N/A — no superseded PRs.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # skipped — no Rust files changed
cargo clippy --all-targets   # skipped — no Rust files changed
cargo test                   # skipped — no Rust files changed
cd web && npm run build      # ✓ built in 2.39s, 1620 modules transformed, no errors
```

- Evidence provided: frontend build output confirms zero errors, zero new npm dependencies
- Rust suite skipped: only `web/src/pages/Config.tsx` was modified; no Rust source touched

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- `dangerouslySetInnerHTML` is used on the `<pre>` overlay — content is the user's own local config file, loaded via the existing `getConfig()` API call, never from the network or another user. Risk is equivalent to rendering any local file in an editor. No sanitization regression: the highlighter HTML-escapes `&`, `<`, `>` before injecting span tags.

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: sensitive field masking behaviour is unchanged — the highlighter operates on whatever string the existing API returns, same as before
- Neutral wording confirmation: no user-facing wording changed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No — no user-facing wording changed

## Human Verification (required)

- Verified scenarios: diff is 126 insertions / 10 deletions against master with no reformatting of existing lines; TypeScript strict-mode error on `rawValue ?? ''` caught and fixed before commit; build passes clean
- Edge cases checked: empty config string (highlighter returns a single newline, pre renders blank — correct); config with inline comments (findUnquotedHash scans past quoted strings correctly); Tab key insertion uses requestAnimationFrame to restore caret position after React re-render
- What was not verified: live browser rendering across all supported themes (owner will validate locally via patch)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `/config` page layout and editor rendering only
- Potential unintended effects: `caret-white` class on the transparent textarea assumes a dark theme — on a light theme the caret may be invisible. This is a known limitation of the overlay technique; a theme-aware caret colour (`caret-current`) can be a follow-up if the theme system PR (#feat/web-theme-system) merges.
- Guardrails/monitoring: visual regression only; no runtime behaviour changed

## Agent Collaboration Notes (recommended)

- Agent tools used: Zed AI (Claude Sonnet)
- Workflow/plan summary: read backlog → filed upstream issue #4195 → restored master file → applied changes via Python script (avoiding editor reformatting) → fixed TS strict-mode error → npm build validation → format-patch → git apply --check dry-run → owner approval → push + PR
- Verification focus: confirmed no quote-style or formatting changes mixed with functional changes; diff reviewed line-by-line before commit
- Confirmation: naming + architecture boundaries followed per AGENTS.md and CONTRIBUTING.md

## Rollback Plan (required)

- Fast rollback: revert `web/src/pages/Config.tsx` — no config, no migration, no backend change
- Feature flags or config toggles: none
- Observable failure symptoms: editor reverts to plain textarea with page-level scroll

## Risks and Mitigations

- Risk: `caret-white` hardcoded caret colour invisible on light themes
  - Mitigation: light theme is not currently shipped; if theme system lands, change `caret-white` to `caret-current` in a follow-up
- Risk: `dangerouslySetInnerHTML` on highlighted content
  - Mitigation: input is HTML-escaped before span tags are injected; content source is the user's own local config, not network input from other users