### PR TITLE
fix(security): make command allowlist matching case-insensitive on Unix

### DIFF
--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -654,17 +654,18 @@ fn is_allowlist_entry_match(allowed: &str, executable: &str, executable_base: &s
         return executable_path == allowed_path;
     }
 
-    // Command-name entries continue to match by basename.
-    // On Windows, also match when the executable has a .exe/.cmd/.bat suffix
-    // that the allowlist entry omits (e.g., allowlist "git" matches "git.exe").
-    if allowed == executable_base {
+    // Command-name entries continue to match by basename (case-insensitive).
+    // `executable_base` is already lowercased by the caller, so we lowercase
+    // the allowlist entry to match. On Windows, also match when the executable
+    // has a .exe/.cmd/.bat suffix that the allowlist entry omits.
+    let allowed_lower = allowed.to_ascii_lowercase();
+    if allowed_lower == executable_base {
         return true;
     }
 
     #[cfg(target_os = "windows")]
     {
         let base_lower = executable_base.to_ascii_lowercase();
-        let allowed_lower = allowed.to_ascii_lowercase();
         for ext in &[".exe", ".cmd", ".bat"] {
             if base_lower == format!("{allowed_lower}{ext}") {
                 return true;
@@ -2248,6 +2249,18 @@ mod tests {
         assert!(p.is_command_allowed("LANG=C grep pattern file"));
         // env assignment + disallowed command — blocked
         assert!(!p.is_command_allowed("FOO=bar rm -rf /"));
+    }
+
+    #[test]
+    fn mixed_case_allowlist_entry_matches_command() {
+        let p = SecurityPolicy {
+            allowed_commands: vec!["icalBuddy".into()],
+            ..SecurityPolicy::default()
+        };
+        // Mixed-case allowlist entry should match the same command
+        assert!(p.is_command_allowed("icalBuddy"));
+        // Also match lowercase invocation (case-insensitive)
+        assert!(p.is_command_allowed("icalbuddy"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Problem**: `is_allowlist_entry_match()` compared the allowlist entry in original case against the already-lowercased executable basename, causing mixed-case entries like `"icalBuddy"` to fail on Unix. Windows had a separate lowercase fallback that worked.
- **Fix**: Lowercase the allowlist entry before the comparison at line 660. Reuse the lowercased value in the Windows extension-matching block.
- **Test**: Added `mixed_case_allowlist_entry_matches_command` verifying both mixed-case and lowercase invocations.

Closes #4446

## Risk

**High** — `src/security/**` behavior change. The fix is minimal (one `.to_ascii_lowercase()` call) and makes Unix behavior consistent with Windows. No security weakening — the comparison is still exact after case normalization.

## Test plan

- [x] `cargo check` — clean
- [x] `cargo clippy --lib --bins -- -D warnings` — clean
- [x] New test: `mixed_case_allowlist_entry_matches_command`
- [ ] CI