### PR TITLE
fix: wrap bearer_token test values in Some() for Option<String>

### DIFF
--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -3472,7 +3472,7 @@ mod tests {
         tc.default_provider = "local_whisper".to_string();
         tc.local_whisper = Some(crate::config::LocalWhisperConfig {
             url: "http://localhost:0/v1/transcribe".to_string(),
-            bearer_token: "unused".to_string(),
+            bearer_token: Some("unused".to_string()),
             max_audio_bytes: 10 * 1024 * 1024,
             timeout_secs: 30,
         });
@@ -3554,7 +3554,7 @@ mod tests {
         config.enabled = true;
         config.local_whisper = Some(crate::config::LocalWhisperConfig {
             url: format!("{}/v1/transcribe", whisper_server.uri()),
-            bearer_token: "test-token".to_string(),
+            bearer_token: Some("test-token".to_string()),
             max_audio_bytes: 10 * 1024 * 1024,
             timeout_secs: 30,
         });

--- a/src/channels/mattermost.rs
+++ b/src/channels/mattermost.rs
@@ -1447,7 +1447,7 @@ mod tests {
                 google: None,
                 local_whisper: Some(crate::config::LocalWhisperConfig {
                     url: whisper_url,
-                    bearer_token: "test_token".to_string(),
+                    bearer_token: Some("test_token".to_string()),
                     max_audio_bytes: 25_000_000,
                     timeout_secs: 300,
                 }),
@@ -1497,7 +1497,7 @@ mod tests {
                 google: None,
                 local_whisper: Some(crate::config::LocalWhisperConfig {
                     url: mock_server.uri(),
-                    bearer_token: "test_token".to_string(),
+                    bearer_token: Some("test_token".to_string()),
                     max_audio_bytes: 25_000_000,
                     timeout_secs: 300,
                 }),

--- a/src/channels/wati.rs
+++ b/src/channels/wati.rs
@@ -939,7 +939,7 @@ mod tests {
             google: None,
             local_whisper: Some(crate::config::LocalWhisperConfig {
                 url: format!("{}/v1/transcribe", whisper_server.uri()),
-                bearer_token: "test-token".to_string(),
+                bearer_token: Some("test-token".to_string()),
                 max_audio_bytes: 25 * 1024 * 1024,
                 timeout_secs: 300,
             }),
@@ -992,7 +992,7 @@ mod tests {
             google: None,
             local_whisper: Some(crate::config::LocalWhisperConfig {
                 url: "http://localhost:8000/v1/transcribe".to_string(),
-                bearer_token: "test-token".to_string(),
+                bearer_token: Some("test-token".to_string()),
                 max_audio_bytes: 25 * 1024 * 1024,
                 timeout_secs: 300,
             }),
@@ -1038,7 +1038,7 @@ mod tests {
             default_provider: "local_whisper".into(),
             local_whisper: Some(crate::config::LocalWhisperConfig {
                 url: "http://localhost:8001/v1/transcribe".into(),
-                bearer_token: "test-token".into(),
+                bearer_token: Some("test-token".into()),
                 max_audio_bytes: 25 * 1024 * 1024,
                 timeout_secs: 120,
             }),


### PR DESCRIPTION
## Summary
- Fix compilation errors in `wati.rs`, `mattermost.rs`, and `lark.rs` tests where `bearer_token` was passed as `String` instead of `Option<String>`
- `LocalWhisperConfig.bearer_token` was changed to `Option<String>` but these test sites were not updated

## Test plan
- [x] `cargo check` compiles cleanly
- [ ] CI gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)