### PR TITLE
fix(config): add weather tool to default_auto_approve list

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4256,6 +4256,7 @@ fn default_auto_approve() -> Vec<String> {
         "glob_search".into(),
         "content_search".into(),
         "image_info".into(),
+        "weather".into(),
     ]
 }
 


### PR DESCRIPTION
## Summary
- Add "weather" tool to the default_auto_approve list to allow it to work from channels

## Problem
The weather tool cannot be invoked from channels because it's not in the default_auto_approve list. This is the same issue as #4083 which was fixed by adding web_search_tool to the list.

## Solution
Add "weather" to the default_auto_approve function in src/config/schema.rs, following the same pattern as the fix for #4083 (PR #4094).

## Testing
- Tool name verified as "weather" in src/tools/weather_tool.rs:359
- Same pattern as existing auto-approve tools

Fixes #4170