### PR TITLE
fix(gateway): pass tool specs in WebSocket streaming path

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -1739,15 +1739,17 @@ mod tests {
             let mut count = self.call_count.lock();
             *count += 1;
             if *count == 1 {
-                let tc = crate::providers::traits::StreamEvent::ToolCall(
-                    crate::providers::ToolCall {
+                let tc =
+                    crate::providers::traits::StreamEvent::ToolCall(crate::providers::ToolCall {
                         id: "tc_stream_1".into(),
                         name: "echo".into(),
                         arguments: "{}".into(),
-                    },
-                );
-                stream::iter(vec![Ok(tc), Ok(crate::providers::traits::StreamEvent::Final)])
-                    .boxed()
+                    });
+                stream::iter(vec![
+                    Ok(tc),
+                    Ok(crate::providers::traits::StreamEvent::Final),
+                ])
+                .boxed()
             } else {
                 let chunk = crate::providers::traits::StreamEvent::TextDelta(
                     crate::providers::traits::StreamChunk {


### PR DESCRIPTION
## Summary

- **Root cause**: `Agent::turn_streamed()` passed `tools: None` to `provider.stream_chat()`, so LLM providers never received tool definitions during WebSocket streaming. Without tool definitions, providers cannot return `ToolCall` stream events, causing the tool-call-execute-continue cycle to never trigger.
- **Fix**: Pass tool specs in the streaming `stream_chat()` call using `self.tool_dispatcher.should_send_tool_specs()`, matching the behavior of the CLI `turn()` method and the non-streaming fallback path.
- **Test**: Added `turn_streamed_passes_tool_specs_to_provider` test that verifies tool specs are forwarded through the streaming path and that tool calls execute and produce results.

## Test plan

- [x] New unit test `turn_streamed_passes_tool_specs_to_provider` verifies:
  - Tool specs are passed to `stream_chat` on every iteration
  - Tool call events are emitted to the event channel
  - Tool results are emitted after execution
  - The agent loop continues after tool execution and returns the final response
- [x] All 8 `agent::agent::tests` pass
- [x] All 112 `gateway` tests pass

Fixes #4743

🤖 Generated with [Claude Code](https://claude.com/claude-code)