### PR TITLE
fix(security): exempt media markers from high-entropy leak detection

### DIFF
--- a/src/security/leak_detector.rs
+++ b/src/security/leak_detector.rs
@@ -308,12 +308,19 @@ impl LeakDetector {
         // Entropy threshold scales with sensitivity: at 0.7 this is ~4.37.
         let entropy_threshold = 3.5 + self.sensitivity * 1.25;
 
-        // Strip URLs before extracting tokens so that path segments like
-        // "org/documents/2024-report-a1b2c3d4e5f6g7h8i9j0" are not mistaken
-        // for high-entropy credentials.
+        // Strip URLs and media markers before extracting tokens so that path
+        // segments are not mistaken for high-entropy credentials.
+        // Media markers like [IMAGE:/path/to/file.png] contain filesystem paths
+        // that look like high-entropy tokens when `/` is included in the token
+        // character set (#4604).
         static URL_PATTERN: OnceLock<Regex> = OnceLock::new();
         let url_re = URL_PATTERN.get_or_init(|| Regex::new(r"https?://\S+").unwrap());
-        let content_without_urls = url_re.replace_all(content, "");
+        static MEDIA_MARKER_PATTERN: OnceLock<Regex> = OnceLock::new();
+        let media_re = MEDIA_MARKER_PATTERN.get_or_init(|| {
+            Regex::new(r"\[(IMAGE|VIDEO|VOICE|AUDIO|DOCUMENT|FILE):[^\]]*\]").unwrap()
+        });
+        let content_stripped = url_re.replace_all(content, "");
+        let content_without_urls = media_re.replace_all(&content_stripped, "");
 
         let tokens = extract_candidate_tokens(&content_without_urls);
 
@@ -475,6 +482,17 @@ MIIEowIBAAKCAQEA0ZPr5JeyVDonXsKhfq...
         assert!(
             matches!(result, LeakResult::Clean),
             "Long URL paths should not be redacted"
+        );
+    }
+
+    #[test]
+    fn media_markers_not_redacted_as_high_entropy() {
+        let detector = LeakDetector::new();
+        let content = "Here is the image: [IMAGE:/Users/matt/.zeroclaw/workspace/skills/image-gen/images/20260324_135911.png]";
+        let result = detector.scan(content);
+        assert!(
+            matches!(result, LeakResult::Clean),
+            "Local media markers should not be redacted"
         );
     }
 


### PR DESCRIPTION
## Summary

- **Problem**: The outbound leak detector redacts local filesystem paths inside `[IMAGE:...]` markers as "High-entropy tokens", corrupting the path and breaking image delivery (#4604).
- **Root cause**: `extract_candidate_tokens()` includes `/` in the token character set, so a path like `zeroclaw/workspace/skills/image-gen/images/20260324_135911` becomes one long mixed alpha+digit token that exceeds the entropy threshold.
- **Fix**: Strip media markers (`[IMAGE:...]`, `[VIDEO:...]`, `[VOICE:...]`, `[AUDIO:...]`, `[DOCUMENT:...]`, `[FILE:...]`) before the high-entropy scan, matching the existing URL-stripping pattern.
- **Test**: Added `media_markers_not_redacted_as_high_entropy`.

Closes #4604

## Risk

**High** — `src/security/**` behavior change. The fix is additive (strips more content before scanning) and doesn't weaken detection of actual credentials outside media markers. The regex matches only the specific bracket-syntax media markers.

## Test plan

- [x] `cargo check` + `cargo clippy` + `cargo fmt` — clean
- [x] New test: `media_markers_not_redacted_as_high_entropy`
- [x] Existing test `detects_high_entropy_token_outside_url` still passes (credentials still detected)
- [ ] CI