### PR TITLE
fix(tests): serialize OpenAI Codex env-var tests to prevent race

### DIFF
--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -767,6 +767,17 @@ impl Provider for OpenAiCodexProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    /// Serialize tests that mutate process-global env vars.
+    ///
+    /// `std::env::set_var` / `remove_var` are process-wide, so parallel test
+    /// threads that touch the same env vars race against each other. Acquiring
+    /// this lock before any `EnvGuard::set` call prevents that.
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
 
     struct EnvGuard {
         key: &'static str,
@@ -841,6 +852,7 @@ mod tests {
 
     #[test]
     fn resolve_responses_url_prefers_explicit_endpoint_env() {
+        let _lock = env_lock();
         let _endpoint_guard = EnvGuard::set(
             CODEX_RESPONSES_URL_ENV,
             Some("https://env.example.com/v1/responses"),
@@ -856,6 +868,7 @@ mod tests {
 
     #[test]
     fn resolve_responses_url_uses_provider_api_url_override() {
+        let _lock = env_lock();
         let _endpoint_guard = EnvGuard::set(CODEX_RESPONSES_URL_ENV, None);
         let _base_guard = EnvGuard::set(CODEX_BASE_URL_ENV, None);
 


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: two `resolve_responses_url` tests in `src/providers/openai_codex.rs` race under parallel execution — one sets `ZEROCLAW_CODEX_RESPONSES_URL`, the other clears it, and `std::env::set_var`/`remove_var` are process-global
- Why it matters: intermittent `cargo test` failures block pre-push hooks and CI for all contributors
- What changed: added a shared `OnceLock<Mutex<()>>` env lock (matching the existing pattern in `skills/mod.rs` and `config/schema.rs`) so both tests serialize env-var mutations
- What did **not** change (scope boundary): no production code changes, no new dependencies, `EnvGuard` struct unchanged

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `tests`, `provider`
- Module labels: `provider: openai_codex`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `provider`

## Linked Issue

- Closes #4210

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check                    # ✅ pass
cargo clippy --all-targets -- -D warnings     # ✅ pass (0 warnings)
cargo test --locked                           # ✅ 4770 passed, 0 failed
cargo test resolve_responses_url              # ✅ 2 passed, 0 failed (both tests pass reliably)
```

- Evidence provided: full CI triple + targeted test confirmation
- If any command is intentionally skipped: none

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: test-only change, no user data involved
- Neutral wording confirmation: all identifiers use project-scoped naming

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: ran `cargo test resolve_responses_url` 10+ times in a loop with default thread parallelism — 0 failures after fix (vs ~30% failure rate before)
- Edge cases checked: mutex poisoning (test panic leaves mutex poisoned — `unwrap()` on lock matches project convention; a panicking test already fails the suite)
- What was not verified: no other env-mutating tests in this file need the lock (confirmed: only these two tests touch `CODEX_RESPONSES_URL_ENV` / `CODEX_BASE_URL_ENV`)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: test execution only — no production code paths
- Potential unintended effects: the two tests now run sequentially instead of in parallel (adds ~0ms since they are pure in-memory operations)
- Guardrails/monitoring for early detection: N/A (test-only)

## Rollback Plan (required)

- Fast rollback command/path: revert this commit (removes the lock, tests revert to racy behavior)
- Feature flags or config toggles: N/A
- Observable failure symptoms: the original intermittent test failure returns

## Risks and Mitigations

- Risk: None. Test-only change, 13 lines added, follows existing project pattern.