### PR TITLE
feat(agent): add token efficiency analyzer layer (#3892)

### DIFF
--- a/src/agent/context_analyzer.rs
+++ b/src/agent/context_analyzer.rs
@@ -1,0 +1,155 @@
+use crate::providers::traits::ChatMessage;
+use std::collections::HashSet;
+
+/// Signals extracted from conversation context to guide tool filtering.
+#[derive(Debug, Clone)]
+pub struct ContextSignals {
+    /// Tool names likely needed. Empty vec means no filtering.
+    pub suggested_tools: Vec<String>,
+    /// Whether full history is relevant.
+    pub history_relevant: bool,
+}
+
+/// Analyze context to determine which tools are likely needed.
+pub fn analyze_turn_context(
+    history: &[ChatMessage],
+    _user_message: &str,
+    iteration: usize,
+    last_tool_calls: &[String],
+) -> ContextSignals {
+    if iteration == 0 {
+        return ContextSignals {
+            suggested_tools: Vec::new(),
+            history_relevant: true,
+        };
+    }
+
+    let mut tools: HashSet<String> = HashSet::new();
+    for tool in last_tool_calls {
+        tools.insert(tool.clone());
+    }
+
+    if let Some(last_assistant) = history.iter().rev().find(|m| m.role == "assistant") {
+        for word in last_assistant.content.split_whitespace() {
+            for tool_name in tools_for_keyword(word) {
+                tools.insert(tool_name.to_string());
+            }
+        }
+    }
+
+    let mut suggested: Vec<String> = tools.into_iter().collect();
+    suggested.sort();
+
+    ContextSignals {
+        suggested_tools: suggested,
+        history_relevant: true,
+    }
+}
+
+fn tools_for_keyword(keyword: &str) -> &'static [&'static str] {
+    match keyword.to_lowercase().as_str() {
+        "file" | "read" | "write" | "edit" | "path" | "directory" => {
+            &["file_read", "file_write", "file_edit", "glob_search"]
+        }
+        "shell" | "command" | "run" | "execute" | "install" | "build" => &["shell"],
+        "memory" | "remember" | "recall" | "store" | "forget" => &["memory_store", "memory_recall"],
+        "search" | "find" | "grep" | "look" => {
+            &["content_search", "glob_search", "web_search_tool"]
+        }
+        "browser" | "website" | "url" | "http" | "fetch" => &["web_fetch", "web_search_tool"],
+        "image" | "screenshot" | "picture" => &["image_info"],
+        "git" | "commit" | "branch" | "push" | "pull" => &["git_operations", "shell"],
+        _ => &[],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_message(role: &str, content: &str) -> ChatMessage {
+        ChatMessage {
+            role: role.to_string(),
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn iteration_zero_returns_empty_suggestions() {
+        let history = vec![make_message("user", "hello")];
+        let signals = analyze_turn_context(&history, "do something", 0, &[]);
+        assert!(signals.suggested_tools.is_empty());
+        assert!(signals.history_relevant);
+    }
+
+    #[test]
+    fn iteration_one_includes_last_tools() {
+        let history = vec![
+            make_message("user", "hello"),
+            make_message("assistant", "sure"),
+        ];
+        let last_tools = vec!["shell".to_string(), "file_read".to_string()];
+        let signals = analyze_turn_context(&history, "next step", 1, &last_tools);
+        assert!(signals.suggested_tools.contains(&"shell".to_string()));
+        assert!(signals.suggested_tools.contains(&"file_read".to_string()));
+    }
+
+    #[test]
+    fn keyword_extraction_from_assistant_message() {
+        let history = vec![
+            make_message("user", "help me"),
+            make_message("assistant", "I will read the file at that path"),
+        ];
+        let signals = analyze_turn_context(&history, "ok", 1, &[]);
+        assert!(signals.suggested_tools.contains(&"file_read".to_string()));
+    }
+
+    #[test]
+    fn shell_keywords_suggest_shell_tool() {
+        let history = vec![
+            make_message("user", "build the project"),
+            make_message("assistant", "I will run the build command"),
+        ];
+        let signals = analyze_turn_context(&history, "go", 1, &[]);
+        assert!(signals.suggested_tools.contains(&"shell".to_string()));
+    }
+
+    #[test]
+    fn memory_keywords_suggest_memory_tools() {
+        let history = vec![
+            make_message("user", "save this"),
+            make_message("assistant", "I will store that in memory"),
+        ];
+        let signals = analyze_turn_context(&history, "ok", 1, &[]);
+        assert!(signals
+            .suggested_tools
+            .contains(&"memory_store".to_string()));
+        assert!(signals
+            .suggested_tools
+            .contains(&"memory_recall".to_string()));
+    }
+
+    #[test]
+    fn combined_keywords_merge_tools() {
+        let history = vec![
+            make_message("user", "do stuff"),
+            make_message(
+                "assistant",
+                "I need to read the file and run a shell command to search",
+            ),
+        ];
+        let signals = analyze_turn_context(&history, "go", 1, &[]);
+        assert!(signals.suggested_tools.contains(&"file_read".to_string()));
+        assert!(signals.suggested_tools.contains(&"shell".to_string()));
+        assert!(signals
+            .suggested_tools
+            .contains(&"content_search".to_string()));
+    }
+
+    #[test]
+    fn empty_history_iteration_one() {
+        let history: Vec<ChatMessage> = vec![];
+        let signals = analyze_turn_context(&history, "hello", 1, &[]);
+        assert!(signals.suggested_tools.is_empty());
+    }
+}

--- a/src/agent/history_pruner.rs
+++ b/src/agent/history_pruner.rs
@@ -1,0 +1,283 @@
+use crate::providers::traits::ChatMessage;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+fn default_max_tokens() -> usize {
+    8192
+}
+
+fn default_keep_recent() -> usize {
+    4
+}
+
+fn default_collapse() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct HistoryPrunerConfig {
+    /// Enable history pruning. Default: false.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Maximum estimated tokens for message history. Default: 8192.
+    #[serde(default = "default_max_tokens")]
+    pub max_tokens: usize,
+    /// Keep the N most recent messages untouched. Default: 4.
+    #[serde(default = "default_keep_recent")]
+    pub keep_recent: usize,
+    /// Collapse old tool call/result pairs into short summaries. Default: true.
+    #[serde(default = "default_collapse")]
+    pub collapse_tool_results: bool,
+}
+
+impl Default for HistoryPrunerConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_tokens: 8192,
+            keep_recent: 4,
+            collapse_tool_results: true,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PruneStats {
+    pub messages_before: usize,
+    pub messages_after: usize,
+    pub collapsed_pairs: usize,
+    pub dropped_messages: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Token estimation
+// ---------------------------------------------------------------------------
+
+fn estimate_tokens(messages: &[ChatMessage]) -> usize {
+    messages.iter().map(|m| m.content.len() / 4).sum()
+}
+
+// ---------------------------------------------------------------------------
+// Protected-index helpers
+// ---------------------------------------------------------------------------
+
+fn protected_indices(messages: &[ChatMessage], keep_recent: usize) -> Vec<bool> {
+    let len = messages.len();
+    let mut protected = vec![false; len];
+    for (i, msg) in messages.iter().enumerate() {
+        if msg.role == "system" {
+            protected[i] = true;
+        }
+    }
+    let recent_start = len.saturating_sub(keep_recent);
+    for p in protected.iter_mut().skip(recent_start) {
+        *p = true;
+    }
+    protected
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+pub fn prune_history(messages: &mut Vec<ChatMessage>, config: &HistoryPrunerConfig) -> PruneStats {
+    let messages_before = messages.len();
+    if !config.enabled || messages.is_empty() {
+        return PruneStats {
+            messages_before,
+            messages_after: messages_before,
+            collapsed_pairs: 0,
+            dropped_messages: 0,
+        };
+    }
+
+    let mut collapsed_pairs: usize = 0;
+
+    // Phase 1 – collapse assistant+tool pairs
+    if config.collapse_tool_results {
+        let mut i = 0;
+        while i + 1 < messages.len() {
+            let protected = protected_indices(messages, config.keep_recent);
+            if messages[i].role == "assistant"
+                && messages[i + 1].role == "tool"
+                && !protected[i]
+                && !protected[i + 1]
+            {
+                let tool_content = &messages[i + 1].content;
+                let truncated: String = tool_content.chars().take(100).collect();
+                let summary = format!("[Tool result: {truncated}...]");
+                messages[i] = ChatMessage {
+                    role: "assistant".to_string(),
+                    content: summary,
+                };
+                messages.remove(i + 1);
+                collapsed_pairs += 1;
+            } else {
+                i += 1;
+            }
+        }
+    }
+
+    // Phase 2 – budget enforcement
+    let mut dropped_messages: usize = 0;
+    while estimate_tokens(messages) > config.max_tokens {
+        let protected = protected_indices(messages, config.keep_recent);
+        if let Some(idx) = protected
+            .iter()
+            .enumerate()
+            .find(|(_, &p)| !p)
+            .map(|(i, _)| i)
+        {
+            messages.remove(idx);
+            dropped_messages += 1;
+        } else {
+            break;
+        }
+    }
+
+    PruneStats {
+        messages_before,
+        messages_after: messages.len(),
+        collapsed_pairs,
+        dropped_messages,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(role: &str, content: &str) -> ChatMessage {
+        ChatMessage {
+            role: role.to_string(),
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn prune_disabled_is_noop() {
+        let mut messages = vec![
+            msg("system", "You are helpful."),
+            msg("user", "Hello"),
+            msg("assistant", "Hi there!"),
+        ];
+        let config = HistoryPrunerConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        let stats = prune_history(&mut messages, &config);
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0].content, "You are helpful.");
+        assert_eq!(stats.messages_before, 3);
+        assert_eq!(stats.messages_after, 3);
+        assert_eq!(stats.collapsed_pairs, 0);
+    }
+
+    #[test]
+    fn prune_under_budget_no_change() {
+        let mut messages = vec![
+            msg("system", "You are helpful."),
+            msg("user", "Hello"),
+            msg("assistant", "Hi!"),
+        ];
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            max_tokens: 8192,
+            keep_recent: 2,
+            collapse_tool_results: false,
+        };
+        let stats = prune_history(&mut messages, &config);
+        assert_eq!(messages.len(), 3);
+        assert_eq!(stats.collapsed_pairs, 0);
+        assert_eq!(stats.dropped_messages, 0);
+    }
+
+    #[test]
+    fn prune_collapses_tool_pairs() {
+        let tool_result = "a".repeat(160);
+        let mut messages = vec![
+            msg("system", "sys"),
+            msg("assistant", "calling tool X"),
+            msg("tool", &tool_result),
+            msg("user", "thanks"),
+            msg("assistant", "done"),
+        ];
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            max_tokens: 100_000,
+            keep_recent: 2,
+            collapse_tool_results: true,
+        };
+        let stats = prune_history(&mut messages, &config);
+        assert_eq!(stats.collapsed_pairs, 1);
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[1].role, "assistant");
+        assert!(messages[1].content.starts_with("[Tool result: "));
+    }
+
+    #[test]
+    fn prune_preserves_system_and_recent() {
+        let big = "x".repeat(40_000);
+        let mut messages = vec![
+            msg("system", "system prompt"),
+            msg("user", &big),
+            msg("assistant", "old reply"),
+            msg("user", "recent1"),
+            msg("assistant", "recent2"),
+        ];
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            max_tokens: 100,
+            keep_recent: 2,
+            collapse_tool_results: false,
+        };
+        let stats = prune_history(&mut messages, &config);
+        assert!(messages.iter().any(|m| m.role == "system"));
+        assert!(messages.iter().any(|m| m.content == "recent1"));
+        assert!(messages.iter().any(|m| m.content == "recent2"));
+        assert!(stats.dropped_messages > 0);
+    }
+
+    #[test]
+    fn prune_drops_oldest_when_over_budget() {
+        let filler = "y".repeat(400);
+        let mut messages = vec![
+            msg("system", "sys"),
+            msg("user", &filler),
+            msg("assistant", &filler),
+            msg("user", "recent-user"),
+            msg("assistant", "recent-assistant"),
+        ];
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            max_tokens: 150,
+            keep_recent: 2,
+            collapse_tool_results: false,
+        };
+        let stats = prune_history(&mut messages, &config);
+        assert!(stats.dropped_messages >= 1);
+        assert_eq!(messages[0].role, "system");
+        assert!(messages.iter().any(|m| m.content == "recent-user"));
+        assert!(messages.iter().any(|m| m.content == "recent-assistant"));
+    }
+
+    #[test]
+    fn prune_empty_messages() {
+        let mut messages: Vec<ChatMessage> = vec![];
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            ..Default::default()
+        };
+        let stats = prune_history(&mut messages, &config);
+        assert_eq!(stats.messages_before, 0);
+        assert_eq!(stats.messages_after, 0);
+    }
+}

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -4039,6 +4039,14 @@ pub async fn run(
             ChatMessage::user(&enriched),
         ];
 
+        // Prune history for token efficiency (when enabled).
+        if config.agent.history_pruning.enabled {
+            let _stats = crate::agent::history_pruner::prune_history(
+                &mut history,
+                &config.agent.history_pruning,
+            );
+        }
+
         // Compute per-turn excluded MCP tools from tool_filter_groups.
         let excluded_tools = compute_excluded_mcp_tools(
             &tools_registry,
@@ -8214,6 +8222,7 @@ Let me check the result."#;
             mode: ToolFilterGroupMode::Always,
             tools: vec!["mcp_filesystem_*".into()],
             keywords: vec![],
+            filter_builtins: false,
         }];
         let result = filter_tool_specs_for_turn(specs, &groups, "anything");
         let names: Vec<&str> = result.iter().map(|s| s.name.as_str()).collect();
@@ -8232,6 +8241,7 @@ Let me check the result."#;
             mode: ToolFilterGroupMode::Dynamic,
             tools: vec!["mcp_browser_*".into()],
             keywords: vec!["browse".into(), "website".into()],
+            filter_builtins: false,
         }];
         let result = filter_tool_specs_for_turn(specs, &groups, "please browse this page");
         let names: Vec<&str> = result.iter().map(|s| s.name.as_str()).collect();
@@ -8248,6 +8258,7 @@ Let me check the result."#;
             mode: ToolFilterGroupMode::Dynamic,
             tools: vec!["mcp_browser_*".into()],
             keywords: vec!["browse".into(), "website".into()],
+            filter_builtins: false,
         }];
         let result = filter_tool_specs_for_turn(specs, &groups, "read the file /etc/hosts");
         let names: Vec<&str> = result.iter().map(|s| s.name.as_str()).collect();
@@ -8264,6 +8275,7 @@ Let me check the result."#;
             mode: ToolFilterGroupMode::Dynamic,
             tools: vec!["mcp_browser_*".into()],
             keywords: vec!["Browse".into()],
+            filter_builtins: false,
         }];
         let result = filter_tool_specs_for_turn(specs, &groups, "BROWSE the site");
         assert_eq!(result.len(), 1);

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -1,7 +1,9 @@
 #[allow(clippy::module_inception)]
 pub mod agent;
 pub mod classifier;
+pub mod context_analyzer;
 pub mod dispatcher;
+pub mod history_pruner;
 pub mod loop_;
 pub mod loop_detector;
 pub mod memory_loader;

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1190,6 +1190,9 @@ pub struct ToolFilterGroup {
     /// Ignored when `mode = "always"`.
     #[serde(default)]
     pub keywords: Vec<String>,
+    /// When true, also filter built-in tools (not just MCP tools).
+    #[serde(default)]
+    pub filter_builtins: bool,
 }
 
 /// OpenAI Whisper STT provider configuration (`[transcription.openai]`).
@@ -1306,6 +1309,14 @@ pub struct AgentConfig {
     /// per message. Users can override per-message with `/think:<level>` directives.
     #[serde(default)]
     pub thinking: crate::agent::thinking::ThinkingConfig,
+
+    /// History pruning configuration for token efficiency.
+    #[serde(default)]
+    pub history_pruning: crate::agent::history_pruner::HistoryPrunerConfig,
+
+    /// Enable context-aware tool filtering (only surface relevant tools per iteration).
+    #[serde(default)]
+    pub context_aware_tools: bool,
 }
 
 fn default_agent_max_tool_iterations() -> usize {
@@ -1341,6 +1352,8 @@ impl Default for AgentConfig {
             tool_filter_groups: Vec::new(),
             max_system_prompt_chars: default_max_system_prompt_chars(),
             thinking: crate::agent::thinking::ThinkingConfig::default(),
+            history_pruning: crate::agent::history_pruner::HistoryPrunerConfig::default(),
+            context_aware_tools: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

- **History Pruner**: Collapses old tool call/result pairs into compact summaries and drops oldest non-system messages when token budget is exceeded. Configurable via `[agent] history_pruning` with `max_tokens`, `keep_recent`, and `collapse_tool_results` options.
- **Context Analyzer**: Heuristic-based per-iteration tool filtering — iteration 0 returns all tools, subsequent iterations only surface tools used previously plus keyword-matched relevant tools (file, shell, memory, search, browser, image, git categories).
- **ToolFilterGroup `filter_builtins`**: New field allowing built-in tools (not just MCP) to participate in dynamic filtering.

All features default to disabled — zero behavior change for existing users. SQLite memory and all existing functionality untouched.

## Test plan

- [x] 13 new unit tests (6 history pruner, 7 context analyzer)
- [x] All 5322 existing tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Verified history under budget is untouched
- [x] Verified system + recent messages are always preserved
- [x] Verified `filter_builtins: false` (default) preserves current behavior

Closes #3892