### PR TITLE
fix(ci): use shared concurrency group for master push events

### DIFF
--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.sha }}
+  group: ci-${{ github.event.pull_request.number || 'push-master' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

- Fix CI jobs stuck in "queued" state after back-to-back merges to master
- The concurrency group used `github.sha` for push events, giving each merge its own group — so multiple full CI runs queued simultaneously without cancelling each other
- Changed to a fixed `push-master` group so only the latest push runs CI; older runs are auto-cancelled

## Test plan

- [x] Verify stale queued runs are cancelled
- [ ] Merge this PR and confirm only one CI run executes for the push event
- [ ] Verify PR-triggered CI still uses per-PR concurrency groups (no regression)