### PR TITLE
fix(skills): prevent runtime panic on UTF-8 string truncation

### DIFF
--- a/src/skills/creator.rs
+++ b/src/skills/creator.rs
@@ -106,8 +106,14 @@ impl SkillCreator {
         // Trim leading/trailing hyphens, then truncate.
         let trimmed = collapsed.trim_matches('-');
         if trimmed.len() > 64 {
-            // Truncate at a hyphen boundary if possible.
-            let truncated = &trimmed[..64];
+            // Find the nearest valid character boundary at or before 64 bytes.
+            let safe_index = trimmed
+                .char_indices()
+                .map(|(i, _)| i)
+                .take_while(|&i| i <= 64)
+                .last()
+                .unwrap_or(0);
+            let truncated = &trimmed[..safe_index];
             truncated.trim_end_matches('-').to_string()
         } else {
             trimmed.to_string()


### PR DESCRIPTION
## Summary
Resolved a critical runtime panic that occurs when truncating strings containing multi-byte UTF-8 characters (e.g., Chinese, Japanese, or emojis) at an invalid character boundary.

## Changes
- **Safe Slicing:** Replaced direct byte-index slicing (`&s[..64]`) with a safe character boundary lookup.
- **char_indices():** Uses `.char_indices()` to identify the nearest valid UTF-8 boundary at or before the 64-byte limit.
- **Zero Regression:** Preserves the existing logic that trims trailing hyphens after truncation.

## Impact
Fixes #4139. This is a stability fix for the skill creation workflow, preventing daemon crashes when processing non-ASCII input.

## Verified
- Reproduced the panic locally with a standalone Rust script using the reporter's exact input.
- Verified that the new logic correctly truncates at the last valid character before the limit without panicking.
- Tested with mixed ASCII/UTF-8 strings.