### PR TITLE
chore(ci): unify release pipeline for full auto-sync

### DIFF
--- a/.github/workflows/pub-homebrew-core.yml
+++ b/.github/workflows/pub-homebrew-core.yml
@@ -1,6 +1,22 @@
 name: Pub Homebrew Core
 
 on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Existing release tag to publish (vX.Y.Z)"
+        required: true
+        type: string
+      dry_run:
+        description: "Patch formula only (no push/PR)"
+        required: false
+        default: false
+        type: boolean
+    secrets:
+      HOMEBREW_UPSTREAM_PR_TOKEN:
+        required: false
+      HOMEBREW_CORE_BOT_TOKEN:
+        required: false
   workflow_dispatch:
     inputs:
       release_tag:

--- a/.github/workflows/publish-crates-auto.yml
+++ b/.github/workflows/publish-crates-auto.yml
@@ -41,6 +41,14 @@ jobs:
           echo "Current version: ${current}"
           echo "Previous version: ${previous}"
 
+          # Skip if stable release workflow will handle this version
+          # (indicated by an existing or imminent stable tag)
+          if git ls-remote --exit-code --tags origin "refs/tags/v${current}" >/dev/null 2>&1; then
+            echo "Stable tag v${current} exists — stable release workflow handles crates.io"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [[ "$current" != "$previous" && -n "$current" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "version=${current}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -26,22 +26,43 @@ jobs:
     outputs:
       version: ${{ steps.ver.outputs.version }}
       tag: ${{ steps.ver.outputs.tag }}
+      skip: ${{ steps.ver.outputs.skip }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 2
       - name: Compute beta version
         id: ver
         shell: bash
         run: |
           set -euo pipefail
           base_version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
+
+          # Skip beta if this is a version bump commit (stable release handles it)
+          commit_msg=$(git log -1 --pretty=format:"%s")
+          if [[ "$commit_msg" =~ ^chore:\ bump\ version ]]; then
+            echo "Version bump commit detected — skipping beta release"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Skip beta if a stable tag already exists for this version
+          if git ls-remote --exit-code --tags origin "refs/tags/v${base_version}" >/dev/null 2>&1; then
+            echo "Stable tag v${base_version} exists — skipping beta release"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           beta_tag="v${base_version}-beta.${GITHUB_RUN_NUMBER}"
           echo "version=${base_version}" >> "$GITHUB_OUTPUT"
           echo "tag=${beta_tag}" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
           echo "Beta release: ${beta_tag}"
 
   release-notes:
     name: Generate Release Notes
-    if: github.repository == 'zeroclaw-labs/zeroclaw'
+    needs: [version]
+    if: github.repository == 'zeroclaw-labs/zeroclaw' && needs.version.outputs.skip != 'true'
     runs-on: ubuntu-latest
     outputs:
       notes: ${{ steps.notes.outputs.body }}
@@ -132,7 +153,8 @@ jobs:
 
   web:
     name: Build Web Dashboard
-    if: github.repository == 'zeroclaw-labs/zeroclaw'
+    needs: [version]
+    if: github.repository == 'zeroclaw-labs/zeroclaw' && needs.version.outputs.skip != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -1,6 +1,9 @@
 name: Release Stable
 
 on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"   # stable tags only (no -beta suffix)
   workflow_dispatch:
     inputs:
       version:
@@ -33,10 +36,21 @@ jobs:
       - name: Validate semver and Cargo.toml match
         id: check
         shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version || '' }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
-          input_version="${{ inputs.version }}"
           cargo_version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
+
+          # Resolve version from tag push or manual input
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            # Tag push: extract version from tag name (v0.5.9 -> 0.5.9)
+            input_version="${REF_NAME#v}"
+          else
+            input_version="$INPUT_VERSION"
+          fi
 
           if [[ ! "$input_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Version must be semver (X.Y.Z). Got: ${input_version}"
@@ -49,9 +63,13 @@ jobs:
           fi
 
           tag="v${input_version}"
-          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
-            echo "::error::Tag ${tag} already exists."
-            exit 1
+
+          # Only check tag existence for manual dispatch (tag push means it already exists)
+          if [[ "$EVENT_NAME" != "push" ]]; then
+            if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+              echo "::error::Tag ${tag} already exists."
+              exit 1
+            fi
           fi
 
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
@@ -286,6 +304,14 @@ jobs:
           NOTES: ${{ needs.release-notes.outputs.notes }}
         run: printf '%s\n' "$NOTES" > release-notes.md
 
+      - name: Create tag if manual dispatch
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          git tag -a "$TAG" -m "zeroclaw $TAG"
+          git push origin "$TAG"
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -456,6 +482,16 @@ jobs:
     needs: [validate, publish]
     if: ${{ !cancelled() && needs.publish.result == 'success' }}
     uses: ./.github/workflows/pub-aur.yml
+    with:
+      release_tag: ${{ needs.validate.outputs.tag }}
+      dry_run: false
+    secrets: inherit
+
+  homebrew:
+    name: Update Homebrew Core
+    needs: [validate, publish]
+    if: ${{ !cancelled() && needs.publish.result == 'success' }}
+    uses: ./.github/workflows/pub-homebrew-core.yml
     with:
       release_tag: ${{ needs.validate.outputs.tag }}
       dry_run: false

--- a/scripts/release/cut_release_tag.sh
+++ b/scripts/release/cut_release_tag.sh
@@ -77,7 +77,9 @@ echo "Created annotated tag: $TAG"
 if [[ "$PUSH_TAG" == "true" ]]; then
   git push origin "$TAG"
   echo "Pushed tag to origin: $TAG"
-  echo "GitHub release pipeline will run via .github/workflows/pub-release.yml"
+  echo "Release Stable workflow will auto-trigger via tag push."
+  echo "Monitor: gh workflow view 'Release Stable' --web"
 else
   echo "Next step: git push origin $TAG"
+  echo "This will auto-trigger the Release Stable workflow (builds, Docker, crates.io, website, Scoop, AUR, Homebrew, tweet)."
 fi


### PR DESCRIPTION
## Summary

Fixes the release pipeline so everything syncs simultaneously when a version is released. Currently several systems are disconnected or race each other.

### Problems fixed

- **Homebrew never auto-triggered** — `pub-homebrew-core.yml` was manual-only, not called from the stable release workflow
- **crates.io double-publish race** — `publish-crates-auto.yml` fires on `Cargo.toml` changes, racing the stable release workflow's crates-io job
- **Beta/stable race** — `release-beta-on-push.yml` fires on version bump commits, creating a beta release alongside the stable one
- **No tag-push trigger** — `release-stable-manual.yml` only worked via manual dispatch, so `cut_release_tag.sh --push` didn't trigger anything
- **Wrong workflow reference** — `cut_release_tag.sh` referenced nonexistent `pub-release.yml`

### Changes

- **`release-stable-manual.yml`**: Add `on.push.tags` trigger for stable tags (`vX.Y.Z`). Add Homebrew Core as downstream job. Auto-create git tag on manual dispatch.
- **`pub-homebrew-core.yml`**: Add `workflow_call` trigger so it can be called from the stable release workflow.
- **`release-beta-on-push.yml`**: Skip version bump commits and commits where a stable tag already exists for the version.
- **`publish-crates-auto.yml`**: Skip when a stable tag exists (stable workflow handles crates.io).
- **`scripts/release/cut_release_tag.sh`**: Fix workflow reference and improve output messaging.

### New release flow

One action triggers everything simultaneously:
```
git push origin v0.5.9   (or manual dispatch)
         │
         ▼
  Release Stable workflow
         │
         ├── Build (7 platforms)
         ├── GitHub Release + checksums
         ├── crates.io publish
         ├── Docker images (distroless + debian)
         ├── Website redeploy
         ├── Scoop manifest update
         ├── AUR package update
         ├── Homebrew Core PR  ← NEW
         └── Tweet release     ← after website is live
```

## Test plan

- [ ] Verify YAML syntax passes CI lint
- [ ] After merge, cut tag `v0.5.9` and confirm all downstream jobs trigger
- [ ] Verify beta release does NOT fire for the version bump commit
- [ ] Verify auto crates.io publish skips when stable tag exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)