### PR TITLE
chore: bump version to 0.6.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12329,7 +12329,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "aardvark-sys",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "zeroclawlabs"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 authors = ["theonlyhennygod"]
 license = "MIT OR Apache-2.0"

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/config.schema.json",
   "productName": "ZeroClaw",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "identifier": "ai.zeroclawlabs.desktop",
   "build": {
     "devUrl": "http://127.0.0.1:42617/_app/",


### PR DESCRIPTION
## Summary

- Bump version from 0.6.2 → 0.6.3 in `Cargo.toml`, `Cargo.lock`, and `apps/tauri/tauri.conf.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)