### PR TITLE
fix(config): stop serde_ignored from dropping [autonomy] section values

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -7516,16 +7516,31 @@ impl Config {
                 .await
                 .context("Failed to read config file")?;
 
-            // Track ignored/unknown config keys to warn users about silent misconfigurations
-            // (e.g., using [providers.ollama] which doesn't exist instead of top-level api_url)
+            // Deserialize the config with the standard TOML parser.
+            //
+            // Previously this used `serde_ignored::deserialize` for both
+            // deserialization and unknown-key detection.  However,
+            // `serde_ignored` silently drops field values inside nested
+            // structs that carry `#[serde(default)]` (e.g. the entire
+            // `[autonomy]` table), causing user-supplied values to be
+            // replaced by defaults.  See #4171.
+            //
+            // We now deserialize with `toml::from_str` (which is correct)
+            // and run `serde_ignored` separately just for diagnostics.
+            let mut config: Config =
+                toml::from_str(&contents).context("Failed to deserialize config file")?;
+
+            // Detect unknown/ignored config keys for diagnostic warnings.
+            // This second pass uses serde_ignored but discards the parsed
+            // result — only the ignored-path list is kept.
             let mut ignored_paths: Vec<String> = Vec::new();
-            let mut config: Config = serde_ignored::deserialize(
-                toml::de::Deserializer::parse(&contents).context("Failed to parse config file")?,
+            let _: Result<Config, _> = serde_ignored::deserialize(
+                toml::de::Deserializer::parse(&contents)
+                    .unwrap_or_else(|_| unreachable!("already parsed above")),
                 |path| {
                     ignored_paths.push(path.to_string());
                 },
-            )
-            .context("Failed to deserialize config file")?;
+            );
 
             // Warn about each unknown config key.
             // serde_ignored + #[serde(default)] on nested structs can produce
@@ -9984,6 +9999,37 @@ default_temperature = 0.7
         assert_eq!(parsed.memory.conversation_retention_days, 30);
         // provider_timeout_secs defaults to 120 when not specified
         assert_eq!(parsed.provider_timeout_secs, 120);
+    }
+
+    /// Regression test for #4171: the `[autonomy]` section must not be
+    /// silently dropped when parsing config TOML.
+    #[test]
+    async fn autonomy_section_is_not_silently_ignored() {
+        let raw = r#"
+default_temperature = 0.7
+
+[autonomy]
+level = "full"
+max_actions_per_hour = 99
+auto_approve = ["file_read", "memory_recall", "http_request"]
+"#;
+        let parsed = parse_test_config(raw);
+        assert_eq!(
+            parsed.autonomy.level,
+            AutonomyLevel::Full,
+            "autonomy.level must be parsed from config (was silently defaulting to Supervised)"
+        );
+        assert_eq!(
+            parsed.autonomy.max_actions_per_hour, 99,
+            "autonomy.max_actions_per_hour must be parsed from config"
+        );
+        assert!(
+            parsed
+                .autonomy
+                .auto_approve
+                .contains(&"http_request".to_string()),
+            "autonomy.auto_approve must include http_request from config"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `serde_ignored::deserialize` silently drops field values inside nested structs that carry `#[serde(default)]`, causing the entire `[autonomy]` table to be ignored at config load time. The daemon always ran in Supervised mode even when `config.toml` explicitly set `level = "full"`.
- Why it matters: Any non-CLI channel (Telegram, Discord, etc.) using `http_request` or other approval-gated tools was permanently blocked because there is no interactive operator to approve and the autonomy level was always Supervised.
- What changed: Split config loading into two passes -- `toml::from_str` for the authoritative parse, `serde_ignored` only for diagnostic unknown-key warnings (result discarded). Added regression test.
- What did **not** change: The unknown-key warning system still works. No behavioral change to approval logic, security policy, or tool execution.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: XS`
- Scope labels: `config`
- Module labels: `config: schema`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `config`

## Linked Issue

- Closes #4171

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass (0 warnings)
cargo test --lib config::schema::tests   # 235 passed, 1 pre-existing failure (unrelated)
cargo test --lib approval   # 48 passed
```

- Evidence provided: test output confirming all approval and config tests pass
- If any command is intentionally skipped, explain why: Full `cargo test` not run (takes >10min); scoped to affected modules

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Autonomy level = "full" parsed correctly from TOML; auto_approve list honored; max_actions_per_hour value preserved
- Edge cases checked: Minimal config (no [autonomy] section) still defaults to Supervised; unknown-key warnings still emitted
- What was not verified: Full daemon end-to-end with Telegram channel (requires live environment)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Config loading path only
- Potential unintended effects: The `serde_ignored` diagnostic pass now runs separately, adding negligible overhead (parses TOML twice)
- Guardrails/monitoring for early detection: Regression test `autonomy_section_is_not_silently_ignored` will catch if this regresses

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None
- Observable failure symptoms: `zeroclaw status` reporting wrong autonomy level; tools blocked in channels

## Risks and Mitigations

- Risk: Double TOML parse adds marginal startup latency
  - Mitigation: Config loading happens once at startup; the overhead is negligible (~1ms for typical configs)