### PR TITLE
fix(cost): enable cost tracking by default

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1515,8 +1515,8 @@ impl Default for IdentityConfig {
 /// Cost tracking and budget enforcement configuration (`[cost]` section).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct CostConfig {
-    /// Enable cost tracking (default: false)
-    #[serde(default)]
+    /// Enable cost tracking (default: true)
+    #[serde(default = "default_cost_enabled")]
     pub enabled: bool,
 
     /// Daily spending limit in USD (default: 10.00)
@@ -1564,10 +1564,14 @@ fn default_warn_percent() -> u8 {
     80
 }
 
+fn default_cost_enabled() -> bool {
+    true
+}
+
 impl Default for CostConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             daily_limit_usd: default_daily_limit(),
             monthly_limit_usd: default_monthly_limit(),
             warn_at_percent: default_warn_percent(),


### PR DESCRIPTION
## Summary

Fixes #3679

- Cost tracking was disabled by default (`enabled: false`), causing the `/api/cost` endpoint to always return zeros
- This was a regression from the `main` → `master` branch switch where the default changed
- Changes the `CostConfig.enabled` default to `true` so cost tracking works out of the box
- Existing users who explicitly set `enabled = false` in their config are unaffected

## Test plan

- [x] `cargo check` passes
- [x] All 18 cost-related tests pass (`cargo test --lib -- cost`)
- [ ] CI passes