### PR TITLE
fix(cron): reuse live WhatsApp channel for cron delivery

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -135,7 +135,7 @@ pub fn live_channels_registry() -> &'static Mutex<HashMap<String, Arc<dyn Channe
     LIVE_CHANNELS.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-pub fn register_live_channels(channels: &HashMap<String, Arc<dyn Channel>>) {
+pub fn register_live_channels<S: ::std::hash::BuildHasher>(channels: &HashMap<String, Arc<dyn Channel>, S>) {
     let mut registry = live_channels_registry().lock().unwrap();
     for (name, ch) in channels {
         registry.insert(name.clone(), Arc::clone(ch));

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -127,6 +127,7 @@ use std::time::{Duration, Instant, SystemTime};
 use tokio_util::sync::CancellationToken;
 
 /// Process-global registry of live (connected) channel instances.
+///
 /// Populated by `start_channels()` so that subsystems like cron can
 /// reuse the daemon's connected channels instead of creating new ones.
 static LIVE_CHANNELS: OnceLock<Mutex<HashMap<String, Arc<dyn Channel>>>> = OnceLock::new();

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -126,6 +126,33 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant, SystemTime};
 use tokio_util::sync::CancellationToken;
 
+/// Process-global registry of live (connected) channel instances.
+/// Populated by `start_channels()` so that subsystems like cron can
+/// reuse the daemon's connected channels instead of creating new ones.
+static LIVE_CHANNELS: OnceLock<Mutex<HashMap<String, Arc<dyn Channel>>>> = OnceLock::new();
+
+pub fn live_channels_registry() -> &'static Mutex<HashMap<String, Arc<dyn Channel>>> {
+    LIVE_CHANNELS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub fn register_live_channels(channels: &HashMap<String, Arc<dyn Channel>>) {
+    let mut registry = live_channels_registry().lock().unwrap();
+    for (name, ch) in channels {
+        registry.insert(name.clone(), Arc::clone(ch));
+    }
+}
+
+pub fn get_live_channel(name: &str) -> Option<Arc<dyn Channel>> {
+    let registry = live_channels_registry().lock().unwrap();
+    registry.get(name).cloned()
+}
+
+pub fn clear_live_channels() {
+    if let Some(registry) = LIVE_CHANNELS.get() {
+        registry.lock().unwrap().clear();
+    }
+}
+
 /// Observer wrapper that forwards tool-call events to a channel sender
 /// for real-time threaded notifications.
 struct ChannelNotifyObserver {
@@ -4558,6 +4585,9 @@ pub async fn doctor_channels(config: Config) -> Result<()> {
 /// Start all configured channels and route messages to the agent
 #[allow(clippy::too_many_lines)]
 pub async fn start_channels(config: Config) -> Result<()> {
+    // Clear any previously registered live channels (e.g. on restart).
+    clear_live_channels();
+
     let provider_name = resolved_default_provider(&config);
     let provider_runtime_options = providers::ProviderRuntimeOptions {
         auth_profile_override: None,
@@ -4939,6 +4969,9 @@ pub async fn start_channels(config: Config) -> Result<()> {
             map.insert(name.clone(), Arc::clone(ch));
         }
     }
+
+    // Register live channels for subsystems like cron delivery.
+    register_live_channels(channels_by_name.as_ref());
 
     let max_in_flight_messages = compute_max_in_flight_messages(channels.len());
 

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -548,29 +548,36 @@ pub(crate) async fn deliver_announcement(
         "whatsapp" | "whatsapp-web" | "whatsapp_web" => {
             #[cfg(feature = "whatsapp-web")]
             {
-                let wa = config
-                    .channels_config
-                    .whatsapp
-                    .as_ref()
-                    .ok_or_else(|| anyhow::anyhow!("whatsapp channel not configured"))?;
-                if !wa.is_web_config() {
-                    anyhow::bail!(
-                        "whatsapp cron delivery requires Web mode (session_path must be set)"
+                // Try to reuse the daemon's live (connected) channel first.
+                if let Some(live_ch) = crate::channels::get_live_channel("whatsapp") {
+                    live_ch
+                        .send(&SendMessage::new(safe_output.as_str(), target))
+                        .await?;
+                } else {
+                    let wa = config
+                        .channels_config
+                        .whatsapp
+                        .as_ref()
+                        .ok_or_else(|| anyhow::anyhow!("whatsapp channel not configured"))?;
+                    if !wa.is_web_config() {
+                        anyhow::bail!(
+                            "whatsapp cron delivery requires Web mode (session_path must be set)"
+                        );
+                    }
+                    let channel = WhatsAppWebChannel::new(
+                        wa.session_path.clone().unwrap_or_default(),
+                        wa.pair_phone.clone(),
+                        wa.pair_code.clone(),
+                        wa.allowed_numbers.clone(),
+                        wa.mode.clone(),
+                        wa.dm_policy.clone(),
+                        wa.group_policy.clone(),
+                        wa.self_chat_mode,
                     );
+                    channel
+                        .send(&SendMessage::new(safe_output.as_str(), target))
+                        .await?;
                 }
-                let channel = WhatsAppWebChannel::new(
-                    wa.session_path.clone().unwrap_or_default(),
-                    wa.pair_phone.clone(),
-                    wa.pair_code.clone(),
-                    wa.allowed_numbers.clone(),
-                    wa.mode.clone(),
-                    wa.dm_policy.clone(),
-                    wa.group_policy.clone(),
-                    wa.self_chat_mode,
-                );
-                channel
-                    .send(&SendMessage::new(safe_output.as_str(), target))
-                    .await?;
             }
             #[cfg(not(feature = "whatsapp-web"))]
             {


### PR DESCRIPTION
## Summary

- Adds a process-global live channel registry (`LIVE_CHANNELS`) in `src/channels/mod.rs` so that subsystems like cron can look up the daemon's already-connected channel instances
- `start_channels()` now registers all channels into the registry after initialization (and clears it on restart)
- `deliver_announcement()` in `src/cron/scheduler.rs` now tries `get_live_channel("whatsapp")` first, falling back to creating a new `WhatsAppWebChannel` only if no live channel is registered
- This prevents the 403 errors caused by creating a new disconnected `WhatsAppWebChannel` (which has `client: None` because `listen()` was never called)

Re-applies the approach from PR #2116 (commit 1a037270) which was accidentally merged to `main` instead of `master`.

Fixes #4537

## Test plan

- [ ] Verify `cargo check` passes (confirmed locally)
- [ ] Verify WhatsApp Web cron delivery uses the live channel when the daemon is running
- [ ] Verify fallback path still works for non-Web (Cloud/API) WhatsApp configurations
- [ ] Verify `clear_live_channels()` properly resets state on daemon restart