### PR TITLE
feat(dashboard): add 24 color theme palettes

### DIFF
--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
-import { X, Settings, Sun, Moon, Monitor, Laptop, Check, Type, CaseSensitive } from 'lucide-react';
+import { X, Settings, Sun, Moon, Monitor, Laptop, Check, Type, CaseSensitive, Palette } from 'lucide-react';
 import { useTheme } from '@/hooks/useTheme';
 import { t } from '@/lib/i18n';
-import type { ThemeName, AccentColor, UiFont, MonoFont } from '@/contexts/ThemeContextDef';
+import type { AccentColor, UiFont, MonoFont, ThemeMode } from '@/contexts/ThemeContextDef';
 import { uiFontStacks, monoFontStacks } from '@/contexts/ThemeContextDef';
+import { colorThemes } from '@/contexts/colorThemes';
 
-const themeOptions: { value: ThemeName; icon: typeof Sun; labelKey: string }[] = [
+const themeOptions: { value: ThemeMode; icon: typeof Sun; labelKey: string }[] = [
   { value: 'system', icon: Laptop, labelKey: 'theme.system' },
   { value: 'dark', icon: Moon, labelKey: 'theme.dark' },
   { value: 'light', icon: Sun, labelKey: 'theme.light' },
@@ -49,6 +50,71 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
   );
 }
 
+/** Mini terminal preview card for a color theme. */
+function ThemePreviewCard({
+  theme,
+  active,
+  onClick,
+}: {
+  theme: typeof colorThemes[number];
+  active: boolean;
+  onClick: () => void;
+}) {
+  const [bg, c1, c2, c3, text] = theme.preview;
+  return (
+    <button
+      onClick={onClick}
+      className="flex flex-col gap-1.5 p-2 rounded-xl border transition-all text-left group"
+      style={{
+        borderColor: active ? 'var(--pc-accent)' : 'var(--pc-border)',
+        background: active ? 'var(--pc-accent-glow)' : 'transparent',
+        boxShadow: active ? '0 0 12px var(--pc-accent-glow)' : 'none',
+        minWidth: '110px',
+      }}
+      aria-pressed={active}
+    >
+      {/* Mini terminal */}
+      <div
+        className="w-full rounded-lg overflow-hidden"
+        style={{ background: bg, border: `1px solid ${theme.scheme === 'dark' ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)'}` }}
+      >
+        {/* Title bar dots */}
+        <div className="flex gap-1 px-2 py-1.5">
+          <span className="w-[6px] h-[6px] rounded-full" style={{ background: '#ff5f57' }} />
+          <span className="w-[6px] h-[6px] rounded-full" style={{ background: '#febc2e' }} />
+          <span className="w-[6px] h-[6px] rounded-full" style={{ background: '#28c840' }} />
+        </div>
+        {/* Fake code lines */}
+        <div className="px-2 pb-2 flex flex-col gap-[3px]">
+          <div className="flex gap-1 items-center">
+            <span className="h-[3px] rounded-full" style={{ background: c1, width: '30%' }} />
+            <span className="h-[3px] rounded-full" style={{ background: text, width: '20%', opacity: 0.4 }} />
+          </div>
+          <div className="flex gap-1 items-center">
+            <span className="h-[3px] rounded-full" style={{ background: text, width: '15%', opacity: 0.3 }} />
+            <span className="h-[3px] rounded-full" style={{ background: c2, width: '25%' }} />
+            <span className="h-[3px] rounded-full" style={{ background: c3, width: '18%' }} />
+          </div>
+          <div className="flex gap-1 items-center">
+            <span className="h-[3px] rounded-full" style={{ background: c3, width: '22%' }} />
+            <span className="h-[3px] rounded-full" style={{ background: text, width: '28%', opacity: 0.3 }} />
+          </div>
+        </div>
+      </div>
+      {/* Label */}
+      <div className="flex items-center gap-1 px-0.5">
+        {active && <Check size={10} style={{ color: 'var(--pc-accent)' }} />}
+        <span
+          className="text-[10px] font-medium truncate"
+          style={{ color: active ? 'var(--pc-accent-light)' : 'var(--pc-text-muted)' }}
+        >
+          {theme.name}
+        </span>
+      </div>
+    </button>
+  );
+}
+
 interface Props {
   open: boolean;
   onClose: () => void;
@@ -56,17 +122,22 @@ interface Props {
 
 export function SettingsModal({ open, onClose }: Props) {
   const {
-    theme, accent, uiFont, monoFont, uiFontSize, monoFontSize,
-    setTheme, setAccent, setUiFont, setMonoFont, setUiFontSize, setMonoFontSize,
+    theme, accent, colorTheme, uiFont, monoFont, uiFontSize, monoFontSize,
+    setTheme, setAccent, setColorTheme, setUiFont, setMonoFont, setUiFontSize, setMonoFontSize,
   } = useTheme();
 
-  type TabId = 'appearance' | 'typography';
+  type TabId = 'appearance' | 'themes' | 'typography';
   const [tab, setTab] = useState<TabId>('appearance');
 
-  const tabs: { id: TabId; label: string }[] = useMemo(() => [
-    { id: 'appearance', label: t('settings.tab.appearance') },
-    { id: 'typography', label: t('settings.tab.typography') },
+  const tabs: { id: TabId; label: string; icon: typeof Palette }[] = useMemo(() => [
+    { id: 'appearance', label: t('settings.tab.appearance'), icon: Settings },
+    { id: 'themes', label: 'Themes', icon: Palette },
+    { id: 'typography', label: t('settings.tab.typography'), icon: Type },
   ], []);
+
+  // Group themes by scheme for the themes tab
+  const darkThemes = useMemo(() => colorThemes.filter(ct => ct.scheme === 'dark'), []);
+  const lightThemes = useMemo(() => colorThemes.filter(ct => ct.scheme === 'light'), []);
 
   useEffect(() => {
     if (!open) return;
@@ -89,7 +160,7 @@ export function SettingsModal({ open, onClose }: Props) {
     >
       <div className="absolute inset-0" style={{ background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(8px)' }} />
       <div
-        className="relative w-full max-w-xl mx-4 rounded-3xl border shadow-2xl animate-fade-in"
+        className="relative w-full max-w-2xl mx-4 rounded-3xl border shadow-2xl animate-fade-in"
         style={{ background: 'var(--pc-bg-base)', borderColor: 'var(--pc-border)' }}
         onClick={(e) => e.stopPropagation()}
       >
@@ -115,14 +186,14 @@ export function SettingsModal({ open, onClose }: Props) {
         </div>
 
         {/* Body */}
-        <div className="px-6 py-4 max-h-[60vh] overflow-y-auto">
+        <div className="px-6 py-4 max-h-[65vh] overflow-y-auto">
           {/* Tabs */}
           <div className="flex gap-2 mb-4">
             {tabs.map(tTab => (
               <button
                 key={tTab.id}
                 onClick={() => setTab(tTab.id)}
-                className="flex-1 rounded-xl border px-3 py-2 text-xs font-medium transition-colors"
+                className="flex-1 rounded-xl border px-3 py-2 text-xs font-medium transition-colors flex items-center justify-center gap-1.5"
                 style={tab === tTab.id
                   ? { borderColor: 'var(--pc-accent-dim)', background: 'var(--pc-accent-glow)', color: 'var(--pc-accent-light)' }
                   : { borderColor: 'var(--pc-border)', color: 'var(--pc-text-muted)', background: 'transparent' }
@@ -130,6 +201,7 @@ export function SettingsModal({ open, onClose }: Props) {
                 onMouseEnter={(e) => { if (tab !== tTab.id) e.currentTarget.style.background = 'var(--pc-hover)'; }}
                 onMouseLeave={(e) => { if (tab !== tTab.id) e.currentTarget.style.background = 'transparent'; }}
               >
+                <tTab.icon size={13} />
                 {tTab.label}
               </button>
             ))}
@@ -188,6 +260,54 @@ export function SettingsModal({ open, onClose }: Props) {
                       {accent === opt.value && <Check size={14} style={{ color: 'white' }} />}
                     </button>
                   ))}
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* Themes Tab */}
+          {tab === 'themes' && (
+            <>
+              <SectionTitle>Dark Themes</SectionTitle>
+              <div className="grid grid-cols-3 sm:grid-cols-4 gap-2 mb-4">
+                {darkThemes.map(ct => (
+                  <ThemePreviewCard
+                    key={ct.id}
+                    theme={ct}
+                    active={colorTheme === ct.id}
+                    onClick={() => setColorTheme(ct.id)}
+                  />
+                ))}
+              </div>
+
+              <SectionTitle>Light Themes</SectionTitle>
+              <div className="grid grid-cols-3 sm:grid-cols-4 gap-2 mb-4">
+                {lightThemes.map(ct => (
+                  <ThemePreviewCard
+                    key={ct.id}
+                    theme={ct}
+                    active={colorTheme === ct.id}
+                    onClick={() => setColorTheme(ct.id)}
+                  />
+                ))}
+              </div>
+
+              {/* Active theme info */}
+              <div
+                className="rounded-2xl border p-3 mt-2"
+                style={{ background: 'var(--pc-bg-surface)', borderColor: 'var(--pc-border)' }}
+              >
+                <div className="flex items-center gap-2">
+                  <Palette size={14} style={{ color: 'var(--pc-accent)' }} />
+                  <span className="text-xs font-medium" style={{ color: 'var(--pc-text-primary)' }}>
+                    {colorThemes.find(ct => ct.id === colorTheme)?.name ?? 'Default Dark'}
+                  </span>
+                  <span
+                    className="text-[10px] px-1.5 py-0.5 rounded-full"
+                    style={{ background: 'var(--pc-accent-glow)', color: 'var(--pc-accent-light)' }}
+                  >
+                    Active
+                  </span>
                 </div>
               </div>
             </>

--- a/web/src/contexts/ThemeContext.tsx
+++ b/web/src/contexts/ThemeContext.tsx
@@ -1,78 +1,12 @@
 import { useState, useEffect, useCallback, type ReactNode } from 'react';
 import { ThemeContext, type ThemeContextValue } from './ThemeContextDef';
 import { loadStored, STORAGE_KEY } from './themeStorage';
-import type { ThemeName, AccentColor, UiFont, MonoFont } from './ThemeContextDef';
+import type { ThemeMode, AccentColor, UiFont, MonoFont } from './ThemeContextDef';
 import { uiFontStacks, monoFontStacks } from './ThemeContextDef';
 import { loadUiFont, loadMonoFont } from './fontLoader';
+import { colorThemeMap, DEFAULT_DARK_THEME, DEFAULT_LIGHT_THEME, type ColorThemeId } from './colorThemes';
 
-type ConcreteTheme = 'dark' | 'light' | 'oled';
-
-const themes: Record<ConcreteTheme, Record<string, string>> = {
-  dark: {
-    '--pc-bg-base': '#1e1e24',
-    '--color-scheme': 'dark',
-    '--pc-bg-surface': '#232329',
-    '--pc-bg-elevated': '#27272a',
-    '--pc-bg-input': '#1a1a20',
-    '--pc-bg-sidebar': 'rgba(30,30,36,0.95)',
-    '--pc-bg-code': '#1a1a20',
-    '--pc-border': 'rgba(255,255,255,0.08)',
-    '--pc-border-strong': 'rgba(255,255,255,0.1)',
-    '--pc-text-primary': '#d4d4d8',
-    '--pc-text-secondary': '#a1a1aa',
-    '--pc-text-muted': '#71717a',
-    '--pc-text-faint': '#52525b',
-    '--pc-scrollbar-thumb': '#52525b',
-    '--pc-scrollbar-track': '#27272a',
-    '--pc-scrollbar-thumb-hover': '#71717a',
-    '--pc-hover': 'rgba(255,255,255,0.05)',
-    '--pc-hover-strong': 'rgba(255,255,255,0.08)',
-    '--pc-separator': 'rgba(255,255,255,0.05)',
-  },
-  light: {
-    '--pc-bg-base': '#f4f4f5',
-    '--color-scheme': 'light',
-    '--pc-bg-surface': '#ffffff',
-    '--pc-bg-elevated': '#e4e4e7',
-    '--pc-bg-input': '#ffffff',
-    '--pc-bg-sidebar': 'rgba(255,255,255,0.95)',
-    '--pc-bg-code': '#f4f4f5',
-    '--pc-border': 'rgba(0,0,0,0.08)',
-    '--pc-border-strong': 'rgba(0,0,0,0.12)',
-    '--pc-text-primary': '#18181b',
-    '--pc-text-secondary': '#3f3f46',
-    '--pc-text-muted': '#71717a',
-    '--pc-text-faint': '#a1a1aa',
-    '--pc-scrollbar-thumb': '#a1a1aa',
-    '--pc-scrollbar-track': '#e4e4e7',
-    '--pc-scrollbar-thumb-hover': '#71717a',
-    '--pc-hover': 'rgba(0,0,0,0.05)',
-    '--pc-hover-strong': 'rgba(0,0,0,0.08)',
-    '--pc-separator': 'rgba(0,0,0,0.08)',
-  },
-  oled: {
-    '--pc-bg-base': '#000000',
-    '--color-scheme': 'dark',
-    '--pc-bg-surface': '#0a0a0a',
-    '--pc-bg-elevated': '#141414',
-    '--pc-bg-input': '#0a0a0a',
-    '--pc-bg-sidebar': 'rgba(0,0,0,0.95)',
-    '--pc-bg-code': '#0a0a0a',
-    '--pc-border': 'rgba(255,255,255,0.06)',
-    '--pc-border-strong': 'rgba(255,255,255,0.08)',
-    '--pc-text-primary': '#d4d4d8',
-    '--pc-text-secondary': '#a1a1aa',
-    '--pc-text-muted': '#71717a',
-    '--pc-text-faint': '#3f3f46',
-    '--pc-scrollbar-thumb': '#3f3f46',
-    '--pc-scrollbar-track': '#0a0a0a',
-    '--pc-scrollbar-thumb-hover': '#52525b',
-    '--pc-hover': 'rgba(255,255,255,0.04)',
-    '--pc-hover-strong': 'rgba(255,255,255,0.06)',
-    '--pc-separator': 'rgba(255,255,255,0.04)',
-  },
-};
-
+/** Accent-only overrides (applied on top of color theme when user picks a custom accent). */
 const accents: Record<AccentColor, Record<string, string>> = {
   cyan: {
     '--pc-accent': '#22d3ee',
@@ -129,16 +63,32 @@ function applyVars(vars: Record<string, string>) {
   }
 }
 
-function resolveTheme(name: ThemeName): 'dark' | 'light' | 'oled' {
-  if (name === 'system') {
-    return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+/** Resolve which color theme to use based on the mode. */
+function resolveColorTheme(mode: ThemeMode, colorTheme: ColorThemeId): ColorThemeId {
+  if (mode === 'system') {
+    const preferLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+    const ct = colorThemeMap[colorTheme];
+    // If the selected theme matches system preference, use it; otherwise pick the right default
+    if (ct && ((preferLight && ct.scheme === 'light') || (!preferLight && ct.scheme === 'dark'))) {
+      return colorTheme;
+    }
+    return preferLight ? DEFAULT_LIGHT_THEME : DEFAULT_DARK_THEME;
   }
-  return name;
+  if (mode === 'oled') return 'oled-black';
+  return colorTheme;
+}
+
+function resolveThemeScheme(mode: ThemeMode, colorTheme: ColorThemeId): 'dark' | 'light' | 'oled' {
+  if (mode === 'oled') return 'oled';
+  const resolved = resolveColorTheme(mode, colorTheme);
+  const ct = colorThemeMap[resolved];
+  return ct?.scheme ?? 'dark';
 }
 
 interface ThemeSettings {
-  theme: ThemeName;
+  theme: ThemeMode;
   accent: AccentColor;
+  colorTheme: ColorThemeId;
   uiFont: UiFont;
   monoFont: MonoFont;
   uiFontSize: number;
@@ -156,8 +106,9 @@ function fontVars(uiFont: UiFont, monoFont: MonoFont, uiFontSize: number, monoFo
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
   const [stored] = useState(loadStored);
-  const [theme, setThemeState] = useState<ThemeName>(stored.theme);
+  const [theme, setThemeState] = useState<ThemeMode>(stored.theme);
   const [accent, setAccentState] = useState<AccentColor>(stored.accent);
+  const [colorTheme, setColorThemeState] = useState<ColorThemeId>(stored.colorTheme);
   const [uiFont, setUiFontState] = useState<UiFont>(stored.uiFont);
   const [monoFont, setMonoFontState] = useState<MonoFont>(stored.monoFont);
   const [uiFontSize, setUiFontSizeState] = useState<number>(stored.uiFontSize);
@@ -167,6 +118,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({
       theme: s.theme,
       accent: s.accent,
+      colorTheme: s.colorTheme,
       uiFont: s.uiFont,
       monoFont: s.monoFont,
       uiFontSize: s.uiFontSize,
@@ -175,61 +127,83 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const applyAll = useCallback((s: ThemeSettings) => {
+    const resolvedId = resolveColorTheme(s.theme, s.colorTheme);
+    const ct = colorThemeMap[resolvedId];
+    const themeVars = ct?.vars ?? colorThemeMap[DEFAULT_DARK_THEME].vars;
+    // Color theme provides base + its own accent. User accent overrides on top.
     applyVars({
-      ...themes[resolveTheme(s.theme)],
+      ...themeVars,
       ...accents[s.accent],
       ...fontVars(s.uiFont, s.monoFont, s.uiFontSize, s.monoFontSize),
     });
   }, []);
 
-  const setTheme = useCallback((t: ThemeName) => {
+  const setTheme = useCallback((t: ThemeMode) => {
     setThemeState(t);
-    const next: ThemeSettings = { theme: t, accent, uiFont, monoFont, uiFontSize, monoFontSize };
+    const next: ThemeSettings = { theme: t, accent, colorTheme, uiFont, monoFont, uiFontSize, monoFontSize };
     applyAll(next);
     persist(next);
-  }, [accent, applyAll, persist, uiFont, monoFont, uiFontSize, monoFontSize]);
+  }, [accent, colorTheme, uiFont, monoFont, uiFontSize, monoFontSize, applyAll, persist]);
 
   const setAccent = useCallback((a: AccentColor) => {
     setAccentState(a);
-    const next: ThemeSettings = { theme, accent: a, uiFont, monoFont, uiFontSize, monoFontSize };
+    const next: ThemeSettings = { theme, accent: a, colorTheme, uiFont, monoFont, uiFontSize, monoFontSize };
     applyAll(next);
     persist(next);
-  }, [theme, applyAll, persist, uiFont, monoFont, uiFontSize, monoFontSize]);
+  }, [theme, colorTheme, uiFont, monoFont, uiFontSize, monoFontSize, applyAll, persist]);
+
+  const setColorTheme = useCallback((c: ColorThemeId) => {
+    setColorThemeState(c);
+    // Auto-adjust theme mode to match the color theme's scheme
+    const ct = colorThemeMap[c];
+    let newMode = theme;
+    if (ct && theme !== 'system') {
+      if (c === 'oled-black') {
+        newMode = 'oled';
+      } else {
+        newMode = ct.scheme;
+      }
+      setThemeState(newMode);
+    }
+    const next: ThemeSettings = { theme: newMode, accent, colorTheme: c, uiFont, monoFont, uiFontSize, monoFontSize };
+    applyAll(next);
+    persist(next);
+  }, [theme, accent, uiFont, monoFont, uiFontSize, monoFontSize, applyAll, persist]);
 
   const setUiFont = useCallback((f: UiFont) => {
     setUiFontState(f);
     loadUiFont(f);
-    const next: ThemeSettings = { theme, accent, uiFont: f, monoFont, uiFontSize, monoFontSize };
+    const next: ThemeSettings = { theme, accent, colorTheme, uiFont: f, monoFont, uiFontSize, monoFontSize };
     applyAll(next);
     persist(next);
-  }, [theme, accent, applyAll, persist, monoFont, uiFontSize, monoFontSize]);
+  }, [theme, accent, colorTheme, applyAll, persist, monoFont, uiFontSize, monoFontSize]);
 
   const setMonoFont = useCallback((f: MonoFont) => {
     setMonoFontState(f);
     loadMonoFont(f);
-    const next: ThemeSettings = { theme, accent, uiFont, monoFont: f, uiFontSize, monoFontSize };
+    const next: ThemeSettings = { theme, accent, colorTheme, uiFont, monoFont: f, uiFontSize, monoFontSize };
     applyAll(next);
     persist(next);
-  }, [theme, accent, applyAll, persist, uiFont, uiFontSize, monoFontSize]);
+  }, [theme, accent, colorTheme, applyAll, persist, uiFont, uiFontSize, monoFontSize]);
 
   const setUiFontSize = useCallback((size: number) => {
     const clamped = Math.min(20, Math.max(12, size));
     setUiFontSizeState(clamped);
-    const next: ThemeSettings = { theme, accent, uiFont, monoFont, uiFontSize: clamped, monoFontSize };
+    const next: ThemeSettings = { theme, accent, colorTheme, uiFont, monoFont, uiFontSize: clamped, monoFontSize };
     applyAll(next);
     persist(next);
-  }, [theme, accent, applyAll, persist, uiFont, monoFont, monoFontSize]);
+  }, [theme, accent, colorTheme, applyAll, persist, uiFont, monoFont, monoFontSize]);
 
   const setMonoFontSize = useCallback((size: number) => {
     const clamped = Math.min(20, Math.max(12, size));
     setMonoFontSizeState(clamped);
-    const next: ThemeSettings = { theme, accent, uiFont, monoFont, uiFontSize, monoFontSize: clamped };
+    const next: ThemeSettings = { theme, accent, colorTheme, uiFont, monoFont, uiFontSize, monoFontSize: clamped };
     applyAll(next);
     persist(next);
-  }, [theme, accent, applyAll, persist, uiFont, monoFont, uiFontSize]);
+  }, [theme, accent, colorTheme, applyAll, persist, uiFont, monoFont, uiFontSize]);
 
   useEffect(() => {
-    applyAll({ theme, accent, uiFont, monoFont, uiFontSize, monoFontSize });
+    applyAll({ theme, accent, colorTheme, uiFont, monoFont, uiFontSize, monoFontSize });
     loadUiFont(uiFont);
     loadMonoFont(monoFont);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -237,16 +211,16 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (theme !== 'system') return;
     const mq = window.matchMedia('(prefers-color-scheme: light)');
-    const handler = () => applyAll({ theme: mq.matches ? 'light' : 'dark', accent, uiFont, monoFont, uiFontSize, monoFontSize });
+    const handler = () => applyAll({ theme, accent, colorTheme, uiFont, monoFont, uiFontSize, monoFontSize });
     mq.addEventListener('change', handler);
     return () => mq.removeEventListener('change', handler);
-  }, [theme, accent, applyAll, uiFont, monoFont, uiFontSize, monoFontSize]);
+  }, [theme, accent, colorTheme, applyAll, uiFont, monoFont, uiFontSize, monoFontSize]);
 
-  const resolvedTheme = resolveTheme(theme);
+  const resolvedTheme = resolveThemeScheme(theme, colorTheme);
 
   const value: ThemeContextValue = {
-    theme, accent, uiFont, monoFont, uiFontSize, monoFontSize,
-    resolvedTheme, setTheme, setAccent, setUiFont, setMonoFont, setUiFontSize, setMonoFontSize,
+    theme, accent, colorTheme, uiFont, monoFont, uiFontSize, monoFontSize,
+    resolvedTheme, setTheme, setAccent, setColorTheme, setUiFont, setMonoFont, setUiFontSize, setMonoFontSize,
   };
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;

--- a/web/src/contexts/ThemeContextDef.ts
+++ b/web/src/contexts/ThemeContextDef.ts
@@ -1,9 +1,13 @@
 import { createContext } from 'react';
+import type { ColorThemeId } from './colorThemes';
 
-export type ThemeName = 'system' | 'dark' | 'light' | 'oled';
+export type ThemeMode = 'system' | 'dark' | 'light' | 'oled';
 export type AccentColor = 'cyan' | 'violet' | 'emerald' | 'amber' | 'rose' | 'blue';
 export type UiFont = 'system' | 'inter' | 'segoe' | 'sf';
 export type MonoFont = 'jetbrains' | 'fira' | 'cascadia' | 'system-mono';
+
+/** @deprecated Use ThemeMode instead. Kept for storage backward-compat. */
+export type ThemeName = ThemeMode;
 
 export const uiFontStacks: Record<UiFont, string> = {
   system: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
@@ -20,15 +24,17 @@ export const monoFontStacks: Record<MonoFont, string> = {
 };
 
 export interface ThemeContextValue {
-  theme: ThemeName;
+  theme: ThemeMode;
   accent: AccentColor;
+  colorTheme: ColorThemeId;
   uiFont: UiFont;
   monoFont: MonoFont;
   uiFontSize: number;
   monoFontSize: number;
   resolvedTheme: 'dark' | 'light' | 'oled';
-  setTheme: (t: ThemeName) => void;
+  setTheme: (t: ThemeMode) => void;
   setAccent: (a: AccentColor) => void;
+  setColorTheme: (c: ColorThemeId) => void;
   setUiFont: (f: UiFont) => void;
   setMonoFont: (f: MonoFont) => void;
   setUiFontSize: (size: number) => void;
@@ -38,6 +44,7 @@ export interface ThemeContextValue {
 export const ThemeContext = createContext<ThemeContextValue>({
   theme: 'dark',
   accent: 'cyan',
+  colorTheme: 'default-dark',
   uiFont: 'system',
   monoFont: 'jetbrains',
   uiFontSize: 15,
@@ -45,6 +52,7 @@ export const ThemeContext = createContext<ThemeContextValue>({
   resolvedTheme: 'dark',
   setTheme: () => {},
   setAccent: () => {},
+  setColorTheme: () => {},
   setUiFont: () => {},
   setMonoFont: () => {},
   setUiFontSize: () => {},

--- a/web/src/contexts/colorThemes.ts
+++ b/web/src/contexts/colorThemes.ts
@@ -1,0 +1,285 @@
+/**
+ * Color theme palettes for the ZeroClaw dashboard.
+ *
+ * Each theme defines the full set of --pc-* CSS variables.
+ * Themes are grouped by scheme ('dark' | 'light') so the system
+ * preference resolver can pick the right default.
+ */
+
+export type ColorThemeId =
+  | 'default-dark' | 'default-light' | 'oled-black'
+  | 'nord-dark' | 'nord-light'
+  | 'dracula'
+  | 'monokai'
+  | 'solarized-dark' | 'solarized-light'
+  | 'kanagawa-wave' | 'kanagawa-dragon' | 'kanagawa-lotus'
+  | 'rose-pine' | 'rose-pine-moon' | 'rose-pine-dawn'
+  | 'night-owl'
+  | 'everforest-dark' | 'everforest-light'
+  | 'cobalt2'
+  | 'flexoki-dark' | 'flexoki-light'
+  | 'hacker-green'
+  | 'material-dark' | 'material-light';
+
+export interface ColorThemeDef {
+  id: ColorThemeId;
+  name: string;
+  scheme: 'dark' | 'light';
+  /** Preview colors for the settings card [bg, bar1, bar2, bar3, text] */
+  preview: [string, string, string, string, string];
+  vars: Record<string, string>;
+}
+
+function darkBase(
+  bgBase: string, bgSurface: string, bgElevated: string,
+  bgInput: string, bgCode: string,
+  textPrimary: string, textSecondary: string, textMuted: string, textFaint: string,
+  accent: string, accentLight: string,
+): Record<string, string> {
+  const r = parseInt(accent.slice(1, 3), 16);
+  const g = parseInt(accent.slice(3, 5), 16);
+  const b = parseInt(accent.slice(5, 7), 16);
+  return {
+    '--pc-bg-base': bgBase,
+    '--color-scheme': 'dark',
+    '--pc-bg-surface': bgSurface,
+    '--pc-bg-elevated': bgElevated,
+    '--pc-bg-input': bgInput,
+    '--pc-bg-sidebar': `${bgBase}f2`,
+    '--pc-bg-code': bgCode,
+    '--pc-border': 'rgba(255,255,255,0.08)',
+    '--pc-border-strong': 'rgba(255,255,255,0.12)',
+    '--pc-text-primary': textPrimary,
+    '--pc-text-secondary': textSecondary,
+    '--pc-text-muted': textMuted,
+    '--pc-text-faint': textFaint,
+    '--pc-scrollbar-thumb': textFaint,
+    '--pc-scrollbar-track': bgSurface,
+    '--pc-scrollbar-thumb-hover': textMuted,
+    '--pc-hover': 'rgba(255,255,255,0.05)',
+    '--pc-hover-strong': 'rgba(255,255,255,0.08)',
+    '--pc-separator': 'rgba(255,255,255,0.05)',
+    '--pc-accent': accent,
+    '--pc-accent-light': accentLight,
+    '--pc-accent-dim': `rgba(${r},${g},${b},0.3)`,
+    '--pc-accent-glow': `rgba(${r},${g},${b},0.1)`,
+    '--pc-accent-rgb': `${r},${g},${b}`,
+  };
+}
+
+function lightBase(
+  bgBase: string, bgSurface: string, bgElevated: string,
+  bgInput: string, bgCode: string,
+  textPrimary: string, textSecondary: string, textMuted: string, textFaint: string,
+  accent: string, accentLight: string,
+): Record<string, string> {
+  const r = parseInt(accent.slice(1, 3), 16);
+  const g = parseInt(accent.slice(3, 5), 16);
+  const b = parseInt(accent.slice(5, 7), 16);
+  return {
+    '--pc-bg-base': bgBase,
+    '--color-scheme': 'light',
+    '--pc-bg-surface': bgSurface,
+    '--pc-bg-elevated': bgElevated,
+    '--pc-bg-input': bgInput,
+    '--pc-bg-sidebar': `${bgSurface}f2`,
+    '--pc-bg-code': bgCode,
+    '--pc-border': 'rgba(0,0,0,0.08)',
+    '--pc-border-strong': 'rgba(0,0,0,0.12)',
+    '--pc-text-primary': textPrimary,
+    '--pc-text-secondary': textSecondary,
+    '--pc-text-muted': textMuted,
+    '--pc-text-faint': textFaint,
+    '--pc-scrollbar-thumb': textFaint,
+    '--pc-scrollbar-track': bgElevated,
+    '--pc-scrollbar-thumb-hover': textMuted,
+    '--pc-hover': 'rgba(0,0,0,0.04)',
+    '--pc-hover-strong': 'rgba(0,0,0,0.07)',
+    '--pc-separator': 'rgba(0,0,0,0.06)',
+    '--pc-accent': accent,
+    '--pc-accent-light': accentLight,
+    '--pc-accent-dim': `rgba(${r},${g},${b},0.25)`,
+    '--pc-accent-glow': `rgba(${r},${g},${b},0.08)`,
+    '--pc-accent-rgb': `${r},${g},${b}`,
+  };
+}
+
+export const colorThemes: ColorThemeDef[] = [
+  // ── Defaults ────────────────────────────────────────────────
+  {
+    id: 'default-dark', name: 'Default Dark', scheme: 'dark',
+    preview: ['#1e1e24', '#22d3ee', '#a78bfa', '#f59e0b', '#d4d4d8'],
+    vars: darkBase('#1e1e24', '#232329', '#27272a', '#1a1a20', '#1a1a20',
+      '#d4d4d8', '#a1a1aa', '#71717a', '#52525b', '#22d3ee', '#67e8f9'),
+  },
+  {
+    id: 'default-light', name: 'Default Light', scheme: 'light',
+    preview: ['#f4f4f5', '#22d3ee', '#8b5cf6', '#f59e0b', '#18181b'],
+    vars: lightBase('#f4f4f5', '#ffffff', '#e4e4e7', '#ffffff', '#f4f4f5',
+      '#18181b', '#3f3f46', '#71717a', '#a1a1aa', '#0891b2', '#06b6d4'),
+  },
+  {
+    id: 'oled-black', name: 'OLED Black', scheme: 'dark',
+    preview: ['#000000', '#22d3ee', '#8b5cf6', '#10b981', '#d4d4d8'],
+    vars: darkBase('#000000', '#0a0a0a', '#141414', '#0a0a0a', '#0a0a0a',
+      '#d4d4d8', '#a1a1aa', '#71717a', '#3f3f46', '#22d3ee', '#67e8f9'),
+  },
+
+  // ── Nord ────────────────────────────────────────────────────
+  {
+    id: 'nord-dark', name: 'Nord Dark', scheme: 'dark',
+    preview: ['#2e3440', '#88c0d0', '#81a1c1', '#a3be8c', '#eceff4'],
+    vars: darkBase('#2e3440', '#3b4252', '#434c5e', '#2e3440', '#2e3440',
+      '#eceff4', '#d8dee9', '#7b88a1', '#4c566a', '#88c0d0', '#8fbcbb'),
+  },
+  {
+    id: 'nord-light', name: 'Nord Light', scheme: 'light',
+    preview: ['#eceff4', '#5e81ac', '#88c0d0', '#a3be8c', '#2e3440'],
+    vars: lightBase('#eceff4', '#e5e9f0', '#d8dee9', '#e5e9f0', '#e5e9f0',
+      '#2e3440', '#3b4252', '#4c566a', '#7b88a1', '#5e81ac', '#81a1c1'),
+  },
+
+  // ── Dracula ─────────────────────────────────────────────────
+  {
+    id: 'dracula', name: 'Dracula', scheme: 'dark',
+    preview: ['#282a36', '#bd93f9', '#ff79c6', '#50fa7b', '#f8f8f2'],
+    vars: darkBase('#282a36', '#21222c', '#343746', '#1e1f29', '#1e1f29',
+      '#f8f8f2', '#c0c0d0', '#6272a4', '#44475a', '#bd93f9', '#caa9fa'),
+  },
+
+  // ── Monokai ─────────────────────────────────────────────────
+  {
+    id: 'monokai', name: 'Monokai', scheme: 'dark',
+    preview: ['#272822', '#f92672', '#a6e22e', '#e6db74', '#f8f8f2'],
+    vars: darkBase('#272822', '#2d2e27', '#3e3d32', '#1e1f1c', '#1e1f1c',
+      '#f8f8f2', '#c0c0b0', '#75715e', '#49483e', '#f92672', '#fd5fa0'),
+  },
+
+  // ── Solarized ───────────────────────────────────────────────
+  {
+    id: 'solarized-dark', name: 'Solarized Dark', scheme: 'dark',
+    preview: ['#002b36', '#268bd2', '#2aa198', '#b58900', '#839496'],
+    vars: darkBase('#002b36', '#073642', '#0a4050', '#002028', '#002028',
+      '#839496', '#93a1a1', '#657b83', '#586e75', '#268bd2', '#6cb6e8'),
+  },
+  {
+    id: 'solarized-light', name: 'Solarized Light', scheme: 'light',
+    preview: ['#fdf6e3', '#268bd2', '#2aa198', '#b58900', '#073642'],
+    vars: lightBase('#fdf6e3', '#eee8d5', '#ddd6c1', '#fdf6e3', '#eee8d5',
+      '#073642', '#586e75', '#657b83', '#93a1a1', '#268bd2', '#2aa198'),
+  },
+
+  // ── Kanagawa ────────────────────────────────────────────────
+  {
+    id: 'kanagawa-wave', name: 'Kanagawa Wave', scheme: 'dark',
+    preview: ['#1f1f28', '#7e9cd8', '#957fb8', '#e6c384', '#dcd7ba'],
+    vars: darkBase('#1f1f28', '#2a2a37', '#363646', '#16161d', '#16161d',
+      '#dcd7ba', '#c8c093', '#727169', '#54546d', '#7e9cd8', '#7fb4ca'),
+  },
+  {
+    id: 'kanagawa-dragon', name: 'Kanagawa Dragon', scheme: 'dark',
+    preview: ['#181616', '#8ba4b0', '#a292a3', '#c4b28a', '#c5c9c5'],
+    vars: darkBase('#181616', '#201d1d', '#2d2a2a', '#12120f', '#12120f',
+      '#c5c9c5', '#a6a69c', '#737c73', '#625e5a', '#8ba4b0', '#9cabba'),
+  },
+  {
+    id: 'kanagawa-lotus', name: 'Kanagawa Lotus', scheme: 'light',
+    preview: ['#f2ecbc', '#4d699b', '#b35b79', '#836f4a', '#1f1f28'],
+    vars: lightBase('#f2ecbc', '#e7dba0', '#d5cea3', '#f2ecbc', '#e7dba0',
+      '#1f1f28', '#545464', '#716e61', '#8a8980', '#4d699b', '#6693bf'),
+  },
+
+  // ── Ros\u00e9 Pine ──────────────────────────────────────────────
+  {
+    id: 'rose-pine', name: 'Ros\u00e9 Pine', scheme: 'dark',
+    preview: ['#191724', '#ebbcba', '#c4a7e7', '#f6c177', '#e0def4'],
+    vars: darkBase('#191724', '#1f1d2e', '#26233a', '#13111e', '#13111e',
+      '#e0def4', '#908caa', '#6e6a86', '#524f67', '#ebbcba', '#f2d5ce'),
+  },
+  {
+    id: 'rose-pine-moon', name: 'Ros\u00e9 Pine Moon', scheme: 'dark',
+    preview: ['#232136', '#ea9a97', '#c4a7e7', '#f6c177', '#e0def4'],
+    vars: darkBase('#232136', '#2a273f', '#393552', '#1b1930', '#1b1930',
+      '#e0def4', '#908caa', '#6e6a86', '#44415a', '#ea9a97', '#f0b8b6'),
+  },
+  {
+    id: 'rose-pine-dawn', name: 'Ros\u00e9 Pine Dawn', scheme: 'light',
+    preview: ['#faf4ed', '#d7827e', '#907aa9', '#ea9d34', '#575279'],
+    vars: lightBase('#faf4ed', '#fffaf3', '#f2e9de', '#fffaf3', '#f2e9de',
+      '#575279', '#797593', '#9893a5', '#cecacd', '#d7827e', '#b4637a'),
+  },
+
+  // ── Night Owl ───────────────────────────────────────────────
+  {
+    id: 'night-owl', name: 'Night Owl', scheme: 'dark',
+    preview: ['#011627', '#82aaff', '#c792ea', '#addb67', '#d6deeb'],
+    vars: darkBase('#011627', '#0b2942', '#122d42', '#010e1a', '#010e1a',
+      '#d6deeb', '#a7bbc7', '#5f7e97', '#37536b', '#82aaff', '#a0c4ff'),
+  },
+
+  // ── Everforest ──────────────────────────────────────────────
+  {
+    id: 'everforest-dark', name: 'Everforest Dark', scheme: 'dark',
+    preview: ['#2d353b', '#a7c080', '#83c092', '#dbbc7f', '#d3c6aa'],
+    vars: darkBase('#2d353b', '#343f44', '#3d484d', '#272e33', '#272e33',
+      '#d3c6aa', '#9da9a0', '#7a8478', '#56635f', '#a7c080', '#83c092'),
+  },
+  {
+    id: 'everforest-light', name: 'Everforest Light', scheme: 'light',
+    preview: ['#fdf6e3', '#8da101', '#35a77c', '#dfa000', '#5c6a72'],
+    vars: lightBase('#fdf6e3', '#f3ead3', '#e9dfc4', '#f3ead3', '#eee8d5',
+      '#5c6a72', '#708089', '#829181', '#a6b0a0', '#8da101', '#93b259'),
+  },
+
+  // ── Cobalt2 ─────────────────────────────────────────────────
+  {
+    id: 'cobalt2', name: 'Cobalt2', scheme: 'dark',
+    preview: ['#193549', '#ffc600', '#ff9d00', '#80ffbb', '#ffffff'],
+    vars: darkBase('#193549', '#1f4662', '#234d6e', '#0d2b3e', '#0d2b3e',
+      '#ffffff', '#a0c4d8', '#507a8f', '#305a6f', '#ffc600', '#ffd740'),
+  },
+
+  // ── Flexoki ─────────────────────────────────────────────────
+  {
+    id: 'flexoki-dark', name: 'Flexoki Dark', scheme: 'dark',
+    preview: ['#100f0f', '#ce5d97', '#879a39', '#da702c', '#cecdc3'],
+    vars: darkBase('#100f0f', '#1c1b1a', '#282726', '#100f0f', '#1c1b1a',
+      '#cecdc3', '#b7b5ac', '#878580', '#575653', '#ce5d97', '#d68fb2'),
+  },
+  {
+    id: 'flexoki-light', name: 'Flexoki Light', scheme: 'light',
+    preview: ['#fffcf0', '#ce5d97', '#879a39', '#da702c', '#100f0f'],
+    vars: lightBase('#fffcf0', '#f2f0e5', '#e6e4d9', '#fffcf0', '#f2f0e5',
+      '#100f0f', '#343331', '#575653', '#878580', '#ce5d97', '#a02f6f'),
+  },
+
+  // ── Hacker Green ────────────────────────────────────────────
+  {
+    id: 'hacker-green', name: 'Hacker Green', scheme: 'dark',
+    preview: ['#0a0e0a', '#00ff41', '#00cc33', '#008f11', '#33ff66'],
+    vars: darkBase('#0a0e0a', '#0d120d', '#121a12', '#080c08', '#080c08',
+      '#00ff41', '#00cc33', '#008f11', '#005a0a', '#00ff41', '#33ff66'),
+  },
+
+  // ── Material ────────────────────────────────────────────────
+  {
+    id: 'material-dark', name: 'Material Dark', scheme: 'dark',
+    preview: ['#212121', '#89ddff', '#c792ea', '#ffcb6b', '#eeffff'],
+    vars: darkBase('#212121', '#292929', '#333333', '#1a1a1a', '#1a1a1a',
+      '#eeffff', '#b0bec5', '#616161', '#424242', '#89ddff', '#80cbc4'),
+  },
+  {
+    id: 'material-light', name: 'Material Light', scheme: 'light',
+    preview: ['#fafafa', '#6182b8', '#7c4dff', '#f76d47', '#212121'],
+    vars: lightBase('#fafafa', '#ffffff', '#eaeaea', '#ffffff', '#f5f5f5',
+      '#212121', '#424242', '#757575', '#bdbdbd', '#6182b8', '#7c4dff'),
+  },
+];
+
+/** Lookup map for O(1) access by id. */
+export const colorThemeMap: Record<ColorThemeId, ColorThemeDef> =
+  Object.fromEntries(colorThemes.map(t => [t.id, t])) as Record<ColorThemeId, ColorThemeDef>;
+
+/** Default theme ids for system preference resolution. */
+export const DEFAULT_DARK_THEME: ColorThemeId = 'default-dark';
+export const DEFAULT_LIGHT_THEME: ColorThemeId = 'default-light';

--- a/web/src/contexts/themeStorage.ts
+++ b/web/src/contexts/themeStorage.ts
@@ -1,11 +1,14 @@
-import type { ThemeName, AccentColor, UiFont, MonoFont } from './ThemeContextDef';
+import type { AccentColor, UiFont, MonoFont, ThemeMode } from './ThemeContextDef';
 import { uiFontStacks, monoFontStacks } from './ThemeContextDef';
+import type { ColorThemeId } from './colorThemes';
+import { colorThemeMap } from './colorThemes';
 
 export const STORAGE_KEY = 'zeroclaw-theme';
 
 export interface StoredTheme {
-  theme: ThemeName;
+  theme: ThemeMode;
   accent: AccentColor;
+  colorTheme: ColorThemeId;
   uiFont: UiFont;
   monoFont: MonoFont;
   uiFontSize: number;
@@ -15,14 +18,24 @@ export interface StoredTheme {
 const DEFAULTS: StoredTheme = {
   theme: 'dark',
   accent: 'cyan',
+  colorTheme: 'default-dark',
   uiFont: 'system',
   monoFont: 'jetbrains',
   uiFontSize: 15,
   monoFontSize: 14,
 };
 
-const validThemes: ThemeName[] = ['dark', 'light', 'oled', 'system'];
+const validThemes: ThemeMode[] = ['dark', 'light', 'oled', 'system'];
 const validAccents: AccentColor[] = ['cyan', 'violet', 'emerald', 'amber', 'rose', 'blue'];
+
+/** Migrate old theme mode to a color theme id for backward compatibility. */
+function migrateThemeToColorTheme(themeMode: ThemeMode): ColorThemeId {
+  switch (themeMode) {
+    case 'light': return 'default-light';
+    case 'oled': return 'oled-black';
+    default: return 'default-dark';
+  }
+}
 
 export function loadStored(): StoredTheme {
   try {
@@ -35,8 +48,17 @@ export function loadStored(): StoredTheme {
       const monoFont: MonoFont = monoFontStacks[parsed.monoFont as MonoFont] ? parsed.monoFont as MonoFont : DEFAULTS.monoFont;
       const uiFontSize = Number.isFinite(parsed.uiFontSize) ? Math.min(20, Math.max(12, Number(parsed.uiFontSize))) : DEFAULTS.uiFontSize;
       const monoFontSize = Number.isFinite(parsed.monoFontSize) ? Math.min(20, Math.max(12, Number(parsed.monoFontSize))) : DEFAULTS.monoFontSize;
+
+      // Validate or migrate color theme
+      let colorTheme: ColorThemeId = DEFAULTS.colorTheme;
+      if (parsed.colorTheme && colorThemeMap[parsed.colorTheme as ColorThemeId]) {
+        colorTheme = parsed.colorTheme as ColorThemeId;
+      } else if (themeValid) {
+        colorTheme = migrateThemeToColorTheme(parsed.theme);
+      }
+
       if (themeValid && accentValid) {
-        return { theme: parsed.theme, accent: parsed.accent, uiFont, monoFont, uiFontSize, monoFontSize };
+        return { theme: parsed.theme, accent: parsed.accent, colorTheme, uiFont, monoFont, uiFontSize, monoFontSize };
       }
     }
   } catch { /* ignore */ }


### PR DESCRIPTION
## Summary
- Add **Themes** tab to settings modal with 24 color palettes (Nord, Dracula, Monokai, Solarized, Kanagawa, Rosé Pine, Night Owl, Everforest, Cobalt2, Flexoki, Material, Hacker Green, etc.)
- Each theme shown as a mini terminal preview card grouped by dark/light
- Accent colors still work as an overlay on top of any color theme
- Backward-compatible localStorage migration for existing users

## Test plan
- [ ] Open dashboard settings, verify new **Themes** tab appears
- [ ] Click through dark themes — verify background, text, borders update live
- [ ] Click through light themes — verify scheme switches correctly
- [ ] Switch accent color on top of a color theme — verify overlay works
- [ ] Refresh page — verify theme persists from localStorage
- [ ] Clear localStorage — verify defaults load without errors (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)