### PR TITLE
fix(security): add python/node to default allowed commands

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4389,6 +4389,10 @@ impl Default for AutonomyConfig {
                 "head".into(),
                 "tail".into(),
                 "date".into(),
+                "python".into(),
+                "python3".into(),
+                "pip".into(),
+                "node".into(),
             ],
             forbidden_paths: vec![
                 "/etc".into(),

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -117,6 +117,10 @@ fn default_allowed_commands() -> Vec<String> {
         "uname".into(),
         "uptime".into(),
         "hostname".into(),
+        "python".into(),
+        "python3".into(),
+        "pip".into(),
+        "node".into(),
     ];
     // `free` is Linux-only; it does not exist on macOS or other BSDs.
     #[cfg(target_os = "linux")]
@@ -157,6 +161,10 @@ fn default_allowed_commands() -> Vec<String> {
         "uname".into(),
         "uptime".into(),
         "hostname".into(),
+        "python".into(),
+        "python3".into(),
+        "pip".into(),
+        "node".into(),
     ]
 }
 


### PR DESCRIPTION
## Summary
- Add `python`, `python3`, `pip`, and `node` to `default_allowed_commands()` in both `src/security/policy.rs` (Unix + Windows) and `src/config/schema.rs` (AutonomyConfig default)
- Root cause: After #3691 added `#[serde(default)]` to `AutonomyConfig`, omitting `allowed_commands` from config silently fell back to the restrictive default list that excluded common scripting runtimes

Closes #4338

## Test plan
- [ ] `cargo test` passes
- [ ] Shell tool can execute `python -V` and `python3 --version` without security policy rejection
- [ ] Existing allowed commands still work
- [ ] Windows default list also updated