### PR TITLE
fix(onboard): merge channel config instead of overwriting in --channels-only mode

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6133,6 +6133,62 @@ pub struct ChannelsConfig {
 }
 
 impl ChannelsConfig {
+    /// Merge `other` into `self`: for every `Option` channel field, if `other`
+    /// has `Some(value)` it overwrites `self`; if `None` the existing value is
+    /// preserved.  Scalar / non-channel fields (`cli`, `message_timeout_secs`,
+    /// etc.) are left untouched so a channels-only repair does not reset them.
+    pub fn merge_from(&mut self, other: ChannelsConfig) {
+        macro_rules! merge_opt {
+            ($($field:ident),* $(,)?) => {
+                $(
+                    if other.$field.is_some() {
+                        self.$field = other.$field;
+                    }
+                )*
+            };
+        }
+
+        merge_opt!(
+            telegram,
+            discord,
+            discord_history,
+            slack,
+            mattermost,
+            webhook,
+            imessage,
+            matrix,
+            signal,
+            whatsapp,
+            linq,
+            wati,
+            nextcloud_talk,
+            email,
+            gmail_push,
+            irc,
+            lark,
+            feishu,
+            dingtalk,
+            wecom,
+            qq,
+            twitter,
+            mochat,
+            clawdtalk,
+            reddit,
+            bluesky,
+            voice_call,
+        );
+
+        #[cfg(feature = "channel-nostr")]
+        if other.nostr.is_some() {
+            self.nostr = other.nostr;
+        }
+
+        #[cfg(feature = "voice-wake")]
+        if other.voice_wake.is_some() {
+            self.voice_wake = other.voice_wake;
+        }
+    }
+
     /// get channels' metadata and `.is_some()`, except webhook
     #[rustfmt::skip]
     pub fn channels_except_webhook(&self) -> Vec<(Box<dyn super::traits::ConfigHandle>, bool)> {

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -274,7 +274,8 @@ pub async fn run_channels_repair_wizard() -> Result<Config> {
     let mut config = Box::pin(Config::load_or_init()).await?;
 
     print_step(1, 1, "Channels (How You Talk to ZeroClaw)");
-    config.channels_config = setup_channels()?;
+    let new_channels = setup_channels()?;
+    config.channels_config.merge_from(new_channels);
     config.save().await?;
     persist_workspace_selection(&config.config_path).await?;
 


### PR DESCRIPTION
## Summary

- `zeroclaw onboard --channels-only` now merges/upserts channels instead of replacing the entire config
- Added `ChannelsConfig::merge_from()` method that only overwrites channels the user explicitly reconfigured, preserving all others
- Uses a `merge_opt!` macro to handle all 28+ optional channel fields including `#[cfg(feature)]` gated ones
- Scalar fields (`cli`, `message_timeout_secs`, `ack_reactions`) are left untouched

## Root cause

`wizard.rs:275` assigned `config.channels_config = setup_channels()?;` — `setup_channels()` returns a fresh `ChannelsConfig::default()` with only the wizard-configured channels populated, wiping all others.

## Files changed

- `src/config/schema.rs` — new `ChannelsConfig::merge_from()` method
- `src/onboard/wizard.rs` — use merge instead of assignment

## Test plan

- [ ] Configure Discord + Matrix, then run `onboard --channels-only` configuring only Matrix — Discord config should be preserved
- [ ] Verify scalar fields are not reset
- [ ] Build compiles with `channel-nostr` and `voice-wake` features

Closes #4655