### PR TITLE
fix(channels): add use_markdown_blocks config for Slack block compatibility

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3956,6 +3956,7 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                     sl.allowed_users.clone(),
                 )
                 .with_workspace_dir(config.workspace_dir.clone())
+                .with_markdown_blocks(sl.use_markdown_blocks)
                 .with_transcription(config.transcription.clone()),
             ))
         }
@@ -4087,6 +4088,7 @@ fn collect_configured_channels(
                 .with_thread_replies(sl.thread_replies.unwrap_or(true))
                 .with_group_reply_policy(sl.mention_only, Vec::new())
                 .with_workspace_dir(config.workspace_dir.clone())
+                .with_markdown_blocks(sl.use_markdown_blocks)
                 .with_proxy_url(sl.proxy_url.clone())
                 .with_transcription(config.transcription.clone()),
             ),

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -32,6 +32,8 @@ pub struct SlackChannel {
     workspace_dir: Option<PathBuf>,
     /// Maps channel_id -> thread_ts for active assistant threads (used for status indicators).
     active_assistant_thread: Mutex<HashMap<String, String>>,
+    /// Use the newer `markdown` block type (richer formatting, 12k char limit).
+    use_markdown_blocks: bool,
     /// Per-channel proxy URL override.
     proxy_url: Option<String>,
     /// Voice transcription config — when set, audio file attachments are
@@ -130,6 +132,7 @@ impl SlackChannel {
             user_display_name_cache: Mutex::new(HashMap::new()),
             workspace_dir: None,
             active_assistant_thread: Mutex::new(HashMap::new()),
+            use_markdown_blocks: false,
             proxy_url: None,
             transcription: None,
             transcription_manager: None,
@@ -161,6 +164,13 @@ impl SlackChannel {
     }
 
     /// Set a per-channel proxy URL that overrides the global proxy config.
+    /// Enable the newer `markdown` block type for richer formatting.
+    /// Only use this if your Slack workspace supports it.
+    pub fn with_markdown_blocks(mut self, enabled: bool) -> Self {
+        self.use_markdown_blocks = enabled;
+        self
+    }
+
     pub fn with_proxy_url(mut self, proxy_url: Option<String>) -> Self {
         self.proxy_url = proxy_url;
         self
@@ -2672,21 +2682,38 @@ impl Channel for SlackChannel {
                 "text": message.content
             });
 
-            // Use Slack's native markdown blocks for rich formatting.
-            // Split into multiple blocks to respect the per-block text limit.
+            // Add rich formatting blocks, split into chunks for the per-block limit.
+            // The newer `markdown` block type (12k chars) offers richer formatting but
+            // isn't available on all workspaces, causing `invalid_blocks` errors (#4563).
+            // Default to the universally supported `section` block with `mrkdwn`.
+            let block_limit = if self.use_markdown_blocks {
+                SLACK_MARKDOWN_BLOCK_MAX_CHARS
+            } else {
+                SLACK_BLOCK_TEXT_MAX_CHARS
+            };
             if message.content.len() <= SLACK_MARKDOWN_BLOCK_MAX_CHARS {
                 let chunks = split_text_into_chunks(
                     &message.content,
-                    SLACK_BLOCK_TEXT_MAX_CHARS,
+                    block_limit,
                     SLACK_MAX_BLOCKS_PER_MESSAGE,
                 );
                 let blocks: Vec<serde_json::Value> = chunks
                     .into_iter()
                     .map(|chunk| {
-                        serde_json::json!({
-                            "type": "markdown",
-                            "text": chunk
-                        })
+                        if self.use_markdown_blocks {
+                            serde_json::json!({
+                                "type": "markdown",
+                                "text": chunk
+                            })
+                        } else {
+                            serde_json::json!({
+                                "type": "section",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text": chunk
+                                }
+                            })
+                        }
                     })
                     .collect();
                 body["blocks"] = serde_json::Value::Array(blocks);

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6242,6 +6242,11 @@ pub struct SlackConfig {
     /// Direct messages remain allowed.
     #[serde(default)]
     pub mention_only: bool,
+    /// Use the newer Slack `markdown` block type (12 000 char limit, richer formatting).
+    /// Defaults to false (uses universally supported `section` blocks with `mrkdwn`).
+    /// Enable this only if your Slack workspace supports the `markdown` block type.
+    #[serde(default)]
+    pub use_markdown_blocks: bool,
     /// Per-channel proxy URL (http, https, socks5, socks5h).
     /// Overrides the global `[proxy]` setting for this channel only.
     #[serde(default)]

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -4052,6 +4052,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     interrupt_on_new_message: false,
                     thread_replies: None,
                     mention_only: false,
+                    use_markdown_blocks: false,
                     proxy_url: None,
                 });
             }


### PR DESCRIPTION
## Summary

- **Problem**: Slack's `"type": "markdown"` block isn't available on all workspaces, causing `invalid_blocks` errors (#4563).
- **Fix**: Default to universally supported `section` blocks with `mrkdwn`. Add `channels.slack.use_markdown_blocks` config option for workspaces that support the newer `markdown` block type.
- **Rebased** on top of #4575 (message splitting into multiple blocks). The splitting logic works with both block formats.

Closes #4563
Supersedes #4566 (pre-#4575 version)

```toml
[channels.slack]
use_markdown_blocks = true  # opt-in for workspaces with markdown block support
```

## Risk

**Medium** — `src/channels/**` behavior change. Default behavior changes from `markdown` to `section` blocks. Users who need `markdown` blocks can opt in via config.

## Test plan

- [x] `cargo check` + `cargo clippy` + `cargo fmt` — clean
- [ ] CI