### PR TITLE
fix(config): resolve temp directory canonicalization for non-existent…

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -7953,9 +7953,27 @@ fn active_workspace_state_path(default_dir: &Path) -> PathBuf {
 /// Returns `true` if `path` lives under the OS temp directory.
 fn is_temp_directory(path: &Path) -> bool {
     let temp = std::env::temp_dir();
+
+    // Fast path: exact lexical prefix match.
+    // Handles the case where canonicalization fails but paths match directly.
+    if path.starts_with(&temp) {
+        return true;
+    }
+
     // Canonicalize when possible to handle symlinks (macOS /var → /private/var)
     let canon_temp = temp.canonicalize().unwrap_or_else(|_| temp.clone());
-    let canon_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+
+    // If the path doesn't exist yet, canonicalize() will fail (io::Error NotFound).
+    // In that case, we can try to canonicalize its parent directory to resolve symlinks.
+    let canon_path = path.canonicalize().unwrap_or_else(|_| {
+        if let Some(parent) = path.parent() {
+            if let Ok(canon_parent) = parent.canonicalize() {
+                return canon_parent.join(path.file_name().unwrap_or_default());
+            }
+        }
+        path.to_path_buf()
+    });
+
     canon_path.starts_with(&canon_temp)
 }
 


### PR DESCRIPTION
… paths on macOS

## Summary
Fixes the intermittent [load_or_init_uses_persisted_active_workspace_marker](cci:1://file:///Users/wangyingtao.10/zeroclaw-dev/src/config/schema.rs:13273:4-13318:5) test failure on macOS.

Resolves an issue where [is_temp_directory()](cci:1://file:///Users/wangyingtao.10/zeroclaw-dev/src/config/schema.rs:7952:0-7977:1) would incorrectly return false for non-existent files inside the macOS temp directory. Since `canonicalize()` fails on missing paths, it returned the raw `/var/...` path instead of `/private/var/...`, causing the temp directory prefix check to fail.

- Add a fast-path string comparison before canonicalization in [is_temp_directory()](cci:1://file:///Users/wangyingtao.10/zeroclaw-dev/src/config/schema.rs:7952:0-7977:1)
- Add a fallback to canonicalize the path's parent directory if the leaf node doesn't exist yet
- Original author: @<your_username>

## Test plan
- `cargo check` passes
- `cargo fmt` clean
- `load_or_init_uses_persisted_active_workspace_marker` test now reliably passes on macOS
