### PR TITLE
fix(acp): use camelCase field names in ACP JSON-RPC responses

### DIFF
--- a/src/channels/acp_server.rs
+++ b/src/channels/acp_server.rs
@@ -221,15 +221,15 @@ impl AcpServer {
 
     fn handle_initialize(&self, _params: &Value) -> RpcResult {
         Ok(serde_json::json!({
-            "protocol_version": "1.0",
-            "server_info": {
+            "protocolVersion": "1.0",
+            "serverInfo": {
                 "name": "zeroclaw-acp",
                 "version": env!("CARGO_PKG_VERSION"),
             },
             "capabilities": {
                 "streaming": true,
-                "max_sessions": self.acp_config.max_sessions,
-                "session_timeout_secs": self.acp_config.session_timeout_secs,
+                "maxSessions": self.acp_config.max_sessions,
+                "sessionTimeoutSecs": self.acp_config.session_timeout_secs,
             },
             "methods": [
                 "initialize",
@@ -255,7 +255,8 @@ impl AcpServer {
         }
 
         let workspace_dir = params
-            .get("workspace_dir")
+            .get("workspaceDir")
+            .or_else(|| params.get("workspace_dir"))
             .and_then(|v| v.as_str())
             .unwrap_or_else(|| self.config.workspace_dir.to_str().unwrap_or("."))
             .to_string();
@@ -285,14 +286,15 @@ impl AcpServer {
         info!("Created session {session_id} (workspace: {workspace_dir})");
 
         Ok(serde_json::json!({
-            "session_id": session_id,
-            "workspace_dir": workspace_dir,
+            "sessionId": session_id,
+            "workspaceDir": workspace_dir,
         }))
     }
 
     async fn handle_session_prompt(&self, params: &Value, _request_id: &Value) -> RpcResult {
         let session_id = params
-            .get("session_id")
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
             .and_then(|v| v.as_str())
             .ok_or_else(|| RpcError {
                 code: INVALID_PARAMS,
@@ -342,7 +344,7 @@ impl AcpServer {
                     jsonrpc: "2.0",
                     method: "session/event",
                     params: serde_json::json!({
-                        "session_id": session_id,
+                        "sessionId": session_id,
                         "type": "chunk",
                         "content": delta,
                     }),
@@ -351,7 +353,7 @@ impl AcpServer {
                     jsonrpc: "2.0",
                     method: "session/event",
                     params: serde_json::json!({
-                        "session_id": session_id,
+                        "sessionId": session_id,
                         "type": "tool_call",
                         "name": name,
                         "args": args,
@@ -361,7 +363,7 @@ impl AcpServer {
                     jsonrpc: "2.0",
                     method: "session/event",
                     params: serde_json::json!({
-                        "session_id": session_id,
+                        "sessionId": session_id,
                         "type": "tool_result",
                         "name": name,
                         "output": output,
@@ -371,7 +373,7 @@ impl AcpServer {
                     jsonrpc: "2.0",
                     method: "session/event",
                     params: serde_json::json!({
-                        "session_id": session_id,
+                        "sessionId": session_id,
                         "type": "thinking",
                         "content": delta,
                     }),
@@ -401,18 +403,19 @@ impl AcpServer {
         }
 
         Ok(serde_json::json!({
-            "session_id": session_id,
+            "sessionId": session_id,
             "content": result,
         }))
     }
 
     async fn handle_session_stop(&self, params: &Value) -> RpcResult {
         let session_id = params
-            .get("session_id")
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
             .and_then(|v| v.as_str())
             .ok_or_else(|| RpcError {
                 code: INVALID_PARAMS,
-                message: "Missing required parameter: session_id".to_string(),
+                message: "Missing required parameter: sessionId".to_string(),
                 data: None,
             })?;
 
@@ -420,7 +423,7 @@ impl AcpServer {
         if sessions.remove(session_id).is_some() {
             info!("Stopped session {session_id}");
             Ok(serde_json::json!({
-                "session_id": session_id,
+                "sessionId": session_id,
                 "stopped": true,
             }))
         } else {


### PR DESCRIPTION
## Summary

- ACP JSON-RPC responses now use camelCase field names to match the protocol spec
- VSCode ACP client extension can now connect successfully
- Request params accept both `sessionId` (preferred) and `session_id` (fallback) for backward compatibility

## Root cause

ZeroClaw returned `session_id` (snake_case) but the ACP protocol and VSCode extension expect `sessionId` (camelCase). The extension parsed the response but couldn't find the session ID field.

## Changes

| Before (snake_case) | After (camelCase) |
|---------------------|-------------------|
| `session_id` | `sessionId` |
| `workspace_dir` | `workspaceDir` |
| `protocol_version` | `protocolVersion` |
| `server_info` | `serverInfo` |
| `max_sessions` | `maxSessions` |
| `session_timeout_secs` | `sessionTimeoutSecs` |

## Files changed

- `src/channels/acp_server.rs` — camelCase responses + dual-format request parsing

## Test plan

- [ ] VSCode ACP client connects and shows session ID
- [ ] `session/new` returns `sessionId` field
- [ ] `session/prompt` and `session/stop` accept both `sessionId` and `session_id`
- [ ] Existing ACP clients using snake_case still work (fallback)

Closes #4731