### PR TITLE
feat(channels): add mention_only config option for Matrix channel

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -35,6 +35,7 @@ pub struct MatrixChannel {
     room_id: String,
     allowed_users: Vec<String>,
     allowed_rooms: Vec<String>,
+    mention_only: bool,
     session_owner_hint: Option<String>,
     session_device_id_hint: Option<String>,
     zeroclaw_dir: Option<PathBuf>,
@@ -64,6 +65,7 @@ impl std::fmt::Debug for MatrixChannel {
             .field("room_id", &self.room_id)
             .field("allowed_users", &self.allowed_users)
             .field("allowed_rooms", &self.allowed_rooms)
+            .field("mention_only", &self.mention_only)
             .finish_non_exhaustive()
     }
 }
@@ -143,6 +145,7 @@ impl MatrixChannel {
             room_id,
             allowed_users,
             vec![],
+            false,
             None,
             None,
             None,
@@ -163,6 +166,7 @@ impl MatrixChannel {
             room_id,
             allowed_users,
             vec![],
+            false,
             owner_hint,
             device_id_hint,
             None,
@@ -184,6 +188,7 @@ impl MatrixChannel {
             room_id,
             allowed_users,
             vec![],
+            false,
             owner_hint,
             device_id_hint,
             zeroclaw_dir,
@@ -196,6 +201,7 @@ impl MatrixChannel {
         room_id: String,
         allowed_users: Vec<String>,
         allowed_rooms: Vec<String>,
+        mention_only: bool,
         owner_hint: Option<String>,
         device_id_hint: Option<String>,
         zeroclaw_dir: Option<PathBuf>,
@@ -220,6 +226,7 @@ impl MatrixChannel {
             room_id,
             allowed_users,
             allowed_rooms,
+            mention_only,
             session_owner_hint: Self::normalize_optional_field(owner_hint),
             session_device_id_hint: Self::normalize_optional_field(device_id_hint),
             zeroclaw_dir,
@@ -865,6 +872,7 @@ impl Channel for MatrixChannel {
         let my_user_id_for_handler = my_user_id.clone();
         let allowed_users_for_handler = self.allowed_users.clone();
         let allowed_rooms_for_handler = self.allowed_rooms.clone();
+        let mention_only_for_handler = self.mention_only;
         let dedupe_for_handler = Arc::clone(&recent_event_cache);
         let homeserver_for_handler = self.homeserver.clone();
         let access_token_for_handler = self.access_token.clone();
@@ -907,6 +915,59 @@ impl Channel for MatrixChannel {
                 let sender = event.sender.to_string();
                 if !MatrixChannel::is_sender_allowed(&allowed_users, &sender) {
                     return;
+                }
+
+                // mention_only filtering: in group rooms, only respond when
+                // the message text mentions the bot's user ID or display name.
+                // Direct messages (rooms with ≤2 joined members) bypass this.
+                if mention_only_for_handler {
+                    let is_dm = room.joined_members_count() <= 2
+                        || room.is_direct().await.unwrap_or(false);
+                    if !is_dm {
+                        let text_body = match &event.content.msgtype {
+                            MessageType::Text(c) => Some(c.body.as_str()),
+                            MessageType::Notice(c) => Some(c.body.as_str()),
+                            _ => None,
+                        };
+                        let mentioned = if let Some(text) = text_body {
+                            let text_lower = text.to_lowercase();
+                            let uid = my_user_id.as_str().to_lowercase();
+                            // Check for full user ID (e.g. @bot:matrix.org)
+                            let has_uid = text_lower.contains(&uid);
+                            // Check for localpart (e.g. "bot" from @bot:matrix.org)
+                            let has_localpart = uid
+                                .strip_prefix('@')
+                                .and_then(|rest| rest.split(':').next())
+                                .map(|local| text_lower.contains(local))
+                                .unwrap_or(false);
+                            // Check display name from room member profile
+                            let has_display_name = match room
+                                .get_member_no_sync(
+                                    &OwnedUserId::try_from(my_user_id.as_str())
+                                        .expect("valid user id"),
+                                )
+                                .await
+                            {
+                                Ok(Some(member)) => member
+                                    .display_name()
+                                    .map(|dn| text_lower.contains(&dn.to_lowercase()))
+                                    .unwrap_or(false),
+                                _ => false,
+                            };
+                            has_uid || has_localpart || has_display_name
+                        } else {
+                            // Non-text messages (images, files, etc.) don't contain
+                            // mentions — skip them in mention_only mode.
+                            false
+                        };
+                        if !mentioned {
+                            tracing::debug!(
+                                "Matrix: mention_only active, ignoring message without bot mention in room {}",
+                                room.room_id()
+                            );
+                            return;
+                        }
+                    }
                 }
 
                 // Helper: extract mxc:// download URL and filename for media types
@@ -2071,6 +2132,7 @@ mod tests {
             "!r:m".to_string(),
             vec!["@user:m".to_string()],
             vec!["!allowed:matrix.org".to_string()],
+            false,
             None,
             None,
             None,
@@ -2090,6 +2152,7 @@ mod tests {
                 "#ops:matrix.org".to_string(),
                 "!direct:matrix.org".to_string(),
             ],
+            false,
             None,
             None,
             None,
@@ -2107,6 +2170,7 @@ mod tests {
             "!r:m".to_string(),
             vec![],
             vec!["!Room:Matrix.org".to_string()],
+            false,
             None,
             None,
             None,
@@ -2123,6 +2187,7 @@ mod tests {
             "!r:m".to_string(),
             vec![],
             vec!["  !room:matrix.org  ".to_string(), "   ".to_string()],
+            false,
             None,
             None,
             None,

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4157,6 +4157,7 @@ fn collect_configured_channels(
                     mx.room_id.clone(),
                     mx.allowed_users.clone(),
                     mx.allowed_rooms.clone(),
+                    mx.mention_only,
                     mx.user_id.clone(),
                     mx.device_id.clone(),
                     config.config_path.parent().map(|path| path.to_path_buf()),

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6607,6 +6607,10 @@ pub struct MatrixConfig {
     /// Supports canonical room IDs (`!abc:server`) and aliases (`#room:server`).
     #[serde(default)]
     pub allowed_rooms: Vec<String>,
+    /// When true, only respond to messages that @-mention the bot in group rooms.
+    /// Direct messages are always processed.
+    #[serde(default)]
+    pub mention_only: bool,
     /// Whether to interrupt an in-flight agent response when a new message arrives.
     #[serde(default)]
     pub interrupt_on_new_message: bool,
@@ -12201,6 +12205,7 @@ default_temperature = 0.7
             room_id: "!room123:matrix.org".into(),
             allowed_users: vec!["@user:matrix.org".into()],
             allowed_rooms: vec![],
+            mention_only: false,
             interrupt_on_new_message: false,
             stream_mode: StreamMode::default(),
             draft_update_interval_ms: 1500,
@@ -12226,6 +12231,7 @@ default_temperature = 0.7
             room_id: "!abc:synapse.local".into(),
             allowed_users: vec!["@admin:synapse.local".into(), "*".into()],
             allowed_rooms: vec![],
+            mention_only: false,
             interrupt_on_new_message: false,
             stream_mode: StreamMode::default(),
             draft_update_interval_ms: 1500,
@@ -12323,6 +12329,7 @@ allowed_users = ["@ops:matrix.org"]
                 room_id: "!r:m".into(),
                 allowed_users: vec!["@u:m".into()],
                 allowed_rooms: vec![],
+                mention_only: false,
                 interrupt_on_new_message: false,
                 stream_mode: StreamMode::default(),
                 draft_update_interval_ms: 1500,

--- a/src/integrations/registry.rs
+++ b/src/integrations/registry.rs
@@ -892,6 +892,7 @@ mod tests {
             room_id: "!r:m".into(),
             allowed_users: vec![],
             allowed_rooms: vec![],
+            mention_only: false,
             interrupt_on_new_message: false,
             stream_mode: crate::config::StreamMode::default(),
             draft_update_interval_ms: 1500,

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -4230,6 +4230,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     room_id,
                     allowed_users,
                     allowed_rooms: vec![],
+                    mention_only: false,
                     interrupt_on_new_message: false,
                     stream_mode: StreamMode::Partial,
                     draft_update_interval_ms: 1500,


### PR DESCRIPTION
## Summary

- Add `mention_only` field to `MatrixConfig` (default: `false`, consistent with other channels)
- When enabled, the bot only responds in group rooms when @-mentioned (by user ID, localpart, or display name)
- Direct messages (rooms with ≤2 members or `is_direct()`) bypass the filter
- Non-text messages (images, files) are skipped in mention_only mode

## Usage

```toml
[channels.matrix]
mention_only = true
```

## Implementation

Follows the same pattern as Telegram and Discord:
- Check room member count / `is_direct()` to detect DMs
- For group rooms, extract text body and check for bot user ID (`@bot:server`), localpart (`bot`), or display name
- Uses `room.get_member()` to resolve the bot's display name

## Files changed

- `src/config/schema.rs` — add `mention_only: bool` to `MatrixConfig`
- `src/channels/matrix.rs` — mention filtering logic in event handler + `new_full` parameter
- `src/channels/mod.rs` — pass config value to constructor
- `src/integrations/registry.rs` — update test struct
- `src/onboard/wizard.rs` — default value in wizard

## Test plan

- [ ] `mention_only = false` (default): bot responds to all messages in all rooms
- [ ] `mention_only = true`: bot only responds when mentioned in group rooms
- [ ] DMs always get responses regardless of setting
- [ ] Build compiles with `--features channel-matrix`

Closes #4666