### PR TITLE
feat(web): responsive mobile sidebar with hamburger toggle

### DIFF
--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { LogOut, Settings } from 'lucide-react';
+import { LogOut, Menu, Settings } from 'lucide-react';
 import { t } from '@/lib/i18n';
 import { useLocaleContext } from '@/App';
 import { useAuth } from '@/hooks/useAuth';
@@ -19,7 +19,11 @@ const routeTitles: Record<string, string> = {
   '/doctor': 'nav.doctor',
 };
 
-export default function Header() {
+interface HeaderProps {
+  onMenuToggle: () => void;
+}
+
+export default function Header({ onMenuToggle }: HeaderProps) {
   const location = useLocation();
   const { logout } = useAuth();
   const { locale, setAppLocale } = useLocaleContext();
@@ -37,8 +41,23 @@ export default function Header() {
   return (
     <>
       <header className="h-14 flex items-center justify-between px-6 border-b animate-fade-in" style={{ background: 'var(--pc-bg-surface)', borderColor: 'var(--pc-border)', backdropFilter: 'blur(12px)', }}>
-        {/* Page title */}
-        <h1 className="h-9 leading-9 text-lg font-semibold tracking-tight" style={{ color: 'var(--pc-text-primary)' }}>{pageTitle}</h1>
+        <div className="flex items-center gap-3">
+          {/* Hamburger — visible only on mobile */}
+          <button
+            type="button"
+            onClick={onMenuToggle}
+            className="md:hidden p-1.5 -ml-1.5 rounded-lg transition-colors duration-200"
+            style={{ color: 'var(--pc-text-muted)' }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--pc-text-primary)'; e.currentTarget.style.background = 'var(--pc-hover)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--pc-text-muted)'; e.currentTarget.style.background = 'transparent'; }}
+            aria-label="Open menu"
+          >
+            <Menu className="h-5 w-5" />
+          </button>
+
+          {/* Page title */}
+          <h1 className="h-9 leading-9 text-lg font-semibold tracking-tight" style={{ color: 'var(--pc-text-primary)' }}>{pageTitle}</h1>
+        </div>
 
         {/* Right-side controls */}
         <div className="flex items-center gap-2 h-9">
@@ -93,12 +112,13 @@ export default function Header() {
             }}
           >
             <LogOut className="h-3.5 w-3.5" />
-            <span>{t('auth.logout')}</span>
+            <span className="hidden sm:inline">{t('auth.logout')}</span>
           </button>
         </div>
       </header>
 
       <SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
     </>
+
   );
 }

--- a/web/src/components/layout/Layout.tsx
+++ b/web/src/components/layout/Layout.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import Sidebar from '@/components/layout/Sidebar';
 import Header from '@/components/layout/Header';
@@ -5,15 +6,21 @@ import { ErrorBoundary } from '@/App';
 
 export default function Layout() {
   const { pathname } = useLocation();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  // Close sidebar on route change (mobile navigation)
+  useEffect(() => {
+    setSidebarOpen(false);
+  }, [pathname]);
 
   return (
     <div className="min-h-screen text-white" style={{ background: 'var(--pc-bg-base)' }}>
       {/* Fixed sidebar */}
-      <Sidebar />
+      <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
-      {/* Main area offset by sidebar width (240px / w-60) */}
-      <div className="ml-60 flex flex-col flex-1 min-w-0 h-screen">
-        <Header />
+      {/* Main area offset by sidebar width on desktop, full-width on mobile */}
+      <div className="md:ml-60 ml-0 flex flex-col flex-1 min-w-0 h-screen">
+        <Header onMenuToggle={() => setSidebarOpen(true)} />
 
         {/* Page content — ErrorBoundary keyed by pathname so the nav shell
             survives a page crash and the boundary resets on route change */}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -29,65 +29,93 @@ const navItems = [
   { to: '/canvas', icon: Monitor, labelKey: 'nav.canvas' },
 ];
 
-export default function Sidebar() {
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function Sidebar({ open, onClose }: SidebarProps) {
   return (
-    <aside className="fixed top-0 left-0 h-screen w-60 flex flex-col border-r" style={{ background: 'var(--pc-bg-base)', borderColor: 'var(--pc-border)' }}>
-      {/* Logo / Title */}
-      <div className="flex items-center gap-3 px-4 py-4 border-b h-14" style={{ borderColor: 'var(--pc-border)' }}>
-        <div className="relative shrink-0">
-          <div className="absolute -inset-1.5 rounded-xl" style={{ background: 'linear-gradient(135deg, rgba(var(--pc-accent-rgb), 0.15), rgba(var(--pc-accent-rgb), 0.05))' }} />
-          <img
-            src={`${basePath}/_app/zeroclaw-trans.png`}
-            alt="ZeroClaw"
-            className="relative h-9 w-9 rounded-xl object-cover"
-            onError={(e) => {
-              const img = e.currentTarget;
-              img.style.display = 'none';
-            }}
-          />
+    <>
+      {/* Backdrop — mobile only, visible when sidebar is open */}
+      {open && (
+        <div
+          className="md:hidden fixed inset-0 z-40 bg-black/60 backdrop-blur-sm transition-opacity"
+          onClick={onClose}
+          onKeyDown={(e) => { if (e.key === 'Escape') onClose(); }}
+          role="button"
+          tabIndex={-1}
+          aria-label="Close menu"
+        />
+      )}
+
+      <aside
+        className={[
+          'fixed top-0 left-0 h-screen w-60 flex flex-col border-r z-50',
+          // Mobile: slide in/out with transition
+          'max-md:-translate-x-full max-md:transition-transform max-md:duration-200 max-md:ease-out',
+          open ? 'max-md:translate-x-0' : '',
+        ].join(' ')}
+        style={{ background: 'var(--pc-bg-base)', borderColor: 'var(--pc-border)' }}
+      >
+        {/* Logo / Title */}
+        <div className="flex items-center gap-3 px-4 py-4 border-b h-14" style={{ borderColor: 'var(--pc-border)' }}>
+          <div className="relative shrink-0">
+            <div className="absolute -inset-1.5 rounded-xl" style={{ background: 'linear-gradient(135deg, rgba(var(--pc-accent-rgb), 0.15), rgba(var(--pc-accent-rgb), 0.05))' }} />
+            <img
+              src={`${basePath}/_app/zeroclaw-trans.png`}
+              alt="ZeroClaw"
+              className="relative h-9 w-9 rounded-xl object-cover"
+              onError={(e) => {
+                const img = e.currentTarget;
+                img.style.display = 'none';
+              }}
+            />
+          </div>
+          <span className="text-sm font-semibold tracking-wide" style={{ color: 'var(--pc-text-primary)' }}>
+            ZeroClaw
+          </span>
         </div>
-        <span className="text-sm font-semibold tracking-wide" style={{ color: 'var(--pc-text-primary)' }}>
-          ZeroClaw
-        </span>
-      </div>
 
-      {/* Navigation */}
-      <nav className="flex-1 overflow-y-auto py-4 px-3 space-y-1">
-        {navItems.map(({ to, icon: Icon, labelKey }, idx) => (
-          <NavLink
-            key={to}
-            to={to}
-            end={to === '/'}
-            className={({ isActive }) =>
-              [
-                'flex items-center gap-3 px-3 py-2.5 rounded-2xl text-sm font-medium transition-all group',
-                isActive
-                  ? 'text-[var(--pc-accent-light)]'
-                  : 'text-[var(--pc-text-muted)] hover:text-[var(--pc-text-secondary)] hover:bg-[var(--pc-hover)]',
-              ].join(' ')
-            }
-            style={({ isActive }) => ({
-              animationDelay: `${idx * 40}ms`,
-              ...(isActive ? {
-                background: 'var(--pc-accent-glow)',
-                border: '1px solid var(--pc-accent-dim)',
-              } : {}),
-            })}
-          >
-            {({ isActive }) => (
-              <>
-                <Icon className={`h-5 w-5 flex-shrink-0 transition-colors ${isActive ? 'text-[var(--pc-accent)]' : 'group-hover:text-[var(--pc-accent)]'}`} />
-                <span>{t(labelKey)}</span>
-              </>
-            )}
-          </NavLink>
-        ))}
-      </nav>
+        {/* Navigation */}
+        <nav className="flex-1 overflow-y-auto py-4 px-3 space-y-1">
+          {navItems.map(({ to, icon: Icon, labelKey }, idx) => (
+            <NavLink
+              key={to}
+              to={to}
+              end={to === '/'}
+              onClick={onClose}
+              className={({ isActive }) =>
+                [
+                  'flex items-center gap-3 px-3 py-2.5 rounded-2xl text-sm font-medium transition-all group',
+                  isActive
+                    ? 'text-[var(--pc-accent-light)]'
+                    : 'text-[var(--pc-text-muted)] hover:text-[var(--pc-text-secondary)] hover:bg-[var(--pc-hover)]',
+                ].join(' ')
+              }
+              style={({ isActive }) => ({
+                animationDelay: `${idx * 40}ms`,
+                ...(isActive ? {
+                  background: 'var(--pc-accent-glow)',
+                  border: '1px solid var(--pc-accent-dim)',
+                } : {}),
+              })}
+            >
+              {({ isActive }) => (
+                <>
+                  <Icon className={`h-5 w-5 flex-shrink-0 transition-colors ${isActive ? 'text-[var(--pc-accent)]' : 'group-hover:text-[var(--pc-accent)]'}`} />
+                  <span>{t(labelKey)}</span>
+                </>
+              )}
+            </NavLink>
+          ))}
+        </nav>
 
-      {/* Footer */}
-      <div className="px-5 py-4 border-t text-[10px] uppercase tracking-wider" style={{ borderColor: 'var(--pc-border)', color: 'var(--pc-text-faint)' }}>
-        ZeroClaw Runtime
-      </div>
-    </aside>
+        {/* Footer */}
+        <div className="px-5 py-4 border-t text-[10px] uppercase tracking-wider" style={{ borderColor: 'var(--pc-border)', color: 'var(--pc-text-faint)' }}>
+          ZeroClaw Runtime
+        </div>
+      </aside>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The web dashboard sidebar is fixed at 240px and always visible, making it unusable on mobile devices — it consumes ~60% of the screen width, leaving dashboard content squished and barely readable.
- Why it matters: ZeroClaw is increasingly used as a Home Assistant addon where users access the dashboard from phones and tablets.
- What changed: On viewports below 768px (`md`), the sidebar is hidden off-screen and replaced by a hamburger button in the header. Tapping it slides the sidebar in as an overlay drawer with a backdrop. Tapping the backdrop or navigating closes it.
- What did **not** change (scope boundary): Desktop layout is completely unchanged — no visual diff on screens >= 768px. No new dependencies, no new components, no state management beyond a single `useState`.

Supersedes #3773 (rebased on latest master to resolve conflicts with the CSS-variable theming and basePath changes).

## Screenshots

Before:
<img width="33%" height="33%" alt="image" src="https://github.com/user-attachments/assets/fde25421-dfb3-4814-b04f-106ef8a3e2a7" />  <img width="33%" height="33%" alt="image" src="https://github.com/user-attachments/assets/b4f2d0ea-d36d-4b0d-b099-57044583a967" />

After:
<img width="30%" height="30%" alt="image" src="https://github.com/user-attachments/assets/0b9aa4ab-76c0-4a59-ab6b-8684e108d1d4" /> <img width="30%" height="30%" alt="image" src="https://github.com/user-attachments/assets/02dc8fa1-2d40-4cb4-9ceb-38cdb65eb2ad" /> <img width="30%" height="30%" alt="image" src="https://github.com/user-attachments/assets/8a9550c4-70b1-4126-9218-b546ab2a6e58" />

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `gateway`
- Module labels: `gateway: web-dashboard`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `gateway`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #3773

## Validation Evidence (required)

No Rust changes — only 3 TypeScript/TSX files in `web/src/components/layout/`.

```bash
cd web && npm run build   # tsc -b && vite build — passes clean
```

Cargo checks not applicable (no `.rs` changes).

- Evidence provided: `npm run build` passes (TypeScript type check + Vite production build)
- If any command is intentionally skipped, explain why: `cargo fmt/clippy/test` skipped — no Rust source changes

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: No identity-like wording introduced

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (no user-facing text changes — hamburger is icon-only, existing i18n labels unchanged)

## Human Verification (required)

- Verified scenarios: Desktop >= 768px unchanged, mobile < 768px sidebar hidden + hamburger visible, overlay opens/closes on tap, nav click closes sidebar, backdrop click closes sidebar
- Edge cases checked: Rapid open/close toggling, route change auto-closes, sidebar scroll on small screens with many nav items
- What **was** verified: Tablet landscape (768px-1024px boundary)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Web dashboard layout only (3 components: Layout, Header, Sidebar)
- Potential unintended effects: None — desktop path is unchanged, mobile path is additive
- Guardrails/monitoring for early detection: Visual regression on dashboard load

## Rollback Plan (required)

- Fast rollback command/path: Revert single commit
- Feature flags or config toggles: None needed — CSS-only behavior gated by `md:` breakpoint
- Observable failure symptoms: Sidebar not appearing on desktop, or hamburger not working on mobile

## Risks and Mitigations

- Risk: Tailwind `max-md:` prefix may behave differently across Tailwind versions
  - Mitigation: Tested with Tailwind CSS 4.0 (project's current version), `max-md:` is stable syntax