### PR TITLE
fix(provider): complete native OpenAI Codex Responses tool calling

### DIFF
--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -127,11 +127,6 @@ struct ResponsesUsage {
 struct ResponsesToolSpec {
     #[serde(rename = "type")]
     kind: String,
-    function: ResponsesToolFunctionSpec,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct ResponsesToolFunctionSpec {
     name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
@@ -821,11 +816,9 @@ impl OpenAiCodexProvider {
                 .iter()
                 .map(|tool| ResponsesToolSpec {
                     kind: "function".to_string(),
-                    function: ResponsesToolFunctionSpec {
-                        name: tool.name.clone(),
-                        description: Some(tool.description.clone()),
-                        parameters: tool.parameters.clone(),
-                    },
+                    name: tool.name.clone(),
+                    description: Some(tool.description.clone()),
+                    parameters: tool.parameters.clone(),
                 })
                 .collect()
         })
@@ -1863,7 +1856,8 @@ data: [DONE]
         assert_eq!(body["stream"], true);
         assert_eq!(body["tool_choice"], "auto");
         assert_eq!(body["tools"][0]["type"], "function");
-        assert_eq!(body["tools"][0]["function"]["name"], "shell");
+        assert_eq!(body["tools"][0]["name"], "shell");
+        assert_eq!(body["tools"][0]["parameters"]["type"], "object");
         assert_eq!(body["input"][0]["role"], "user");
         assert_eq!(body["input"][0]["content"][0]["type"], "input_text");
         assert_eq!(result.text.as_deref(), Some("Let me check."));


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: `openai-codex` native tool calling was wired to the Responses API with a partial transport only. The provider advertised native tools, but sent `stream = false`, serialized tools in chat-completions shape, and could not parse streamed native Responses payloads back into tool calls.
- Why it matters: the current branch fails real Codex tool runs with `400 Bad Request` (`Stream must be set to true`, then `Missing required parameter: 'tools[0].name'`) instead of exercising native tool calling.
- What changed: enable streamed native Responses requests, send tool specs in Responses API format, parse streamed `response.completed` SSE payloads into native tool calls, and add focused provider tests for JSON + SSE native paths.
- What did **not** change (scope boundary): no config schema changes, no auth/token storage changes, no provider routing changes outside `src/providers/openai_codex.rs`.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): expected `size: L`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `provider,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `provider: openai-codex`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `provider`

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
  - `./scripts/ci/rust_quality_gate.sh` passed locally (`cargo fmt --all -- --check` + `cargo clippy --locked --all-targets -- -D clippy::correctness`)
  - `cargo test --locked providers::openai_codex` passed locally after the change
  - manual provider verification on a Linux server with `openai-codex` as default provider succeeded after rebuild when run with the same proxy env as the service (`zeroclaw agent ...` returned the server time)
- If any command is intentionally skipped, explain why:
  - `cargo test` / `cargo test --locked` full-repo sweep is intentionally not claimed as green here. Earlier clean-baseline runs on this branch ancestry hit existing unrelated upstream failures outside `openai_codex`; this PR re-ran the focused provider suite instead because the change is isolated to `src/providers/openai_codex.rs`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no real user payloads, tokens, or secrets were added to code/tests/fixtures; provider tests use neutral synthetic examples
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - native `openai-codex` requests now send `stream = true`
  - native `openai-codex` tools now serialize in Responses API format with top-level `name/description/parameters`
  - native JSON responses are parsed back into ZeroClaw tool calls
  - native SSE `response.completed` payloads are parsed back into ZeroClaw tool calls and usage
  - rebuilt and smoke-tested the provider on a Linux daemon deployment
- Edge cases checked:
  - SSE output-text deltas followed by `response.completed`
  - tool call history mapping through `function_call` / `function_call_output`
  - provider still handles JSON native responses, not just SSE
- What was not verified:
  - full upstream `cargo test --locked` sweep after this exact patchset
  - non-default custom Codex-compatible gateways that may have accepted the older nested `function` tool shape

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `provider: openai-codex` native tool-calling path only
- Potential unintended effects:
  - custom endpoints pretending to be Codex Responses but expecting the previous nested `function` shape would now receive the canonical Responses shape
  - streamed native responses that omit `response.completed` entirely still rely on existing fallback behavior
- Guardrails/monitoring for early detection:
  - focused provider tests for request shape + SSE parsing
  - runtime trace / provider error logs on real deployments
  - immediate symptom if broken: `openai-codex` tool turns fail with 4xx instead of producing native tool calls

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local code editing, local Rust test runs, Linux server rebuild/smoke test
- Workflow/plan summary (if any): reproduce live failures, align provider transport with Responses API contract, add regression tests, rebuild on a real daemon host, re-test through the service network path
- Verification focus: transport contract (`stream`), tool schema shape, SSE/native response parsing, deployment smoke test
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path:
  - revert this PR merge on `master`, or revert commits `53583104`, `40c78681`, and `7baf4483` if maintainers want to back out incrementally while the branch is still stacked
- Feature flags or config toggles (if any): none
- Observable failure symptoms:
  - `openai-codex` requests fail with 4xx transport errors during native tool turns
  - provider falls back to no answer / failed tool loop instead of returning tool calls

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
  - Responses-compatible custom gateways may have tolerated the old nested `function` tool object and reject the canonical top-level schema differently.
  - Mitigation:
    - this change is intentionally scoped to the `openai-codex` provider, which targets the Responses API contract; focused tests now lock the expected request shape.
- Risk:
  - Native SSE parsing depends on `response.completed` / `response.done` carrying the final response object.
  - Mitigation:
    - existing plain JSON parsing remains intact, and new tests cover both JSON and SSE native paths.
