### PR TITLE
feat: add Tavily as configurable web search provider

### DIFF
--- a/scripts/rpi-config.toml
+++ b/scripts/rpi-config.toml
@@ -493,7 +493,10 @@ user_agent = "ZeroClaw/1.0"
 
 [web_search]
 enabled = false
+# Provider options: "duckduckgo" (free, default), "brave" (requires brave_api_key),
+# "searxng" (self-hosted, requires searxng_instance_url), "tavily" (requires tavily_api_key)
 provider = "duckduckgo"
+# tavily_api_key = ""
 fallback_providers = []
 retries_per_provider = 0
 retry_backoff_ms = 250

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2730,12 +2730,15 @@ pub struct WebSearchConfig {
     /// Enable `web_search_tool` for web searches
     #[serde(default)]
     pub enabled: bool,
-    /// Search provider: "duckduckgo" (free), "brave" (requires API key), or "searxng" (self-hosted)
+    /// Search provider: "duckduckgo" (free), "brave" (requires API key), "searxng" (self-hosted), or "tavily" (requires API key)
     #[serde(default = "default_web_search_provider")]
     pub provider: String,
     /// Brave Search API key (required if provider is "brave")
     #[serde(default)]
     pub brave_api_key: Option<String>,
+    /// Tavily API key (required if provider is "tavily")
+    #[serde(default)]
+    pub tavily_api_key: Option<String>,
     /// SearXNG instance URL (required if provider is "searxng"), e.g. "https://searx.example.com"
     #[serde(default)]
     pub searxng_instance_url: Option<String>,
@@ -2765,6 +2768,7 @@ impl Default for WebSearchConfig {
             enabled: true,
             provider: default_web_search_provider(),
             brave_api_key: None,
+            tavily_api_key: None,
             searxng_instance_url: None,
             max_results: default_web_search_max_results(),
             timeout_secs: default_web_search_timeout_secs(),
@@ -8873,6 +8877,12 @@ impl Config {
 
             decrypt_optional_secret(
                 &store,
+                &mut config.web_search.tavily_api_key,
+                "config.web_search.tavily_api_key",
+            )?;
+
+            decrypt_optional_secret(
+                &store,
                 &mut config.storage.provider.config.db_url,
                 "config.storage.provider.config.db_url",
             )?;
@@ -10135,6 +10145,16 @@ impl Config {
             }
         }
 
+        // Tavily API key: ZEROCLAW_TAVILY_API_KEY or TAVILY_API_KEY
+        if let Ok(api_key) =
+            std::env::var("ZEROCLAW_TAVILY_API_KEY").or_else(|_| std::env::var("TAVILY_API_KEY"))
+        {
+            let api_key = api_key.trim();
+            if !api_key.is_empty() {
+                self.web_search.tavily_api_key = Some(api_key.to_string());
+            }
+        }
+
         // SearXNG instance URL: ZEROCLAW_SEARXNG_INSTANCE_URL or SEARXNG_INSTANCE_URL
         if let Ok(instance_url) = std::env::var("ZEROCLAW_SEARXNG_INSTANCE_URL")
             .or_else(|_| std::env::var("SEARXNG_INSTANCE_URL"))
@@ -10329,6 +10349,12 @@ impl Config {
             &store,
             &mut config_to_save.web_search.brave_api_key,
             "config.web_search.brave_api_key",
+        )?;
+
+        encrypt_optional_secret(
+            &store,
+            &mut config_to_save.web_search.tavily_api_key,
+            "config.web_search.tavily_api_key",
         )?;
 
         encrypt_optional_secret(

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -571,6 +571,7 @@ pub fn all_tools_with_runtime(
         tool_arcs.push(Arc::new(WebSearchTool::new_with_config(
             root_config.web_search.provider.clone(),
             root_config.web_search.brave_api_key.clone(),
+            root_config.web_search.tavily_api_key.clone(),
             root_config.web_search.searxng_instance_url.clone(),
             root_config.web_search.max_results,
             root_config.web_search.timeout_secs,

--- a/src/tools/web_search_provider_routing.rs
+++ b/src/tools/web_search_provider_routing.rs
@@ -3,6 +3,7 @@ pub enum WebSearchProviderRoute {
     DuckDuckGo,
     Brave,
     SearXNG,
+    Tavily,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15,6 +16,7 @@ pub struct WebSearchProviderResolution {
 pub const DEFAULT_WEB_SEARCH_PROVIDER: &str = "duckduckgo";
 const BRAVE_PROVIDER: &str = "brave";
 const SEARXNG_PROVIDER: &str = "searxng";
+const TAVILY_PROVIDER: &str = "tavily";
 
 pub fn resolve_web_search_provider(raw_provider: &str) -> WebSearchProviderResolution {
     let normalized = raw_provider.trim().to_ascii_lowercase();
@@ -34,6 +36,11 @@ pub fn resolve_web_search_provider(raw_provider: &str) -> WebSearchProviderResol
         "searxng" | "searx" | "searx-ng" | "searx_ng" => WebSearchProviderResolution {
             route: WebSearchProviderRoute::SearXNG,
             canonical_provider: SEARXNG_PROVIDER,
+            used_fallback: false,
+        },
+        "tavily" | "tavily-search" | "tavily_search" => WebSearchProviderResolution {
+            route: WebSearchProviderRoute::Tavily,
+            canonical_provider: TAVILY_PROVIDER,
             used_fallback: false,
         },
         _ => WebSearchProviderResolution {
@@ -77,6 +84,17 @@ mod tests {
             let resolved = resolve_web_search_provider(alias);
             assert_eq!(resolved.route, WebSearchProviderRoute::SearXNG);
             assert_eq!(resolved.canonical_provider, SEARXNG_PROVIDER);
+            assert!(!resolved.used_fallback);
+        }
+    }
+
+    #[test]
+    fn resolve_aliases_to_tavily() {
+        let tavily_aliases = ["tavily", "tavily-search", "tavily_search"];
+        for alias in tavily_aliases {
+            let resolved = resolve_web_search_provider(alias);
+            assert_eq!(resolved.route, WebSearchProviderRoute::Tavily);
+            assert_eq!(resolved.canonical_provider, TAVILY_PROVIDER);
             assert!(!resolved.used_fallback);
         }
     }

--- a/src/tools/web_search_tool.rs
+++ b/src/tools/web_search_tool.rs
@@ -8,17 +8,19 @@ use std::time::Duration;
 
 /// Web search tool for searching the internet.
 /// Supports multiple providers: DuckDuckGo (free), Brave (requires API key),
-/// SearXNG (self-hosted, requires instance URL).
+/// SearXNG (self-hosted, requires instance URL), Tavily (requires API key).
 ///
-/// The Brave API key is resolved lazily at execution time: if the boot-time key
+/// API keys are resolved lazily at execution time: if the boot-time key
 /// is missing or still encrypted, the tool re-reads `config.toml`, decrypts the
-/// `[web_search] brave_api_key` field, and uses the result. This ensures that
+/// relevant `[web_search]` field, and uses the result. This ensures that
 /// keys set or rotated after boot, and encrypted keys, are correctly picked up.
 pub struct WebSearchTool {
     /// Provider selector as configured by user. Routed via provider aliases at runtime.
     provider: String,
     /// Boot-time key snapshot (may be `None` if not yet configured at startup).
     boot_brave_api_key: Option<String>,
+    /// Boot-time Tavily API key snapshot (may be `None` if not yet configured at startup).
+    boot_tavily_api_key: Option<String>,
     /// SearXNG instance base URL (e.g. "https://searx.example.com").
     searxng_instance_url: Option<String>,
     max_results: usize,
@@ -39,6 +41,7 @@ impl WebSearchTool {
         Self {
             provider: provider.trim().to_lowercase(),
             boot_brave_api_key: brave_api_key,
+            boot_tavily_api_key: None,
             searxng_instance_url: None,
             max_results: max_results.clamp(1, 10),
             timeout_secs: timeout_secs.max(1),
@@ -55,6 +58,7 @@ impl WebSearchTool {
     pub fn new_with_config(
         provider: String,
         brave_api_key: Option<String>,
+        tavily_api_key: Option<String>,
         searxng_instance_url: Option<String>,
         max_results: usize,
         timeout_secs: u64,
@@ -64,6 +68,7 @@ impl WebSearchTool {
         Self {
             provider: provider.trim().to_lowercase(),
             boot_brave_api_key: brave_api_key,
+            boot_tavily_api_key: tavily_api_key,
             searxng_instance_url,
             max_results: max_results.clamp(1, 10),
             timeout_secs: timeout_secs.max(1),
@@ -121,6 +126,121 @@ impl WebSearchTool {
         } else {
             Ok(raw_key)
         }
+    }
+
+    /// Resolve the Tavily API key, preferring the boot-time value but falling
+    /// back to a fresh config read + decryption when the boot-time value is
+    /// absent.
+    fn resolve_tavily_api_key(&self) -> anyhow::Result<String> {
+        // Fast path: boot-time key is present and usable (not an encrypted blob).
+        if let Some(ref key) = self.boot_tavily_api_key {
+            if !key.is_empty() && !crate::security::SecretStore::is_encrypted(key) {
+                return Ok(key.clone());
+            }
+        }
+
+        // Slow path: re-read config.toml to pick up keys set/rotated after boot.
+        self.reload_tavily_api_key()
+    }
+
+    /// Re-read `config.toml` and decrypt `[web_search] tavily_api_key`.
+    fn reload_tavily_api_key(&self) -> anyhow::Result<String> {
+        let contents = std::fs::read_to_string(&self.config_path).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to read config file {} for Tavily API key: {e}",
+                self.config_path.display()
+            )
+        })?;
+
+        let config: crate::config::Config = toml::from_str(&contents).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to parse config file {} for Tavily API key: {e}",
+                self.config_path.display()
+            )
+        })?;
+
+        let raw_key = config
+            .web_search
+            .tavily_api_key
+            .filter(|k| !k.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("Tavily API key not configured"))?;
+
+        // Decrypt if necessary.
+        if crate::security::SecretStore::is_encrypted(&raw_key) {
+            let zeroclaw_dir = self.config_path.parent().unwrap_or_else(|| Path::new("."));
+            let store = crate::security::SecretStore::new(zeroclaw_dir, self.secrets_encrypt);
+            let plaintext = store.decrypt(&raw_key)?;
+            if plaintext.is_empty() {
+                anyhow::bail!("Tavily API key not configured (decrypted value is empty)");
+            }
+            Ok(plaintext)
+        } else {
+            Ok(raw_key)
+        }
+    }
+
+    async fn search_tavily(&self, query: &str) -> anyhow::Result<String> {
+        let api_key = self.resolve_tavily_api_key()?;
+
+        let builder = reqwest::Client::builder().timeout(Duration::from_secs(self.timeout_secs));
+        let builder = crate::config::apply_runtime_proxy_to_builder(builder, "tool.web_search");
+        let client = builder.build()?;
+
+        let body = json!({
+            "query": query,
+            "max_results": self.max_results,
+            "search_depth": "basic",
+            "include_answer": false,
+        });
+
+        let response = client
+            .post("https://api.tavily.com/search")
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", api_key))
+            .json(&body)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            anyhow::bail!("Tavily search failed with status: {}", response.status());
+        }
+
+        let json: serde_json::Value = response.json().await?;
+        self.parse_tavily_results(&json, query)
+    }
+
+    fn parse_tavily_results(
+        &self,
+        json: &serde_json::Value,
+        query: &str,
+    ) -> anyhow::Result<String> {
+        let results = json
+            .get("results")
+            .and_then(|r| r.as_array())
+            .ok_or_else(|| anyhow::anyhow!("Invalid Tavily API response"))?;
+
+        if results.is_empty() {
+            return Ok(format!("No results found for: {}", query));
+        }
+
+        let mut lines = vec![format!("Search results for: {} (via Tavily)", query)];
+
+        for (i, result) in results.iter().take(self.max_results).enumerate() {
+            let title = result
+                .get("title")
+                .and_then(|t| t.as_str())
+                .unwrap_or("No title");
+            let url = result.get("url").and_then(|u| u.as_str()).unwrap_or("");
+            let content = result.get("content").and_then(|c| c.as_str()).unwrap_or("");
+
+            lines.push(format!("{}. {}", i + 1, title));
+            lines.push(format!("   {}", url));
+            if !content.is_empty() {
+                lines.push(format!("   {}", content));
+            }
+        }
+
+        Ok(lines.join("\n"))
     }
 
     async fn search_duckduckgo(&self, query: &str) -> anyhow::Result<String> {
@@ -422,6 +542,7 @@ impl Tool for WebSearchTool {
             WebSearchProviderRoute::DuckDuckGo => self.search_duckduckgo(query).await?,
             WebSearchProviderRoute::Brave => self.search_brave(query).await?,
             WebSearchProviderRoute::SearXNG => self.search_searxng(query).await?,
+            WebSearchProviderRoute::Tavily => self.search_tavily(query).await?,
         };
 
         Ok(ToolResult {
@@ -555,6 +676,7 @@ mod tests {
             "brave".to_string(),
             None,
             None,
+            None,
             5,
             15,
             config_path,
@@ -582,6 +704,7 @@ mod tests {
             "brave".to_string(),
             Some(encrypted),
             None,
+            None,
             5,
             15,
             config_path,
@@ -599,6 +722,7 @@ mod tests {
 
         let tool = WebSearchTool::new_with_config(
             "searxng".to_string(),
+            None,
             None,
             None,
             5,
@@ -663,6 +787,7 @@ mod tests {
         let tool = WebSearchTool {
             provider: "searxng".to_string(),
             boot_brave_api_key: None,
+            boot_tavily_api_key: None,
             searxng_instance_url: Some("https://searx.example.com".to_string()),
             max_results: 5,
             timeout_secs: 15,
@@ -687,6 +812,7 @@ mod tests {
             "searxng".to_string(),
             None,
             None,
+            None,
             5,
             15,
             config_path,
@@ -708,6 +834,7 @@ mod tests {
             "brave".to_string(),
             None,
             None,
+            None,
             5,
             15,
             config_path.clone(),
@@ -727,5 +854,124 @@ mod tests {
         // Now should succeed with the updated key
         let key = tool.resolve_brave_api_key().unwrap();
         assert_eq!(key, "runtime-updated-key");
+    }
+
+    #[tokio::test]
+    async fn test_execute_tavily_without_api_key() {
+        let tool = WebSearchTool::new("tavily".to_string(), None, 5, 15);
+        let result = tool.execute(json!({"query": "test"})).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("API key"));
+    }
+
+    #[test]
+    fn test_resolve_tavily_api_key_uses_boot_key() {
+        let tool = WebSearchTool {
+            provider: "tavily".to_string(),
+            boot_brave_api_key: None,
+            boot_tavily_api_key: Some("tvly-plaintext-key".to_string()),
+            searxng_instance_url: None,
+            max_results: 5,
+            timeout_secs: 15,
+            config_path: PathBuf::new(),
+            secrets_encrypt: false,
+        };
+        let key = tool.resolve_tavily_api_key().unwrap();
+        assert_eq!(key, "tvly-plaintext-key");
+    }
+
+    #[test]
+    fn test_resolve_tavily_api_key_reloads_from_config() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "[web_search]\ntavily_api_key = \"tvly-fresh-key\"\n",
+        )
+        .unwrap();
+
+        let tool = WebSearchTool::new_with_config(
+            "tavily".to_string(),
+            None,
+            None,
+            None,
+            5,
+            15,
+            config_path,
+            false,
+        );
+        let key = tool.resolve_tavily_api_key().unwrap();
+        assert_eq!(key, "tvly-fresh-key");
+    }
+
+    #[test]
+    fn test_resolve_tavily_api_key_decrypts_encrypted_key() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let store = crate::security::SecretStore::new(tmp.path(), true);
+        let encrypted = store.encrypt("tvly-secret-key").unwrap();
+
+        let config_path = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            format!("[web_search]\ntavily_api_key = \"{}\"\n", encrypted),
+        )
+        .unwrap();
+
+        let tool = WebSearchTool::new_with_config(
+            "tavily".to_string(),
+            None,
+            Some(encrypted),
+            None,
+            5,
+            15,
+            config_path,
+            true,
+        );
+        let key = tool.resolve_tavily_api_key().unwrap();
+        assert_eq!(key, "tvly-secret-key");
+    }
+
+    #[test]
+    fn test_parse_tavily_results_empty() {
+        let tool = WebSearchTool::new("tavily".to_string(), None, 5, 15);
+        let json = serde_json::json!({"results": []});
+        let result = tool.parse_tavily_results(&json, "test").unwrap();
+        assert!(result.contains("No results found"));
+    }
+
+    #[test]
+    fn test_parse_tavily_results_with_data() {
+        let tool = WebSearchTool::new("tavily".to_string(), None, 5, 15);
+        let json = serde_json::json!({
+            "results": [
+                {
+                    "title": "Tavily Example",
+                    "url": "https://example.com",
+                    "content": "Search API for LLMs"
+                },
+                {
+                    "title": "Another Result",
+                    "url": "https://example.org",
+                    "content": "More information here"
+                }
+            ]
+        });
+        let result = tool.parse_tavily_results(&json, "test").unwrap();
+        assert!(result.contains("Tavily Example"));
+        assert!(result.contains("https://example.com"));
+        assert!(result.contains("Search API for LLMs"));
+        assert!(result.contains("via Tavily"));
+    }
+
+    #[test]
+    fn test_parse_tavily_results_invalid_response() {
+        let tool = WebSearchTool::new("tavily".to_string(), None, 5, 15);
+        let json = serde_json::json!({"error": "bad request"});
+        let result = tool.parse_tavily_results(&json, "test");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid Tavily API response"));
     }
 }


### PR DESCRIPTION
## Summary

Adds Tavily as a first-class web search provider alongside DuckDuckGo, Brave, and SearXNG. This is a purely additive change — no existing provider paths are modified.

- Added `Tavily` variant to `WebSearchProviderRoute` with aliases: `tavily`, `tavily-search`, `tavily_search`
- Added `tavily_api_key: Option<String>` to `WebSearchConfig` with encryption/decryption support
- Implemented `search_tavily()` using POST to `https://api.tavily.com/search` with Bearer auth
- Added `ZEROCLAW_TAVILY_API_KEY` / `TAVILY_API_KEY` env var override support
- Wired Tavily into tool construction pipeline (`mod.rs`)
- Added comprehensive unit tests for routing, key resolution (boot/config/encrypted), result parsing, and error handling

## Files changed

- `src/tools/web_search_provider_routing.rs` — `Tavily` enum variant + aliases + test
- `src/tools/web_search_tool.rs` — `boot_tavily_api_key` field, key resolver, `search_tavily()`, result parser, tests
- `src/config/schema.rs` — `tavily_api_key` field, Default, encrypt/decrypt hooks, env override
- `src/tools/mod.rs` — pass `tavily_api_key` to `WebSearchTool::new_with_config()`
- `scripts/rpi-config.toml` — document Tavily provider option

## Dependency changes

- None (uses existing `reqwest` + `serde_json`)

## Environment variable changes

- Added `TAVILY_API_KEY` / `ZEROCLAW_TAVILY_API_KEY` env var support

## Configuration

Set `provider = "tavily"` and `tavily_api_key = "tvly-..."` in `[web_search]` section, or use the `TAVILY_API_KEY` environment variable.

## Notes for reviewers

- The Tavily REST API is called via `POST /search` with Bearer token auth and JSON body
- Key resolution follows the same lazy-reload + decryption pattern as Brave
- `examples/config.example.toml` had no `[web_search]` section so was not modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Automated Review

- Passed after 1 attempt(s)
- Final review: The Tavily migration is correct and complete. The implementation faithfully follows the existing Brave provider pattern: config schema field with serde default, encrypt/decrypt hooks, env var override (ZEROCLAW_TAVILY_API_KEY / TAVILY_API_KEY), lazy key resolution with encrypted-blob detection, REST call to the correct Tavily endpoint with Bearer auth, response parsing, routing enum variant, and wiring in mod.rs. All reportedly changed files are present and consistent. Tests cover routing aliases, boot-key fast path, config-reload slow path, decryption, empty/valid/invalid response parsing, and the no-key error case. Two minor issues were found — neither is blocking.
