### PR TITLE
fix(matrix): break OTK conflict retry loop and improve E2EE diagnostics

### DIFF
--- a/docs/security/matrix-e2ee-guide.md
+++ b/docs/security/matrix-e2ee-guide.md
@@ -126,7 +126,7 @@ After updating config, restart daemon and send a new message (not just old timel
 
 ZeroClaw needs a stable `device_id` for E2EE session restore. Without it, a new device is registered on every restart, breaking key sharing and device verification.
 
-**Option 1: From `whoami` (easiest)**
+#### Option 1: From `whoami` (easiest)
 
 ```bash
 curl -sS -H "Authorization: Bearer $MATRIX_TOKEN" \
@@ -141,7 +141,7 @@ Response includes `device_id` if the token is bound to a device session:
 
 If `device_id` is missing, the token was created without a device login (e.g., via admin API). Use Option 2 instead.
 
-**Option 2: From a password login**
+#### Option 2: From a password login
 
 ```bash
 curl -sS -X POST "https://your.homeserver/_matrix/client/v3/login" \
@@ -157,7 +157,7 @@ Response:
 
 Use both the returned `access_token` and `device_id` in your config. This creates a proper device session.
 
-**Option 3: From Element or another Matrix client**
+#### Option 3: From Element or another Matrix client
 
 1. Log in as the bot account in Element
 2. Go to Settings → Sessions
@@ -179,7 +179,7 @@ Keep `device_id` stable — changing it forces a new device registration, which 
 
 **Cause:** The bot's local crypto store was reset (e.g., deleted data directory, reinstalled) without deregistering the old device on the homeserver. The homeserver still has old one-time keys for this device, and the SDK fails to upload new ones.
 
-**Fix:**
+#### Fix
 
 1. Stop ZeroClaw.
 

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -377,10 +377,7 @@ impl MatrixChannel {
                 let stored = tokio::fs::read_to_string(&path).await?;
                 let stored = stored.trim().to_string();
                 if !stored.is_empty() {
-                    tracing::info!(
-                        "Matrix using persisted device_id from {}",
-                        path.display()
-                    );
+                    tracing::info!("Matrix using persisted device_id from {}", path.display());
                     return Ok(stored);
                 }
             }
@@ -2257,8 +2254,7 @@ mod tests {
 
     #[test]
     fn sanitize_error_for_log_scrubs_secret_prefixes() {
-        let sanitized =
-            MatrixChannel::sanitize_error_for_log(&"auth failed: sk-proj-abc123xyz");
+        let sanitized = MatrixChannel::sanitize_error_for_log(&"auth failed: sk-proj-abc123xyz");
         assert!(!sanitized.contains("sk-proj-abc123xyz"));
         assert!(sanitized.contains("[REDACTED]"));
     }


### PR DESCRIPTION
## Summary

- Detect one-time key upload conflicts in the Matrix sync callback and stop retrying instead of looping forever
- Auto-generate and persist `device_id` when not configured — users no longer need to manually obtain one via curl or Element
- Sanitize sync error messages before logging to prevent secret leakage
- Add `debug!`-level logging at key E2EE decision points (visible via `RUST_LOG=zeroclaw::channels::matrix=debug`)
- Add doc references to all E2EE error/warning messages pointing to specific guide sections
- Update Matrix E2EE guide with: how to find device_id (4G), OTK recovery steps (4H), debug logging (section 5)

## Test plan

- [x] `cargo check --features channel-matrix` compiles clean
- [x] `cargo clippy --features channel-matrix -- -D warnings` — no warnings
- [x] `cargo test --features channel-matrix` — 34 Matrix tests pass (including 2 new)
- [x] Verified on live Matrix homeserver: bot starts, syncs, responds in encrypted rooms
- [x] Wrong recovery key logs clear warning with doc reference, bot continues
- [x] No device_id configured: auto-generates `ZEROCLAW_<random>`, persists to disk, reuses on restart

Closes #4633
Refs #4667

🤖 Generated with [Claude Code](https://claude.com/claude-code)