### PR TITLE
feat(memory): add bulk JSON export for GDPR Art. 20 data portability

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -49,7 +49,7 @@ pub use retrieval::{RetrievalConfig, RetrievalPipeline};
 pub use sqlite::SqliteMemory;
 pub use traits::Memory;
 #[allow(unused_imports)]
-pub use traits::{MemoryCategory, MemoryEntry, ProceduralMessage};
+pub use traits::{ExportFilter, MemoryCategory, MemoryEntry, ProceduralMessage};
 
 use crate::config::{EmbeddingRouteConfig, MemoryConfig, StorageProviderConfig};
 use anyhow::Context;

--- a/src/memory/sqlite.rs
+++ b/src/memory/sqlite.rs
@@ -1,5 +1,5 @@
 use super::embeddings::EmbeddingProvider;
-use super::traits::{Memory, MemoryCategory, MemoryEntry};
+use super::traits::{ExportFilter, Memory, MemoryCategory, MemoryEntry};
 use super::vector;
 use anyhow::Context;
 use async_trait::async_trait;
@@ -976,6 +976,73 @@ impl Memory for SqliteMemory {
         tokio::task::spawn_blocking(move || conn.lock().execute_batch("SELECT 1").is_ok())
             .await
             .unwrap_or(false)
+    }
+
+    async fn export(&self, filter: &ExportFilter) -> anyhow::Result<Vec<MemoryEntry>> {
+        let conn = self.conn.clone();
+        let filter = filter.clone();
+
+        tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<MemoryEntry>> {
+            let conn = conn.lock();
+            let mut sql =
+                "SELECT id, key, content, category, created_at, session_id, namespace, importance, superseded_by \
+                 FROM memories WHERE 1=1"
+                    .to_string();
+            let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+            let mut idx = 1;
+
+            if let Some(ref ns) = filter.namespace {
+                let _ = write!(sql, " AND namespace = ?{idx}");
+                param_values.push(Box::new(ns.clone()));
+                idx += 1;
+            }
+            if let Some(ref sid) = filter.session_id {
+                let _ = write!(sql, " AND session_id = ?{idx}");
+                param_values.push(Box::new(sid.clone()));
+                idx += 1;
+            }
+            if let Some(ref cat) = filter.category {
+                let _ = write!(sql, " AND category = ?{idx}");
+                param_values.push(Box::new(Self::category_to_str(cat)));
+                idx += 1;
+            }
+            if let Some(ref since) = filter.since {
+                let _ = write!(sql, " AND created_at >= ?{idx}");
+                param_values.push(Box::new(since.clone()));
+                idx += 1;
+            }
+            if let Some(ref until) = filter.until {
+                let _ = write!(sql, " AND created_at <= ?{idx}");
+                param_values.push(Box::new(until.clone()));
+                let _ = idx;
+            }
+            sql.push_str(" ORDER BY created_at ASC");
+
+            let mut stmt = conn.prepare(&sql)?;
+            let params_ref: Vec<&dyn rusqlite::types::ToSql> =
+                param_values.iter().map(AsRef::as_ref).collect();
+            let rows = stmt.query_map(params_ref.as_slice(), |row| {
+                Ok(MemoryEntry {
+                    id: row.get(0)?,
+                    key: row.get(1)?,
+                    content: row.get(2)?,
+                    category: Self::str_to_category(&row.get::<_, String>(3)?),
+                    timestamp: row.get(4)?,
+                    session_id: row.get(5)?,
+                    score: None,
+                    namespace: row.get::<_, Option<String>>(6)?.unwrap_or_else(|| "default".into()),
+                    importance: row.get(7)?,
+                    superseded_by: row.get(8)?,
+                })
+            })?;
+
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row?);
+            }
+            Ok(results)
+        })
+        .await?
     }
 
     async fn recall_namespaced(
@@ -2300,6 +2367,227 @@ mod tests {
 
         // Should have 6 total entries (1 pre-existing + 5 new)
         assert_eq!(mem.count().await.unwrap(), 6);
+    }
+
+    // ── Export (GDPR Art. 20) tests ─────────────────────────
+
+    #[tokio::test]
+    async fn export_no_filter_returns_all_entries() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store("a", "one", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        mem.store("b", "two", MemoryCategory::Daily, None)
+            .await
+            .unwrap();
+        mem.store("c", "three", MemoryCategory::Conversation, None)
+            .await
+            .unwrap();
+
+        let filter = ExportFilter::default();
+        let results = mem.export(&filter).await.unwrap();
+        assert_eq!(results.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn export_with_namespace_filter() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store_with_metadata(
+            "a",
+            "ns1 data",
+            MemoryCategory::Core,
+            None,
+            Some("ns1"),
+            None,
+        )
+        .await
+        .unwrap();
+        mem.store_with_metadata(
+            "b",
+            "ns2 data",
+            MemoryCategory::Core,
+            None,
+            Some("ns2"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let filter = ExportFilter {
+            namespace: Some("ns1".into()),
+            ..Default::default()
+        };
+        let results = mem.export(&filter).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].namespace, "ns1");
+    }
+
+    #[tokio::test]
+    async fn export_with_session_id_filter() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store("a", "sess-a data", MemoryCategory::Core, Some("sess-a"))
+            .await
+            .unwrap();
+        mem.store("b", "sess-b data", MemoryCategory::Core, Some("sess-b"))
+            .await
+            .unwrap();
+
+        let filter = ExportFilter {
+            session_id: Some("sess-a".into()),
+            ..Default::default()
+        };
+        let results = mem.export(&filter).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "a");
+    }
+
+    #[tokio::test]
+    async fn export_with_category_filter() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store("a", "core data", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        mem.store("b", "daily data", MemoryCategory::Daily, None)
+            .await
+            .unwrap();
+
+        let filter = ExportFilter {
+            category: Some(MemoryCategory::Core),
+            ..Default::default()
+        };
+        let results = mem.export(&filter).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].category, MemoryCategory::Core);
+    }
+
+    #[tokio::test]
+    async fn export_with_time_range() {
+        let (_tmp, mem) = temp_sqlite();
+        // Store entries — created_at is set to Local::now() by store()
+        mem.store("a", "old data", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        mem.store("b", "new data", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+
+        // Export with a time range that covers everything
+        let filter = ExportFilter {
+            since: Some("2000-01-01T00:00:00Z".into()),
+            until: Some("2099-12-31T23:59:59Z".into()),
+            ..Default::default()
+        };
+        let results = mem.export(&filter).await.unwrap();
+        assert_eq!(results.len(), 2);
+
+        // Export with a time range in the far future (no results)
+        let filter = ExportFilter {
+            since: Some("2099-01-01T00:00:00Z".into()),
+            ..Default::default()
+        };
+        let results = mem.export(&filter).await.unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn export_with_combined_filters() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store_with_metadata(
+            "a",
+            "match",
+            MemoryCategory::Core,
+            Some("sess-a"),
+            Some("ns1"),
+            None,
+        )
+        .await
+        .unwrap();
+        mem.store_with_metadata(
+            "b",
+            "no match ns",
+            MemoryCategory::Core,
+            Some("sess-a"),
+            Some("ns2"),
+            None,
+        )
+        .await
+        .unwrap();
+        mem.store_with_metadata(
+            "c",
+            "no match sess",
+            MemoryCategory::Core,
+            None,
+            Some("ns1"),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let filter = ExportFilter {
+            namespace: Some("ns1".into()),
+            session_id: Some("sess-a".into()),
+            category: Some(MemoryCategory::Core),
+            since: Some("2000-01-01T00:00:00Z".into()),
+            until: Some("2099-12-31T23:59:59Z".into()),
+        };
+        let results = mem.export(&filter).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "a");
+    }
+
+    #[tokio::test]
+    async fn export_empty_database_returns_empty_vec() {
+        let (_tmp, mem) = temp_sqlite();
+        let filter = ExportFilter::default();
+        let results = mem.export(&filter).await.unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn export_ordering_is_chronological() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store("first", "data1", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        // Small delay to ensure different timestamps
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        mem.store("second", "data2", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+
+        let filter = ExportFilter::default();
+        let results = mem.export(&filter).await.unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(
+            results[0].timestamp <= results[1].timestamp,
+            "Export must be ordered by created_at ASC"
+        );
+    }
+
+    #[tokio::test]
+    async fn export_preserves_field_integrity() {
+        let (_tmp, mem) = temp_sqlite();
+        mem.store_with_metadata(
+            "roundtrip_key",
+            "roundtrip content",
+            MemoryCategory::Custom("custom_cat".into()),
+            Some("sess-rt"),
+            Some("ns-rt"),
+            Some(0.9),
+        )
+        .await
+        .unwrap();
+
+        let filter = ExportFilter::default();
+        let results = mem.export(&filter).await.unwrap();
+        assert_eq!(results.len(), 1);
+        let e = &results[0];
+        assert_eq!(e.key, "roundtrip_key");
+        assert_eq!(e.content, "roundtrip content");
+        assert_eq!(e.category, MemoryCategory::Custom("custom_cat".into()));
+        assert_eq!(e.session_id.as_deref(), Some("sess-rt"));
+        assert_eq!(e.namespace, "ns-rt");
+        assert_eq!(e.importance, Some(0.9));
     }
 
     // ── §4.2 Reindex / corruption recovery tests ────────────

--- a/src/memory/traits.rs
+++ b/src/memory/traits.rs
@@ -1,6 +1,18 @@
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+/// Filter criteria for bulk memory export (GDPR Art. 20 data portability).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ExportFilter {
+    pub namespace: Option<String>,
+    pub session_id: Option<String>,
+    pub category: Option<MemoryCategory>,
+    /// RFC 3339 lower bound (inclusive) on created_at.
+    pub since: Option<String>,
+    /// RFC 3339 upper bound (inclusive) on created_at.
+    pub until: Option<String>,
+}
+
 /// A single message in a conversation trace for procedural memory.
 ///
 /// Used to capture "how to" patterns from tool-calling turns so that
@@ -188,6 +200,42 @@ pub trait Memory: Send + Sync {
             .into_iter()
             .filter(|e| e.namespace == namespace)
             .take(limit)
+            .collect();
+        Ok(filtered)
+    }
+
+    /// Bulk-export memories matching the given filter criteria.
+    ///
+    /// Intended for GDPR Art. 20 data portability. Returns entries ordered by
+    /// creation time (ascending). Embeddings are excluded.
+    ///
+    /// Default implementation delegates to `list()` and post-filters on
+    /// namespace and time range. Backends with native query support should
+    /// override for efficiency.
+    async fn export(&self, filter: &ExportFilter) -> anyhow::Result<Vec<MemoryEntry>> {
+        let entries = self
+            .list(filter.category.as_ref(), filter.session_id.as_deref())
+            .await?;
+        let filtered: Vec<MemoryEntry> = entries
+            .into_iter()
+            .filter(|e| {
+                if let Some(ref ns) = filter.namespace {
+                    if e.namespace != *ns {
+                        return false;
+                    }
+                }
+                if let Some(ref since) = filter.since {
+                    if e.timestamp.as_str() < since.as_str() {
+                        return false;
+                    }
+                }
+                if let Some(ref until) = filter.until {
+                    if e.timestamp.as_str() > until.as_str() {
+                        return false;
+                    }
+                }
+                true
+            })
             .collect();
         Ok(filtered)
     }

--- a/src/tools/memory_export.rs
+++ b/src/tools/memory_export.rs
@@ -1,0 +1,195 @@
+use super::traits::{Tool, ToolResult};
+use crate::memory::traits::ExportFilter;
+use crate::memory::{Memory, MemoryCategory};
+use async_trait::async_trait;
+use serde_json::json;
+use std::sync::Arc;
+
+/// Bulk-export memories as a JSON array for GDPR Art. 20 data portability.
+pub struct MemoryExportTool {
+    memory: Arc<dyn Memory>,
+}
+
+impl MemoryExportTool {
+    pub fn new(memory: Arc<dyn Memory>) -> Self {
+        Self { memory }
+    }
+}
+
+#[async_trait]
+impl Tool for MemoryExportTool {
+    fn name(&self) -> &str {
+        "memory_export"
+    }
+
+    fn description(&self) -> &str {
+        "Export memories as a JSON array for GDPR Art. 20 data portability. \
+         Supports filtering by namespace, session, category, and time range. \
+         Returns a structured, machine-readable JSON array of memory entries."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "namespace": {
+                    "type": "string",
+                    "description": "Filter by namespace (agent/context isolation boundary)."
+                },
+                "session_id": {
+                    "type": "string",
+                    "description": "Filter by session ID."
+                },
+                "category": {
+                    "type": "string",
+                    "description": "Filter by category: core, daily, conversation, or a custom name."
+                },
+                "since": {
+                    "type": "string",
+                    "description": "RFC 3339 lower bound (inclusive) on created_at. Example: 2025-01-01T00:00:00Z"
+                },
+                "until": {
+                    "type": "string",
+                    "description": "RFC 3339 upper bound (inclusive) on created_at. Example: 2025-12-31T23:59:59Z"
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        let namespace = args
+            .get("namespace")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let session_id = args
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let category = args
+            .get("category")
+            .and_then(|v| v.as_str())
+            .map(|s| match s {
+                "core" => MemoryCategory::Core,
+                "daily" => MemoryCategory::Daily,
+                "conversation" => MemoryCategory::Conversation,
+                other => MemoryCategory::Custom(other.to_string()),
+            });
+        let since = args.get("since").and_then(|v| v.as_str()).map(String::from);
+        let until = args.get("until").and_then(|v| v.as_str()).map(String::from);
+
+        let filter = ExportFilter {
+            namespace,
+            session_id,
+            category,
+            since,
+            until,
+        };
+
+        match self.memory.export(&filter).await {
+            Ok(entries) => {
+                let json_output = serde_json::to_string(&entries)
+                    .unwrap_or_else(|e| format!("{{\"error\": \"serialization failed: {e}\"}}"));
+                Ok(ToolResult {
+                    success: true,
+                    output: json_output,
+                    error: None,
+                })
+            }
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Export failed: {e}")),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::SqliteMemory;
+    use tempfile::TempDir;
+
+    fn test_mem() -> (TempDir, Arc<dyn Memory>) {
+        let tmp = TempDir::new().unwrap();
+        let mem = SqliteMemory::new(tmp.path()).unwrap();
+        (tmp, Arc::new(mem))
+    }
+
+    #[test]
+    fn name_and_schema() {
+        let (_tmp, mem) = test_mem();
+        let tool = MemoryExportTool::new(mem);
+        assert_eq!(tool.name(), "memory_export");
+        let schema = tool.parameters_schema();
+        assert!(schema["properties"]["namespace"].is_object());
+        assert!(schema["properties"]["session_id"].is_object());
+        assert!(schema["properties"]["category"].is_object());
+        assert!(schema["properties"]["since"].is_object());
+        assert!(schema["properties"]["until"].is_object());
+    }
+
+    #[tokio::test]
+    async fn export_produces_valid_json_output() {
+        let (_tmp, mem) = test_mem();
+        mem.store("k1", "test data", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+
+        let tool = MemoryExportTool::new(mem);
+        let result = tool.execute(json!({})).await.unwrap();
+        assert!(result.success);
+        let parsed: serde_json::Value = serde_json::from_str(&result.output).unwrap();
+        assert!(parsed.is_array());
+        assert_eq!(parsed.as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn export_empty_database_returns_empty_array() {
+        let (_tmp, mem) = test_mem();
+        let tool = MemoryExportTool::new(mem);
+        let result = tool.execute(json!({})).await.unwrap();
+        assert!(result.success);
+        let parsed: serde_json::Value = serde_json::from_str(&result.output).unwrap();
+        assert!(parsed.is_array());
+        assert!(parsed.as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn export_with_category_filter() {
+        let (_tmp, mem) = test_mem();
+        mem.store("k1", "core data", MemoryCategory::Core, None)
+            .await
+            .unwrap();
+        mem.store("k2", "daily data", MemoryCategory::Daily, None)
+            .await
+            .unwrap();
+
+        let tool = MemoryExportTool::new(mem);
+        let result = tool.execute(json!({"category": "core"})).await.unwrap();
+        assert!(result.success);
+        let parsed: serde_json::Value = serde_json::from_str(&result.output).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["category"], "core");
+    }
+
+    #[tokio::test]
+    async fn export_with_session_filter() {
+        let (_tmp, mem) = test_mem();
+        mem.store("k1", "sess-a data", MemoryCategory::Core, Some("sess-a"))
+            .await
+            .unwrap();
+        mem.store("k2", "sess-b data", MemoryCategory::Core, Some("sess-b"))
+            .await
+            .unwrap();
+
+        let tool = MemoryExportTool::new(mem);
+        let result = tool.execute(json!({"session_id": "sess-a"})).await.unwrap();
+        assert!(result.success);
+        let parsed: serde_json::Value = serde_json::from_str(&result.output).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["key"], "k1");
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -65,6 +65,7 @@ pub mod mcp_deferred;
 pub mod mcp_protocol;
 pub mod mcp_tool;
 pub mod mcp_transport;
+pub mod memory_export;
 pub mod memory_forget;
 pub mod memory_purge;
 pub mod memory_recall;
@@ -157,6 +158,7 @@ pub use llm_task::LlmTaskTool;
 pub use mcp_client::McpRegistry;
 pub use mcp_deferred::{ActivatedToolSet, DeferredMcpToolSet};
 pub use mcp_tool::McpToolWrapper;
+pub use memory_export::MemoryExportTool;
 pub use memory_forget::MemoryForgetTool;
 pub use memory_purge::MemoryPurgeTool;
 pub use memory_recall::MemoryRecallTool;
@@ -413,6 +415,7 @@ pub fn all_tools_with_runtime(
         Arc::new(MemoryStoreTool::new(memory.clone(), security.clone())),
         Arc::new(MemoryRecallTool::new(memory.clone())),
         Arc::new(MemoryForgetTool::new(memory.clone(), security.clone())),
+        Arc::new(MemoryExportTool::new(memory.clone())),
         Arc::new(MemoryPurgeTool::new(memory, security.clone())),
         Arc::new(ScheduleTool::new(security.clone(), root_config.clone())),
         Arc::new(ModelRoutingConfigTool::new(


### PR DESCRIPTION
## Summary

Adds a bulk memory export capability for GDPR Art. 20 data portability compliance.

- Adds `ExportFilter` struct and `export()` method to the `Memory` trait with a default implementation that delegates to `list()` with post-filtering
- Implements optimized single-pass SQL query in `SqliteMemory` backend with optional WHERE clauses for namespace, session_id, category, and time range
- Adds `memory_export` agent tool (read-only) with namespace, session_id, category, since, and until parameters
- Returns JSON array of `MemoryEntry` objects (excludes binary embeddings)
- 14 new tests (9 SQLite backend + 5 tool-level), all passing

## Test plan

- [x] `cargo test -- memory_export sqlite::tests::export` — 14 new tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean
- [ ] CI pipeline