### PR TITLE
feat(qq): add TranscriptionManager wiring for audio attachments

### DIFF
--- a/src/channels/qq.rs
+++ b/src/channels/qq.rs
@@ -15,6 +15,9 @@ use uuid::Uuid;
 const QQ_API_BASE: &str = "https://api.sgroup.qq.com";
 const QQ_AUTH_URL: &str = "https://bots.qq.com/app/getAppAccessToken";
 
+/// Maximum audio download size for transcription (25 MB).
+const QQ_MAX_AUDIO_DOWNLOAD_BYTES: u64 = 25 * 1024 * 1024;
+
 /// Maximum upload size for QQ media files (10 MB).
 const QQ_MAX_UPLOAD_BYTES: u64 = 10 * 1024 * 1024;
 
@@ -300,6 +303,8 @@ pub struct QQChannel {
     session_id: Arc<RwLock<Option<String>>>,
     /// Last sequence number received, used for gateway resume (opcode 6).
     last_sequence: Arc<RwLock<Option<i64>>>,
+    transcription: Option<crate::config::TranscriptionConfig>,
+    transcription_manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
 }
 
 impl QQChannel {
@@ -316,6 +321,8 @@ impl QQChannel {
             proxy_url: None,
             session_id: Arc::new(RwLock::new(None)),
             last_sequence: Arc::new(RwLock::new(None)),
+            transcription: None,
+            transcription_manager: None,
         }
     }
 
@@ -324,11 +331,96 @@ impl QQChannel {
         self.workspace_dir = Some(dir);
         self
     }
-
     /// Set a per-channel proxy URL that overrides the global proxy config.
     pub fn with_proxy_url(mut self, proxy_url: Option<String>) -> Self {
         self.proxy_url = proxy_url;
         self
+    }
+
+    pub fn with_transcription(mut self, config: crate::config::TranscriptionConfig) -> Self {
+        match super::transcription::TranscriptionManager::new(&config) {
+            Ok(m) => {
+                self.transcription_manager = Some(std::sync::Arc::new(m));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "transcription manager init failed, audio transcription disabled: {e}"
+                );
+            }
+        }
+        self.transcription = Some(config);
+        self
+    }
+
+    fn is_audio_attachment(attachment: &serde_json::Value) -> bool {
+        let content_type = attachment
+            .get("content_type")
+            .and_then(|ct| ct.as_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        if content_type.starts_with("audio/") {
+            return true;
+        }
+        let filename = attachment
+            .get("filename")
+            .and_then(|f| f.as_str())
+            .unwrap_or("");
+        if let Some(ext) = filename.rsplit_once('.').map(|(_, e)| e) {
+            return matches!(
+                ext.to_ascii_lowercase().as_str(),
+                "flac" | "mp3" | "mpeg" | "mpga" | "m4a" | "ogg" | "oga" | "opus" | "wav"
+            );
+        }
+        false
+    }
+
+    async fn try_transcribe_attachment(&self, attachment: &serde_json::Value) -> Option<String> {
+        if !Self::is_audio_attachment(attachment) {
+            return None;
+        }
+        let manager = self.transcription_manager.as_deref()?;
+        let url = attachment.get("url").and_then(|u| u.as_str())?.trim();
+        if url.is_empty() {
+            return None;
+        }
+        if ensure_https(url).is_err() {
+            tracing::warn!("QQ: refusing to fetch audio over non-HTTPS URL");
+            return None;
+        }
+        let token = self.get_token().await.ok()?;
+        let resp = self
+            .http_client()
+            .get(url)
+            .header("Authorization", format!("QQBot {token}"))
+            .send()
+            .await
+            .ok()?;
+        if !resp.status().is_success() {
+            tracing::warn!("QQ: audio attachment fetch failed: {}", resp.status());
+            return None;
+        }
+        if let Some(content_length) = resp.content_length() {
+            if content_length > QQ_MAX_AUDIO_DOWNLOAD_BYTES {
+                tracing::warn!(
+                    "QQ: audio download skipped: content-length {content_length} exceeds {} bytes",
+                    QQ_MAX_AUDIO_DOWNLOAD_BYTES
+                );
+                return None;
+            }
+        }
+        let audio_data = resp.bytes().await.ok()?;
+        let filename = attachment
+            .get("filename")
+            .and_then(|f| f.as_str())
+            .filter(|f| !f.is_empty())
+            .unwrap_or("audio.ogg");
+        match manager.transcribe(&audio_data, filename).await {
+            Ok(transcript) => Some(transcript),
+            Err(e) => {
+                tracing::warn!("QQ: transcription failed: {e}");
+                None
+            }
+        }
     }
 
     fn http_client(&self) -> reqwest::Client {

--- a/src/hardware/uf2.rs
+++ b/src/hardware/uf2.rs
@@ -364,7 +364,10 @@ mod tests {
         // Either succeeds (real UF2) or fails with a clear placeholder message.
         match result {
             Ok(dir) => {
-                assert!(dir.exists(), "firmware dir should exist after ensure_firmware_dir");
+                assert!(
+                    dir.exists(),
+                    "firmware dir should exist after ensure_firmware_dir"
+                );
                 assert!(dir.ends_with("pico"), "firmware dir should end with 'pico'");
             }
             Err(e) => {
@@ -416,7 +419,10 @@ mod tests {
 
         let port = std::path::Path::new("/dev/ttyACM_fake_test");
         let result = deploy_main_py(port, firmware_dir).await;
-        assert!(result.is_err(), "deploy should fail when main.py is missing");
+        assert!(
+            result.is_err(),
+            "deploy should fail when main.py is missing"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("main.py not found"),

--- a/src/peripherals/uno_q_bridge.rs
+++ b/src/peripherals/uno_q_bridge.rs
@@ -208,7 +208,10 @@ mod tests {
         let tool = UnoQGpioReadTool;
         let result = tool.execute(json!({"pin": 13})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.is_some(), "should report bridge connection error");
+        assert!(
+            result.error.is_some(),
+            "should report bridge connection error"
+        );
     }
 
     // ── UnoQGpioWriteTool ───────────────────────────────────────────────
@@ -277,7 +280,10 @@ mod tests {
         let tool = UnoQGpioWriteTool;
         let result = tool.execute(json!({"pin": 13, "value": 1})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.is_some(), "should report bridge connection error");
+        assert!(
+            result.error.is_some(),
+            "should report bridge connection error"
+        );
     }
 
     // ── Constants ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: QQ channel has platform ASR but no `TranscriptionManager` integration for audio attachments, so it cannot use alternative/configurable transcription providers.
- Why it matters: Wiring `TranscriptionManager` gives operators the option to use their configured provider (Groq, OpenAI, local Whisper, etc.) for QQ audio, in addition to or instead of platform ASR.
- What changed: Add `transcription_manager` and `transcription` fields to `QQChannel`, add `with_transcription()` builder that constructs the manager from config.
- What did **not** change: Existing platform ASR handling, message dedup, upload cache, reply tracking, proxy support.

## Plan Context

This is **PR 10 of 15** in the audio transcription rollout. #4102 is PR 1.

```
PR 1  (#4102) — LocalWhisperProvider + LocalWhisperConfig
    ├── PR 2  (#4109) — Telegram + WhatsApp Web wiring
    │       └── PR 15 (#4309) — deprecate transcribe_audio()
    ├── PR 3  (#4114) — configurable max_audio_bytes
    ├── PR 4  (#4305) — Matrix (whisper-cpp fallback preserved)
    ├── PR 5  (#4312) — Discord
    ├── PR 6  (#4313) — WhatsApp Cloud
    ├── PR 7  (#4302) — Signal
    ├── PR 8  (#4314) — Slack
    ├── PR 9  (#4303) — Linq
    ├── PR 10 (#4315) — QQ ← YOU ARE HERE
    ├── PR 11 (#4304) — Email
    ├── PR 12 (#4306) — Lark
    ├── PR 13 (#4307) — Mattermost
    ├── PR 14 (#4308) — WATI
    │
    Fix PRs (review observations)
    └── FIX-A (#4351) — encrypt bearer_token at rest
```

PRs 2–14 are independent of each other once PR 1 merges. PR 15 requires PR 2. FIX-A is standalone.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: qq`

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Depends on #4102
- Related #4311

## Validation Evidence (required)

```
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided: pending CI