### PR TITLE
fix(gateway): improve WebSocket chat error handling and diagnostics

### DIFF
--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -169,8 +169,21 @@ async fn handle_socket(
     let mut agent = match crate::agent::Agent::from_config(&config).await {
         Ok(a) => a,
         Err(e) => {
-            let err = serde_json::json!({"type": "error", "message": format!("Failed to initialise agent: {e}")});
+            tracing::error!(error = %e, "Agent initialization failed");
+            let err = serde_json::json!({
+                "type": "error",
+                "message": format!("Failed to initialise agent: {e}"),
+                "code": "AGENT_INIT_FAILED"
+            });
             let _ = sender.send(Message::Text(err.to_string().into())).await;
+            let _ = sender
+                .send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                    code: 1011,
+                    reason: axum::extract::ws::Utf8Bytes::from_static(
+                        "Agent initialization failed",
+                    ),
+                })))
+                .await;
             return;
         }
     };
@@ -299,8 +312,12 @@ async fn handle_socket(
         // Parse incoming message
         let parsed: serde_json::Value = match serde_json::from_str(&msg) {
             Ok(v) => v,
-            Err(_) => {
-                let err = serde_json::json!({"type": "error", "message": "Invalid JSON"});
+            Err(e) => {
+                let err = serde_json::json!({
+                    "type": "error",
+                    "message": format!("Invalid JSON: {}", e),
+                    "code": "INVALID_JSON"
+                });
                 let _ = sender.send(Message::Text(err.to_string().into())).await;
                 continue;
             }
@@ -312,7 +329,8 @@ async fn handle_socket(
                 "type": "error",
                 "message": format!(
                     "Unsupported message type \"{msg_type}\". Send {{\"type\":\"message\",\"content\":\"your text\"}}"
-                )
+                ),
+                "code": "UNKNOWN_MESSAGE_TYPE"
             });
             let _ = sender.send(Message::Text(err.to_string().into())).await;
             continue;
@@ -320,6 +338,12 @@ async fn handle_socket(
 
         let content = parsed["content"].as_str().unwrap_or("").to_string();
         if content.is_empty() {
+            let err = serde_json::json!({
+                "type": "error",
+                "message": "Message content cannot be empty",
+                "code": "EMPTY_CONTENT"
+            });
+            let _ = sender.send(Message::Text(err.to_string().into())).await;
             continue;
         }
 
@@ -378,10 +402,24 @@ async fn process_chat_message(
             }));
         }
         Err(e) => {
+            tracing::error!(error = %e, "Agent turn failed");
             let sanitized = crate::providers::sanitize_api_error(&e.to_string());
+            let error_code = if sanitized.to_lowercase().contains("api key")
+                || sanitized.to_lowercase().contains("authentication")
+                || sanitized.to_lowercase().contains("unauthorized")
+            {
+                "AUTH_ERROR"
+            } else if sanitized.to_lowercase().contains("provider")
+                || sanitized.to_lowercase().contains("model")
+            {
+                "PROVIDER_ERROR"
+            } else {
+                "AGENT_ERROR"
+            };
             let err = serde_json::json!({
                 "type": "error",
                 "message": sanitized,
+                "code": error_code,
             });
             let _ = sender.send(Message::Text(err.to_string().into())).await;
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -46,7 +46,7 @@ use reliable::ReliableProvider;
 use serde::Deserialize;
 use std::path::PathBuf;
 
-const MAX_API_ERROR_CHARS: usize = 200;
+const MAX_API_ERROR_CHARS: usize = 500;
 const MINIMAX_INTL_BASE_URL: &str = "https://api.minimax.io/v1";
 const MINIMAX_CN_BASE_URL: &str = "https://api.minimaxi.com/v1";
 const MINIMAX_OAUTH_GLOBAL_TOKEN_ENDPOINT: &str = "https://api.minimax.io/oauth/token";
@@ -3333,18 +3333,18 @@ mod tests {
 
     #[test]
     fn sanitize_truncates_long_error() {
-        let long = "a".repeat(400);
+        let long = "a".repeat(600);
         let result = sanitize_api_error(&long);
-        assert!(result.len() <= 203);
+        assert!(result.len() <= 503);
         assert!(result.ends_with("..."));
     }
 
     #[test]
     fn sanitize_truncates_after_scrub() {
-        let input = format!("{} sk-abcdef123456 {}", "a".repeat(190), "b".repeat(190));
+        let input = format!("{} sk-abcdef123456 {}", "a".repeat(290), "b".repeat(290));
         let result = sanitize_api_error(&input);
         assert!(!result.contains("sk-abcdef123456"));
-        assert!(result.len() <= 203);
+        assert!(result.len() <= 503);
     }
 
     #[test]

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -42,8 +42,11 @@ export default function AgentChat() {
       setError(null);
     };
 
-    ws.onClose = () => {
+    ws.onClose = (ev: CloseEvent) => {
       setConnected(false);
+      if (ev.code !== 1000 && ev.code !== 1001) {
+        setError(`Connection closed unexpectedly (code: ${ev.code}). Please check your configuration.`);
+      }
     };
 
     ws.onError = () => {
@@ -110,6 +113,11 @@ export default function AgentChat() {
               timestamp: new Date(),
             },
           ]);
+          if (msg.code === 'AGENT_INIT_FAILED' || msg.code === 'AUTH_ERROR' || msg.code === 'PROVIDER_ERROR') {
+            setError(`Configuration error: ${msg.message}. Please check your provider settings (API key, model, etc.).`);
+          } else if (msg.code === 'INVALID_JSON' || msg.code === 'UNKNOWN_MESSAGE_TYPE' || msg.code === 'EMPTY_CONTENT') {
+            setError(`Message error: ${msg.message}`);
+          }
           setTyping(false);
           pendingContentRef.current = '';
           break;

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -120,4 +120,5 @@ export interface WsMessage {
   args?: any;
   output?: string;
   message?: string;
+  code?: string;
 }


### PR DESCRIPTION
## Summary
- Add error codes (AGENT_INIT_FAILED, AUTH_ERROR, PROVIDER_ERROR, INVALID_JSON, UNKNOWN_MESSAGE_TYPE, EMPTY_CONTENT) to WebSocket error messages
- Send Close frame with code 1011 on agent init failure
- Add tracing logs for agent init and turn errors  
- Increase MAX_API_ERROR_CHARS from 200 to 500
- Frontend: handle abnormal close codes and show config error hints

Supersedes #4366 (rebased on master after conflicts from #4361 and #4362 merges)
Fixes #3681
Original work by @mark-linyb

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo check` compiles cleanly
- [x] `cargo test --lib -- gateway providers::tests::sanitize` — 110 passed, 0 failed
- [x] Full test suite: 5,015 passed, 2 failed (pre-existing security::policy failures)