### PR TITLE
fix(web): remove unused import blocking release pipeline

### DIFF
--- a/web/src/pages/Tools.tsx
+++ b/web/src/pages/Tools.tsx
@@ -6,7 +6,6 @@ import {
   ChevronRight,
   Terminal,
   Package,
-  ChevronsUpDown,
 } from 'lucide-react';
 import type { ToolSpec, CliTool } from '@/types/api';
 import { getTools, getCliTools } from '@/lib/api';


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Unused `ChevronsUpDown` import in `Tools.tsx` causes TypeScript strict mode (`tsc -b`) to fail, blocking both Release Beta and Auto-sync crates.io pipelines
- Why it matters: v0.5.7 release is stuck — neither beta artifacts nor crates.io publish can complete
- What changed: Removed 1 unused import
- What did **not** change: No functional changes

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `docs`
- Module labels: N/A

## Change Metadata

- Change type: `fix`
- Primary scope: `ci`

## Validation Evidence (required)

- One-line TypeScript fix — import removed, no references exist in file

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Rollback Plan (required)

- Fast rollback command/path: `git revert <sha>`

## Risks and Mitigations

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)