### PR TITLE
fix(acp): use camelCase JSON keys in ACP server responses

### DIFF
--- a/src/channels/acp_server.rs
+++ b/src/channels/acp_server.rs
@@ -221,15 +221,15 @@ impl AcpServer {
 
     fn handle_initialize(&self, _params: &Value) -> RpcResult {
         Ok(serde_json::json!({
-            "protocol_version": "1.0",
-            "server_info": {
+            "protocolVersion": "1.0",
+            "serverInfo": {
                 "name": "zeroclaw-acp",
                 "version": env!("CARGO_PKG_VERSION"),
             },
             "capabilities": {
                 "streaming": true,
-                "max_sessions": self.acp_config.max_sessions,
-                "session_timeout_secs": self.acp_config.session_timeout_secs,
+                "maxSessions": self.acp_config.max_sessions,
+                "sessionTimeoutSecs": self.acp_config.session_timeout_secs,
             },
             "methods": [
                 "initialize",
@@ -255,7 +255,9 @@ impl AcpServer {
         }
 
         let workspace_dir = params
-            .get("workspace_dir")
+            .get("cwd")
+            .or_else(|| params.get("workspaceDir"))
+            .or_else(|| params.get("workspace_dir"))
             .and_then(|v| v.as_str())
             .unwrap_or_else(|| self.config.workspace_dir.to_str().unwrap_or("."))
             .to_string();
@@ -285,18 +287,19 @@ impl AcpServer {
         info!("Created session {session_id} (workspace: {workspace_dir})");
 
         Ok(serde_json::json!({
-            "session_id": session_id,
-            "workspace_dir": workspace_dir,
+            "sessionId": session_id,
+            "workspaceDir": workspace_dir,
         }))
     }
 
     async fn handle_session_prompt(&self, params: &Value, _request_id: &Value) -> RpcResult {
         let session_id = params
-            .get("session_id")
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
             .and_then(|v| v.as_str())
             .ok_or_else(|| RpcError {
                 code: INVALID_PARAMS,
-                message: "Missing required parameter: session_id".to_string(),
+                message: "Missing required parameter: sessionId".to_string(),
                 data: None,
             })?
             .to_string();
@@ -342,7 +345,7 @@ impl AcpServer {
                     jsonrpc: "2.0",
                     method: "session/event",
                     params: serde_json::json!({
-                        "session_id": session_id,
+                        "sessionId": session_id,
                         "type": "chunk",
                         "content": delta,
                     }),
@@ -351,7 +354,7 @@ impl AcpServer {
                     jsonrpc: "2.0",
                     method: "session/event",
                     params: serde_json::json!({
-                        "session_id": session_id,
+                        "sessionId": session_id,
                         "type": "tool_call",
                         "name": name,
                         "args": args,
@@ -361,7 +364,7 @@ impl AcpServer {
                     jsonrpc: "2.0",
                     method: "session/event",
                     params: serde_json::json!({
-                        "session_id": session_id,
+                        "sessionId": session_id,
                         "type": "tool_result",
                         "name": name,
                         "output": output,
@@ -371,7 +374,7 @@ impl AcpServer {
                     jsonrpc: "2.0",
                     method: "session/event",
                     params: serde_json::json!({
-                        "session_id": session_id,
+                        "sessionId": session_id,
                         "type": "thinking",
                         "content": delta,
                     }),
@@ -401,18 +404,19 @@ impl AcpServer {
         }
 
         Ok(serde_json::json!({
-            "session_id": session_id,
+            "sessionId": session_id,
             "content": result,
         }))
     }
 
     async fn handle_session_stop(&self, params: &Value) -> RpcResult {
         let session_id = params
-            .get("session_id")
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
             .and_then(|v| v.as_str())
             .ok_or_else(|| RpcError {
                 code: INVALID_PARAMS,
-                message: "Missing required parameter: session_id".to_string(),
+                message: "Missing required parameter: sessionId".to_string(),
                 data: None,
             })?;
 
@@ -420,7 +424,7 @@ impl AcpServer {
         if sessions.remove(session_id).is_some() {
             info!("Stopped session {session_id}");
             Ok(serde_json::json!({
-                "session_id": session_id,
+                "sessionId": session_id,
                 "stopped": true,
             }))
         } else {


### PR DESCRIPTION
## Summary

- Changes all ACP JSON-RPC response fields from snake_case to camelCase to match the ACP protocol spec expected by the VSCode ACP client extension
- Key renames: `session_id` → `sessionId`, `protocol_version` → `protocolVersion`, `server_info` → `serverInfo`, `workspace_dir` → `workspaceDir`, `max_sessions` → `maxSessions`, `session_timeout_secs` → `sessionTimeoutSecs`
- Also accepts camelCase input params (`sessionId`, `workspaceDir`, `cwd`) with snake_case fallback for backward compatibility

## Validation Evidence

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings  # pass
cargo test --lib -- channels::acp_server::tests  # 8 passed, 0 failed
```

## Closes

Closes #4731

Reported-by: @shady831213