### PR TITLE
fix(ci): raise binary size safeguard for feature-rich release builds

### DIFF
--- a/scripts/ci/check_binary_size.sh
+++ b/scripts/ci/check_binary_size.sh
@@ -7,10 +7,13 @@
 #   binary_path  Path to the binary to check (required)
 #   label        Optional label for step summary (e.g. target triple)
 #
-# Thresholds:
-#   >20MB  — hard error (safeguard)
-#   >15MB  — warning (advisory)
-#   >5MB   — warning (target)
+# Environment:
+#   BINARY_SIZE_LIMIT_MB  Override hard-error threshold (default: 50)
+#
+# Thresholds (defaults):
+#   >50MB  — hard error (safeguard)
+#   >40MB  — warning (advisory)
+#   >20MB  — warning (target)
 #
 # Writes to GITHUB_STEP_SUMMARY when the variable is set and label is provided.
 
@@ -24,6 +27,12 @@ if [ ! -f "$BIN" ]; then
   exit 1
 fi
 
+# Configurable hard limit (in MB), default 50MB
+LIMIT_MB="${BINARY_SIZE_LIMIT_MB:-50}"
+LIMIT_BYTES=$((LIMIT_MB * 1024 * 1024))
+WARN_BYTES=$((40 * 1024 * 1024))
+TARGET_BYTES=$((20 * 1024 * 1024))
+
 # macOS stat uses -f%z, Linux stat uses -c%s
 SIZE=$(stat -f%z "$BIN" 2>/dev/null || stat -c%s "$BIN")
 SIZE_MB=$((SIZE / 1024 / 1024))
@@ -34,13 +43,13 @@ if [ -n "$LABEL" ] && [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
   echo "- Size: ${SIZE_MB}MB ($SIZE bytes)" >> "$GITHUB_STEP_SUMMARY"
 fi
 
-if [ "$SIZE" -gt 20971520 ]; then
-  echo "::error::Binary exceeds 20MB safeguard (${SIZE_MB}MB)"
+if [ "$SIZE" -gt "$LIMIT_BYTES" ]; then
+  echo "::error::Binary exceeds ${LIMIT_MB}MB safeguard (${SIZE_MB}MB)"
   exit 1
-elif [ "$SIZE" -gt 15728640 ]; then
-  echo "::warning::Binary exceeds 15MB advisory target (${SIZE_MB}MB)"
-elif [ "$SIZE" -gt 5242880 ]; then
-  echo "::warning::Binary exceeds 5MB target (${SIZE_MB}MB)"
+elif [ "$SIZE" -gt "$WARN_BYTES" ]; then
+  echo "::warning::Binary exceeds 40MB advisory target (${SIZE_MB}MB)"
+elif [ "$SIZE" -gt "$TARGET_BYTES" ]; then
+  echo "::warning::Binary exceeds 20MB target (${SIZE_MB}MB)"
 else
   echo "Binary size within target."
 fi


### PR DESCRIPTION
## Summary

- Raises the binary size hard-error threshold from 20MB to 50MB in `scripts/ci/check_binary_size.sh`
- Updates advisory/target warning thresholds proportionally
- Adds `BINARY_SIZE_LIMIT_MB` env var for per-workflow override

## Problem

All 6 Release Beta build targets fail at the "Check binary size" step because release builds with features (`channel-matrix,channel-lark,whatsapp-web`) produce binaries that exceed the 20MB safeguard:

| Target | Size | Old Limit |
|---|---|---|
| x86_64-unknown-linux-gnu | **35MB** | 20MB |
| x86_64-pc-windows-msvc | **30MB** | 20MB |
| aarch64-apple-darwin | **22MB** | 20MB |
| aarch64-unknown-linux-gnu | ~30MB | 20MB |
| armv7-unknown-linux-gnueabihf | ~28MB | 20MB |
| aarch64-linux-android | ~25MB | 20MB |

This cascades into skipping **Publish Beta Release**, **Push Docker Image**, and **Trigger Website Redeploy**.

## New thresholds

| Level | Old | New |
|---|---|---|
| Hard error (safeguard) | 20MB | **50MB** |
| Warning (advisory) | 15MB | **40MB** |
| Warning (target) | 5MB | **20MB** |

The 50MB hard limit gives room for growth while still catching genuine bloat regressions. Workflows can override via `BINARY_SIZE_LIMIT_MB` env var.

## Test plan

- [ ] Verify this PR's CI passes
- [ ] After merge, confirm Release Beta builds pass the size check
- [ ] Confirm Publish, Docker, and Redeploy jobs run successfully