### PR TITLE
fix(heartbeat): inject current datetime into scheduler decision prompt

### DIFF
--- a/src/heartbeat/engine.rs
+++ b/src/heartbeat/engine.rs
@@ -325,14 +325,18 @@ impl HeartbeatEngine {
 
     /// Build the Phase 1 LLM decision prompt for two-phase heartbeat.
     pub fn build_decision_prompt(tasks: &[HeartbeatTask]) -> String {
-        let mut prompt = String::from(
+        let now = Utc::now();
+        let mut prompt = format!(
             "You are a heartbeat scheduler. Review the following periodic tasks and decide \
              whether any should be executed right now.\n\n\
+             Current time: {} UTC ({})\n\n\
              Consider:\n\
              - Task priority (high tasks are more urgent)\n\
              - Whether the task is time-sensitive or can wait\n\
              - Whether running the task now would provide value\n\n\
              Tasks:\n",
+            now.format("%Y-%m-%d %H:%M:%S"),
+            now.format("%A"),
         );
 
         for (i, task) in tasks.iter().enumerate() {
@@ -585,6 +589,10 @@ mod tests {
         assert!(prompt.contains("2. [medium] Review calendar"));
         assert!(prompt.contains("skip"));
         assert!(prompt.contains("run:"));
+        assert!(
+            prompt.contains("Current time:"),
+            "prompt must include current datetime for time-sensitive decisions"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Problem**: `build_decision_prompt()` asks the LLM to evaluate time-sensitive tasks without providing the current date/time, causing incorrect day/time reasoning.
- **Fix**: Inject `Current time: 2026-03-24 10:15:30 UTC (Monday)` into the prompt header.
- **Test**: Updated `decision_prompt_includes_all_tasks` to verify datetime presence.

Closes #4447

## Risk

**Medium** — heartbeat prompt change. No security impact. The LLM now has accurate temporal context for scheduling decisions.

## Test plan

- [x] `cargo check` + `cargo clippy` — clean
- [x] Updated existing test
- [ ] CI