### PR TITLE
chore: bump version to 0.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9530,7 +9530,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "aardvark-sys",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"

--- a/dist/aur/.SRCINFO
+++ b/dist/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = zeroclaw
 	pkgdesc = Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.
-	pkgver = 0.5.6
+	pkgver = 0.5.7
 	pkgrel = 1
 	url = https://github.com/zeroclaw-labs/zeroclaw
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = zeroclaw
 	makedepends = git
 	depends = gcc-libs
 	depends = openssl
-	source = zeroclaw-0.5.6.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.5.6.tar.gz
+	source = zeroclaw-0.5.7.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.5.7.tar.gz
 	sha256sums = SKIP
 
 pkgname = zeroclaw

--- a/dist/aur/PKGBUILD
+++ b/dist/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: zeroclaw-labs <bot@zeroclaw.dev>
 pkgname=zeroclaw
-pkgver=0.5.6
+pkgver=0.5.7
 pkgrel=1
 pkgdesc="Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant."
 arch=('x86_64')

--- a/dist/scoop/zeroclaw.json
+++ b/dist/scoop/zeroclaw.json
@@ -1,11 +1,11 @@
 {
-    "version": "0.5.6",
+    "version": "0.5.7",
     "description": "Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.",
     "homepage": "https://github.com/zeroclaw-labs/zeroclaw",
     "license": "MIT|Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.5.6/zeroclaw-x86_64-pc-windows-msvc.zip",
+            "url": "https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.5.7/zeroclaw-x86_64-pc-windows-msvc.zip",
             "hash": "",
             "bin": "zeroclaw.exe"
         }


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Version needs bumping after memory system upgrade
- Why it matters: Ensures release artifacts and package managers reflect the latest changes
- What changed: Version bumped from 0.5.6 → 0.5.7 in Cargo.toml, Cargo.lock, Scoop manifest, AUR PKGBUILD + .SRCINFO
- What did **not** change: No code changes

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `chore`
- Module labels: N/A
- Contributor tier label: N/A

## Change Metadata

- Change type: `chore`
- Primary scope: `multi`

## Linked Issue

- Related #4226

## Validation Evidence (required)

```bash
cargo check  # ✅ pass — compiles as v0.5.7
```

- Evidence provided: Cargo.lock updated automatically
- If any command is intentionally skipped: Full test suite not re-run (no code changes, version-only bump)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: `cargo check` compiles as v0.5.7
- Edge cases checked: All 4 version files updated consistently
- What was not verified: N/A

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Release pipeline, package managers
- Potential unintended effects: None
- Guardrails/monitoring for early detection: CI checks

## Rollback Plan (required)

- Fast rollback command/path: `git revert <sha>`
- Feature flags or config toggles: N/A
- Observable failure symptoms: Version mismatch in binaries

## Risks and Mitigations

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)