### PR TITLE
feat(calendar): add calendar-driven no-show detection triggers

### DIFF
--- a/src/calendar/mod.rs
+++ b/src/calendar/mod.rs
@@ -1,0 +1,2 @@
+pub mod poller;
+pub mod types;

--- a/src/calendar/poller.rs
+++ b/src/calendar/poller.rs
@@ -1,0 +1,97 @@
+use crate::calendar::types::{CalendarTriggerConfig, NoShowEvent, TrackedEvent};
+use crate::sop::types::{SopEvent, SopTriggerSource};
+use chrono::{DateTime, Duration, Utc};
+use std::collections::{HashMap, HashSet};
+
+pub struct CalendarPoller {
+    config: CalendarTriggerConfig,
+    /// Events currently being tracked: event_id -> TrackedEvent
+    tracked_events: HashMap<String, TrackedEvent>,
+    /// Event IDs that already fired a no-show (prevent duplicates)
+    already_fired: HashSet<String>,
+}
+
+impl CalendarPoller {
+    pub fn new(config: CalendarTriggerConfig) -> Self {
+        Self {
+            config,
+            tracked_events: HashMap::new(),
+            already_fired: HashSet::new(),
+        }
+    }
+
+    /// Update the set of tracked events from a calendar query result.
+    /// Returns how many events were added/updated.
+    pub fn track_events(&mut self, events: Vec<TrackedEvent>) -> usize {
+        let mut count = 0;
+        for event in events {
+            if !self.already_fired.contains(&event.event_id) {
+                self.tracked_events.insert(event.event_id.clone(), event);
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Detect no-shows: events whose start_time + threshold has passed.
+    /// Returns SopEvents for each detected no-show.
+    pub fn detect_no_shows(&mut self, now: DateTime<Utc>) -> Vec<SopEvent> {
+        let threshold = Duration::minutes(i64::from(self.config.no_show_threshold_minutes));
+        let mut sop_events = Vec::new();
+        let mut fired_ids = Vec::new();
+
+        for (id, event) in &self.tracked_events {
+            if self.already_fired.contains(id) {
+                continue;
+            }
+            if now >= event.start_time + threshold {
+                let no_show = NoShowEvent {
+                    event_id: event.event_id.clone(),
+                    event_title: event.event_title.clone(),
+                    expected_start: event.start_time,
+                    detected_at: now,
+                    calendar_source: self.config.calendar_source.clone(),
+                    calendar_id: event.calendar_id.clone(),
+                };
+                let sop_event = SopEvent {
+                    source: SopTriggerSource::Calendar,
+                    topic: Some("calendar.no_show".to_string()),
+                    payload: Some(serde_json::to_string(&no_show).unwrap()),
+                    timestamp: now.to_rfc3339(),
+                };
+                sop_events.push(sop_event);
+                fired_ids.push(id.clone());
+            }
+        }
+
+        for id in fired_ids {
+            self.already_fired.insert(id.clone());
+            self.tracked_events.remove(&id);
+        }
+
+        sop_events
+    }
+
+    /// Remove tracked events that are too old (past + 1 hour). Prevents memory leak.
+    pub fn cleanup_stale(&mut self, now: DateTime<Utc>) {
+        let cutoff = now - Duration::hours(1);
+        self.tracked_events.retain(|_, e| e.start_time > cutoff);
+        // Also clean already_fired for very old events (> 24h)
+        // We'd need timestamps for that, but for now we clean tracked_events
+    }
+
+    /// Number of currently tracked events.
+    pub fn tracked_count(&self) -> usize {
+        self.tracked_events.len()
+    }
+
+    /// Number of events that have already fired no-show alerts.
+    pub fn fired_count(&self) -> usize {
+        self.already_fired.len()
+    }
+
+    /// Access config (for trigger matching)
+    pub fn config(&self) -> &CalendarTriggerConfig {
+        &self.config
+    }
+}

--- a/src/calendar/types.rs
+++ b/src/calendar/types.rs
@@ -1,0 +1,47 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Configuration for calendar-driven trigger polling.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CalendarTriggerConfig {
+    /// Calendar provider (e.g. "microsoft365")
+    pub calendar_source: String,
+    /// Seconds between polls for upcoming events (default 300)
+    #[serde(default = "default_poll_interval")]
+    pub poll_interval_secs: u64,
+    /// Minutes after event start before declaring no-show (default 10)
+    #[serde(default = "default_no_show_threshold")]
+    pub no_show_threshold_minutes: u32,
+    /// Calendar IDs to watch (empty = primary calendar only)
+    #[serde(default)]
+    pub watch_calendars: Vec<String>,
+}
+
+fn default_poll_interval() -> u64 {
+    300
+}
+fn default_no_show_threshold() -> u32 {
+    10
+}
+
+/// Emitted when a calendar event's expected attendee doesn't show.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NoShowEvent {
+    pub event_id: String,
+    pub event_title: String,
+    pub expected_start: DateTime<Utc>,
+    pub detected_at: DateTime<Utc>,
+    pub calendar_source: String,
+    /// Which calendar this event was in
+    #[serde(default)]
+    pub calendar_id: String,
+}
+
+/// A tracked upcoming calendar event being monitored for no-shows.
+#[derive(Debug, Clone)]
+pub struct TrackedEvent {
+    pub event_id: String,
+    pub event_title: String,
+    pub start_time: DateTime<Utc>,
+    pub calendar_id: String,
+}

--- a/src/hardware/uf2.rs
+++ b/src/hardware/uf2.rs
@@ -364,7 +364,10 @@ mod tests {
         // Either succeeds (real UF2) or fails with a clear placeholder message.
         match result {
             Ok(dir) => {
-                assert!(dir.exists(), "firmware dir should exist after ensure_firmware_dir");
+                assert!(
+                    dir.exists(),
+                    "firmware dir should exist after ensure_firmware_dir"
+                );
                 assert!(dir.ends_with("pico"), "firmware dir should end with 'pico'");
             }
             Err(e) => {
@@ -416,7 +419,10 @@ mod tests {
 
         let port = std::path::Path::new("/dev/ttyACM_fake_test");
         let result = deploy_main_py(port, firmware_dir).await;
-        assert!(result.is_err(), "deploy should fail when main.py is missing");
+        assert!(
+            result.is_err(),
+            "deploy should fail when main.py is missing"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("main.py not found"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ use serde::{Deserialize, Serialize};
 pub mod agent;
 pub(crate) mod approval;
 pub(crate) mod auth;
+pub mod calendar;
 pub mod channels;
 pub(crate) mod cli_input;
 pub mod commands;

--- a/src/peripherals/uno_q_bridge.rs
+++ b/src/peripherals/uno_q_bridge.rs
@@ -208,7 +208,10 @@ mod tests {
         let tool = UnoQGpioReadTool;
         let result = tool.execute(json!({"pin": 13})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.is_some(), "should report bridge connection error");
+        assert!(
+            result.error.is_some(),
+            "should report bridge connection error"
+        );
     }
 
     // ── UnoQGpioWriteTool ───────────────────────────────────────────────
@@ -277,7 +280,10 @@ mod tests {
         let tool = UnoQGpioWriteTool;
         let result = tool.execute(json!({"pin": 13, "value": 1})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.is_some(), "should report bridge connection error");
+        assert!(
+            result.error.is_some(),
+            "should report bridge connection error"
+        );
     }
 
     // ── Constants ───────────────────────────────────────────────────────

--- a/src/sop/engine.rs
+++ b/src/sop/engine.rs
@@ -723,6 +723,42 @@ fn trigger_matches(trigger: &SopTrigger, event: &SopEvent) -> bool {
 
         (SopTrigger::Manual, SopTriggerSource::Manual) => true,
 
+        (
+            SopTrigger::Calendar {
+                calendar_source,
+                calendar_ids,
+            },
+            SopTriggerSource::Calendar,
+        ) => {
+            // Parse payload to check calendar_source match
+            let payload_match = event
+                .payload
+                .as_deref()
+                .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+                .map_or(false, |v| {
+                    v.get("calendar_source")
+                        .and_then(|s| s.as_str())
+                        .map_or(false, |s| s == calendar_source)
+                });
+            if !payload_match {
+                return false;
+            }
+            // If calendar_ids is empty, match any calendar
+            if calendar_ids.is_empty() {
+                return true;
+            }
+            // Check if event's calendar_id is in the watch list
+            event
+                .payload
+                .as_deref()
+                .and_then(|p| serde_json::from_str::<serde_json::Value>(p).ok())
+                .map_or(false, |v| {
+                    v.get("calendar_id")
+                        .and_then(|s| s.as_str())
+                        .map_or(false, |id| calendar_ids.iter().any(|c| c == id))
+                })
+        }
+
         _ => false,
     }
 }
@@ -1315,6 +1351,182 @@ mod tests {
             timestamp: now_iso8601(),
         };
         assert_eq!(engine.match_trigger(&event).len(), 1);
+    }
+
+    // ── Calendar trigger matching ────────────────────────
+
+    #[test]
+    fn calendar_trigger_matches_any_calendar_when_ids_empty() {
+        let sop = Sop {
+            triggers: vec![SopTrigger::Calendar {
+                calendar_source: "microsoft365".to_string(),
+                calendar_ids: vec![],
+            }],
+            ..test_sop("cal-any", SopExecutionMode::Auto, SopPriority::Normal)
+        };
+        let engine = engine_with_sops(vec![sop]);
+
+        // Calendar trigger with empty calendar_ids should match any calendar_id
+        let event = SopEvent {
+            source: SopTriggerSource::Calendar,
+            topic: Some("calendar.no_show".to_string()),
+            payload: Some(
+                r#"{"event_id":"e1","event_title":"Standup","expected_start":"2026-01-01T10:00:00Z","detected_at":"2026-01-01T10:10:00Z","calendar_source":"microsoft365","calendar_id":"work-cal"}"#
+                    .to_string(),
+            ),
+            timestamp: now_iso8601(),
+        };
+        let matches = engine.match_trigger(&event);
+        assert_eq!(
+            matches.len(),
+            1,
+            "Empty calendar_ids should match any calendar"
+        );
+    }
+
+    #[test]
+    fn calendar_trigger_matches_specific_calendar_id() {
+        let sop = Sop {
+            triggers: vec![SopTrigger::Calendar {
+                calendar_source: "microsoft365".to_string(),
+                calendar_ids: vec!["work-cal".to_string()],
+            }],
+            ..test_sop("cal-specific", SopExecutionMode::Auto, SopPriority::Normal)
+        };
+        let engine = engine_with_sops(vec![sop]);
+
+        // Event from work-cal should match
+        let event = SopEvent {
+            source: SopTriggerSource::Calendar,
+            topic: Some("calendar.no_show".to_string()),
+            payload: Some(
+                r#"{"event_id":"e1","event_title":"Standup","expected_start":"2026-01-01T10:00:00Z","detected_at":"2026-01-01T10:10:00Z","calendar_source":"microsoft365","calendar_id":"work-cal"}"#
+                    .to_string(),
+            ),
+            timestamp: now_iso8601(),
+        };
+        let matches = engine.match_trigger(&event);
+        assert_eq!(matches.len(), 1);
+    }
+
+    #[test]
+    fn calendar_trigger_rejects_wrong_calendar_id() {
+        let sop = Sop {
+            triggers: vec![SopTrigger::Calendar {
+                calendar_source: "microsoft365".to_string(),
+                calendar_ids: vec!["work-cal".to_string()],
+            }],
+            ..test_sop("cal-specific", SopExecutionMode::Auto, SopPriority::Normal)
+        };
+        let engine = engine_with_sops(vec![sop]);
+
+        // Event from personal-cal should NOT match trigger watching work-cal
+        let event = SopEvent {
+            source: SopTriggerSource::Calendar,
+            topic: Some("calendar.no_show".to_string()),
+            payload: Some(
+                r#"{"event_id":"e2","event_title":"Dentist","expected_start":"2026-01-01T14:00:00Z","detected_at":"2026-01-01T14:10:00Z","calendar_source":"microsoft365","calendar_id":"personal-cal"}"#
+                    .to_string(),
+            ),
+            timestamp: now_iso8601(),
+        };
+        let matches = engine.match_trigger(&event);
+        assert!(matches.is_empty(), "Wrong calendar_id should not match");
+    }
+
+    #[test]
+    fn calendar_trigger_rejects_wrong_source() {
+        let sop = Sop {
+            triggers: vec![SopTrigger::Calendar {
+                calendar_source: "microsoft365".to_string(),
+                calendar_ids: vec![],
+            }],
+            ..test_sop("cal-m365", SopExecutionMode::Auto, SopPriority::Normal)
+        };
+        let engine = engine_with_sops(vec![sop]);
+
+        // Event from google calendar should NOT match microsoft365 trigger
+        let event = SopEvent {
+            source: SopTriggerSource::Calendar,
+            topic: Some("calendar.no_show".to_string()),
+            payload: Some(
+                r#"{"event_id":"e3","event_title":"Meeting","expected_start":"2026-01-01T15:00:00Z","detected_at":"2026-01-01T15:10:00Z","calendar_source":"google","calendar_id":"work-cal"}"#
+                    .to_string(),
+            ),
+            timestamp: now_iso8601(),
+        };
+        let matches = engine.match_trigger(&event);
+        assert!(
+            matches.is_empty(),
+            "Google calendar event should not match microsoft365 trigger"
+        );
+    }
+
+    #[test]
+    fn calendar_trigger_multiple_calendars() {
+        let sop = Sop {
+            triggers: vec![SopTrigger::Calendar {
+                calendar_source: "microsoft365".to_string(),
+                calendar_ids: vec!["work-cal".to_string(), "team-cal".to_string()],
+            }],
+            ..test_sop("cal-multi", SopExecutionMode::Auto, SopPriority::Normal)
+        };
+        let engine = engine_with_sops(vec![sop]);
+
+        // work-cal should match
+        let event1 = SopEvent {
+            source: SopTriggerSource::Calendar,
+            topic: Some("calendar.no_show".to_string()),
+            payload: Some(
+                r#"{"event_id":"e1","event_title":"Standup","expected_start":"2026-01-01T10:00:00Z","detected_at":"2026-01-01T10:10:00Z","calendar_source":"microsoft365","calendar_id":"work-cal"}"#
+                    .to_string(),
+            ),
+            timestamp: now_iso8601(),
+        };
+        assert_eq!(engine.match_trigger(&event1).len(), 1);
+
+        // team-cal should match
+        let event2 = SopEvent {
+            source: SopTriggerSource::Calendar,
+            topic: Some("calendar.no_show".to_string()),
+            payload: Some(
+                r#"{"event_id":"e2","event_title":"Planning","expected_start":"2026-01-01T14:00:00Z","detected_at":"2026-01-01T14:10:00Z","calendar_source":"microsoft365","calendar_id":"team-cal"}"#
+                    .to_string(),
+            ),
+            timestamp: now_iso8601(),
+        };
+        assert_eq!(engine.match_trigger(&event2).len(), 1);
+
+        // personal-cal should NOT match
+        let event3 = SopEvent {
+            source: SopTriggerSource::Calendar,
+            topic: Some("calendar.no_show".to_string()),
+            payload: Some(
+                r#"{"event_id":"e3","event_title":"Gym","expected_start":"2026-01-01T18:00:00Z","detected_at":"2026-01-01T18:10:00Z","calendar_source":"microsoft365","calendar_id":"personal-cal"}"#
+                    .to_string(),
+            ),
+            timestamp: now_iso8601(),
+        };
+        assert!(engine.match_trigger(&event3).is_empty());
+    }
+
+    #[test]
+    fn calendar_trigger_rejects_wrong_trigger_source() {
+        let sop = Sop {
+            triggers: vec![SopTrigger::Calendar {
+                calendar_source: "microsoft365".to_string(),
+                calendar_ids: vec![],
+            }],
+            ..test_sop("cal-sop", SopExecutionMode::Auto, SopPriority::Normal)
+        };
+        let engine = engine_with_sops(vec![sop]);
+
+        // MQTT event should not match Calendar trigger
+        let event = mqtt_event("calendar/event", r#"{"some":"data"}"#);
+        assert!(
+            engine.match_trigger(&event).is_empty(),
+            "MQTT event should not match Calendar trigger"
+        );
     }
 
     // ── Run lifecycle ───────────────────────────────────

--- a/src/sop/types.rs
+++ b/src/sop/types.rs
@@ -85,6 +85,11 @@ pub enum SopTrigger {
         condition: Option<String>,
     },
     Manual,
+    Calendar {
+        calendar_source: String,
+        #[serde(default)]
+        calendar_ids: Vec<String>,
+    },
 }
 
 impl fmt::Display for SopTrigger {
@@ -95,6 +100,9 @@ impl fmt::Display for SopTrigger {
             Self::Cron { expression } => write!(f, "cron:{expression}"),
             Self::Peripheral { board, signal, .. } => write!(f, "peripheral:{board}/{signal}"),
             Self::Manual => write!(f, "manual"),
+            Self::Calendar {
+                calendar_source, ..
+            } => write!(f, "calendar:{calendar_source}"),
         }
     }
 }
@@ -234,6 +242,7 @@ pub enum SopTriggerSource {
     Cron,
     Peripheral,
     Manual,
+    Calendar,
 }
 
 impl fmt::Display for SopTriggerSource {
@@ -244,6 +253,7 @@ impl fmt::Display for SopTriggerSource {
             Self::Cron => write!(f, "cron"),
             Self::Peripheral => write!(f, "peripheral"),
             Self::Manual => write!(f, "manual"),
+            Self::Calendar => write!(f, "calendar"),
         }
     }
 }

--- a/tests/integration/calendar_triggers.rs
+++ b/tests/integration/calendar_triggers.rs
@@ -1,0 +1,207 @@
+use chrono::{Duration, Utc};
+use zeroclaw::calendar::poller::CalendarPoller;
+use zeroclaw::calendar::types::{CalendarTriggerConfig, NoShowEvent, TrackedEvent};
+use zeroclaw::sop::types::{SopTrigger, SopTriggerSource};
+
+fn default_config() -> CalendarTriggerConfig {
+    CalendarTriggerConfig {
+        calendar_source: "microsoft365".to_string(),
+        poll_interval_secs: 300,
+        no_show_threshold_minutes: 10,
+        watch_calendars: vec![],
+    }
+}
+
+#[test]
+fn calendar_trigger_config_defaults() {
+    let json = r#"{"calendar_source": "microsoft365"}"#;
+    let config: CalendarTriggerConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.poll_interval_secs, 300);
+    assert_eq!(config.no_show_threshold_minutes, 10);
+    assert!(config.watch_calendars.is_empty());
+}
+
+#[test]
+fn calendar_trigger_config_custom_values() {
+    let json = r#"{"calendar_source":"google","poll_interval_secs":60,"no_show_threshold_minutes":5,"watch_calendars":["cal1","cal2"]}"#;
+    let config: CalendarTriggerConfig = serde_json::from_str(json).unwrap();
+    assert_eq!(config.calendar_source, "google");
+    assert_eq!(config.poll_interval_secs, 60);
+    assert_eq!(config.no_show_threshold_minutes, 5);
+    assert_eq!(config.watch_calendars, vec!["cal1", "cal2"]);
+}
+
+#[test]
+fn no_show_event_serialization_roundtrip() {
+    let now = Utc::now();
+    let event = NoShowEvent {
+        event_id: "evt-123".to_string(),
+        event_title: "Team standup".to_string(),
+        expected_start: now,
+        detected_at: now + Duration::minutes(10),
+        calendar_source: "microsoft365".to_string(),
+        calendar_id: "primary".to_string(),
+    };
+    let json = serde_json::to_string(&event).unwrap();
+    let deser: NoShowEvent = serde_json::from_str(&json).unwrap();
+    assert_eq!(event, deser);
+}
+
+#[test]
+fn poller_track_events() {
+    let mut poller = CalendarPoller::new(default_config());
+    let events = vec![
+        TrackedEvent {
+            event_id: "evt-1".to_string(),
+            event_title: "Meeting A".to_string(),
+            start_time: Utc::now() + Duration::minutes(30),
+            calendar_id: "primary".to_string(),
+        },
+        TrackedEvent {
+            event_id: "evt-2".to_string(),
+            event_title: "Meeting B".to_string(),
+            start_time: Utc::now() + Duration::hours(1),
+            calendar_id: "primary".to_string(),
+        },
+    ];
+    let added = poller.track_events(events);
+    assert_eq!(added, 2);
+    assert_eq!(poller.tracked_count(), 2);
+}
+
+#[test]
+fn poller_detect_no_show_after_threshold() {
+    let mut poller = CalendarPoller::new(default_config());
+    let start = Utc::now() - Duration::minutes(15); // 15 min ago
+    poller.track_events(vec![TrackedEvent {
+        event_id: "evt-1".to_string(),
+        event_title: "Standup".to_string(),
+        start_time: start,
+        calendar_id: "primary".to_string(),
+    }]);
+
+    let events = poller.detect_no_shows(Utc::now());
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].source, SopTriggerSource::Calendar);
+    assert_eq!(events[0].topic.as_deref(), Some("calendar.no_show"));
+
+    // Parse payload
+    let payload: NoShowEvent = serde_json::from_str(events[0].payload.as_ref().unwrap()).unwrap();
+    assert_eq!(payload.event_id, "evt-1");
+    assert_eq!(payload.event_title, "Standup");
+    assert_eq!(payload.calendar_source, "microsoft365");
+}
+
+#[test]
+fn poller_no_detection_before_threshold() {
+    let mut poller = CalendarPoller::new(default_config());
+    let start = Utc::now() - Duration::minutes(5); // Only 5 min ago, threshold is 10
+    poller.track_events(vec![TrackedEvent {
+        event_id: "evt-1".to_string(),
+        event_title: "Standup".to_string(),
+        start_time: start,
+        calendar_id: "primary".to_string(),
+    }]);
+
+    let events = poller.detect_no_shows(Utc::now());
+    assert_eq!(events.len(), 0);
+}
+
+#[test]
+fn poller_no_duplicate_fires() {
+    let mut poller = CalendarPoller::new(default_config());
+    let start = Utc::now() - Duration::minutes(15);
+    poller.track_events(vec![TrackedEvent {
+        event_id: "evt-1".to_string(),
+        event_title: "Standup".to_string(),
+        start_time: start,
+        calendar_id: "primary".to_string(),
+    }]);
+
+    let events1 = poller.detect_no_shows(Utc::now());
+    assert_eq!(events1.len(), 1);
+
+    // Second detection should not re-fire
+    let events2 = poller.detect_no_shows(Utc::now());
+    assert_eq!(events2.len(), 0);
+    assert_eq!(poller.fired_count(), 1);
+}
+
+#[test]
+fn poller_already_fired_events_not_retracked() {
+    let mut poller = CalendarPoller::new(default_config());
+    let start = Utc::now() - Duration::minutes(15);
+    let tracked = vec![TrackedEvent {
+        event_id: "evt-1".to_string(),
+        event_title: "Standup".to_string(),
+        start_time: start,
+        calendar_id: "primary".to_string(),
+    }];
+
+    poller.track_events(tracked.clone());
+    poller.detect_no_shows(Utc::now()); // fires evt-1
+
+    // Try to re-add the same event
+    let added = poller.track_events(tracked);
+    assert_eq!(added, 0); // Should not be re-tracked
+}
+
+#[test]
+fn poller_cleanup_stale_events() {
+    let mut poller = CalendarPoller::new(default_config());
+    let old_start = Utc::now() - Duration::hours(2); // 2 hours ago — stale
+    let recent_start = Utc::now() + Duration::minutes(30); // upcoming
+
+    poller.track_events(vec![
+        TrackedEvent {
+            event_id: "old".to_string(),
+            event_title: "Old meeting".to_string(),
+            start_time: old_start,
+            calendar_id: "primary".to_string(),
+        },
+        TrackedEvent {
+            event_id: "upcoming".to_string(),
+            event_title: "Future meeting".to_string(),
+            start_time: recent_start,
+            calendar_id: "primary".to_string(),
+        },
+    ]);
+
+    assert_eq!(poller.tracked_count(), 2);
+    poller.cleanup_stale(Utc::now());
+    assert_eq!(poller.tracked_count(), 1); // only upcoming remains
+}
+
+#[test]
+fn sop_trigger_calendar_variant_display() {
+    let trigger = SopTrigger::Calendar {
+        calendar_source: "microsoft365".to_string(),
+        calendar_ids: vec!["primary".to_string()],
+    };
+    assert_eq!(trigger.to_string(), "calendar:microsoft365");
+}
+
+#[test]
+fn sop_trigger_source_calendar_display() {
+    assert_eq!(SopTriggerSource::Calendar.to_string(), "calendar");
+}
+
+#[test]
+fn sop_trigger_calendar_serialization() {
+    let trigger = SopTrigger::Calendar {
+        calendar_source: "microsoft365".to_string(),
+        calendar_ids: vec![],
+    };
+    let json = serde_json::to_string(&trigger).unwrap();
+    let deser: SopTrigger = serde_json::from_str(&json).unwrap();
+    assert_eq!(trigger, deser);
+}
+
+#[test]
+fn sop_trigger_source_calendar_serialization() {
+    let source = SopTriggerSource::Calendar;
+    let json = serde_json::to_string(&source).unwrap();
+    assert_eq!(json, "\"calendar\"");
+    let deser: SopTriggerSource = serde_json::from_str(&json).unwrap();
+    assert_eq!(source, deser);
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -1,6 +1,7 @@
 mod agent;
 mod agent_robustness;
 mod backup_cron_scheduling;
+mod calendar_triggers;
 mod channel_matrix;
 mod channel_routing;
 mod hooks;


### PR DESCRIPTION
## Summary

- Add `Calendar` variant to `SopTrigger` and `SopTriggerSource` enums for calendar-driven SOP activation
- Implement `CalendarPoller` with configurable poll interval and no-show threshold detection
- Add `CalendarTriggerConfig`, `NoShowEvent`, and `TrackedEvent` types in new `src/calendar/` module
- Wire calendar trigger matching into `trigger_matches()` in the SOP engine
- Emit `SopEvent` with `source=Calendar`, `topic="calendar.no_show"` when no-show detected

## Design

Follows the existing cron scheduler poll-based pattern. The `CalendarPoller` tracks upcoming events, detects no-shows when `now >= event.start_time + threshold`, and prevents duplicate fires via an `already_fired` guard set. Stale events are cleaned up after 1 hour.

Calendar source matching in `trigger_matches()` uses `serde_json::Value` payload parsing to avoid circular module dependencies. Empty `calendar_ids` matches any calendar.

## Test plan

- [x] 13 integration tests covering config defaults, serialization, poller tracking, no-show detection, threshold enforcement, duplicate prevention, stale cleanup, and enum display/serialization
- [x] 6 unit tests for `trigger_matches` Calendar arm: any-calendar matching, specific calendar ID matching, wrong calendar ID/source rejection, multiple calendar filtering
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean