### PR TITLE
feat(channels): migrate inline transcription to TranscriptionManager

### DIFF
--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -23,6 +23,7 @@ pub struct DiscordChannel {
     /// Voice transcription config — when set, audio attachments are
     /// downloaded, transcribed, and their text inlined into the message.
     transcription: Option<crate::config::TranscriptionConfig>,
+    transcription_manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
 }
 
 impl DiscordChannel {
@@ -42,6 +43,7 @@ impl DiscordChannel {
             typing_handles: Mutex::new(HashMap::new()),
             proxy_url: None,
             transcription: None,
+            transcription_manager: None,
         }
     }
 
@@ -53,8 +55,19 @@ impl DiscordChannel {
 
     /// Configure voice transcription for audio attachments.
     pub fn with_transcription(mut self, config: crate::config::TranscriptionConfig) -> Self {
-        if config.enabled {
-            self.transcription = Some(config);
+        if !config.enabled {
+            return self;
+        }
+        match super::transcription::TranscriptionManager::new(&config) {
+            Ok(m) => {
+                self.transcription_manager = Some(std::sync::Arc::new(m));
+                self.transcription = Some(config);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "transcription manager init failed, voice transcription disabled: {e}"
+                );
+            }
         }
         self
     }
@@ -148,7 +161,7 @@ fn is_discord_audio_attachment(content_type: &str, filename: &str) -> bool {
 async fn transcribe_discord_audio_attachments(
     attachments: &[serde_json::Value],
     client: &reqwest::Client,
-    config: &crate::config::TranscriptionConfig,
+    manager: &super::transcription::TranscriptionManager,
 ) -> String {
     let mut parts: Vec<String> = Vec::new();
     for att in attachments {
@@ -187,7 +200,7 @@ async fn transcribe_discord_audio_attachments(
             }
         };
 
-        match super::transcription::transcribe_audio(audio_data, name, config).await {
+        match manager.transcribe(&audio_data, name).await {
             Ok(text) => {
                 let trimmed = text.trim();
                 if !trimmed.is_empty() {
@@ -835,11 +848,11 @@ impl Channel for DiscordChannel {
                         let mut text_parts = process_attachments(&atts, &client).await;
 
                         // Transcribe audio attachments when transcription is configured
-                        if let Some(ref transcription_config) = self.transcription {
+                        if let Some(ref transcription_manager) = self.transcription_manager {
                             let voice_text = transcribe_discord_audio_attachments(
                                 &atts,
                                 &client,
-                                transcription_config,
+                                transcription_manager,
                             )
                             .await;
                             if !voice_text.is_empty() {

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -42,6 +42,8 @@ pub struct MatrixChannel {
     http_client: Client,
     reaction_events: Arc<RwLock<HashMap<String, String>>>,
     voice_mode: Arc<AtomicBool>,
+    transcription: Option<crate::config::TranscriptionConfig>,
+    transcription_manager: Option<Arc<super::transcription::TranscriptionManager>>,
 }
 
 impl std::fmt::Debug for MatrixChannel {
@@ -215,7 +217,28 @@ impl MatrixChannel {
             http_client: Client::new(),
             reaction_events: Arc::new(RwLock::new(HashMap::new())),
             voice_mode: Arc::new(AtomicBool::new(false)),
+            transcription: None,
+            transcription_manager: None,
         }
+    }
+
+    /// Configure voice transcription for audio messages.
+    pub fn with_transcription(mut self, config: crate::config::TranscriptionConfig) -> Self {
+        if !config.enabled {
+            return self;
+        }
+        match super::transcription::TranscriptionManager::new(&config) {
+            Ok(m) => {
+                self.transcription_manager = Some(Arc::new(m));
+                self.transcription = Some(config);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "transcription manager init failed, voice transcription disabled: {e}"
+                );
+            }
+        }
+        self
     }
 
     fn encode_path_segment(value: &str) -> String {
@@ -763,6 +786,7 @@ impl Channel for MatrixChannel {
         let homeserver_for_handler = self.homeserver.clone();
         let access_token_for_handler = self.access_token.clone();
         let voice_mode_for_handler = Arc::clone(&self.voice_mode);
+        let transcription_mgr_for_handler = self.transcription_manager.clone();
 
         client.add_event_handler(move |event: OriginalSyncRoomMessageEvent, room: Room| {
             let tx = tx_handler.clone();
@@ -774,6 +798,7 @@ impl Channel for MatrixChannel {
             let homeserver = homeserver_for_handler.clone();
             let access_token = access_token_for_handler.clone();
             let voice_mode = Arc::clone(&voice_mode_for_handler);
+            let transcription_mgr = transcription_mgr_for_handler.clone();
 
             async move {
                 if !MatrixChannel::room_matches_target(
@@ -875,51 +900,36 @@ impl Channel for MatrixChannel {
 
                 // Voice transcription: if this was an audio message, transcribe it
                 let body = if body.starts_with("[audio:") {
-                    if let Some(path_start) = body.find("saved to ") {
+                    if let (Some(path_start), Some(ref manager)) = (body.find("saved to "), &transcription_mgr) {
                         let audio_path = body[path_start + 9..].to_string();
-                        let wav_path = format!("{}.16k.wav", audio_path);
-                        let convert_ok = tokio::process::Command::new("ffmpeg")
-                            .args([
-                                "-y",
-                                "-i",
-                                &audio_path,
-                                "-ar",
-                                "16000",
-                                "-ac",
-                                "1",
-                                "-f",
-                                "wav",
-                                &wav_path,
-                            ])
-                            .stderr(std::process::Stdio::null())
-                            .output()
-                            .await
-                            .map(|o| o.status.success())
-                            .unwrap_or(false);
-                        if convert_ok {
-                            let transcription = tokio::process::Command::new("whisper-cpp")
-                                .args([
-                                    "-m",
-                                    "/tmp/ggml-base.en.bin",
-                                    "-f",
-                                    &wav_path,
-                                    "--no-timestamps",
-                                    "-nt",
-                                ])
-                                .output()
-                                .await
-                                .ok()
-                                .filter(|o| o.status.success())
-                                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
-                                .filter(|s| !s.is_empty());
-                            if let Some(text) = transcription {
-                                voice_mode.store(true, Ordering::Relaxed);
-                                format!("[Voice message]: {}", text)
-                            } else {
+                        let file_name = audio_path
+                            .rsplit('/')
+                            .next()
+                            .unwrap_or("audio.ogg")
+                            .to_string();
+                        match tokio::fs::read(&audio_path).await {
+                            Ok(audio_data) => {
+                                match manager.transcribe(&audio_data, &file_name).await {
+                                    Ok(text) => {
+                                        let trimmed = text.trim();
+                                        if trimmed.is_empty() {
+                                            tracing::info!("Matrix: voice transcription returned empty text, skipping");
+                                            body
+                                        } else {
+                                            voice_mode.store(true, Ordering::Relaxed);
+                                            format!("[Voice message]: {}", trimmed)
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!("Matrix: voice transcription failed: {e}");
+                                        body
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!("Matrix: failed to read audio file {}: {e}", audio_path);
                                 body
                             }
-                        } else {
-                            body
                         }
                     } else {
                         body

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3897,16 +3897,19 @@ fn collect_configured_channels(
     if let Some(ref mx) = config.channels_config.matrix {
         channels.push(ConfiguredChannel {
             display_name: "Matrix",
-            channel: Arc::new(MatrixChannel::new_full(
-                mx.homeserver.clone(),
-                mx.access_token.clone(),
-                mx.room_id.clone(),
-                mx.allowed_users.clone(),
-                mx.allowed_rooms.clone(),
-                mx.user_id.clone(),
-                mx.device_id.clone(),
-                config.config_path.parent().map(|path| path.to_path_buf()),
-            )),
+            channel: Arc::new(
+                MatrixChannel::new_full(
+                    mx.homeserver.clone(),
+                    mx.access_token.clone(),
+                    mx.room_id.clone(),
+                    mx.allowed_users.clone(),
+                    mx.allowed_rooms.clone(),
+                    mx.user_id.clone(),
+                    mx.device_id.clone(),
+                    config.config_path.parent().map(|path| path.to_path_buf()),
+                )
+                .with_transcription(config.transcription.clone()),
+            ),
         });
     }
 

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -37,6 +37,7 @@ pub struct SlackChannel {
     /// Voice transcription config — when set, audio file attachments are
     /// downloaded, transcribed, and their text inlined into the message.
     transcription: Option<crate::config::TranscriptionConfig>,
+    transcription_manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
 }
 
 const SLACK_HISTORY_MAX_RETRIES: u32 = 3;
@@ -129,6 +130,7 @@ impl SlackChannel {
             active_assistant_thread: Mutex::new(HashMap::new()),
             proxy_url: None,
             transcription: None,
+            transcription_manager: None,
         }
     }
 
@@ -164,8 +166,19 @@ impl SlackChannel {
 
     /// Configure voice transcription for audio file attachments.
     pub fn with_transcription(mut self, config: crate::config::TranscriptionConfig) -> Self {
-        if config.enabled {
-            self.transcription = Some(config);
+        if !config.enabled {
+            return self;
+        }
+        match super::transcription::TranscriptionManager::new(&config) {
+            Ok(m) => {
+                self.transcription_manager = Some(std::sync::Arc::new(m));
+                self.transcription = Some(config);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "transcription manager init failed, voice transcription disabled: {e}"
+                );
+            }
         }
         self
     }
@@ -1509,7 +1522,7 @@ impl SlackChannel {
     /// transcription provider. Returns `None` if transcription is not configured
     /// or if the download/transcription fails.
     async fn try_transcribe_audio_file(&self, file: &serde_json::Value) -> Option<String> {
-        let config = self.transcription.as_ref()?;
+        let manager = self.transcription_manager.as_deref()?;
 
         let url = Self::slack_file_download_url(file)?;
         let file_name = Self::slack_file_name(file);
@@ -1544,7 +1557,8 @@ impl SlackChannel {
             format!("voice.{mime_ext}")
         };
 
-        match super::transcription::transcribe_audio(audio_data, &transcription_filename, config)
+        match manager
+            .transcribe(&audio_data, &transcription_filename)
             .await
         {
             Ok(text) => {

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -330,6 +330,7 @@ pub struct TelegramChannel {
     /// Override for local Bot API servers or testing.
     api_base: String,
     transcription: Option<crate::config::TranscriptionConfig>,
+    transcription_manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
     voice_transcriptions: Mutex<std::collections::HashMap<String, String>>,
     workspace_dir: Option<std::path::PathBuf>,
     ack_reactions: bool,
@@ -375,6 +376,7 @@ impl TelegramChannel {
             bot_username: Mutex::new(None),
             api_base: "https://api.telegram.org".to_string(),
             transcription: None,
+            transcription_manager: None,
             voice_transcriptions: Mutex::new(std::collections::HashMap::new()),
             workspace_dir: None,
             ack_reactions: true,
@@ -423,8 +425,19 @@ impl TelegramChannel {
 
     /// Configure voice transcription.
     pub fn with_transcription(mut self, config: crate::config::TranscriptionConfig) -> Self {
-        if config.enabled {
-            self.transcription = Some(config);
+        if !config.enabled {
+            return self;
+        }
+        match super::transcription::TranscriptionManager::new(&config) {
+            Ok(m) => {
+                self.transcription_manager = Some(std::sync::Arc::new(m));
+                self.transcription = Some(config);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "transcription manager init failed, voice transcription disabled: {e}"
+                );
+            }
         }
         self
     }
@@ -1167,6 +1180,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
     /// or the message exceeds duration limits.
     async fn try_parse_voice_message(&self, update: &serde_json::Value) -> Option<ChannelMessage> {
         let config = self.transcription.as_ref()?;
+        let manager = self.transcription_manager.as_deref()?;
         let message = update.get("message")?;
 
         let (file_id, duration) = Self::parse_voice_metadata(message)?;
@@ -1235,14 +1249,13 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             }
         };
 
-        let text =
-            match super::transcription::transcribe_audio(audio_data, &file_name, config).await {
-                Ok(t) => t,
-                Err(e) => {
-                    tracing::warn!("Voice transcription failed: {e}");
-                    return None;
-                }
-            };
+        let text = match manager.transcribe(&audio_data, &file_name).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!("Voice transcription failed: {e}");
+                return None;
+            }
+        };
 
         if text.trim().is_empty() {
             tracing::info!("Voice transcription returned empty text, skipping");
@@ -4348,10 +4361,12 @@ mod tests {
     fn with_transcription_sets_config_when_enabled() {
         let mut tc = crate::config::TranscriptionConfig::default();
         tc.enabled = true;
+        tc.api_key = Some("test_key".to_string());
 
         let ch =
             TelegramChannel::new("token".into(), vec!["*".into()], false).with_transcription(tc);
         assert!(ch.transcription.is_some());
+        assert!(ch.transcription_manager.is_some());
     }
 
     #[test]
@@ -4360,6 +4375,7 @@ mod tests {
         let ch =
             TelegramChannel::new("token".into(), vec!["*".into()], false).with_transcription(tc);
         assert!(ch.transcription.is_none());
+        assert!(ch.transcription_manager.is_none());
     }
 
     #[tokio::test]
@@ -4382,6 +4398,7 @@ mod tests {
     async fn try_parse_voice_message_skips_when_duration_exceeds_limit() {
         let mut tc = crate::config::TranscriptionConfig::default();
         tc.enabled = true;
+        tc.api_key = Some("test_key".to_string());
         tc.max_duration_secs = 5;
 
         let ch =
@@ -4403,6 +4420,7 @@ mod tests {
     async fn try_parse_voice_message_rejects_unauthorized_sender_before_download() {
         let mut tc = crate::config::TranscriptionConfig::default();
         tc.enabled = true;
+        tc.api_key = Some("test_key".to_string());
         tc.max_duration_secs = 120;
 
         let ch = TelegramChannel::new("token".into(), vec!["alice".into()], false)
@@ -4453,15 +4471,17 @@ mod tests {
             audio_data.len()
         );
 
-        // 2. Call transcribe_audio() — real Groq Whisper API
+        // 2. Call TranscriptionManager.transcribe() — real Groq Whisper API
         let config = crate::config::TranscriptionConfig {
             enabled: true,
             ..Default::default()
         };
-        let transcript: String =
-            crate::channels::transcription::transcribe_audio(audio_data, "hello.mp3", &config)
-                .await
-                .expect("transcribe_audio should succeed with valid GROQ_API_KEY");
+        let manager = crate::channels::transcription::TranscriptionManager::new(&config)
+            .expect("TranscriptionManager::new should succeed with valid GROQ_API_KEY");
+        let transcript: String = manager
+            .transcribe(&audio_data, "hello.mp3")
+            .await
+            .expect("transcribe should succeed with valid GROQ_API_KEY");
 
         // 3. Verify Whisper actually recognized "hello"
         assert!(

--- a/src/channels/whatsapp_web.rs
+++ b/src/channels/whatsapp_web.rs
@@ -74,6 +74,7 @@ pub struct WhatsAppWebChannel {
     tx: Arc<Mutex<Option<tokio::sync::mpsc::Sender<ChannelMessage>>>>,
     /// Voice transcription (STT) config
     transcription: Option<crate::config::TranscriptionConfig>,
+    transcription_manager: Option<std::sync::Arc<super::transcription::TranscriptionManager>>,
     /// Text-to-speech config for voice replies
     tts_config: Option<crate::config::TtsConfig>,
     /// Chats awaiting a voice reply — maps chat JID to the latest substantive
@@ -122,6 +123,7 @@ impl WhatsAppWebChannel {
             client: Arc::new(Mutex::new(None)),
             tx: Arc::new(Mutex::new(None)),
             transcription: None,
+            transcription_manager: None,
             tts_config: None,
             pending_voice: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             voice_chats: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
@@ -131,8 +133,19 @@ impl WhatsAppWebChannel {
     /// Configure voice transcription (STT) for incoming voice notes.
     #[cfg(feature = "whatsapp-web")]
     pub fn with_transcription(mut self, config: crate::config::TranscriptionConfig) -> Self {
-        if config.enabled {
-            self.transcription = Some(config);
+        if !config.enabled {
+            return self;
+        }
+        match super::transcription::TranscriptionManager::new(&config) {
+            Ok(m) => {
+                self.transcription_manager = Some(std::sync::Arc::new(m));
+                self.transcription = Some(config);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "transcription manager init failed, voice transcription disabled: {e}"
+                );
+            }
         }
         self
     }
@@ -338,8 +351,10 @@ impl WhatsAppWebChannel {
         client: &wa_rs::Client,
         audio: &wa_rs_proto::whatsapp::message::AudioMessage,
         transcription_config: Option<&crate::config::TranscriptionConfig>,
+        transcription_manager: Option<&super::transcription::TranscriptionManager>,
     ) -> Option<String> {
         let config = transcription_config?;
+        let manager = transcription_manager?;
 
         // Enforce duration limit
         if let Some(seconds) = audio.seconds {
@@ -378,7 +393,7 @@ impl WhatsAppWebChannel {
             file_name
         );
 
-        match super::transcription::transcribe_audio(audio_data, file_name, config).await {
+        match manager.transcribe(&audio_data, file_name).await {
             Ok(text) if text.trim().is_empty() => {
                 tracing::info!("WhatsApp Web: voice transcription returned empty text, skipping");
                 None
@@ -644,6 +659,7 @@ impl Channel for WhatsAppWebChannel {
             let retry_count_clone = retry_count.clone();
             let session_revoked_clone = session_revoked.clone();
             let transcription_config = self.transcription.clone();
+            let transcription_mgr = self.transcription_manager.clone();
             let voice_chats = self.voice_chats.clone();
             let wa_mode = self.mode.clone();
             let wa_dm_policy = self.dm_policy.clone();
@@ -661,6 +677,7 @@ impl Channel for WhatsAppWebChannel {
                     let retry_count = retry_count_clone.clone();
                     let session_revoked = session_revoked_clone.clone();
                     let transcription_config = transcription_config.clone();
+                    let transcription_mgr = transcription_mgr.clone();
                     let voice_chats = voice_chats.clone();
                     let wa_mode = wa_mode.clone();
                     let wa_dm_policy = wa_dm_policy.clone();
@@ -763,6 +780,7 @@ impl Channel for WhatsAppWebChannel {
                                             &client,
                                             audio,
                                             transcription_config.as_ref(),
+                                            transcription_mgr.as_deref(),
                                         )
                                         .await
                                     } else {
@@ -1343,9 +1361,11 @@ mod tests {
     fn with_transcription_sets_config_when_enabled() {
         let mut tc = crate::config::TranscriptionConfig::default();
         tc.enabled = true;
+        tc.api_key = Some("test_key".to_string());
 
         let ch = make_channel().with_transcription(tc);
         assert!(ch.transcription.is_some());
+        assert!(ch.transcription_manager.is_some());
     }
 
     #[test]
@@ -1354,6 +1374,7 @@ mod tests {
         let tc = crate::config::TranscriptionConfig::default(); // enabled = false
         let ch = make_channel().with_transcription(tc);
         assert!(ch.transcription.is_none());
+        assert!(ch.transcription_manager.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Five channels (Telegram, Discord, Slack, WhatsApp Web, Matrix) use inline `TranscriptionConfig`/`transcribe_audio()` calls instead of the centralized `TranscriptionManager`
- Why it matters: Unified provider selection, fallback logic, and global cap enforcement across all channels
- What changed: Each channel now stores an `Option<Arc<TranscriptionManager>>`, builds it in `with_transcription()`, and calls `manager.transcribe()` instead of the legacy shim. Matrix replaces the `whisper-cpp` shell-out with the manager API.
- What did **not** change: Channel wiring in `collect_configured_channels()` (already present for all except Matrix, which is now added), public API surface, existing fallback behavior when transcription is not configured

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `channel`
- Module labels: `channel: telegram`, `channel: discord`, `channel: slack`, `channel: whatsapp_web`, `channel: matrix`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `refactor`
- Primary scope: `channel`

## Linked Issue

- Closes #4311

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings  # pass
cargo test   # 119 passed, 0 failed
```

- Evidence provided: All three validation commands pass locally

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No (Matrix previously shelled out to whisper-cpp; now uses the same HTTP-based transcription API as other channels)

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: All unit tests pass; `with_transcription` builder tests updated to provide valid API key for manager init
- Edge cases checked: Disabled transcription config, missing API key (manager init fails gracefully with warning), empty transcription results
- What was not verified: Live transcription with real audio (covered by existing ignored e2e tests)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Voice message transcription in Telegram, Discord, Slack, WhatsApp Web, Matrix
- Potential unintended effects: Matrix channel no longer requires local `whisper-cpp` + `ffmpeg` binaries for transcription; users relying on the local whisper-cpp path must configure a transcription provider in config
- Guardrails/monitoring for early detection: Existing transcription warning logs when manager init fails

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit
- Feature flags or config toggles: Transcription is gated by `transcription.enabled` config flag
- Observable failure symptoms: Voice messages not transcribed; warning logs about missing transcription manager

## Risks and Mitigations

- Risk: Matrix users relying on local whisper-cpp shell-out lose that path
  - Mitigation: They can configure `local_whisper` provider in transcription config for equivalent functionality