### PR TITLE
feat(gateway): stream tool call events over WebSocket

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -17,6 +17,33 @@ use std::io::Write as IoWrite;
 use std::sync::Arc;
 use std::time::Instant;
 
+/// Events emitted during a streaming agent turn.
+///
+/// Used by `turn_streaming()` to push real-time updates to callers
+/// (e.g. WebSocket handlers) as tool calls execute.
+#[derive(Debug, Clone)]
+pub enum AgentEvent {
+    /// The agent is about to invoke a tool.
+    ToolCall {
+        id: String,
+        name: String,
+        args: serde_json::Value,
+    },
+    /// A tool has finished executing.
+    ToolResult {
+        id: String,
+        name: String,
+        output: String,
+        success: bool,
+    },
+    /// Intermediate text emitted before tool calls.
+    Text(String),
+    /// Final complete response — the turn is finished.
+    Done(String),
+    /// An error occurred during the turn.
+    Error(String),
+}
+
 pub struct Agent {
     provider: Box<dyn Provider>,
     tools: Vec<Box<dyn Tool>>,
@@ -798,6 +825,223 @@ impl Agent {
         )
     }
 
+    /// Streaming version of [`turn()`] that emits [`AgentEvent`]s as tool
+    /// calls execute, allowing callers to display real-time progress.
+    ///
+    /// The final response text is both sent as `AgentEvent::Done` on the
+    /// channel and returned as `Ok(String)`.
+    ///
+    /// If the receiver is dropped (e.g. client disconnects), the turn
+    /// completes normally but stops emitting events — the agent still
+    /// produces the response text for session persistence.
+    ///
+    /// NOTE: This method intentionally mirrors the logic in [`turn()`].
+    /// A future refactor could extract the shared agent loop into a
+    /// private helper that both methods call.
+    pub async fn turn_streaming(
+        &mut self,
+        user_message: &str,
+        tx: &tokio::sync::mpsc::Sender<AgentEvent>,
+    ) -> Result<String> {
+        if self.history.is_empty() {
+            let system_prompt = self.build_system_prompt()?;
+            self.history
+                .push(ConversationMessage::Chat(ChatMessage::system(
+                    system_prompt,
+                )));
+        }
+
+        let context = self
+            .memory_loader
+            .load_context(
+                self.memory.as_ref(),
+                user_message,
+                self.memory_session_id.as_deref(),
+            )
+            .await
+            .unwrap_or_default();
+
+        if self.auto_save {
+            let _ = self
+                .memory
+                .store(
+                    "user_msg",
+                    user_message,
+                    MemoryCategory::Conversation,
+                    self.memory_session_id.as_deref(),
+                )
+                .await;
+        }
+
+        let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S %Z");
+        let enriched = if context.is_empty() {
+            format!("[{now}] {user_message}")
+        } else {
+            format!("{context}[{now}] {user_message}")
+        };
+
+        self.history
+            .push(ConversationMessage::Chat(ChatMessage::user(enriched)));
+
+        let effective_model = self.classify_model(user_message);
+
+        for _ in 0..self.config.max_tool_iterations {
+            let messages = self.tool_dispatcher.to_provider_messages(&self.history);
+
+            // Response cache: check before LLM call
+            let cache_key = if self.temperature == 0.0 {
+                self.response_cache.as_ref().map(|_| {
+                    let last_user = messages
+                        .iter()
+                        .rfind(|m| m.role == "user")
+                        .map(|m| m.content.as_str())
+                        .unwrap_or("");
+                    let system = messages
+                        .iter()
+                        .find(|m| m.role == "system")
+                        .map(|m| m.content.as_str());
+                    crate::memory::response_cache::ResponseCache::cache_key(
+                        &effective_model,
+                        system,
+                        last_user,
+                    )
+                })
+            } else {
+                None
+            };
+
+            if let (Some(ref cache), Some(ref key)) = (&self.response_cache, &cache_key) {
+                if let Ok(Some(cached)) = cache.get(key) {
+                    self.observer.record_event(&ObserverEvent::CacheHit {
+                        cache_type: "response".into(),
+                        tokens_saved: 0,
+                    });
+                    self.history
+                        .push(ConversationMessage::Chat(ChatMessage::assistant(
+                            cached.clone(),
+                        )));
+                    self.trim_history();
+                    let _ = tx.send(AgentEvent::Done(cached.clone())).await;
+                    return Ok(cached);
+                }
+                self.observer.record_event(&ObserverEvent::CacheMiss {
+                    cache_type: "response".into(),
+                });
+            }
+
+            let response = match self
+                .provider
+                .chat(
+                    ChatRequest {
+                        messages: &messages,
+                        tools: if self.tool_dispatcher.should_send_tool_specs() {
+                            Some(&self.tool_specs)
+                        } else {
+                            None
+                        },
+                    },
+                    &effective_model,
+                    self.temperature,
+                )
+                .await
+            {
+                Ok(resp) => resp,
+                Err(err) => {
+                    let _ = tx.send(AgentEvent::Error(err.to_string())).await;
+                    return Err(err);
+                }
+            };
+
+            let (text, calls) = self.tool_dispatcher.parse_response(&response);
+            if calls.is_empty() {
+                let final_text = if text.is_empty() {
+                    response.text.unwrap_or_default()
+                } else {
+                    text
+                };
+
+                // Store in response cache
+                if let (Some(ref cache), Some(ref key)) = (&self.response_cache, &cache_key) {
+                    let token_count = response
+                        .usage
+                        .as_ref()
+                        .and_then(|u| u.output_tokens)
+                        .unwrap_or(0);
+                    #[allow(clippy::cast_possible_truncation)]
+                    let _ = cache.put(key, &effective_model, &final_text, token_count as u32);
+                }
+
+                self.history
+                    .push(ConversationMessage::Chat(ChatMessage::assistant(
+                        final_text.clone(),
+                    )));
+                self.trim_history();
+
+                let _ = tx.send(AgentEvent::Done(final_text.clone())).await;
+                return Ok(final_text);
+            }
+
+            // Emit intermediate text
+            if !text.is_empty() {
+                self.history
+                    .push(ConversationMessage::Chat(ChatMessage::assistant(
+                        text.clone(),
+                    )));
+                let _ = tx.send(AgentEvent::Text(text)).await;
+            }
+
+            // Emit tool_call events for each pending call
+            for call in &calls {
+                let id = call
+                    .tool_call_id
+                    .clone()
+                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+                let _ = tx
+                    .send(AgentEvent::ToolCall {
+                        id: id.clone(),
+                        name: call.name.clone(),
+                        args: call.arguments.clone(),
+                    })
+                    .await;
+            }
+
+            self.history.push(ConversationMessage::AssistantToolCalls {
+                text: response.text.clone(),
+                tool_calls: response.tool_calls.clone(),
+                reasoning_content: response.reasoning_content.clone(),
+            });
+
+            let results = self.execute_tools(&calls).await;
+
+            // Emit tool_result events for each completed call
+            for (call, result) in calls.iter().zip(results.iter()) {
+                let id = call
+                    .tool_call_id
+                    .clone()
+                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+                let _ = tx
+                    .send(AgentEvent::ToolResult {
+                        id,
+                        name: result.name.clone(),
+                        output: result.output.clone(),
+                        success: result.success,
+                    })
+                    .await;
+            }
+
+            let formatted = self.tool_dispatcher.format_results(&results);
+            self.history.push(formatted);
+            self.trim_history();
+        }
+
+        let err_msg = format!(
+            "Agent exceeded maximum tool iterations ({})",
+            self.config.max_tool_iterations
+        );
+        let _ = tx.send(AgentEvent::Error(err_msg.clone())).await;
+        anyhow::bail!("{err_msg}")
+    }
+
     pub async fn run_single(&mut self, message: &str) -> Result<String> {
         self.turn(message).await
     }
@@ -1323,5 +1567,190 @@ mod tests {
             matches!(&history[2], ConversationMessage::Chat(m) if m.role == "assistant" && m.content == "hi there")
         );
         assert_eq!(history.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn turn_streaming_emits_done_for_text_response() {
+        let provider = Box::new(MockProvider {
+            responses: Mutex::new(vec![crate::providers::ChatResponse {
+                text: Some("streamed hello".into()),
+                tool_calls: vec![],
+                usage: None,
+                reasoning_content: None,
+            }]),
+        });
+
+        let memory_cfg = crate::config::MemoryConfig {
+            backend: "none".into(),
+            ..crate::config::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            crate::memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed"),
+        );
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+
+        let mut agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(XmlToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed");
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+        let result = agent.turn_streaming("hi", &tx).await.unwrap();
+        assert_eq!(result, "streamed hello");
+        drop(tx);
+
+        // Should have received a Done event
+        let mut got_done = false;
+        while let Some(event) = rx.recv().await {
+            if matches!(event, AgentEvent::Done(ref text) if text == "streamed hello") {
+                got_done = true;
+            }
+        }
+        assert!(got_done, "expected AgentEvent::Done with response text");
+    }
+
+    #[tokio::test]
+    async fn turn_streaming_emits_tool_events() {
+        let provider = Box::new(MockProvider {
+            responses: Mutex::new(vec![
+                crate::providers::ChatResponse {
+                    text: Some(String::new()),
+                    tool_calls: vec![crate::providers::ToolCall {
+                        id: "tc1".into(),
+                        name: "echo".into(),
+                        arguments: r#"{"input": "test"}"#.into(),
+                    }],
+                    usage: None,
+                    reasoning_content: None,
+                },
+                crate::providers::ChatResponse {
+                    text: Some("tool done".into()),
+                    tool_calls: vec![],
+                    usage: None,
+                    reasoning_content: None,
+                },
+            ]),
+        });
+
+        let memory_cfg = crate::config::MemoryConfig {
+            backend: "none".into(),
+            ..crate::config::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            crate::memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed"),
+        );
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+
+        let mut agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed");
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+        let result = agent.turn_streaming("use the tool", &tx).await.unwrap();
+        assert_eq!(result, "tool done");
+        drop(tx);
+
+        // Collect all events
+        let mut events = vec![];
+        while let Some(event) = rx.recv().await {
+            events.push(event);
+        }
+
+        // Should have ToolCall, ToolResult, and Done events
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ToolCall { name, .. } if name == "echo")),
+            "expected AgentEvent::ToolCall for 'echo'"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::ToolResult { name, .. } if name == "echo")),
+            "expected AgentEvent::ToolResult for 'echo'"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::Done(ref text) if text == "tool done")),
+            "expected AgentEvent::Done"
+        );
+    }
+
+    /// A provider that always returns an error.
+    struct FailingProvider;
+
+    #[async_trait]
+    impl Provider for FailingProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> Result<String> {
+            anyhow::bail!("provider unavailable")
+        }
+
+        async fn chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: f64,
+        ) -> Result<crate::providers::ChatResponse> {
+            anyhow::bail!("provider unavailable")
+        }
+    }
+
+    #[tokio::test]
+    async fn turn_streaming_emits_error_on_provider_failure() {
+        let provider: Box<dyn Provider> = Box::new(FailingProvider);
+
+        let memory_cfg = crate::config::MemoryConfig {
+            backend: "none".into(),
+            ..crate::config::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            crate::memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed"),
+        );
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+
+        let mut agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(XmlToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed");
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(32);
+        let result = agent.turn_streaming("trigger error", &tx).await;
+        assert!(result.is_err(), "expected error from provider");
+        drop(tx);
+
+        // Should have received an Error event
+        let mut got_error = false;
+        while let Some(event) = rx.recv().await {
+            if matches!(event, AgentEvent::Error(_)) {
+                got_error = true;
+            }
+        }
+        assert!(got_error, "expected AgentEvent::Error on provider failure");
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -11,6 +11,6 @@ pub mod thinking;
 mod tests;
 
 #[allow(unused_imports)]
-pub use agent::{Agent, AgentBuilder};
+pub use agent::{Agent, AgentBuilder, AgentEvent};
 #[allow(unused_imports)]
 pub use loop_::{process_message, run};

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -311,7 +311,10 @@ async fn handle_socket(
     }
 }
 
-/// Process a single chat message through the agent and send the response.
+/// Process a single chat message through the agent and stream events to the client.
+///
+/// Uses `turn_streaming()` to emit real-time `tool_call` and `tool_result`
+/// frames so clients can display tool execution progress.
 async fn process_chat_message(
     state: &AppState,
     agent: &mut crate::agent::Agent,
@@ -319,6 +322,8 @@ async fn process_chat_message(
     content: &str,
     session_key: &str,
 ) {
+    use crate::agent::AgentEvent;
+
     let provider_label = state
         .config
         .lock()
@@ -333,20 +338,65 @@ async fn process_chat_message(
         "model": state.model,
     }));
 
-    // Multi-turn chat via persistent Agent (history is maintained across turns)
-    match agent.turn(content).await {
-        Ok(response) => {
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<AgentEvent>(32);
+
+    // Run the agent turn and event forwarding concurrently.
+    // We use a channel + select loop so we can stream events to the WS
+    // client as they're produced, while the agent keeps running.
+    let turn_result = tokio::join!(
+        // Producer: run the agent turn, sending events to tx
+        async {
+            let result = agent.turn_streaming(content, &tx).await;
+            drop(tx); // close channel so the consumer loop exits
+            result
+        },
+        // Consumer: forward events from rx to the WebSocket
+        async {
+            while let Some(event) = rx.recv().await {
+                let frame = match &event {
+                    AgentEvent::ToolCall { id, name, args } => serde_json::json!({
+                        "type": "tool_call",
+                        "id": id,
+                        "name": name,
+                        "args": args,
+                    }),
+                    AgentEvent::ToolResult {
+                        id,
+                        name,
+                        output,
+                        success,
+                    } => serde_json::json!({
+                        "type": "tool_result",
+                        "id": id,
+                        "name": name,
+                        "output": output,
+                        "success": success,
+                    }),
+                    AgentEvent::Text(text) => serde_json::json!({
+                        "type": "chunk",
+                        "content": text,
+                    }),
+                    AgentEvent::Done(full_response) => serde_json::json!({
+                        "type": "done",
+                        "full_response": full_response,
+                    }),
+                    AgentEvent::Error(message) => serde_json::json!({
+                        "type": "error",
+                        "message": message,
+                    }),
+                };
+                let _ = sender.send(Message::Text(frame.to_string().into())).await;
+            }
+        }
+    );
+
+    match turn_result.0 {
+        Ok(ref response) => {
             // Persist assistant response
             if let Some(ref backend) = state.session_backend {
-                let assistant_msg = crate::providers::ChatMessage::assistant(&response);
+                let assistant_msg = crate::providers::ChatMessage::assistant(response);
                 let _ = backend.append(session_key, &assistant_msg);
             }
-
-            let done = serde_json::json!({
-                "type": "done",
-                "full_response": response,
-            });
-            let _ = sender.send(Message::Text(done.to_string().into())).await;
 
             // Broadcast agent_end event
             let _ = state.event_tx.send(serde_json::json!({
@@ -355,15 +405,10 @@ async fn process_chat_message(
                 "model": state.model,
             }));
         }
-        Err(e) => {
+        Err(ref e) => {
             let sanitized = crate::providers::sanitize_api_error(&e.to_string());
-            let err = serde_json::json!({
-                "type": "error",
-                "message": sanitized,
-            });
-            let _ = sender.send(Message::Text(err.to_string().into())).await;
-
-            // Broadcast error event
+            // Error frame was already sent by turn_streaming via the channel;
+            // broadcast to internal event bus for monitoring.
             let _ = state.event_tx.send(serde_json::json!({
                 "type": "error",
                 "component": "ws_chat",


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: WebSocket chat currently returns a single `done` frame with the complete response. Tool calls execute invisibly inside `agent.turn()` — clients cannot display real-time tool execution progress.
- Why it matters: Dashboard UIs and orchestrators (like [Eyrie](https://github.com/Audacity88/eyrie)) need to show which tools are running, their arguments, and results as they happen — not just the final text.
- What changed: Added `AgentEvent` enum and `turn_streaming()` method that emits tool call/result events via an mpsc channel. Updated the WS handler to use `turn_streaming()` and forward events as JSON frames.
- What did **not** change: `turn()` is untouched — all existing callers (CLI, channels, webhooks) are unaffected. Session persistence, memory, caching, and observer logic are identical.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: M`
- Scope labels: `agent`, `gateway`
- Module labels: `agent: streaming`, `gateway: websocket`
- Contributor tier label: N/A
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `multi` (agent + gateway)

## Linked Issue

- Related: complements PR #4328 (observe_group for passive group participation)
- Related: builds on #4275 (named sessions — merged)

## Validation Evidence (required)

\`\`\`bash
cargo fmt --all -- --check    # clean
cargo clippy --all-targets -- -D warnings  # clean (0 warnings)
cargo test agent::agent::tests::turn_streaming  # 3/3 passed
\`\`\`

Tests:
- \`turn_streaming_emits_done_for_text_response\` — text-only response emits Done event
- \`turn_streaming_emits_tool_events\` — tool invocation emits ToolCall + ToolResult + Done
- \`turn_streaming_emits_error_on_provider_failure\` — provider error emits Error event and returns Err

Manual testing:
- Connected via WebSocket, sent "list the files in your workspace using ls"
- Received: session_start → chunk → tool_call (shell, ls -la) → tool_result (file listing) → done
- Verified tool_call includes id, name, args; tool_result includes id, name, output, success
- Simple messages (no tools) still produce just done frame (backward compatible)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Scenario Testing (required)

- Verified scenarios: text-only response, single tool call, multi-step tool chain (agent retries after error), provider failure
- Edge cases checked: receiver dropped mid-turn (agent completes normally, events silently stop), empty tool call list (no tool events emitted), cached response (Done event sent from cache)
- What was not verified: concurrent WebSocket connections to same session, very large tool outputs

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: WebSocket chat handler (\`process_chat_message\` in ws.rs), agent module (new public type + method)
- Potential unintended effects: WebSocket clients that don't handle tool_call/tool_result frames will see unknown frame types. These are safely ignorable — the done frame still contains the full response.
- Guardrails/monitoring: Existing turn() is unchanged. New method is opt-in (only used by WS handler).

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (Opus 4.6) for implementation and testing
- Workflow/plan summary: spec written in STREAMING_SPEC.md, implemented turn_streaming mirroring turn, updated WS handler with tokio::join producer/consumer pattern
- Verification focus: event completeness (all tool calls emit both start and result), error propagation, backward compatibility
- Confirmation: naming + architecture boundaries followed. One concern per PR. No changes to existing turn() method.

## Rollback Plan (required)

- Fast rollback command/path: revert commit, rebuild. WS handler falls back to non-streaming turn() behavior.
- Feature flags or config toggles: None — streaming is always active in WS chat. Non-WS paths (CLI, channels, webhooks) are unaffected.
- Observable failure symptoms: tool_call/tool_result frames missing from WS responses (would indicate turn_streaming not being called)

## Risks and Mitigations

- Risk: \`turn_streaming()\` duplicates logic from \`turn()\` — future changes to \`turn()\` may not be reflected
  - Mitigation: documented in source code comment; a future refactor can extract shared logic into a private helper

- Risk: Channel send failures are silently ignored (\`let _ = tx.send(...)\`)
  - Mitigation: intentional — if the WS client disconnects, the agent should complete its turn normally for session persistence. Documented in method doc comment.

Generated with [Claude Code](https://claude.com/claude-code)