### PR TITLE
feat(providers): support Bearer token API keys for Amazon Bedrock

### DIFF
--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -1,8 +1,10 @@
 //! AWS Bedrock provider using the Converse API.
 //!
-//! Authentication: AWS AKSK (Access Key ID + Secret Access Key)
-//! via environment variables. SigV4 signing is implemented manually
-//! using hmac/sha2 crates — no AWS SDK dependency.
+//! Authentication: supports two methods:
+//! - **Bearer token**: set `BEDROCK_API_KEY` env var (takes precedence).
+//! - **SigV4 signing**: AWS AKSK (Access Key ID + Secret Access Key)
+//!   via environment variables or EC2 IMDSv2. SigV4 signing is implemented
+//!   manually using hmac/sha2 crates — no AWS SDK dependency.
 
 use crate::providers::traits::{
     ChatMessage, ChatRequest as ProviderChatRequest, ChatResponse as ProviderChatResponse,
@@ -21,6 +23,14 @@ const ENDPOINT_PREFIX: &str = "bedrock-runtime";
 const SIGNING_SERVICE: &str = "bedrock";
 const DEFAULT_REGION: &str = "us-east-1";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+// ── Authentication ──────────────────────────────────────────────
+
+/// Authentication method for Bedrock: either SigV4 (AKSK) or Bearer token.
+enum BedrockAuth {
+    SigV4(AwsCredentials),
+    BearerToken(String),
+}
 
 // ── AWS Credentials ─────────────────────────────────────────────
 
@@ -452,19 +462,38 @@ struct ResponseToolUseWrapper {
 // ── BedrockProvider ─────────────────────────────────────────────
 
 pub struct BedrockProvider {
-    credentials: Option<AwsCredentials>,
+    auth: Option<BedrockAuth>,
 }
 
 impl BedrockProvider {
     pub fn new() -> Self {
+        // Bearer token takes precedence over SigV4 credentials.
+        if let Some(token) = env_optional("BEDROCK_API_KEY") {
+            return Self {
+                auth: Some(BedrockAuth::BearerToken(token)),
+            };
+        }
         Self {
-            credentials: AwsCredentials::from_env().ok(),
+            auth: AwsCredentials::from_env().ok().map(BedrockAuth::SigV4),
         }
     }
 
     pub async fn new_async() -> Self {
-        let credentials = AwsCredentials::resolve().await.ok();
-        Self { credentials }
+        // Bearer token takes precedence over SigV4 credentials.
+        if let Some(token) = env_optional("BEDROCK_API_KEY") {
+            return Self {
+                auth: Some(BedrockAuth::BearerToken(token)),
+            };
+        }
+        let auth = AwsCredentials::resolve().await.ok().map(BedrockAuth::SigV4);
+        Self { auth }
+    }
+
+    /// Create a provider using a Bearer token for authentication.
+    pub fn with_bearer_token(token: &str) -> Self {
+        Self {
+            auth: Some(BedrockAuth::BearerToken(token.to_string())),
+        }
     }
 
     fn http_client(&self) -> Client {
@@ -476,6 +505,13 @@ impl BedrockProvider {
     /// may misparse them. Dots, hyphens, and alphanumerics are safe.
     fn encode_model_path(model_id: &str) -> String {
         model_id.replace(':', "%3A")
+    }
+
+    /// Resolve the AWS region from environment variables.
+    fn resolve_region() -> String {
+        env_optional("AWS_REGION")
+            .or_else(|| env_optional("AWS_DEFAULT_REGION"))
+            .unwrap_or_else(|| DEFAULT_REGION.to_string())
     }
 
     /// Build the actual request URL. Uses raw model ID (reqwest sends colons as-is).
@@ -491,22 +527,38 @@ impl BedrockProvider {
         format!("/model/{encoded}/converse")
     }
 
-    fn require_credentials(&self) -> anyhow::Result<&AwsCredentials> {
-        self.credentials.as_ref().ok_or_else(|| {
+    fn require_auth(&self) -> anyhow::Result<&BedrockAuth> {
+        self.auth.as_ref().ok_or_else(|| {
             anyhow::anyhow!(
-                "AWS Bedrock credentials not set. Set AWS_ACCESS_KEY_ID and \
-                 AWS_SECRET_ACCESS_KEY environment variables, or run on an EC2 \
-                 instance with an IAM role attached."
+                "AWS Bedrock credentials not set. Set BEDROCK_API_KEY for Bearer \
+                 token auth, or AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY for \
+                 SigV4 auth, or run on an EC2 instance with an IAM role attached."
             )
         })
     }
 
-    /// Resolve credentials: use cached if available, otherwise fetch from IMDS.
-    async fn resolve_credentials(&self) -> anyhow::Result<AwsCredentials> {
-        if let Ok(creds) = AwsCredentials::from_env() {
-            return Ok(creds);
+    /// Resolve auth: use cached if available, otherwise try env vars then IMDS.
+    async fn resolve_auth(&self) -> anyhow::Result<BedrockAuth> {
+        // If we already have auth cached, re-resolve from the same source.
+        if let Some(ref auth) = self.auth {
+            match auth {
+                BedrockAuth::BearerToken(token) => {
+                    return Ok(BedrockAuth::BearerToken(token.clone()));
+                }
+                BedrockAuth::SigV4(_) => {
+                    // Re-resolve SigV4 credentials (they may have rotated).
+                }
+            }
         }
-        AwsCredentials::from_imds().await
+        // Check Bearer token first.
+        if let Some(token) = env_optional("BEDROCK_API_KEY") {
+            return Ok(BedrockAuth::BearerToken(token));
+        }
+        // Fall back to SigV4.
+        if let Ok(creds) = AwsCredentials::from_env() {
+            return Ok(BedrockAuth::SigV4(creds));
+        }
+        Ok(BedrockAuth::SigV4(AwsCredentials::from_imds().await?))
     }
 
     // ── Cache heuristics (same thresholds as AnthropicProvider) ──
@@ -876,7 +928,7 @@ impl BedrockProvider {
 
     async fn send_converse_request(
         &self,
-        credentials: &AwsCredentials,
+        auth: &BedrockAuth,
         model: &str,
         request_body: &ConverseRequest,
     ) -> anyhow::Result<ConverseResponse> {
@@ -912,44 +964,62 @@ impl BedrockProvider {
                 }
             }
         }
-        let url = Self::endpoint_url(&credentials.region, model);
-        let canonical_uri = Self::canonical_uri(model);
-        let now = chrono::Utc::now();
-        let host = credentials.host();
-        let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
 
-        let mut headers_to_sign = vec![
-            ("content-type".to_string(), "application/json".to_string()),
-            ("host".to_string(), host),
-            ("x-amz-date".to_string(), amz_date.clone()),
-        ];
-        if let Some(ref token) = credentials.session_token {
-            headers_to_sign.push(("x-amz-security-token".to_string(), token.clone()));
-        }
-        headers_to_sign.sort_by(|a, b| a.0.cmp(&b.0));
+        let response: reqwest::Response = match auth {
+            BedrockAuth::BearerToken(token) => {
+                let region = Self::resolve_region();
+                let url = Self::endpoint_url(&region, model);
 
-        let authorization = build_authorization_header(
-            credentials,
-            "POST",
-            &canonical_uri,
-            "",
-            &headers_to_sign,
-            &payload,
-            &now,
-        );
+                self.http_client()
+                    .post(&url)
+                    .header("content-type", "application/json")
+                    .header("Authorization", format!("Bearer {token}"))
+                    .body(payload)
+                    .send()
+                    .await?
+            }
+            BedrockAuth::SigV4(credentials) => {
+                let url = Self::endpoint_url(&credentials.region, model);
+                let canonical_uri = Self::canonical_uri(model);
+                let now = chrono::Utc::now();
+                let host = credentials.host();
+                let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
 
-        let mut request = self
-            .http_client()
-            .post(&url)
-            .header("content-type", "application/json")
-            .header("x-amz-date", &amz_date)
-            .header("authorization", &authorization);
+                let mut headers_to_sign = vec![
+                    ("content-type".to_string(), "application/json".to_string()),
+                    ("host".to_string(), host),
+                    ("x-amz-date".to_string(), amz_date.clone()),
+                ];
+                if let Some(ref session_token) = credentials.session_token {
+                    headers_to_sign
+                        .push(("x-amz-security-token".to_string(), session_token.clone()));
+                }
+                headers_to_sign.sort_by(|a, b| a.0.cmp(&b.0));
 
-        if let Some(ref token) = credentials.session_token {
-            request = request.header("x-amz-security-token", token);
-        }
+                let authorization = build_authorization_header(
+                    credentials,
+                    "POST",
+                    &canonical_uri,
+                    "",
+                    &headers_to_sign,
+                    &payload,
+                    &now,
+                );
 
-        let response: reqwest::Response = request.body(payload).send().await?;
+                let mut request = self
+                    .http_client()
+                    .post(&url)
+                    .header("content-type", "application/json")
+                    .header("x-amz-date", &amz_date)
+                    .header("authorization", &authorization);
+
+                if let Some(ref session_token) = credentials.session_token {
+                    request = request.header("x-amz-security-token", session_token);
+                }
+
+                request.body(payload).send().await?
+            }
+        };
 
         if !response.status().is_success() {
             return Err(super::api_error("Bedrock", response).await);
@@ -999,7 +1069,7 @@ impl Provider for BedrockProvider {
         model: &str,
         temperature: f64,
     ) -> anyhow::Result<String> {
-        let credentials = self.resolve_credentials().await?;
+        let auth = self.resolve_auth().await?;
 
         let system = system_prompt.map(|text| {
             let mut blocks = vec![SystemBlock::Text(TextBlock {
@@ -1026,9 +1096,7 @@ impl Provider for BedrockProvider {
             tool_config: None,
         };
 
-        let response = self
-            .send_converse_request(&credentials, model, &request)
-            .await?;
+        let response = self.send_converse_request(&auth, model, &request).await?;
 
         Self::parse_converse_response(response)
             .text
@@ -1041,7 +1109,7 @@ impl Provider for BedrockProvider {
         model: &str,
         temperature: f64,
     ) -> anyhow::Result<ProviderChatResponse> {
-        let credentials = self.resolve_credentials().await?;
+        let auth = self.resolve_auth().await?;
 
         let (system_blocks, mut converse_messages) = Self::convert_messages(request.messages);
 
@@ -1082,17 +1150,20 @@ impl Provider for BedrockProvider {
         };
 
         let response = self
-            .send_converse_request(&credentials, model, &converse_request)
+            .send_converse_request(&auth, model, &converse_request)
             .await?;
 
         Ok(Self::parse_converse_response(response))
     }
 
     async fn warmup(&self) -> anyhow::Result<()> {
-        if let Some(ref creds) = self.credentials {
-            let url = format!("https://{ENDPOINT_PREFIX}.{}.amazonaws.com/", creds.region);
-            let _ = self.http_client().get(&url).send().await;
-        }
+        let region = match self.auth {
+            Some(BedrockAuth::SigV4(ref creds)) => creds.region.clone(),
+            Some(BedrockAuth::BearerToken(_)) => Self::resolve_region(),
+            None => return Ok(()),
+        };
+        let url = format!("https://{ENDPOINT_PREFIX}.{region}.amazonaws.com/");
+        let _ = self.http_client().get(&url).send().await;
         Ok(())
     }
 }
@@ -1103,6 +1174,35 @@ impl Provider for BedrockProvider {
 mod tests {
     use super::*;
     use crate::providers::traits::ChatMessage;
+
+    /// RAII guard that sets/unsets an env var and restores the original on drop.
+    struct EnvGuard {
+        key: String,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &str, value: Option<&str>) -> Self {
+            let original = std::env::var(key).ok();
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+            Self {
+                key: key.to_string(),
+                original,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(v) => std::env::set_var(&self.key, v),
+                None => std::env::remove_var(&self.key),
+            }
+        }
+    }
 
     // ── SigV4 signing tests ─────────────────────────────────────
 
@@ -1255,7 +1355,7 @@ mod tests {
 
     #[tokio::test]
     async fn chat_fails_without_credentials() {
-        let provider = BedrockProvider { credentials: None };
+        let provider = BedrockProvider { auth: None };
         let result = provider
             .chat_with_system(None, "hello", "anthropic.claude-sonnet-4-6", 0.7)
             .await;
@@ -1268,6 +1368,45 @@ mod tests {
                 || err.to_lowercase().contains("builder error"),
             "Expected missing-credentials style error, got: {err}"
         );
+    }
+
+    // ── Bearer token tests ──────────────────────────────────────
+
+    #[test]
+    fn creates_with_bearer_token() {
+        let provider = BedrockProvider::with_bearer_token("test-api-key");
+        assert!(provider.auth.is_some());
+        assert!(
+            matches!(provider.auth, Some(BedrockAuth::BearerToken(ref t)) if t == "test-api-key")
+        );
+    }
+
+    #[test]
+    fn bearer_token_from_env() {
+        let _guard = EnvGuard::set("BEDROCK_API_KEY", Some("env-bearer-token"));
+        // Clear SigV4 vars to ensure Bearer is chosen.
+        let _ak_guard = EnvGuard::set("AWS_ACCESS_KEY_ID", None);
+        let _sk_guard = EnvGuard::set("AWS_SECRET_ACCESS_KEY", None);
+
+        let provider = BedrockProvider::new();
+        assert!(matches!(
+            provider.auth,
+            Some(BedrockAuth::BearerToken(ref t)) if t == "env-bearer-token"
+        ));
+    }
+
+    #[test]
+    fn bearer_token_precedence() {
+        let _bearer_guard = EnvGuard::set("BEDROCK_API_KEY", Some("bearer-key"));
+        let _ak_guard = EnvGuard::set("AWS_ACCESS_KEY_ID", Some("AKIAEXAMPLE"));
+        let _sk_guard = EnvGuard::set("AWS_SECRET_ACCESS_KEY", Some("secret"));
+
+        let provider = BedrockProvider::new();
+        // Bearer token should take priority over SigV4 credentials.
+        assert!(matches!(
+            provider.auth,
+            Some(BedrockAuth::BearerToken(ref t)) if t == "bearer-key"
+        ));
     }
 
     // ── Endpoint URL tests ──────────────────────────────────────
@@ -1550,14 +1689,14 @@ mod tests {
 
     #[tokio::test]
     async fn warmup_without_credentials_is_noop() {
-        let provider = BedrockProvider { credentials: None };
+        let provider = BedrockProvider { auth: None };
         let result = provider.warmup().await;
         assert!(result.is_ok());
     }
 
     #[test]
     fn capabilities_reports_native_tool_calling() {
-        let provider = BedrockProvider { credentials: None };
+        let provider = BedrockProvider { auth: None };
         let caps = provider.capabilities();
         assert!(caps.native_tool_calling);
     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -890,9 +890,18 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
         }
         name if is_glm_alias(name) => vec!["GLM_API_KEY"],
         name if is_minimax_alias(name) => vec![MINIMAX_OAUTH_TOKEN_ENV, MINIMAX_API_KEY_ENV],
-        // Bedrock uses AWS AKSK from env vars (AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY),
-        // not a single API key. Credential resolution happens inside BedrockProvider.
-        "bedrock" | "aws-bedrock" => return None,
+        // Bedrock supports Bearer token auth via BEDROCK_API_KEY env var, in addition
+        // to AWS AKSK (SigV4). If BEDROCK_API_KEY is set, return it; otherwise return
+        // None and let BedrockProvider handle SigV4 credential resolution internally.
+        "bedrock" | "aws-bedrock" => {
+            if let Ok(val) = std::env::var("BEDROCK_API_KEY") {
+                let trimmed = val.trim().to_string();
+                if !trimmed.is_empty() {
+                    return Some(trimmed);
+                }
+            }
+            return None;
+        }
         name if is_qianfan_alias(name) => vec!["QIANFAN_API_KEY"],
         name if is_doubao_alias(name) => {
             vec!["ARK_API_KEY", "VOLCENGINE_API_KEY", "DOUBAO_API_KEY"]
@@ -1247,7 +1256,13 @@ fn create_provider_with_url_and_options(
                 api_version.as_deref(),
             )))
         }
-        "bedrock" | "aws-bedrock" => Ok(Box::new(bedrock::BedrockProvider::new())),
+        "bedrock" | "aws-bedrock" => {
+            if let Some(api_key) = key {
+                Ok(Box::new(bedrock::BedrockProvider::with_bearer_token(api_key)))
+            } else {
+                Ok(Box::new(bedrock::BedrockProvider::new()))
+            }
+        }
         name if is_qwen_oauth_alias(name) => {
             let base_url = api_url
                 .map(str::trim)
@@ -2268,6 +2283,7 @@ mod tests {
     fn resolve_provider_credential_bedrock_uses_internal_credential_path() {
         let _generic_guard = EnvGuard::set("API_KEY", Some("generic-key"));
         let _override_guard = EnvGuard::set("OPENROUTER_API_KEY", Some("openrouter-key"));
+        let _bedrock_guard = EnvGuard::set("BEDROCK_API_KEY", None);
 
         assert_eq!(
             resolve_provider_credential("bedrock", Some("explicit")),
@@ -2275,6 +2291,20 @@ mod tests {
         );
         assert!(resolve_provider_credential("bedrock", None).is_none());
         assert!(resolve_provider_credential("aws-bedrock", None).is_none());
+    }
+
+    #[test]
+    fn resolve_provider_credential_bedrock_returns_bearer_token_from_env() {
+        let _bedrock_guard = EnvGuard::set("BEDROCK_API_KEY", Some("bedrock-bearer-token"));
+
+        assert_eq!(
+            resolve_provider_credential("bedrock", None),
+            Some("bedrock-bearer-token".to_string())
+        );
+        assert_eq!(
+            resolve_provider_credential("aws-bedrock", None),
+            Some("bedrock-bearer-token".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Bedrock provider only supports SigV4 auth (AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY), requiring complex credential management
- Why it matters: AWS now supports [Bearer token API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html) for Bedrock, simplifying auth and removing the need for STS session tokens
- What changed: Added `BedrockAuth` enum with `SigV4` and `BearerToken` variants; `BEDROCK_API_KEY` env var takes precedence over SigV4 credentials; updated factory to pass Bearer token when available
- What did **not** change (scope boundary): SigV4 auth remains fully functional; no config schema changes; no new dependencies

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: M`
- Scope labels: `provider`
- Module labels: `provider: bedrock`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `provider`

## Linked Issue

- Closes #3742

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass
cargo test   # pass
```

- Evidence provided: all three commands pass locally
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (same Bedrock endpoints, different auth header)
- Secrets/tokens handling changed? Yes — new `BEDROCK_API_KEY` env var read
- File system access scope changed? No
- If any Yes: Bearer token is read from env only, never logged, and passed via HTTPS Authorization header — same pattern as OpenAI/Anthropic providers

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No personal data; test tokens are dummy strings
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes — SigV4 auth unchanged when BEDROCK_API_KEY is unset
- Config/env changes? Yes — optional new env var `BEDROCK_API_KEY`
- Migration needed? No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Bearer token construction, SigV4 fallback, env var precedence
- Edge cases checked: missing credentials (both auth types), Bearer token takes priority over SigV4
- What was not verified: live Bedrock API call with real Bearer token (requires AWS account with API keys enabled)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Bedrock provider initialization only
- Potential unintended effects: None — additive change, existing auth path unchanged
- Guardrails/monitoring for early detection: Existing provider tests cover both paths

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit
- Feature flags or config toggles: Unset `BEDROCK_API_KEY` to disable Bearer token auth
- Observable failure symptoms: Auth errors from Bedrock API if token is invalid

## Risks and Mitigations

- Risk: Bearer token could be invalid/expired silently
  - Mitigation: Same error handling as SigV4 — Bedrock API returns clear 401/403 errors