### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12364,7 +12364,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "aardvark-sys",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.5.9"
+version = "0.6.0"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "ZeroClaw",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "identifier": "ai.zeroclawlabs.desktop",
   "build": {
     "devUrl": "http://127.0.0.1:42617/_app/",


### PR DESCRIPTION
## Summary

- Bump version from 0.5.9 → 0.6.0 across Cargo.toml, Cargo.lock, and tauri.conf.json

### What's in 0.6.0
- macOS desktop menu bar app (Tauri) with auto-pairing, blue gradient Z icons, health polling
- Media pipeline channels
- SOP engine improvements
- CLI tool integrations (codex, gemini, opencode)

## Test plan

- [x] `cargo check` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)