### PR TITLE
feat(memory): wire external reranker into retrieval pipeline

### DIFF
--- a/deploy/reranker/migrate-mem0-to-sqlite.py
+++ b/deploy/reranker/migrate-mem0-to-sqlite.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""
+Migrate memories from mem0 server to ZeroClaw's built-in SQLite brain.db.
+
+Usage:
+    # Export from mem0 server, then import to brain.db
+    python migrate-mem0-to-sqlite.py \
+        --mem0-url http://localhost:18080 \
+        --brain-db ~/zeroclaw-workspace/memory/brain.db
+
+    # Or export from mem0 to JSON first, then import separately
+    python migrate-mem0-to-sqlite.py --export-only --mem0-url http://localhost:18080 --output memories.json
+    python migrate-mem0-to-sqlite.py --import-only --input memories.json --brain-db ~/zeroclaw-workspace/memory/brain.db
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+import uuid
+from datetime import datetime, timezone
+
+
+def export_from_mem0(mem0_url: str, output_path: str = None) -> list[dict]:
+    """Export all memories from mem0 server via /api/v1/memories/export endpoint."""
+    import urllib.request
+
+    url = f"{mem0_url.rstrip('/')}/api/v1/memories/export"
+    print(f"Fetching memories from {url} ...")
+
+    try:
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+    except Exception as e:
+        print(f"Error fetching from mem0: {e}")
+        print("Make sure the mem0 server has the /export endpoint.")
+        sys.exit(1)
+
+    # Support both "memories" and "items" keys (mem0 server uses "items")
+    memories = data.get("memories", data.get("items", []))
+    total = data.get("total", len(memories))
+    print(f"Exported {total} memories from mem0 server")
+
+    if output_path:
+        with open(output_path, "w") as f:
+            json.dump({"memories": memories, "total": total, "exported_at": datetime.now(timezone.utc).isoformat()}, f, indent=2)
+        print(f"Saved to {output_path}")
+
+    return memories
+
+
+def import_to_sqlite(memories: list[dict], brain_db_path: str):
+    """Import memories into ZeroClaw's SQLite brain.db."""
+
+    os.makedirs(os.path.dirname(brain_db_path) or ".", exist_ok=True)
+
+    conn = sqlite3.connect(brain_db_path)
+
+    # Create schema if not exists (matches zeroclaw's init_schema)
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS memories (
+            id          TEXT PRIMARY KEY,
+            key         TEXT NOT NULL UNIQUE,
+            content     TEXT NOT NULL,
+            category    TEXT NOT NULL DEFAULT 'core',
+            embedding   BLOB,
+            created_at  TEXT NOT NULL,
+            updated_at  TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_memories_category ON memories(category);
+        CREATE INDEX IF NOT EXISTS idx_memories_key ON memories(key);
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+            key, content, content=memories, content_rowid=rowid
+        );
+
+        CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+            INSERT INTO memories_fts(rowid, key, content)
+            VALUES (new.rowid, new.key, new.content);
+        END;
+        CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+            INSERT INTO memories_fts(memories_fts, rowid, key, content)
+            VALUES ('delete', old.rowid, old.key, old.content);
+        END;
+        CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+            INSERT INTO memories_fts(memories_fts, rowid, key, content)
+            VALUES ('delete', old.rowid, old.key, old.content);
+            INSERT INTO memories_fts(rowid, key, content)
+            VALUES (new.rowid, new.key, new.content);
+        END;
+
+        CREATE TABLE IF NOT EXISTS embedding_cache (
+            content_hash TEXT PRIMARY KEY,
+            embedding    BLOB NOT NULL,
+            created_at   TEXT NOT NULL,
+            accessed_at  TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_cache_accessed ON embedding_cache(accessed_at);
+    """)
+
+    # Run migrations to add missing columns (same as zeroclaw's init_schema)
+    schema_sql = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='memories'"
+    ).fetchone()[0]
+
+    if "session_id" not in schema_sql:
+        conn.executescript("""
+            ALTER TABLE memories ADD COLUMN session_id TEXT;
+            CREATE INDEX IF NOT EXISTS idx_memories_session ON memories(session_id);
+        """)
+
+    if "namespace" not in schema_sql:
+        conn.executescript("""
+            ALTER TABLE memories ADD COLUMN namespace TEXT DEFAULT 'default';
+            CREATE INDEX IF NOT EXISTS idx_memories_namespace ON memories(namespace);
+        """)
+
+    if "importance" not in schema_sql:
+        conn.execute("ALTER TABLE memories ADD COLUMN importance REAL DEFAULT 0.5;")
+
+    if "superseded_by" not in schema_sql:
+        conn.execute("ALTER TABLE memories ADD COLUMN superseded_by TEXT;")
+
+    conn.commit()
+
+    # Import memories
+    inserted = 0
+    skipped = 0
+    updated = 0
+
+    for mem in memories:
+        mem_id = mem.get("id", str(uuid.uuid4()))
+        content = mem.get("memory", mem.get("content", "")).strip()
+        if not content:
+            skipped += 1
+            continue
+
+        # Extract metadata
+        metadata = mem.get("metadata", {}) or {}
+
+        # Derive key from content (first 80 chars, sanitized)
+        key = metadata.get("key", "")
+        if not key:
+            key = content[:80].replace("\n", " ").strip()
+            # Make unique by appending short hash
+            import hashlib
+            key = f"{key}_{hashlib.sha256(content.encode()).hexdigest()[:8]}"
+
+        category = metadata.get("category", "core")
+        session_id = metadata.get("session_id")
+        scope = metadata.get("scope")
+
+        # Parse timestamps
+        created_at = mem.get("created_at", mem.get("timestamp", datetime.now(timezone.utc).isoformat()))
+        updated_at = mem.get("updated_at", created_at)
+
+        try:
+            conn.execute(
+                """INSERT INTO memories (id, key, content, category, embedding, created_at, updated_at, session_id, namespace, importance)
+                   VALUES (?, ?, ?, ?, NULL, ?, ?, ?, 'default', 0.5)
+                   ON CONFLICT(key) DO UPDATE SET
+                       content = excluded.content,
+                       category = excluded.category,
+                       updated_at = excluded.updated_at,
+                       session_id = excluded.session_id""",
+                (mem_id, key, content, category, created_at, updated_at, session_id),
+            )
+            if conn.total_changes > inserted + updated + skipped:
+                inserted += 1
+            else:
+                updated += 1
+        except sqlite3.IntegrityError:
+            # UUID collision — regenerate
+            new_id = str(uuid.uuid4())
+            try:
+                conn.execute(
+                    """INSERT INTO memories (id, key, content, category, embedding, created_at, updated_at, session_id, namespace, importance)
+                       VALUES (?, ?, ?, ?, NULL, ?, ?, ?, 'default', 0.5)
+                       ON CONFLICT(key) DO UPDATE SET
+                           content = excluded.content,
+                           category = excluded.category,
+                           updated_at = excluded.updated_at,
+                           session_id = excluded.session_id""",
+                    (new_id, key, content, category, created_at, updated_at, session_id),
+                )
+                inserted += 1
+            except Exception as e:
+                print(f"  Failed to insert memory {mem_id}: {e}")
+                skipped += 1
+
+    conn.commit()
+
+    # Verify
+    count = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+    fts_count = conn.execute("SELECT COUNT(*) FROM memories_fts").fetchone()[0]
+
+    conn.close()
+
+    print(f"\nMigration complete:")
+    print(f"  Inserted: {inserted}")
+    print(f"  Updated:  {updated}")
+    print(f"  Skipped:  {skipped}")
+    print(f"  Total in DB: {count}")
+    print(f"  FTS indexed: {fts_count}")
+    print(f"  Embeddings: NULL (will be generated on first search by zeroclaw)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Migrate mem0 memories to ZeroClaw SQLite")
+    parser.add_argument("--mem0-url", default="http://localhost:18080", help="mem0 server URL")
+    parser.add_argument("--brain-db", default=os.path.expanduser("~/zeroclaw-workspace/memory/brain.db"), help="Path to brain.db")
+    parser.add_argument("--export-only", action="store_true", help="Only export from mem0 to JSON")
+    parser.add_argument("--import-only", action="store_true", help="Only import from JSON to brain.db")
+    parser.add_argument("--output", "-o", default="mem0-export.json", help="JSON output path (for --export-only)")
+    parser.add_argument("--input", "-i", help="JSON input path (for --import-only)")
+    args = parser.parse_args()
+
+    if args.export_only:
+        export_from_mem0(args.mem0_url, args.output)
+    elif args.import_only:
+        if not args.input:
+            print("--input required for --import-only")
+            sys.exit(1)
+        with open(args.input) as f:
+            data = json.load(f)
+        memories = data.get("memories", data) if isinstance(data, dict) else data
+        import_to_sqlite(memories, args.brain_db)
+    else:
+        memories = export_from_mem0(args.mem0_url)
+        if memories:
+            import_to_sqlite(memories, args.brain_db)
+        else:
+            print("No memories to migrate.")
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/reranker/requirements.txt
+++ b/deploy/reranker/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.100.0
+uvicorn[standard]>=0.22.0
+sentence-transformers>=2.7.0
+torch>=2.0.0
+pydantic>=2.0.0

--- a/deploy/reranker/reranker-server.py
+++ b/deploy/reranker/reranker-server.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+ZeroClaw Reranker Server
+========================
+
+Lightweight FastAPI server wrapping a cross-encoder reranker model.
+
+Accepts a query + list of candidate documents, returns them reranked
+with relevance scores. Designed for ZeroClaw's retrieval pipeline.
+
+Usage:
+    pip install fastapi uvicorn sentence-transformers torch
+    python reranker-server.py
+
+    # or with a custom model:
+    RERANKER_MODEL=BAAI/bge-reranker-v2-m3 python reranker-server.py
+
+Config env vars:
+    RERANKER_MODEL   - HuggingFace model name (default: BAAI/bge-reranker-v2-m3)
+    RERANKER_HOST    - Listen host (default: 0.0.0.0)
+    RERANKER_PORT    - Listen port (default: 8787)
+    RERANKER_DEVICE  - torch device: "cpu", "cuda", "mps" (default: auto-detect)
+    RERANKER_MAX_LEN - Max sequence length (default: 512)
+"""
+
+import os
+import time
+import logging
+from typing import Optional
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("reranker")
+
+# ── Config ───────────────────────────────────────────────────
+MODEL_NAME = os.getenv("RERANKER_MODEL", "BAAI/bge-reranker-v2-m3")
+HOST = os.getenv("RERANKER_HOST", "0.0.0.0")
+PORT = int(os.getenv("RERANKER_PORT", "8787"))
+MAX_LEN = int(os.getenv("RERANKER_MAX_LEN", "512"))
+
+def detect_device() -> str:
+    """Auto-detect best available device."""
+    import torch
+    explicit = os.getenv("RERANKER_DEVICE", "").strip()
+    if explicit:
+        return explicit
+    if torch.cuda.is_available():
+        return "cuda"
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+# ── Models ───────────────────────────────────────────────────
+class RerankRequest(BaseModel):
+    query: str = Field(..., description="The search query")
+    documents: list[str] = Field(..., description="Candidate documents to rerank")
+    top_k: Optional[int] = Field(None, description="Return only top K results (default: all)")
+
+class RerankResult(BaseModel):
+    index: int
+    document: str
+    score: float
+
+class RerankResponse(BaseModel):
+    results: list[RerankResult]
+    model: str
+    elapsed_ms: float
+
+# ── App ──────────────────────────────────────────────────────
+app = FastAPI(title="ZeroClaw Reranker", version="1.0.0")
+
+# Global model reference (loaded on startup)
+_model = None
+_device = None
+
+@app.on_event("startup")
+def load_model():
+    global _model, _device
+    from sentence_transformers import CrossEncoder
+
+    _device = detect_device()
+    logger.info(f"Loading reranker model: {MODEL_NAME} on device: {_device}")
+
+    start = time.time()
+    _model = CrossEncoder(MODEL_NAME, max_length=MAX_LEN, device=_device)
+    elapsed = time.time() - start
+    logger.info(f"Model loaded in {elapsed:.1f}s")
+
+@app.get("/health")
+def health():
+    return {
+        "status": "ok",
+        "model": MODEL_NAME,
+        "device": _device,
+    }
+
+@app.post("/rerank", response_model=RerankResponse)
+def rerank(req: RerankRequest):
+    if _model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded yet")
+
+    if not req.documents:
+        return RerankResponse(results=[], model=MODEL_NAME, elapsed_ms=0.0)
+
+    if not req.query.strip():
+        raise HTTPException(status_code=400, detail="Query must not be empty")
+
+    start = time.time()
+
+    # Build query-document pairs for cross-encoder
+    pairs = [(req.query, doc) for doc in req.documents]
+    scores = _model.predict(pairs)
+
+    # Build scored results
+    scored = []
+    for i, (doc, score) in enumerate(zip(req.documents, scores)):
+        scored.append(RerankResult(
+            index=i,
+            document=doc,
+            score=float(score),
+        ))
+
+    # Sort by score descending
+    scored.sort(key=lambda x: x.score, reverse=True)
+
+    # Apply top_k if specified
+    if req.top_k is not None and req.top_k > 0:
+        scored = scored[:req.top_k]
+
+    elapsed_ms = (time.time() - start) * 1000
+    logger.info(
+        f"Reranked {len(req.documents)} docs in {elapsed_ms:.1f}ms "
+        f"(top score: {scored[0].score:.4f})" if scored else
+        f"Reranked 0 docs in {elapsed_ms:.1f}ms"
+    )
+
+    return RerankResponse(
+        results=scored,
+        model=MODEL_NAME,
+        elapsed_ms=elapsed_ms,
+    )
+
+# ── OpenAI-compatible /v1/rerank endpoint ────────────────────
+# Some embedding providers expose reranking at this path.
+# We support it for interoperability.
+
+class OpenAIRerankRequest(BaseModel):
+    model: Optional[str] = None
+    query: str
+    documents: list[str]
+    top_n: Optional[int] = None
+
+class OpenAIRerankResult(BaseModel):
+    index: int
+    relevance_score: float
+
+class OpenAIRerankResponse(BaseModel):
+    results: list[OpenAIRerankResult]
+    model: str
+
+@app.post("/v1/rerank", response_model=OpenAIRerankResponse)
+def rerank_v1(req: OpenAIRerankRequest):
+    """OpenAI-compatible rerank endpoint."""
+    if _model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded yet")
+
+    if not req.documents:
+        return OpenAIRerankResponse(results=[], model=MODEL_NAME)
+
+    if not req.query.strip():
+        raise HTTPException(status_code=400, detail="Query must not be empty")
+
+    pairs = [(req.query, doc) for doc in req.documents]
+    scores = _model.predict(pairs)
+
+    scored = []
+    for i, score in enumerate(scores):
+        scored.append(OpenAIRerankResult(
+            index=i,
+            relevance_score=float(score),
+        ))
+
+    scored.sort(key=lambda x: x.relevance_score, reverse=True)
+
+    if req.top_n is not None and req.top_n > 0:
+        scored = scored[:req.top_n]
+
+    return OpenAIRerankResponse(
+        results=scored,
+        model=req.model or MODEL_NAME,
+    )
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host=HOST, port=PORT, log_level="info")

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -3887,12 +3887,16 @@ pub struct MemoryConfig {
     /// Retrieval stages to execute in order. Valid: "cache", "fts", "vector".
     #[serde(default = "default_retrieval_stages")]
     pub retrieval_stages: Vec<String>,
-    /// Enable LLM reranking when candidate count exceeds threshold.
+    /// Enable reranking when candidate count exceeds threshold.
     #[serde(default)]
     pub rerank_enabled: bool,
     /// Minimum candidate count to trigger reranking.
     #[serde(default = "default_rerank_threshold")]
     pub rerank_threshold: usize,
+    /// Reranker server URL (e.g. "http://localhost:8787").
+    /// When set, uses an external cross-encoder reranker server.
+    #[serde(default)]
+    pub rerank_url: Option<String>,
     /// FTS score above which to early-return without vector search (0.0–1.0).
     #[serde(default = "default_fts_early_return_score")]
     pub fts_early_return_score: f64,
@@ -4043,6 +4047,7 @@ impl Default for MemoryConfig {
             retrieval_stages: default_retrieval_stages(),
             rerank_enabled: false,
             rerank_threshold: default_rerank_threshold(),
+            rerank_url: None,
             fts_early_return_score: default_fts_early_return_score(),
             default_namespace: default_namespace(),
             conflict_threshold: default_conflict_threshold(),

--- a/src/memory/retrieval.rs
+++ b/src/memory/retrieval.rs
@@ -4,8 +4,10 @@
 //! - **Stage 1 (Hot cache):** In-memory LRU of recent recall results.
 //! - **Stage 2 (FTS):** FTS5 keyword search with optional early-return.
 //! - **Stage 3 (Vector):** Vector similarity search + hybrid merge.
+//! - **Stage 4 (Rerank):** Optional cross-encoder reranking via external server.
 //!
-//! Configurable via `[memory]` settings: `retrieval_stages`, `fts_early_return_score`.
+//! Configurable via `[memory]` settings: `retrieval_stages`, `fts_early_return_score`,
+//! `rerank_enabled`, `rerank_threshold`, `rerank_url`.
 
 use super::traits::{Memory, MemoryEntry};
 use parking_lot::Mutex;
@@ -30,6 +32,12 @@ pub struct RetrievalConfig {
     pub cache_max_entries: usize,
     /// TTL for cached results.
     pub cache_ttl: Duration,
+    /// Enable cross-encoder reranking.
+    pub rerank_enabled: bool,
+    /// Minimum candidate count to trigger reranking.
+    pub rerank_threshold: usize,
+    /// Reranker server URL (e.g. "http://localhost:8787").
+    pub rerank_url: Option<String>,
 }
 
 impl Default for RetrievalConfig {
@@ -39,6 +47,9 @@ impl Default for RetrievalConfig {
             fts_early_return_score: 0.85,
             cache_max_entries: 256,
             cache_ttl: Duration::from_secs(300),
+            rerank_enabled: false,
+            rerank_threshold: 5,
+            rerank_url: None,
         }
     }
 }
@@ -110,6 +121,105 @@ impl RetrievalPipeline {
         );
     }
 
+    /// Call external reranker server to reorder results by relevance.
+    ///
+    /// Falls back to original order on any error.
+    async fn rerank_results(
+        &self,
+        query: &str,
+        results: Vec<MemoryEntry>,
+    ) -> Vec<MemoryEntry> {
+        let url = match &self.config.rerank_url {
+            Some(u) if !u.is_empty() => u.clone(),
+            _ => return results,
+        };
+
+        if results.len() < self.config.rerank_threshold {
+            return results;
+        }
+
+        let documents: Vec<String> = results
+            .iter()
+            .map(|e| format!("{}: {}", e.key, e.content))
+            .collect();
+
+        let body = serde_json::json!({
+            "query": query,
+            "documents": documents,
+        });
+
+        let client = crate::config::build_runtime_proxy_client("memory.reranker");
+        let rerank_endpoint = format!("{}/rerank", url.trim_end_matches('/'));
+
+        let resp = match client
+            .post(&rerank_endpoint)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("reranker request failed: {e}");
+                return results;
+            }
+        };
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            tracing::warn!("reranker returned {status}: {text}");
+            return results;
+        }
+
+        #[derive(serde::Deserialize)]
+        struct RerankResult {
+            index: usize,
+            score: f64,
+        }
+
+        #[derive(serde::Deserialize)]
+        struct RerankResponse {
+            results: Vec<RerankResult>,
+        }
+
+        let reranked: RerankResponse = match resp.json().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("reranker response parse failed: {e}");
+                return results;
+            }
+        };
+
+        tracing::debug!(
+            "reranker returned {} scored results",
+            reranked.results.len()
+        );
+
+        // Reorder entries by reranker scores
+        let mut reordered: Vec<MemoryEntry> = Vec::with_capacity(reranked.results.len());
+        for rr in &reranked.results {
+            if rr.index < results.len() {
+                let mut entry = results[rr.index].clone();
+                entry.score = Some(rr.score);
+                reordered.push(entry);
+            }
+        }
+
+        // Append any entries the reranker didn't return (shouldn't happen,
+        // but be defensive)
+        let reranked_indices: std::collections::HashSet<usize> =
+            reranked.results.iter().map(|r| r.index).collect();
+        for (i, entry) in results.into_iter().enumerate() {
+            if !reranked_indices.contains(&i) {
+                reordered.push(entry);
+            }
+        }
+
+        reordered
+    }
+
     /// Execute the multi-stage retrieval pipeline.
     pub async fn recall(
         &self,
@@ -157,6 +267,13 @@ impl RetrievalPipeline {
                                 }
                             }
                         }
+
+                        // Apply reranking if enabled
+                        let results = if self.config.rerank_enabled {
+                            self.rerank_results(query, results).await
+                        } else {
+                            results
+                        };
 
                         self.store_in_cache(ck, results.clone());
                         return Ok(results);
@@ -263,5 +380,13 @@ mod tests {
             .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].content, "cached content");
+    }
+
+    #[test]
+    fn rerank_config_defaults() {
+        let config = RetrievalConfig::default();
+        assert!(!config.rerank_enabled);
+        assert_eq!(config.rerank_threshold, 5);
+        assert!(config.rerank_url.is_none());
     }
 }

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -423,6 +423,7 @@ fn memory_config_defaults_for_backend(backend: &str) -> MemoryConfig {
         retrieval_stages: vec!["cache".into(), "fts".into(), "vector".into()],
         rerank_enabled: false,
         rerank_threshold: 5,
+        rerank_url: None,
         fts_early_return_score: 0.85,
         default_namespace: "default".into(),
         conflict_threshold: 0.85,


### PR DESCRIPTION
## Summary
- **Implement external reranker support** in `RetrievalPipeline` — the `rerank_enabled` / `rerank_threshold` config fields existed as scaffolding with zero implementation; this PR wires them up to an actual external cross-encoder reranker server via new `rerank_url` config field
- **Graceful fallback**: if the reranker is unreachable or returns an error, the pipeline silently falls back to the original hybrid-merge order (no crash, no degradation)
- **Deploy tooling**: includes a standalone FastAPI reranker server (`deploy/reranker/reranker-server.py`) wrapping `BAAI/bge-reranker-v2-m3`, and a `migrate-mem0-to-sqlite.py` script for migrating mem0/qdrant data into the built-in SQLite backend

## Changes
| File | What |
|---|---|
| `src/memory/retrieval.rs` | Add `rerank_results()` method + call it after FTS/vector stage when enabled |
| `src/config/schema.rs` | Add `rerank_url: Option<String>` to `MemoryConfig` |
| `src/onboard/wizard.rs` | Add `rerank_url: None` to wizard defaults |
| `deploy/reranker/reranker-server.py` | Standalone cross-encoder reranker server (FastAPI) |
| `deploy/reranker/migrate-mem0-to-sqlite.py` | mem0 → SQLite migration script |
| `deploy/reranker/requirements.txt` | Python dependencies for reranker server |

## Config example
```toml
[memory]
rerank_enabled = true
rerank_threshold = 3
rerank_url = "http://localhost:8787"
```

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib -- memory::retrieval` — all 5 tests pass (including new `rerank_config_defaults`)
- [x] Tested end-to-end on production deployment with bge-reranker-v2-m3 server
- [ ] Reranker unreachable → verify graceful fallback (no crash)
- [ ] Candidate count below threshold → verify reranker is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)