### PR TITLE
feat(gateway): mutual TLS (mTLS) for high-security deployments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6303,6 +6303,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7388,6 +7398,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "readlock"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7923,6 +7946,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -12214,6 +12246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12391,6 +12432,8 @@ dependencies = [
  "hmac",
  "hostname",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "image",
  "indicatif",
  "landlock",
@@ -12414,6 +12457,7 @@ dependencies = [
  "prost 0.14.3",
  "qrcode",
  "rand 0.10.0",
+ "rcgen",
  "regex",
  "reqwest 0.12.28",
  "ring",
@@ -12421,6 +12465,7 @@ dependencies = [
  "rusqlite",
  "rust-embed",
  "rustls",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schemars 1.2.1",
  "scopeguard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ nostr-sdk = { version = "0.44", default-features = false, features = ["nip04", "
 regex = "1.10"
 hostname = "0.4.2"
 rustls = "0.23"
+rustls-pemfile = "2"
 rustls-pki-types = "1.14.0"
 tokio-rustls = "0.26.4"
 webpki-roots = "1.0.6"
@@ -167,7 +168,9 @@ async-imap = { version = "0.11",features = ["runtime-tokio"], default-features =
 
 # HTTP server (gateway) — replaces raw TCP for proper HTTP/1.1 compliance
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio", "query", "ws", "macros"] }
-tower = { version = "0.5", default-features = false }
+hyper = { version = "1", features = ["http1", "server"] }
+hyper-util = { version = "0.1", features = ["tokio", "server-auto", "server-graceful"] }
+tower = { version = "0.5", default-features = false, features = ["util"] }
 tower-http = { version = "0.6", default-features = false, features = ["limit", "timeout"] }
 http-body-util = "0.1"
 
@@ -310,6 +313,7 @@ tempfile = "3.26"
 criterion = { version = "0.8", features = ["async_tokio"] }
 wiremock = "0.6"
 scopeguard = "1.2"
+rcgen = "0.13"
 
 [[test]]
 name = "component"

--- a/examples/config.example.toml
+++ b/examples/config.example.toml
@@ -117,3 +117,14 @@ allow_override = false
 # Also transcribe non-PTT (forwarded / regular) audio on WhatsApp.
 # Default: false (only voice notes are transcribed).
 # transcribe_non_ptt_audio = false
+
+# ── Gateway TLS / mTLS Configuration ──────────────────────────
+# [gateway.tls]
+# enabled = false
+# cert_path = "/path/to/server.crt"
+# key_path = "/path/to/server.key"
+# [gateway.tls.client_auth]
+# enabled = false
+# ca_cert_path = "/path/to/ca.crt"
+# require_client_cert = true
+# pinned_certs = []

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1912,6 +1912,10 @@ pub struct GatewayConfig {
     /// Pairing dashboard configuration
     #[serde(default)]
     pub pairing_dashboard: PairingDashboardConfig,
+
+    /// TLS configuration for the gateway server (`[gateway.tls]`).
+    #[serde(default)]
+    pub tls: Option<GatewayTlsConfig>,
 }
 
 fn default_gateway_port() -> u16 {
@@ -1968,6 +1972,7 @@ impl Default for GatewayConfig {
             session_persistence: true,
             session_ttl_hours: 0,
             pairing_dashboard: PairingDashboardConfig::default(),
+            tls: None,
         }
     }
 }
@@ -2018,6 +2023,38 @@ impl Default for PairingDashboardConfig {
             lockout_secs: default_pairing_lockout_secs(),
         }
     }
+}
+
+/// TLS configuration for the gateway server (`[gateway.tls]`).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GatewayTlsConfig {
+    /// Enable TLS for the gateway (default: false).
+    #[serde(default)]
+    pub enabled: bool,
+    /// Path to the PEM-encoded server certificate file.
+    pub cert_path: String,
+    /// Path to the PEM-encoded server private key file.
+    pub key_path: String,
+    /// Client certificate authentication (mutual TLS) settings.
+    #[serde(default)]
+    pub client_auth: Option<GatewayClientAuthConfig>,
+}
+
+/// Client certificate authentication (mTLS) configuration (`[gateway.tls.client_auth]`).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct GatewayClientAuthConfig {
+    /// Enable client certificate verification (default: false).
+    #[serde(default)]
+    pub enabled: bool,
+    /// Path to the PEM-encoded CA certificate used to verify client certs.
+    pub ca_cert_path: String,
+    /// Reject connections that do not present a valid client certificate (default: true).
+    #[serde(default = "default_true")]
+    pub require_client_cert: bool,
+    /// Optional SHA-256 fingerprints for certificate pinning.
+    /// When non-empty, only client certs matching one of these fingerprints are accepted.
+    #[serde(default)]
+    pub pinned_certs: Vec<String>,
 }
 
 /// Secure transport configuration for inter-node communication (`[node_transport]`).
@@ -12340,6 +12377,7 @@ channel_id = "C123"
             session_persistence: true,
             session_ttl_hours: 0,
             pairing_dashboard: PairingDashboardConfig::default(),
+            tls: None,
         };
         let toml_str = toml::to_string(&g).unwrap();
         let parsed: GatewayConfig = toml::from_str(&toml_str).unwrap();

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -15,6 +15,7 @@ pub mod canvas;
 pub mod nodes;
 pub mod sse;
 pub mod static_files;
+pub mod tls;
 pub mod ws;
 
 use crate::channels::{
@@ -961,16 +962,81 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         inner
     };
 
-    // Run the server with graceful shutdown
-    axum::serve(
-        listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    )
-    .with_graceful_shutdown(async move {
-        let _ = shutdown_rx.changed().await;
-        tracing::info!("🦀 ZeroClaw Gateway shutting down...");
-    })
-    .await?;
+    // ── TLS / mTLS setup ───────────────────────────────────────────
+    let tls_acceptor = match &config.gateway.tls {
+        Some(tls_cfg) if tls_cfg.enabled => {
+            let has_mtls = tls_cfg.client_auth.as_ref().is_some_and(|ca| ca.enabled);
+            if has_mtls {
+                tracing::info!("TLS enabled with mutual TLS (mTLS) client verification");
+            } else {
+                tracing::info!("TLS enabled (no client certificate requirement)");
+            }
+            Some(tls::build_tls_acceptor(tls_cfg)?)
+        }
+        _ => None,
+    };
+
+    if let Some(tls_acceptor) = tls_acceptor {
+        // Manual TLS accept loop — serves each connection via hyper.
+        let app = app.into_make_service_with_connect_info::<SocketAddr>();
+        let mut app = app;
+
+        let mut shutdown_signal = shutdown_rx;
+        loop {
+            tokio::select! {
+                conn = listener.accept() => {
+                    let (tcp_stream, remote_addr) = conn?;
+                    let tls_acceptor = tls_acceptor.clone();
+                    let svc = tower::MakeService::<
+                        SocketAddr,
+                        hyper::Request<hyper::body::Incoming>,
+                    >::make_service(&mut app, remote_addr)
+                    .await
+                    .expect("infallible make_service");
+
+                    tokio::spawn(async move {
+                        let tls_stream = match tls_acceptor.accept(tcp_stream).await {
+                            Ok(s) => s,
+                            Err(e) => {
+                                tracing::debug!("TLS handshake failed from {remote_addr}: {e}");
+                                return;
+                            }
+                        };
+                        let io = hyper_util::rt::TokioIo::new(tls_stream);
+                        let hyper_svc = hyper::service::service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
+                            let mut svc = svc.clone();
+                            async move {
+                                tower::Service::call(&mut svc, req).await
+                            }
+                        });
+                        if let Err(e) = hyper_util::server::conn::auto::Builder::new(
+                            hyper_util::rt::TokioExecutor::new(),
+                        )
+                        .serve_connection(io, hyper_svc)
+                        .await
+                        {
+                            tracing::debug!("connection error from {remote_addr}: {e}");
+                        }
+                    });
+                }
+                _ = shutdown_signal.changed() => {
+                    tracing::info!("🦀 ZeroClaw Gateway shutting down...");
+                    break;
+                }
+            }
+        }
+    } else {
+        // Plain TCP — use axum's built-in serve.
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(async move {
+            let _ = shutdown_rx.changed().await;
+            tracing::info!("🦀 ZeroClaw Gateway shutting down...");
+        })
+        .await?;
+    }
 
     Ok(())
 }

--- a/src/gateway/tls.rs
+++ b/src/gateway/tls.rs
@@ -1,0 +1,456 @@
+//! TLS and mutual TLS (mTLS) support for the gateway server.
+//!
+//! Builds a [`rustls::ServerConfig`] from the gateway TLS configuration,
+//! optionally requiring client certificates verified against a trusted CA
+//! with optional certificate pinning (SHA-256 fingerprint matching).
+
+use crate::config::schema::{GatewayClientAuthConfig, GatewayTlsConfig};
+use anyhow::{Context, Result};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::danger::{ClientCertVerified, ClientCertVerifier};
+use rustls::server::WebPkiClientVerifier;
+use rustls::RootCertStore;
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use tokio_rustls::TlsAcceptor;
+
+/// Build a [`TlsAcceptor`] from the gateway TLS configuration.
+pub fn build_tls_acceptor(config: &GatewayTlsConfig) -> Result<TlsAcceptor> {
+    let server_config = build_server_config(config)?;
+    Ok(TlsAcceptor::from(Arc::new(server_config)))
+}
+
+/// Build a [`rustls::ServerConfig`] from the gateway TLS configuration.
+pub fn build_server_config(config: &GatewayTlsConfig) -> Result<rustls::ServerConfig> {
+    let certs = load_certs(&config.cert_path).with_context(|| {
+        format!(
+            "failed to load server certificate from {}",
+            config.cert_path
+        )
+    })?;
+    let key = load_private_key(&config.key_path)
+        .with_context(|| format!("failed to load private key from {}", config.key_path))?;
+
+    let client_auth_config = config.client_auth.as_ref().filter(|ca| ca.enabled);
+
+    let builder = rustls::ServerConfig::builder();
+
+    let server_config = if let Some(client_auth) = client_auth_config {
+        let verifier = build_client_verifier(client_auth)
+            .context("failed to build client certificate verifier")?;
+        builder
+            .with_client_cert_verifier(verifier)
+            .with_single_cert(certs, key)
+            .context("invalid server certificate or key")?
+    } else {
+        builder
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .context("invalid server certificate or key")?
+    };
+
+    Ok(server_config)
+}
+
+/// Build a client certificate verifier from the client auth configuration.
+fn build_client_verifier(config: &GatewayClientAuthConfig) -> Result<Arc<dyn ClientCertVerifier>> {
+    let ca_certs = load_certs(&config.ca_cert_path)
+        .with_context(|| format!("failed to load CA certificate from {}", config.ca_cert_path))?;
+
+    let mut root_store = RootCertStore::empty();
+    for cert in &ca_certs {
+        root_store
+            .add(cert.clone())
+            .context("failed to add CA certificate to root store")?;
+    }
+
+    let base_verifier = if config.require_client_cert {
+        WebPkiClientVerifier::builder(Arc::new(root_store))
+            .build()
+            .context("failed to build WebPKI client verifier")?
+    } else {
+        WebPkiClientVerifier::builder(Arc::new(root_store))
+            .allow_unauthenticated()
+            .build()
+            .context("failed to build WebPKI client verifier (optional auth)")?
+    };
+
+    if config.pinned_certs.is_empty() {
+        Ok(base_verifier)
+    } else {
+        let normalized: Vec<String> = config
+            .pinned_certs
+            .iter()
+            .map(|fp| fp.replace(':', "").to_lowercase())
+            .collect();
+        Ok(Arc::new(PinnedCertVerifier {
+            inner: base_verifier,
+            pinned_fingerprints: normalized,
+        }))
+    }
+}
+
+/// Compute the SHA-256 fingerprint of a DER-encoded certificate.
+pub fn cert_sha256_fingerprint(cert_der: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(cert_der);
+    let hash = hasher.finalize();
+    hex::encode(hash)
+}
+
+/// A client certificate verifier that delegates to a base verifier and then
+/// checks that the presented certificate matches one of the pinned SHA-256
+/// fingerprints.
+#[derive(Debug)]
+struct PinnedCertVerifier {
+    inner: Arc<dyn ClientCertVerifier>,
+    pinned_fingerprints: Vec<String>,
+}
+
+impl ClientCertVerifier for PinnedCertVerifier {
+    fn offer_client_auth(&self) -> bool {
+        self.inner.offer_client_auth()
+    }
+
+    fn client_auth_mandatory(&self) -> bool {
+        self.inner.client_auth_mandatory()
+    }
+
+    fn root_hint_subjects(&self) -> &[rustls::DistinguishedName] {
+        self.inner.root_hint_subjects()
+    }
+
+    fn verify_client_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        now: rustls::pki_types::UnixTime,
+    ) -> std::result::Result<ClientCertVerified, rustls::Error> {
+        // First, run the standard WebPKI verification.
+        self.inner
+            .verify_client_cert(end_entity, intermediates, now)?;
+
+        // Then check the fingerprint against the pinned set.
+        let fingerprint = cert_sha256_fingerprint(end_entity.as_ref());
+        if self.pinned_fingerprints.contains(&fingerprint) {
+            Ok(ClientCertVerified::assertion())
+        } else {
+            Err(rustls::Error::General(format!(
+                "client certificate fingerprint {fingerprint} is not in the pinned set"
+            )))
+        }
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        self.inner.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> std::result::Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        self.inner.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.inner.supported_verify_schemes()
+    }
+}
+
+/// Load PEM-encoded certificates from a file.
+fn load_certs(path: &str) -> Result<Vec<CertificateDer<'static>>> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("cannot open certificate file: {path}"))?;
+    let mut reader = std::io::BufReader::new(file);
+    let certs: Vec<CertificateDer<'static>> = rustls_pemfile::certs(&mut reader)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| format!("failed to parse PEM certificates from {path}"))?;
+    if certs.is_empty() {
+        anyhow::bail!("no certificates found in {path}");
+    }
+    Ok(certs)
+}
+
+/// Load a PEM-encoded private key from a file.
+fn load_private_key(path: &str) -> Result<PrivateKeyDer<'static>> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("cannot open private key file: {path}"))?;
+    let mut reader = std::io::BufReader::new(file);
+    let key = rustls_pemfile::private_key(&mut reader)
+        .with_context(|| format!("failed to parse private key from {path}"))?
+        .ok_or_else(|| anyhow::anyhow!("no private key found in {path}"))?;
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ensure the rustls `CryptoProvider` is installed (idempotent).
+    fn ensure_crypto_provider() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    }
+
+    /// Generate a self-signed CA cert + key pair.
+    /// Returns (cert_pem, key_pem, key_pair) so the key can be reused for signing.
+    fn test_ca() -> (String, String, rcgen::KeyPair) {
+        let ca_key = rcgen::KeyPair::generate().unwrap();
+        let mut ca_params = rcgen::CertificateParams::new(vec!["Test CA".into()]).unwrap();
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+        (ca_cert.pem(), ca_key.serialize_pem(), ca_key)
+    }
+
+    /// Generate a server certificate signed by the given CA.
+    fn test_server_cert(ca_cert_pem: &str, ca_key: &rcgen::KeyPair) -> (String, String) {
+        // Re-parse the CA cert for signing.
+        let ca_key_clone = rcgen::KeyPair::from_pem(&ca_key.serialize_pem()).unwrap();
+        let mut ca_params = rcgen::CertificateParams::new(vec!["Test CA".into()]).unwrap();
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca = ca_params.self_signed(&ca_key_clone).unwrap();
+
+        let mut server_params = rcgen::CertificateParams::new(vec!["localhost".into()]).unwrap();
+        server_params.is_ca = rcgen::IsCa::NoCa;
+        let server_key = rcgen::KeyPair::generate().unwrap();
+        let server_cert = server_params
+            .signed_by(&server_key, &ca, &ca_key_clone)
+            .unwrap();
+        let _ = ca_cert_pem;
+        (server_cert.pem(), server_key.serialize_pem())
+    }
+
+    fn write_temp_file(content: &str) -> tempfile::NamedTempFile {
+        use std::io::Write;
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn test_load_valid_cert_and_key() {
+        let (ca_cert_pem, _ca_key_pem, ca_key) = test_ca();
+        let (server_cert_pem, server_key_pem) = test_server_cert(&ca_cert_pem, &ca_key);
+
+        let cert_file = write_temp_file(&server_cert_pem);
+        let key_file = write_temp_file(&server_key_pem);
+
+        let certs = load_certs(cert_file.path().to_str().unwrap()).unwrap();
+        assert!(!certs.is_empty());
+
+        let _key = load_private_key(key_file.path().to_str().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn test_invalid_cert_path_produces_clear_error() {
+        let err = load_certs("/nonexistent/path/cert.pem").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("cannot open certificate file"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_invalid_key_path_produces_clear_error() {
+        let err = load_private_key("/nonexistent/path/key.pem").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("cannot open private key file"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_build_server_config_no_client_auth() {
+        ensure_crypto_provider();
+        let (ca_cert_pem, _ca_key_pem, ca_key) = test_ca();
+        let (server_cert_pem, server_key_pem) = test_server_cert(&ca_cert_pem, &ca_key);
+
+        let cert_file = write_temp_file(&server_cert_pem);
+        let key_file = write_temp_file(&server_key_pem);
+
+        let tls_config = GatewayTlsConfig {
+            enabled: true,
+            cert_path: cert_file.path().to_str().unwrap().to_string(),
+            key_path: key_file.path().to_str().unwrap().to_string(),
+            client_auth: None,
+        };
+
+        // Should build successfully without client auth.
+        let _server_config = build_server_config(&tls_config).unwrap();
+    }
+
+    #[test]
+    fn test_build_server_config_with_client_auth() {
+        ensure_crypto_provider();
+        let (ca_cert_pem, _ca_key_pem, ca_key) = test_ca();
+        let (server_cert_pem, server_key_pem) = test_server_cert(&ca_cert_pem, &ca_key);
+
+        let cert_file = write_temp_file(&server_cert_pem);
+        let key_file = write_temp_file(&server_key_pem);
+        let ca_file = write_temp_file(&ca_cert_pem);
+
+        let tls_config = GatewayTlsConfig {
+            enabled: true,
+            cert_path: cert_file.path().to_str().unwrap().to_string(),
+            key_path: key_file.path().to_str().unwrap().to_string(),
+            client_auth: Some(GatewayClientAuthConfig {
+                enabled: true,
+                ca_cert_path: ca_file.path().to_str().unwrap().to_string(),
+                require_client_cert: true,
+                pinned_certs: vec![],
+            }),
+        };
+
+        // Should build successfully with mandatory client auth.
+        let _server_config = build_server_config(&tls_config).unwrap();
+    }
+
+    #[test]
+    fn test_build_server_config_client_auth_optional() {
+        ensure_crypto_provider();
+        let (ca_cert_pem, _ca_key_pem, ca_key) = test_ca();
+        let (server_cert_pem, server_key_pem) = test_server_cert(&ca_cert_pem, &ca_key);
+
+        let cert_file = write_temp_file(&server_cert_pem);
+        let key_file = write_temp_file(&server_key_pem);
+        let ca_file = write_temp_file(&ca_cert_pem);
+
+        let tls_config = GatewayTlsConfig {
+            enabled: true,
+            cert_path: cert_file.path().to_str().unwrap().to_string(),
+            key_path: key_file.path().to_str().unwrap().to_string(),
+            client_auth: Some(GatewayClientAuthConfig {
+                enabled: true,
+                ca_cert_path: ca_file.path().to_str().unwrap().to_string(),
+                require_client_cert: false,
+                pinned_certs: vec![],
+            }),
+        };
+
+        // Should build successfully with optional client auth.
+        let _server_config = build_server_config(&tls_config).unwrap();
+    }
+
+    #[test]
+    fn test_cert_fingerprint_matching() {
+        let (ca_cert_pem, _ca_key_pem, _ca_key) = test_ca();
+        let ca_file = write_temp_file(&ca_cert_pem);
+        let certs = load_certs(ca_file.path().to_str().unwrap()).unwrap();
+        let fingerprint = cert_sha256_fingerprint(certs[0].as_ref());
+
+        // Fingerprint should be a 64-char hex string (SHA-256).
+        assert_eq!(fingerprint.len(), 64);
+        assert!(fingerprint.chars().all(|c| c.is_ascii_hexdigit()));
+
+        // Same cert should produce the same fingerprint.
+        let fingerprint2 = cert_sha256_fingerprint(certs[0].as_ref());
+        assert_eq!(fingerprint, fingerprint2);
+    }
+
+    #[test]
+    fn test_fingerprint_differs_for_different_certs() {
+        let (ca_cert_pem1, _, _) = test_ca();
+        let (ca_cert_pem2, _, _) = test_ca();
+        let f1 = write_temp_file(&ca_cert_pem1);
+        let f2 = write_temp_file(&ca_cert_pem2);
+        let certs1 = load_certs(f1.path().to_str().unwrap()).unwrap();
+        let certs2 = load_certs(f2.path().to_str().unwrap()).unwrap();
+        let fp1 = cert_sha256_fingerprint(certs1[0].as_ref());
+        let fp2 = cert_sha256_fingerprint(certs2[0].as_ref());
+        assert_ne!(fp1, fp2);
+    }
+
+    #[test]
+    fn test_config_defaults_deserialization() {
+        let toml_str = r#"
+            cert_path = "/tmp/cert.pem"
+            key_path = "/tmp/key.pem"
+        "#;
+        let config: GatewayTlsConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.enabled);
+        assert!(config.client_auth.is_none());
+    }
+
+    #[test]
+    fn test_client_auth_config_defaults() {
+        let toml_str = r#"
+            ca_cert_path = "/tmp/ca.pem"
+        "#;
+        let config: GatewayClientAuthConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.enabled);
+        assert!(config.require_client_cert);
+        assert!(config.pinned_certs.is_empty());
+    }
+
+    #[test]
+    fn test_build_server_config_with_pinning() {
+        ensure_crypto_provider();
+        let (ca_cert_pem, _ca_key_pem, ca_key) = test_ca();
+        let (server_cert_pem, server_key_pem) = test_server_cert(&ca_cert_pem, &ca_key);
+
+        let cert_file = write_temp_file(&server_cert_pem);
+        let key_file = write_temp_file(&server_key_pem);
+        let ca_file = write_temp_file(&ca_cert_pem);
+
+        let tls_config = GatewayTlsConfig {
+            enabled: true,
+            cert_path: cert_file.path().to_str().unwrap().to_string(),
+            key_path: key_file.path().to_str().unwrap().to_string(),
+            client_auth: Some(GatewayClientAuthConfig {
+                enabled: true,
+                ca_cert_path: ca_file.path().to_str().unwrap().to_string(),
+                require_client_cert: true,
+                pinned_certs: vec!["aabbccdd".to_string()],
+            }),
+        };
+
+        // Should build successfully - pinning is checked at connection time, not config time.
+        let _server_config = build_server_config(&tls_config).unwrap();
+    }
+
+    #[test]
+    fn test_empty_cert_file_produces_error() {
+        let empty_file = write_temp_file("");
+        let err = load_certs(empty_file.path().to_str().unwrap()).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("no certificates found"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_disabled_client_auth_skipped() {
+        ensure_crypto_provider();
+        let (ca_cert_pem, _ca_key_pem, ca_key) = test_ca();
+        let (server_cert_pem, server_key_pem) = test_server_cert(&ca_cert_pem, &ca_key);
+
+        let cert_file = write_temp_file(&server_cert_pem);
+        let key_file = write_temp_file(&server_key_pem);
+
+        // client_auth present but enabled=false should be treated as no client auth.
+        let tls_config = GatewayTlsConfig {
+            enabled: true,
+            cert_path: cert_file.path().to_str().unwrap().to_string(),
+            key_path: key_file.path().to_str().unwrap().to_string(),
+            client_auth: Some(GatewayClientAuthConfig {
+                enabled: false,
+                ca_cert_path: "/nonexistent".to_string(),
+                require_client_cert: true,
+                pinned_certs: vec![],
+            }),
+        };
+
+        // Should succeed because client_auth.enabled=false skips the CA loading.
+        let _server_config = build_server_config(&tls_config).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GatewayTlsConfig` and `GatewayClientAuthConfig` to config schema with `[gateway.tls]` and `[gateway.tls.client_auth]` TOML sections
- Creates `src/gateway/tls.rs` with `build_tls_acceptor()` using rustls ServerConfig
- Implements client certificate verification via `WebPkiClientVerifier` with optional/mandatory modes
- Adds `PinnedCertVerifier` for SHA-256 certificate pinning
- Modifies `run_gateway()` to use TLS accept loop with `tokio_rustls::TlsAcceptor` + `hyper_util` when TLS is enabled
- Preserves plain TCP path when TLS is not configured
- Adds `rustls-pemfile`, `hyper`, `hyper-util` dependencies; `rcgen` as dev-dependency
- Includes 13 unit tests covering cert loading, ServerConfig building, client auth modes, cert pinning, fingerprint matching, and error cases
- Adds example config in `config.example.toml`

Closes #4521

## Test plan
- [ ] Verify `cargo check` passes
- [ ] Verify `cargo test gateway::tls` passes (13 tests)
- [ ] Verify all existing tests still pass
- [ ] Verify gateway starts normally without TLS config (plain TCP preserved)
- [ ] Verify gateway binds with TLS when cert/key provided
- [ ] Verify mTLS rejects connections without valid client cert
- [ ] Verify certificate pinning accepts only pinned certs