### PR TITLE
fix(memory): strip media markers before memory consolidation

### DIFF
--- a/src/memory/consolidation.rs
+++ b/src/memory/consolidation.rs
@@ -45,9 +45,9 @@ Do not include any text outside the JSON object."#;
 /// that contain local filesystem paths.  These must never be forwarded to
 /// upstream provider APIs — they would leak local paths and cause API errors.
 fn strip_media_markers(text: &str) -> String {
-    // Matches [IMAGE:...], [DOCUMENT:...], [VIDEO:...], [VOICE:...], [AUDIO:...]
+    // Matches [IMAGE:...], [DOCUMENT:...], [FILE:...], [VIDEO:...], [VOICE:...], [AUDIO:...]
     static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
-        regex::Regex::new(r"\[(?:IMAGE|DOCUMENT|VIDEO|VOICE|AUDIO):[^\]]*\]").unwrap()
+        regex::Regex::new(r"\[(?:IMAGE|DOCUMENT|FILE|VIDEO|VOICE|AUDIO):[^\]]*\]").unwrap()
     });
     RE.replace_all(text, "[media attachment]").into_owned()
 }


### PR DESCRIPTION
## Summary

- Strip `[IMAGE:]`, `[DOCUMENT:]`, `[VIDEO:]`, `[VOICE:]`, `[AUDIO:]` markers before sending turn text to the provider for memory consolidation
- Replaces markers with `[media attachment]` placeholder so the LLM knows media was present
- Prevents local filesystem paths from leaking to upstream APIs

## Root cause

`consolidate_turn()` built `"User: {user_message}\nAssistant: {assistant_response}"` and sent it directly to `provider.chat_with_system()`. When the user message contained `[IMAGE:/absolute/path/to/photo.jpg]`, the local path was forwarded to the upstream API, causing errors and path leakage.

## Files changed

- `src/memory/consolidation.rs` — new `strip_media_markers()` function using lazy regex, applied to both user and assistant text before consolidation

## Test plan

- [ ] Send a photo via Telegram with autosave enabled — consolidation succeeds without path errors
- [ ] Consolidated memory entry says `[media attachment]` instead of local path
- [ ] Non-media messages consolidate unchanged

Closes #4753