### PR TITLE
fix(provider): resolve 502 errors with custom OpenAI providers

### DIFF
--- a/src/channels/wati.rs
+++ b/src/channels/wati.rs
@@ -354,6 +354,7 @@ impl WatiChannel {
             timestamp,
             thread_ts: None,
             interruption_scope_id: None,
+            attachments: vec![],
         });
 
         messages

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -17,6 +17,9 @@ struct ChatRequest {
     model: String,
     messages: Vec<Message>,
     temperature: f64,
+    /// Explicitly disable streaming so custom OpenAI-compatible proxies
+    /// (e.g. sub2api) do not default to SSE mode when the field is absent.
+    stream: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -58,6 +61,9 @@ struct NativeChatRequest {
     model: String,
     messages: Vec<NativeMessage>,
     temperature: f64,
+    /// Explicitly disable streaming so custom OpenAI-compatible proxies
+    /// (e.g. sub2api) do not default to SSE mode when the field is absent.
+    stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<NativeToolSpec>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -368,6 +374,7 @@ impl Provider for OpenAiProvider {
             model: model.to_string(),
             messages,
             temperature: adjusted_temperature,
+            stream: false,
         };
 
         let response = self
@@ -409,6 +416,7 @@ impl Provider for OpenAiProvider {
             model: model.to_string(),
             messages: Self::convert_messages(request.messages),
             temperature: adjusted_temperature,
+            stream: false,
             tool_choice: tools.as_ref().map(|_| "auto".to_string()),
             tools,
         };
@@ -475,6 +483,7 @@ impl Provider for OpenAiProvider {
             model: model.to_string(),
             messages: Self::convert_messages(messages),
             temperature: adjusted_temperature,
+            stream: false,
             tool_choice: native_tools.as_ref().map(|_| "auto".to_string()),
             tools: native_tools,
         };
@@ -575,11 +584,13 @@ mod tests {
                 },
             ],
             temperature: 0.7,
+            stream: false,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("\"role\":\"system\""));
         assert!(json.contains("\"role\":\"user\""));
         assert!(json.contains("gpt-4o"));
+        assert!(json.contains("\"stream\":false"));
     }
 
     #[test]
@@ -591,10 +602,12 @@ mod tests {
                 content: "hello".to_string(),
             }],
             temperature: 0.0,
+            stream: false,
         };
         let json = serde_json::to_string(&req).unwrap();
-        assert!(!json.contains("system"));
+        assert!(!json.contains("\"role\":\"system\""));
         assert!(json.contains("\"temperature\":0.0"));
+        assert!(json.contains("\"stream\":false"));
     }
 
     #[test]

--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -39,8 +39,15 @@ pub fn is_non_retryable(err: &anyhow::Error) -> bool {
     }
     // Fallback: parse status codes from stringified errors (some providers
     // embed codes in error messages rather than returning typed HTTP errors).
+    //
+    // IMPORTANT: only scan the *header* portion (before the first ": " separator).
+    // The error message format is "{provider} API error ({status}): {body}".
+    // Scanning the full string would cause embedded 4xx codes in the JSON response
+    // body (e.g. sub2api 502 body: `{"error":{"code":400}}`) to be misclassified
+    // as non-retryable, aborting the retry loop prematurely. Fix for #4299/#4296.
     let msg = err.to_string();
-    for word in msg.split(|c: char| !c.is_ascii_digit()) {
+    let header = msg.split(": ").next().unwrap_or(&msg);
+    for word in header.split(|c: char| !c.is_ascii_digit()) {
         if let Ok(code) = word.parse::<u16>() {
             if (400..500).contains(&code) {
                 return code != 429 && code != 408;
@@ -2358,5 +2365,37 @@ mod tests {
         // A regular 400 error (e.g. invalid API key) should still be non-retryable.
         let err = anyhow::anyhow!("400 Bad Request: invalid api key provided");
         assert!(is_non_retryable(&err));
+    }
+
+    // ── §2.x Regression: #4299/#4296 – sub2api 502 with embedded 400 ─────
+
+    #[test]
+    fn non_retryable_does_not_flag_502_with_embedded_400_in_body() {
+        // Regression test for #4299/#4296: custom OpenAI-compatible proxies
+        // (e.g. sub2api) may return a 502 whose JSON body contains a nested
+        // `"code": 400` field. The string-based fallback must NOT pick up that
+        // embedded 400 and incorrectly classify the error as non-retryable.
+        let err = anyhow::anyhow!(
+            "{}",
+            r#"OpenAI API error (502 Bad Gateway): {"error":{"message":"Upstream request failed","type":"upstream_error","code":400}}"#
+        );
+        assert!(
+            !is_non_retryable(&err),
+            "502 with embedded 400 in body must NOT be treated as non-retryable; \
+             the retry loop must keep trying"
+        );
+    }
+
+    #[test]
+    fn non_retryable_flags_genuine_400_error() {
+        // Genuine 400 from a custom proxy must still be non-retryable.
+        let err = anyhow::anyhow!(
+            "{}",
+            r#"OpenAI API error (400 Bad Request): {"error":{"message":"invalid request"}}"#
+        );
+        assert!(
+            is_non_retryable(&err),
+            "genuine 400 HTTP status must still be treated as non-retryable"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #4299, Fixes #4296

Custom OpenAI-compatible proxies (e.g. sub2api) were causing permanent 502 failures instead of triggering retries.

- **Root cause**: `is_non_retryable()` in `reliable.rs` scanned the entire stringified error message for 4xx status codes. When a proxy returns HTTP 502 with a JSON body like `{"error":{"code":400}}`, the scanner found the embedded `400` in the body before finding the `502` in the header, and incorrectly classified the transient 502 as a permanent non-retryable error — immediately aborting the retry loop.
- **Fix**: restrict the string-based status code scan to the header portion of the error message only (before the first `": "` separator), matching the format `{provider} API error ({status}): {body}` produced by `mod.rs`.
- **Hardening**: add `stream: false` to all OpenAI request payloads so custom proxies do not accidentally default to SSE streaming mode when the field is absent.
- **Incidental fix**: pre-existing compile error in `wati.rs` where a `ChannelMessage` initializer was missing the `attachments` field.

## Test plan

- [x] `cargo fmt && cargo build` passes
- [x] All existing tests pass (`cargo test`)
- [x] New regression test `non_retryable_does_not_flag_502_with_embedded_400_in_body` passes — verifies 502+embedded 400 body is NOT flagged as non-retryable
- [x] New regression test `non_retryable_flags_genuine_400_error` passes — verifies genuine 400 responses remain non-retryable

🤖 Generated with [Claude Code](https://claude.com/claude-code)