### PR TITLE
fix(qq): tolerate transient heartbeat ACK misses

### DIFF
--- a/src/channels/qq.rs
+++ b/src/channels/qq.rs
@@ -1849,15 +1849,18 @@ allowed_users = ["user1"]
         // First tick: counter is 0, send heartbeat
         assert!(missed < max_missed);
         missed += 1;
+        assert_eq!(missed, 1, "counter should be 1 after first heartbeat");
 
         // ACK received: reset
         missed = 0;
+        assert_eq!(missed, 0, "counter should reset on ACK");
 
         // 3 consecutive misses without ACK
-        for i in 0..max_missed {
-            if missed > 0 && missed >= max_missed {
-                panic!("should not reach zombie state at miss count {i}");
-            }
+        for _ in 0..max_missed {
+            assert!(
+                missed < max_missed,
+                "should not reach zombie state before {max_missed} misses"
+            );
             missed += 1;
         }
         assert!(


### PR DESCRIPTION
## Summary

- Replace the single-miss heartbeat ACK detection with a **missed-ACK counter** (threshold: 3 consecutive misses) so that transient network hiccups or server-side GC pauses no longer kill the WebSocket connection
- Add a **grace period** (10% of the server-provided heartbeat interval, capped at 5s) to the heartbeat timer so that slightly-delayed ACKs are not immediately counted as missed
- Log informational messages for each tolerated miss to preserve operator visibility into connection health
- Add 4 unit tests covering grace period arithmetic, counter logic, ACK reset behavior, and overflow safety

## Test plan

- [x] All 43 QQ channel tests pass (`cargo test --lib channels::qq::tests`)
- [ ] Deploy to staging and monitor QQ channel stability under degraded network conditions
- [ ] Verify logs show "tolerating transient delay" messages instead of immediate disconnects
- [ ] Confirm that genuinely dead connections are still detected after 3 missed ACKs

Fixes #4744