### PR TITLE
fix(security): use whoami for Windows ACL user identity to prevent corrupted SID

### DIFF
--- a/src/security/secrets.rs
+++ b/src/security/secrets.rs
@@ -191,7 +191,14 @@ impl SecretStore {
             #[cfg(windows)]
             {
                 // On Windows, use icacls to restrict permissions to current user only
-                let username = std::env::var("USERNAME").unwrap_or_default();
+                // Use whoami command to get full user identity (COMPUTER\User or DOMAIN\User)
+                // which is required by icacls for correct parsing
+                let username = std::process::Command::new("whoami")
+                    .output()
+                    .ok()
+                    .filter(|o| o.status.success())
+                    .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+                    .unwrap_or_else(|| std::env::var("USERNAME").unwrap_or_default());
                 let Some(grant_arg) = build_windows_icacls_grant_arg(&username) else {
                     tracing::warn!(
                         "USERNAME environment variable is empty; \


### PR DESCRIPTION
On Windows, the .secret_key file permissions were being set incorrectly,
resulting in malformed ACL entries with garbled SID values (e.g., S-1-5-21-89xxx).

Root cause: Using %USERNAME% environment variable alone caused
icacls to misparse the user identity, producing corrupted ACLs that denied access
to the legitimate user. For example, my %USERNAME% is "Nero", but the icacls need "nero/nero".

Fix: Use the whoami command to obtain the full user identity in
COMPUTER\Username or DOMAIN\Username format, which icacls requires for correct
parsing. Fall back to %USERNAME% if whoami fails.

This ensures the .secret_key file is accessible only by the current user with
proper ACL entries.

## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): master
- Problem:On Windows, the `.secret_key` file (which stores the encryption key for API keys) was being created with corrupted ACL entries showing garbled SID values like `S-1-5-21-89xxx` instead of the proper user identity, causing access denied errors for the legitimate user.
- Why it matters:The `.secret_key` file protects encrypted API keys stored in the config. If permissions are broken, the user cannot access their own keys, breaking the entire secrets system. Additionally, malformed ACLs represent a security issue as the intended access control is not enforced correctly.
- What changed:Modified `load_or_create_key()` in `src/security/secrets.rs` to use `whoami` command instead of `%USERNAME%` environment variable when constructing the icacls grant argument. `whoami` returns the full user identity in `COMPUTER\Username` or `DOMAIN\Username` format, which `icacls` requires for correct parsing
- What did **not** change (scope boundary):
No changes to the `build_windows_icacls_grant_arg()` function signature or behavior.
No changes to Unix/Linux permission handling (still uses `chmod 0600`).
No changes to encryption/decryption logic.
No changes to test cases (existing tests remain valid).
No new dependencies added.
## Label Snapshot (required)

- Risk label (`risk: low|medium|high`):low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):XS
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):security
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`):no
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):auto-managed
- If any auto-label is incorrect, note requested correction:N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`):bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):security

## Linked Issue
- Closes #4532
- Related #4532

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```
pass
- Evidence provided (test/log/trace/screenshot/perf):
<img width="1190" height="397" alt="image" src="https://github.com/user-attachments/assets/0b9be154-eb01-485f-b3ce-54a1bb39efe8" />

- If any command is intentionally skipped, explain why:
The cmd `cargo clippy --all-targets -- -D warnings` can no longer pass, and it has nothing to do with my changes. You can check the line of this error.

<img width="986" height="309" alt="image" src="https://github.com/user-attachments/assets/e1f365d6-7e15-4fe9-ae37-2428b20dead7" />


## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)No
- New external network calls? (`Yes/No`)No
- Secrets/tokens handling changed? (`Yes/No`)No
- File system access scope changed? (`Yes/No`)No
- If any `Yes`, describe risk and mitigation:N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):pass
- Redaction/anonymization notes:N/A
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):N/A

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`)No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - Created test file with original code (`Nero:F`) → ACL showed corrupted entry `NERO\:(F)` (username lost)
  - Created test file with fixed code (`nero\nero:F`) → ACL showed correct entry `NERO\Nero:(F)`
  - Confirmed `whoami` returns `nero\nero` format on the reporter's system
  - Confirmed `%USERNAME%` returns just `Nero` (computer name missing)
  - Verified the corrupted file became inaccessible (delete denied) - proving the bug's impact
- Edge cases checked:
  - `whoami` command failure fallback to `%USERNAME%` (code path preserved)
  - `whoami` output trimming (whitespace handling)
  - Empty/whitespace username still returns `None` (via `build_windows_icacls_grant_arg`)
  - Domain users (`DOMAIN\Username`) and local users (`COMPUTER\Username`) both supported
- What was not verified:
  - Other windows versions
  - Non-English Windows locales.
  - Corporate environments with complex group policies affecting `whoami` or `icacls`
## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:ZeroClaw onboarding/key initialization workflow (`zeroclaw onboard`)
- Potential unintended effects:N/A
- Guardrails/monitoring for early detection:Users will experience immediate failure (access denied) if ACL is broken - no silent corruption.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any):
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path:git revert
- Feature flags or config toggles (if any):
- Observable failure symptoms:`.secret_key` file shows `S-1-5-21-xxx` SID

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:None
  - Mitigation:
