### PR TITLE
fix(matrix): handle unused Result from backups().disable()

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -586,7 +586,7 @@ impl MatrixChannel {
         if client.encryption().backups().are_enabled().await {
             tracing::info!("Matrix room-key backup is enabled for this device.");
         } else {
-            client.encryption().backups().disable().await;
+            let _ = client.encryption().backups().disable().await;
             tracing::warn!(
                 "Matrix room-key backup is not enabled for this device; automatic backup attempts have been disabled to suppress recurring warnings. To enable backups, configure server-side key backup and recovery for this device."
             );


### PR DESCRIPTION
## Summary
- Add `let _ =` prefix to `client.encryption().backups().disable().await` at `src/channels/matrix.rs:589` to suppress the `unused_must_use` compiler warning

Closes #4339

## Test plan
- [ ] `cargo build --release --features channel-matrix` completes without warnings
- [ ] Matrix channel functionality unaffected (backup disable behavior unchanged)