### PR TITLE
fix(onboard): add --quick flag and ZEROCLAW_INTERACTIVE env override

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2647,9 +2647,11 @@ mod tests {
     fn onboard_cli_quick_and_channels_only_conflict() {
         // --quick and --channels-only should both parse at the CLI level
         // (the conflict is checked at runtime), but we verify both flags parse.
-        let cli =
-            Cli::try_parse_from(["zeroclaw", "onboard", "--quick", "--channels-only"]);
-        assert!(cli.is_ok(), "--quick --channels-only should parse at CLI level");
+        let cli = Cli::try_parse_from(["zeroclaw", "onboard", "--quick", "--channels-only"]);
+        assert!(
+            cli.is_ok(),
+            "--quick --channels-only should parse at CLI level"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `--quick` flag to force non-interactive quick setup mode
- Adds `ZEROCLAW_INTERACTIVE=1` env var to force interactive wizard when TTY auto-detection fails
- Fixes regression where `zeroclaw onboard` skips interactive prompts on some terminals (Debian, SSH, tmux)
- Preserves existing TTY auto-detection as default behavior
- Adds validation: `--quick` and `--channels-only` cannot be combined
- Adds 2 new CLI tests

Closes #3658

## Test plan
- [ ] Verify `cargo check` passes
- [ ] Verify all onboard CLI tests pass (`cargo test onboard_cli`)
- [ ] Verify `zeroclaw onboard` still launches interactive wizard in a normal terminal
- [ ] Verify `zeroclaw onboard --quick` forces quick setup
- [ ] Verify `ZEROCLAW_INTERACTIVE=1 zeroclaw onboard` forces interactive mode
- [ ] Verify `zeroclaw onboard --quick --channels-only` is rejected