### PR TITLE
fix: build web dashboard during install.sh (#4207)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1448,6 +1448,25 @@ else
   step_dot "Skipping install"
 fi
 
+# --- Build web dashboard ---
+if [[ "$SKIP_BUILD" == false && -d "$WORK_DIR/web" ]]; then
+  if have_cmd node && have_cmd npm; then
+    step_dot "Building web dashboard"
+    if (cd "$WORK_DIR/web" && npm ci --ignore-scripts 2>/dev/null && npm run build 2>/dev/null); then
+      step_ok "Web dashboard built"
+    else
+      warn "Web dashboard build failed — dashboard will not be available"
+    fi
+  else
+    warn "node/npm not found — skipping web dashboard build"
+    warn "Install Node.js (>=18) and re-run, or build manually: cd web && npm ci && npm run build"
+  fi
+else
+  if [[ "$SKIP_BUILD" == true ]]; then
+    step_dot "Skipping web dashboard build"
+  fi
+fi
+
 ZEROCLAW_BIN=""
 if [[ -x "$HOME/.cargo/bin/zeroclaw" ]]; then
   ZEROCLAW_BIN="$HOME/.cargo/bin/zeroclaw"


### PR DESCRIPTION
## Summary

- Fixes #4207: After installing via `install.sh`, the web dashboard shows "Web dashboard not available" because the install script never builds it.
- Adds a web dashboard build step (`npm ci && npm run build`) after the cargo install phase, gated on `SKIP_BUILD` being false and the `web/` directory existing.
- Gracefully degrades: warns if node/npm are missing or if the build fails, rather than failing the entire install.

## Test plan

- [ ] Run `install.sh` on a machine with node/npm installed and verify `web/dist/` is created
- [ ] Run `install.sh` on a machine without node/npm and verify a warning is printed but install completes
- [ ] Run `install.sh --skip-build` and verify the web dashboard build is skipped
- [ ] Verify `bash -n install.sh` passes (syntax check)