### PR TITLE
fix(providers): add UTF-8 accumulator for chunked SSE streaming

### DIFF
--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -960,22 +960,35 @@ fn sse_bytes_to_chunks(
         }
 
         let mut bytes_stream = response.bytes_stream();
+        // Accumulate partial UTF-8 sequences that may be split across
+        // HTTP/1.1 chunked transfer boundaries (e.g. 3-byte CJK chars).
+        let mut utf8_buf: Vec<u8> = Vec::new();
 
         while let Some(item) = bytes_stream.next().await {
             match item {
                 Ok(bytes) => {
-                    let text = match String::from_utf8(bytes.to_vec()) {
-                        Ok(t) => t,
+                    utf8_buf.extend_from_slice(&bytes);
+                    let text = match std::str::from_utf8(&utf8_buf) {
+                        Ok(s) => {
+                            let owned = s.to_string();
+                            utf8_buf.clear();
+                            owned
+                        }
                         Err(e) => {
-                            let _ = tx
-                                .send(Err(StreamError::InvalidSse(format!(
-                                    "Invalid UTF-8: {}",
-                                    e
-                                ))))
-                                .await;
-                            break;
+                            let valid_up_to = e.valid_up_to();
+                            if valid_up_to == 0 && utf8_buf.len() < 4 {
+                                // Could still be an incomplete multi-byte char; wait for more data
+                                continue;
+                            }
+                            let valid =
+                                String::from_utf8_lossy(&utf8_buf[..valid_up_to]).into_owned();
+                            utf8_buf.drain(..valid_up_to);
+                            valid
                         }
                     };
+                    if text.is_empty() {
+                        continue;
+                    }
 
                     buffer.push_str(&text);
 
@@ -1039,21 +1052,32 @@ fn sse_bytes_to_events(
         }
 
         let mut bytes_stream = response.bytes_stream();
+        // Accumulate partial UTF-8 sequences split across chunk boundaries.
+        let mut utf8_buf: Vec<u8> = Vec::new();
         while let Some(item) = bytes_stream.next().await {
             match item {
                 Ok(bytes) => {
-                    let text = match String::from_utf8(bytes.to_vec()) {
-                        Ok(t) => t,
+                    utf8_buf.extend_from_slice(&bytes);
+                    let text = match std::str::from_utf8(&utf8_buf) {
+                        Ok(s) => {
+                            let owned = s.to_string();
+                            utf8_buf.clear();
+                            owned
+                        }
                         Err(e) => {
-                            let _ = tx
-                                .send(Err(StreamError::InvalidSse(format!(
-                                    "Invalid UTF-8: {}",
-                                    e
-                                ))))
-                                .await;
-                            return;
+                            let valid_up_to = e.valid_up_to();
+                            if valid_up_to == 0 && utf8_buf.len() < 4 {
+                                continue;
+                            }
+                            let valid =
+                                String::from_utf8_lossy(&utf8_buf[..valid_up_to]).into_owned();
+                            utf8_buf.drain(..valid_up_to);
+                            valid
                         }
                     };
+                    if text.is_empty() {
+                        continue;
+                    }
 
                     buffer.push_str(&text);
 


### PR DESCRIPTION
## Summary

- Add a partial UTF-8 byte accumulator to both SSE streaming paths in the compatible provider
- Handles HTTP/1.1 chunked transfer encoding that splits multi-byte UTF-8 characters (CJK = 3 bytes) across chunk boundaries
- Previously caused `"Invalid UTF-8: incomplete utf-8 byte sequence"` errors and silently dropped responses

## Root cause

`String::from_utf8(bytes.to_vec())` fails when HTTP/1.1 chunks don't align to UTF-8 character boundaries. This was acknowledged in PR #3632 as a known risk with a deferred follow-up.

## Fix

Replace strict `String::from_utf8` with a byte buffer (`Vec<u8>`) that:
1. Appends incoming chunk bytes
2. Tries `std::str::from_utf8` on the accumulated buffer
3. On success: yields the full string, clears buffer
4. On partial error: yields the valid prefix, retains trailing incomplete bytes for the next chunk
5. If no valid bytes yet and buffer < 4 bytes: waits for more data (max UTF-8 char is 4 bytes)

Applied to both `stream_chat_with_system` and `stream_chat` paths.

## Files changed

- `src/providers/compatible.rs` — UTF-8 accumulator in both streaming functions

## Test plan

- [ ] Stream CJK content via HTTP/1.1 custom provider — no UTF-8 errors
- [ ] ASCII-only streaming still works unchanged
- [ ] Mixed multi-byte content (emoji, CJK, Latin) streams correctly

Closes #4748