### PR TITLE
feat(knowledge): add client relationship node types and tool actions

### DIFF
--- a/src/hardware/uf2.rs
+++ b/src/hardware/uf2.rs
@@ -364,7 +364,10 @@ mod tests {
         // Either succeeds (real UF2) or fails with a clear placeholder message.
         match result {
             Ok(dir) => {
-                assert!(dir.exists(), "firmware dir should exist after ensure_firmware_dir");
+                assert!(
+                    dir.exists(),
+                    "firmware dir should exist after ensure_firmware_dir"
+                );
                 assert!(dir.ends_with("pico"), "firmware dir should end with 'pico'");
             }
             Err(e) => {
@@ -416,7 +419,10 @@ mod tests {
 
         let port = std::path::Path::new("/dev/ttyACM_fake_test");
         let result = deploy_main_py(port, firmware_dir).await;
-        assert!(result.is_err(), "deploy should fail when main.py is missing");
+        assert!(
+            result.is_err(),
+            "deploy should fail when main.py is missing"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("main.py not found"),

--- a/src/memory/knowledge_graph.rs
+++ b/src/memory/knowledge_graph.rs
@@ -25,6 +25,10 @@ pub enum NodeType {
     Lesson,
     Expert,
     Technology,
+    // Client relationship types
+    Client,
+    Contact,
+    Interaction,
 }
 
 impl NodeType {
@@ -35,6 +39,9 @@ impl NodeType {
             Self::Lesson => "lesson",
             Self::Expert => "expert",
             Self::Technology => "technology",
+            Self::Client => "client",
+            Self::Contact => "contact",
+            Self::Interaction => "interaction",
         }
     }
 
@@ -45,6 +52,9 @@ impl NodeType {
             "lesson" => Ok(Self::Lesson),
             "expert" => Ok(Self::Expert),
             "technology" => Ok(Self::Technology),
+            "client" => Ok(Self::Client),
+            "contact" => Ok(Self::Contact),
+            "interaction" => Ok(Self::Interaction),
             other => anyhow::bail!("unknown node type: {other}"),
         }
     }
@@ -59,6 +69,10 @@ pub enum Relation {
     Extends,
     AuthoredBy,
     AppliesTo,
+    // Client relationship types
+    ManagesClient,
+    ContactOf,
+    InteractedWith,
 }
 
 impl Relation {
@@ -69,6 +83,9 @@ impl Relation {
             Self::Extends => "extends",
             Self::AuthoredBy => "authored_by",
             Self::AppliesTo => "applies_to",
+            Self::ManagesClient => "manages_client",
+            Self::ContactOf => "contact_of",
+            Self::InteractedWith => "interacted_with",
         }
     }
 
@@ -79,6 +96,9 @@ impl Relation {
             "extends" => Ok(Self::Extends),
             "authored_by" => Ok(Self::AuthoredBy),
             "applies_to" => Ok(Self::AppliesTo),
+            "manages_client" => Ok(Self::ManagesClient),
+            "contact_of" => Ok(Self::ContactOf),
+            "interacted_with" => Ok(Self::InteractedWith),
             other => anyhow::bail!("unknown relation: {other}"),
         }
     }
@@ -386,6 +406,47 @@ impl KnowledgeGraph {
             let relation_str: String = row.get(8)?;
             let relation = Relation::parse(&relation_str)?;
             results.push((node, relation));
+        }
+        Ok(results)
+    }
+
+    /// Find nodes with edges pointing to the given node (inbound edges).
+    pub fn find_inbound(&self, node_id: &str) -> anyhow::Result<Vec<(KnowledgeNode, Relation)>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(
+            "SELECT n.id, n.node_type, n.title, n.content, n.tags,
+                    n.created_at, n.updated_at, n.source_project,
+                    e.relation
+             FROM edges e
+             JOIN nodes n ON n.id = e.from_id
+             WHERE e.to_id = ?1",
+        )?;
+        let mut results = Vec::new();
+        let mut rows = stmt.query(params![node_id])?;
+        while let Some(row) = rows.next()? {
+            let node = row_to_node(row)?;
+            let relation_str: String = row.get(8)?;
+            let relation = Relation::parse(&relation_str)?;
+            results.push((node, relation));
+        }
+        Ok(results)
+    }
+
+    /// Query nodes by type, ordered by most recently updated.
+    pub fn query_by_type(
+        &self,
+        node_type: &NodeType,
+        limit: usize,
+    ) -> anyhow::Result<Vec<KnowledgeNode>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(
+            "SELECT id, node_type, title, content, tags, created_at, updated_at, source_project
+             FROM nodes WHERE node_type = ?1 ORDER BY updated_at DESC LIMIT ?2",
+        )?;
+        let mut results = Vec::new();
+        let mut rows = stmt.query(params![node_type.as_str(), limit as i64])?;
+        while let Some(row) = rows.next()? {
+            results.push(row_to_node(row)?);
         }
         Ok(results)
     }
@@ -843,6 +904,9 @@ mod tests {
             NodeType::Lesson,
             NodeType::Expert,
             NodeType::Technology,
+            NodeType::Client,
+            NodeType::Contact,
+            NodeType::Interaction,
         ] {
             assert_eq!(&NodeType::parse(nt.as_str()).unwrap(), nt);
         }
@@ -856,6 +920,9 @@ mod tests {
             Relation::Extends,
             Relation::AuthoredBy,
             Relation::AppliesTo,
+            Relation::ManagesClient,
+            Relation::ContactOf,
+            Relation::InteractedWith,
         ] {
             assert_eq!(&Relation::parse(r.as_str()).unwrap(), r);
         }

--- a/src/peripherals/uno_q_bridge.rs
+++ b/src/peripherals/uno_q_bridge.rs
@@ -208,7 +208,10 @@ mod tests {
         let tool = UnoQGpioReadTool;
         let result = tool.execute(json!({"pin": 13})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.is_some(), "should report bridge connection error");
+        assert!(
+            result.error.is_some(),
+            "should report bridge connection error"
+        );
     }
 
     // ── UnoQGpioWriteTool ───────────────────────────────────────────────
@@ -277,7 +280,10 @@ mod tests {
         let tool = UnoQGpioWriteTool;
         let result = tool.execute(json!({"pin": 13, "value": 1})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.is_some(), "should report bridge connection error");
+        assert!(
+            result.error.is_some(),
+            "should report bridge connection error"
+        );
     }
 
     // ── Constants ───────────────────────────────────────────────────────

--- a/src/tools/knowledge_tool.rs
+++ b/src/tools/knowledge_tool.rs
@@ -27,7 +27,7 @@ impl Tool for KnowledgeTool {
     }
 
     fn description(&self) -> &str {
-        "Manage a knowledge graph of architecture decisions, solution patterns, lessons learned, and experts. Actions: capture, search, relate, suggest, expert_find, lessons_extract, graph_stats."
+        "Manage a knowledge graph of architecture decisions, solution patterns, lessons learned, experts, and client relationships. Actions: capture, search, relate, suggest, expert_find, lessons_extract, graph_stats, client_network, interaction_log."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -36,12 +36,12 @@ impl Tool for KnowledgeTool {
             "properties": {
                 "action": {
                     "type": "string",
-                    "enum": ["capture", "search", "relate", "suggest", "expert_find", "lessons_extract", "graph_stats"],
+                    "enum": ["capture", "search", "relate", "suggest", "expert_find", "lessons_extract", "graph_stats", "client_network", "interaction_log"],
                     "description": "The action to perform"
                 },
                 "node_type": {
                     "type": "string",
-                    "enum": ["pattern", "decision", "lesson", "expert", "technology"],
+                    "enum": ["pattern", "decision", "lesson", "expert", "technology", "client", "contact", "interaction"],
                     "description": "Type of knowledge node (for capture)"
                 },
                 "title": {
@@ -75,8 +75,16 @@ impl Tool for KnowledgeTool {
                 },
                 "relation": {
                     "type": "string",
-                    "enum": ["uses", "replaces", "extends", "authored_by", "applies_to"],
+                    "enum": ["uses", "replaces", "extends", "authored_by", "applies_to", "manages_client", "contact_of", "interacted_with"],
                     "description": "Relationship type (for relate)"
+                },
+                "client_id": {
+                    "type": "string",
+                    "description": "Client node ID (for client_network, interaction_log)"
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results (for interaction_log)"
                 },
                 "filters": {
                     "type": "object",
@@ -106,6 +114,8 @@ impl Tool for KnowledgeTool {
             "expert_find" => self.handle_expert_find(&args),
             "lessons_extract" => self.handle_lessons_extract(&args),
             "graph_stats" => self.handle_graph_stats(),
+            "client_network" => self.handle_client_network(&args),
+            "interaction_log" => self.handle_interaction_log(&args),
             other => Ok(ToolResult {
                 success: false,
                 output: String::new(),
@@ -409,6 +419,100 @@ impl KnowledgeTool {
                 error: Some(format!("failed to get stats: {e}")),
             }),
         }
+    }
+
+    fn handle_client_network(&self, args: &serde_json::Value) -> anyhow::Result<ToolResult> {
+        let client_id = args
+            .get("client_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("missing 'client_id' for client_network"))?;
+
+        let client = self
+            .graph
+            .get_node(client_id)?
+            .ok_or_else(|| anyhow::anyhow!("client node not found: {client_id}"))?;
+
+        if client.node_type != NodeType::Client {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "node {} is not a client (is {})",
+                    client_id,
+                    client.node_type.as_str()
+                )),
+            });
+        }
+
+        // Get contacts and interactions pointing to this client
+        let inbound = self.graph.find_inbound(client_id)?;
+        let contacts: Vec<_> = inbound
+            .iter()
+            .filter(|(n, r)| n.node_type == NodeType::Contact && *r == Relation::ContactOf)
+            .map(|(n, _)| json!({"id": &n.id, "name": &n.title, "tags": &n.tags}))
+            .collect();
+
+        let outbound = self.graph.find_related(client_id)?;
+        let interactions: Vec<_> = outbound.iter()
+            .filter(|(n, r)| n.node_type == NodeType::Interaction && *r == Relation::InteractedWith)
+            .map(|(n, _)| json!({"id": &n.id, "title": &n.title, "date": &n.created_at, "summary": truncate_str(&n.content, 200)}))
+            .collect();
+
+        Ok(ToolResult {
+            success: true,
+            output: json!({
+                "client": {"id": &client.id, "name": &client.title, "tags": &client.tags},
+                "contacts": contacts,
+                "interactions": interactions,
+                "contact_count": contacts.len(),
+                "interaction_count": interactions.len(),
+            })
+            .to_string(),
+            error: None,
+        })
+    }
+
+    fn handle_interaction_log(&self, args: &serde_json::Value) -> anyhow::Result<ToolResult> {
+        let client_id = args
+            .get("client_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("missing 'client_id' for interaction_log"))?;
+
+        let limit = args
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .and_then(|v| usize::try_from(v).ok())
+            .unwrap_or(20);
+
+        let outbound = self.graph.find_related(client_id)?;
+        let mut interactions: Vec<_> = outbound
+            .into_iter()
+            .filter(|(n, r)| n.node_type == NodeType::Interaction && *r == Relation::InteractedWith)
+            .map(|(n, _)| n)
+            .collect();
+
+        // Sort by created_at descending (most recent first)
+        interactions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        interactions.truncate(limit);
+
+        let entries: Vec<_> = interactions
+            .iter()
+            .map(|n| {
+                json!({
+                    "id": &n.id,
+                    "title": &n.title,
+                    "content": &n.content,
+                    "date": &n.created_at,
+                    "tags": &n.tags,
+                })
+            })
+            .collect();
+
+        Ok(ToolResult {
+            success: true,
+            output: json!({"interactions": entries, "count": entries.len()}).to_string(),
+            error: None,
+        })
     }
 }
 

--- a/tests/integration/knowledge_client.rs
+++ b/tests/integration/knowledge_client.rs
@@ -1,0 +1,298 @@
+//! Integration tests for knowledge graph client relationship features.
+
+use serde_json::json;
+use std::sync::Arc;
+use tempfile::TempDir;
+use zeroclaw::memory::knowledge_graph::{KnowledgeGraph, NodeType, Relation};
+use zeroclaw::tools::knowledge_tool::KnowledgeTool;
+use zeroclaw::tools::traits::Tool;
+
+fn test_setup() -> (TempDir, Arc<KnowledgeGraph>, KnowledgeTool) {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("knowledge.db");
+    let graph = Arc::new(KnowledgeGraph::new(&db_path, 10000).unwrap());
+    let tool = KnowledgeTool::new(Arc::clone(&graph));
+    (tmp, graph, tool)
+}
+
+#[tokio::test]
+async fn capture_client_contact_interaction_roundtrip() {
+    let (_tmp, _graph, tool) = test_setup();
+
+    // Create client node
+    let client_result = tool
+        .execute(json!({
+            "action": "capture",
+            "node_type": "client",
+            "title": "Acme Corp",
+            "content": "Enterprise client focused on logistics automation",
+            "tags": ["enterprise", "logistics"]
+        }))
+        .await
+        .unwrap();
+    assert!(client_result.success);
+    let client_output: serde_json::Value = serde_json::from_str(&client_result.output).unwrap();
+    let client_id = client_output["node_id"].as_str().unwrap();
+
+    // Create contact node
+    let contact_result = tool
+        .execute(json!({
+            "action": "capture",
+            "node_type": "contact",
+            "title": "Jane Smith",
+            "content": "CTO at Acme Corp, technical decision maker",
+            "tags": ["technical", "decision-maker"]
+        }))
+        .await
+        .unwrap();
+    assert!(contact_result.success);
+    let contact_output: serde_json::Value = serde_json::from_str(&contact_result.output).unwrap();
+    let contact_id = contact_output["node_id"].as_str().unwrap();
+
+    // Create interaction node
+    let interaction_result = tool
+        .execute(json!({
+            "action": "capture",
+            "node_type": "interaction",
+            "title": "Discovery call - Q1 2026",
+            "content": "Discussed API integration requirements and timeline",
+            "tags": ["call", "discovery"]
+        }))
+        .await
+        .unwrap();
+    assert!(interaction_result.success);
+    let interaction_output: serde_json::Value =
+        serde_json::from_str(&interaction_result.output).unwrap();
+    let interaction_id = interaction_output["node_id"].as_str().unwrap();
+
+    // Create relationships
+    // Contact -> Client (contact_of)
+    let relate1 = tool
+        .execute(json!({
+            "action": "relate",
+            "from_id": contact_id,
+            "to_id": client_id,
+            "relation": "contact_of"
+        }))
+        .await
+        .unwrap();
+    assert!(relate1.success);
+
+    // Client -> Interaction (interacted_with)
+    let relate2 = tool
+        .execute(json!({
+            "action": "relate",
+            "from_id": client_id,
+            "to_id": interaction_id,
+            "relation": "interacted_with"
+        }))
+        .await
+        .unwrap();
+    assert!(relate2.success);
+
+    // Verify client_network returns all three
+    let network_result = tool
+        .execute(json!({
+            "action": "client_network",
+            "client_id": client_id
+        }))
+        .await
+        .unwrap();
+    assert!(network_result.success);
+    let network_output: serde_json::Value = serde_json::from_str(&network_result.output).unwrap();
+
+    assert_eq!(network_output["client"]["name"], "Acme Corp");
+    assert_eq!(network_output["contact_count"], 1);
+    assert_eq!(network_output["interaction_count"], 1);
+    assert_eq!(network_output["contacts"][0]["name"], "Jane Smith");
+    assert_eq!(
+        network_output["interactions"][0]["title"],
+        "Discovery call - Q1 2026"
+    );
+}
+
+#[tokio::test]
+async fn interaction_log_returns_sorted_recent() {
+    let (_tmp, graph, tool) = test_setup();
+
+    // Create client
+    let client_id = graph
+        .add_node(NodeType::Client, "TestClient", "Test client", &[], None)
+        .unwrap();
+
+    // Create 5 interactions with different timestamps
+    let mut interaction_ids = Vec::new();
+    for i in 1..=5 {
+        let id = graph
+            .add_node(
+                NodeType::Interaction,
+                &format!("Interaction {}", i),
+                &format!("Content {}", i),
+                &[],
+                None,
+            )
+            .unwrap();
+        interaction_ids.push(id.clone());
+
+        // Add edge from client to interaction
+        graph
+            .add_edge(&client_id, &id, Relation::InteractedWith)
+            .unwrap();
+
+        // Small delay to ensure different timestamps
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    // Query interaction log
+    let result = tool
+        .execute(json!({
+            "action": "interaction_log",
+            "client_id": client_id
+        }))
+        .await
+        .unwrap();
+
+    assert!(result.success);
+    let output: serde_json::Value = serde_json::from_str(&result.output).unwrap();
+    assert_eq!(output["count"], 5);
+
+    // Verify they're sorted by most recent first (Interaction 5 should be first)
+    let interactions = output["interactions"].as_array().unwrap();
+    assert_eq!(interactions[0]["title"], "Interaction 5");
+    assert_eq!(interactions[4]["title"], "Interaction 1");
+}
+
+#[tokio::test]
+async fn interaction_log_respects_limit() {
+    let (_tmp, graph, tool) = test_setup();
+
+    // Create client
+    let client_id = graph
+        .add_node(NodeType::Client, "TestClient", "Test client", &[], None)
+        .unwrap();
+
+    // Create 10 interactions
+    for i in 1..=10 {
+        let id = graph
+            .add_node(
+                NodeType::Interaction,
+                &format!("Interaction {}", i),
+                &format!("Content {}", i),
+                &[],
+                None,
+            )
+            .unwrap();
+        graph
+            .add_edge(&client_id, &id, Relation::InteractedWith)
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+
+    // Query with limit=3
+    let result = tool
+        .execute(json!({
+            "action": "interaction_log",
+            "client_id": client_id,
+            "limit": 3
+        }))
+        .await
+        .unwrap();
+
+    assert!(result.success);
+    let output: serde_json::Value = serde_json::from_str(&result.output).unwrap();
+    assert_eq!(output["count"], 3);
+}
+
+#[tokio::test]
+async fn client_network_rejects_non_client_node() {
+    let (_tmp, graph, tool) = test_setup();
+
+    // Create a Pattern node
+    let pattern_id = graph
+        .add_node(NodeType::Pattern, "Some Pattern", "Not a client", &[], None)
+        .unwrap();
+
+    // Try to call client_network with a non-client node
+    let result = tool
+        .execute(json!({
+            "action": "client_network",
+            "client_id": pattern_id
+        }))
+        .await
+        .unwrap();
+
+    assert!(!result.success);
+    assert!(result.error.unwrap().contains("not a client"));
+}
+
+#[tokio::test]
+async fn new_node_types_work_with_existing_search() {
+    let (_tmp, graph, tool) = test_setup();
+
+    // Create a Client node with tags
+    tool.execute(json!({
+        "action": "capture",
+        "node_type": "client",
+        "title": "SearchTest Corp",
+        "content": "Client for testing search functionality",
+        "tags": ["test", "search"]
+    }))
+    .await
+    .unwrap();
+
+    // Verify search finds it
+    let search_result = tool
+        .execute(json!({
+            "action": "search",
+            "query": "SearchTest"
+        }))
+        .await
+        .unwrap();
+
+    assert!(search_result.success);
+    let output: serde_json::Value = serde_json::from_str(&search_result.output).unwrap();
+    assert!(output["count"].as_u64().unwrap() > 0);
+
+    // Verify query_by_tags finds it
+    let clients = graph.query_by_tags(&["test".to_string()]).unwrap();
+    assert_eq!(clients.len(), 1);
+    assert_eq!(clients[0].title, "SearchTest Corp");
+}
+
+#[tokio::test]
+async fn new_relations_work_with_subgraph() {
+    let (_tmp, graph, _tool) = test_setup();
+
+    // Create client and interaction
+    let client_id = graph
+        .add_node(
+            NodeType::Client,
+            "SubgraphClient",
+            "Testing subgraph",
+            &[],
+            None,
+        )
+        .unwrap();
+
+    let interaction_id = graph
+        .add_node(
+            NodeType::Interaction,
+            "SubgraphInteraction",
+            "Testing subgraph edge",
+            &[],
+            None,
+        )
+        .unwrap();
+
+    // Create edge with InteractedWith relation
+    graph
+        .add_edge(&client_id, &interaction_id, Relation::InteractedWith)
+        .unwrap();
+
+    // Verify get_subgraph traverses the new relation
+    let (nodes, edges) = graph.get_subgraph(&client_id, 1).unwrap();
+
+    assert_eq!(nodes.len(), 2); // client + interaction
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].relation, Relation::InteractedWith);
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -4,6 +4,7 @@ mod backup_cron_scheduling;
 mod channel_matrix;
 mod channel_routing;
 mod hooks;
+mod knowledge_client;
 mod memory_comparison;
 mod memory_loop_continuity;
 mod memory_restart;


### PR DESCRIPTION
## Summary

- Add `Client`, `Contact`, and `Interaction` node types to the knowledge graph for modeling client relationships
- Add `ManagesClient`, `ContactOf`, and `InteractedWith` relations for linking entities
- Add `query_by_type()` and `find_inbound()` methods to `KnowledgeGraph`
- Add `client_network` and `interaction_log` tool actions to the knowledge tool
- Update tool description and parameter schema with new types/relations/actions

## Test plan

- [x] 6 new integration tests covering roundtrip capture/relate/query, sort order, limit parameter, error cases, search integration, and subgraph traversal
- [x] All existing knowledge graph unit tests pass (13 tests)
- [x] All existing knowledge tool unit tests pass (7 tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean