### PR TITLE
fix(ci): remove push trigger from CI workflow to unblock PRs

### DIFF
--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -1,14 +1,12 @@
 name: CI
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Removes the `push` trigger from `ci-run.yml` so it only runs on `pull_request` events
- Simplifies the concurrency group to use only the PR number

## Problem

The CI workflow triggers on both `push` (master) and `pull_request` events. The `push` runs share a concurrency group that cancels in-flight Lint jobs. Since Test, Build, and Check all depend on Lint via `needs: [lint]`, they get **skipped**. The CI Required Gate then sees cancelled/skipped upstream jobs and **fails**.

This failing `CI / CI Required Gate (push)` check blocks PR merges even when the PR's own `(pull_request)` checks pass.

## Why this is safe

- `checks-on-pr.yml` (Quality Gate) validates PRs with lint, test, build, security, and 32-bit checks
- `ci-run.yml` adds PR-specific extras (strict delta lint, docs quality, all-features, benchmarks) — only needs `pull_request` context
- `release-beta-on-push.yml` handles post-merge master builds and releases

## Test plan

- [ ] Verify this PR's CI checks pass (no `(push)` duplicates)
- [ ] Confirm merges to master still trigger Release Beta workflow