### PR TITLE
fix(security): exempt media markers from high-entropy leak detection

### DIFF
--- a/src/security/leak_detector.rs
+++ b/src/security/leak_detector.rs
@@ -558,7 +558,9 @@ MIIEowIBAAKCAQEA0ZPr5JeyVDonXsKhfq...
                 assert!(patterns.iter().any(|p| p.contains("High-entropy")));
                 assert!(redacted.contains("[REDACTED_HIGH_ENTROPY_TOKEN]"));
             }
-            LeakResult::Clean => panic!("Should still detect high-entropy tokens outside media markers"),
+            LeakResult::Clean => {
+                panic!("Should still detect high-entropy tokens outside media markers")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Strip `[IMAGE:...]`, `[VIDEO:...]`, `[DOCUMENT:...]`, `[VOICE:...]`, `[AUDIO:...]` markers before high-entropy token scanning
- Prevents local file paths in media markers from being falsely redacted as "High-entropy token"
- 3 new unit tests added, all 18 leak detector tests pass

## Test plan
- [ ] `media_marker_image_path_not_redacted` - `[IMAGE:/path/to/20260324_135911.png]` passes clean
- [ ] `media_marker_video_not_redacted` - `[VIDEO:/path/to/file/name123456.mp4]` passes clean
- [ ] `actual_high_entropy_still_detected` - real high-entropy tokens still caught
- [ ] All existing leak detector tests pass

Fixes #4604