### PR TITLE
fix: whatsapp personal mode

### DIFF
--- a/docs/reference/api/channels-reference.md
+++ b/docs/reference/api/channels-reference.md
@@ -211,7 +211,19 @@ user_id = "@zeroclaw:matrix.example.com"   # optional, recommended for E2EE
 device_id = "DEVICEID123"                  # optional, recommended for E2EE
 room_id = "!room:matrix.example.com"       # or room alias (#ops:matrix.example.com)
 allowed_users = ["*"]
+stream_mode = "partial"                    # optional: off | partial | multi_message (default: partial via wizard)
+draft_update_interval_ms = 1500            # optional: edit throttle for partial streaming
+multi_message_delay_ms = 800               # optional: delay between paragraph sends in multi_message mode
 ```
+
+Matrix streaming notes:
+
+- `stream_mode = "partial"` sends an editable draft message that updates token-by-token via Matrix `m.replace` edits as the LLM streams its response.
+- `stream_mode = "multi_message"` delivers the response incrementally as separate messages, splitting at paragraph boundaries (`\n\n`) as tokens arrive. Code fences are never split across messages.
+- `draft_update_interval_ms` controls edit throttling in partial mode (default: 1500ms, higher than Telegram to account for E2EE re-encryption overhead and federation latency).
+- `multi_message_delay_ms` controls minimum delay between paragraph sends in multi_message mode (default: 800ms).
+- Both modes work in encrypted and unencrypted rooms — the matrix-sdk handles E2EE transparently.
+- Existing configs without `stream_mode` default to `off` (no behavior change).
 
 See [Matrix E2EE Guide](../../security/matrix-e2ee-guide.md) for encrypted-room troubleshooting.
 

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -10,7 +10,8 @@ use matrix_sdk::{
         events::relation::{Annotation, Thread},
         events::room::member::StrippedRoomMemberEvent,
         events::room::message::{
-            MessageType, OriginalSyncRoomMessageEvent, Relation, RoomMessageEventContent,
+            MessageType, OriginalSyncRoomMessageEvent, Relation, ReplacementMetadata,
+            RoomMessageEventContent,
         },
         events::room::MediaSource,
         OwnedEventId, OwnedRoomId, OwnedUserId,
@@ -44,6 +45,16 @@ pub struct MatrixChannel {
     voice_mode: Arc<AtomicBool>,
     transcription: Option<crate::config::TranscriptionConfig>,
     transcription_manager: Option<Arc<super::transcription::TranscriptionManager>>,
+    stream_mode: crate::config::StreamMode,
+    draft_update_interval_ms: u64,
+    multi_message_delay_ms: u64,
+    /// Per-room rate-limit tracking for Partial draft edits.
+    last_draft_edit: Arc<Mutex<HashMap<String, std::time::Instant>>>,
+    /// Tracks how much text has been sent in MultiMessage mode so we can
+    /// detect new paragraphs from the accumulated text passed to `update_draft`.
+    multi_message_sent_len: Arc<Mutex<HashMap<String, usize>>>,
+    /// Thread context captured from `send_draft()` for MultiMessage paragraph delivery.
+    multi_message_thread_ts: Arc<Mutex<HashMap<String, Option<String>>>>,
 }
 
 impl std::fmt::Debug for MatrixChannel {
@@ -219,7 +230,27 @@ impl MatrixChannel {
             voice_mode: Arc::new(AtomicBool::new(false)),
             transcription: None,
             transcription_manager: None,
+            stream_mode: crate::config::StreamMode::Off,
+            draft_update_interval_ms: 1500,
+            multi_message_delay_ms: 800,
+            last_draft_edit: Arc::new(Mutex::new(HashMap::new())),
+            multi_message_sent_len: Arc::new(Mutex::new(HashMap::new())),
+            multi_message_thread_ts: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    /// Configure streaming mode for progressive draft updates or
+    /// paragraph-split multi-message delivery.
+    pub fn with_streaming(
+        mut self,
+        stream_mode: crate::config::StreamMode,
+        draft_update_interval_ms: u64,
+        multi_message_delay_ms: u64,
+    ) -> Self {
+        self.stream_mode = stream_mode;
+        self.draft_update_interval_ms = draft_update_interval_ms;
+        self.multi_message_delay_ms = multi_message_delay_ms;
+        self
     }
 
     /// Configure voice transcription for audio messages.
@@ -239,6 +270,58 @@ impl MatrixChannel {
             }
         }
         self
+    }
+
+    /// Extract the room ID from a recipient string (handles `sender||room_id` format).
+    fn extract_room_id(recipient: &str, fallback_room_id: &str) -> String {
+        if recipient.contains("||") {
+            recipient.split_once("||").unwrap().1.to_string()
+        } else {
+            fallback_room_id.to_string()
+        }
+    }
+
+    /// Get a joined Matrix room by ID, syncing once if not immediately available.
+    async fn get_joined_room(&self, room_id_str: &str) -> anyhow::Result<matrix_sdk::Room> {
+        let client = self.matrix_client().await?;
+        let target_room: OwnedRoomId = room_id_str.parse()?;
+
+        let mut room = client.get_room(&target_room);
+        if room.is_none() {
+            let _ = client.sync_once(SyncSettings::new()).await;
+            room = client.get_room(&target_room);
+        }
+
+        let room = room.ok_or_else(|| {
+            anyhow::anyhow!("Matrix room '{}' not found in joined rooms", room_id_str)
+        })?;
+
+        if room.state() != RoomState::Joined {
+            anyhow::bail!("Matrix room '{}' is not in joined state", room_id_str);
+        }
+
+        Ok(room)
+    }
+
+    /// Edit an existing message using Matrix's m.replace relation.
+    /// The matrix-sdk handles E2EE transparently — edits in encrypted rooms
+    /// are re-encrypted automatically.
+    async fn edit_message(
+        &self,
+        room_id_str: &str,
+        original_event_id: &str,
+        new_text: &str,
+    ) -> anyhow::Result<()> {
+        let room = self.get_joined_room(room_id_str).await?;
+        let original_id: OwnedEventId = original_event_id
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Invalid event ID for edit: {}", original_event_id))?;
+
+        let replacement = RoomMessageEventContent::text_markdown(new_text)
+            .make_replacement(ReplacementMetadata::new(original_id, None));
+
+        room.send(replacement).await?;
+        Ok(())
     }
 
     fn encode_path_segment(value: &str) -> String {
@@ -1260,6 +1343,265 @@ impl Channel for MatrixChannel {
 
         room.redact(&event_id, reason.as_deref(), None).await?;
         Ok(())
+    }
+
+    // ── Streaming support ──────────────────────────────────────────
+
+    fn supports_draft_updates(&self) -> bool {
+        self.stream_mode != crate::config::StreamMode::Off
+    }
+
+    async fn send_draft(&self, message: &SendMessage) -> anyhow::Result<Option<String>> {
+        use crate::config::StreamMode;
+        match self.stream_mode {
+            StreamMode::Off => Ok(None),
+            StreamMode::Partial => {
+                // Send initial "..." draft message; return event_id for later edits.
+                let room_id = Self::extract_room_id(&message.recipient, &self.room_id);
+                let room = self.get_joined_room(&room_id).await?;
+
+                let initial_text = if message.content.is_empty() {
+                    "..."
+                } else {
+                    &message.content
+                };
+
+                let mut content = RoomMessageEventContent::text_markdown(initial_text);
+
+                // Preserve threading if applicable.
+                if let Some(ref thread_ts) = message.thread_ts {
+                    if let Ok(thread_root) = thread_ts.parse::<OwnedEventId>() {
+                        content.relates_to = Some(Relation::Thread(Thread::plain(
+                            thread_root.clone(),
+                            thread_root,
+                        )));
+                    }
+                }
+
+                let response = room.send(content).await?;
+                let event_id = response.event_id.to_string();
+
+                self.last_draft_edit
+                    .lock()
+                    .await
+                    .insert(room_id, std::time::Instant::now());
+
+                Ok(Some(event_id))
+            }
+            StreamMode::MultiMessage => {
+                // MultiMessage: no initial draft — paragraphs are sent as new messages.
+                // Return a synthetic ID so the draft_updater task runs.
+                // Capture thread context for paragraph delivery.
+                let room_id = Self::extract_room_id(&message.recipient, &self.room_id);
+                self.multi_message_sent_len.lock().await.clear();
+                self.multi_message_thread_ts
+                    .lock()
+                    .await
+                    .insert(room_id, message.thread_ts.clone());
+                Ok(Some("multi_message_synthetic".to_string()))
+            }
+        }
+    }
+
+    async fn update_draft(
+        &self,
+        recipient: &str,
+        message_id: &str,
+        text: &str,
+    ) -> anyhow::Result<()> {
+        use crate::config::StreamMode;
+        let room_id = Self::extract_room_id(recipient, &self.room_id);
+
+        match self.stream_mode {
+            StreamMode::Off => Ok(()),
+            StreamMode::Partial => {
+                // Rate-limit edits per room.
+                {
+                    let last_edits = self.last_draft_edit.lock().await;
+                    if let Some(last_time) = last_edits.get(&room_id) {
+                        let elapsed =
+                            u64::try_from(last_time.elapsed().as_millis()).unwrap_or(u64::MAX);
+                        if elapsed < self.draft_update_interval_ms {
+                            return Ok(());
+                        }
+                    }
+                }
+
+                if let Err(e) = self.edit_message(&room_id, message_id, text).await {
+                    tracing::debug!("Matrix draft update edit failed: {e}");
+                    return Ok(());
+                }
+
+                self.last_draft_edit
+                    .lock()
+                    .await
+                    .insert(room_id, std::time::Instant::now());
+
+                Ok(())
+            }
+            StreamMode::MultiMessage => {
+                // The draft_updater passes the full accumulated text each call.
+                // Track how much we've already sent and only process new content.
+                let thread_ts = self
+                    .multi_message_thread_ts
+                    .lock()
+                    .await
+                    .get(&room_id)
+                    .cloned()
+                    .flatten();
+                let mut sent_map = self.multi_message_sent_len.lock().await;
+                let sent_so_far = sent_map.get(&room_id).copied().unwrap_or(0);
+
+                // If accumulated text is shorter than what we've tracked, a
+                // DraftEvent::Clear reset the accumulator — reset our counter.
+                if text.len() < sent_so_far {
+                    sent_map.insert(room_id.clone(), 0);
+                    return Ok(());
+                }
+                if text.len() == sent_so_far {
+                    return Ok(());
+                }
+
+                let new_text = &text[sent_so_far..];
+                // Scan for paragraph boundaries (\n\n outside code fences).
+                let mut scan_pos = 0;
+                let mut in_fence = false;
+                let bytes = new_text.as_bytes();
+
+                while scan_pos < bytes.len() {
+                    let ch = bytes[scan_pos];
+
+                    // Detect code fence toggles (``` at start of line).
+                    if ch == b'`'
+                        && scan_pos + 2 < bytes.len()
+                        && bytes[scan_pos + 1] == b'`'
+                        && bytes[scan_pos + 2] == b'`'
+                        && (scan_pos == 0
+                            || bytes[scan_pos - 1] == b'\n'
+                            || (sent_so_far + scan_pos == 0))
+                    {
+                        in_fence = !in_fence;
+                    }
+
+                    // Detect \n\n paragraph boundary outside fences.
+                    if !in_fence
+                        && ch == b'\n'
+                        && scan_pos + 1 < bytes.len()
+                        && bytes[scan_pos + 1] == b'\n'
+                    {
+                        let paragraph = new_text[..scan_pos].trim().to_string();
+                        if !paragraph.is_empty() {
+                            let msg = SendMessage::new(&paragraph, recipient)
+                                .in_thread(thread_ts.clone());
+                            if let Err(e) = self.send(&msg).await {
+                                tracing::debug!("Multi-message paragraph send failed: {e}");
+                            }
+                            if self.multi_message_delay_ms > 0 {
+                                tokio::time::sleep(std::time::Duration::from_millis(
+                                    self.multi_message_delay_ms,
+                                ))
+                                .await;
+                            }
+                        }
+                        // Advance past the \n\n and update tracking.
+                        let consumed = scan_pos + 2;
+                        *sent_map.entry(room_id.clone()).or_insert(0) += consumed;
+                        // Recurse on remaining text by slicing.
+                        let remaining = &new_text[consumed..];
+                        if !remaining.is_empty() {
+                            drop(sent_map);
+                            return self.update_draft(recipient, message_id, text).await;
+                        }
+                        return Ok(());
+                    }
+
+                    scan_pos += 1;
+                }
+
+                // No paragraph boundary found yet — buffer continues accumulating.
+                Ok(())
+            }
+        }
+    }
+
+    async fn update_draft_progress(
+        &self,
+        recipient: &str,
+        message_id: &str,
+        text: &str,
+    ) -> anyhow::Result<()> {
+        // Only Partial mode shows progress (via m.replace edit).
+        // MultiMessage ignores progress — no draft message to show it in.
+        if self.stream_mode == crate::config::StreamMode::Partial {
+            self.update_draft(recipient, message_id, text).await
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn finalize_draft(
+        &self,
+        recipient: &str,
+        message_id: &str,
+        text: &str,
+    ) -> anyhow::Result<()> {
+        use crate::config::StreamMode;
+        let room_id = Self::extract_room_id(recipient, &self.room_id);
+
+        match self.stream_mode {
+            StreamMode::Off => Ok(()),
+            StreamMode::Partial => {
+                // Final m.replace edit with complete text.
+                self.last_draft_edit.lock().await.remove(&room_id);
+                self.edit_message(&room_id, message_id, text).await
+            }
+            StreamMode::MultiMessage => {
+                // Flush any remaining buffered text that didn't hit a \n\n boundary.
+                let mut sent_map = self.multi_message_sent_len.lock().await;
+                let sent_so_far = sent_map.get(&room_id).copied().unwrap_or(0);
+
+                if text.len() > sent_so_far {
+                    let remaining = text[sent_so_far..].trim().to_string();
+                    if !remaining.is_empty() {
+                        let thread_ts = self
+                            .multi_message_thread_ts
+                            .lock()
+                            .await
+                            .get(&room_id)
+                            .cloned()
+                            .flatten();
+                        let msg = SendMessage::new(&remaining, recipient).in_thread(thread_ts);
+                        if let Err(e) = self.send(&msg).await {
+                            tracing::debug!("Multi-message final flush failed: {e}");
+                        }
+                    }
+                }
+
+                sent_map.remove(&room_id);
+                self.multi_message_thread_ts.lock().await.remove(&room_id);
+                Ok(())
+            }
+        }
+    }
+
+    async fn cancel_draft(&self, recipient: &str, message_id: &str) -> anyhow::Result<()> {
+        use crate::config::StreamMode;
+        let room_id = Self::extract_room_id(recipient, &self.room_id);
+
+        match self.stream_mode {
+            StreamMode::Off => Ok(()),
+            StreamMode::Partial => {
+                // Redact the draft message.
+                self.last_draft_edit.lock().await.remove(&room_id);
+                self.redact_message(&room_id, message_id, None).await
+            }
+            StreamMode::MultiMessage => {
+                // Paragraphs already sent can't be unsent. Just clean up state.
+                self.multi_message_sent_len.lock().await.remove(&room_id);
+                self.multi_message_thread_ts.lock().await.remove(&room_id);
+                Ok(())
+            }
+        }
     }
 }
 

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1895,8 +1895,9 @@ fn sanitize_channel_response(response: &str, tools: &[Box<dyn Tool>]) -> String 
         .map(|tool| tool.name().to_ascii_lowercase())
         .collect();
     // Strip any [Used tools: ...] prefix that the LLM may have echoed from
-    // history context (#4400).
-    let stripped_summary = strip_tool_summary_prefix(response);
+    // history context (#4400). Trim first to handle leading/trailing whitespace.
+    let trimmed_response = response.trim();
+    let stripped_summary = strip_tool_summary_prefix(trimmed_response);
     // Strip XML-style tool-call tags (e.g. <tool_call>...</tool_call>)
     let stripped_xml = strip_tool_call_tags(&stripped_summary);
     // Strip isolated tool-call JSON artifacts
@@ -4160,6 +4161,11 @@ fn collect_configured_channels(
                     mx.device_id.clone(),
                     config.config_path.parent().map(|path| path.to_path_buf()),
                 )
+                .with_streaming(
+                    mx.stream_mode,
+                    mx.draft_update_interval_ms,
+                    mx.multi_message_delay_ms,
+                )
                 .with_transcription(config.transcription.clone()),
             ),
         });
@@ -5325,6 +5331,18 @@ mod tests {
             strip_tool_summary_prefix(input),
             "The command output is 42."
         );
+    }
+
+    #[test]
+    fn sanitize_channel_response_strips_used_tools_with_leading_whitespace() {
+        let tools: Vec<Box<dyn Tool>> = Vec::new();
+        // Issue #4478: response with leading whitespace before [Used tools: ...]
+        let input = "  [Used tools: web_search_tool]\nHere is the search result.";
+
+        let result = sanitize_channel_response(input, &tools);
+
+        assert!(!result.contains("[Used tools:"));
+        assert!(result.contains("Here is the search result."));
     }
 
     #[test]

--- a/src/channels/traits.rs
+++ b/src/channels/traits.rs
@@ -140,6 +140,19 @@ pub trait Channel: Send + Sync {
         Ok(())
     }
 
+    /// Whether this channel supports multi-message streaming delivery, where
+    /// the response is sent as multiple separate messages at paragraph
+    /// boundaries as tokens arrive from the provider.
+    fn supports_multi_message_streaming(&self) -> bool {
+        false
+    }
+
+    /// Minimum delay (ms) between sending each paragraph in multi-message mode.
+    /// Channels should override this to avoid platform rate limits.
+    fn multi_message_delay_ms(&self) -> u64 {
+        800
+    }
+
     /// Add a reaction (emoji) to a message.
     ///
     /// `channel_id` is the platform channel/conversation identifier (e.g. Discord channel ID).

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6310,10 +6310,21 @@ pub enum StreamMode {
     Off,
     /// Update a draft message with every flush interval.
     Partial,
+    /// Send the response as multiple separate messages at paragraph boundaries.
+    #[serde(rename = "multi_message")]
+    MultiMessage,
 }
 
 fn default_draft_update_interval_ms() -> u64 {
     1000
+}
+
+fn default_multi_message_delay_ms() -> u64 {
+    800
+}
+
+fn default_matrix_draft_update_interval_ms() -> u64 {
+    1500
 }
 
 /// Telegram bot channel configuration.
@@ -6599,6 +6610,17 @@ pub struct MatrixConfig {
     /// Whether to interrupt an in-flight agent response when a new message arrives.
     #[serde(default)]
     pub interrupt_on_new_message: bool,
+    /// Streaming mode for progressive response delivery.
+    /// `"off"` (default): single message. `"partial"`: edit-in-place draft.
+    /// `"multi_message"`: paragraph-split delivery.
+    #[serde(default)]
+    pub stream_mode: StreamMode,
+    /// Minimum interval (ms) between draft message edits in Partial mode.
+    #[serde(default = "default_matrix_draft_update_interval_ms")]
+    pub draft_update_interval_ms: u64,
+    /// Delay (ms) between sending each paragraph in MultiMessage mode.
+    #[serde(default = "default_multi_message_delay_ms")]
+    pub multi_message_delay_ms: u64,
 }
 
 impl ChannelConfig for MatrixConfig {
@@ -12187,6 +12209,9 @@ default_temperature = 0.7
             allowed_users: vec!["@user:matrix.org".into()],
             allowed_rooms: vec![],
             interrupt_on_new_message: false,
+            stream_mode: StreamMode::default(),
+            draft_update_interval_ms: 1500,
+            multi_message_delay_ms: 800,
         };
         let json = serde_json::to_string(&mc).unwrap();
         let parsed: MatrixConfig = serde_json::from_str(&json).unwrap();
@@ -12209,6 +12234,9 @@ default_temperature = 0.7
             allowed_users: vec!["@admin:synapse.local".into(), "*".into()],
             allowed_rooms: vec![],
             interrupt_on_new_message: false,
+            stream_mode: StreamMode::default(),
+            draft_update_interval_ms: 1500,
+            multi_message_delay_ms: 800,
         };
         let toml_str = toml::to_string(&mc).unwrap();
         let parsed: MatrixConfig = toml::from_str(&toml_str).unwrap();
@@ -12303,6 +12331,9 @@ allowed_users = ["@ops:matrix.org"]
                 allowed_users: vec!["@u:m".into()],
                 allowed_rooms: vec![],
                 interrupt_on_new_message: false,
+                stream_mode: StreamMode::default(),
+                draft_update_interval_ms: 1500,
+                multi_message_delay_ms: 800,
             }),
             signal: None,
             whatsapp: None,

--- a/src/integrations/registry.rs
+++ b/src/integrations/registry.rs
@@ -893,6 +893,9 @@ mod tests {
             allowed_users: vec![],
             allowed_rooms: vec![],
             interrupt_on_new_message: false,
+            stream_mode: crate::config::StreamMode::default(),
+            draft_update_interval_ms: 1500,
+            multi_message_delay_ms: 800,
         });
         let entries = all_integrations();
         let mx = entries.iter().find(|e| e.name == "Matrix").unwrap();

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -4231,6 +4231,9 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     allowed_users,
                     allowed_rooms: vec![],
                     interrupt_on_new_message: false,
+                    stream_mode: StreamMode::Partial,
+                    draft_update_interval_ms: 1500,
+                    multi_message_delay_ms: 800,
                 });
             }
             ChannelMenuChoice::Signal => {


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): master
- Problem: #4505
- Why it matters: it provides additional security to whatsapp integrations and fixes the personal mode configuation
- What changed: whatsapp and whatsapp web channels
- What did **not** change (scope boundary): everything else

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): s
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): channel: whatsapp
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): distinguished contributor
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): feature
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): channel

## Linked Issue

- Closes #4505
- Related #4505
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- New external network calls? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- File system access scope changed? (`Yes/No`) No
- If any `Yes`, describe risk and mitigation: trigger the bot only for whatsapp messages that contain specific keywords

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? (`Yes/No`) yes
- Config/env changes? (`Yes/No`) yes
- Migration needed? (`Yes/No`) no
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`)
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any):
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
  - Mitigation:
