### PR TITLE
fix(memory): replace ILIKE with full-text search in postgres recall()

### DIFF
--- a/src/memory/postgres.rs
+++ b/src/memory/postgres.rs
@@ -100,6 +100,8 @@ impl PostgresMemory {
             CREATE INDEX IF NOT EXISTS idx_memories_category ON {qualified_table}(category);
             CREATE INDEX IF NOT EXISTS idx_memories_session_id ON {qualified_table}(session_id);
             CREATE INDEX IF NOT EXISTS idx_memories_updated_at ON {qualified_table}(updated_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_memories_content_fts ON {qualified_table} USING gin(to_tsvector('simple', content));
+            CREATE INDEX IF NOT EXISTS idx_memories_key_fts ON {qualified_table} USING gin(to_tsvector('simple', key));
             "
         ))?;
 
@@ -267,12 +269,16 @@ impl Memory for PostgresMemory {
                 "
                 SELECT id, key, content, category, created_at, session_id,
                        (
-                         CASE WHEN key ILIKE '%' || $1 || '%' THEN 2.0 ELSE 0.0 END +
-                         CASE WHEN content ILIKE '%' || $1 || '%' THEN 1.0 ELSE 0.0 END
+                         CASE WHEN to_tsvector('simple', key) @@ plainto_tsquery('simple', $1)
+                           THEN ts_rank_cd(to_tsvector('simple', key), plainto_tsquery('simple', $1)) * 2.0
+                           ELSE 0.0 END +
+                         CASE WHEN to_tsvector('simple', content) @@ plainto_tsquery('simple', $1)
+                           THEN ts_rank_cd(to_tsvector('simple', content), plainto_tsquery('simple', $1))
+                           ELSE 0.0 END
                        ) AS score
                 FROM {qualified_table}
                 WHERE ($2::TEXT IS NULL OR session_id = $2)
-                  AND ($1 = '' OR key ILIKE '%' || $1 || '%' OR content ILIKE '%' || $1 || '%')
+                  AND ($1 = '' OR to_tsvector('simple', key || ' ' || content) @@ plainto_tsquery('simple', $1))
                   {time_filter}
                 ORDER BY score DESC, updated_at DESC
                 LIMIT $3


### PR DESCRIPTION
## Summary

- Replace ILIKE substring matching with PostgreSQL full-text search (`to_tsvector`/`plainto_tsquery`/`ts_rank_cd`) in the postgres memory backend's `recall()` method
- Add GIN indexes on `key` and `content` tsvector columns for query performance
- Fixes #4204

## Motivation

The previous ILIKE-based implementation had three problems:
1. Multi-word queries were treated as a single substring (no tokenization)
2. Scores were flat (only 2.0, 1.0, or 0.0) with no continuous relevance ranking
3. Substring matching produced false positives (e.g., "rust" matching "frustrate")

## Changes

- **Schema init**: Added two GIN indexes (`idx_memories_content_fts`, `idx_memories_key_fts`) using `to_tsvector('simple', ...)` for indexed full-text search
- **`recall()` query**: Replaced `ILIKE '%' || $1 || '%'` with `to_tsvector('simple', ...) @@ plainto_tsquery('simple', $1)` for proper tokenized matching, and `ts_rank_cd()` for continuous relevance scoring
- Key matches are still weighted 2x relative to content matches
- Empty query fallback and time/session filtering are preserved

## Risk

Medium — changes SQL query behavior in the postgres memory backend. No schema migration needed (indexes are created with `IF NOT EXISTS`). Existing data is immediately searchable via FTS without reindexing.

## Test plan

- [ ] Verify `cargo fmt --all -- --check` passes
- [ ] Verify `cargo clippy --all-targets -- -D warnings` passes
- [ ] Manual test: multi-word queries return relevant results
- [ ] Manual test: "rust" no longer matches "frustrate"
- [ ] Manual test: scores are continuous rather than flat 0/1/2