### PR TITLE
fix(config): handle top-level [cli] section in config parsing

### DIFF
--- a/tests/component/config_schema.rs
+++ b/tests/component/config_schema.rs
@@ -455,3 +455,68 @@ allowed_users = ["@user:example.com"]
     );
     assert!(parsed.channels_config.matrix.is_some());
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #3456 – top-level [cli] section must not clash with channels_config.cli
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn config_toplevel_cli_section_with_whatsapp_parses() {
+    // Exact config from issue #3456
+    let toml_str = r#"
+[cli]
+
+[channels_config.whatsapp]
+session_path = "~/.zeroclaw/state/whatsapp-web/session.db"
+allowed_numbers = ["*"]
+"#;
+    let parsed: Config = toml::from_str(toml_str)
+        .expect("top-level [cli] section with [channels_config.whatsapp] should parse");
+    assert!(parsed.channels_config.whatsapp.is_some());
+    let wa = parsed.channels_config.whatsapp.unwrap();
+    assert_eq!(
+        wa.session_path.as_deref(),
+        Some("~/.zeroclaw/state/whatsapp-web/session.db")
+    );
+    assert_eq!(wa.allowed_numbers, vec!["*".to_string()]);
+}
+
+#[test]
+fn config_only_whatsapp_channel_parses() {
+    let toml_str = r#"
+[channels_config.whatsapp]
+session_path = "~/.zeroclaw/state/whatsapp-web/session.db"
+allowed_numbers = ["*"]
+"#;
+    let parsed: Config =
+        toml::from_str(toml_str).expect("config with only whatsapp channel should parse");
+    assert!(parsed.channels_config.whatsapp.is_some());
+    assert!(
+        parsed.channels_config.cli,
+        "cli should default to true when omitted"
+    );
+}
+
+#[test]
+fn config_channels_explicit_cli_true_with_whatsapp() {
+    let toml_str = r#"
+[channels_config]
+cli = true
+
+[channels_config.whatsapp]
+session_path = "~/.zeroclaw/state/whatsapp-web/session.db"
+allowed_numbers = ["*"]
+"#;
+    let parsed: Config = toml::from_str(toml_str)
+        .expect("explicit channels_config.cli=true with whatsapp should parse");
+    assert!(parsed.channels_config.cli);
+    assert!(parsed.channels_config.whatsapp.is_some());
+}
+
+#[test]
+fn config_empty_parses_with_all_defaults() {
+    let parsed: Config = toml::from_str("").expect("empty config should parse with all defaults");
+    assert!(parsed.channels_config.cli);
+    assert!(parsed.channels_config.whatsapp.is_none());
+    assert!((parsed.default_temperature - 0.7).abs() < f64::EPSILON);
+}


### PR DESCRIPTION
## Summary
- Adds regression tests for issue #3456 where a top-level `[cli]` section in `config.toml` alongside `[channels_config.whatsapp]` caused a "missing field `cli`" deserialization error
- The bug is not reproducible on current master (unknown top-level keys are already ignored by serde), but these tests guard against future regressions
- Adds 4 new test cases: exact user config from issue, whatsapp-only config, explicit cli=true with whatsapp, and empty config defaults

## Test plan
- [x] `cargo test --test component` passes (191 tests, 0 failures)
- [x] `cargo fmt --all` produces no changes
- [x] `cargo clippy --all-targets -- -D warnings` passes clean

Fixes #3456