### PR TITLE
fix(memory): add closing tag to memory context injection

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -616,7 +616,7 @@ async fn build_context(
             if context == "[Memory context]\n" {
                 context.clear();
             } else {
-                context.push('\n');
+                context.push_str("[/Memory context]\n\n");
             }
         }
     }

--- a/src/agent/memory_loader.rs
+++ b/src/agent/memory_loader.rs
@@ -74,7 +74,7 @@ impl MemoryLoader for DefaultMemoryLoader {
             return Ok(String::new());
         }
 
-        context.push('\n');
+        context.push_str("[/Memory context]\n\n");
         Ok(context)
     }
 }

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1787,7 +1787,7 @@ async fn build_memory_context(
         }
 
         if included > 0 {
-            context.push('\n');
+            context.push_str("[/Memory context]\n\n");
         }
     }
 

--- a/tests/integration/agent.rs
+++ b/tests/integration/agent.rs
@@ -260,7 +260,7 @@ async fn e2e_multi_turn_history_fidelity() {
 async fn e2e_memory_enrichment_injects_context() {
     let (provider, recorded) = RecordingProvider::new(vec![text_response("enriched response")]);
 
-    let memory_context = "[Memory context]\n- user_name: test_user\n\n";
+    let memory_context = "[Memory context]\n- user_name: test_user\n[/Memory context]\n\n";
     let loader = StaticMemoryLoader::new(memory_context);
 
     let mut agent = build_recording_agent(Box::new(provider), vec![], Some(Box::new(loader)));
@@ -306,7 +306,7 @@ async fn e2e_multi_turn_with_memory_enrichment() {
     let (provider, recorded) =
         RecordingProvider::new(vec![text_response("answer 1"), text_response("answer 2")]);
 
-    let memory_context = "[Memory context]\n- project: zeroclaw\n\n";
+    let memory_context = "[Memory context]\n- project: zeroclaw\n[/Memory context]\n\n";
     let loader = StaticMemoryLoader::new(memory_context);
 
     let mut agent = build_recording_agent(Box::new(provider), vec![], Some(Box::new(loader)));


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): master
- Problem: Memory context is injected with `[Memory context]` opening marker but no closing tag — just a bare `\n`. Models cannot distinguish where memory ends and user content begins.
- Why it matters: causes model to misinterpret user intent by confusing memory context with user message.
- What changed: replaced trailing `\n` with `[/Memory context]\n\n` at 3 injection points; updated integration test fixtures.
- What did **not** change (scope boundary): no logic changes to memory loading, no config changes, no new dependencies.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): risk: low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): size: XS
- Scope labels: memory, tests
- Module labels: memory: context-injection
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: bug
- Primary scope: memory

## Linked Issue

- Closes #4642

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pass
cargo test   # pass (including updated fixtures)
```

- Evidence provided: local build + test pass
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: memory context with entries renders `[Memory context]...[/Memory context]` boundary; empty memory context still returns empty string
- Edge cases checked: empty memory (no entries) — cleared as before, no closing tag emitted
- What was not verified: multi-provider interaction

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: prompt construction in agent loop, memory loader, channel memory builder
- Potential unintended effects: none — only adds a closing marker string
- Guardrails/monitoring for early detection: existing integration tests updated and passing

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: none
- Observable failure symptoms: memory context missing closing tag (same as current behavior)

## Risks and Mitigations

None — additive string change with no behavior side effects beyond improved prompt boundary clarity.