### PR TITLE
fix(web/logs): layout, footer status indicator, and empty-state note

### DIFF
--- a/web/src/pages/Logs.tsx
+++ b/web/src/pages/Logs.tsx
@@ -24,7 +24,13 @@ function eventTypeStyle(type: string): { color: string; bg: string; border: stri
       return { color: 'var(--color-status-warning)', bg: 'rgba(255, 170, 0, 0.06)', border: 'rgba(255, 170, 0, 0.2)' };
     case 'tool_call':
     case 'tool_result':
+    case 'tool_call_start':
       return { color: '#a78bfa', bg: 'rgba(167, 139, 250, 0.06)', border: 'rgba(167, 139, 250, 0.2)' };
+    case 'llm_request':
+      return { color: '#38bdf8', bg: 'rgba(56, 189, 248, 0.06)', border: 'rgba(56, 189, 248, 0.2)' };
+    case 'agent_start':
+    case 'agent_end':
+      return { color: '#34d399', bg: 'rgba(52, 211, 153, 0.06)', border: 'rgba(52, 211, 153, 0.2)' };
     case 'message':
     case 'chat':
       return { color: 'var(--pc-accent)', bg: 'var(--pc-accent-glow)', border: 'var(--pc-accent-dim)' };
@@ -43,6 +49,7 @@ export default function Logs() {
   const [paused, setPaused] = useState(false);
   const [connected, setConnected] = useState(false);
   const [autoScroll, setAutoScroll] = useState(true);
+  const [infoDismissed, setInfoDismissed] = useState(false);
   const [typeFilters, setTypeFilters] = useState<Set<string>>(new Set());
   const containerRef = useRef<HTMLDivElement>(null);
   const sseRef = useRef<SSEClient | null>(null);
@@ -121,21 +128,12 @@ export default function Logs() {
   const filteredEntries = typeFilters.size === 0 ? entries : entries.filter((e) => typeFilters.has(e.event.type));
 
   return (
-    <div className="flex flex-col h-[calc(100vh-3.5rem)]">
+    <div className="flex flex-col h-full">
       {/* Toolbar */}
       <div className="flex items-center justify-between px-6 py-3 border-b animate-fade-in" style={{ borderColor: 'var(--pc-border)', background: 'var(--pc-bg-surface)' }}>
         <div className="flex items-center gap-3">
           <Activity className="h-5 w-5" style={{ color: 'var(--pc-accent)' }} />
           <h2 className="text-sm font-semibold uppercase tracking-wider" style={{ color: 'var(--pc-text-primary)' }}>{t('logs.live_logs')}</h2>
-          <div className="flex items-center gap-2 ml-2">
-            <span className="status-dot" style={
-              connected ? { background: 'var(--color-status-success)', boxShadow: '0 0 6px var(--color-status-success)' } : { background: 'var(--color-status-error)', boxShadow: '0 0 6px var(--color-status-error)' }
-            }
-            />
-            <span className="text-[10px]" style={{ color: 'var(--pc-text-faint)' }}>
-              {connected ? t('logs.connected') : t('logs.disconnected')}
-            </span>
-          </div>
           <span className="text-[10px] font-mono ml-2" style={{ color: 'var(--pc-text-faint)' }}>
             {filteredEntries.length} {t('logs.events')}
           </span>
@@ -195,11 +193,32 @@ export default function Logs() {
         </div>
       )}
 
+      {/* Informational banner — what appears here and what does not */}
+      {!infoDismissed && (
+        <div className="flex items-start gap-3 px-6 py-3 border-b flex-shrink-0" style={{ borderColor: 'rgba(56, 189, 248, 0.2)', background: 'rgba(56, 189, 248, 0.05)' }}>
+          <div className="flex-1 text-xs" style={{ color: 'var(--pc-text-secondary)' }}>
+            <span className="font-semibold" style={{ color: '#38bdf8' }}>What appears here: </span>
+            agent activity over SSE — LLM requests, tool calls, agent start/end, and errors.
+            {' '}<span className="font-semibold" style={{ color: 'var(--pc-text-muted)' }}>What does not: </span>
+            daemon stdout and <code>RUST_LOG</code> tracing output go to the terminal or log file, not this stream.
+            {' '}To see tracing logs, run the daemon with <code>RUST_LOG=info zeroclaw</code> and check your terminal.
+          </div>
+          <button
+            onClick={() => setInfoDismissed(true)}
+            className="flex-shrink-0 text-[10px] btn-icon"
+            aria-label="Dismiss"
+            style={{ color: 'var(--pc-text-faint)' }}
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
       {/* Log entries */}
       <div
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto p-4 space-y-2"
+        className="flex-1 overflow-y-auto p-4 space-y-2 min-h-0"
       >
         {filteredEntries.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full animate-fade-in" style={{ color: 'var(--pc-text-muted)' }}>
@@ -248,6 +267,15 @@ export default function Logs() {
             );
           })
           )}
+      </div>
+      {/* Footer: connection status */}
+      <div className="flex items-center justify-center gap-2 px-6 py-2 border-t flex-shrink-0" style={{ borderColor: 'var(--pc-border)', background: 'var(--pc-bg-surface)' }}>
+        <span className="status-dot" style={
+          connected ? { background: 'var(--color-status-success)', boxShadow: '0 0 6px var(--color-status-success)' } : { background: 'var(--color-status-error)', boxShadow: '0 0 6px var(--color-status-error)' }
+        } />
+        <span className="text-[10px]" style={{ color: 'var(--pc-text-faint)' }}>
+          {connected ? t('logs.connected') : t('logs.disconnected')}
+        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The `/logs` page had three usability issues: a flex child missing `min-h-0` causing potential overflow; the connection indicator cluttering the toolbar; and no explanation for why the page is empty at idle, which users mistake for a misconfiguration.
- Why it matters: The empty-at-idle confusion is the most common source of confusion — the SSE stream only carries agent activity events, not daemon stdout or tracing output, and there is nothing in the UI to explain this. Moving the connection indicator to a footer matches the `/agent` page precedent and declutters the toolbar. The `min-h-0` fix prevents scroll overflow in strict flex implementations.
- What changed: `h-[calc(100vh-3.5rem)]` replaced with `h-full`; connection indicator moved from toolbar to a compact footer strip; `min-h-0` added to log entries div; dismissible informational banner added explaining what the SSE stream does and does not carry; `tool_call_start`, `llm_request`, `agent_start`, `agent_end` added to `eventTypeStyle()` with distinct colours; `infoDismissed` state added.
- What did **not** change: SSE connection logic, event parsing, pause/resume, type filters, the underlying broadcast observer, or any backend code.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `observability`
- Module labels: N/A
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `multi` (web/logs page layout + UX)

## Linked Issue

- Closes #4202

## Supersede Attribution (required when `Supersedes #` is used)

N/A — no superseded PRs.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # skipped — no Rust files changed
cargo clippy --all-targets   # skipped — no Rust files changed
cargo test                   # skipped — no Rust files changed
cd web && npm run build      # ✓ built in 2.44s, 1620 modules transformed, no errors
```

- Evidence provided: frontend build output confirms zero errors
- Rust suite skipped: only `web/src/pages/Logs.tsx` was modified; no Rust source touched

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A — layout and informational copy only, no data handling changed
- Neutral wording confirmation: informational banner uses project-native terminology (`RUST_LOG`, `zeroclaw`)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? Yes — the informational banner contains new user-facing English text. However, the banner is a developer-facing operational note (how to access tracing logs), and the existing `t()` keys for `logs.connected` / `logs.disconnected` are preserved unchanged. The new banner text is hardcoded English; a follow-up i18n pass can wrap it in `t()` keys if the project decides to localise operational hints.
- If No/N.A., link follow-up issue/PR and explain scope decision: banner text is operational/developer-facing; deferring i18n to a follow-up to keep this PR minimal.

## Human Verification (required)

- Verified scenarios: diff reviewed line-by-line — 39 insertions, 11 deletions, no reformatting of existing lines; build passes clean; `git apply --check` dry-run passes on clean master
- Edge cases checked: banner dismissed state is component-local (resets on navigation), which is appropriate — it is informational, not a persistent preference; filter row only renders when events exist so banner always appears above it correctly; footer renders regardless of entry count
- What was not verified: live browser rendering with active agent session producing events (owner will validate locally via patch)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `/logs` page layout and UX only
- Potential unintended effects: `infoDismissed` resets on page navigation — intentional, banner is informational not a persistent setting
- Guardrails/monitoring: visual regression only; no runtime or SSE behaviour changed

## Agent Collaboration Notes (recommended)

- Agent tools used: Zed AI (Claude Sonnet)
- Workflow/plan summary: read backlog → filed upstream issue #4202 → restored master file → applied all changes via Python script (avoiding editor reformatting) → npm build validation → format-patch → git apply --check dry-run → owner approval → push + PR
- Verification focus: confirmed no quote-style or formatting changes mixed with functional changes; diff reviewed before commit
- Confirmation: naming + architecture boundaries followed per AGENTS.md and CONTRIBUTING.md

## Rollback Plan (required)

- Fast rollback: revert `web/src/pages/Logs.tsx` — no config, no migration, no backend change
- Feature flags or config toggles: none
- Observable failure symptoms: page reverts to calc-height layout with connection indicator in toolbar and no empty-state explanation

## Risks and Mitigations

- Risk: informational banner text not covered by i18n
  - Mitigation: text is developer-facing operational guidance; can be wrapped in `t()` keys in a follow-up i18n pass without any behaviour change