### PR TITLE
feat(slack): migrate audio transcription to TranscriptionManager

### DIFF
--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -2163,9 +2163,8 @@ impl SlackChannel {
             .is_some_and(|ext| Self::AUDIO_EXTENSIONS.contains(&ext))
     }
 
-    /// Download an audio file attachment and transcribe it using the configured
-    /// transcription provider. Returns `None` if transcription is not configured
-    /// or if the download/transcription fails.
+    /// Download an audio file attachment and transcribe it via TranscriptionManager.
+    /// Returns `None` if transcription is not configured or if download/transcription fails.
     async fn try_transcribe_audio_file(&self, file: &serde_json::Value) -> Option<String> {
         let manager = self.transcription_manager.as_deref()?;
 
@@ -2177,16 +2176,16 @@ impl SlackChannel {
         let status = resp.status();
         if !status.is_success() {
             tracing::warn!(
-                "Slack voice file download failed for {} ({status})",
+                "Slack audio download failed for {} ({status})",
                 redacted_url
             );
             return None;
         }
 
         let audio_data = match resp.bytes().await {
-            Ok(bytes) => bytes.to_vec(),
+            Ok(bytes) => bytes,
             Err(e) => {
-                tracing::warn!("Slack voice file read failed for {}: {e}", redacted_url);
+                tracing::warn!("Slack audio read failed for {}: {e}", redacted_url);
                 return None;
             }
         };

--- a/src/hardware/uf2.rs
+++ b/src/hardware/uf2.rs
@@ -364,7 +364,10 @@ mod tests {
         // Either succeeds (real UF2) or fails with a clear placeholder message.
         match result {
             Ok(dir) => {
-                assert!(dir.exists(), "firmware dir should exist after ensure_firmware_dir");
+                assert!(
+                    dir.exists(),
+                    "firmware dir should exist after ensure_firmware_dir"
+                );
                 assert!(dir.ends_with("pico"), "firmware dir should end with 'pico'");
             }
             Err(e) => {
@@ -416,7 +419,10 @@ mod tests {
 
         let port = std::path::Path::new("/dev/ttyACM_fake_test");
         let result = deploy_main_py(port, firmware_dir).await;
-        assert!(result.is_err(), "deploy should fail when main.py is missing");
+        assert!(
+            result.is_err(),
+            "deploy should fail when main.py is missing"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("main.py not found"),

--- a/src/peripherals/uno_q_bridge.rs
+++ b/src/peripherals/uno_q_bridge.rs
@@ -208,7 +208,10 @@ mod tests {
         let tool = UnoQGpioReadTool;
         let result = tool.execute(json!({"pin": 13})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.is_some(), "should report bridge connection error");
+        assert!(
+            result.error.is_some(),
+            "should report bridge connection error"
+        );
     }
 
     // ── UnoQGpioWriteTool ───────────────────────────────────────────────
@@ -277,7 +280,10 @@ mod tests {
         let tool = UnoQGpioWriteTool;
         let result = tool.execute(json!({"pin": 13, "value": 1})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.is_some(), "should report bridge connection error");
+        assert!(
+            result.error.is_some(),
+            "should report bridge connection error"
+        );
     }
 
     // ── Constants ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Slack audio transcription uses the inline `transcribe_audio()` shim rather than the centralized `TranscriptionManager`, bypassing `default_provider` selection and the global `max_audio_bytes` cap.
- Why it matters: Centralizing through `TranscriptionManager` ensures uniform provider dispatch, cap enforcement, and reduces per-channel transcription code.
- What changed: Add `transcription_manager` field to `SlackChannel`, build it in `with_transcription()`, modify `try_transcribe_audio_file()` to dispatch through `manager.transcribe()` instead of the shim.
- What did **not** change: Audio file detection logic, text snippet download, proxy support, assistant thread handling.

## Plan Context

This is **PR 8 of 15** in the audio transcription rollout. #4102 is PR 1.

```
PR 1  (#4102) — LocalWhisperProvider + LocalWhisperConfig
    ├── PR 2  (#4109) — Telegram + WhatsApp Web wiring
    │       └── PR 15 (#4309) — deprecate transcribe_audio()
    ├── PR 3  (#4114) — configurable max_audio_bytes
    ├── PR 4  (#4305) — Matrix (whisper-cpp fallback preserved)
    ├── PR 5  (#4312) — Discord
    ├── PR 6  (#4313) — WhatsApp Cloud
    ├── PR 7  (#4302) — Signal
    ├── PR 8  (#4314) — Slack ← YOU ARE HERE
    ├── PR 9  (#4303) — Linq
    ├── PR 10 (#4315) — QQ
    ├── PR 11 (#4304) — Email
    ├── PR 12 (#4306) — Lark
    ├── PR 13 (#4307) — Mattermost
    ├── PR 14 (#4308) — WATI
    │
    Fix PRs (review observations)
    └── FIX-A (#4351) — encrypt bearer_token at rest
```

PRs 2–14 are independent of each other once PR 1 merges. PR 15 requires PR 2. FIX-A is standalone.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `channel`
- Module labels: `channel: slack`

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Depends on #4102
- Related #4311

## Validation Evidence (required)

```
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided: pending CI