### PR TITLE
fix: add weather tool to default auto_approve list

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4256,6 +4256,7 @@ fn default_auto_approve() -> Vec<String> {
         "glob_search".into(),
         "content_search".into(),
         "image_info".into(),
+        "weather".into(),
     ]
 }
 


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The weather tool was missing from the `default_auto_approve()` list, causing it to be silently denied by `ApprovalManager` in non-interactive channel mode (Telegram, Discord, Slack).
- Why it matters: Users invoking the weather tool from channels get silent failures with no feedback.
- What changed: Added `"weather".into()` to the vec in `default_auto_approve()` in `src/config/schema.rs`.
- What did **not** change: No other config, approval logic, or tool behavior was modified.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `config`, `tool`
- Module labels: `tool: weather`, `config: schema`
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `config`

## Linked Issue

- Closes #4170

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass (no output)
cargo clippy --all-targets -- -D warnings   # pass (Finished dev profile)
```

- Evidence provided: CLI output confirms both checks pass.
- If any command is intentionally skipped, explain why: `cargo test` not run — change is a single string addition to a static list with no test coverage of the exact default list contents.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Confirmed weather tool string added to default list, formatting and clippy pass.
- Edge cases checked: Verified no existing tests assert the exact contents of `default_auto_approve()`.
- What was not verified: End-to-end channel invocation (requires running instance).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Approval flow for weather tool in non-interactive channels.
- Potential unintended effects: None — weather tool is read-only HTTP GET to wttr.in.
- Guardrails/monitoring for early detection: Existing approval manager logging.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Single-line addition following established pattern from c301b1d4.
- Verification focus: Formatting, linting, and scope containment.
- Confirmation: naming + architecture boundaries followed.

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit.
- Feature flags or config toggles: Users can override `auto_approve` in their config.
- Observable failure symptoms: Weather tool silently denied in channel mode (same as current bug).

## Risks and Mitigations

- None