### PR TITLE
fix(agent): fallback to non-streaming when stream errors (#4670)

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -1019,6 +1019,7 @@ impl Agent {
             let mut streamed_text = String::new();
             let mut streamed_tool_calls: Vec<crate::providers::traits::ToolCall> = Vec::new();
             let mut got_stream = false;
+            let mut stream_error: Option<String> = None;
 
             while let Some(item) = stream.next().await {
                 match item {
@@ -1068,15 +1069,24 @@ impl Agent {
                         }
                         crate::providers::traits::StreamEvent::Final => break,
                     },
-                    Err(_) => break,
+                    Err(err) => {
+                        stream_error = Some(err.to_string());
+                        break;
+                    }
                 }
             }
             // Drop the stream so we release the borrow on provider.
             drop(stream);
 
-            // If streaming produced text, use it as the response and
-            // check for tool calls via the dispatcher.
-            let response = if got_stream {
+            // If streaming completed without error and produced text, use it
+            // directly. Otherwise, fall back to non-streaming chat.
+            //
+            // Why: some providers can emit partial/error text over stream on
+            // failures (for example model capability mismatches). Returning
+            // that partial stream as the final assistant response causes
+            // user-visible false answers. Fallback chat gives us a clean
+            // authoritative result path.
+            let response = if got_stream && stream_error.is_none() {
                 // Build a synthetic ChatResponse from streamed text
                 crate::providers::ChatResponse {
                     text: Some(streamed_text),
@@ -1085,6 +1095,13 @@ impl Agent {
                     reasoning_content: None,
                 }
             } else {
+                if let Some(ref err) = stream_error {
+                    tracing::warn!(
+                        error = err.as_str(),
+                        model = effective_model.as_str(),
+                        "Streaming turn had an error; attempting non-streaming fallback"
+                    );
+                }
                 // Fall back to non-streaming chat
                 match self
                     .provider
@@ -1103,7 +1120,25 @@ impl Agent {
                     .await
                 {
                     Ok(resp) => resp,
-                    Err(err) => return Err(err),
+                    Err(err) => {
+                        // If streaming produced partial text but fallback failed,
+                        // preserve the partial answer rather than failing hard.
+                        if got_stream {
+                            tracing::warn!(
+                                error = %err,
+                                model = effective_model.as_str(),
+                                "Fallback chat failed after partial stream; returning partial streamed text"
+                            );
+                            crate::providers::ChatResponse {
+                                text: Some(streamed_text),
+                                tool_calls: streamed_tool_calls,
+                                usage: None,
+                                reasoning_content: None,
+                            }
+                        } else {
+                            return Err(err);
+                        }
+                    }
                 }
             };
 
@@ -1280,6 +1315,8 @@ pub async fn run(
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use futures_util::stream;
+    use futures_util::StreamExt;
     use parking_lot::Mutex;
     use std::collections::HashMap;
 
@@ -1413,6 +1450,97 @@ mod tests {
 
         let response = agent.turn("hi").await.unwrap();
         assert_eq!(response, "hello");
+    }
+
+    /// Mock provider that emits error text via stream then fails,
+    /// but succeeds on non-streaming fallback. Reproduces #4670.
+    struct StreamingErrorThenFallbackProvider;
+
+    #[async_trait]
+    impl Provider for StreamingErrorThenFallbackProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> Result<String> {
+            Ok("ok".into())
+        }
+
+        async fn chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: f64,
+        ) -> Result<crate::providers::ChatResponse> {
+            Ok(crate::providers::ChatResponse {
+                text: Some("fallback answer".into()),
+                tool_calls: vec![],
+                usage: None,
+                reasoning_content: None,
+            })
+        }
+
+        fn supports_streaming(&self) -> bool {
+            true
+        }
+
+        fn stream_chat(
+            &self,
+            _request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: f64,
+            _options: crate::providers::traits::StreamOptions,
+        ) -> futures_util::stream::BoxStream<
+            'static,
+            crate::providers::traits::StreamResult<crate::providers::traits::StreamEvent>,
+        > {
+            stream::iter(vec![
+                Ok(crate::providers::traits::StreamEvent::TextDelta(
+                    crate::providers::traits::StreamChunk::delta(
+                        "unknown does not support streaming".to_string(),
+                    ),
+                )),
+                Err(crate::providers::traits::StreamError::Provider(
+                    "unknown does not support streaming".to_string(),
+                )),
+            ])
+            .boxed()
+        }
+    }
+
+    /// Regression test for #4670: streaming error text should not become the
+    /// final response. The agent should fall back to non-streaming chat.
+    #[tokio::test]
+    async fn turn_streamed_falls_back_to_chat_when_stream_errors_after_partial_text() {
+        let provider = Box::new(StreamingErrorThenFallbackProvider);
+
+        let memory_cfg = crate::config::MemoryConfig {
+            backend: "none".into(),
+            ..crate::config::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            crate::memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let mut agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(XmlToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(16);
+        let response = agent.turn_streamed("hi", event_tx).await.unwrap();
+        while event_rx.try_recv().is_ok() {}
+
+        assert_eq!(response, "fallback answer");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: when a streaming provider emits partial/error text then fails (e.g. model capability mismatches), the error text becomes the final assistant response
- Why it matters: users see false answers like "unknown does not support streaming" instead of actual LLM output
- What changed: track stream errors and fall back to non-streaming chat when streaming fails after partial text. If both streaming and fallback fail, preserve partial streamed text as last resort.
- What did **not** change: stream event handling (TextDelta, ToolCall, PreExecuted*, Thinking, Final), tool spec passing (#4774 already landed), non-streaming `turn()` path

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `agent`
- Module labels: `agent: streaming`

## Change Metadata

- Change type: `bug`
- Primary scope: `agent`

## Linked Issue

- Closes #4670
- Related #4774, #4690

## Validation Evidence (required)

\`\`\`bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings  # pass
cargo test --lib turn_streamed_falls_back  # 1 passed, 0 failed
\`\`\`

- Evidence provided: regression test \`turn_streamed_falls_back_to_chat_when_stream_errors_after_partial_text\` reproduces #4670 scenario — mocks a provider that streams error text then fails, verifies fallback returns clean response

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: streaming error produces fallback response (via test)
- Edge cases checked: partial stream text preserved when both streaming and fallback fail
- What was not verified: manual /ws/chat and /webhook end-to-end

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: turn_streamed in agent loop (used by /ws/chat and /webhook)
- Potential unintended effects: none — only adds error tracking and fallback path to existing stream loop
- Guardrails/monitoring: warn-level log on stream error before fallback attempt

## Rollback Plan (required)

- Fast rollback command/path: revert this commit
- Observable failure symptoms: streaming errors return error text as final response instead of falling back

## Risks and Mitigations

- Risk: fallback chat call adds latency on stream failure
  - Mitigation: only triggers on actual stream errors, not on normal empty streams