### PR TITLE
fix(ollama): strip /api/chat suffix from base URL

### DIFF
--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -119,7 +119,8 @@ impl OllamaProvider {
         }
 
         trimmed
-            .strip_suffix("/api")
+            .strip_suffix("/api/chat")
+            .or_else(|| trimmed.strip_suffix("/api"))
             .unwrap_or(trimmed)
             .trim_end_matches('/')
             .to_string()
@@ -902,6 +903,12 @@ mod tests {
     fn custom_url_strips_api_suffix() {
         let p = OllamaProvider::new(Some("https://ollama.com/api/"), None);
         assert_eq!(p.base_url, "https://ollama.com");
+    }
+
+    #[test]
+    fn custom_url_strips_api_chat_suffix() {
+        let p = OllamaProvider::new(Some("http://172.30.30.50:11434/api/chat"), None);
+        assert_eq!(p.base_url, "http://172.30.30.50:11434");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix `normalize_base_url` to also strip `/api/chat` suffix, not just `/api`
- When users configure the full endpoint URL (e.g. `http://host:11434/api/chat`), the old code produced a doubled path `/api/chat/api/chat` causing connection failures on remote Ollama servers
- Added test case for this scenario

Closes #4342

## Test plan
- [ ] `cargo test` — new `custom_url_strips_api_chat_suffix` test passes
- [ ] Existing `custom_url_strips_api_suffix` test still passes
- [ ] Remote Ollama server with `/api/chat` in configured URL connects successfully