### PR TITLE
fix(cron): add WhatsApp Web delivery channel with web-mode guard

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -1,5 +1,7 @@
 #[cfg(feature = "channel-matrix")]
 use crate::channels::MatrixChannel;
+#[cfg(feature = "whatsapp-web")]
+use crate::channels::WhatsAppWebChannel;
 use crate::channels::{
     Channel, DiscordChannel, MattermostChannel, QQChannel, SendMessage, SignalChannel,
     SlackChannel, TelegramChannel,
@@ -481,6 +483,36 @@ pub(crate) async fn deliver_announcement(
             #[cfg(not(feature = "channel-matrix"))]
             {
                 anyhow::bail!("matrix delivery channel requires `channel-matrix` feature");
+            }
+        }
+        "whatsapp" | "whatsapp-web" | "whatsapp_web" => {
+            #[cfg(feature = "whatsapp-web")]
+            {
+                let wa = config
+                    .channels_config
+                    .whatsapp
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("whatsapp channel not configured"))?;
+                if !wa.is_web_config() {
+                    anyhow::bail!(
+                        "whatsapp cron delivery requires Web mode (session_path must be set)"
+                    );
+                }
+                let channel = WhatsAppWebChannel::new(
+                    wa.session_path.clone().unwrap_or_default(),
+                    wa.pair_phone.clone(),
+                    wa.pair_code.clone(),
+                    wa.allowed_numbers.clone(),
+                    wa.mode.clone(),
+                    wa.dm_policy.clone(),
+                    wa.group_policy.clone(),
+                    wa.self_chat_mode,
+                );
+                channel.send(&SendMessage::new(output, target)).await?;
+            }
+            #[cfg(not(feature = "whatsapp-web"))]
+            {
+                anyhow::bail!("whatsapp delivery channel requires `whatsapp-web` feature");
             }
         }
         "qq" => {


### PR DESCRIPTION
## Summary

- Applies PR #4258 by @rareba with a bug fix
- Adds `"whatsapp" | "whatsapp-web" | "whatsapp_web"` match arm to `deliver_announcement` in `src/cron/scheduler.rs`
- Feature-gated behind `whatsapp-web`

## Bug Fixed

The original PR was missing a backend type validation. If WhatsApp is configured for Cloud API mode (`phone_number_id` set but no `session_path`), the code would create a `WhatsAppWebChannel` with an empty session path via `unwrap_or_default()`, causing a confusing runtime failure. Added an `is_web_config()` guard that bails early with: `"whatsapp cron delivery requires Web mode (session_path must be set)"`.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo check` — passes
- `cargo check --features whatsapp-web` — passes

Supersedes #4258