### PR TITLE
fix: serialize env-dependent codex tests to prevent race (#4210)

### DIFF
--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -767,6 +767,12 @@ impl Provider for OpenAiCodexProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Mutex that serializes all tests which mutate process-global env vars
+    /// (`std::env::set_var` / `remove_var`).  Each such test must hold this
+    /// lock for its entire duration so that parallel test threads don't race.
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
     struct EnvGuard {
         key: &'static str,
@@ -841,6 +847,7 @@ mod tests {
 
     #[test]
     fn resolve_responses_url_prefers_explicit_endpoint_env() {
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         let _endpoint_guard = EnvGuard::set(
             CODEX_RESPONSES_URL_ENV,
             Some("https://env.example.com/v1/responses"),
@@ -856,6 +863,7 @@ mod tests {
 
     #[test]
     fn resolve_responses_url_uses_provider_api_url_override() {
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         let _endpoint_guard = EnvGuard::set(CODEX_RESPONSES_URL_ENV, None);
         let _base_guard = EnvGuard::set(CODEX_BASE_URL_ENV, None);
 
@@ -959,6 +967,7 @@ mod tests {
 
     #[test]
     fn resolve_reasoning_effort_prefers_configured_override() {
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         let _guard = EnvGuard::set("ZEROCLAW_CODEX_REASONING_EFFORT", Some("low"));
         assert_eq!(
             resolve_reasoning_effort("gpt-5-codex", Some("high")),
@@ -968,6 +977,7 @@ mod tests {
 
     #[test]
     fn resolve_reasoning_effort_uses_legacy_env_when_unconfigured() {
+        let _lock = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
         let _guard = EnvGuard::set("ZEROCLAW_CODEX_REASONING_EFFORT", Some("minimal"));
         assert_eq!(
             resolve_reasoning_effort("gpt-5-codex", None),


### PR DESCRIPTION
## Summary
- Adds a `static ENV_MUTEX: Mutex<()>` in `openai_codex::tests` that all env-var-mutating tests acquire before calling `EnvGuard::set`
- Prevents intermittent failures when `cargo test` runs these tests on parallel threads, since `std::env::set_var`/`remove_var` are process-global
- Uses `unwrap_or_else(|e| e.into_inner())` to recover from poisoned mutex (if a prior test panicked)

Fixes #4210

## Test plan
- [x] `cargo test resolve_responses_url` passes
- [x] `cargo test resolve_reasoning_effort` passes
- [x] `cargo fmt --all -- --check` clean