### PR TITLE
feat(channel): add transcribe_non_ptt_audio config for WhatsApp STT

### DIFF
--- a/examples/config.example.toml
+++ b/examples/config.example.toml
@@ -109,3 +109,11 @@ allow_override = false
 # [cost.prices."openai/gpt-4o-mini"]
 # input = 0.15
 # output = 0.60
+
+# ── Voice Transcription ─────────────────────────────────────────
+# [transcription]
+# enabled = true
+# default_provider = "groq"
+# Also transcribe non-PTT (forwarded / regular) audio on WhatsApp.
+# Default: false (only voice notes are transcribed).
+# transcribe_non_ptt_audio = false

--- a/src/channels/mattermost.rs
+++ b/src/channels/mattermost.rs
@@ -1212,6 +1212,7 @@ mod tests {
                 assemblyai: None,
                 google: None,
                 local_whisper: None,
+                transcribe_non_ptt_audio: false,
             },
         );
         assert!(ch.transcription_manager.is_some());
@@ -1234,6 +1235,7 @@ mod tests {
                 assemblyai: None,
                 google: None,
                 local_whisper: None,
+                transcribe_non_ptt_audio: false,
             },
         );
         assert!(ch.transcription_manager.is_none());
@@ -1376,6 +1378,7 @@ mod tests {
                 assemblyai: None,
                 google: None,
                 local_whisper: None,
+                transcribe_non_ptt_audio: false,
             },
         );
 
@@ -1448,6 +1451,7 @@ mod tests {
                     max_audio_bytes: 25_000_000,
                     timeout_secs: 300,
                 }),
+                transcribe_non_ptt_audio: false,
             });
 
             let post = json!({
@@ -1497,6 +1501,7 @@ mod tests {
                     max_audio_bytes: 25_000_000,
                     timeout_secs: 300,
                 }),
+                transcribe_non_ptt_audio: false,
             });
 
             let post = json!({

--- a/src/channels/transcription.rs
+++ b/src/channels/transcription.rs
@@ -1153,6 +1153,7 @@ mod tests {
         assert!(config.assemblyai.is_none());
         assert!(config.google.is_none());
         assert!(config.local_whisper.is_none());
+        assert!(!config.transcribe_non_ptt_audio);
     }
 
     // ── LocalWhisperProvider tests (TDD — added below as red/green cycles) ──

--- a/src/channels/wati.rs
+++ b/src/channels/wati.rs
@@ -723,6 +723,7 @@ mod tests {
             assemblyai: None,
             google: None,
             local_whisper: None,
+            transcribe_non_ptt_audio: false,
         };
 
         let ch = WatiChannel::new(
@@ -752,6 +753,7 @@ mod tests {
             assemblyai: None,
             google: None,
             local_whisper: None,
+            transcribe_non_ptt_audio: false,
         };
 
         let ch = WatiChannel::new(
@@ -794,6 +796,7 @@ mod tests {
             assemblyai: None,
             google: None,
             local_whisper: None,
+            transcribe_non_ptt_audio: false,
         };
 
         let ch = WatiChannel::new(
@@ -940,6 +943,7 @@ mod tests {
                 max_audio_bytes: 25 * 1024 * 1024,
                 timeout_secs: 300,
             }),
+            transcribe_non_ptt_audio: false,
         };
 
         let ch = WatiChannel::new(
@@ -992,6 +996,7 @@ mod tests {
                 max_audio_bytes: 25 * 1024 * 1024,
                 timeout_secs: 300,
             }),
+            transcribe_non_ptt_audio: false,
         };
 
         let ch = WatiChannel::new(

--- a/src/channels/whatsapp_web.rs
+++ b/src/channels/whatsapp_web.rs
@@ -756,9 +756,15 @@ impl Channel for WhatsAppWebChannel {
                                     }
                                 }
 
-                                // Attempt voice note transcription (ptt = push-to-talk = voice note)
+                                // Attempt voice note transcription (ptt = push-to-talk = voice note).
+                                // When `transcribe_non_ptt_audio` is enabled in the transcription
+                                // config, also transcribe forwarded / regular audio messages.
                                 let voice_text = if let Some(ref audio) = msg.audio_message {
-                                    if audio.ptt == Some(true) {
+                                    let is_ptt = audio.ptt == Some(true);
+                                    let non_ptt_enabled = transcription_config
+                                        .as_ref()
+                                        .is_some_and(|c| c.transcribe_non_ptt_audio);
+                                    if is_ptt || non_ptt_enabled {
                                         Self::try_transcribe_voice_note(
                                             &client,
                                             audio,

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -827,6 +827,10 @@ pub struct TranscriptionConfig {
     /// Local/self-hosted Whisper-compatible STT provider.
     #[serde(default)]
     pub local_whisper: Option<LocalWhisperConfig>,
+    /// Also transcribe non-PTT (forwarded/regular) audio messages on WhatsApp,
+    /// not just voice notes.  Default: `false` (preserves legacy behavior).
+    #[serde(default)]
+    pub transcribe_non_ptt_audio: bool,
 }
 
 impl Default for TranscriptionConfig {
@@ -845,6 +849,7 @@ impl Default for TranscriptionConfig {
             assemblyai: None,
             google: None,
             local_whisper: None,
+            transcribe_non_ptt_audio: false,
         }
     }
 }
@@ -13740,6 +13745,7 @@ default_model = "persisted-profile"
         assert_eq!(tc.model, "whisper-large-v3-turbo");
         assert!(tc.language.is_none());
         assert_eq!(tc.max_duration_secs, 120);
+        assert!(!tc.transcribe_non_ptt_audio);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: STT only works for PTT (push-to-talk / voice note) audio in WhatsApp Web; forwarded or regular audio messages are silently ignored.
- Why it matters: Users who receive forwarded audio want it transcribed without recompiling.
- What changed: Added `transcribe_non_ptt_audio` boolean (default `false`) to `TranscriptionConfig`. When enabled, the WhatsApp Web channel also transcribes non-PTT audio messages.
- What did **not** change: default behavior remains identical (only PTT audio is transcribed).

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`, `config`
- Module labels: `channel: whatsapp`
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Closes #4343

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass
cargo test --lib   # 5298 passed, 0 failed
```

- Evidence provided: CLI output above
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — new optional `transcribe_non_ptt_audio` in `[transcription]`, defaults to `false`.
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: default behavior unchanged (non-PTT audio still skipped when flag is false)
- Edge cases checked: `transcription_config` is `None` (flag unreachable, safe)
- What was not verified: live WhatsApp audio forwarding (requires paired session)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: WhatsApp Web channel audio handling
- Potential unintended effects: None — gated behind an opt-in flag
- Guardrails/monitoring for early detection: existing transcription logging

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: compilation, clippy, full test suite
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: revert this commit
- Feature flags or config toggles: `transcribe_non_ptt_audio = false` (default)
- Observable failure symptoms: non-PTT audio unexpectedly transcribed or not

## Risks and Mitigations

- Risk: Non-PTT audio could be large or unusual formats
  - Mitigation: existing duration limit and format validation in `try_transcribe_voice_note` still apply