### PR TITLE
fix(config): implement sync_directory for Windows

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -10650,7 +10650,21 @@ async fn sync_directory(path: &Path) -> Result<()> {
         Ok(())
     }
 
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x02000000;
+        let dir = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+            .open(path)
+            .with_context(|| format!("Failed to open directory for fsync: {}", path.display()))?;
+        dir.sync_all()
+            .with_context(|| format!("Failed to fsync directory metadata: {}", path.display()))?;
+        Ok(())
+    }
+
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = path;
         Ok(())


### PR DESCRIPTION
## Summary
- Replace no-op `#[cfg(not(unix))]` branch with proper `#[cfg(windows)]` implementation
- Open directory handle with `FILE_FLAG_BACKUP_SEMANTICS` and call `sync_all()` for durability
- Add `#[cfg(not(any(unix, windows)))]` fallback for other platforms

## Test plan
- [ ] CI passes on all platforms (Linux, macOS, Windows)
- [ ] Windows build compiles with the new `std::os::windows::fs::OpenOptionsExt` usage
- [ ] Existing `sync_directory_handles_existing_directory` test passes

Fixes #4568