### PR TITLE
fix(channels): ensure newline between narration and draft status lines

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -3084,7 +3084,11 @@ pub(crate) async fn run_tool_call_loop(
         if !display_text.is_empty() {
             if !native_tool_calls.is_empty() {
                 if let Some(ref tx) = on_delta {
-                    let _ = tx.send(display_text.clone()).await;
+                    let mut narration = display_text.clone();
+                    if !narration.ends_with('\n') {
+                        narration.push('\n');
+                    }
+                    let _ = tx.send(narration).await;
                 }
             }
             if !silent {
@@ -6360,7 +6364,7 @@ mod tests {
 
         let explanation_idx = deltas
             .iter()
-            .position(|delta| delta == "Task started. Waiting 30 seconds before checking status.")
+            .position(|delta| delta == "Task started. Waiting 30 seconds before checking status.\n")
             .expect("native assistant text should be relayed to on_delta");
         let clear_idx = deltas
             .iter()


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: In draft-capable channels (Telegram), native tool-call narration text that doesn't end with `\n` gets concatenated directly with the next status line, producing garbled output like `Task started.⏳ count_to`
- Why it matters: User-facing draft messages become unreadable when narration and status lines run together
- What changed: The narration delta sent via `on_delta` now always ends with `\n` before being dispatched to the draft updater
- What did **not** change: Non-draft channels, progress line format, final-answer streaming, console output

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `agent`
- Module labels: `agent: loop`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `agent`

## Linked Issue

- Closes #4348

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo check --lib            # pass
cargo test run_tool_call_loop_relays_native_tool_call_text_via_on_delta   # pass
```

- Existing test updated to match new trailing-newline behavior.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Reviewed the delta accumulation path; narration text without trailing newline now gets one appended before dispatch
- Edge cases checked: Narration text that already ends with `\n` (no double newline — guarded by `ends_with` check); empty display_text (guarded by outer `!display_text.is_empty()`)
- What was not verified: Live Telegram draft rendering

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Draft message rendering in channels that support `supports_draft_updates()`
- Potential unintended effects: An extra blank line could appear if the model's narration already ends with `\n` — mitigated by the `ends_with` guard
- Guardrails/monitoring for early detection: Existing test updated to assert trailing newline

## Rollback Plan (required)

- Fast rollback command/path: Revert this single commit
- Feature flags or config toggles: None
- Observable failure symptoms: Narration and status lines concatenated without separator in Telegram drafts

## Risks and Mitigations

- Risk: None — the change is a one-line guard adding a newline character.