### PR TITLE
fix(ci): force ARMv6 codegen for arm-unknown-linux-gnueabihf release binary

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -204,6 +204,9 @@ jobs:
             linker_env: CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER
             linker: arm-linux-gnueabihf-gcc
             skip_prometheus: true
+            # Ubuntu's gcc-arm-linux-gnueabihf defaults to ARMv7 codegen.
+            # Force ARMv6+VFP so the binary runs on Raspberry Pi Zero W (#4556).
+            cflags: "-march=armv6 -mfpu=vfp -mfloat-abi=hard"
           - os: macos-14
             target: aarch64-apple-darwin
             artifact: zeroclaw
@@ -245,9 +248,16 @@ jobs:
 
       - name: Build release
         shell: bash
+        env:
+          TARGET_CFLAGS: ${{ matrix.cflags || '' }}
         run: |
           if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
             export "${{ matrix.linker_env }}=${{ matrix.linker }}"
+          fi
+          if [ -n "$TARGET_CFLAGS" ]; then
+            # Convert target triple to CFLAGS env var format (e.g. arm-unknown-linux-gnueabihf -> arm_unknown_linux_gnueabihf)
+            CFLAGS_VAR="CFLAGS_$(echo '${{ matrix.target }}' | tr '-' '_')"
+            export "$CFLAGS_VAR=$TARGET_CFLAGS"
           fi
           if [ "${{ matrix.skip_prometheus || 'false' }}" = "true" ]; then
             cargo build --release --locked --no-default-features --features "${{ env.RELEASE_CARGO_FEATURES }},channel-nostr,skill-creation" --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary

- The `zeroclaw-arm-unknown-linux-gnueabihf.tar.gz` release asset segfaults on Raspberry Pi Zero W (ARMv6) because Ubuntu's `gcc-arm-linux-gnueabihf` defaults to ARMv7+NEON codegen.
- Pass `-march=armv6 -mfpu=vfp -mfloat-abi=hard` via the `cc` crate's `CFLAGS` env var so the C toolchain emits actual ARMv6 code.
- Uses a new `cflags` matrix field, keeping the fix scoped to only the affected target.

Closes #4556

## Risk

**Low** — CI-only change, single target affected, no code changes.

## Test plan

- [ ] CI: verify the `arm-unknown-linux-gnueabihf` build succeeds
- [ ] `readelf -A` on the resulting binary should show `Tag_CPU_arch: v6` (not v7)
- [ ] Binary should run on Raspberry Pi Zero W without segfault

🤖 Generated with [Claude Code](https://claude.com/claude-code)