### PR TITLE
fix(security): remove invalid 127.0.0.1 from macOS seatbelt policy

### DIFF
--- a/src/security/seatbelt.rs
+++ b/src/security/seatbelt.rs
@@ -189,11 +189,12 @@ fn generate_policy(workspace: &Path) -> String {
     (remote unix-socket (path-literal "/var/run/mDNSResponder")))
 (allow system-socket)
 
-;; Allow localhost connections only (for local dev servers)
+;; Allow localhost connections only (for local dev servers).
+;; Note: macOS sandbox-exec only accepts "localhost:*" or "*:port" in
+;; (remote ip ...) filters — raw IPs like "127.0.0.1:*" cause the
+;; entire policy to fail to parse.
 (allow network-outbound
     (remote ip "localhost:*"))
-(allow network-outbound
-    (remote ip "127.0.0.1:*"))
 
 ;; ── Mach / IPC ─────────────────────────────────────────────
 ;; Allow basic mach services needed for process execution


### PR DESCRIPTION
## Summary

- Remove `(remote ip "127.0.0.1:*")` from the generated seatbelt policy
- macOS `sandbox-exec` rejects raw IP addresses in `(remote ip ...)` filters, causing the **entire policy** to fail to parse
- The existing `(remote ip "localhost:*")` rule already covers loopback connections

## Root cause

PR #4592 added `(remote ip "127.0.0.1:*")` to the seatbelt policy, but macOS `sandbox-exec` only accepts `"localhost:*"` or `"*:port"` as host names — not raw IP addresses. Since seatbelt policies are all-or-nothing, the invalid rule breaks the entire sandbox policy.

## Files changed

- `src/security/seatbelt.rs` — remove invalid rule, add comment explaining the macOS constraint

## Test plan

- [ ] On macOS: sandboxed shell commands with network access (e.g. `curl localhost:8080`) succeed
- [ ] Sandbox still blocks connections to non-localhost addresses

Closes #4764