### PR TITLE
feat(observability): DORA metrics for deployment tracking

### DIFF
--- a/src/observability/dora.rs
+++ b/src/observability/dora.rs
@@ -1,0 +1,393 @@
+use std::collections::VecDeque;
+use std::sync::RwLock;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+
+/// Maximum deployment records kept in the ring buffer.
+/// Covers ~90 days at ~11 deploys/day.
+const MAX_RECORDS: usize = 1000;
+
+/// Time window constants.
+const WINDOW_7D: Duration = Duration::from_secs(7 * 24 * 3600);
+const WINDOW_30D: Duration = Duration::from_secs(30 * 24 * 3600);
+const WINDOW_90D: Duration = Duration::from_secs(90 * 24 * 3600);
+
+// ── Record types ─────────────────────────────────────────────
+
+/// A single deployment record stored in the ring buffer.
+#[derive(Debug, Clone)]
+struct DeploymentRecord {
+    /// When the deployment completed (success or failure).
+    timestamp: DateTime<Utc>,
+    /// Whether the deployment succeeded.
+    success: bool,
+    /// Lead time: duration from commit to deploy completion (if known).
+    lead_time: Option<Duration>,
+}
+
+/// A single recovery record.
+#[derive(Debug, Clone)]
+struct RecoveryRecord {
+    timestamp: DateTime<Utc>,
+    duration: Duration,
+}
+
+// ── Snapshot ─────────────────────────────────────────────────
+
+/// Point-in-time snapshot of DORA metrics for a given time window.
+#[derive(Debug, Clone)]
+pub struct DoraSnapshot {
+    /// Total deployments in the window.
+    pub total_deployments: u64,
+    /// Failed deployments in the window.
+    pub failed_deployments: u64,
+    /// Change failure rate (0.0..=1.0). `None` if no deployments.
+    pub change_failure_rate: Option<f64>,
+    /// Average lead time for changes. `None` if no lead times recorded.
+    pub mean_lead_time: Option<Duration>,
+    /// Mean time to recovery. `None` if no recoveries recorded.
+    pub mttr: Option<Duration>,
+    /// Window duration used for this snapshot.
+    pub window: Duration,
+}
+
+// ── Internal state ───────────────────────────────────────────
+
+#[derive(Debug, Default)]
+struct CollectorState {
+    deployments: VecDeque<DeploymentRecord>,
+    recoveries: VecDeque<RecoveryRecord>,
+}
+
+// ── DoraCollector ────────────────────────────────────────────
+
+/// Thread-safe DORA metrics collector.
+///
+/// Tracks deployment frequency, lead time for changes, change failure rate,
+/// and mean time to recovery (MTTR). Supports time-windowed views at
+/// 7-day, 30-day, and 90-day intervals.
+pub struct DoraCollector {
+    inner: RwLock<CollectorState>,
+}
+
+impl DoraCollector {
+    /// Create an empty collector.
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(CollectorState::default()),
+        }
+    }
+
+    /// Record a completed deployment (success or failure).
+    ///
+    /// `lead_time` is the duration from commit to deploy completion.
+    pub fn record_deployment(&self, success: bool, lead_time: Option<Duration>) {
+        let mut state = self.inner.write().expect("DORA lock poisoned");
+        if state.deployments.len() >= MAX_RECORDS {
+            state.deployments.pop_front();
+        }
+        state.deployments.push_back(DeploymentRecord {
+            timestamp: Utc::now(),
+            success,
+            lead_time,
+        });
+    }
+
+    /// Record a failed deployment. Convenience wrapper around `record_deployment`.
+    pub fn record_failure(&self) {
+        self.record_deployment(false, None);
+    }
+
+    /// Record a recovery from a failed deployment.
+    pub fn record_recovery(&self, duration: Duration) {
+        let mut state = self.inner.write().expect("DORA lock poisoned");
+        if state.recoveries.len() >= MAX_RECORDS {
+            state.recoveries.pop_front();
+        }
+        state.recoveries.push_back(RecoveryRecord {
+            timestamp: Utc::now(),
+            duration,
+        });
+    }
+
+    /// Produce a snapshot of DORA metrics for a 7-day window.
+    pub fn snapshot_7d(&self) -> DoraSnapshot {
+        self.snapshot_window(WINDOW_7D)
+    }
+
+    /// Produce a snapshot of DORA metrics for a 30-day window.
+    pub fn snapshot_30d(&self) -> DoraSnapshot {
+        self.snapshot_window(WINDOW_30D)
+    }
+
+    /// Produce a snapshot of DORA metrics for a 90-day window.
+    pub fn snapshot_90d(&self) -> DoraSnapshot {
+        self.snapshot_window(WINDOW_90D)
+    }
+
+    /// Produce a snapshot of DORA metrics (default 30-day window).
+    pub fn snapshot(&self) -> DoraSnapshot {
+        self.snapshot_window(WINDOW_30D)
+    }
+
+    fn snapshot_window(&self, window: Duration) -> DoraSnapshot {
+        let state = self.inner.read().expect("DORA lock poisoned");
+        let cutoff =
+            Utc::now() - chrono::Duration::from_std(window).unwrap_or(chrono::Duration::MAX);
+
+        // Filter deployments within window
+        let deploys_in_window: Vec<&DeploymentRecord> = state
+            .deployments
+            .iter()
+            .filter(|d| d.timestamp >= cutoff)
+            .collect();
+
+        let total_deployments = deploys_in_window.len() as u64;
+        let failed_deployments = deploys_in_window.iter().filter(|d| !d.success).count() as u64;
+
+        let change_failure_rate = if total_deployments > 0 {
+            Some(failed_deployments as f64 / total_deployments as f64)
+        } else {
+            None
+        };
+
+        // Mean lead time
+        let lead_times: Vec<Duration> = deploys_in_window
+            .iter()
+            .filter_map(|d| d.lead_time)
+            .collect();
+        let mean_lead_time = if lead_times.is_empty() {
+            None
+        } else {
+            let count = u32::try_from(lead_times.len()).unwrap_or(u32::MAX);
+            let total: Duration = lead_times.iter().sum();
+            Some(total / count)
+        };
+
+        // MTTR
+        let recoveries_in_window: Vec<&RecoveryRecord> = state
+            .recoveries
+            .iter()
+            .filter(|r| r.timestamp >= cutoff)
+            .collect();
+        let mttr = if recoveries_in_window.is_empty() {
+            None
+        } else {
+            let count = u32::try_from(recoveries_in_window.len()).unwrap_or(u32::MAX);
+            let total: Duration = recoveries_in_window.iter().map(|r| r.duration).sum();
+            Some(total / count)
+        };
+
+        DoraSnapshot {
+            total_deployments,
+            failed_deployments,
+            change_failure_rate,
+            mean_lead_time,
+            mttr,
+            window,
+        }
+    }
+}
+
+impl Default for DoraCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_collector_returns_none_rates() {
+        let c = DoraCollector::new();
+        let snap = c.snapshot_30d();
+        assert_eq!(snap.total_deployments, 0);
+        assert_eq!(snap.failed_deployments, 0);
+        assert!(snap.change_failure_rate.is_none());
+        assert!(snap.mean_lead_time.is_none());
+        assert!(snap.mttr.is_none());
+    }
+
+    #[test]
+    fn deployment_frequency_counts() {
+        let c = DoraCollector::new();
+        c.record_deployment(true, None);
+        c.record_deployment(true, None);
+        c.record_deployment(false, None);
+
+        let snap = c.snapshot_30d();
+        assert_eq!(snap.total_deployments, 3);
+        assert_eq!(snap.failed_deployments, 1);
+    }
+
+    #[test]
+    fn change_failure_rate_calculation() {
+        let c = DoraCollector::new();
+        c.record_deployment(true, None);
+        c.record_deployment(false, None);
+        c.record_deployment(true, None);
+        c.record_deployment(false, None);
+
+        let snap = c.snapshot_30d();
+        let rate = snap.change_failure_rate.unwrap();
+        assert!((rate - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn change_failure_rate_zero_failures() {
+        let c = DoraCollector::new();
+        c.record_deployment(true, None);
+        c.record_deployment(true, None);
+
+        let snap = c.snapshot_30d();
+        let rate = snap.change_failure_rate.unwrap();
+        assert!((rate - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn change_failure_rate_all_failures() {
+        let c = DoraCollector::new();
+        c.record_deployment(false, None);
+        c.record_deployment(false, None);
+
+        let snap = c.snapshot_30d();
+        let rate = snap.change_failure_rate.unwrap();
+        assert!((rate - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn lead_time_calculation() {
+        let c = DoraCollector::new();
+        c.record_deployment(true, Some(Duration::from_secs(100)));
+        c.record_deployment(true, Some(Duration::from_secs(200)));
+        c.record_deployment(true, Some(Duration::from_secs(300)));
+
+        let snap = c.snapshot_30d();
+        let mean = snap.mean_lead_time.unwrap();
+        assert_eq!(mean, Duration::from_secs(200));
+    }
+
+    #[test]
+    fn lead_time_ignores_none_entries() {
+        let c = DoraCollector::new();
+        c.record_deployment(true, Some(Duration::from_secs(100)));
+        c.record_deployment(true, None); // no lead time
+        c.record_deployment(true, Some(Duration::from_secs(300)));
+
+        let snap = c.snapshot_30d();
+        let mean = snap.mean_lead_time.unwrap();
+        assert_eq!(mean, Duration::from_secs(200));
+    }
+
+    #[test]
+    fn mttr_calculation() {
+        let c = DoraCollector::new();
+        c.record_recovery(Duration::from_secs(60));
+        c.record_recovery(Duration::from_secs(120));
+        c.record_recovery(Duration::from_secs(180));
+
+        let snap = c.snapshot_30d();
+        let mttr = snap.mttr.unwrap();
+        assert_eq!(mttr, Duration::from_secs(120));
+    }
+
+    #[test]
+    fn mttr_none_when_no_recoveries() {
+        let c = DoraCollector::new();
+        c.record_deployment(false, None);
+
+        let snap = c.snapshot_30d();
+        assert!(snap.mttr.is_none());
+    }
+
+    #[test]
+    fn record_failure_convenience() {
+        let c = DoraCollector::new();
+        c.record_failure();
+
+        let snap = c.snapshot_30d();
+        assert_eq!(snap.total_deployments, 1);
+        assert_eq!(snap.failed_deployments, 1);
+        assert!((snap.change_failure_rate.unwrap() - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn rapid_deployments() {
+        let c = DoraCollector::new();
+        for _ in 0..100 {
+            c.record_deployment(true, Some(Duration::from_millis(50)));
+        }
+
+        let snap = c.snapshot_30d();
+        assert_eq!(snap.total_deployments, 100);
+        assert_eq!(snap.mean_lead_time.unwrap(), Duration::from_millis(50));
+    }
+
+    #[test]
+    fn ring_buffer_eviction() {
+        let c = DoraCollector::new();
+        // Fill beyond MAX_RECORDS
+        for i in 0..(MAX_RECORDS + 50) {
+            c.record_deployment(i % 2 == 0, Some(Duration::from_secs(i as u64)));
+        }
+
+        let state = c.inner.read().unwrap();
+        assert_eq!(state.deployments.len(), MAX_RECORDS);
+    }
+
+    #[test]
+    fn recovery_ring_buffer_eviction() {
+        let c = DoraCollector::new();
+        for i in 0..(MAX_RECORDS + 50) {
+            c.record_recovery(Duration::from_secs(i as u64));
+        }
+
+        let state = c.inner.read().unwrap();
+        assert_eq!(state.recoveries.len(), MAX_RECORDS);
+    }
+
+    #[test]
+    fn different_windows_return_correct_window_duration() {
+        let c = DoraCollector::new();
+        c.record_deployment(true, None);
+
+        assert_eq!(c.snapshot_7d().window, WINDOW_7D);
+        assert_eq!(c.snapshot_30d().window, WINDOW_30D);
+        assert_eq!(c.snapshot_90d().window, WINDOW_90D);
+    }
+
+    #[test]
+    fn default_impl_works() {
+        let c = DoraCollector::default();
+        let snap = c.snapshot();
+        assert_eq!(snap.total_deployments, 0);
+    }
+
+    #[test]
+    fn thread_safety_basic() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let c = Arc::new(DoraCollector::new());
+        let mut handles = vec![];
+
+        for _ in 0..4 {
+            let c = Arc::clone(&c);
+            handles.push(thread::spawn(move || {
+                for _ in 0..25 {
+                    c.record_deployment(true, Some(Duration::from_secs(10)));
+                }
+            }));
+        }
+
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let snap = c.snapshot_30d();
+        assert_eq!(snap.total_deployments, 100);
+    }
+}

--- a/src/observability/log.rs
+++ b/src/observability/log.rs
@@ -109,6 +109,21 @@ impl Observer for LogObserver {
             } => {
                 info!(hand = %hand_name, error = %error, duration_ms = duration_ms, "hand.failed");
             }
+            ObserverEvent::DeploymentStarted { deploy_id } => {
+                info!(deploy_id = %deploy_id, "deployment.started");
+            }
+            ObserverEvent::DeploymentCompleted {
+                deploy_id,
+                commit_sha,
+            } => {
+                info!(deploy_id = %deploy_id, commit_sha = %commit_sha, "deployment.completed");
+            }
+            ObserverEvent::DeploymentFailed { deploy_id, reason } => {
+                info!(deploy_id = %deploy_id, reason = %reason, "deployment.failed");
+            }
+            ObserverEvent::RecoveryCompleted { deploy_id } => {
+                info!(deploy_id = %deploy_id, "recovery.completed");
+            }
         }
     }
 
@@ -139,6 +154,14 @@ impl Observer for LogObserver {
             }
             ObserverMetric::HandSuccessRate { hand_name, success } => {
                 info!(hand = %hand_name, success = success, "metric.hand_success_rate");
+            }
+            ObserverMetric::DeploymentLeadTime(d) => {
+                let ms = u64::try_from(d.as_millis()).unwrap_or(u64::MAX);
+                info!(lead_time_ms = ms, "metric.deployment_lead_time");
+            }
+            ObserverMetric::RecoveryTime(d) => {
+                let ms = u64::try_from(d.as_millis()).unwrap_or(u64::MAX);
+                info!(recovery_time_ms = ms, "metric.recovery_time");
             }
         }
     }

--- a/src/observability/mod.rs
+++ b/src/observability/mod.rs
@@ -1,3 +1,4 @@
+pub mod dora;
 pub mod log;
 pub mod multi;
 pub mod noop;

--- a/src/observability/otel.rs
+++ b/src/observability/otel.rs
@@ -430,6 +430,12 @@ impl Observer for OtelObserver {
                 self.hand_duration
                     .record(secs, &[KeyValue::new("hand", hand_name.clone())]);
             }
+            ObserverEvent::DeploymentStarted { .. }
+            | ObserverEvent::DeploymentCompleted { .. }
+            | ObserverEvent::DeploymentFailed { .. }
+            | ObserverEvent::RecoveryCompleted { .. } => {
+                // DORA deployment events: OTel pass-through not yet implemented.
+            }
         }
     }
 
@@ -469,6 +475,9 @@ impl Observer for OtelObserver {
                         KeyValue::new("success", success_str),
                     ],
                 );
+            }
+            ObserverMetric::DeploymentLeadTime(_) | ObserverMetric::RecoveryTime(_) => {
+                // DORA metrics: OTel pass-through not yet implemented.
             }
         }
     }

--- a/src/observability/prometheus.rs
+++ b/src/observability/prometheus.rs
@@ -34,6 +34,15 @@ pub struct PrometheusObserver {
     hand_runs: IntCounterVec,
     hand_duration: HistogramVec,
     hand_findings: IntCounterVec,
+
+    // DORA
+    deployments_total: IntCounterVec,
+    deployment_lead_time: Histogram,
+    deployment_failure_rate: prometheus::Gauge,
+    recovery_time: Histogram,
+    mttr: prometheus::Gauge,
+    deploy_success_count: std::sync::atomic::AtomicU64,
+    deploy_failure_count: std::sync::atomic::AtomicU64,
 }
 
 impl PrometheusObserver {
@@ -182,6 +191,44 @@ impl PrometheusObserver {
         )
         .expect("valid metric");
 
+        let deployments_total = IntCounterVec::new(
+            prometheus::Opts::new("zeroclaw_deployments_total", "Total deployments by status"),
+            &["status"],
+        )
+        .expect("valid metric");
+
+        let deployment_lead_time = Histogram::with_opts(
+            HistogramOpts::new(
+                "zeroclaw_deployment_lead_time_seconds",
+                "Deployment lead time from commit to deploy in seconds",
+            )
+            .buckets(vec![
+                60.0, 300.0, 600.0, 1800.0, 3600.0, 7200.0, 14400.0, 43200.0, 86400.0,
+            ]),
+        )
+        .expect("valid metric");
+
+        let deployment_failure_rate = prometheus::Gauge::new(
+            "zeroclaw_deployment_failure_rate",
+            "Ratio of failed deployments to total deployments",
+        )
+        .expect("valid metric");
+
+        let recovery_time = Histogram::with_opts(
+            HistogramOpts::new(
+                "zeroclaw_recovery_time_seconds",
+                "Time to recover from a failed deployment in seconds",
+            )
+            .buckets(vec![
+                60.0, 300.0, 600.0, 1800.0, 3600.0, 7200.0, 14400.0, 43200.0, 86400.0,
+            ]),
+        )
+        .expect("valid metric");
+
+        let mttr =
+            prometheus::Gauge::new("zeroclaw_mttr_seconds", "Mean time to recovery in seconds")
+                .expect("valid metric");
+
         // Register all metrics
         registry.register(Box::new(agent_starts.clone())).ok();
         registry.register(Box::new(llm_requests.clone())).ok();
@@ -205,6 +252,15 @@ impl PrometheusObserver {
         registry.register(Box::new(hand_runs.clone())).ok();
         registry.register(Box::new(hand_duration.clone())).ok();
         registry.register(Box::new(hand_findings.clone())).ok();
+        registry.register(Box::new(deployments_total.clone())).ok();
+        registry
+            .register(Box::new(deployment_lead_time.clone()))
+            .ok();
+        registry
+            .register(Box::new(deployment_failure_rate.clone()))
+            .ok();
+        registry.register(Box::new(recovery_time.clone())).ok();
+        registry.register(Box::new(mttr.clone())).ok();
 
         Self {
             registry,
@@ -228,6 +284,13 @@ impl PrometheusObserver {
             hand_runs,
             hand_duration,
             hand_findings,
+            deployments_total,
+            deployment_lead_time,
+            deployment_failure_rate,
+            recovery_time,
+            mttr,
+            deploy_success_count: std::sync::atomic::AtomicU64::new(0),
+            deploy_failure_count: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -289,7 +352,9 @@ impl Observer for PrometheusObserver {
             }
             ObserverEvent::ToolCallStart { .. }
             | ObserverEvent::TurnComplete
-            | ObserverEvent::LlmRequest { .. } => {}
+            | ObserverEvent::LlmRequest { .. }
+            | ObserverEvent::DeploymentStarted { .. }
+            | ObserverEvent::RecoveryCompleted { .. } => {}
             ObserverEvent::ToolCall {
                 tool,
                 duration,
@@ -361,6 +426,34 @@ impl Observer for PrometheusObserver {
                     .with_label_values(&[hand_name.as_str()])
                     .observe(*duration_ms as f64 / 1000.0);
             }
+            ObserverEvent::DeploymentCompleted { .. } => {
+                self.deployments_total.with_label_values(&["success"]).inc();
+                let s = self
+                    .deploy_success_count
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                    + 1;
+                let f = self
+                    .deploy_failure_count
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                let total = s + f;
+                if total > 0 {
+                    self.deployment_failure_rate.set(f as f64 / total as f64);
+                }
+            }
+            ObserverEvent::DeploymentFailed { .. } => {
+                self.deployments_total.with_label_values(&["failure"]).inc();
+                let f = self
+                    .deploy_failure_count
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                    + 1;
+                let s = self
+                    .deploy_success_count
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                let total = s + f;
+                if total > 0 {
+                    self.deployment_failure_rate.set(f as f64 / total as f64);
+                }
+            }
         }
     }
 
@@ -400,6 +493,13 @@ impl Observer for PrometheusObserver {
                 self.hand_runs
                     .with_label_values(&[hand_name.as_str(), success_str])
                     .inc();
+            }
+            ObserverMetric::DeploymentLeadTime(d) => {
+                self.deployment_lead_time.observe(d.as_secs_f64());
+            }
+            ObserverMetric::RecoveryTime(d) => {
+                self.recovery_time.observe(d.as_secs_f64());
+                self.mttr.set(d.as_secs_f64());
             }
         }
     }
@@ -676,5 +776,72 @@ mod tests {
         // Token counters should not appear (no data recorded)
         assert!(!output.contains("zeroclaw_tokens_input_total{"));
         assert!(!output.contains("zeroclaw_tokens_output_total{"));
+    }
+
+    #[test]
+    fn dora_deployment_events_track_counters() {
+        let obs = PrometheusObserver::new();
+
+        obs.record_event(&ObserverEvent::DeploymentCompleted {
+            deploy_id: "d1".into(),
+            commit_sha: "abc123".into(),
+        });
+        obs.record_event(&ObserverEvent::DeploymentCompleted {
+            deploy_id: "d2".into(),
+            commit_sha: "def456".into(),
+        });
+        obs.record_event(&ObserverEvent::DeploymentFailed {
+            deploy_id: "d3".into(),
+            reason: "timeout".into(),
+        });
+
+        let output = obs.encode();
+        assert!(output.contains(r#"zeroclaw_deployments_total{status="success"} 2"#));
+        assert!(output.contains(r#"zeroclaw_deployments_total{status="failure"} 1"#));
+    }
+
+    #[test]
+    fn dora_failure_rate_gauge_updates() {
+        let obs = PrometheusObserver::new();
+
+        obs.record_event(&ObserverEvent::DeploymentCompleted {
+            deploy_id: "d1".into(),
+            commit_sha: "abc".into(),
+        });
+        obs.record_event(&ObserverEvent::DeploymentFailed {
+            deploy_id: "d2".into(),
+            reason: "error".into(),
+        });
+
+        let output = obs.encode();
+        // 1 failure out of 2 total = 0.5
+        assert!(output.contains("zeroclaw_deployment_failure_rate 0.5"));
+    }
+
+    #[test]
+    fn dora_lead_time_and_recovery_metrics() {
+        let obs = PrometheusObserver::new();
+
+        obs.record_metric(&ObserverMetric::DeploymentLeadTime(Duration::from_secs(
+            3600,
+        )));
+        obs.record_metric(&ObserverMetric::RecoveryTime(Duration::from_secs(600)));
+
+        let output = obs.encode();
+        assert!(output.contains("zeroclaw_deployment_lead_time_seconds"));
+        assert!(output.contains("zeroclaw_recovery_time_seconds"));
+        assert!(output.contains("zeroclaw_mttr_seconds 600"));
+    }
+
+    #[test]
+    fn dora_started_and_recovery_events_no_panic() {
+        let obs = PrometheusObserver::new();
+
+        obs.record_event(&ObserverEvent::DeploymentStarted {
+            deploy_id: "d1".into(),
+        });
+        obs.record_event(&ObserverEvent::RecoveryCompleted {
+            deploy_id: "d1".into(),
+        });
     }
 }

--- a/src/observability/traits.rs
+++ b/src/observability/traits.rs
@@ -94,6 +94,25 @@ pub enum ObserverEvent {
         error: String,
         duration_ms: u64,
     },
+    /// A deployment has started.
+    DeploymentStarted {
+        /// Identifier for the deployment (e.g., commit SHA or release tag).
+        deploy_id: String,
+    },
+    /// A deployment has completed successfully.
+    DeploymentCompleted {
+        deploy_id: String,
+        /// Commit SHA that was deployed.
+        commit_sha: String,
+    },
+    /// A deployment has failed.
+    DeploymentFailed {
+        deploy_id: String,
+        /// Human-readable failure reason.
+        reason: String,
+    },
+    /// Recovery from a failed deployment has completed.
+    RecoveryCompleted { deploy_id: String },
 }
 
 /// Numeric metrics emitted by the agent runtime.
@@ -119,6 +138,10 @@ pub enum ObserverMetric {
     HandFindingsCount { hand_name: String, count: u64 },
     /// Records a hand run outcome for success-rate tracking.
     HandSuccessRate { hand_name: String, success: bool },
+    /// Time elapsed from commit to deployment (lead time for changes).
+    DeploymentLeadTime(Duration),
+    /// Time elapsed to recover from a failed deployment.
+    RecoveryTime(Duration),
 }
 
 /// Core observability trait for recording agent runtime telemetry.


### PR DESCRIPTION
## Summary
- Adds `DoraCollector` in `src/observability/dora.rs` tracking all four DORA metrics:
  - **Deployment frequency** (total deployments per time window)
  - **Lead time for changes** (mean time from commit to deploy)
  - **Change failure rate** (failed / total deployments)
  - **Mean time to recovery** (average recovery duration)
- Ring buffer storage (max 1000 records) with time-windowed snapshots (7d, 30d, 90d)
- Registers 5 new Prometheus metrics: `zeroclaw_deployments_total{status}`, `zeroclaw_deployment_lead_time_seconds`, `zeroclaw_deployment_failure_rate`, `zeroclaw_recovery_time_seconds`, `zeroclaw_mttr_seconds`
- Adds 4 `ObserverEvent` variants and 2 `ObserverMetric` variants to the observer trait
- Updates log, otel, and prometheus observer backends to handle new variants
- 16 unit tests for DoraCollector + 4 Prometheus integration tests

Closes #4516

## Test plan
- [ ] Verify `cargo check` passes
- [ ] Verify `cargo test observability::dora` passes (16 tests)
- [ ] Verify `cargo test observability::prometheus` passes (all tests including 4 new DORA tests)
- [ ] Verify all existing tests still pass
- [ ] Verify `cargo clippy` is clean
- [ ] Verify Prometheus `/metrics` endpoint includes new DORA metrics