### PR TITLE
feat(channels): add room creation and user invite API to Channel trait

### DIFF
--- a/src/agent/context_compressor.rs
+++ b/src/agent/context_compressor.rs
@@ -272,8 +272,7 @@ impl ContextCompressor {
                 continue;
             }
             let original_len = msg.content.len();
-            msg.content =
-                crate::agent::loop_::truncate_tool_result(&msg.content, max);
+            msg.content = crate::agent::loop_::truncate_tool_result(&msg.content, max);
             saved += original_len - msg.content.len();
         }
         saved

--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -142,7 +142,10 @@ impl InteractiveSessionState {
     }
 }
 
-pub(crate) fn load_interactive_session_history(path: &Path, system_prompt: &str) -> Result<Vec<ChatMessage>> {
+pub(crate) fn load_interactive_session_history(
+    path: &Path,
+    system_prompt: &str,
+) -> Result<Vec<ChatMessage>> {
     if !path.exists() {
         return Ok(vec![ChatMessage::system(system_prompt)]);
     }

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1992,7 +1992,6 @@ struct StreamedChatOutcome {
     forwarded_live_deltas: bool,
 }
 
-
 async fn consume_provider_streaming_response(
     provider: &dyn Provider,
     messages: &[ChatMessage],
@@ -3049,7 +3048,8 @@ pub(crate) async fn run_tool_call_loop(
 
             let signature = {
                 let canonical_args = canonicalize_json_for_tool_signature(&tool_args);
-                let args_json = serde_json::to_string(&canonical_args).unwrap_or_else(|_| "{}".to_string());
+                let args_json =
+                    serde_json::to_string(&canonical_args).unwrap_or_else(|_| "{}".to_string());
                 (tool_name.trim().to_ascii_lowercase(), args_json)
             };
             let dedup_exempt = dedup_exempt_tools.iter().any(|e| e == &tool_name);
@@ -3113,7 +3113,9 @@ pub(crate) async fn run_tool_call_loop(
                 let hint = {
                     let raw = match tool_name.as_str() {
                         "shell" => tool_args.get("command").and_then(|v| v.as_str()),
-                        "file_read" | "file_write" => tool_args.get("path").and_then(|v| v.as_str()),
+                        "file_read" | "file_write" => {
+                            tool_args.get("path").and_then(|v| v.as_str())
+                        }
                         _ => tool_args
                             .get("action")
                             .and_then(|v| v.as_str())

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -10,11 +10,11 @@ pub mod history;
 pub mod history_pruner;
 pub mod loop_;
 pub mod loop_detector;
-pub mod tool_execution;
 pub mod memory_loader;
 pub mod personality;
 pub mod prompt;
 pub mod thinking;
+pub mod tool_execution;
 
 #[cfg(test)]
 mod tests;

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -1760,6 +1760,93 @@ impl Channel for MatrixChannel {
             }
         }
     }
+
+    async fn create_room(
+        &self,
+        name: Option<&str>,
+        topic: Option<&str>,
+        invites: Vec<String>,
+        visibility: Option<&str>,
+        encryption: Option<bool>,
+    ) -> anyhow::Result<String> {
+        use matrix_sdk::ruma::{
+            api::client::room::{create_room::v3::Request as CreateRoomRequest, Visibility},
+            serde::Raw,
+            OwnedUserId,
+        };
+
+        let client = self
+            .sdk_client
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("Matrix SDK client not initialized"))?;
+
+        let mut request = CreateRoomRequest::new();
+
+        if let Some(name) = name {
+            request.name = Some(name.to_string());
+        }
+
+        if let Some(topic) = topic {
+            request.topic = Some(topic.to_string());
+        }
+
+        // Parse and add invites
+        for user_id_str in invites {
+            let user_id: OwnedUserId = user_id_str
+                .parse()
+                .map_err(|_| anyhow::anyhow!("Invalid user ID: {}", user_id_str))?;
+            request.invite.push(user_id);
+        }
+
+        // Set visibility
+        if let Some(vis) = visibility {
+            request.visibility = match vis {
+                "private" => Visibility::Private,
+                "public" => Visibility::Public,
+                _ => anyhow::bail!("Invalid visibility: must be 'private' or 'public'"),
+            };
+        }
+
+        // Set encryption via raw JSON to avoid ruma version-dependent type differences
+        if encryption.unwrap_or(false) {
+            let enc_json = serde_json::json!({
+                "type": "m.room.encryption",
+                "state_key": "",
+                "content": {
+                    "algorithm": "m.megolm.v1.aes-sha2"
+                }
+            });
+            let raw = Raw::from_json(serde_json::value::to_raw_value(&enc_json)?);
+            request.initial_state.push(raw);
+        }
+
+        let response = client.create_room(request).await?;
+        Ok(response.room_id().to_string())
+    }
+
+    async fn invite_user(&self, room_id: &str, user_id: &str) -> anyhow::Result<()> {
+        use matrix_sdk::ruma::{OwnedRoomId, OwnedUserId};
+
+        let client = self
+            .sdk_client
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("Matrix SDK client not initialized"))?;
+
+        let room_id: OwnedRoomId = room_id
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Invalid room ID: {}", room_id))?;
+
+        let room = client
+            .get_room(&room_id)
+            .ok_or_else(|| anyhow::anyhow!("Matrix room not found for invite"))?;
+
+        let user_id: OwnedUserId = user_id
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Invalid user ID: {}", user_id))?;
+
+        room.invite_user_by_id(&user_id).await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/channels/traits.rs
+++ b/src/channels/traits.rs
@@ -211,6 +211,34 @@ pub trait Channel: Send + Sync {
     ) -> anyhow::Result<()> {
         Ok(())
     }
+
+    /// Create a room/channel/conversation on the platform.
+    ///
+    /// `name` is the human-readable room name.
+    /// `topic` is an optional room description or purpose.
+    /// `invites` is a list of user IDs to invite to the room.
+    /// `visibility` is an optional visibility setting ("public" or "private").
+    /// `encryption` is an optional flag to enable end-to-end encryption.
+    ///
+    /// Returns the platform-scoped room identifier.
+    async fn create_room(
+        &self,
+        _name: Option<&str>,
+        _topic: Option<&str>,
+        _invites: Vec<String>,
+        _visibility: Option<&str>,
+        _encryption: Option<bool>,
+    ) -> anyhow::Result<String> {
+        Ok(String::new())
+    }
+
+    /// Invite a user to a room/channel/conversation.
+    ///
+    /// `room_id` is the platform-scoped room identifier.
+    /// `user_id` is the platform-scoped user identifier.
+    async fn invite_user(&self, _room_id: &str, _user_id: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -340,6 +368,34 @@ mod tests {
             .is_ok());
         assert!(channel
             .redact_message("chan_1", "msg_2", None)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn default_create_room_returns_success() {
+        let channel = DummyChannel;
+
+        let room_id = channel
+            .create_room(
+                Some("Test Room"),
+                Some("Test Topic"),
+                vec!["@user:example.com".to_string()],
+                Some("private"),
+                Some(true),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(room_id, "");
+    }
+
+    #[tokio::test]
+    async fn default_invite_user_returns_success() {
+        let channel = DummyChannel;
+
+        assert!(channel
+            .invite_user("room_1", "@user:example.com")
             .await
             .is_ok());
     }

--- a/tests/integration/channel_matrix.rs
+++ b/tests/integration/channel_matrix.rs
@@ -65,6 +65,17 @@ enum ChannelEvent {
         message_id: String,
         reason: Option<String>,
     },
+    CreateRoom {
+        name: Option<String>,
+        topic: Option<String>,
+        invites: Vec<String>,
+        visibility: Option<String>,
+        encryption: Option<bool>,
+    },
+    InviteUser {
+        room_id: String,
+        user_id: String,
+    },
 }
 
 /// Full-featured matrix test channel that tracks every trait method invocation.
@@ -277,6 +288,38 @@ impl Channel for MatrixTestChannel {
                 message_id: message_id.to_string(),
                 reason,
             });
+        Ok(())
+    }
+
+    async fn create_room(
+        &self,
+        name: Option<&str>,
+        topic: Option<&str>,
+        invites: Vec<String>,
+        visibility: Option<&str>,
+        encryption: Option<bool>,
+    ) -> anyhow::Result<String> {
+        let room_id = format!(
+            "!test_room_{}:example.com",
+            self.events.lock().unwrap().len()
+        );
+
+        self.events.lock().unwrap().push(ChannelEvent::CreateRoom {
+            name: name.map(String::from),
+            topic: topic.map(String::from),
+            invites,
+            visibility: visibility.map(String::from),
+            encryption,
+        });
+
+        Ok(room_id)
+    }
+
+    async fn invite_user(&self, room_id: &str, user_id: &str) -> anyhow::Result<()> {
+        self.events.lock().unwrap().push(ChannelEvent::InviteUser {
+            room_id: room_id.to_string(),
+            user_id: user_id.to_string(),
+        });
         Ok(())
     }
 }
@@ -612,7 +655,68 @@ async fn redact_message_lifecycle() {
 }
 
 // ═════════════════════════════════════════════════════════════════════════════
-// 7. CHANNEL MESSAGE IDENTITY & FIELD SEMANTICS
+// 7. ROOM CREATION AND INVITE SUPPORT
+// ═════════════════════════════════════════════════════════════════════════════
+
+#[tokio::test]
+async fn create_room_lifecycle() {
+    let ch = MatrixTestChannel::new("matrix");
+
+    let room_id = ch
+        .create_room(
+            Some("Project Discussion"),
+            Some("Discuss project updates"),
+            vec![
+                "@alice:example.com".to_string(),
+                "@bob:example.com".to_string(),
+            ],
+            Some("private"),
+            Some(true),
+        )
+        .await
+        .unwrap();
+
+    assert!(!room_id.is_empty());
+
+    let events = ch.events();
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        ChannelEvent::CreateRoom {
+            name,
+            topic,
+            invites,
+            visibility,
+            encryption
+        } if name == &Some("Project Discussion".to_string())
+            && topic == &Some("Discuss project updates".to_string())
+            && invites.len() == 2
+            && visibility == &Some("private".to_string())
+            && encryption == &Some(true)
+    ));
+}
+
+#[tokio::test]
+async fn invite_user_lifecycle() {
+    let ch = MatrixTestChannel::new("matrix");
+
+    ch.invite_user("!room:example.com", "@user:example.com")
+        .await
+        .unwrap();
+
+    let events = ch.events();
+    assert_eq!(events.len(), 1);
+    assert!(matches!(
+        &events[0],
+        ChannelEvent::InviteUser {
+            room_id,
+            user_id
+        } if room_id == "!room:example.com" && user_id == "@user:example.com"
+    ));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// 8. CHANNEL MESSAGE IDENTITY & FIELD SEMANTICS
 // ═════════════════════════════════════════════════════════════════════════════
 
 #[test]
@@ -1350,6 +1454,20 @@ async fn minimal_channel_all_defaults_succeed() {
         .await
         .is_ok());
     assert!(ch.redact_message("c", "m", None).await.is_ok());
+    let room_id = ch
+        .create_room(
+            Some("Test"),
+            Some("Topic"),
+            vec!["@user:example.com".to_string()],
+            Some("private"),
+            Some(true),
+        )
+        .await
+        .unwrap();
+    assert!(ch
+        .invite_user(&room_id, "@another:example.com")
+        .await
+        .is_ok());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Add `create_room()` and `invite_user()` methods to the `Channel` trait with default no-op implementations. Implement both for `MatrixChannel` using the Matrix SDK.

### Changes

- **Modified:** `src/channels/traits.rs` — added `create_room()` and `invite_user()` trait methods with default implementations
- **Modified:** `src/channels/matrix.rs` — `MatrixChannel` implementation using `matrix_sdk` room creation and invite APIs
- **Modified:** `tests/integration/channel_matrix.rs` — new enum variants, test channel implementations, lifecycle tests, updated minimal channel contract test

### Parameters

`create_room(name, topic, invites, visibility, encryption)`:
- `name`: optional room name
- `topic`: optional room description
- `invites`: list of user IDs to invite
- `visibility`: `"private"` or `"public"`
- `encryption`: optional flag for E2EE (Megolm v1)

`invite_user(room_id, user_id)`:
- `room_id`: platform-scoped room identifier
- `user_id`: platform-scoped user identifier

### Test coverage

- Trait default tests (DummyChannel returns empty/Ok)
- MatrixTestChannel lifecycle tests (create_room, invite_user)
- Minimal channel contract test (Box<dyn Channel> dispatch)
- 8 trait tests + 53 integration tests passing

### Risk

**Medium** — channel trait boundary modification. All existing implementations continue to compile without changes (default no-op implementations).

### Breaking changes

None. New trait methods have default implementations.

### Non-goals

- No tool exposure (deferred to future PR)
- No Discord/Telegram/Slack implementations (use trait defaults)
- No advanced room settings (power levels, aliases, federation)
- No bulk invites or room membership management