### PR TITLE
fix(channels): restore multi-room listening for Matrix allowed_rooms

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -849,11 +849,19 @@ impl Channel for MatrixChannel {
 
         let _ = client.sync_once(SyncSettings::new()).await;
 
-        tracing::info!(
-            "Matrix channel listening on room {} (configured as {})...",
-            target_room_id,
-            self.room_id
-        );
+        if self.allowed_rooms.is_empty() {
+            tracing::info!(
+                "Matrix channel listening on room {} (configured as {})...",
+                target_room_id,
+                self.room_id
+            );
+        } else {
+            tracing::info!(
+                "Matrix channel listening on {} allowed rooms (default: {})...",
+                self.allowed_rooms.len(),
+                self.room_id
+            );
+        }
 
         let recent_event_cache = Arc::new(Mutex::new((
             std::collections::VecDeque::new(),
@@ -884,17 +892,18 @@ impl Channel for MatrixChannel {
             let transcription_mgr = transcription_mgr_for_handler.clone();
 
             async move {
-                if !MatrixChannel::room_matches_target(
-                    target_room.as_str(),
-                    room.room_id().as_str(),
-                ) {
-                    return;
-                }
-
-                // Room allowlist: skip messages from rooms not in the configured list
-                if !MatrixChannel::is_room_allowed_static(&allowed_rooms, room.room_id().as_ref()) {
+                // Multi-room support: if allowed_rooms is configured, accept
+                // messages from any listed room; otherwise fall back to the
+                // single target room_id for backward compatibility.
+                let incoming = room.room_id().as_str();
+                let room_accepted = if allowed_rooms.is_empty() {
+                    MatrixChannel::room_matches_target(target_room.as_str(), incoming)
+                } else {
+                    MatrixChannel::is_room_allowed_static(&allowed_rooms, incoming)
+                };
+                if !room_accepted {
                     tracing::debug!(
-                        "Matrix: ignoring message from room {} (not in allowed_rooms)",
+                        "Matrix: ignoring message from room {} (not in allowed_rooms / target room)",
                         room.room_id()
                     );
                     return;


### PR DESCRIPTION
## Summary

- When `allowed_rooms` is configured, the Matrix bot now listens and responds in **all** listed rooms, not just the single `room_id`
- When `allowed_rooms` is empty, behavior is unchanged (single `room_id` only)
- Reply routing was already correct — replies use the originating room's ID

## Root cause

The event handler had two sequential checks: first `room_matches_target` (rejecting anything not from `room_id`), then `is_room_allowed_static`. Since the first check already rejected messages from other rooms, the second was dead code for multi-room scenarios. Commit `0051a0c2` re-introduced this regression.

## Fix

Replaced the two sequential checks with a single combined check:
```rust
let room_accepted = if allowed_rooms.is_empty() {
    // Backward compatible: single room_id
    MatrixChannel::room_matches_target(target_room, incoming)
} else {
    // Multi-room: any room in allowed_rooms
    MatrixChannel::is_room_allowed_static(&allowed_rooms, incoming)
};
```

## Files changed

- `src/channels/matrix.rs` — combined room filter logic + improved startup log

## Test plan

- [ ] `allowed_rooms = []` + `room_id` set: bot listens in single room only (unchanged)
- [ ] `allowed_rooms = ["!room1:srv", "!room2:srv"]`: bot responds in both rooms
- [ ] Messages from unlisted rooms are still rejected
- [ ] Replies route to the correct originating room

Closes #4658