### PR TITLE
fix(ci): release notes empty on tag push

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -106,9 +106,16 @@ jobs:
         id: notes
         shell: bash
         env:
-          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_VERSION: ${{ inputs.version || '' }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
+
+          # Resolve version from tag push or manual input
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            INPUT_VERSION="${REF_NAME#v}"
+          fi
 
           # Find the previous stable tag (exclude beta tags)
           PREV_TAG=$(git tag --sort=-creatordate | grep -vE '\-beta\.' | grep -v "^v${INPUT_VERSION}$" | head -1 || echo "")


### PR DESCRIPTION
## Problem

The `release-notes` job in `release-stable-manual.yml` uses `${{ inputs.version }}` to populate the release notes, but `inputs.version` is only set for `workflow_dispatch` triggers. When the workflow fires on a **tag push** (the common release path), the variable is empty.

This causes the v0.6.2 release (and likely earlier ones) to have:
- **Broken changelog link**: `*Full changelog: v0.6.1...v*` instead of `v0.6.1...v0.6.2`
- **Missing contributors**: the tag exclusion filter `grep -v "^v$"` doesn't correctly skip the current release tag, potentially skewing the commit range
- **Fallback "Incremental improvements" text** instead of the actual feature list

See: https://github.com/zeroclaw-labs/zeroclaw/releases/tag/v0.6.2

## Fix

Add the same `EVENT_NAME`/`REF_NAME` fallback that the `validate` job already uses (lines 40-53) to the `release-notes` job. When `event_name == "push"`, extract the version from the tag ref name instead of relying on `inputs.version`.

## Test plan

- [ ] Trigger a manual `workflow_dispatch` release — `inputs.version` is used as before
- [ ] Next tag push release — version is correctly extracted from `github.ref_name`