### PR TITLE
feat: register skill tools as callable tool specs (#4040)

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -3737,6 +3737,11 @@ pub async fn run(
 
     // ── Build system prompt from workspace MD files (OpenClaw framework) ──
     let skills = crate::skills::load_skills_with_config(&config.workspace_dir, &config);
+
+    // Register skill-defined tools as callable tool specs in the tool registry
+    // so the LLM can invoke them via native function calling, not just XML prompts.
+    tools::register_skill_tools(&mut tools_registry, &skills, security.clone());
+
     let mut tool_descs: Vec<(&str, &str)> = vec![
         (
             "shell",
@@ -4451,6 +4456,10 @@ pub async fn process_message(
     let i18n_descs = crate::i18n::ToolDescriptions::load(&i18n_locale, &i18n_search_dirs);
 
     let skills = crate::skills::load_skills_with_config(&config.workspace_dir, &config);
+
+    // Register skill-defined tools as callable tool specs (process_message path).
+    tools::register_skill_tools(&mut tools_registry, &skills, security.clone());
+
     let mut tool_descs: Vec<(&str, &str)> = vec![
         ("shell", "Execute terminal commands."),
         ("file_read", "Read file contents."),

--- a/src/agent/prompt.rs
+++ b/src/agent/prompt.rs
@@ -473,8 +473,9 @@ mod tests {
         assert!(output.contains("<available_skills>"));
         assert!(output.contains("<name>deploy</name>"));
         assert!(output.contains("<instruction>Run smoke tests before deploy.</instruction>"));
-        assert!(output.contains("<name>release_checklist</name>"));
-        assert!(output.contains("<kind>shell</kind>"));
+        // Registered tools (shell kind) appear under <callable_tools> with prefixed names
+        assert!(output.contains("<callable_tools"));
+        assert!(output.contains("<name>deploy.release_checklist</name>"));
     }
 
     #[test]
@@ -516,10 +517,10 @@ mod tests {
         assert!(output.contains("<location>skills/deploy/SKILL.md</location>"));
         assert!(output.contains("read_skill(name)"));
         assert!(!output.contains("<instruction>Run smoke tests before deploy.</instruction>"));
-        // Compact mode should still include tools so the LLM knows about them
-        assert!(output.contains("<tools>"));
-        assert!(output.contains("<name>release_checklist</name>"));
-        assert!(output.contains("<kind>shell</kind>"));
+        // Compact mode should still include tools so the LLM knows about them.
+        // Registered tools (shell kind) appear under <callable_tools> with prefixed names.
+        assert!(output.contains("<callable_tools"));
+        assert!(output.contains("<name>deploy.release_checklist</name>"));
     }
 
     #[test]

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -7700,9 +7700,9 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(prompt.contains("<instructions>"));
         assert!(prompt
             .contains("<instruction>Always run cargo test before final response.</instruction>"));
-        assert!(prompt.contains("<tools>"));
-        assert!(prompt.contains("<name>lint</name>"));
-        assert!(prompt.contains("<kind>shell</kind>"));
+        // Registered tools (shell kind) appear under <callable_tools> with prefixed names
+        assert!(prompt.contains("<callable_tools"));
+        assert!(prompt.contains("<name>code-review.lint</name>"));
         assert!(!prompt.contains("loaded on demand"));
     }
 
@@ -7745,10 +7745,10 @@ BTC is currently around $65,000 based on latest tool output."#
         assert!(!prompt.contains("<instructions>"));
         assert!(!prompt
             .contains("<instruction>Always run cargo test before final response.</instruction>"));
-        // Compact mode should still include tools so the LLM knows about them
-        assert!(prompt.contains("<tools>"));
-        assert!(prompt.contains("<name>lint</name>"));
-        assert!(prompt.contains("<kind>shell</kind>"));
+        // Compact mode should still include tools so the LLM knows about them.
+        // Registered tools (shell kind) appear under <callable_tools> with prefixed names.
+        assert!(prompt.contains("<callable_tools"));
+        assert!(prompt.contains("<name>code-review.lint</name>"));
     }
 
     #[test]

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -738,15 +738,47 @@ pub fn skills_to_prompt_with_mode(
         }
 
         if !skill.tools.is_empty() {
-            let _ = writeln!(prompt, "    <tools>");
-            for tool in &skill.tools {
-                let _ = writeln!(prompt, "      <tool>");
-                write_xml_text_element(&mut prompt, 8, "name", &tool.name);
-                write_xml_text_element(&mut prompt, 8, "description", &tool.description);
-                write_xml_text_element(&mut prompt, 8, "kind", &tool.kind);
-                let _ = writeln!(prompt, "      </tool>");
+            // Tools with known kinds (shell, script, http) are registered as
+            // callable tool specs and can be invoked directly via function calling.
+            // We note them here for context but mark them as callable.
+            let registered: Vec<_> = skill
+                .tools
+                .iter()
+                .filter(|t| matches!(t.kind.as_str(), "shell" | "script" | "http"))
+                .collect();
+            let unregistered: Vec<_> = skill
+                .tools
+                .iter()
+                .filter(|t| !matches!(t.kind.as_str(), "shell" | "script" | "http"))
+                .collect();
+
+            if !registered.is_empty() {
+                let _ = writeln!(prompt, "    <callable_tools hint=\"These are registered as callable tool specs. Invoke them directly by name ({{}}.{{}}) instead of using shell.\">");
+                for tool in &registered {
+                    let _ = writeln!(prompt, "      <tool>");
+                    write_xml_text_element(
+                        &mut prompt,
+                        8,
+                        "name",
+                        &format!("{}.{}", skill.name, tool.name),
+                    );
+                    write_xml_text_element(&mut prompt, 8, "description", &tool.description);
+                    let _ = writeln!(prompt, "      </tool>");
+                }
+                let _ = writeln!(prompt, "    </callable_tools>");
             }
-            let _ = writeln!(prompt, "    </tools>");
+
+            if !unregistered.is_empty() {
+                let _ = writeln!(prompt, "    <tools>");
+                for tool in &unregistered {
+                    let _ = writeln!(prompt, "      <tool>");
+                    write_xml_text_element(&mut prompt, 8, "name", &tool.name);
+                    write_xml_text_element(&mut prompt, 8, "description", &tool.description);
+                    write_xml_text_element(&mut prompt, 8, "kind", &tool.kind);
+                    let _ = writeln!(prompt, "      </tool>");
+                }
+                let _ = writeln!(prompt, "    </tools>");
+            }
         }
 
         let _ = writeln!(prompt, "  </skill>");
@@ -754,6 +786,47 @@ pub fn skills_to_prompt_with_mode(
 
     prompt.push_str("</available_skills>");
     prompt
+}
+
+/// Convert skill tools into callable `Tool` trait objects.
+///
+/// Each skill's `[[tools]]` entries are converted to either `SkillShellTool`
+/// (for `shell`/`script` kinds) or `SkillHttpTool` (for `http` kind),
+/// enabling them to appear as first-class callable tool specs rather than
+/// only as XML in the system prompt.
+pub fn skills_to_tools(
+    skills: &[Skill],
+    security: std::sync::Arc<crate::security::SecurityPolicy>,
+) -> Vec<Box<dyn crate::tools::traits::Tool>> {
+    let mut tools: Vec<Box<dyn crate::tools::traits::Tool>> = Vec::new();
+    for skill in skills {
+        for tool in &skill.tools {
+            match tool.kind.as_str() {
+                "shell" | "script" => {
+                    tools.push(Box::new(crate::tools::skill_tool::SkillShellTool::new(
+                        &skill.name,
+                        tool,
+                        security.clone(),
+                    )));
+                }
+                "http" => {
+                    tools.push(Box::new(crate::tools::skill_http::SkillHttpTool::new(
+                        &skill.name,
+                        tool,
+                    )));
+                }
+                other => {
+                    tracing::warn!(
+                        "Unknown skill tool kind '{}' for {}.{}, skipping",
+                        other,
+                        skill.name,
+                        tool.name
+                    );
+                }
+            }
+        }
+    }
+    tools
 }
 
 /// Get the skills directory path
@@ -1517,10 +1590,10 @@ command = "echo hello"
         assert!(prompt.contains("read_skill(name)"));
         assert!(!prompt.contains("<instructions>"));
         assert!(!prompt.contains("<instruction>Do the thing.</instruction>"));
-        // Compact mode should still include tools so the LLM knows about them
-        assert!(prompt.contains("<tools>"));
-        assert!(prompt.contains("<name>run</name>"));
-        assert!(prompt.contains("<kind>shell</kind>"));
+        // Compact mode should still include tools so the LLM knows about them.
+        // Registered tools (shell/script/http) appear under <callable_tools>.
+        assert!(prompt.contains("<callable_tools"));
+        assert!(prompt.contains("<name>test.run</name>"));
     }
 
     #[test]
@@ -1710,9 +1783,11 @@ description = "Bare minimum"
         }];
         let prompt = skills_to_prompt(&skills, Path::new("/tmp"));
         assert!(prompt.contains("weather"));
-        assert!(prompt.contains("<name>get_weather</name>"));
+        // Registered tools (shell kind) now appear under <callable_tools> with
+        // prefixed names (skill_name.tool_name).
+        assert!(prompt.contains("<callable_tools"));
+        assert!(prompt.contains("<name>weather.get_weather</name>"));
         assert!(prompt.contains("<description>Fetch forecast</description>"));
-        assert!(prompt.contains("<kind>shell</kind>"));
     }
 
     #[test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -81,6 +81,8 @@ pub mod screenshot;
 pub mod security_ops;
 pub mod sessions;
 pub mod shell;
+pub mod skill_http;
+pub mod skill_tool;
 pub mod swarm;
 pub mod text_browser;
 pub mod tool_search;
@@ -156,6 +158,10 @@ pub use screenshot::ScreenshotTool;
 pub use security_ops::SecurityOpsTool;
 pub use sessions::{SessionsHistoryTool, SessionsListTool, SessionsSendTool};
 pub use shell::ShellTool;
+#[allow(unused_imports)]
+pub use skill_http::SkillHttpTool;
+#[allow(unused_imports)]
+pub use skill_tool::SkillShellTool;
 pub use swarm::SwarmTool;
 pub use text_browser::TextBrowserTool;
 pub use tool_search::ToolSearchTool;
@@ -255,6 +261,33 @@ pub fn default_tools_with_runtime(
         Box::new(GlobSearchTool::new(security.clone())),
         Box::new(ContentSearchTool::new(security)),
     ]
+}
+
+/// Register skill-defined tools into an existing tool registry.
+///
+/// Converts each skill's `[[tools]]` entries into callable `Tool` implementations
+/// and appends them to the registry. Skill tools that would shadow a built-in tool
+/// name are skipped with a warning.
+pub fn register_skill_tools(
+    tools_registry: &mut Vec<Box<dyn Tool>>,
+    skills: &[crate::skills::Skill],
+    security: Arc<SecurityPolicy>,
+) {
+    let skill_tools = crate::skills::skills_to_tools(skills, security);
+    let existing_names: std::collections::HashSet<String> = tools_registry
+        .iter()
+        .map(|t| t.name().to_string())
+        .collect();
+    for tool in skill_tools {
+        if existing_names.contains(tool.name()) {
+            tracing::warn!(
+                "Skill tool '{}' shadows built-in tool, skipping",
+                tool.name()
+            );
+        } else {
+            tools_registry.push(tool);
+        }
+    }
 }
 
 /// Create full tool registry including memory tools and optional Composio

--- a/src/tools/skill_http.rs
+++ b/src/tools/skill_http.rs
@@ -1,0 +1,224 @@
+//! HTTP-based tool derived from a skill's `[[tools]]` section.
+//!
+//! Each `SkillTool` with `kind = "http"` is converted into a `SkillHttpTool`
+//! that implements the `Tool` trait. The command field is used as the URL
+//! template and args are substituted as query parameters or path segments.
+
+use super::traits::{Tool, ToolResult};
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Maximum response body size (1 MB).
+const MAX_RESPONSE_BYTES: usize = 1_048_576;
+/// HTTP request timeout (seconds).
+const HTTP_TIMEOUT_SECS: u64 = 30;
+
+/// A tool derived from a skill's `[[tools]]` section that makes HTTP requests.
+pub struct SkillHttpTool {
+    tool_name: String,
+    tool_description: String,
+    url_template: String,
+    args: HashMap<String, String>,
+}
+
+impl SkillHttpTool {
+    /// Create a new skill HTTP tool.
+    ///
+    /// The tool name is prefixed with the skill name (`skill_name.tool_name`)
+    /// to prevent collisions with built-in tools.
+    pub fn new(skill_name: &str, tool: &crate::skills::SkillTool) -> Self {
+        Self {
+            tool_name: format!("{}.{}", skill_name, tool.name),
+            tool_description: tool.description.clone(),
+            url_template: tool.command.clone(),
+            args: tool.args.clone(),
+        }
+    }
+
+    fn build_parameters_schema(&self) -> serde_json::Value {
+        let mut properties = serde_json::Map::new();
+        let mut required = Vec::new();
+
+        for (name, description) in &self.args {
+            properties.insert(
+                name.clone(),
+                serde_json::json!({
+                    "type": "string",
+                    "description": description
+                }),
+            );
+            required.push(serde_json::Value::String(name.clone()));
+        }
+
+        serde_json::json!({
+            "type": "object",
+            "properties": properties,
+            "required": required
+        })
+    }
+
+    /// Substitute `{{arg_name}}` placeholders in the URL template with
+    /// the provided argument values.
+    fn substitute_args(&self, args: &serde_json::Value) -> String {
+        let mut url = self.url_template.clone();
+        if let Some(obj) = args.as_object() {
+            for (key, value) in obj {
+                let placeholder = format!("{{{{{}}}}}", key);
+                let replacement = value.as_str().unwrap_or_default();
+                url = url.replace(&placeholder, replacement);
+            }
+        }
+        url
+    }
+}
+
+#[async_trait]
+impl Tool for SkillHttpTool {
+    fn name(&self) -> &str {
+        &self.tool_name
+    }
+
+    fn description(&self) -> &str {
+        &self.tool_description
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        self.build_parameters_schema()
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        let url = self.substitute_args(&args);
+
+        // Validate URL scheme
+        if !url.starts_with("http://") && !url.starts_with("https://") {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Only http:// and https:// URLs are allowed, got: {url}"
+                )),
+            });
+        }
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(HTTP_TIMEOUT_SECS))
+            .build()
+            .map_err(|e| anyhow::anyhow!("Failed to build HTTP client: {e}"))?;
+
+        let response = match client.get(&url).send().await {
+            Ok(resp) => resp,
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!("HTTP request failed: {e}")),
+                });
+            }
+        };
+
+        let status = response.status();
+        let body = match response.bytes().await {
+            Ok(bytes) => {
+                let mut text = String::from_utf8_lossy(&bytes).to_string();
+                if text.len() > MAX_RESPONSE_BYTES {
+                    let mut b = MAX_RESPONSE_BYTES.min(text.len());
+                    while b > 0 && !text.is_char_boundary(b) {
+                        b -= 1;
+                    }
+                    text.truncate(b);
+                    text.push_str("\n... [response truncated at 1MB]");
+                }
+                text
+            }
+            Err(e) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(format!("Failed to read response body: {e}")),
+                });
+            }
+        };
+
+        Ok(ToolResult {
+            success: status.is_success(),
+            output: body,
+            error: if status.is_success() {
+                None
+            } else {
+                Some(format!("HTTP {}", status))
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skills::SkillTool;
+
+    fn sample_http_tool() -> SkillTool {
+        let mut args = HashMap::new();
+        args.insert("city".to_string(), "City name to look up".to_string());
+
+        SkillTool {
+            name: "get_weather".to_string(),
+            description: "Fetch weather for a city".to_string(),
+            kind: "http".to_string(),
+            command: "https://api.example.com/weather?city={{city}}".to_string(),
+            args,
+        }
+    }
+
+    #[test]
+    fn skill_http_tool_name_is_prefixed() {
+        let tool = SkillHttpTool::new("weather_skill", &sample_http_tool());
+        assert_eq!(tool.name(), "weather_skill.get_weather");
+    }
+
+    #[test]
+    fn skill_http_tool_description() {
+        let tool = SkillHttpTool::new("weather_skill", &sample_http_tool());
+        assert_eq!(tool.description(), "Fetch weather for a city");
+    }
+
+    #[test]
+    fn skill_http_tool_parameters_schema() {
+        let tool = SkillHttpTool::new("weather_skill", &sample_http_tool());
+        let schema = tool.parameters_schema();
+
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["city"].is_object());
+        assert_eq!(schema["properties"]["city"]["type"], "string");
+    }
+
+    #[test]
+    fn skill_http_tool_substitute_args() {
+        let tool = SkillHttpTool::new("weather_skill", &sample_http_tool());
+        let result = tool.substitute_args(&serde_json::json!({"city": "London"}));
+        assert_eq!(result, "https://api.example.com/weather?city=London");
+    }
+
+    #[test]
+    fn skill_http_tool_spec_roundtrip() {
+        let tool = SkillHttpTool::new("weather_skill", &sample_http_tool());
+        let spec = tool.spec();
+        assert_eq!(spec.name, "weather_skill.get_weather");
+        assert_eq!(spec.description, "Fetch weather for a city");
+        assert_eq!(spec.parameters["type"], "object");
+    }
+
+    #[test]
+    fn skill_http_tool_empty_args() {
+        let st = SkillTool {
+            name: "ping".to_string(),
+            description: "Ping endpoint".to_string(),
+            kind: "http".to_string(),
+            command: "https://api.example.com/ping".to_string(),
+            args: HashMap::new(),
+        };
+        let tool = SkillHttpTool::new("s", &st);
+        let schema = tool.parameters_schema();
+        assert!(schema["properties"].as_object().unwrap().is_empty());
+    }
+}

--- a/src/tools/skill_tool.rs
+++ b/src/tools/skill_tool.rs
@@ -1,0 +1,323 @@
+//! Shell-based tool derived from a skill's `[[tools]]` section.
+//!
+//! Each `SkillTool` with `kind = "shell"` or `kind = "script"` is converted
+//! into a `SkillShellTool` that implements the `Tool` trait. The tool name is
+//! prefixed with the skill name (e.g. `my_skill.run_lint`) to avoid collisions
+//! with built-in tools.
+
+use super::traits::{Tool, ToolResult};
+use crate::security::SecurityPolicy;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Maximum execution time for a skill shell command (seconds).
+const SKILL_SHELL_TIMEOUT_SECS: u64 = 60;
+/// Maximum output size in bytes (1 MB).
+const MAX_OUTPUT_BYTES: usize = 1_048_576;
+
+/// A tool derived from a skill's `[[tools]]` section that executes shell commands.
+pub struct SkillShellTool {
+    tool_name: String,
+    tool_description: String,
+    command_template: String,
+    args: HashMap<String, String>,
+    security: Arc<SecurityPolicy>,
+}
+
+impl SkillShellTool {
+    /// Create a new skill shell tool.
+    ///
+    /// The tool name is prefixed with the skill name (`skill_name.tool_name`)
+    /// to prevent collisions with built-in tools.
+    pub fn new(
+        skill_name: &str,
+        tool: &crate::skills::SkillTool,
+        security: Arc<SecurityPolicy>,
+    ) -> Self {
+        Self {
+            tool_name: format!("{}.{}", skill_name, tool.name),
+            tool_description: tool.description.clone(),
+            command_template: tool.command.clone(),
+            args: tool.args.clone(),
+            security,
+        }
+    }
+
+    fn build_parameters_schema(&self) -> serde_json::Value {
+        let mut properties = serde_json::Map::new();
+        let mut required = Vec::new();
+
+        for (name, description) in &self.args {
+            properties.insert(
+                name.clone(),
+                serde_json::json!({
+                    "type": "string",
+                    "description": description
+                }),
+            );
+            required.push(serde_json::Value::String(name.clone()));
+        }
+
+        serde_json::json!({
+            "type": "object",
+            "properties": properties,
+            "required": required
+        })
+    }
+
+    /// Substitute `{{arg_name}}` placeholders in the command template with
+    /// the provided argument values. Unknown placeholders are left as-is.
+    fn substitute_args(&self, args: &serde_json::Value) -> String {
+        let mut command = self.command_template.clone();
+        if let Some(obj) = args.as_object() {
+            for (key, value) in obj {
+                let placeholder = format!("{{{{{}}}}}", key);
+                let replacement = value.as_str().unwrap_or_default();
+                command = command.replace(&placeholder, replacement);
+            }
+        }
+        command
+    }
+}
+
+#[async_trait]
+impl Tool for SkillShellTool {
+    fn name(&self) -> &str {
+        &self.tool_name
+    }
+
+    fn description(&self) -> &str {
+        &self.tool_description
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        self.build_parameters_schema()
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        let command = self.substitute_args(&args);
+
+        // Rate limit check
+        if self.security.is_rate_limited() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
+            });
+        }
+
+        // Security validation — always requires explicit approval (approved=true)
+        // since skill tools are user-defined and should be treated as medium-risk.
+        match self.security.validate_command_execution(&command, true) {
+            Ok(_) => {}
+            Err(reason) => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some(reason),
+                });
+            }
+        }
+
+        if let Some(path) = self.security.forbidden_path_argument(&command) {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Path blocked by security policy: {path}")),
+            });
+        }
+
+        if !self.security.record_action() {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some("Rate limit exceeded: action budget exhausted".into()),
+            });
+        }
+
+        // Build and execute the command
+        let mut cmd = tokio::process::Command::new("sh");
+        cmd.arg("-c").arg(&command);
+        cmd.current_dir(&self.security.workspace_dir);
+        cmd.env_clear();
+
+        // Only pass safe environment variables
+        for var in &[
+            "PATH", "HOME", "TERM", "LANG", "LC_ALL", "USER", "SHELL", "TMPDIR",
+        ] {
+            if let Ok(val) = std::env::var(var) {
+                cmd.env(var, val);
+            }
+        }
+
+        let result =
+            tokio::time::timeout(Duration::from_secs(SKILL_SHELL_TIMEOUT_SECS), cmd.output()).await;
+
+        match result {
+            Ok(Ok(output)) => {
+                let mut stdout = String::from_utf8_lossy(&output.stdout).to_string();
+                let mut stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+                if stdout.len() > MAX_OUTPUT_BYTES {
+                    let mut b = MAX_OUTPUT_BYTES.min(stdout.len());
+                    while b > 0 && !stdout.is_char_boundary(b) {
+                        b -= 1;
+                    }
+                    stdout.truncate(b);
+                    stdout.push_str("\n... [output truncated at 1MB]");
+                }
+                if stderr.len() > MAX_OUTPUT_BYTES {
+                    let mut b = MAX_OUTPUT_BYTES.min(stderr.len());
+                    while b > 0 && !stderr.is_char_boundary(b) {
+                        b -= 1;
+                    }
+                    stderr.truncate(b);
+                    stderr.push_str("\n... [stderr truncated at 1MB]");
+                }
+
+                Ok(ToolResult {
+                    success: output.status.success(),
+                    output: stdout,
+                    error: if stderr.is_empty() {
+                        None
+                    } else {
+                        Some(stderr)
+                    },
+                })
+            }
+            Ok(Err(e)) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Failed to execute command: {e}")),
+            }),
+            Err(_) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "Command timed out after {SKILL_SHELL_TIMEOUT_SECS}s and was killed"
+                )),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::security::{AutonomyLevel, SecurityPolicy};
+    use crate::skills::SkillTool;
+
+    fn test_security() -> Arc<SecurityPolicy> {
+        Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: std::env::temp_dir(),
+            ..SecurityPolicy::default()
+        })
+    }
+
+    fn sample_skill_tool() -> SkillTool {
+        let mut args = HashMap::new();
+        args.insert("file".to_string(), "The file to lint".to_string());
+        args.insert(
+            "format".to_string(),
+            "Output format (json|text)".to_string(),
+        );
+
+        SkillTool {
+            name: "run_lint".to_string(),
+            description: "Run the linter on a file".to_string(),
+            kind: "shell".to_string(),
+            command: "lint --file {{file}} --format {{format}}".to_string(),
+            args,
+        }
+    }
+
+    #[test]
+    fn skill_shell_tool_name_is_prefixed() {
+        let tool = SkillShellTool::new("my_skill", &sample_skill_tool(), test_security());
+        assert_eq!(tool.name(), "my_skill.run_lint");
+    }
+
+    #[test]
+    fn skill_shell_tool_description() {
+        let tool = SkillShellTool::new("my_skill", &sample_skill_tool(), test_security());
+        assert_eq!(tool.description(), "Run the linter on a file");
+    }
+
+    #[test]
+    fn skill_shell_tool_parameters_schema() {
+        let tool = SkillShellTool::new("my_skill", &sample_skill_tool(), test_security());
+        let schema = tool.parameters_schema();
+
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"]["file"].is_object());
+        assert_eq!(schema["properties"]["file"]["type"], "string");
+        assert!(schema["properties"]["format"].is_object());
+
+        let required = schema["required"]
+            .as_array()
+            .expect("required should be array");
+        assert_eq!(required.len(), 2);
+    }
+
+    #[test]
+    fn skill_shell_tool_substitute_args() {
+        let tool = SkillShellTool::new("my_skill", &sample_skill_tool(), test_security());
+        let result = tool.substitute_args(&serde_json::json!({
+            "file": "src/main.rs",
+            "format": "json"
+        }));
+        assert_eq!(result, "lint --file src/main.rs --format json");
+    }
+
+    #[test]
+    fn skill_shell_tool_substitute_missing_arg() {
+        let tool = SkillShellTool::new("my_skill", &sample_skill_tool(), test_security());
+        let result = tool.substitute_args(&serde_json::json!({"file": "test.rs"}));
+        // Missing {{format}} placeholder stays in the command
+        assert!(result.contains("{{format}}"));
+        assert!(result.contains("test.rs"));
+    }
+
+    #[test]
+    fn skill_shell_tool_empty_args_schema() {
+        let st = SkillTool {
+            name: "simple".to_string(),
+            description: "Simple tool".to_string(),
+            kind: "shell".to_string(),
+            command: "echo hello".to_string(),
+            args: HashMap::new(),
+        };
+        let tool = SkillShellTool::new("s", &st, test_security());
+        let schema = tool.parameters_schema();
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"].as_object().unwrap().is_empty());
+        assert!(schema["required"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn skill_shell_tool_executes_echo() {
+        let st = SkillTool {
+            name: "hello".to_string(),
+            description: "Say hello".to_string(),
+            kind: "shell".to_string(),
+            command: "echo hello-skill".to_string(),
+            args: HashMap::new(),
+        };
+        let tool = SkillShellTool::new("test", &st, test_security());
+        let result = tool.execute(serde_json::json!({})).await.unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("hello-skill"));
+    }
+
+    #[test]
+    fn skill_shell_tool_spec_roundtrip() {
+        let tool = SkillShellTool::new("my_skill", &sample_skill_tool(), test_security());
+        let spec = tool.spec();
+        assert_eq!(spec.name, "my_skill.run_lint");
+        assert_eq!(spec.description, "Run the linter on a file");
+        assert_eq!(spec.parameters["type"], "object");
+    }
+}


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Skill `[[tools]]` are only rendered as XML in the system prompt, meaning the LLM cannot invoke them via native function calling
- Why it matters: Native tool calling is more reliable and structured than parsing XML tool descriptions from the system prompt
- What changed: Skill tools with known kinds (shell, script, http) are now registered as first-class `Tool` trait implementations in the tool registry
- What did **not** change: Skill loading, SKILL.toml/SKILL.md parsing, security policy enforcement

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: M`
- Scope labels: `skills`, `tool`
- Module labels: `tool: skill_tool`, `tool: skill_http`
- Contributor tier label: auto-managed
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (skills + tools + agent)

## Linked Issue

- Closes #4040

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass
cargo test   # 4866+ passed, 2 pre-existing failures unrelated to this PR
```

- Evidence provided: All 18 directly affected tests pass (skill_tool, skill_http, skills_section, prompt_skills tests)
- Pre-existing failures in `config::schema::tests::load_or_init_uses_persisted_active_workspace_marker` and `security::policy::tests::workspace_only_false_allows_resolved_outside_workspace` are unrelated

## Security Impact (required)

- New permissions/capabilities? Yes — skill-defined shell commands can now be executed via function calling (previously only available via XML prompt)
- New external network calls? Yes — SkillHttpTool makes HTTP requests to URLs defined in skill tool configs
- Secrets/tokens handling changed? No
- File system access scope changed? No
- Mitigation: SkillShellTool validates commands through SecurityPolicy (validate_command_execution, forbidden_path_argument, rate limiting). Shell environment is cleared and only safe vars passed. SkillHttpTool validates URL scheme (http/https only). Both tool types have output size limits (1MB) and timeouts (60s/30s).

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Tool spec generation, arg substitution, shell execution, schema roundtrips, deduplication logic, prompt rendering changes
- Edge cases checked: Empty args, missing template placeholders, tool name collision with built-ins
- What was not verified: End-to-end with a live LLM invoking skill tools

## Side Effects / Blast Radius (required)

- Affected subsystems: skills prompt rendering (XML format changed from `<tools>` to `<callable_tools>` for registered kinds), agent loop (skill tools added to tool registry)
- Potential unintended effects: LLMs that relied on exact `<tools>` XML format may need adjustment
- Guardrails: SecurityPolicy validation on all shell executions, URL scheme validation on HTTP tools

## Rollback Plan (required)

- Fast rollback command: `git revert <commit>`
- Feature flags: None (always active when skills have tools)
- Observable failure symptoms: Skill tools not appearing in function calling, or unexpected tool execution errors

## Risks and Mitigations

- Risk: Skill-defined shell commands could be malicious
  - Mitigation: All commands pass through SecurityPolicy.validate_command_execution with approved=true, forbidden path checks, and rate limiting
- Risk: Prompt format change breaks LLM behavior
  - Mitigation: Registered tools are still listed in the prompt (under `<callable_tools>`) with guidance to invoke directly