### PR TITLE
feat(gateway): add named sessions with human-readable labels

### DIFF
--- a/src/channels/session_backend.rs
+++ b/src/channels/session_backend.rs
@@ -12,6 +12,8 @@ use chrono::{DateTime, Utc};
 pub struct SessionMetadata {
     /// Session key (e.g. `telegram_user123`).
     pub key: String,
+    /// Optional human-readable name (e.g. `eyrie-commander-briefing`).
+    pub name: Option<String>,
     /// When the session was first created.
     pub created_at: DateTime<Utc>,
     /// When the last message was appended.
@@ -54,6 +56,7 @@ pub trait SessionBackend: Send + Sync {
                 let messages = self.load(&key);
                 SessionMetadata {
                     key,
+                    name: None,
                     created_at: Utc::now(),
                     last_activity: Utc::now(),
                     message_count: messages.len(),
@@ -81,6 +84,11 @@ pub trait SessionBackend: Send + Sync {
     fn delete_session(&self, _session_key: &str) -> std::io::Result<bool> {
         Ok(false)
     }
+
+    /// Set or update the human-readable name for a session.
+    fn set_session_name(&self, _session_key: &str, _name: &str) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -91,6 +99,7 @@ mod tests {
     fn session_metadata_is_constructible() {
         let meta = SessionMetadata {
             key: "test".into(),
+            name: None,
             created_at: Utc::now(),
             last_activity: Utc::now(),
             message_count: 5,

--- a/src/channels/session_sqlite.rs
+++ b/src/channels/session_sqlite.rs
@@ -51,7 +51,8 @@ impl SqliteSessionBackend {
                 session_key  TEXT PRIMARY KEY,
                 created_at   TEXT NOT NULL,
                 last_activity TEXT NOT NULL,
-                message_count INTEGER NOT NULL DEFAULT 0
+                message_count INTEGER NOT NULL DEFAULT 0,
+                name         TEXT
              );
 
              CREATE VIRTUAL TABLE IF NOT EXISTS sessions_fts USING fts5(
@@ -68,6 +69,18 @@ impl SqliteSessionBackend {
              END;",
         )
         .context("Failed to initialize session schema")?;
+
+        // Migration: add name column to existing databases
+        let has_name: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM pragma_table_info('session_metadata') WHERE name = 'name'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap_or(false);
+        if !has_name {
+            let _ = conn.execute("ALTER TABLE session_metadata ADD COLUMN name TEXT", []);
+        }
 
         Ok(Self {
             conn: Mutex::new(conn),
@@ -226,7 +239,7 @@ impl SessionBackend for SqliteSessionBackend {
     fn list_sessions_with_metadata(&self) -> Vec<SessionMetadata> {
         let conn = self.conn.lock();
         let mut stmt = match conn.prepare(
-            "SELECT session_key, created_at, last_activity, message_count
+            "SELECT session_key, created_at, last_activity, message_count, name
              FROM session_metadata ORDER BY last_activity DESC",
         ) {
             Ok(s) => s,
@@ -238,6 +251,7 @@ impl SessionBackend for SqliteSessionBackend {
             let created_str: String = row.get(1)?;
             let activity_str: String = row.get(2)?;
             let count: i64 = row.get(3)?;
+            let name: Option<String> = row.get(4)?;
 
             let created = DateTime::parse_from_rfc3339(&created_str)
                 .map(|dt| dt.with_timezone(&Utc))
@@ -249,6 +263,7 @@ impl SessionBackend for SqliteSessionBackend {
             #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
             Ok(SessionMetadata {
                 key,
+                name,
                 created_at: created,
                 last_activity: activity,
                 message_count: count as usize,
@@ -321,6 +336,17 @@ impl SessionBackend for SqliteSessionBackend {
         Ok(true)
     }
 
+    fn set_session_name(&self, session_key: &str, name: &str) -> std::io::Result<()> {
+        let conn = self.conn.lock();
+        let name_val = if name.is_empty() { None } else { Some(name) };
+        conn.execute(
+            "UPDATE session_metadata SET name = ?1 WHERE session_key = ?2",
+            params![name_val, session_key],
+        )
+        .map_err(std::io::Error::other)?;
+        Ok(())
+    }
+
     fn search(&self, query: &SessionQuery) -> Vec<SessionMetadata> {
         let Some(keyword) = &query.keyword else {
             return self.list_sessions_with_metadata();
@@ -357,14 +383,16 @@ impl SessionBackend for SqliteSessionBackend {
         keys.iter()
             .filter_map(|key| {
                 conn.query_row(
-                    "SELECT created_at, last_activity, message_count FROM session_metadata WHERE session_key = ?1",
+                    "SELECT created_at, last_activity, message_count, name FROM session_metadata WHERE session_key = ?1",
                     params![key],
                     |row| {
                         let created_str: String = row.get(0)?;
                         let activity_str: String = row.get(1)?;
                         let count: i64 = row.get(2)?;
+                        let name: Option<String> = row.get(3)?;
                         Ok(SessionMetadata {
                             key: key.clone(),
+                            name,
                             created_at: DateTime::parse_from_rfc3339(&created_str)
                                 .map(|dt| dt.with_timezone(&Utc))
                                 .unwrap_or_else(|_| Utc::now()),
@@ -554,5 +582,56 @@ mod tests {
         let msgs = backend.load("test_user");
         assert_eq!(msgs.len(), 2);
         assert_eq!(msgs[0].content, "hello");
+    }
+
+    #[test]
+    fn set_session_name_persists() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        backend.append("s1", &ChatMessage::user("hello")).unwrap();
+        backend.set_session_name("s1", "My Session").unwrap();
+
+        let meta = backend.list_sessions_with_metadata();
+        assert_eq!(meta.len(), 1);
+        assert_eq!(meta[0].name.as_deref(), Some("My Session"));
+    }
+
+    #[test]
+    fn set_session_name_updates_existing() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        backend.append("s1", &ChatMessage::user("hello")).unwrap();
+        backend.set_session_name("s1", "First").unwrap();
+        backend.set_session_name("s1", "Second").unwrap();
+
+        let meta = backend.list_sessions_with_metadata();
+        assert_eq!(meta[0].name.as_deref(), Some("Second"));
+    }
+
+    #[test]
+    fn sessions_without_name_return_none() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        backend.append("s1", &ChatMessage::user("hello")).unwrap();
+
+        let meta = backend.list_sessions_with_metadata();
+        assert_eq!(meta.len(), 1);
+        assert!(meta[0].name.is_none());
+    }
+
+    #[test]
+    fn empty_name_clears_to_none() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        backend.append("s1", &ChatMessage::user("hello")).unwrap();
+        backend.set_session_name("s1", "Named").unwrap();
+        backend.set_session_name("s1", "").unwrap();
+
+        let meta = backend.list_sessions_with_metadata();
+        assert!(meta[0].name.is_none());
     }
 }

--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -1280,12 +1280,16 @@ pub async fn handle_api_sessions_list(
         .into_iter()
         .filter_map(|meta| {
             let session_id = meta.key.strip_prefix("gw_")?;
-            Some(serde_json::json!({
+            let mut entry = serde_json::json!({
                 "session_id": session_id,
                 "created_at": meta.created_at.to_rfc3339(),
                 "last_activity": meta.last_activity.to_rfc3339(),
                 "message_count": meta.message_count,
-            }))
+            });
+            if let Some(name) = meta.name {
+                entry["name"] = serde_json::Value::String(name);
+            }
+            Some(entry)
         })
         .collect();
 
@@ -1321,6 +1325,45 @@ pub async fn handle_api_session_delete(
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": format!("Failed to delete session: {e}")})),
+        )
+            .into_response(),
+    }
+}
+
+/// PUT /api/sessions/{id} — rename a gateway session
+pub async fn handle_api_session_rename(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let Some(ref backend) = state.session_backend else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "Session persistence is disabled"})),
+        )
+            .into_response();
+    };
+
+    let name = body["name"].as_str().unwrap_or("").trim();
+    if name.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "name is required"})),
+        )
+            .into_response();
+    }
+
+    let session_key = format!("gw_{id}");
+    match backend.set_session_name(&session_key, name) {
+        Ok(()) => Json(serde_json::json!({"session_id": id, "name": name})).into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": format!("Failed to rename session: {e}")})),
         )
             .into_response(),
     }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -886,7 +886,7 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         .route("/api/cli-tools", get(api::handle_api_cli_tools))
         .route("/api/health", get(api::handle_api_health))
         .route("/api/sessions", get(api::handle_api_sessions_list))
-        .route("/api/sessions/{id}", delete(api::handle_api_session_delete))
+        .route("/api/sessions/{id}", delete(api::handle_api_session_delete).put(api::handle_api_session_rename))
         // ── Pairing + Device management API ──
         .route("/api/pairing/initiate", post(api_pairing::initiate_pairing))
         .route("/api/pair", post(api_pairing::submit_pairing_enhanced))

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -1,13 +1,21 @@
 //! WebSocket agent chat handler.
 //!
+//! Connect: `ws://host:port/ws/chat?session_id=ID&name=My+Session`
+//!
 //! Protocol:
 //! ```text
+//! Server -> Client: {"type":"session_start","session_id":"...","name":"...","resumed":true,"message_count":42}
 //! Client -> Server: {"type":"message","content":"Hello"}
 //! Server -> Client: {"type":"chunk","content":"Hi! "}
 //! Server -> Client: {"type":"tool_call","name":"shell","args":{...}}
 //! Server -> Client: {"type":"tool_result","name":"shell","output":"..."}
 //! Server -> Client: {"type":"done","full_response":"..."}
 //! ```
+//!
+//! Query params:
+//! - `session_id` — resume or create a session (default: new UUID)
+//! - `name` — optional human-readable label for the session
+//! - `token` — bearer auth token (alternative to Authorization header)
 
 use super::AppState;
 use axum::{
@@ -53,6 +61,8 @@ const BEARER_SUBPROTO_PREFIX: &str = "bearer.";
 pub struct WsQuery {
     pub token: Option<String>,
     pub session_id: Option<String>,
+    /// Optional human-readable name for the session.
+    pub name: Option<String>,
 }
 
 /// Extract a bearer token from WebSocket-compatible sources.
@@ -134,14 +144,20 @@ pub async fn handle_ws_chat(
     };
 
     let session_id = params.session_id;
-    ws.on_upgrade(move |socket| handle_socket(socket, state, session_id))
+    let session_name = params.name;
+    ws.on_upgrade(move |socket| handle_socket(socket, state, session_id, session_name))
         .into_response()
 }
 
 /// Gateway session key prefix to avoid collisions with channel sessions.
 const GW_SESSION_PREFIX: &str = "gw_";
 
-async fn handle_socket(socket: WebSocket, state: AppState, session_id: Option<String>) {
+async fn handle_socket(
+    socket: WebSocket,
+    state: AppState,
+    session_id: Option<String>,
+    session_name: Option<String>,
+) {
     let (mut sender, mut receiver) = socket.split();
 
     // Resolve session ID: use provided or generate a new UUID
@@ -170,15 +186,22 @@ async fn handle_socket(socket: WebSocket, state: AppState, session_id: Option<St
             agent.seed_history(&messages);
             resumed = true;
         }
+        // Set session name if provided (on first connect or rename)
+        if let Some(ref name) = session_name {
+            let _ = backend.set_session_name(&session_key, name);
+        }
     }
 
     // Send session_start message to client
-    let session_start = serde_json::json!({
+    let mut session_start = serde_json::json!({
         "type": "session_start",
         "session_id": session_id,
         "resumed": resumed,
         "message_count": message_count,
     });
+    if let Some(ref name) = session_name {
+        session_start["name"] = serde_json::Value::String(name.clone());
+    }
     let _ = sender
         .send(Message::Text(session_start.to_string().into()))
         .await;


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Gateway sessions are identified only by opaque UUIDs, making them hard to manage in orchestrators and dashboards
- Why it matters: External tools (like [Eyrie](https://github.com/Audacity88/eyrie)) need to create purpose-specific sessions (e.g., "commander-briefing", "project-chess-coach") and display them with meaningful labels
- What changed: Added optional human-readable `name` field to sessions — settable on WS connect or via rename API, returned in session list and session_start frame
- What did **not** change: Session persistence logic, message storage, FTS5 search, session cleanup/TTL, authentication, or the existing session_id-based addressing

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `gateway`
- Module labels: `gateway: sessions`
- Contributor tier label: N/A (first contribution)
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `gateway`

## Linked Issue

- Related: orchestrator tools that manage multi-agent sessions need named sessions for UX

## Validation Evidence (required)

```bash
cargo fmt --all -- --check    # ✅ clean
cargo clippy --all-targets -- -D warnings  # ✅ clean (0 warnings)
cargo test                    # ✅ 14/14 passed (4 new + 10 existing session_sqlite tests)
```

New tests:
- `set_session_name_persists` — name survives round-trip through metadata
- `set_session_name_updates_existing` — rename overwrites previous name
- `sessions_without_name_return_none` — unnamed sessions have `name: None`
- `empty_name_clears_to_none` — setting empty string clears the name

Manual testing:
- Created session with `?name=my-session` on WS connect — name persists in metadata
- Renamed via `PUT /api/sessions/{id}` — name updates
- Sessions list returns name when set, omits when null
- `session_start` frame includes name field
- Existing sessions without names work unchanged
- Migration adds column to existing database without data loss

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Scenario Testing (required)

- Verified scenarios: WS connect with name, rename API, list with names, migration on existing DB
- Edge cases checked: empty name (clears to null), unnamed sessions (backward compat), rename nonexistent session (no-op)
- What was not verified: JSONL backend (only SQLite tested — JSONL `set_session_name` is a no-op default)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: gateway WS handler, session list API, SQLite session backend
- Potential unintended effects: None — name is purely additive metadata. Existing clients that don't send `?name=` see no change.
- Guardrails/monitoring: Migration uses `ALTER TABLE ADD COLUMN` which is safe on SQLite. `pragma_table_info` check prevents double-migration.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (Opus 4.6) for implementation and testing
- Workflow/plan summary: designed for Eyrie orchestrator integration, implemented incrementally with manual WS testing
- Verification focus: backward compatibility, migration safety, API consistency
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: revert commit, rebuild. The `name` column in SQLite is ignored by older code (no migration needed to roll back).
- Feature flags or config toggles: None needed — feature is opt-in (clients must send `?name=` to use it)
- Observable failure symptoms: `name` field missing from session list or session_start frame

## Risks and Mitigations

- Risk: SQLite migration (`ALTER TABLE ADD COLUMN`) on large session databases could be slow
  - Mitigation: `ALTER TABLE ADD COLUMN` is an O(1) metadata operation in SQLite — it does not rewrite the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)