### PR TITLE
fix(channels): prevent draft streaming hang after tool loop completion

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2542,9 +2542,12 @@ async fn process_channel_message(
         break loop_result;
     };
 
+    tracing::debug!("Post-loop: dropping delta_tx and awaiting draft updater");
+    drop(delta_tx);
     if let Some(handle) = draft_updater {
         let _ = handle.await;
     }
+    tracing::debug!("Post-loop: draft updater completed");
 
     // Thread the final reply only if tools were used (multi-message response)
     if notify_observer_flag.tools_used.load(Ordering::Relaxed) && msg.channel != "cli" {


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: In draft-capable channels (Telegram), after the tool loop completes, the `draft_updater` task never terminates because the original `delta_tx` mpsc sender is still alive on the stack, keeping the channel open. This causes `draft_updater.await` to block indefinitely, preventing the post-loop code (final message send, "LLM call completed" log) from executing.
- Why it matters: Worker tasks hang forever on draft-streaming channels, never delivering the final response to the user.
- What changed: Added `drop(delta_tx)` before awaiting the draft updater, and added `tracing::debug!` at the start/end of the post-loop path for observability.
- What did **not** change: No changes to the tool loop, draft updater logic, LLM call path, or any other channel behavior.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: telegram`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #4300

## Validation Evidence (required)

```bash
cargo check --lib   # pass
cargo fmt --all -- --check   # pass
```

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Traced `delta_tx` lifetime; confirmed sender is never dropped before `draft_updater.await`, causing the mpsc channel to stay open
- Edge cases checked: Non-streaming channels (no `delta_tx`) unaffected; cancellation path already handles draft cleanup separately
- What was not verified: Live Telegram end-to-end test

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Draft-streaming message path in channels that support `supports_draft_updates()`
- Potential unintended effects: None — `delta_tx` is not used after the tool loop
- Guardrails/monitoring for early detection: New `tracing::debug!` lines make the post-loop path observable

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None
- Observable failure symptoms: If reverted, draft-streaming channels will hang again after tool loop completion

## Risks and Mitigations

- Risk: None — the dropped sender is never referenced after the tool loop.