### PR TITLE
feat(cli): streaming output and Ctrl+C cancellation for agent REPL

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -4673,15 +4673,13 @@ pub async fn run(
             final_output = response.clone();
             if content_was_streamed.load(std::sync::atomic::Ordering::Relaxed) {
                 println!();
-            } else {
-                if let Err(e) = crate::channels::Channel::send(
-                    &cli,
-                    &crate::channels::traits::SendMessage::new(format!("\n{response}\n"), "user"),
-                )
-                .await
-                {
-                    eprintln!("\nError sending CLI response: {e}\n");
-                }
+            } else if let Err(e) = crate::channels::Channel::send(
+                &cli,
+                &crate::channels::traits::SendMessage::new(format!("\n{response}\n"), "user"),
+            )
+            .await
+            {
+                eprintln!("\nError sending CLI response: {e}\n");
             }
             observer.record_event(&ObserverEvent::TurnComplete);
 


### PR DESCRIPTION
## Summary

The `zeroclaw agent` interactive REPL currently buffers the entire LLM response and prints it at the end. Tool calls execute silently with no feedback. This wires the existing `DraftEvent` streaming channel into the REPL:

- **Streaming responses** — text appears progressively as the LLM generates it
- **Tool call progress** — dimmed status lines on stderr: `⏳ shell_command: ls`, `✅ shell_command (3s)`, `❌ http_request (5s): timeout`
- **Ctrl+C cancellation** — cancels the in-flight turn via `CancellationToken` and returns to the prompt instead of killing the process

No changes to the daemon/channel path or single-message (`-m`) mode.

## Test plan

- [x] All 202 agent loop tests pass
- [x] Compiles clean, `cargo fmt` clean
- [x] Manual: `zeroclaw agent` — ask a multi-tool question, verify progress lines appear dimmed and response streams
- [x] Manual: Ctrl+C during response — verify it cancels and returns to prompt
- [ ] Manual: pipe test `echo "hello" | zeroclaw agent 2>/dev/null` — only response on stdout