### PR TITLE
fix(lark): use IMAGE_ERROR prefix for failed downloads to prevent session poisoning

### DIFF
--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -943,7 +943,7 @@ impl LarkChannel {
                                 Some(marker) => (marker, Vec::new()),
                                 None => {
                                     tracing::warn!("Lark WS: failed to download image {image_key}");
-                                    (format!("[IMAGE:{image_key} | download failed]"), Vec::new())
+                                    (format!("[IMAGE_ERROR:{image_key} | download failed]"), Vec::new())
                                 }
                             }
                         }
@@ -1677,7 +1677,7 @@ impl LarkChannel {
                             Some(m) => m,
                             None => {
                                 tracing::warn!("Lark: failed to download image {key}");
-                                format!("[IMAGE:{key} | download failed]")
+                                format!("[IMAGE_ERROR:{key} | download failed]")
                             }
                         };
                         (marker, Vec::new())


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): master
- Problem: When Lark (FeiShu) channel image download fails, it generates invalid `[IMAGE:xxx | download failed]` marker that blocks the entire conversation
- Why it matters: Users with vision-capable providers (GPT-4V, Claude 3, Gemini) cannot continue any conversation after a failed image download
- What changed: Changed error marker prefix from `[IMAGE:` to `[IMAGE_ERROR:` in `src/channels/lark.rs` (lines 946 and 1676)
- What did **not** change (scope boundary): No changes to multimodal module, other channels, or any other files. Note: `[ATTACHMENT:...]` markers for failed file downloads were left unchanged because they are NOT processed by the multimodal pipeline and do not cause session blocking.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): risk: low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): size: XS
- Scope labels: channel
- Module labels: channel:lark
- Contributor tier label (auto-managed/read-only): N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): channel

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked): N/A
- Supersedes # (if replacing older PR): N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:
- Evidence provided (test/log/trace/screenshot/perf): CI will validate
- If any command is intentionally skipped, explain why: It`s just a little bug, don`t need test

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: No personal data involved
- Neutral wording confirmation: Yes, no identity-like wording used

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- N/A - no docs or user-facing wording changes

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Code review, verified `parse_image_markers` only matches `[IMAGE:` prefix (see `src/multimodal.rs` line 7)
- Edge cases checked: Confirmed `[ATTACHMENT:...]` markers are NOT processed by multimodal pipeline and do not cause session blocking
- What was not verified: Manual test with actual Lark channel (no access to FeiShu environment)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Lark channel only
- Potential unintended effects: None - error markers now visible as plain text instead of blocking conversation
- Guardrails/monitoring for early detection: Users will see `[IMAGE_ERROR:...]` in conversation instead of blocked session

## Agent Collaboration Notes (recommended)

- Agent tools used: Cursor AI assistant for code analysis and documentation
- Workflow/plan summary: Analyzed bug root cause, verified multimodal only processes `[IMAGE:` prefix, implemented targeted fix
- Verification focus: Verified multimodal module behavior, confirmed `[ATTACHMENT:...]` markers are not affected
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-hash>`
- Feature flags or config toggles (if any): None
- Observable failure symptoms: If regression, users would see different error message format

## Risks and Mitigations

- Risk: Error message format change may confuse users familiar with old format
  - Mitigation: New format `[IMAGE_ERROR:...]` is more descriptive and clearly indicates an error state

## Future Consideration

For naming consistency, `[ATTACHMENT:xxx | download failed]` markers in Lark channel (lines 967 and 1707) could similarly be changed to `[ATTACHMENT_ERROR:...]`. However, this is **not required** because:
- `[ATTACHMENT:...]` markers are NOT processed by the multimodal pipeline
- They do NOT cause session blocking
- This PR focuses only on the bug fix for the blocking issue