### PR TITLE
fix(docker): disable require_pairing by default in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ RUN mkdir -p /zeroclaw-data/.zeroclaw /zeroclaw-data/workspace && \
         'port = 42617' \
         'host = "[::]"' \
         'allow_public_bind = true' \
+        'require_pairing = false' \
         '' \
         '[autonomy]' \
         'level = "supervised"' \

--- a/dev/config.template.toml
+++ b/dev/config.template.toml
@@ -10,6 +10,7 @@ default_temperature = 0.7
 port = 42617
 host = "[::]"
 allow_public_bind = true
+require_pairing = false
 
 # Cost tracking and budget enforcement configuration
 # Enable to track API usage costs and enforce spending limits

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -10059,6 +10059,11 @@ impl Config {
             self.gateway.allow_public_bind = val == "1" || val.eq_ignore_ascii_case("true");
         }
 
+        // Require pairing: ZEROCLAW_REQUIRE_PAIRING
+        if let Ok(val) = std::env::var("ZEROCLAW_REQUIRE_PAIRING") {
+            self.gateway.require_pairing = val == "1" || val.eq_ignore_ascii_case("true");
+        }
+
         // Temperature: ZEROCLAW_TEMPERATURE
         if let Ok(temp_str) = std::env::var("ZEROCLAW_TEMPERATURE") {
             match temp_str.parse::<f64>() {
@@ -13936,6 +13941,23 @@ default_model = "persisted-profile"
         assert_eq!(config.gateway.host, "0.0.0.0");
 
         std::env::remove_var("HOST");
+    }
+
+    #[test]
+    async fn env_override_require_pairing() {
+        let _env_guard = env_override_lock().await;
+        let mut config = Config::default();
+        assert!(config.gateway.require_pairing);
+
+        std::env::set_var("ZEROCLAW_REQUIRE_PAIRING", "false");
+        config.apply_env_overrides();
+        assert!(!config.gateway.require_pairing);
+
+        std::env::set_var("ZEROCLAW_REQUIRE_PAIRING", "true");
+        config.apply_env_overrides();
+        assert!(config.gateway.require_pairing);
+
+        std::env::remove_var("ZEROCLAW_REQUIRE_PAIRING");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Set `require_pairing = false` in the Dockerfile embedded config and dev template so Docker users get instant dashboard access without a pairing code
- Add `ZEROCLAW_REQUIRE_PAIRING` env var override in `schema.rs` so users can opt back into pairing if needed
- Add test for the new env override

## Context
Docker quick-start users run `docker run -p 42617:42617 ghcr.io/zeroclaw-labs/zeroclaw:latest` and the dashboard loads fine (static assets skip auth), but all API/WebSocket calls fail with 401 because `require_pairing` defaults to `true`. The Dockerfile already sets `allow_public_bind = true`, acknowledging Docker's different trust model — `require_pairing` should match.

Bare-metal / brew / cargo installs are **unchanged** (pairing still enabled by default).

Closes #4678

## Test plan
- [ ] Build Docker image and verify dashboard loads with full API access (no pairing dialog)
- [ ] Verify `ZEROCLAW_REQUIRE_PAIRING=true` re-enables pairing in Docker
- [ ] Verify bare-metal install still defaults to `require_pairing = true`
- [ ] Run `cargo test env_override_require_pairing`