### PR TITLE
feat: add SearXNG search provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,3 +118,7 @@ PROVIDER=openrouter
 # Optional: Brave Search (requires API key from https://brave.com/search/api)
 # WEB_SEARCH_PROVIDER=brave
 # BRAVE_API_KEY=your-brave-search-api-key
+#
+# Optional: SearXNG (self-hosted, requires instance URL)
+# WEB_SEARCH_PROVIDER=searxng
+# SEARXNG_INSTANCE_URL=https://searx.example.com

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2296,12 +2296,15 @@ pub struct WebSearchConfig {
     /// Enable `web_search_tool` for web searches
     #[serde(default)]
     pub enabled: bool,
-    /// Search provider: "duckduckgo" (free, no API key) or "brave" (requires API key)
+    /// Search provider: "duckduckgo" (free), "brave" (requires API key), or "searxng" (self-hosted)
     #[serde(default = "default_web_search_provider")]
     pub provider: String,
     /// Brave Search API key (required if provider is "brave")
     #[serde(default)]
     pub brave_api_key: Option<String>,
+    /// SearXNG instance URL (required if provider is "searxng"), e.g. "https://searx.example.com"
+    #[serde(default)]
+    pub searxng_instance_url: Option<String>,
     /// Maximum results per search (1-10)
     #[serde(default = "default_web_search_max_results")]
     pub max_results: usize,
@@ -2328,6 +2331,7 @@ impl Default for WebSearchConfig {
             enabled: false,
             provider: default_web_search_provider(),
             brave_api_key: None,
+            searxng_instance_url: None,
             max_results: default_web_search_max_results(),
             timeout_secs: default_web_search_timeout_secs(),
         }
@@ -8937,6 +8941,16 @@ impl Config {
             let api_key = api_key.trim();
             if !api_key.is_empty() {
                 self.web_search.brave_api_key = Some(api_key.to_string());
+            }
+        }
+
+        // SearXNG instance URL: ZEROCLAW_SEARXNG_INSTANCE_URL or SEARXNG_INSTANCE_URL
+        if let Ok(instance_url) = std::env::var("ZEROCLAW_SEARXNG_INSTANCE_URL")
+            .or_else(|_| std::env::var("SEARXNG_INSTANCE_URL"))
+        {
+            let instance_url = instance_url.trim();
+            if !instance_url.is_empty() {
+                self.web_search.searxng_instance_url = Some(instance_url.to_string());
             }
         }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -458,6 +458,7 @@ pub fn all_tools_with_runtime(
         tool_arcs.push(Arc::new(WebSearchTool::new_with_config(
             root_config.web_search.provider.clone(),
             root_config.web_search.brave_api_key.clone(),
+            root_config.web_search.searxng_instance_url.clone(),
             root_config.web_search.max_results,
             root_config.web_search.timeout_secs,
             root_config.config_path.clone(),

--- a/src/tools/web_search_provider_routing.rs
+++ b/src/tools/web_search_provider_routing.rs
@@ -2,6 +2,7 @@
 pub enum WebSearchProviderRoute {
     DuckDuckGo,
     Brave,
+    SearXNG,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -13,6 +14,7 @@ pub struct WebSearchProviderResolution {
 
 pub const DEFAULT_WEB_SEARCH_PROVIDER: &str = "duckduckgo";
 const BRAVE_PROVIDER: &str = "brave";
+const SEARXNG_PROVIDER: &str = "searxng";
 
 pub fn resolve_web_search_provider(raw_provider: &str) -> WebSearchProviderResolution {
     let normalized = raw_provider.trim().to_ascii_lowercase();
@@ -27,6 +29,11 @@ pub fn resolve_web_search_provider(raw_provider: &str) -> WebSearchProviderResol
         "brave" | "brave-search" | "brave_search" => WebSearchProviderResolution {
             route: WebSearchProviderRoute::Brave,
             canonical_provider: BRAVE_PROVIDER,
+            used_fallback: false,
+        },
+        "searxng" | "searx" | "searx-ng" | "searx_ng" => WebSearchProviderResolution {
+            route: WebSearchProviderRoute::SearXNG,
+            canonical_provider: SEARXNG_PROVIDER,
             used_fallback: false,
         },
         _ => WebSearchProviderResolution {
@@ -59,6 +66,17 @@ mod tests {
             let resolved = resolve_web_search_provider(alias);
             assert_eq!(resolved.route, WebSearchProviderRoute::Brave);
             assert_eq!(resolved.canonical_provider, BRAVE_PROVIDER);
+            assert!(!resolved.used_fallback);
+        }
+    }
+
+    #[test]
+    fn resolve_aliases_to_searxng() {
+        let searxng_aliases = ["searxng", "searx", "searx-ng", "searx_ng"];
+        for alias in searxng_aliases {
+            let resolved = resolve_web_search_provider(alias);
+            assert_eq!(resolved.route, WebSearchProviderRoute::SearXNG);
+            assert_eq!(resolved.canonical_provider, SEARXNG_PROVIDER);
             assert!(!resolved.used_fallback);
         }
     }

--- a/src/tools/web_search_tool.rs
+++ b/src/tools/web_search_tool.rs
@@ -7,7 +7,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 /// Web search tool for searching the internet.
-/// Supports multiple providers: DuckDuckGo (free), Brave (requires API key).
+/// Supports multiple providers: DuckDuckGo (free), Brave (requires API key),
+/// SearXNG (self-hosted, requires instance URL).
 ///
 /// The Brave API key is resolved lazily at execution time: if the boot-time key
 /// is missing or still encrypted, the tool re-reads `config.toml`, decrypts the
@@ -18,6 +19,8 @@ pub struct WebSearchTool {
     provider: String,
     /// Boot-time key snapshot (may be `None` if not yet configured at startup).
     boot_brave_api_key: Option<String>,
+    /// SearXNG instance base URL (e.g. "https://searx.example.com").
+    searxng_instance_url: Option<String>,
     max_results: usize,
     timeout_secs: u64,
     /// Path to `config.toml` for lazy re-read of keys at execution time.
@@ -36,6 +39,7 @@ impl WebSearchTool {
         Self {
             provider: provider.trim().to_lowercase(),
             boot_brave_api_key: brave_api_key,
+            searxng_instance_url: None,
             max_results: max_results.clamp(1, 10),
             timeout_secs: timeout_secs.max(1),
             config_path: PathBuf::new(),
@@ -51,6 +55,7 @@ impl WebSearchTool {
     pub fn new_with_config(
         provider: String,
         brave_api_key: Option<String>,
+        searxng_instance_url: Option<String>,
         max_results: usize,
         timeout_secs: u64,
         config_path: PathBuf,
@@ -59,6 +64,7 @@ impl WebSearchTool {
         Self {
             provider: provider.trim().to_lowercase(),
             boot_brave_api_key: brave_api_key,
+            searxng_instance_url,
             max_results: max_results.clamp(1, 10),
             timeout_secs: timeout_secs.max(1),
             config_path,
@@ -248,6 +254,105 @@ impl WebSearchTool {
 
         Ok(lines.join("\n"))
     }
+
+    /// Resolve the SearXNG instance URL from the boot-time config or by
+    /// re-reading `config.toml` at runtime.
+    fn resolve_searxng_instance_url(&self) -> anyhow::Result<String> {
+        if let Some(ref url) = self.searxng_instance_url {
+            if !url.is_empty() {
+                return Ok(url.clone());
+            }
+        }
+
+        // Slow path: re-read config.toml to pick up values set after boot.
+        let contents = std::fs::read_to_string(&self.config_path).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to read config file {} for SearXNG instance URL: {e}",
+                self.config_path.display()
+            )
+        })?;
+
+        let config: crate::config::Config = toml::from_str(&contents).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to parse config file {} for SearXNG instance URL: {e}",
+                self.config_path.display()
+            )
+        })?;
+
+        config
+            .web_search
+            .searxng_instance_url
+            .filter(|u| !u.is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "SearXNG instance URL not configured. Set [web_search] searxng_instance_url \
+                     in config.toml or the SEARXNG_INSTANCE_URL environment variable."
+                )
+            })
+    }
+
+    async fn search_searxng(&self, query: &str) -> anyhow::Result<String> {
+        let instance_url = self.resolve_searxng_instance_url()?;
+        let base_url = instance_url.trim_end_matches('/');
+
+        let encoded_query = urlencoding::encode(query);
+        let search_url = format!(
+            "{}/search?q={}&format=json&pageno=1",
+            base_url, encoded_query
+        );
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(self.timeout_secs))
+            .user_agent("ZeroClaw/1.0")
+            .build()?;
+
+        let response = client
+            .get(&search_url)
+            .header("Accept", "application/json")
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            anyhow::bail!("SearXNG search failed with status: {}", response.status());
+        }
+
+        let json: serde_json::Value = response.json().await?;
+        self.parse_searxng_results(&json, query)
+    }
+
+    fn parse_searxng_results(
+        &self,
+        json: &serde_json::Value,
+        query: &str,
+    ) -> anyhow::Result<String> {
+        let results = json
+            .get("results")
+            .and_then(|r| r.as_array())
+            .ok_or_else(|| anyhow::anyhow!("Invalid SearXNG API response"))?;
+
+        if results.is_empty() {
+            return Ok(format!("No results found for: {}", query));
+        }
+
+        let mut lines = vec![format!("Search results for: {} (via SearXNG)", query)];
+
+        for (i, result) in results.iter().take(self.max_results).enumerate() {
+            let title = result
+                .get("title")
+                .and_then(|t| t.as_str())
+                .unwrap_or("No title");
+            let url = result.get("url").and_then(|u| u.as_str()).unwrap_or("");
+            let content = result.get("content").and_then(|c| c.as_str()).unwrap_or("");
+
+            lines.push(format!("{}. {}", i + 1, title));
+            lines.push(format!("   {}", url));
+            if !content.is_empty() {
+                lines.push(format!("   {}", content));
+            }
+        }
+
+        Ok(lines.join("\n"))
+    }
 }
 
 fn decode_ddg_redirect_url(raw_url: &str) -> String {
@@ -314,6 +419,7 @@ impl Tool for WebSearchTool {
         let result = match resolution.route {
             WebSearchProviderRoute::DuckDuckGo => self.search_duckduckgo(query).await?,
             WebSearchProviderRoute::Brave => self.search_brave(query).await?,
+            WebSearchProviderRoute::SearXNG => self.search_searxng(query).await?,
         };
 
         Ok(ToolResult {
@@ -443,8 +549,15 @@ mod tests {
         .unwrap();
 
         // No boot key -- forces reload from config
-        let tool =
-            WebSearchTool::new_with_config("brave".to_string(), None, 5, 15, config_path, false);
+        let tool = WebSearchTool::new_with_config(
+            "brave".to_string(),
+            None,
+            None,
+            5,
+            15,
+            config_path,
+            false,
+        );
         let key = tool.resolve_brave_api_key().unwrap();
         assert_eq!(key, "fresh-key-from-disk");
     }
@@ -466,6 +579,7 @@ mod tests {
         let tool = WebSearchTool::new_with_config(
             "brave".to_string(),
             Some(encrypted),
+            None,
             5,
             15,
             config_path,
@@ -473,6 +587,111 @@ mod tests {
         );
         let key = tool.resolve_brave_api_key().unwrap();
         assert_eq!(key, "brave-secret-key");
+    }
+
+    #[tokio::test]
+    async fn test_execute_searxng_without_instance_url() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(&config_path, "[web_search]\n").unwrap();
+
+        let tool = WebSearchTool::new_with_config(
+            "searxng".to_string(),
+            None,
+            None,
+            5,
+            15,
+            config_path,
+            false,
+        );
+        let result = tool.execute(json!({"query": "test"})).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("SearXNG instance URL not configured"));
+    }
+
+    #[test]
+    fn test_parse_searxng_results_empty() {
+        let tool = WebSearchTool::new("searxng".to_string(), None, 5, 15);
+        let json = serde_json::json!({"results": []});
+        let result = tool.parse_searxng_results(&json, "test").unwrap();
+        assert!(result.contains("No results found"));
+    }
+
+    #[test]
+    fn test_parse_searxng_results_with_data() {
+        let tool = WebSearchTool::new("searxng".to_string(), None, 5, 15);
+        let json = serde_json::json!({
+            "results": [
+                {
+                    "title": "SearXNG Example",
+                    "url": "https://example.com",
+                    "content": "A privacy-respecting metasearch engine"
+                },
+                {
+                    "title": "Another Result",
+                    "url": "https://example.org",
+                    "content": "More information here"
+                }
+            ]
+        });
+        let result = tool.parse_searxng_results(&json, "test").unwrap();
+        assert!(result.contains("SearXNG Example"));
+        assert!(result.contains("https://example.com"));
+        assert!(result.contains("A privacy-respecting metasearch engine"));
+        assert!(result.contains("via SearXNG"));
+    }
+
+    #[test]
+    fn test_parse_searxng_results_invalid_response() {
+        let tool = WebSearchTool::new("searxng".to_string(), None, 5, 15);
+        let json = serde_json::json!({"error": "bad request"});
+        let result = tool.parse_searxng_results(&json, "test");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid SearXNG API response"));
+    }
+
+    #[test]
+    fn test_resolve_searxng_instance_url_from_boot() {
+        let tool = WebSearchTool {
+            provider: "searxng".to_string(),
+            boot_brave_api_key: None,
+            searxng_instance_url: Some("https://searx.example.com".to_string()),
+            max_results: 5,
+            timeout_secs: 15,
+            config_path: PathBuf::new(),
+            secrets_encrypt: false,
+        };
+        let url = tool.resolve_searxng_instance_url().unwrap();
+        assert_eq!(url, "https://searx.example.com");
+    }
+
+    #[test]
+    fn test_resolve_searxng_instance_url_reloads_from_config() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "[web_search]\nsearxng_instance_url = \"https://search.local\"\n",
+        )
+        .unwrap();
+
+        let tool = WebSearchTool::new_with_config(
+            "searxng".to_string(),
+            None,
+            None,
+            5,
+            15,
+            config_path,
+            false,
+        );
+        let url = tool.resolve_searxng_instance_url().unwrap();
+        assert_eq!(url, "https://search.local");
     }
 
     #[test]
@@ -485,6 +704,7 @@ mod tests {
 
         let tool = WebSearchTool::new_with_config(
             "brave".to_string(),
+            None,
             None,
             5,
             15,


### PR DESCRIPTION
## Summary

- Adds SearXNG as a third web search provider option alongside DuckDuckGo and Brave
- SearXNG is a self-hosted, privacy-respecting metasearch engine that aggregates results from multiple search engines
- Configurable via `[web_search] searxng_instance_url` in `config.toml` or `SEARXNG_INSTANCE_URL` env var
- Uses SearXNG's JSON output API (`/search?q=query&format=json`)

Closes #4152

## Changes

- `src/tools/web_search_provider_routing.rs`: Add `SearXNG` variant with aliases (`searxng`, `searx`, `searx-ng`, `searx_ng`)
- `src/tools/web_search_tool.rs`: Add `searxng_instance_url` field, `search_searxng()`, `parse_searxng_results()`, and `resolve_searxng_instance_url()` with lazy config reload
- `src/config/schema.rs`: Add `searxng_instance_url` to `WebSearchConfig` + env override support
- `src/tools/mod.rs`: Pass `searxng_instance_url` through tool registration
- `.env.example`: Document SearXNG configuration

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] All 27 web_search tests pass (including 7 new SearXNG-specific tests)
- [ ] Manual test: configure a SearXNG instance URL and verify search results are returned
- [ ] Verify that existing DuckDuckGo and Brave providers are unaffected