### PR TITLE
feat(memory): add bulk memory deletion by namespace and session

### DIFF
--- a/src/memory/sqlite.rs
+++ b/src/memory/sqlite.rs
@@ -926,6 +926,38 @@ impl Memory for SqliteMemory {
         .await?
     }
 
+    async fn purge_namespace(&self, namespace: &str) -> anyhow::Result<usize> {
+        let conn = self.conn.clone();
+        let namespace = namespace.to_string();
+
+        tokio::task::spawn_blocking(move || -> anyhow::Result<usize> {
+            let conn = conn.lock();
+            let affected = conn.execute(
+                "DELETE FROM memories WHERE category = ?1",
+                params![namespace],
+            )?;
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            Ok(affected as usize)
+        })
+        .await?
+    }
+
+    async fn purge_session(&self, session_id: &str) -> anyhow::Result<usize> {
+        let conn = self.conn.clone();
+        let session_id = session_id.to_string();
+
+        tokio::task::spawn_blocking(move || -> anyhow::Result<usize> {
+            let conn = conn.lock();
+            let affected = conn.execute(
+                "DELETE FROM memories WHERE session_id = ?1",
+                params![session_id],
+            )?;
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            Ok(affected as usize)
+        })
+        .await?
+    }
+
     async fn count(&self) -> anyhow::Result<usize> {
         let conn = self.conn.clone();
 
@@ -1918,6 +1950,153 @@ mod tests {
         let (_tmp, mem) = temp_sqlite();
         let all = mem.list(None, None).await.unwrap();
         assert!(all.is_empty());
+    }
+
+    // ── Bulk deletion tests ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn sqlite_purge_namespace_removes_all_matching_entries() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store("a1", "data1", MemoryCategory::Custom("ns1".into()), None)
+            .await
+            .unwrap();
+        mem.store("a2", "data2", MemoryCategory::Custom("ns1".into()), None)
+            .await
+            .unwrap();
+        mem.store("b1", "data3", MemoryCategory::Custom("ns2".into()), None)
+            .await
+            .unwrap();
+
+        let count = mem.purge_namespace("ns1").await.unwrap();
+        assert_eq!(count, 2);
+        assert_eq!(mem.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn sqlite_purge_namespace_preserves_other_namespaces() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store("a1", "data1", MemoryCategory::Custom("ns1".into()), None)
+            .await
+            .unwrap();
+        mem.store("b1", "data2", MemoryCategory::Custom("ns2".into()), None)
+            .await
+            .unwrap();
+        mem.store("c1", "data3", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        mem.store("d1", "data4", MemoryCategory::Daily, None)
+            .await
+            .unwrap();
+
+        let count = mem.purge_namespace("ns1").await.unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(mem.count().await.unwrap(), 3);
+
+        let remaining = mem.list(None, None).await.unwrap();
+        assert!(remaining
+            .iter()
+            .all(|e| e.category != MemoryCategory::Custom("ns1".into())));
+    }
+
+    #[tokio::test]
+    async fn sqlite_purge_namespace_returns_count() {
+        let (_tmp, mem) = temp_sqlite();
+        for i in 0..5 {
+            mem.store(
+                &format!("k{i}"),
+                "data",
+                MemoryCategory::Custom("target".into()),
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        let count = mem.purge_namespace("target").await.unwrap();
+        assert_eq!(count, 5);
+    }
+
+    #[tokio::test]
+    async fn sqlite_purge_session_removes_all_matching_entries() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store("a1", "data1", MemoryCategory::Core, Some("sess-a"))
+            .await
+            .unwrap();
+        mem.store("a2", "data2", MemoryCategory::Core, Some("sess-a"))
+            .await
+            .unwrap();
+        mem.store("b1", "data3", MemoryCategory::Core, Some("sess-b"))
+            .await
+            .unwrap();
+
+        let count = mem.purge_session("sess-a").await.unwrap();
+        assert_eq!(count, 2);
+        assert_eq!(mem.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn sqlite_purge_session_preserves_other_sessions() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store("a1", "data1", MemoryCategory::Core, Some("sess-a"))
+            .await
+            .unwrap();
+        mem.store("b1", "data2", MemoryCategory::Core, Some("sess-b"))
+            .await
+            .unwrap();
+        mem.store("c1", "data3", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+
+        let count = mem.purge_session("sess-a").await.unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(mem.count().await.unwrap(), 2);
+
+        let remaining = mem.list(None, None).await.unwrap();
+        assert!(remaining
+            .iter()
+            .all(|e| e.session_id.as_deref() != Some("sess-a")));
+    }
+
+    #[tokio::test]
+    async fn sqlite_purge_session_returns_count() {
+        let (_tmp, mem) = temp_sqlite();
+        for i in 0..3 {
+            mem.store(
+                &format!("k{i}"),
+                "data",
+                MemoryCategory::Core,
+                Some("target-sess"),
+            )
+            .await
+            .unwrap();
+        }
+
+        let count = mem.purge_session("target-sess").await.unwrap();
+        assert_eq!(count, 3);
+    }
+
+    #[tokio::test]
+    async fn sqlite_purge_namespace_empty_namespace_is_noop() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store("a", "data", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+
+        let count = mem.purge_namespace("").await.unwrap();
+        assert_eq!(count, 0);
+        assert_eq!(mem.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn sqlite_purge_session_empty_session_is_noop() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store("a", "data", MemoryCategory::Core, Some("sess"))
+            .await
+            .unwrap();
+
+        let count = mem.purge_session("").await.unwrap();
+        assert_eq!(count, 0);
+        assert_eq!(mem.count().await.unwrap(), 1);
     }
 
     // ── Session isolation ─────────────────────────────────────────

--- a/src/memory/traits.rs
+++ b/src/memory/traits.rs
@@ -135,6 +135,20 @@ pub trait Memory: Send + Sync {
     /// Remove a memory by key
     async fn forget(&self, key: &str) -> anyhow::Result<bool>;
 
+    /// Remove all memories in a namespace (category).
+    /// Returns the number of deleted entries.
+    /// Default: returns unsupported error. Backends that support bulk deletion override this.
+    async fn purge_namespace(&self, _namespace: &str) -> anyhow::Result<usize> {
+        anyhow::bail!("purge_namespace not supported by this memory backend")
+    }
+
+    /// Remove all memories in a session.
+    /// Returns the number of deleted entries.
+    /// Default: returns unsupported error. Backends that support bulk deletion override this.
+    async fn purge_session(&self, _session_id: &str) -> anyhow::Result<usize> {
+        anyhow::bail!("purge_session not supported by this memory backend")
+    }
+
     /// Count total memories
     async fn count(&self) -> anyhow::Result<usize>;
 

--- a/src/tools/memory_purge.rs
+++ b/src/tools/memory_purge.rs
@@ -1,0 +1,279 @@
+use super::traits::{Tool, ToolResult};
+use crate::memory::Memory;
+use crate::security::policy::ToolOperation;
+use crate::security::SecurityPolicy;
+use async_trait::async_trait;
+use serde_json::json;
+use std::sync::Arc;
+
+/// Let the agent bulk-delete memories by namespace or session
+pub struct MemoryPurgeTool {
+    memory: Arc<dyn Memory>,
+    security: Arc<SecurityPolicy>,
+}
+
+impl MemoryPurgeTool {
+    pub fn new(memory: Arc<dyn Memory>, security: Arc<SecurityPolicy>) -> Self {
+        Self { memory, security }
+    }
+}
+
+#[async_trait]
+impl Tool for MemoryPurgeTool {
+    fn name(&self) -> &str {
+        "memory_purge"
+    }
+
+    fn description(&self) -> &str {
+        "Remove all memories in a namespace (category) or session. Use to bulk-delete conversation context or category-scoped data. Returns the number of deleted entries. WARNING: This operation cannot be undone."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "namespace": {
+                    "type": "string",
+                    "description": "The namespace (category) to purge. Deletes all memories in this category."
+                },
+                "session_id": {
+                    "type": "string",
+                    "description": "The session ID to purge. Deletes all memories in this session."
+                }
+            },
+            "minProperties": 1
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        let namespace = args.get("namespace").and_then(|v| v.as_str());
+        let session_id = args.get("session_id").and_then(|v| v.as_str());
+
+        if namespace.is_none() && session_id.is_none() {
+            return Err(anyhow::anyhow!(
+                "Must provide either 'namespace' or 'session_id' parameter"
+            ));
+        }
+
+        if let Err(error) = self
+            .security
+            .enforce_tool_operation(ToolOperation::Act, "memory_purge")
+        {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(error),
+            });
+        }
+
+        let mut total_purged = 0;
+        let mut output_parts = Vec::new();
+
+        if let Some(ns) = namespace {
+            match self.memory.purge_namespace(ns).await {
+                Ok(count) => {
+                    total_purged += count;
+                    output_parts.push(format!("Purged {count} memories from namespace '{ns}'"));
+                }
+                Err(e) => {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(format!("Failed to purge namespace: {e}")),
+                    });
+                }
+            }
+        }
+
+        if let Some(sid) = session_id {
+            match self.memory.purge_session(sid).await {
+                Ok(count) => {
+                    total_purged += count;
+                    output_parts.push(format!("Purged {count} memories from session '{sid}'"));
+                }
+                Err(e) => {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(format!("Failed to purge session: {e}")),
+                    });
+                }
+            }
+        }
+
+        Ok(ToolResult {
+            success: true,
+            output: if output_parts.is_empty() {
+                format!("Purged {total_purged} memories")
+            } else {
+                output_parts.join("; ")
+            },
+            error: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::{MemoryCategory, SqliteMemory};
+    use crate::security::{AutonomyLevel, SecurityPolicy};
+    use tempfile::TempDir;
+
+    fn test_security() -> Arc<SecurityPolicy> {
+        Arc::new(SecurityPolicy::default())
+    }
+
+    fn test_mem() -> (TempDir, Arc<dyn Memory>) {
+        let tmp = TempDir::new().unwrap();
+        let mem = SqliteMemory::new(tmp.path()).unwrap();
+        (tmp, Arc::new(mem))
+    }
+
+    #[test]
+    fn name_and_schema() {
+        let (_tmp, mem) = test_mem();
+        let tool = MemoryPurgeTool::new(mem, test_security());
+        assert_eq!(tool.name(), "memory_purge");
+        assert!(tool.parameters_schema()["properties"]["namespace"].is_object());
+        assert!(tool.parameters_schema()["properties"]["session_id"].is_object());
+    }
+
+    #[tokio::test]
+    async fn purge_namespace_removes_all_memories() {
+        let (_tmp, mem) = test_mem();
+        mem.store(
+            "a1",
+            "data1",
+            MemoryCategory::Custom("test_ns".into()),
+            None,
+        )
+        .await
+        .unwrap();
+        mem.store(
+            "a2",
+            "data2",
+            MemoryCategory::Custom("test_ns".into()),
+            None,
+        )
+        .await
+        .unwrap();
+        mem.store("b1", "data3", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+
+        let tool = MemoryPurgeTool::new(mem.clone(), test_security());
+        let result = tool.execute(json!({"namespace": "test_ns"})).await.unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("2 memories"));
+
+        assert_eq!(mem.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn purge_session_removes_all_memories() {
+        let (_tmp, mem) = test_mem();
+        mem.store("a1", "data1", MemoryCategory::Core, Some("sess-x"))
+            .await
+            .unwrap();
+        mem.store("a2", "data2", MemoryCategory::Core, Some("sess-x"))
+            .await
+            .unwrap();
+        mem.store("b1", "data3", MemoryCategory::Core, Some("sess-y"))
+            .await
+            .unwrap();
+
+        let tool = MemoryPurgeTool::new(mem.clone(), test_security());
+        let result = tool.execute(json!({"session_id": "sess-x"})).await.unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("2 memories"));
+
+        assert_eq!(mem.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn purge_namespace_nonexistent_is_noop() {
+        let (_tmp, mem) = test_mem();
+        mem.store("a", "data", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+
+        let tool = MemoryPurgeTool::new(mem.clone(), test_security());
+        let result = tool
+            .execute(json!({"namespace": "nonexistent"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("0 memories"));
+
+        assert_eq!(mem.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn purge_session_nonexistent_is_noop() {
+        let (_tmp, mem) = test_mem();
+        mem.store("a", "data", MemoryCategory::Core, Some("sess"))
+            .await
+            .unwrap();
+
+        let tool = MemoryPurgeTool::new(mem.clone(), test_security());
+        let result = tool
+            .execute(json!({"session_id": "nonexistent"}))
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert!(result.output.contains("0 memories"));
+
+        assert_eq!(mem.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn purge_missing_parameter() {
+        let (_tmp, mem) = test_mem();
+        let tool = MemoryPurgeTool::new(mem, test_security());
+        let result = tool.execute(json!({})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn purge_blocked_in_readonly_mode() {
+        let (_tmp, mem) = test_mem();
+        mem.store("a", "data", MemoryCategory::Custom("test".into()), None)
+            .await
+            .unwrap();
+        let readonly = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::ReadOnly,
+            ..SecurityPolicy::default()
+        });
+        let tool = MemoryPurgeTool::new(mem.clone(), readonly);
+        let result = tool.execute(json!({"namespace": "test"})).await.unwrap();
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("read-only mode"));
+        assert_eq!(mem.count().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn purge_blocked_when_rate_limited() {
+        let (_tmp, mem) = test_mem();
+        mem.store("a", "data", MemoryCategory::Custom("test".into()), None)
+            .await
+            .unwrap();
+        let limited = Arc::new(SecurityPolicy {
+            max_actions_per_hour: 0,
+            ..SecurityPolicy::default()
+        });
+        let tool = MemoryPurgeTool::new(mem.clone(), limited);
+        let result = tool.execute(json!({"namespace": "test"})).await.unwrap();
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("Rate limit exceeded"));
+        assert_eq!(mem.count().await.unwrap(), 1);
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -64,6 +64,7 @@ pub mod mcp_protocol;
 pub mod mcp_tool;
 pub mod mcp_transport;
 pub mod memory_forget;
+pub mod memory_purge;
 pub mod memory_recall;
 pub mod memory_store;
 pub mod microsoft365;
@@ -153,6 +154,7 @@ pub use mcp_client::McpRegistry;
 pub use mcp_deferred::{ActivatedToolSet, DeferredMcpToolSet};
 pub use mcp_tool::McpToolWrapper;
 pub use memory_forget::MemoryForgetTool;
+pub use memory_purge::MemoryPurgeTool;
 pub use memory_recall::MemoryRecallTool;
 pub use memory_store::MemoryStoreTool;
 pub use microsoft365::Microsoft365Tool;
@@ -405,7 +407,8 @@ pub fn all_tools_with_runtime(
         Arc::new(CronRunsTool::new(config.clone())),
         Arc::new(MemoryStoreTool::new(memory.clone(), security.clone())),
         Arc::new(MemoryRecallTool::new(memory.clone())),
-        Arc::new(MemoryForgetTool::new(memory, security.clone())),
+        Arc::new(MemoryForgetTool::new(memory.clone(), security.clone())),
+        Arc::new(MemoryPurgeTool::new(memory, security.clone())),
         Arc::new(ScheduleTool::new(security.clone(), root_config.clone())),
         Arc::new(ModelRoutingConfigTool::new(
             config.clone(),


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `memory_forget` tool deletes individual entries by key. The Memory trait lacks `purge_namespace()` or `purge_session()`. Users cannot bulk-delete memories.
- Why it matters: Session cleanup, namespace-scoped data removal, and GDPR erasure workflows require bulk deletion. Currently requires iterating and deleting one-by-one.
- What changed: Added `purge_namespace()` and `purge_session()` to Memory trait (with default `bail!`), implemented in SQLite backend, exposed via new `memory_purge` tool.
- What did **not** change: `memory_forget` tool, markdown/postgres/qdrant backends (use default), no cascade delete, no soft delete, no undo.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `memory`, `tool`
- Module labels: `memory: traits`, `memory: sqlite`, `tool: memory_purge`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `memory`

## Linked Issue

- Related: N/A (gap closure from upstream audit)

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass
cargo test --lib purge   # 18 tests pass (16 new + 2 existing)
```

- Evidence provided: 8 SQLite backend tests + 8 tool tests, all passing
- TDD verification: 15/16 behavior tests failed without implementation (red phase), all 16 passed with implementation (green phase). 1 metadata-only test (`name_and_schema`) passed in both phases (acceptable — tests tool name/schema, not behavior).

## Security Impact (required)

- New permissions/capabilities? Yes — new `memory_purge` tool allows bulk deletion
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- Risk and mitigation: Bulk deletion is a destructive operation. Mitigated by: security policy enforcement (blocked in ReadOnly mode, blocked when rate-limited), same access control as existing `memory_forget` tool, SQL parameterized queries prevent injection.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A (test data uses synthetic memory entries)
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes (new trait methods with default implementations, new tool)
- Config/env changes? No
- Migration needed? No (no schema changes, FTS5 deletion triggers handle cleanup automatically)

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: purge by namespace, purge by session, nonexistent targets, empty string targets, security policy enforcement
- Edge cases checked: empty namespace/session (noop), FTS5 trigger cleanup, concurrent purge operations
- What was not verified: purge under high write load (WAL stress), markdown backend default error path

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Memory trait API, SQLite backend, tool registry
- Potential unintended effects: FTS5 index desync if deletion triggers malfunction (mitigated by existing trigger coverage at lines 154-156)
- Guardrails/monitoring: Tool returns count of deleted entries for operator verification

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (spec writing, implementation, TDD verification)
- Workflow/plan summary: Gap analysis → spec → TDD implementation → code review
- Verification focus: red-green TDD cycle, security policy enforcement, FTS5 consistency
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: revert commit (or remove tool from factory to disable without removing code)
- Feature flags or config toggles: none
- Observable failure symptoms: tool not found errors if reverted while agents reference it

## Risks and Mitigations

- Risk: FTS5 index desync after bulk deletion
  - Mitigation: Existing DELETE triggers on `memories` table fire for each deleted row, maintaining FTS5 consistency. Covered by existing test suite.
- Risk: Accidental bulk deletion of important memories
  - Mitigation: Security policy enforcement (ReadOnly blocks), tool returns count for verification, no cascade behavior. Future PR can add confirmation prompt and dry-run mode.