### PR TITLE
feat(channels): extend /new session reset to all channels

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -722,10 +722,6 @@ fn supports_runtime_model_switch(channel_name: &str) -> bool {
 }
 
 fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRuntimeCommand> {
-    if !supports_runtime_model_switch(channel_name) {
-        return None;
-    }
-
     let trimmed = content.trim();
     if !trimmed.starts_with('/') {
         return None;
@@ -740,7 +736,10 @@ fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRun
         .to_ascii_lowercase();
 
     match base_command.as_str() {
-        "/models" => {
+        // `/new` is available on every channel — no model-switch gate.
+        "/new" => Some(ChannelRuntimeCommand::NewSession),
+        // Model/provider switching is channel-gated.
+        "/models" if supports_runtime_model_switch(channel_name) => {
             if let Some(provider) = parts.next() {
                 Some(ChannelRuntimeCommand::SetProvider(
                     provider.trim().to_string(),
@@ -749,7 +748,7 @@ fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRun
                 Some(ChannelRuntimeCommand::ShowProviders)
             }
         }
-        "/model" => {
+        "/model" if supports_runtime_model_switch(channel_name) => {
             let model = parts.collect::<Vec<_>>().join(" ").trim().to_string();
             if model.is_empty() {
                 Some(ChannelRuntimeCommand::ShowModel)
@@ -757,7 +756,6 @@ fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRun
                 Some(ChannelRuntimeCommand::SetModel(model))
             }
         }
-        "/new" => Some(ChannelRuntimeCommand::NewSession),
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The `/new` command for resetting conversation history was gated behind `supports_runtime_model_switch()`, which only returned `true` for Telegram, Discord, and Matrix. All other channels (WhatsApp, QQ, Mattermost, Slack, IRC, etc.) had no way to reset sessions.
- Why it matters: Users on non-Telegram/Discord/Matrix channels cannot clear conversation history, leading to context buildup and no fresh-start option.
- What changed: Moved the `supports_runtime_model_switch()` guard to apply only to `/model` and `/models` commands via match-arm guards, so `/new` is now parsed and handled for every channel.
- What did **not** change: `/model` and `/models` remain gated to Telegram, Discord, and Matrix. Session clearing logic, `mark_sender_for_new_session`, and `refreshed_new_session_system_prompt` are unchanged.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: all`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Closes #4236

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass (no output)
cargo check --lib            # pass
```

- Evidence provided: compilation check, format check
- If any command is intentionally skipped, explain why: `cargo test` and `cargo clippy` skipped — Windows local env may differ from CI (Rust 1.92.0 Linux). The change is a 2-line logic restructure with no new code paths; CI will validate fully.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Confirmed `/new` is parsed via `parse_runtime_command` which feeds into `handle_runtime_command_if_needed`, the shared handler used by all channels.
- Edge cases checked: `/model` and `/models` still correctly gated to Telegram/Discord/Matrix only. Non-slash messages still return `None`.
- What was not verified: Runtime e2e on each individual channel (requires channel credentials).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: All channel message processing paths that call `handle_runtime_command_if_needed`
- Potential unintended effects: None — channels that previously ignored `/new` (treating it as a regular message forwarded to the LLM) will now intercept it as a command. This is the desired behavior.
- Guardrails/monitoring for early detection: Existing `/new` test (`process_channel_message_refreshes_available_skills_after_new_session`) validates the flow.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Searched for `/new` handling, identified the `supports_runtime_model_switch` gate as the blocker, restructured the match arms to apply the gate only to model commands.
- Verification focus: Minimal diff, no new dependencies, compilation clean.
- Confirmation: naming + architecture boundaries followed.

## Rollback Plan (required)

- Fast rollback command/path: Revert the single commit.
- Feature flags or config toggles: None needed.
- Observable failure symptoms: `/new` not working on a channel would be immediately visible to users.

## Risks and Mitigations

- Risk: Channels where `/new` was previously treated as a normal message will now intercept it.
  - Mitigation: This is the intended behavior per #4236. The `/new` string is unlikely to appear in normal conversation.