### PR TITLE
fix(agent): parse square bracket [TOOL_CALL] markup from non-native tool models

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1237,20 +1237,29 @@ fn parse_xml_attribute_tool_calls(response: &str) -> Vec<ParsedToolCall> {
 /// }}
 /// /TOOL_CALL
 /// ```
+/// Also handles the square bracket variant emitted by models like MiniMax 2.7:
+/// ```text
+/// [TOOL_CALL]{tool => "shell", args => {--command "echo hello"}}[/TOOL_CALL]
+/// ```
 fn parse_perl_style_tool_calls(response: &str) -> Vec<ParsedToolCall> {
     let mut calls = Vec::new();
 
     // Regex to find TOOL_CALL blocks - handle double closing braces }}
-    static PERL_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(?s)TOOL_CALL\s*\{(.+?)\}\}\s*/TOOL_CALL").unwrap());
+    // Matches both `TOOL_CALL { ... }} /TOOL_CALL` and `[TOOL_CALL]{ ... }}[/TOOL_CALL]`
+    static PERL_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?s)(?:\[TOOL_CALL\]|TOOL_CALL)\s*\{(.+?)\}\}\s*(?:\[/TOOL_CALL\]|/TOOL_CALL)")
+            .unwrap()
+    });
 
     // Regex to find tool => "name" in the content
     static TOOL_NAME_RE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r#"tool\s*=>\s*"([^"]+)""#).unwrap());
 
-    // Regex to find args => { ... } block
+    // Regex to find args => { ... } block.
+    // The closing brace is optional: in the square bracket variant [TOOL_CALL]{...}}[/TOOL_CALL]
+    // the outer regex may consume the inner closing brace, so the args content may run to end of string.
     static ARGS_BLOCK_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(?s)args\s*=>\s*\{(.+?)\}").unwrap());
+        LazyLock::new(|| Regex::new(r"(?s)args\s*=>\s*\{(.+?)(?:\}|$)").unwrap());
 
     // Regex to find --key "value" pairs
     static ARGS_RE: LazyLock<Regex> =
@@ -2115,6 +2124,7 @@ fn detect_tool_call_parse_issue(response: &str, parsed_calls: &[ParsedToolCall])
         || trimmed.contains("```tool ") // Generic ```tool <name> pattern
         || trimmed.contains("\"tool_calls\"")
         || trimmed.contains("TOOL_CALL")
+        || trimmed.contains("[TOOL_CALL]")
         || trimmed.contains("<FunctionCall>");
 
     if looks_like_tool_payload {
@@ -7813,6 +7823,47 @@ Tail"#;
         assert_eq!(
             calls[0].arguments.get("command").unwrap().as_str().unwrap(),
             "uname -a"
+        );
+    }
+
+    #[test]
+    fn parse_tool_calls_handles_square_bracket_tool_call_blocks() {
+        let response =
+            r#"[TOOL_CALL]{tool => "shell", args => {--command "echo hello"}}[/TOOL_CALL]"#;
+
+        let calls = parse_perl_style_tool_calls(response);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "shell");
+        assert_eq!(
+            calls[0].arguments.get("command").unwrap().as_str().unwrap(),
+            "echo hello"
+        );
+    }
+
+    #[test]
+    fn parse_tool_calls_handles_square_bracket_multiline() {
+        let response = r#"[TOOL_CALL]
+{tool => "file_read", args => {
+  --path "/tmp/test.txt"
+  --description "Read test file"
+}}
+[/TOOL_CALL]"#;
+
+        let calls = parse_perl_style_tool_calls(response);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "file_read");
+        assert_eq!(
+            calls[0].arguments.get("path").unwrap().as_str().unwrap(),
+            "/tmp/test.txt"
+        );
+        assert_eq!(
+            calls[0]
+                .arguments
+                .get("description")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "Read test file"
         );
     }
 


### PR DESCRIPTION
## Summary

- Updated Perl-style tool call parser regex to match both `TOOL_CALL{...}/TOOL_CALL` and `[TOOL_CALL]{...}[/TOOL_CALL]` square bracket variants
- Fixed args block regex to handle brace consumption differences between the two formats
- Added `[TOOL_CALL]` to the `looks_like_tool_payload` detection
- Added 2 new tests for square bracket parsing (inline + multiline)

Models like MiniMax 2.7 via OpenRouter don't support native tool calling and emit tool calls using square bracket markup. The parser now correctly extracts and executes these.

## Test plan

- [x] `cargo check` — compiles clean
- [x] All 64 `parse_tool_calls` tests pass (including 2 new)
- [x] Existing Perl-style format still works (no regression)
- [x] Square bracket inline: `[TOOL_CALL]{tool => "shell", args => {--command echo "hello"}}[/TOOL_CALL]`
- [x] Square bracket multiline with multiple args

Closes #4758