### PR TITLE
fix(onboard): check only stdin for TTY to restore interactive prompts

### DIFF
--- a/src/channels/wati.rs
+++ b/src/channels/wati.rs
@@ -354,6 +354,7 @@ impl WatiChannel {
             timestamp,
             thread_ts: None,
             interruption_scope_id: None,
+            attachments: vec![],
         });
 
         messages

--- a/src/main.rs
+++ b/src/main.rs
@@ -886,9 +886,17 @@ async fn main() -> Result<()> {
 
         // Auto-detect: run the interactive wizard when in a TTY with no
         // provider flags, quick setup otherwise (scriptable path).
+        //
+        // Only stdin needs to be a terminal — the wizard reads user input from
+        // stdin and dialoguer opens /dev/tty directly for rendering, so stdout
+        // being redirected (e.g. `zeroclaw onboard | tee setup.log`) must not
+        // prevent the interactive wizard from launching.  Requiring stdout to
+        // also be a TTY was the root cause of #3658: on some systems and
+        // terminal configurations stdout.is_terminal() returned false even
+        // when the user was sitting at an interactive prompt.
         let has_provider_flags =
             api_key.is_some() || provider.is_some() || model.is_some() || memory.is_some();
-        let is_tty = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
+        let is_tty = std::io::stdin().is_terminal();
 
         let config = if channels_only {
             Box::pin(onboard::run_channels_repair_wizard()).await

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -2153,7 +2153,13 @@ fn resolve_interactive_onboarding_mode(
         return Ok(InteractiveOnboardingMode::FullOnboarding);
     }
 
-    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+    // Only stdin needs to be a terminal to determine whether the session is
+    // interactive; stdout may be redirected for logging without affecting our
+    // ability to read user input.  Checking both stdin and stdout with ||
+    // was overly strict: on some systems stdout.is_terminal() returned false
+    // at an interactive prompt, causing the wizard to bail unexpectedly
+    // (#3658).
+    if !std::io::stdin().is_terminal() {
         bail!(
             "Refusing to overwrite existing config at {} in non-interactive mode. Re-run with --force if overwrite is intentional.",
             config_path.display()
@@ -2206,7 +2212,8 @@ fn ensure_onboard_overwrite_allowed(config_path: &Path, force: bool) -> Result<(
 
     #[cfg(not(test))]
     {
-        if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        // Only stdin needs to be a terminal — see #3658.
+        if !std::io::stdin().is_terminal() {
             bail!(
                 "Refusing to overwrite existing config at {} in non-interactive mode. Re-run with --force if overwrite is intentional.",
                 config_path.display()


### PR DESCRIPTION
## Summary

Fixes #3658.

In v0.3.2 the `zeroclaw onboard` TTY-detection guard required **both**
`stdin` and `stdout` to report as terminals:

```rust
let is_tty = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
```

On a number of Linux systems (Debian trixie being the first reported
case) and certain terminal emulators, `stdout.is_terminal()` evaluates
to `false` even when the user is sitting at an interactive prompt,
causing the router to fall through to `run_quick_setup` and print
*"Quick Setup — generating config with sensible defaults…"* instead of
launching the interactive wizard.

The same `|| !stdout.is_terminal()` pattern was repeated in two safety
guards inside `src/onboard/wizard.rs` (`resolve_interactive_onboarding_mode`
and `ensure_onboard_overwrite_allowed`), causing those guards to bail
out unnecessarily in the same scenario.

### Fix

Gate all three checks on `stdin.is_terminal()` only.

- The wizard reads all user input **from stdin** — that is the only fd
  that needs to be a terminal for the prompts to work.
- `dialoguer` opens `/dev/tty` directly for its TUI rendering, so
  stdout does not need to be attached to a terminal.
- Redirecting stdout (e.g. `zeroclaw onboard | tee setup.log`) is a
  legitimate use-case and must not prevent interactive mode.

### Also fixes

A pre-existing compile error in `src/channels/wati.rs`: the audio
transcription path was missing the new `attachments` field added to
`ChannelMessage` in a recent commit.

## Test plan

- [x] `cargo fmt` — no changes
- [x] `cargo build` — clean
- [x] `cargo test` — all pass (505 unit tests, 5 system tests)
- Manual: `zeroclaw onboard` in a normal terminal now launches the
  interactive wizard instead of immediately generating the default config

🤖 Generated with [Claude Code](https://claude.com/claude-code)