### PR TITLE
fix(ci): remove push trigger from CI workflow to unblock PRs

### DIFF
--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -1,13 +1,11 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || 'push-master' }}
+  group: ci-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

- Removes the `push` trigger from `ci-run.yml` so it only runs on `pull_request` events
- Simplifies the concurrency group to use only the PR number (no more `push-master` fallback)

## Problem

The CI workflow triggered on both `push` (master) and `pull_request` events. When multiple commits landed on master, the shared concurrency group `ci-push-master` with `cancel-in-progress: true` would cancel the in-flight Lint job. Since Test, Build, and Check (all features) all depend on Lint via `needs: [lint]`, they were **skipped**. The CI Required Gate then saw cancelled/skipped upstream jobs and **failed**.

This failing `CI / CI Required Gate (push)` check appeared alongside PR checks and blocked merges — even when the PR's own `(pull_request)` checks all passed.

## Why this is safe

- `checks-on-pr.yml` (Quality Gate) already validates PRs with lint, test, build, security, and 32-bit checks
- `ci-run.yml` adds PR-specific extras (strict delta lint, docs quality, all-features check) that only need the `pull_request` context
- `release-beta-on-push.yml` already handles post-merge master builds and releases

## Test plan

- [ ] Verify this PR's own CI checks all pass (no `(push)` duplicates)
- [ ] Confirm existing open PRs no longer show failing `CI / CI Required Gate (push)`
- [ ] Verify merges to master still trigger `Release Beta` workflow