### PR TITLE
fix(security): take ownership of .secret_key on Windows

### DIFF
--- a/src/security/secrets.rs
+++ b/src/security/secrets.rs
@@ -200,6 +200,28 @@ impl SecretStore {
                     return Ok(key);
                 };
 
+                // First, ensure the current user owns the file. Without this,
+                // Windows may assign an invalid SID as owner, making the file
+                // unreadable for subsequent commands. (See issue #4532.)
+                match std::process::Command::new("takeown")
+                    .arg("/F")
+                    .arg(&self.key_path)
+                    .output()
+                {
+                    Ok(o) if !o.status.success() => {
+                        tracing::warn!(
+                            "Failed to take ownership of key file via takeown (exit code {:?})",
+                            o.status.code()
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!("Could not take ownership of key file: {e}");
+                    }
+                    _ => {
+                        tracing::debug!("Key file ownership set to current user via takeown");
+                    }
+                }
+
                 match std::process::Command::new("icacls")
                     .arg(&self.key_path)
                     .args(["/inheritance:r", "/grant:r"])
@@ -846,6 +868,29 @@ mod tests {
             perms.mode() & 0o777,
             0o600,
             "Key file must be owner-only (0600)"
+        );
+    }
+
+    /// Document the expected ordering on Windows: `takeown` runs before `icacls`.
+    ///
+    /// Without `takeown`, the file owner may be an invalid SID, causing `icacls`
+    /// grants to succeed against an unowned file that later becomes unreadable.
+    /// This test verifies the code structure expectation (see issue #4532).
+    #[test]
+    fn takeown_runs_before_icacls_on_windows() {
+        // Read the source to confirm `takeown` appears before `icacls` in the
+        // Windows cfg block of `load_or_create_key`. This is a structural
+        // documentation test — the actual commands are Windows-only.
+        let source = include_str!("secrets.rs");
+        let takeown_pos = source
+            .find("Command::new(\"takeown\")")
+            .expect("takeown call must exist in secrets.rs");
+        let icacls_pos = source
+            .find("Command::new(\"icacls\")")
+            .expect("icacls call must exist in secrets.rs");
+        assert!(
+            takeown_pos < icacls_pos,
+            "takeown must run before icacls to fix file ownership first (issue #4532)"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Adds `takeown /F` call before `icacls` when creating `.secret_key` on Windows
- Fixes file ownership being set to an invalid SID, making the key file unreadable
- Adds structural test to ensure `takeown` always runs before `icacls`

Fixes #4532

## Test plan
- [ ] Verify `takeown /F` is called before `icacls` in Windows codepath
- [ ] Test with elevated and non-elevated terminals on Windows
- [ ] Confirm `.secret_key` has correct owner SID after `zeroclaw onboard`
- [ ] Run `cargo test` for the new ordering test