### PR TITLE
fix(dashboard): add missing /api/channels endpoint for Channels view

### DIFF
--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -229,6 +229,38 @@ pub async fn handle_api_tools(
     Json(serde_json::json!({"tools": tools})).into_response()
 }
 
+/// GET /api/channels — list configured channels for the dashboard
+pub async fn handle_api_channels(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let config = state.config.lock().clone();
+    let channels: Vec<serde_json::Value> = config
+        .channels_config
+        .channels()
+        .into_iter()
+        .map(|(channel, enabled)| {
+            let status = if enabled { "active" } else { "inactive" };
+            let health = if enabled { "healthy" } else { "down" };
+            serde_json::json!({
+                "name": channel.name(),
+                "type": channel.desc(),
+                "enabled": enabled,
+                "status": status,
+                "message_count": 0,
+                "last_message_at": serde_json::Value::Null,
+                "health": health,
+            })
+        })
+        .collect();
+
+    Json(serde_json::json!({ "channels": channels })).into_response()
+}
+
 /// GET /api/cron — list cron jobs
 pub async fn handle_api_cron_list(
     State(state): State<AppState>,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -900,6 +900,7 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         .route("/api/status", get(api::handle_api_status))
         .route("/api/config", get(api::handle_api_config_get))
         .route("/api/tools", get(api::handle_api_tools))
+        .route("/api/channels", get(api::handle_api_channels))
         .route("/api/cron", get(api::handle_api_cron_list))
         .route("/api/cron", post(api::handle_api_cron_add))
         .route(


### PR DESCRIPTION
## Summary

Fix the dashboard Channels tab by adding the missing `GET /api/channels` gateway endpoint.

## Problem

The web dashboard requested `/api/channels`, but the gateway had no matching route.
That caused the request to fall through to the SPA handler and return HTML instead of JSON, which broke the Channels view.

## Fix

- add `GET /api/channels` to the gateway router
- return channel metadata derived from the current config
- keep the same auth behavior used by the other dashboard API endpoints

## Result

The dashboard Channels tab receives JSON instead of the SPA shell and can render again.

## Verification

- `cargo check -p zeroclawlabs` passes
- verified live deployment returns:
  - `200 OK`
  - `Content-Type: application/json`
  - JSON payload from `/api/channels`

## Scope

This PR only restores the missing dashboard API route.
It does not include Docker or deployment changes.