### PR TITLE
fix(skills): surface actionable warning when skills are skipped

### DIFF
--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -93,6 +93,33 @@ fn default_version() -> String {
     "0.1.0".to_string()
 }
 
+/// Emit a user-visible warning when a skill directory is skipped due to audit
+/// findings. When the findings mention blocked scripts and `allow_scripts` is
+/// `false`, the message includes actionable remediation guidance so users know
+/// how to enable their skill.
+fn warn_skipped_skill(path: &Path, summary: &str, allow_scripts: bool) {
+    let scripts_blocked = summary.contains("script-like files are blocked");
+    if scripts_blocked && !allow_scripts {
+        tracing::warn!(
+            "skipping skill directory {}: {summary}. \
+             To allow script files in skills, set `skills.allow_scripts = true` in your config.",
+            path.display(),
+        );
+        eprintln!(
+            "warning: skill '{}' was skipped because it contains script files. \
+             Set `skills.allow_scripts = true` in your zeroclaw config to enable it.",
+            path.file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| path.display().to_string()),
+        );
+    } else {
+        tracing::warn!(
+            "skipping insecure skill directory {}: {summary}",
+            path.display(),
+        );
+    }
+}
+
 /// Load all skills from the workspace skills directory
 pub fn load_skills(workspace_dir: &Path) -> Vec<Skill> {
     load_skills_with_open_skills_config(workspace_dir, None, None, None)
@@ -169,11 +196,8 @@ pub fn load_skills_from_directory(skills_dir: &Path, allow_scripts: bool) -> Vec
         ) {
             Ok(report) if report.is_clean() => {}
             Ok(report) => {
-                tracing::warn!(
-                    "skipping insecure skill directory {}: {}",
-                    path.display(),
-                    report.summary()
-                );
+                let summary = report.summary();
+                warn_skipped_skill(&path, &summary, allow_scripts);
                 continue;
             }
             Err(err) => {
@@ -236,11 +260,8 @@ fn load_open_skills_from_directory(skills_dir: &Path, allow_scripts: bool) -> Ve
         ) {
             Ok(report) if report.is_clean() => {}
             Ok(report) => {
-                tracing::warn!(
-                    "skipping insecure open-skill directory {}: {}",
-                    path.display(),
-                    report.summary()
-                );
+                let summary = report.summary();
+                warn_skipped_skill(&path, &summary, allow_scripts);
                 continue;
             }
             Err(err) => {
@@ -2029,6 +2050,43 @@ description = "Bare minimum"
         assert!(skills[0].tags.iter().any(|tag| tag == "open-skills"));
         assert!(skills[0].prompts[0].contains("# PDF Guide"));
         assert!(!skills[0].prompts[0].contains("description: Use this skill"));
+    }
+
+    #[test]
+    fn skill_with_scripts_skipped_when_allow_scripts_false() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills_dir = dir.path().join("skills");
+        let skill_dir = skills_dir.join("obsidian");
+        fs::create_dir_all(&skill_dir).unwrap();
+
+        fs::write(
+            skill_dir.join("SKILL.toml"),
+            r#"
+[skill]
+name = "obsidian"
+description = "Obsidian vault tool"
+
+[[tools]]
+name = "search"
+description = "Search vault"
+kind = "shell"
+command = "obsidian search {{query}}"
+"#,
+        )
+        .unwrap();
+        fs::write(skill_dir.join("setup.sh"), "#!/bin/bash\necho setup\n").unwrap();
+
+        // With allow_scripts=false (default), skill should be skipped
+        let skills = load_skills_from_directory(&skills_dir, false);
+        assert!(
+            skills.is_empty(),
+            "skill with script files should be skipped when allow_scripts=false"
+        );
+
+        // With allow_scripts=true, skill should load
+        let skills = load_skills_from_directory(&skills_dir, true);
+        assert_eq!(skills.len(), 1, "skill should load when allow_scripts=true");
+        assert_eq!(skills[0].name, "obsidian");
     }
 }
 


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: When `skills.allow_scripts` is `false` (default) and a skill contains script files, the skill is silently skipped. The user sees only the LLM's generic "tool is not available in this environment" with no guidance.
- Why it matters: Blocks users who install skills with shell tools (like Obsidian CLI) from using them, with no actionable error.
- What changed: Added `warn_skipped_skill()` helper that emits both a `tracing::warn!` and a user-visible `eprintln!` when a skill is skipped due to blocked scripts, suggesting `skills.allow_scripts = true`.
- What did **not** change: audit logic, security policy defaults, skill loading pipeline.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `skills`
- Module labels: `skills: loader`
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `skills`

## Linked Issue

- Closes #4292

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass
cargo test --lib skills   # 83 pass including new test
```

- Evidence provided: unit test `skill_with_scripts_skipped_when_allow_scripts_false` verifies that skills with scripts are skipped when `allow_scripts=false` and loaded when `allow_scripts=true`.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- Note: The default `allow_scripts=false` policy is unchanged. This PR only improves error messaging.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No (documents existing `skills.allow_scripts` config)
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (stderr warning only, not user-facing docs)

## Human Verification (required)

- Verified scenarios: skill with .sh file skipped with allow_scripts=false, loaded with allow_scripts=true
- Edge cases checked: skill with non-script audit findings (generic warning), skill name extraction from path
- What was not verified: actual terminal output appearance (eprintln format verified by code review)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: skill loading startup output
- Potential unintended effects: Users may see new stderr warnings on startup if they have skills with script files — this is intentional and actionable
- Guardrails/monitoring: warning is only emitted when scripts are specifically blocked, not for other audit failures

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None
- Observable failure symptoms: Users would stop seeing the helpful warning and revert to the silent skip behavior

## Risks and Mitigations

- Risk: None — this is a messaging-only change that doesn't alter security policy.