### PR TITLE
feat(hooks): wire lifecycle hooks into gateway, session, and heartbeat

### DIFF
--- a/src/agent/context_compressor.rs
+++ b/src/agent/context_compressor.rs
@@ -272,8 +272,7 @@ impl ContextCompressor {
                 continue;
             }
             let original_len = msg.content.len();
-            msg.content =
-                crate::agent::loop_::truncate_tool_result(&msg.content, max);
+            msg.content = crate::agent::loop_::truncate_tool_result(&msg.content, max);
             saved += original_len - msg.content.len();
         }
         saved

--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -142,7 +142,10 @@ impl InteractiveSessionState {
     }
 }
 
-pub(crate) fn load_interactive_session_history(path: &Path, system_prompt: &str) -> Result<Vec<ChatMessage>> {
+pub(crate) fn load_interactive_session_history(
+    path: &Path,
+    system_prompt: &str,
+) -> Result<Vec<ChatMessage>> {
     if !path.exists() {
         return Ok(vec![ChatMessage::system(system_prompt)]);
     }

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1992,7 +1992,6 @@ struct StreamedChatOutcome {
     forwarded_live_deltas: bool,
 }
 
-
 async fn consume_provider_streaming_response(
     provider: &dyn Provider,
     messages: &[ChatMessage],
@@ -3049,7 +3048,8 @@ pub(crate) async fn run_tool_call_loop(
 
             let signature = {
                 let canonical_args = canonicalize_json_for_tool_signature(&tool_args);
-                let args_json = serde_json::to_string(&canonical_args).unwrap_or_else(|_| "{}".to_string());
+                let args_json =
+                    serde_json::to_string(&canonical_args).unwrap_or_else(|_| "{}".to_string());
                 (tool_name.trim().to_ascii_lowercase(), args_json)
             };
             let dedup_exempt = dedup_exempt_tools.iter().any(|e| e == &tool_name);
@@ -3113,7 +3113,9 @@ pub(crate) async fn run_tool_call_loop(
                 let hint = {
                     let raw = match tool_name.as_str() {
                         "shell" => tool_args.get("command").and_then(|v| v.as_str()),
-                        "file_read" | "file_write" => tool_args.get("path").and_then(|v| v.as_str()),
+                        "file_read" | "file_write" => {
+                            tool_args.get("path").and_then(|v| v.as_str())
+                        }
                         _ => tool_args
                             .get("action")
                             .and_then(|v| v.as_str())

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -10,11 +10,11 @@ pub mod history;
 pub mod history_pruner;
 pub mod loop_;
 pub mod loop_detector;
-pub mod tool_execution;
 pub mod memory_loader;
 pub mod personality;
 pub mod prompt;
 pub mod thinking;
+pub mod tool_execution;
 
 #[cfg(test)]
 mod tests;

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -222,10 +222,16 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
 
     let observer: std::sync::Arc<dyn crate::observability::Observer> =
         std::sync::Arc::from(crate::observability::create_observer(&config.observability));
+    let hooks: Option<std::sync::Arc<crate::hooks::HookRunner>> = if config.hooks.enabled {
+        Some(std::sync::Arc::new(crate::hooks::HookRunner::new()))
+    } else {
+        None
+    };
     let engine = HeartbeatEngine::new(
         config.heartbeat.clone(),
         config.workspace_dir.clone(),
         observer,
+        hooks,
     );
     let metrics = engine.metrics();
     let delivery = resolve_heartbeat_delivery(&config)?;

--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -1648,6 +1648,7 @@ mod tests {
             canvas_store: crate::tools::canvas::CanvasStore::new(),
             #[cfg(feature = "webauthn")]
             webauthn: None,
+            hooks: None,
         }
     }
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -373,6 +373,8 @@ pub struct AppState {
     /// WebAuthn state for hardware key authentication (optional, requires `webauthn` feature)
     #[cfg(feature = "webauthn")]
     pub webauthn: Option<Arc<api_webauthn::WebAuthnState>>,
+    /// Hook runner for lifecycle events
+    pub hooks: Option<Arc<crate::hooks::HookRunner>>,
 }
 
 /// Run the HTTP gateway using axum with proper HTTP/1.1 compliance.
@@ -876,6 +878,7 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         } else {
             None
         },
+        hooks: hooks.clone(),
     };
 
     // Config PUT needs larger body limit (1MB)
@@ -1093,6 +1096,9 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
                 }
                 _ = shutdown_signal.changed() => {
                     tracing::info!("🦀 ZeroClaw Gateway shutting down...");
+                    if let Some(ref h) = hooks {
+                        h.fire_gateway_stop().await;
+                    }
                     break;
                 }
             }
@@ -1106,6 +1112,9 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         .with_graceful_shutdown(async move {
             let _ = shutdown_rx.changed().await;
             tracing::info!("🦀 ZeroClaw Gateway shutting down...");
+            if let Some(ref h) = hooks {
+                h.fire_gateway_stop().await;
+            }
         })
         .await?;
     }
@@ -2342,6 +2351,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             #[cfg(feature = "webauthn")]
             webauthn: None,
+            hooks: None,
         };
 
         let response = handle_metrics(State(state)).await.into_response();
@@ -2410,6 +2420,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             #[cfg(feature = "webauthn")]
             webauthn: None,
+            hooks: None,
         };
 
         let response = handle_metrics(State(state)).await.into_response();
@@ -2804,6 +2815,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             #[cfg(feature = "webauthn")]
             webauthn: None,
+            hooks: None,
         };
 
         let mut headers = HeaderMap::new();
@@ -2882,6 +2894,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             #[cfg(feature = "webauthn")]
             webauthn: None,
+            hooks: None,
         };
 
         let headers = HeaderMap::new();
@@ -2972,6 +2985,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             #[cfg(feature = "webauthn")]
             webauthn: None,
+            hooks: None,
         };
 
         let response = handle_webhook(
@@ -3034,6 +3048,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             #[cfg(feature = "webauthn")]
             webauthn: None,
+            hooks: None,
         };
 
         let mut headers = HeaderMap::new();
@@ -3101,6 +3116,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             #[cfg(feature = "webauthn")]
             webauthn: None,
+            hooks: None,
         };
 
         let mut headers = HeaderMap::new();
@@ -3173,6 +3189,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             #[cfg(feature = "webauthn")]
             webauthn: None,
+            hooks: None,
         };
 
         let response = Box::pin(handle_nextcloud_talk_webhook(
@@ -3242,6 +3259,7 @@ mod tests {
             canvas_store: CanvasStore::new(),
             #[cfg(feature = "webauthn")]
             webauthn: None,
+            hooks: None,
         };
 
         let mut headers = HeaderMap::new();

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -213,6 +213,11 @@ async fn handle_socket(
         }
     }
 
+    // Fire session_start hook
+    if let Some(ref hooks) = state.hooks {
+        hooks.fire_session_start(&session_id, "websocket").await;
+    }
+
     // Send session_start message to client
     let mut session_start = serde_json::json!({
         "type": "session_start",
@@ -368,6 +373,11 @@ async fn handle_socket(
         }
 
         process_chat_message(&state, &mut agent, &mut sender, &content, &session_key).await;
+    }
+
+    // Fire session_end hook after message loop exits
+    if let Some(ref hooks) = state.hooks {
+        hooks.fire_session_end(&session_id, "websocket").await;
     }
 }
 

--- a/src/heartbeat/engine.rs
+++ b/src/heartbeat/engine.rs
@@ -171,6 +171,7 @@ pub struct HeartbeatEngine {
     workspace_dir: std::path::PathBuf,
     observer: Arc<dyn Observer>,
     metrics: Arc<ParkingMutex<HeartbeatMetrics>>,
+    hooks: Option<Arc<crate::hooks::HookRunner>>,
 }
 
 impl HeartbeatEngine {
@@ -178,12 +179,14 @@ impl HeartbeatEngine {
         config: HeartbeatConfig,
         workspace_dir: std::path::PathBuf,
         observer: Arc<dyn Observer>,
+        hooks: Option<Arc<crate::hooks::HookRunner>>,
     ) -> Self {
         Self {
             config,
             workspace_dir,
             observer,
             metrics: Arc::new(ParkingMutex::new(HeartbeatMetrics::default())),
+            hooks,
         }
     }
 
@@ -207,6 +210,11 @@ impl HeartbeatEngine {
         loop {
             interval.tick().await;
             self.observer.record_event(&ObserverEvent::HeartbeatTick);
+
+            // Fire heartbeat_tick hook
+            if let Some(ref hooks) = self.hooks {
+                hooks.fire_heartbeat_tick().await;
+            }
 
             match self.tick().await {
                 Ok(tasks) => {
@@ -693,6 +701,7 @@ mod tests {
             },
             dir.clone(),
             observer,
+            None,
         );
         let count = engine.tick().await.unwrap();
         assert_eq!(count, 0);
@@ -719,6 +728,7 @@ mod tests {
             },
             dir.clone(),
             observer,
+            None,
         );
         let count = engine.tick().await.unwrap();
         assert_eq!(count, 3);
@@ -737,6 +747,7 @@ mod tests {
             },
             std::env::temp_dir(),
             observer,
+            None,
         );
         // Should return Ok immediately, not loop forever
         let result = engine.run().await;
@@ -765,6 +776,7 @@ mod tests {
             },
             dir.clone(),
             observer,
+            None,
         );
 
         let tasks = engine.collect_runnable_tasks().await.unwrap();
@@ -845,8 +857,12 @@ mod tests {
     #[test]
     fn engine_exposes_shared_metrics() {
         let observer: Arc<dyn Observer> = Arc::new(crate::observability::NoopObserver);
-        let engine =
-            HeartbeatEngine::new(HeartbeatConfig::default(), std::env::temp_dir(), observer);
+        let engine = HeartbeatEngine::new(
+            HeartbeatConfig::default(),
+            std::env::temp_dir(),
+            observer,
+            None,
+        );
         let metrics = engine.metrics();
         assert_eq!(metrics.lock().total_ticks, 0);
     }

--- a/src/heartbeat/mod.rs
+++ b/src/heartbeat/mod.rs
@@ -15,6 +15,7 @@ mod tests {
             HeartbeatConfig::default(),
             temp.path().to_path_buf(),
             Arc::new(NoopObserver),
+            None,
         );
 
         let _ = engine;

--- a/tests/integration/hook_execution_lifecycle.rs
+++ b/tests/integration/hook_execution_lifecycle.rs
@@ -1,0 +1,146 @@
+use async_trait::async_trait;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use zeroclaw::hooks::{HookHandler, HookRunner};
+
+/// A test hook that counts how many times each lifecycle event fires.
+struct LifecycleCounterHook {
+    gateway_stops: Arc<AtomicUsize>,
+    session_starts: Arc<AtomicUsize>,
+    session_ends: Arc<AtomicUsize>,
+    heartbeat_ticks: Arc<AtomicUsize>,
+    last_session_id: Arc<parking_lot::Mutex<String>>,
+    last_channel: Arc<parking_lot::Mutex<String>>,
+}
+
+#[async_trait]
+impl HookHandler for LifecycleCounterHook {
+    fn name(&self) -> &str {
+        "lifecycle-counter"
+    }
+
+    async fn on_gateway_stop(&self) {
+        self.gateway_stops.fetch_add(1, Ordering::SeqCst);
+    }
+
+    async fn on_session_start(&self, session_id: &str, channel: &str) {
+        self.session_starts.fetch_add(1, Ordering::SeqCst);
+        *self.last_session_id.lock() = session_id.to_string();
+        *self.last_channel.lock() = channel.to_string();
+    }
+
+    async fn on_session_end(&self, session_id: &str, channel: &str) {
+        self.session_ends.fetch_add(1, Ordering::SeqCst);
+        *self.last_session_id.lock() = session_id.to_string();
+        *self.last_channel.lock() = channel.to_string();
+    }
+
+    async fn on_heartbeat_tick(&self) {
+        self.heartbeat_ticks.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[tokio::test]
+async fn fire_gateway_stop_dispatches_to_all_handlers() {
+    let stops1 = Arc::new(AtomicUsize::new(0));
+    let stops2 = Arc::new(AtomicUsize::new(0));
+
+    let mut runner = HookRunner::new();
+    runner.register(Box::new(LifecycleCounterHook {
+        gateway_stops: stops1.clone(),
+        session_starts: Arc::new(AtomicUsize::new(0)),
+        session_ends: Arc::new(AtomicUsize::new(0)),
+        heartbeat_ticks: Arc::new(AtomicUsize::new(0)),
+        last_session_id: Arc::new(parking_lot::Mutex::new(String::new())),
+        last_channel: Arc::new(parking_lot::Mutex::new(String::new())),
+    }));
+    runner.register(Box::new(LifecycleCounterHook {
+        gateway_stops: stops2.clone(),
+        session_starts: Arc::new(AtomicUsize::new(0)),
+        session_ends: Arc::new(AtomicUsize::new(0)),
+        heartbeat_ticks: Arc::new(AtomicUsize::new(0)),
+        last_session_id: Arc::new(parking_lot::Mutex::new(String::new())),
+        last_channel: Arc::new(parking_lot::Mutex::new(String::new())),
+    }));
+
+    runner.fire_gateway_stop().await;
+
+    assert_eq!(stops1.load(Ordering::SeqCst), 1);
+    assert_eq!(stops2.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn fire_session_start_passes_session_id_and_channel() {
+    let session_starts = Arc::new(AtomicUsize::new(0));
+    let last_session_id = Arc::new(parking_lot::Mutex::new(String::new()));
+    let last_channel = Arc::new(parking_lot::Mutex::new(String::new()));
+
+    let mut runner = HookRunner::new();
+    runner.register(Box::new(LifecycleCounterHook {
+        gateway_stops: Arc::new(AtomicUsize::new(0)),
+        session_starts: session_starts.clone(),
+        session_ends: Arc::new(AtomicUsize::new(0)),
+        heartbeat_ticks: Arc::new(AtomicUsize::new(0)),
+        last_session_id: last_session_id.clone(),
+        last_channel: last_channel.clone(),
+    }));
+
+    runner.fire_session_start("sess-123", "websocket").await;
+
+    assert_eq!(session_starts.load(Ordering::SeqCst), 1);
+    assert_eq!(*last_session_id.lock(), "sess-123");
+    assert_eq!(*last_channel.lock(), "websocket");
+}
+
+#[tokio::test]
+async fn fire_session_end_passes_session_id_and_channel() {
+    let session_ends = Arc::new(AtomicUsize::new(0));
+    let last_session_id = Arc::new(parking_lot::Mutex::new(String::new()));
+    let last_channel = Arc::new(parking_lot::Mutex::new(String::new()));
+
+    let mut runner = HookRunner::new();
+    runner.register(Box::new(LifecycleCounterHook {
+        gateway_stops: Arc::new(AtomicUsize::new(0)),
+        session_starts: Arc::new(AtomicUsize::new(0)),
+        session_ends: session_ends.clone(),
+        heartbeat_ticks: Arc::new(AtomicUsize::new(0)),
+        last_session_id: last_session_id.clone(),
+        last_channel: last_channel.clone(),
+    }));
+
+    runner.fire_session_end("sess-456", "websocket").await;
+
+    assert_eq!(session_ends.load(Ordering::SeqCst), 1);
+    assert_eq!(*last_session_id.lock(), "sess-456");
+    assert_eq!(*last_channel.lock(), "websocket");
+}
+
+#[tokio::test]
+async fn fire_heartbeat_tick_dispatches_to_all_handlers() {
+    let ticks1 = Arc::new(AtomicUsize::new(0));
+    let ticks2 = Arc::new(AtomicUsize::new(0));
+
+    let mut runner = HookRunner::new();
+    runner.register(Box::new(LifecycleCounterHook {
+        gateway_stops: Arc::new(AtomicUsize::new(0)),
+        session_starts: Arc::new(AtomicUsize::new(0)),
+        session_ends: Arc::new(AtomicUsize::new(0)),
+        heartbeat_ticks: ticks1.clone(),
+        last_session_id: Arc::new(parking_lot::Mutex::new(String::new())),
+        last_channel: Arc::new(parking_lot::Mutex::new(String::new())),
+    }));
+    runner.register(Box::new(LifecycleCounterHook {
+        gateway_stops: Arc::new(AtomicUsize::new(0)),
+        session_starts: Arc::new(AtomicUsize::new(0)),
+        session_ends: Arc::new(AtomicUsize::new(0)),
+        heartbeat_ticks: ticks2.clone(),
+        last_session_id: Arc::new(parking_lot::Mutex::new(String::new())),
+        last_channel: Arc::new(parking_lot::Mutex::new(String::new())),
+    }));
+
+    runner.fire_heartbeat_tick().await;
+
+    assert_eq!(ticks1.load(Ordering::SeqCst), 1);
+    assert_eq!(ticks2.load(Ordering::SeqCst), 1);
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -3,6 +3,7 @@ mod agent_robustness;
 mod backup_cron_scheduling;
 mod channel_matrix;
 mod channel_routing;
+mod hook_execution_lifecycle;
 mod hooks;
 mod memory_comparison;
 mod memory_loop_continuity;


### PR DESCRIPTION
## Summary

Wires void lifecycle hooks into four existing execution points:

- **Gateway shutdown** (`fire_gateway_stop`): fires during graceful shutdown before the server stops accepting connections
- **WebSocket session start/end** (`fire_session_start`, `fire_session_end`): fires after session hydration and after the message loop exits, passing session ID and channel name
- **Heartbeat tick** (`fire_heartbeat_tick`): fires on each heartbeat interval tick before task processing

All four hooks use the existing `HookRunner` parallel dispatch (`join_all`) and are fire-and-forget. Hook panics are isolated via the existing `catch_unwind` wrapper.

## Changes

- `src/gateway/mod.rs`: Add `hooks: Option<Arc<HookRunner>>` to `AppState`; initialize from `config.hooks.enabled`; fire `gateway_stop` in shutdown handler
- `src/gateway/ws.rs`: Fire `session_start` after session hydration, `session_end` after message loop exit
- `src/heartbeat/engine.rs`: Accept optional `HookRunner`; fire `heartbeat_tick` on each interval
- `src/daemon/mod.rs`: Initialize `HookRunner` for heartbeat worker when hooks are enabled
- `tests/integration/hook_execution_lifecycle.rs`: 4 integration tests covering all lifecycle hooks

## Non-goals

- Does not add new hook handler trait methods (uses existing `on_gateway_stop`, `on_session_start`, `on_session_end`, `on_heartbeat_tick`)
- Does not wire `fire_message_sent` (separate PR)
- Does not wire modifying hooks (`run_before_*`) — those are in a separate PR

## Testing

- 4 new integration tests verify dispatch to registered handlers with correct parameters
- Existing `cargo test --all` passes