### PR TITLE
feat(provider): parse proxy tool events from SSE stream

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -947,25 +947,65 @@ impl Agent {
             use futures_util::StreamExt;
 
             let stream_opts = crate::providers::traits::StreamOptions::new(true);
-            let mut stream = self.provider.stream_chat_with_history(
-                &messages,
+            let mut stream = self.provider.stream_chat(
+                crate::providers::ChatRequest {
+                    messages: &messages,
+                    // tools: None — turn_streamed is used by the gateway WS handler
+                    // for dashboard chat. Tool dispatch is handled by the main agent
+                    // loop (run_tool_call_loop) for channel messages. Passing tools
+                    // here would change behavior for all providers, not just proxies.
+                    tools: None,
+                },
                 &effective_model,
                 self.temperature,
                 stream_opts,
             );
 
             let mut streamed_text = String::new();
+            let mut streamed_tool_calls: Vec<crate::providers::traits::ToolCall> = Vec::new();
             let mut got_stream = false;
 
             while let Some(item) = stream.next().await {
                 match item {
-                    Ok(chunk) => {
-                        if !chunk.delta.is_empty() {
-                            got_stream = true;
-                            streamed_text.push_str(&chunk.delta);
-                            let _ = event_tx.send(TurnEvent::Chunk { delta: chunk.delta }).await;
+                    Ok(event) => match event {
+                        crate::providers::traits::StreamEvent::TextDelta(chunk) => {
+                            if !chunk.delta.is_empty() {
+                                got_stream = true;
+                                streamed_text.push_str(&chunk.delta);
+                                let _ =
+                                    event_tx.send(TurnEvent::Chunk { delta: chunk.delta }).await;
+                            }
                         }
-                    }
+                        crate::providers::traits::StreamEvent::ToolCall(tc) => {
+                            got_stream = true;
+                            let _ = event_tx
+                                .send(TurnEvent::ToolCall {
+                                    name: tc.name.clone(),
+                                    args: serde_json::from_str(&tc.arguments).unwrap_or_default(),
+                                })
+                                .await;
+                            streamed_tool_calls.push(tc);
+                        }
+                        crate::providers::traits::StreamEvent::PreExecutedToolCall {
+                            name,
+                            args,
+                        } => {
+                            let _ = event_tx
+                                .send(TurnEvent::ToolCall {
+                                    name,
+                                    args: serde_json::from_str(&args).unwrap_or_default(),
+                                })
+                                .await;
+                            // NOT pushed to streamed_tool_calls — already executed by proxy
+                        }
+                        crate::providers::traits::StreamEvent::PreExecutedToolResult {
+                            name,
+                            output,
+                        } => {
+                            let _ = event_tx.send(TurnEvent::ToolResult { name, output }).await;
+                        }
+                        crate::providers::traits::StreamEvent::Final => break,
+                    },
                     Err(_) => break,
                 }
             }
@@ -978,7 +1018,7 @@ impl Agent {
                 // Build a synthetic ChatResponse from streamed text
                 crate::providers::ChatResponse {
                     text: Some(streamed_text),
-                    tool_calls: Vec::new(),
+                    tool_calls: streamed_tool_calls,
                     usage: None,
                     reasoning_content: None,
                 }

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2390,6 +2390,11 @@ async fn consume_provider_streaming_response(
                     outcome.forwarded_live_deltas = false;
                 }
             }
+            StreamEvent::PreExecutedToolCall { .. } | StreamEvent::PreExecutedToolResult { .. } => {
+                // Pre-executed tool events are for observability only.
+                // They are forwarded to the gateway via turn_streamed but
+                // do not affect the agent's tool dispatch loop.
+            }
             StreamEvent::TextDelta(chunk) => {
                 if chunk.delta.is_empty() {
                     continue;

--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -860,6 +860,40 @@ fn parse_sse_chunk(line: &str) -> StreamResult<Option<StreamChunkResponse>> {
         .map_err(StreamError::Json)
 }
 
+/// Parse custom proxy tool events from SSE lines.
+/// These are emitted by proxies like claude-max-api-proxy that execute tools
+/// internally and forward observability events via custom SSE fields.
+fn parse_proxy_tool_event(line: &str) -> Option<StreamEvent> {
+    let data = line.trim().strip_prefix("data:")?.trim();
+    let obj: serde_json::Value = serde_json::from_str(data).ok()?;
+
+    if let Some(ts) = obj.get("x_tool_start") {
+        let name = ts.get("name")?.as_str()?.to_string();
+        let args = ts
+            .get("arguments")
+            .and_then(|v| v.as_str())
+            .unwrap_or("{}")
+            .to_string();
+        return Some(StreamEvent::PreExecutedToolCall { name, args });
+    }
+
+    if let Some(tr) = obj.get("x_tool_result") {
+        let name = tr
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let output = tr
+            .get("output")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        return Some(StreamEvent::PreExecutedToolResult { name, output });
+    }
+
+    None
+}
+
 fn extract_sse_text_delta(choice: &StreamChoice) -> Option<String> {
     if let Some(content) = &choice.delta.content {
         if !content.is_empty() {
@@ -1000,6 +1034,15 @@ fn sse_bytes_to_events(
                     while let Some(pos) = buffer.find('\n') {
                         let line = buffer[..pos].to_string();
                         buffer.drain(..=pos);
+
+                        // Custom proxy events for pre-executed tool calls
+                        // (e.g. claude-max-api-proxy streaming x_tool_start/x_tool_result)
+                        if let Some(event) = parse_proxy_tool_event(&line) {
+                            if tx.send(Ok(event)).await.is_err() {
+                                return;
+                            }
+                            continue;
+                        }
 
                         let chunk = match parse_sse_chunk(&line) {
                             Ok(Some(chunk)) => chunk,

--- a/src/providers/traits.rs
+++ b/src/providers/traits.rs
@@ -175,6 +175,11 @@ pub enum StreamEvent {
     TextDelta(StreamChunk),
     /// Structured tool call emitted during streaming.
     ToolCall(ToolCall),
+    /// A tool call that was already executed by the provider (e.g. Claude Code proxy).
+    /// Emitted for observability only — not re-executed by the agent's dispatcher.
+    PreExecutedToolCall { name: String, args: String },
+    /// The result of a pre-executed tool call.
+    PreExecutedToolResult { name: String, output: String },
     /// Stream has completed.
     Final,
 }


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: When ZeroClaw uses a proxy that executes tools internally (e.g. Claude Code via `claude-max-api-proxy`), tool calls are invisible — the proxy returns only the final text, so `turn_streamed()` never emits `ToolCall`/`ToolResult` events.
- Why it matters: Observability tooling ([Eyrie dashboard](https://github.com/Audacity88/eyrie), gateway WebSocket clients) cannot show tool activity for proxy-backed sessions.
- What changed: Added `StreamEvent::PreExecutedToolResult` variant and `parse_proxy_tool_event()` in the compatible provider's SSE parser. Custom `x_tool_start`/`x_tool_result` events from proxies are now emitted as `StreamEvent`s, which flow through the existing streaming infrastructure (#4175) to the gateway WebSocket.
- What did **not** change: No changes to `ChatResponse`, no new trait methods, no config toggles. Builds entirely on the `StreamEvent`/`stream_chat()`/`TurnEvent` infrastructure from #4175.

## Rebased on #4175

This PR was originally built before #4175 merged. After rebasing:
- **Dropped**: `ProviderEvent` enum, `chat_with_events()` trait method, `provider_stream` config toggle, `ReliableProvider` delegation — all superseded by #4175's `StreamEvent`, `stream_chat()`, and provider delegation chain.
- **Kept**: Custom SSE event parsing (`x_tool_start`/`x_tool_result`) and `PreExecutedToolResult` variant — the proxy observability gap that #4175 doesn't address.
- **Supersedes**: #4350 (now closed)

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `provider`
- Module labels: `provider: compatible`
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `feature`
- Primary scope: `provider`

## Files Changed (4 files)

1. `src/providers/traits.rs` — Add `StreamEvent::PreExecutedToolResult { name, output }` variant
2. `src/providers/compatible.rs` — Add `parse_proxy_tool_event()` to parse `x_tool_start`/`x_tool_result` from SSE lines
3. `src/agent/loop_.rs` — Handle `PreExecutedToolResult` in tool dispatch loop (no-op, observability only)
4. `src/agent/agent.rs` — Forward `StreamEvent`s as `TurnEvent`s in `turn_streamed()`, including `PreExecutedToolResult` → `TurnEvent::ToolResult`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # ✅ pass
cargo build --release        # ✅ pass
cargo clippy --all-targets -- -D warnings  # ✅ pass
```

- End-to-end test: claude-max-api-proxy emitting custom SSE → ZeroClaw parsing → gateway WS frames → Eyrie dashboard showing tool call cards with names and output

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`

## Compatibility / Migration

- Backward compatible? Yes — new `StreamEvent` variant is additive; unknown SSE events are silently skipped
- Config/env changes? None
- Migration needed? No

## Human Verification (required)

- Verified scenarios: End-to-end with claude-max-api-proxy → ZeroClaw → Eyrie dashboard
- Edge cases checked: Non-proxy providers (events silently ignored), malformed SSE lines (skipped)
- What was not verified: Multiple concurrent tool calls from proxy in a single session

## Side Effects / Blast Radius (required)

- Affected subsystems: compatible provider SSE parser, agent turn_streamed loop
- Potential unintended effects: None — parsing runs before standard chunk parsing, unknown JSON silently returns None
- Guardrails: Custom events use `x_` prefix to avoid collision with standard OpenAI fields

## Rollback Plan (required)

- Fast rollback: Revert the 4 files; `PreExecutedToolResult` events simply stop being emitted
- Observable failure symptoms: Tool call cards disappear from Eyrie dashboard (reverts to current behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)