### PR TITLE
fix(channels): respect max_history_messages config in channel mode

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1185,13 +1185,24 @@ fn append_sender_turn(ctx: &ChannelRuntimeContext, sender_key: &str, turn: ChatM
         }
     }
 
+    // Use the user-configured max_history_messages (fall back to
+    // MAX_CHANNEL_HISTORY when the config value is 0 or absent).
+    let max_history = {
+        let configured = ctx.prompt_config.agent.max_history_messages;
+        if configured > 0 {
+            configured
+        } else {
+            MAX_CHANNEL_HISTORY
+        }
+    };
+
     let mut histories = ctx
         .conversation_histories
         .lock()
         .unwrap_or_else(|e| e.into_inner());
     let turns = histories.entry(sender_key.to_string()).or_default();
     turns.push(turn);
-    while turns.len() > MAX_CHANNEL_HISTORY {
+    while turns.len() > max_history {
         turns.remove(0);
     }
 }


### PR DESCRIPTION
## Summary

- Channel mode now reads `agent.max_history_messages` from config instead of using hardcoded `MAX_CHANNEL_HISTORY` (50)
- Falls back to the constant when config value is 0
- Applies to all channel types (QQ, Telegram, Discord, Slack, etc.)

## Root cause

`append_sender_turn()` used `MAX_CHANNEL_HISTORY` (hardcoded 50) for trimming, ignoring the user-configured `agent.max_history_messages`. The CLI path correctly uses the config value via `trim_history()` in `loop_.rs`.

## Files changed

- `src/channels/mod.rs` — `append_sender_turn()` reads config via `ctx.prompt_config.agent.max_history_messages`

## Test plan

- [ ] Set `max_history_messages = 5`, chat >5 rounds via channel — bot forgets earlier messages
- [ ] Set `max_history_messages = 0` or omit — falls back to 50 (unchanged default)
- [ ] CLI mode still uses config correctly (unchanged)

Closes #4740