### PR TITLE
fix: include channel-lark in Docker build defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN npm run build
 FROM rust:1.94-slim@sha256:da9dab7a6b8dd428e71718402e97207bb3e54167d37b5708616050b1e8f60ed6 AS builder
 
 WORKDIR /app
-ARG ZEROCLAW_CARGO_FEATURES="memory-postgres"
+ARG ZEROCLAW_CARGO_FEATURES="memory-postgres,channel-lark"
 
 # Install build dependencies
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -27,7 +27,7 @@ RUN npm run build
 FROM rust:1.94-bookworm AS builder
 
 WORKDIR /app
-ARG ZEROCLAW_CARGO_FEATURES="memory-postgres"
+ARG ZEROCLAW_CARGO_FEATURES="memory-postgres,channel-lark"
 
 # Install build dependencies
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Docker builds default `ZEROCLAW_CARGO_FEATURES` to `"memory-postgres"`, excluding `channel-lark`, so Lark/Feishu WebSocket (long connection) support is not compiled into container images.
- Why it matters: Users deploying via Docker cannot use Feishu websocket integration without custom build args.
- What changed: Added `channel-lark` to the default `ZEROCLAW_CARGO_FEATURES` ARG in both `Dockerfile` and `Dockerfile.debian`.
- What did **not** change: No source code changes; only Docker build configuration defaults.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: lark`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #3538

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check  # Pass (no formatting issues)
```

- Evidence provided: formatting check passed; no source code changes so clippy/test are not affected.
- If any command is intentionally skipped, explain why: `cargo clippy` and `cargo test` skipped because this change only modifies Dockerfile ARG defaults with no Rust code impact.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No (users can still override `ZEROCLAW_CARGO_FEATURES` at build time)
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Confirmed both Dockerfiles now include `channel-lark` in the default features ARG.
- Edge cases checked: Users who override `ZEROCLAW_CARGO_FEATURES` at build time are unaffected.
- What was not verified: Full Docker image build (no Docker environment available).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Docker image builds will now compile with `channel-lark` feature enabled by default, slightly increasing binary size and build time.
- Potential unintended effects: None expected.
- Guardrails/monitoring for early detection: CI Docker build pipeline will catch compilation failures.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: Correct feature string in both Dockerfiles
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit or set `ZEROCLAW_CARGO_FEATURES="memory-postgres"` as build arg.
- Feature flags or config toggles: `ZEROCLAW_CARGO_FEATURES` build ARG can be overridden.
- Observable failure symptoms: Docker build failure if `channel-lark` feature doesn't compile.

## Risks and Mitigations

- Risk: Slightly larger binary size due to additional feature.
  - Mitigation: `channel-lark` is a lightweight feature; size impact is minimal.