### PR TITLE
fix(gateway): stream ws agent chat responses

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -1,6 +1,7 @@
 use crate::agent::dispatcher::{
     NativeToolDispatcher, ParsedToolCall, ToolDispatcher, ToolExecutionResult, XmlToolDispatcher,
 };
+use crate::agent::loop_::run_tool_call_loop;
 use crate::agent::memory_loader::{DefaultMemoryLoader, MemoryLoader};
 use crate::agent::prompt::{PromptContext, SystemPromptBuilder};
 use crate::config::Config;
@@ -637,7 +638,10 @@ impl Agent {
         self.model_name.clone()
     }
 
-    pub async fn turn(&mut self, user_message: &str) -> Result<String> {
+    async fn prepare_turn_history(
+        &mut self,
+        user_message: &str,
+    ) -> Result<(String, String, Vec<ChatMessage>)> {
         if self.history.is_empty() {
             let system_prompt = self.build_system_prompt()?;
             self.history
@@ -675,10 +679,22 @@ impl Agent {
             format!("{context}[{now}] {user_message}")
         };
 
+        let effective_model = self.classify_model(user_message);
+        let mut history = self.tool_dispatcher.to_provider_messages(&self.history);
+        history.push(ChatMessage::user(enriched.clone()));
+
+        Ok((effective_model, enriched, history))
+    }
+
+    fn replace_history_from_chat_messages(&mut self, history: Vec<ChatMessage>) {
+        self.history = history.into_iter().map(ConversationMessage::Chat).collect();
+        self.trim_history();
+    }
+
+    pub async fn turn(&mut self, user_message: &str) -> Result<String> {
+        let (effective_model, enriched, _) = self.prepare_turn_history(user_message).await?;
         self.history
             .push(ConversationMessage::Chat(ChatMessage::user(enriched)));
-
-        let effective_model = self.classify_model(user_message);
 
         for _ in 0..self.config.max_tool_iterations {
             let messages = self.tool_dispatcher.to_provider_messages(&self.history);
@@ -796,6 +812,44 @@ impl Agent {
             "Agent exceeded maximum tool iterations ({})",
             self.config.max_tool_iterations
         )
+    }
+
+    pub async fn turn_streaming(
+        &mut self,
+        user_message: &str,
+        provider_name: &str,
+        multimodal_config: &crate::config::MultimodalConfig,
+        pacing: &crate::config::PacingConfig,
+        on_delta: Option<tokio::sync::mpsc::Sender<String>>,
+    ) -> Result<String> {
+        let (effective_model, _, mut history) = self.prepare_turn_history(user_message).await?;
+        let result = run_tool_call_loop(
+            self.provider.as_ref(),
+            &mut history,
+            &self.tools,
+            self.observer.as_ref(),
+            provider_name,
+            &effective_model,
+            self.temperature,
+            true,
+            None,
+            "gateway",
+            None,
+            multimodal_config,
+            self.config.max_tool_iterations,
+            None,
+            on_delta,
+            None,
+            &[],
+            &[],
+            None,
+            None,
+            pacing,
+        )
+        .await;
+
+        self.replace_history_from_chat_messages(history);
+        result
     }
 
     pub async fn run_single(&mut self, message: &str) -> Result<String> {

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -7,6 +7,7 @@
 //! Server -> Client: {"type":"session_start","session_id":"...","name":"...","resumed":true,"message_count":42}
 //! Client -> Server: {"type":"message","content":"Hello"}
 //! Server -> Client: {"type":"chunk","content":"Hi! "}
+//! Server -> Client: {"type":"chunk_reset"}
 //! Server -> Client: {"type":"tool_call","name":"shell","args":{...}}
 //! Server -> Client: {"type":"tool_result","name":"shell","output":"..."}
 //! Server -> Client: {"type":"done","full_response":"..."}
@@ -28,6 +29,7 @@ use axum::{
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
+use std::time::Duration;
 use tracing::debug;
 
 /// Optional connection parameters sent as the first WebSocket message.
@@ -151,6 +153,9 @@ pub async fn handle_ws_chat(
 
 /// Gateway session key prefix to avoid collisions with channel sessions.
 const GW_SESSION_PREFIX: &str = "gw_";
+const WS_CHUNK_RESET_TYPE: &str = "chunk_reset";
+const WS_TYPING_CHUNK_CHARS: usize = 6;
+const WS_TYPING_CHUNK_DELAY_MS: u64 = 35;
 
 async fn handle_socket(
     socket: WebSocket,
@@ -319,9 +324,8 @@ async fn process_chat_message(
     content: &str,
     session_key: &str,
 ) {
-    let provider_label = state
-        .config
-        .lock()
+    let config = state.config.lock().clone();
+    let provider_label = config
         .default_provider
         .clone()
         .unwrap_or_else(|| "unknown".to_string());
@@ -329,12 +333,58 @@ async fn process_chat_message(
     // Broadcast agent_start event
     let _ = state.event_tx.send(serde_json::json!({
         "type": "agent_start",
-        "provider": provider_label,
+        "provider": provider_label.clone(),
         "model": state.model,
     }));
 
+    let cost_tracking_context = state.cost_tracker.clone().map(|tracker| {
+        crate::agent::loop_::ToolLoopCostTrackingContext::new(
+            tracker,
+            std::sync::Arc::new(config.cost.prices.clone()),
+        )
+    });
+    let (delta_tx, mut delta_rx) = tokio::sync::mpsc::channel::<String>(64);
+    let turn_future = crate::agent::loop_::TOOL_LOOP_COST_TRACKING_CONTEXT.scope(
+        cost_tracking_context,
+        agent.turn_streaming(
+            content,
+            &provider_label,
+            &config.multimodal,
+            &config.pacing,
+            Some(delta_tx),
+        ),
+    );
+    tokio::pin!(turn_future);
+    let mut typing_mode = false;
+
+    let turn_result = loop {
+        tokio::select! {
+            result = &mut turn_future => break result,
+            maybe_delta = delta_rx.recv() => {
+                let Some(delta) = maybe_delta else {
+                    continue;
+                };
+                if delta == crate::agent::loop_::DRAFT_CLEAR_SENTINEL {
+                    typing_mode = true;
+                }
+                if !send_stream_delta(sender, &delta, typing_mode).await {
+                    return;
+                }
+            }
+        }
+    };
+
+    while let Some(delta) = delta_rx.recv().await {
+        if delta == crate::agent::loop_::DRAFT_CLEAR_SENTINEL {
+            typing_mode = true;
+        }
+        if !send_stream_delta(sender, &delta, typing_mode).await {
+            return;
+        }
+    }
+
     // Multi-turn chat via persistent Agent (history is maintained across turns)
-    match agent.turn(content).await {
+    match turn_result {
         Ok(response) => {
             // Persist assistant response
             if let Some(ref backend) = state.session_backend {
@@ -371,6 +421,60 @@ async fn process_chat_message(
             }));
         }
     }
+}
+
+async fn send_stream_delta(
+    sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
+    delta: &str,
+    typing_mode: bool,
+) -> bool {
+    if delta == crate::agent::loop_::DRAFT_CLEAR_SENTINEL {
+        let payload = serde_json::json!({
+            "type": WS_CHUNK_RESET_TYPE,
+        });
+        return sender
+            .send(Message::Text(payload.to_string().into()))
+            .await
+            .is_ok();
+    }
+
+    if !typing_mode {
+        let payload = serde_json::json!({
+            "type": "chunk",
+            "content": delta,
+        });
+        return sender
+            .send(Message::Text(payload.to_string().into()))
+            .await
+            .is_ok();
+    }
+
+    let mut remaining = delta;
+    while !remaining.is_empty() {
+        let end = remaining
+            .char_indices()
+            .nth(WS_TYPING_CHUNK_CHARS)
+            .map(|(idx, _)| idx)
+            .unwrap_or(remaining.len());
+        let part = &remaining[..end];
+        let payload = serde_json::json!({
+            "type": "chunk",
+            "content": part,
+        });
+        if sender
+            .send(Message::Text(payload.to_string().into()))
+            .await
+            .is_err()
+        {
+            return false;
+        }
+        remaining = &remaining[end..];
+        if !remaining.is_empty() {
+            tokio::time::sleep(Duration::from_millis(WS_TYPING_CHUNK_DELAY_MS)).await;
+        }
+    }
+
+    true
 }
 
 #[cfg(test)]

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -22,6 +22,8 @@ export default function AgentChat() {
   const [typing, setTyping] = useState(false);
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [streamingContent, setStreamingContent] = useState('');
+  const [streamingTimestamp, setStreamingTimestamp] = useState<Date | null>(null);
 
   const wsRef = useRef<WebSocketClient | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -52,9 +54,23 @@ export default function AgentChat() {
 
     ws.onMessage = (msg: WsMessage) => {
       switch (msg.type) {
+        case 'session_start':
+        case 'connected':
+          break;
+
         case 'chunk':
           setTyping(true);
-          pendingContentRef.current += msg.content ?? '';
+          if (msg.content) {
+            pendingContentRef.current += msg.content;
+            setStreamingContent((prev) => prev + msg.content);
+            setStreamingTimestamp((prev) => prev ?? new Date());
+          }
+          break;
+
+        case 'chunk_reset':
+          pendingContentRef.current = '';
+          setStreamingContent('');
+          setStreamingTimestamp(new Date());
           break;
 
         case 'message':
@@ -72,6 +88,8 @@ export default function AgentChat() {
             ]);
           }
           pendingContentRef.current = '';
+          setStreamingContent('');
+          setStreamingTimestamp(null);
           setTyping(false);
           break;
         }
@@ -112,6 +130,8 @@ export default function AgentChat() {
           ]);
           setTyping(false);
           pendingContentRef.current = '';
+          setStreamingContent('');
+          setStreamingTimestamp(null);
           break;
       }
     };
@@ -126,7 +146,7 @@ export default function AgentChat() {
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages, typing]);
+  }, [messages, typing, streamingContent]);
 
   const handleSend = () => {
     const trimmed = input.trim();
@@ -146,6 +166,8 @@ export default function AgentChat() {
       wsRef.current.sendMessage(trimmed);
       setTyping(true);
       pendingContentRef.current = '';
+      setStreamingContent('');
+      setStreamingTimestamp(null);
     } catch {
       setError(t('agent.send_error'));
     }
@@ -289,10 +311,29 @@ export default function AgentChat() {
             <div className="flex-shrink-0 w-9 h-9 rounded-2xl flex items-center justify-center border" style={{ background: 'var(--pc-bg-elevated)', borderColor: 'var(--pc-border)' }}>
               <Bot className="h-4 w-4" style={{ color: 'var(--pc-accent)' }} />
             </div>
-            <div className="rounded-2xl px-4 py-3 border flex items-center gap-1.5" style={{ background: 'var(--pc-bg-elevated)', borderColor: 'var(--pc-border)' }}>
-              <span className="bounce-dot w-1.5 h-1.5 rounded-full" style={{ background: 'var(--pc-accent)' }} />
-              <span className="bounce-dot w-1.5 h-1.5 rounded-full" style={{ background: 'var(--pc-accent)' }} />
-              <span className="bounce-dot w-1.5 h-1.5 rounded-full" style={{ background: 'var(--pc-accent)' }} />
+            <div
+              className={`rounded-2xl px-4 py-3 border ${streamingContent ? '' : 'flex items-center gap-1.5'}`}
+              style={{ background: 'var(--pc-bg-elevated)', borderColor: 'var(--pc-border)' }}
+            >
+              {streamingContent ? (
+                <>
+                  <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">
+                    {streamingContent}
+                    <span className="inline-block w-2 animate-pulse" style={{ color: 'var(--pc-accent)' }}>|</span>
+                  </p>
+                  {streamingTimestamp && (
+                    <p className="text-[10px] mt-1.5" style={{ color: 'var(--pc-text-faint)' }}>
+                      {streamingTimestamp.toLocaleTimeString()}
+                    </p>
+                  )}
+                </>
+              ) : (
+                <>
+                  <span className="bounce-dot w-1.5 h-1.5 rounded-full" style={{ background: 'var(--pc-accent)' }} />
+                  <span className="bounce-dot w-1.5 h-1.5 rounded-full" style={{ background: 'var(--pc-accent)' }} />
+                  <span className="bounce-dot w-1.5 h-1.5 rounded-full" style={{ background: 'var(--pc-accent)' }} />
+                </>
+              )}
             </div>
           </div>
         )}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -113,7 +113,7 @@ export interface SSEEvent {
 }
 
 export interface WsMessage {
-  type: 'message' | 'chunk' | 'tool_call' | 'tool_result' | 'done' | 'error';
+  type: 'message' | 'chunk' | 'chunk_reset' | 'tool_call' | 'tool_result' | 'done' | 'error' | 'session_start' | 'connected';
   content?: string;
   full_response?: string;
   name?: string;


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: the `/agent` page only showed the final assistant response after the full turn completed, so WebSocket chat felt non-streaming even when intermediate deltas existed on the backend side.
- Why it matters: users do not get progressive feedback during long agent turns, and the gateway UI behavior is inconsistent with expected streaming chat UX.
- What changed: added a streaming gateway turn path, forwarded WebSocket `chunk` updates during agent execution, introduced `chunk_reset` for draft clearing, and rendered streamed content live in the React chat page.
- What did **not** change (scope boundary): no provider protocol changes, no config schema changes, no database/session schema changes, and no new feature flags.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: M` (expected; auto-managed)
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `gateway, agent`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `gateway: websocket`, `agent: orchestration`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: `None`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes # `N/A`
- Related # `N/A`
- Depends on # (if stacked) `N/A`
- Supersedes # (if replacing older PR) `N/A`

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Integrated scope by source PR (what was materially carried forward): `N/A`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): no superseded PR content was incorporated.
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`) `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- `cargo fmt --all -- --check`: passed
- `cargo check --lib`: passed
- `cd web && npm run build`: passed
- Evidence provided (test/log/trace/screenshot/perf): manual browser verification on `http://127.0.0.1:42617/agent`; streamed DOM content length increased continuously during a live response instead of appearing all at once.
- If any command is intentionally skipped, explain why: `cargo clippy --all-targets -- -D warnings` and `cargo test` were not run for this PR handoff; earlier local test attempts hit a Windows `link.exe` / `LNK1318 Unexpected PDB error`, while `cargo check --lib` and a release binary build succeeded.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: `N/A`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: only local loopback URLs and project-scoped identifiers were used in validation notes.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N/A`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `N/A`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N/A`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N/A`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: runtime/UI bugfix only; no docs or localized user-facing copy were changed.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `/agent` WebSocket chat now renders incremental chunks live; draft/progress content is cleared before the final answer stream begins; final `done` message still persists the complete assistant response.
- Edge cases checked: streamed content remains visible while typing state is active; session lifecycle messages (`connected`, `session_start`) no longer interfere with rendering; session cost tracking continued to record non-zero totals during local verification.
- What was not verified: full `cargo test`, full `cargo clippy`, and cross-platform/browser behavior outside the local Windows environment.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: gateway WebSocket chat handling, agent turn execution path used by the gateway, and the web `/agent` chat UI.
- Potential unintended effects: chunk pacing may feel too fast or too slow for some response lengths; clients that parse WebSocket message types strictly must tolerate the new `chunk_reset`, `connected`, and `session_start` variants.
- Guardrails/monitoring for early detection: manual `/agent` streaming verification, WebSocket payload inspection, and existing gateway chat completion behavior still ending with `done`.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): shell commands, browser-based manual verification, git, and GitHub CLI.
- Workflow/plan summary (if any): reproduced the missing streaming behavior, implemented backend delta forwarding plus frontend incremental rendering, validated local runtime behavior, then isolated the patch into a small branch for upstream submission.
- Verification focus: streamed rendering correctness, final response persistence, and no config/schema drift.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: revert this commit or disable the branch before release.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: `/agent` shows duplicated partial text, never clears interim drafts, or fails to finish with a `done` response.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: splitting final answer text into small WebSocket chunks could expose client assumptions about whole-message delivery.
  - Mitigation: final responses still terminate with the existing `done` payload containing `full_response`, so persistence and non-streaming consumers retain a complete message boundary.
- Risk: the new gateway streaming path could diverge from the non-streaming `turn()` history flow over time.
  - Mitigation: the patch reuses the same agent history preparation logic and writes the resulting provider chat history back into the agent state after the streaming loop completes.
