### PR TITLE
fix(matrix): disable automatic key backup when no backup key is configured

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -526,8 +526,9 @@ impl MatrixChannel {
         if client.encryption().backups().are_enabled().await {
             tracing::info!("Matrix room-key backup is enabled for this device.");
         } else {
+            client.encryption().backups().disable().await;
             tracing::warn!(
-                "Matrix room-key backup is not enabled for this device; `matrix_sdk_crypto::backups` warnings about missing backup keys may appear until recovery is configured."
+                "Matrix room-key backup is not enabled for this device; automatic backup attempts have been disabled to suppress recurring warnings. To enable backups, configure server-side key backup and recovery for this device."
             );
         }
     }


### PR DESCRIPTION
## Summary
- Explicitly disables automatic room key backup when no backup key is found, preventing the `matrix_sdk_crypto::backups` warning from spamming logs every ~30 seconds during sync
- Updates the diagnostic log message to explain that backups were disabled and how to enable them

Closes #4227

## Test plan
- [ ] Build with `--features channel-matrix` and verify compilation
- [ ] Run with Matrix E2EE enabled and confirm no backup key warning spam in logs
- [ ] Verify E2EE messaging still works correctly after backup is disabled
- [ ] Check that the startup diagnostic log clearly indicates backup status