### PR TITLE
fix(channels): add missing channels to channel send command

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4031,7 +4031,100 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 .with_streaming(sl.stream_drafts, sl.draft_update_interval_ms),
             ))
         }
-        other => anyhow::bail!("Unknown channel '{other}'. Supported: telegram, discord, slack"),
+        "mattermost" => {
+            let mm = config
+                .channels_config
+                .mattermost
+                .as_ref()
+                .context("Mattermost channel is not configured")?;
+            Ok(Arc::new(MattermostChannel::new(
+                mm.url.clone(),
+                mm.bot_token.clone(),
+                mm.channel_id.clone(),
+                mm.allowed_users.clone(),
+                mm.thread_replies.unwrap_or(true),
+                mm.mention_only.unwrap_or(false),
+            )))
+        }
+        "signal" => {
+            let sg = config
+                .channels_config
+                .signal
+                .as_ref()
+                .context("Signal channel is not configured")?;
+            Ok(Arc::new(SignalChannel::new(
+                sg.http_url.clone(),
+                sg.account.clone(),
+                sg.group_id.clone(),
+                sg.allowed_from.clone(),
+                sg.ignore_attachments,
+                sg.ignore_stories,
+            )))
+        }
+        "matrix" => {
+            #[cfg(feature = "channel-matrix")]
+            {
+                let mx = config
+                    .channels_config
+                    .matrix
+                    .as_ref()
+                    .context("Matrix channel is not configured")?;
+                Ok(Arc::new(MatrixChannel::new(
+                    mx.homeserver.clone(),
+                    mx.access_token.clone(),
+                    mx.room_id.clone(),
+                    mx.allowed_users.clone(),
+                )))
+            }
+            #[cfg(not(feature = "channel-matrix"))]
+            {
+                anyhow::bail!("Matrix channel requires the `channel-matrix` feature");
+            }
+        }
+        "whatsapp" | "whatsapp-web" | "whatsapp_web" => {
+            #[cfg(feature = "whatsapp-web")]
+            {
+                let wa = config
+                    .channels_config
+                    .whatsapp
+                    .as_ref()
+                    .context("WhatsApp channel is not configured")?;
+                if !wa.is_web_config() {
+                    anyhow::bail!(
+                        "WhatsApp channel send requires Web mode (session_path must be set)"
+                    );
+                }
+                Ok(Arc::new(WhatsAppWebChannel::new(
+                    wa.session_path.clone().unwrap_or_default(),
+                    wa.pair_phone.clone(),
+                    wa.pair_code.clone(),
+                    wa.allowed_numbers.clone(),
+                    wa.mode.clone(),
+                    wa.dm_policy.clone(),
+                    wa.group_policy.clone(),
+                    wa.self_chat_mode,
+                )))
+            }
+            #[cfg(not(feature = "whatsapp-web"))]
+            {
+                anyhow::bail!("WhatsApp channel requires the `whatsapp-web` feature");
+            }
+        }
+        "qq" => {
+            let qq = config
+                .channels_config
+                .qq
+                .as_ref()
+                .context("QQ channel is not configured")?;
+            Ok(Arc::new(QQChannel::new(
+                qq.app_id.clone(),
+                qq.app_secret.clone(),
+                qq.allowed_users.clone(),
+            )))
+        }
+        other => anyhow::bail!(
+            "Unknown channel '{other}'. Supported: telegram, discord, slack, mattermost, signal, matrix, whatsapp, qq"
+        ),
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds mattermost, signal, matrix, whatsapp/whatsapp-web, and qq channel support to `build_channel_by_id()` used by `zeroclaw channel send`
- These channels were already supported by cron delivery (`deliver_announcement()`) but missing from the CLI send path
- Follows the same construction patterns used in `deliver_announcement()` and `start_channels()`

## Validation Evidence

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings  # pass
cargo test --lib -- channels::tests  # 123 passed, 0 failed
```

## Closes

Closes #4736

Reported-by: @Yanxingang