### PR TITLE
fix(providers): skip responses fallback on transport errors

### DIFF
--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -1315,22 +1315,7 @@ impl Provider for OpenAiCompatibleProvider {
             .await
         {
             Ok(response) => response,
-            Err(chat_error) => {
-                if self.supports_responses_fallback {
-                    let sanitized = super::sanitize_api_error(&chat_error.to_string());
-                    return self
-                        .chat_via_responses(credential, &fallback_messages, model)
-                        .await
-                        .map_err(|responses_err| {
-                            anyhow::anyhow!(
-                                "{} chat completions transport error: {sanitized} (responses fallback failed: {responses_err})",
-                                self.name
-                            )
-                        });
-                }
-
-                return Err(chat_error.into());
-            }
+            Err(chat_error) => return Err(chat_error.into()),
         };
 
         if !response.status().is_success() {
@@ -1427,22 +1412,7 @@ impl Provider for OpenAiCompatibleProvider {
             .await
         {
             Ok(response) => response,
-            Err(chat_error) => {
-                if self.supports_responses_fallback {
-                    let sanitized = super::sanitize_api_error(&chat_error.to_string());
-                    return self
-                        .chat_via_responses(credential, &effective_messages, model)
-                        .await
-                        .map_err(|responses_err| {
-                            anyhow::anyhow!(
-                                "{} chat completions transport error: {sanitized} (responses fallback failed: {responses_err})",
-                                self.name
-                            )
-                        });
-                }
-
-                return Err(chat_error.into());
-            }
+            Err(chat_error) => return Err(chat_error.into()),
         };
 
         if !response.status().is_success() {
@@ -1650,28 +1620,7 @@ impl Provider for OpenAiCompatibleProvider {
             .await
         {
             Ok(response) => response,
-            Err(chat_error) => {
-                if self.supports_responses_fallback {
-                    let sanitized = super::sanitize_api_error(&chat_error.to_string());
-                    return self
-                        .chat_via_responses(credential, &effective_messages, model)
-                        .await
-                        .map(|text| ProviderChatResponse {
-                            text: Some(text),
-                            tool_calls: vec![],
-                            usage: None,
-                            reasoning_content: None,
-                        })
-                        .map_err(|responses_err| {
-                            anyhow::anyhow!(
-                                "{} native chat transport error: {sanitized} (responses fallback failed: {responses_err})",
-                                self.name
-                            )
-                        });
-                }
-
-                return Err(chat_error.into());
-            }
+            Err(chat_error) => return Err(chat_error.into()),
         };
 
         if !response.status().is_success() {
@@ -1864,9 +1813,37 @@ impl Provider for OpenAiCompatibleProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::providers::traits::ChatRequest;
+    use crate::tools::ToolSpec;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use std::time::Duration;
 
     fn make_provider(name: &str, url: &str, key: Option<&str>) -> OpenAiCompatibleProvider {
         OpenAiCompatibleProvider::new(name, url, key, AuthStyle::Bearer)
+    }
+
+    async fn spawn_transport_error_server(
+    ) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let addr = listener.local_addr().expect("listener addr");
+        let connection_count = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&connection_count);
+
+        let handle = tokio::spawn(async move {
+            while let Ok(Ok((stream, _))) =
+                tokio::time::timeout(Duration::from_millis(200), listener.accept()).await
+            {
+                counter.fetch_add(1, Ordering::SeqCst);
+                drop(stream);
+            }
+        });
+
+        (format!("http://{addr}/v1"), connection_count, handle)
     }
 
     #[test]
@@ -2122,6 +2099,97 @@ mod tests {
         assert!(err
             .to_string()
             .contains("requires at least one non-system message"));
+    }
+
+    #[tokio::test]
+    async fn chat_with_system_transport_error_does_not_attempt_responses_fallback() {
+        let (base_url, connection_count, server) = spawn_transport_error_server().await;
+        let provider = make_provider("custom", &base_url, Some("test-key"));
+
+        let err = provider
+            .chat_with_system(Some("policy"), "hello", "gpt-test", 0.0)
+            .await
+            .expect_err("transport error should bubble up");
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        server.abort();
+
+        assert!(
+            connection_count.load(Ordering::SeqCst) <= 1,
+            "transport errors should not trigger a second /responses attempt"
+        );
+        assert!(
+            !err.to_string().contains("responses fallback failed"),
+            "transport error should be reported directly"
+        );
+    }
+
+    #[tokio::test]
+    async fn chat_with_history_transport_error_does_not_attempt_responses_fallback() {
+        let (base_url, connection_count, server) = spawn_transport_error_server().await;
+        let provider = make_provider("custom", &base_url, Some("test-key"));
+
+        let err = provider
+            .chat_with_history(
+                &[ChatMessage::system("policy"), ChatMessage::user("hello")],
+                "gpt-test",
+                0.0,
+            )
+            .await
+            .expect_err("transport error should bubble up");
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        server.abort();
+
+        assert!(
+            connection_count.load(Ordering::SeqCst) <= 1,
+            "transport errors should not trigger a second /responses attempt"
+        );
+        assert!(
+            !err.to_string().contains("responses fallback failed"),
+            "transport error should be reported directly"
+        );
+    }
+
+    #[tokio::test]
+    async fn native_chat_transport_error_does_not_attempt_responses_fallback() {
+        let (base_url, connection_count, server) = spawn_transport_error_server().await;
+        let provider = make_provider("custom", &base_url, Some("test-key"));
+        let messages = [ChatMessage::user("hello")];
+        let tools = [ToolSpec {
+            name: "shell".to_string(),
+            description: "Run shell commands".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "command": {"type": "string"}
+                }
+            }),
+        }];
+
+        let err = provider
+            .chat(
+                ChatRequest {
+                    messages: &messages,
+                    tools: Some(&tools),
+                },
+                "gpt-test",
+                0.0,
+            )
+            .await
+            .expect_err("transport error should bubble up");
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        server.abort();
+
+        assert!(
+            connection_count.load(Ordering::SeqCst) <= 1,
+            "transport errors should not trigger a second /responses attempt"
+        );
+        assert!(
+            !err.to_string().contains("responses fallback failed"),
+            "transport error should be reported directly"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: `OpenAiCompatibleProvider` still retries `/responses` after transport-layer failures from `/chat/completions`, even though the endpoint is already unreachable.
- Why it matters: This adds avoidable latency before surfacing the error and delays `ReliableProvider` failover to the next provider/model.
- What changed: Rebased the original fix onto the latest `upstream/master`; removed transport-error-triggered `/responses` fallback from `chat_with_system`, `chat_with_history`, and native `chat`; kept the existing `404 -> /responses` fallback; preserved the regression tests that count connections and verify transport errors no longer trigger a second request.
- What did **not** change (scope boundary): No changes to `404` fallback behavior, parsing, provider routing order, or non-compatible providers.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `provider,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `provider: compatible`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `auto-managed/read-only`
- If any auto-label is incorrect, note requested correction: `None`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `provider`

## Linked Issue

- Closes #
- Related #896, #2704
- Depends on # (if stacked)
- Supersedes #3260

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `#3260 by @whtiehack`
- Integrated scope by source PR (what was materially carried forward): `Rebased the exact transport-error fallback removal and compatible-provider regression tests from #3260 onto the latest upstream/master.`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): `Self-supersede by the same author; no additional contributor attribution was needed.`
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): `cargo fmt --all -- --check` passed. `cargo clippy --all-targets -- -D warnings` passed. Targeted regression tests (`cargo test transport_error_does_not_attempt_responses_fallback -- --nocapture`) passed and confirmed the three transport-error paths only open a single connection. On current upstream/master in this environment, `cargo test` under default parallel execution repeatedly fails in unrelated `providers::bedrock::tests::bearer_token_from_env` due an env-var race; `cargo test -- --test-threads=1` passed end-to-end.`
- If any command is intentionally skipped, explain why: `None`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: `N.A.`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: `Transport errors are surfaced directly; the change does not expand logging of request/response bodies or credentials.`
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): `Yes`

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N.A.`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `N.A.`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N.A.`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N.A.`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: `Code-only change.`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `Transport error from chat_with_system, chat_with_history, and native chat no longer triggers a second fallback connection.`
- Edge cases checked: `Transport errors now bubble up directly without the extra /responses attempt; the existing 404 fallback branches in compatible provider code remain unchanged in this rebase.`
- What was not verified: `Live provider failover latency and live 404 -> /responses fallback against real upstream endpoints.`

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `OpenAI-compatible provider error handling only.`
- Potential unintended effects: `If a deployment relied on path-specific transport failures where /chat/completions fails before HTTP status but /responses succeeds, this removes that implicit recovery path.`
- Guardrails/monitoring for early detection: `Regression tests assert a single request on transport error; ReliableProvider retains its normal retry/failover logic once the direct transport error is surfaced.`

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `Codex terminal tools (exec_command)`
- Workflow/plan summary (if any): `Reviewed the maintainer comment on #3260, rebased the original single fix commit onto latest upstream/master, reran validation, and opened a fresh PR from a new branch.`
- Verification focus: `Avoiding unnecessary fallback latency while preserving the documented 404 fallback path.`
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: `git revert b885618c`
- Feature flags or config toggles (if any): `None`
- Observable failure symptoms: `A compatible provider now fails fast on transport errors instead of making a second /responses attempt.`

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: `Some custom reverse proxy could theoretically fail /chat/completions at the transport layer while still serving /responses.`
  - Mitigation: `The existing HTTP 404 fallback remains for the documented “wrong path, live endpoint” case; transport failures now surface quickly so ReliableProvider can retry/fail over instead of waiting on an extra request.`
