### PR TITLE
feat(slack): add /config command with Block Kit UI for model switching

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -266,6 +266,7 @@ enum ChannelRuntimeCommand {
     SetProvider(String),
     ShowModel,
     SetModel(String),
+    ShowConfig,
     NewSession,
 }
 
@@ -721,7 +722,7 @@ fn strip_tool_result_content(text: &str) -> String {
 }
 
 fn supports_runtime_model_switch(channel_name: &str) -> bool {
-    matches!(channel_name, "telegram" | "discord" | "matrix")
+    matches!(channel_name, "telegram" | "discord" | "matrix" | "slack")
 }
 
 fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRuntimeCommand> {
@@ -758,6 +759,9 @@ fn parse_runtime_command(channel_name: &str, content: &str) -> Option<ChannelRun
             } else {
                 Some(ChannelRuntimeCommand::SetModel(model))
             }
+        }
+        "/config" if supports_runtime_model_switch(channel_name) => {
+            Some(ChannelRuntimeCommand::ShowConfig)
         }
         _ => None,
     }
@@ -1436,6 +1440,171 @@ fn build_providers_help_response(current: &ChannelRouteSelection) -> String {
     response
 }
 
+/// Build a plain-text `/config` response for non-Slack channels.
+fn build_config_text_response(
+    current: &ChannelRouteSelection,
+    _workspace_dir: &Path,
+    model_routes: &[crate::config::ModelRouteConfig],
+) -> String {
+    let mut resp = String::new();
+    let _ = writeln!(
+        resp,
+        "Current provider: `{}`\nCurrent model: `{}`",
+        current.provider, current.model
+    );
+    resp.push_str("\nAvailable providers:\n");
+    for p in providers::list_providers() {
+        let _ = writeln!(resp, "- `{}`", p.name);
+    }
+    if !model_routes.is_empty() {
+        resp.push_str("\nConfigured model routes:\n");
+        for route in model_routes {
+            let _ = writeln!(
+                resp,
+                "  `{}` -> {} ({})",
+                route.hint, route.model, route.provider
+            );
+        }
+    }
+    resp.push_str(
+        "\nUse `/models <provider>` to switch provider.\nUse `/model <model-id>` to switch model.",
+    );
+    resp
+}
+
+/// Prefix used to signal that a runtime command response contains raw Block Kit
+/// JSON instead of plain text. [`SlackChannel::send`] detects this and posts
+/// the blocks directly via `chat.postMessage`.
+const BLOCK_KIT_PREFIX: &str = "__ZEROCLAW_BLOCK_KIT__";
+
+/// Build a Slack Block Kit JSON payload for the `/config` interactive UI.
+fn build_config_block_kit(
+    current: &ChannelRouteSelection,
+    workspace_dir: &Path,
+    model_routes: &[crate::config::ModelRouteConfig],
+) -> String {
+    let provider_options: Vec<serde_json::Value> = providers::list_providers()
+        .iter()
+        .map(|p| {
+            serde_json::json!({
+                "text": { "type": "plain_text", "text": p.display_name },
+                "value": p.name
+            })
+        })
+        .collect();
+
+    // Build model options from model_routes + cached models.
+    let mut model_options: Vec<serde_json::Value> = model_routes
+        .iter()
+        .map(|r| {
+            let label = if r.hint.is_empty() {
+                r.model.clone()
+            } else {
+                format!("{} ({})", r.model, r.hint)
+            };
+            serde_json::json!({
+                "text": { "type": "plain_text", "text": label },
+                "value": r.model
+            })
+        })
+        .collect();
+
+    let cached = load_cached_model_preview(workspace_dir, &current.provider);
+    for model_id in cached {
+        if !model_options.iter().any(|o| {
+            o.get("value")
+                .and_then(|v| v.as_str())
+                .is_some_and(|v| v == model_id)
+        }) {
+            model_options.push(serde_json::json!({
+                "text": { "type": "plain_text", "text": model_id },
+                "value": model_id
+            }));
+        }
+    }
+
+    // If the current model is not in the list, prepend it.
+    if !model_options.iter().any(|o| {
+        o.get("value")
+            .and_then(|v| v.as_str())
+            .is_some_and(|v| v == current.model)
+    }) {
+        model_options.insert(
+            0,
+            serde_json::json!({
+                "text": { "type": "plain_text", "text": &current.model },
+                "value": &current.model
+            }),
+        );
+    }
+
+    // Find initial options matching current selection.
+    let initial_provider = provider_options
+        .iter()
+        .find(|o| {
+            o.get("value")
+                .and_then(|v| v.as_str())
+                .is_some_and(|v| v == current.provider)
+        })
+        .cloned();
+
+    let initial_model = model_options
+        .iter()
+        .find(|o| {
+            o.get("value")
+                .and_then(|v| v.as_str())
+                .is_some_and(|v| v == current.model)
+        })
+        .cloned();
+
+    let mut provider_select = serde_json::json!({
+        "type": "static_select",
+        "action_id": "zeroclaw_config_provider",
+        "placeholder": { "type": "plain_text", "text": "Select provider" },
+        "options": provider_options
+    });
+    if let Some(init) = initial_provider {
+        provider_select["initial_option"] = init;
+    }
+
+    let mut model_select = serde_json::json!({
+        "type": "static_select",
+        "action_id": "zeroclaw_config_model",
+        "placeholder": { "type": "plain_text", "text": "Select model" },
+        "options": model_options
+    });
+    if let Some(init) = initial_model {
+        model_select["initial_option"] = init;
+    }
+
+    let blocks = serde_json::json!([
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": format!(
+                    "*Model Configuration*\nCurrent: `{}` / `{}`",
+                    current.provider, current.model
+                )
+            }
+        },
+        {
+            "type": "section",
+            "block_id": "config_provider_block",
+            "text": { "type": "mrkdwn", "text": "*Provider*" },
+            "accessory": provider_select
+        },
+        {
+            "type": "section",
+            "block_id": "config_model_block",
+            "text": { "type": "mrkdwn", "text": "*Model*" },
+            "accessory": model_select
+        }
+    ]);
+
+    blocks.to_string()
+}
+
 async fn handle_runtime_command_if_needed(
     ctx: &ChannelRuntimeContext,
     msg: &traits::ChannelMessage,
@@ -1506,6 +1675,19 @@ async fn handle_runtime_command_if_needed(
                     "Model switched to `{}` (provider: `{}`). Context preserved.",
                     current.model, current.provider
                 )
+            }
+        }
+        ChannelRuntimeCommand::ShowConfig => {
+            if msg.channel == "slack" {
+                let blocks_json = build_config_block_kit(
+                    &current,
+                    ctx.workspace_dir.as_path(),
+                    &ctx.model_routes,
+                );
+                // Use a magic prefix so SlackChannel::send() can detect Block Kit JSON.
+                format!("__ZEROCLAW_BLOCK_KIT__{blocks_json}")
+            } else {
+                build_config_text_response(&current, ctx.workspace_dir.as_path(), &ctx.model_routes)
             }
         }
         ChannelRuntimeCommand::NewSession => {

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -1778,6 +1778,79 @@ impl SlackChannel {
             .clone()
     }
 
+    /// Parse a Socket Mode `interactive` envelope containing a `block_actions`
+    /// payload from the `/config` Block Kit UI.  Translates provider/model
+    /// dropdown selections into synthetic `/models <provider>` or `/model <id>`
+    /// commands so the existing runtime command handler can apply them.
+    fn parse_block_action_as_command(
+        envelope: &serde_json::Value,
+        _bot_user_id: &str,
+    ) -> Option<ChannelMessage> {
+        let payload = envelope.get("payload")?;
+
+        let payload_type = payload.get("type").and_then(|v| v.as_str())?;
+        if payload_type != "block_actions" {
+            return None;
+        }
+
+        let actions = payload.get("actions").and_then(|v| v.as_array())?;
+        let action = actions.first()?;
+
+        let action_id = action.get("action_id").and_then(|v| v.as_str())?;
+        let selected_value = action
+            .get("selected_option")
+            .and_then(|o| o.get("value"))
+            .and_then(|v| v.as_str())?;
+
+        let command = match action_id {
+            "zeroclaw_config_provider" => format!("/models {selected_value}"),
+            "zeroclaw_config_model" => format!("/model {selected_value}"),
+            _ => return None,
+        };
+
+        let user = payload
+            .get("user")
+            .and_then(|u| u.get("id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+
+        let channel_id = payload
+            .get("channel")
+            .and_then(|c| c.get("id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+
+        if channel_id.is_empty() {
+            tracing::warn!("Slack block_actions: missing channel ID in interactive payload");
+            return None;
+        }
+
+        let ts = payload
+            .get("message")
+            .and_then(|m| m.get("ts"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("0");
+
+        Some(ChannelMessage {
+            id: format!("slack_{channel_id}_{ts}_action"),
+            sender: user.to_string(),
+            reply_target: channel_id.to_string(),
+            content: command,
+            channel: "slack".to_string(),
+            timestamp: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+            thread_ts: payload
+                .get("message")
+                .and_then(|m| m.get("thread_ts"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            interruption_scope_id: None,
+            attachments: vec![],
+        })
+    }
+
     async fn open_socket_mode_url(&self) -> anyhow::Result<String> {
         let app_token = self
             .configured_app_token()
@@ -1912,6 +1985,17 @@ impl SlackChannel {
                     tracing::warn!("Slack Socket Mode: received disconnect event");
                     break;
                 }
+
+                // Handle interactive payloads (block_actions from /config UI).
+                if envelope_type == "interactive" {
+                    if let Some(msg) = Self::parse_block_action_as_command(&envelope, bot_user_id) {
+                        if tx.send(msg).await.is_err() {
+                            return Ok(());
+                        }
+                    }
+                    continue;
+                }
+
                 if envelope_type != "events_api" {
                     continue;
                 }
@@ -2403,22 +2487,39 @@ impl Channel for SlackChannel {
     }
 
     async fn send(&self, message: &SendMessage) -> anyhow::Result<()> {
-        let mut body = serde_json::json!({
-            "channel": message.recipient,
-            "text": message.content
-        });
-
-        // Use Slack's native markdown block for rich formatting when content fits.
-        if message.content.len() <= SLACK_MARKDOWN_BLOCK_MAX_CHARS {
-            body["blocks"] = serde_json::json!([{
-                "type": "markdown",
+        // Detect Block Kit payloads produced by the `/config` command.
+        let body = if let Some(blocks_json) = message.content.strip_prefix(super::BLOCK_KIT_PREFIX)
+        {
+            let blocks: serde_json::Value = serde_json::from_str(blocks_json)
+                .context("invalid Block Kit JSON in runtime command response")?;
+            let mut body = serde_json::json!({
+                "channel": message.recipient,
+                "text": "Model configuration",
+                "blocks": blocks
+            });
+            if let Some(ts) = self.outbound_thread_ts(message) {
+                body["thread_ts"] = serde_json::json!(ts);
+            }
+            body
+        } else {
+            let mut body = serde_json::json!({
+                "channel": message.recipient,
                 "text": message.content
-            }]);
-        }
+            });
 
-        if let Some(ts) = self.outbound_thread_ts(message) {
-            body["thread_ts"] = serde_json::json!(ts);
-        }
+            // Use Slack's native markdown block for rich formatting when content fits.
+            if message.content.len() <= SLACK_MARKDOWN_BLOCK_MAX_CHARS {
+                body["blocks"] = serde_json::json!([{
+                    "type": "markdown",
+                    "text": message.content
+                }]);
+            }
+
+            if let Some(ts) = self.outbound_thread_ts(message) {
+                body["thread_ts"] = serde_json::json!(ts);
+            }
+            body
+        };
 
         let resp = self
             .http_client()


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Slack users cannot interactively switch provider/model at runtime; the `/model` and `/models` commands require typing exact names.
- Why it matters: Block Kit dropdowns provide a discoverable, low-friction UI for model configuration directly in Slack.
- What changed: Added `/config` command that renders Block Kit `static_select` dropdowns for provider and model; enabled runtime model switching for the `slack` channel; added `block_actions` handling in Socket Mode to apply selections.
- What did **not** change: No changes to the `Channel` trait, no new dependencies, no changes to other channels' behavior.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `channel`
- Module labels: `channel: slack`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Closes #4286

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # Pass
cargo clippy --all-targets -- -D warnings  # Pass (0 warnings)
cargo check  # Pass
```

- Evidence provided: compilation and lint pass
- If any command is intentionally skipped, explain why: `cargo test` not run in full (no Slack integration test harness); unit tests in the file are unaffected.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (uses existing `chat.postMessage` endpoint)
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Docs Impact (required)

- New user-facing behavior or flags? Yes — `/config` command in Slack
- Docs update needed? No (Slack runtime commands are not currently documented in user-facing docs)
- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: compilation, fmt, clippy
- Edge cases checked: empty model_routes, current model not in cached list, missing channel ID in block_actions
- What was not verified: live Slack workspace testing (requires deployed bot)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Slack channel only; runtime model switching now enabled for slack
- Potential unintended effects: Slack users can now use `/model` and `/models` text commands in addition to the new `/config` UI
- Guardrails/monitoring for early detection: existing tracing for runtime command handling covers new paths

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Read existing patterns for runtime commands and Slack Socket Mode, implemented Block Kit UI with interactive payload handling
- Verification focus: compilation, lint, pattern consistency
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: revert this commit
- Feature flags or config toggles: none (inherent to `/config` command availability)
- Observable failure symptoms: `/config` not responding, block_actions not applying

## Risks and Mitigations

- Risk: Block Kit JSON structure may be rejected by Slack API for certain workspace configurations.
  - Mitigation: Uses only `section` blocks with `static_select` accessory — well-supported Block Kit primitives. Error logged via existing `chat.postMessage` error path.