### PR TITLE
feat: adopt AGENTS.md as the primary agent instruction format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,92 @@
-CLAUDE.md
+# AGENTS.md — ZeroClaw
+
+Cross-tool agent instructions for any AI coding assistant working on this repository.
+
+## Commands
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+```
+
+Full pre-PR validation (recommended):
+
+```bash
+./dev/ci.sh all
+```
+
+Docs-only changes: run markdown lint and link-integrity checks. If touching bootstrap scripts: `bash -n install.sh`.
+
+## Project Snapshot
+
+ZeroClaw is a Rust-first autonomous agent runtime optimized for performance, efficiency, stability, extensibility, sustainability, and security.
+
+Core architecture is trait-driven and modular. Extend by implementing traits and registering in factory modules.
+
+Key extension points:
+
+- `src/providers/traits.rs` (`Provider`)
+- `src/channels/traits.rs` (`Channel`)
+- `src/tools/traits.rs` (`Tool`)
+- `src/memory/traits.rs` (`Memory`)
+- `src/observability/traits.rs` (`Observer`)
+- `src/runtime/traits.rs` (`RuntimeAdapter`)
+- `src/peripherals/traits.rs` (`Peripheral`) — hardware boards (STM32, RPi GPIO)
+
+## Repository Map
+
+- `src/main.rs` — CLI entrypoint and command routing
+- `src/lib.rs` — module exports and shared command enums
+- `src/config/` — schema + config loading/merging
+- `src/agent/` — orchestration loop
+- `src/gateway/` — webhook/gateway server
+- `src/security/` — policy, pairing, secret store
+- `src/memory/` — markdown/sqlite memory backends + embeddings/vector merge
+- `src/providers/` — model providers and resilient wrapper
+- `src/channels/` — Telegram/Discord/Slack/etc channels
+- `src/tools/` — tool execution surface (shell, file, memory, browser)
+- `src/peripherals/` — hardware peripherals (STM32, RPi GPIO)
+- `src/runtime/` — runtime adapters (currently native)
+- `docs/` — topic-based documentation (setup-guides, reference, ops, security, hardware, contributing, maintainers)
+- `.github/` — CI, templates, automation workflows
+
+## Risk Tiers
+
+- **Low risk**: docs/chore/tests-only changes
+- **Medium risk**: most `src/**` behavior changes without boundary/security impact
+- **High risk**: `src/security/**`, `src/runtime/**`, `src/gateway/**`, `src/tools/**`, `.github/workflows/**`, access-control boundaries
+
+When uncertain, classify as higher risk.
+
+## Workflow
+
+1. **Read before write** — inspect existing module, factory wiring, and adjacent tests before editing.
+2. **One concern per PR** — avoid mixed feature+refactor+infra patches.
+3. **Implement minimal patch** — no speculative abstractions, no config keys without a concrete use case.
+4. **Validate by risk tier** — docs-only: lightweight checks. Code changes: full relevant checks.
+5. **Document impact** — update PR notes for behavior, risk, side effects, and rollback.
+6. **Queue hygiene** — stacked PR: declare `Depends on #...`. Replacing old PR: declare `Supersedes #...`.
+
+Branch/commit/PR rules:
+- Work from a non-`master` branch. Open a PR to `master`; do not push directly.
+- Use conventional commit titles. Prefer small PRs (`size: XS/S/M`).
+- Follow `.github/pull_request_template.md` fully.
+- Never commit secrets, personal data, or real identity information (see `@docs/contributing/pr-discipline.md`).
+
+## Anti-Patterns
+
+- Do not add heavy dependencies for minor convenience.
+- Do not silently weaken security policy or access constraints.
+- Do not add speculative config/feature flags "just in case".
+- Do not mix massive formatting-only changes with functional changes.
+- Do not modify unrelated modules "while here".
+- Do not bypass failing checks without explicit explanation.
+- Do not hide behavior-changing side effects in refactor commits.
+- Do not include personal identity or sensitive information in test data, examples, docs, or commits.
+
+## Linked References
+
+- `@docs/contributing/change-playbooks.md` — adding providers, channels, tools, peripherals; security/gateway changes; architecture boundaries
+- `@docs/contributing/pr-discipline.md` — privacy rules, superseded-PR attribution/templates, handoff template
+- `@docs/contributing/docs-contract.md` — docs system contract, i18n rules, locale parity

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,90 +1,16 @@
-# CLAUDE.md — ZeroClaw
+# CLAUDE.md — ZeroClaw (Claude Code)
 
-## Commands
+> **Shared instructions live in [`AGENTS.md`](./AGENTS.md).**
+> This file contains only Claude Code-specific directives.
 
-```bash
-cargo fmt --all -- --check
-cargo clippy --all-targets -- -D warnings
-cargo test
-```
+## Claude Code Settings
 
-Full pre-PR validation (recommended):
+Claude Code should read and follow all instructions in `AGENTS.md` at the repository root for project conventions, commands, risk tiers, workflow rules, and anti-patterns.
 
-```bash
-./dev/ci.sh all
-```
+## Hooks
 
-Docs-only changes: run markdown lint and link-integrity checks. If touching bootstrap scripts: `bash -n install.sh`.
+_No custom hooks defined yet._
 
-## Project Snapshot
+## Slash Commands
 
-ZeroClaw is a Rust-first autonomous agent runtime optimized for performance, efficiency, stability, extensibility, sustainability, and security.
-
-Core architecture is trait-driven and modular. Extend by implementing traits and registering in factory modules.
-
-Key extension points:
-
-- `src/providers/traits.rs` (`Provider`)
-- `src/channels/traits.rs` (`Channel`)
-- `src/tools/traits.rs` (`Tool`)
-- `src/memory/traits.rs` (`Memory`)
-- `src/observability/traits.rs` (`Observer`)
-- `src/runtime/traits.rs` (`RuntimeAdapter`)
-- `src/peripherals/traits.rs` (`Peripheral`) — hardware boards (STM32, RPi GPIO)
-
-## Repository Map
-
-- `src/main.rs` — CLI entrypoint and command routing
-- `src/lib.rs` — module exports and shared command enums
-- `src/config/` — schema + config loading/merging
-- `src/agent/` — orchestration loop
-- `src/gateway/` — webhook/gateway server
-- `src/security/` — policy, pairing, secret store
-- `src/memory/` — markdown/sqlite memory backends + embeddings/vector merge
-- `src/providers/` — model providers and resilient wrapper
-- `src/channels/` — Telegram/Discord/Slack/etc channels
-- `src/tools/` — tool execution surface (shell, file, memory, browser)
-- `src/peripherals/` — hardware peripherals (STM32, RPi GPIO)
-- `src/runtime/` — runtime adapters (currently native)
-- `docs/` — topic-based documentation (setup-guides, reference, ops, security, hardware, contributing, maintainers)
-- `.github/` — CI, templates, automation workflows
-
-## Risk Tiers
-
-- **Low risk**: docs/chore/tests-only changes
-- **Medium risk**: most `src/**` behavior changes without boundary/security impact
-- **High risk**: `src/security/**`, `src/runtime/**`, `src/gateway/**`, `src/tools/**`, `.github/workflows/**`, access-control boundaries
-
-When uncertain, classify as higher risk.
-
-## Workflow
-
-1. **Read before write** — inspect existing module, factory wiring, and adjacent tests before editing.
-2. **One concern per PR** — avoid mixed feature+refactor+infra patches.
-3. **Implement minimal patch** — no speculative abstractions, no config keys without a concrete use case.
-4. **Validate by risk tier** — docs-only: lightweight checks. Code changes: full relevant checks.
-5. **Document impact** — update PR notes for behavior, risk, side effects, and rollback.
-6. **Queue hygiene** — stacked PR: declare `Depends on #...`. Replacing old PR: declare `Supersedes #...`.
-
-Branch/commit/PR rules:
-- Work from a non-`master` branch. Open a PR to `master`; do not push directly.
-- Use conventional commit titles. Prefer small PRs (`size: XS/S/M`).
-- Follow `.github/pull_request_template.md` fully.
-- Never commit secrets, personal data, or real identity information (see `@docs/contributing/pr-discipline.md`).
-
-## Anti-Patterns
-
-- Do not add heavy dependencies for minor convenience.
-- Do not silently weaken security policy or access constraints.
-- Do not add speculative config/feature flags "just in case".
-- Do not mix massive formatting-only changes with functional changes.
-- Do not modify unrelated modules "while here".
-- Do not bypass failing checks without explicit explanation.
-- Do not hide behavior-changing side effects in refactor commits.
-- Do not include personal identity or sensitive information in test data, examples, docs, or commits.
-
-## Linked References
-
-- `@docs/contributing/change-playbooks.md` — adding providers, channels, tools, peripherals; security/gateway changes; architecture boundaries
-- `@docs/contributing/pr-discipline.md` — privacy rules, superseded-PR attribution/templates, handoff template
-- `@docs/contributing/docs-contract.md` — docs system contract, i18n rules, locale parity
+_No custom slash commands defined yet._


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: `AGENTS.md` is currently a symlink to `CLAUDE.md`, coupling all agent instructions to a Claude-specific file.
- Why it matters: Other AI coding tools (Codex, Gemini, Cursor, etc.) should read `AGENTS.md` as a tool-agnostic instruction file without depending on a Claude-branded filename.
- What changed: Replaced the `AGENTS.md` symlink with a real file containing all cross-tool instructions. Reduced `CLAUDE.md` to Claude Code-specific directives only, referencing `AGENTS.md` for shared conventions.
- What did **not** change (scope boundary): No instructions were added, removed, or reworded — only moved between files.

## Label Snapshot (required)

- Risk label (`risk: low`):
- Size label (`size: XS`):
- Scope labels (`docs`):
- Module labels: N/A
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`docs`):
- Primary scope (`docs`):

## Linked Issue

- Closes #4289

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

No code changes — docs-only restructuring of agent instruction files.

```bash
# No cargo commands needed; files are markdown only.
```

- Evidence provided: visual diff confirms content was moved, not modified.
- If any command is intentionally skipped, explain why: No Rust code changed; cargo checks not applicable.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass`):
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (internal agent instruction files, not user-facing docs)

## Human Verification (required)

- Verified scenarios: Confirmed `AGENTS.md` is a real file with full shared content; `CLAUDE.md` references it.
- Edge cases checked: Symlink removal verified; no dangling references.
- What was not verified: N/A

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Any AI tool that reads `CLAUDE.md` will now see a pointer to `AGENTS.md` instead of inline instructions.
- Potential unintended effects: Tools that only read `CLAUDE.md` and cannot follow references will lose inline context.
- Guardrails/monitoring for early detection: Claude Code natively reads both `CLAUDE.md` and `AGENTS.md`.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Replaced symlink, split content, committed, pushed, opened PR.
- Verification focus: Content integrity between old and new files.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>`
- Feature flags or config toggles: None
- Observable failure symptoms: Agent tools missing project instructions

## Risks and Mitigations

- Risk: Tools that only parse `CLAUDE.md` inline lose shared instructions.
  - Mitigation: `CLAUDE.md` clearly directs readers to `AGENTS.md`; Claude Code reads both files natively.