### PR TITLE
feat(channels): add inbound message debouncing for rapid senders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12329,7 +12329,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "aardvark-sys",
  "anyhow",

--- a/src/channels/debounce.rs
+++ b/src/channels/debounce.rs
@@ -1,0 +1,191 @@
+//! Inbound message debouncing for rapid senders.
+//!
+//! When users type fast and send multiple messages in quick succession, each
+//! message would normally trigger a separate LLM call. [`MessageDebouncer`]
+//! accumulates rapid messages per sender within a configurable time window and
+//! emits them as a single concatenated message, reducing unnecessary agent runs.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+/// Result of submitting a message to the debouncer.
+pub enum DebounceResult {
+    /// The message was accumulated and a timer is running. The caller should
+    /// skip processing — the debounced message will arrive via the returned
+    /// [`tokio::sync::oneshot::Receiver`] when the window expires.
+    Pending(tokio::sync::oneshot::Receiver<String>),
+    /// Debouncing is disabled (window = 0); pass the message through immediately.
+    Passthrough(String),
+}
+
+struct DebouncerEntry {
+    messages: Vec<String>,
+    timer_handle: JoinHandle<()>,
+    /// Sender for the final concatenated message. Replaced on each reset.
+    result_tx: Option<tokio::sync::oneshot::Sender<String>>,
+}
+
+/// Accumulates rapid inbound messages per sender and fires a single combined
+/// message after the debounce window elapses without new input.
+pub struct MessageDebouncer {
+    window: Duration,
+    entries: Arc<Mutex<HashMap<String, DebouncerEntry>>>,
+}
+
+impl MessageDebouncer {
+    /// Create a new debouncer with the given window.
+    /// A zero duration disables debouncing (all messages pass through).
+    pub fn new(window: Duration) -> Self {
+        Self {
+            window,
+            entries: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Returns `true` when debouncing is active (non-zero window).
+    pub fn enabled(&self) -> bool {
+        !self.window.is_zero()
+    }
+
+    /// Submit a message for debouncing.
+    ///
+    /// - If the window is zero, returns [`DebounceResult::Passthrough`] immediately.
+    /// - Otherwise, accumulates the message under `sender_key` and returns
+    ///   [`DebounceResult::Pending`] with a receiver that will eventually yield the
+    ///   concatenated messages once the window expires.
+    ///
+    /// Each new message resets the timer. When the timer fires it concatenates all
+    /// accumulated messages with `"\n"` and sends them through the oneshot channel.
+    pub async fn debounce(&self, sender_key: &str, message: &str) -> DebounceResult {
+        if !self.enabled() {
+            return DebounceResult::Passthrough(message.to_owned());
+        }
+
+        let mut entries = self.entries.lock().await;
+        let entries_ref = Arc::clone(&self.entries);
+        let key = sender_key.to_owned();
+        let window = self.window;
+
+        if let Some(entry) = entries.get_mut(&key) {
+            // Cancel the previous timer — we'll start a fresh one.
+            entry.timer_handle.abort();
+            entry.messages.push(message.to_owned());
+
+            // Replace the oneshot so the *new* caller gets the result.
+            // The previous caller's receiver will see a `RecvError` (dropped sender),
+            // which the dispatch loop interprets as "superseded — do nothing".
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            entry.result_tx = Some(tx);
+
+            // Spawn a new timer.
+            let key_clone = key.clone();
+            entry.timer_handle = tokio::spawn(async move {
+                tokio::time::sleep(window).await;
+                fire_debounced(&entries_ref, &key_clone).await;
+            });
+
+            DebounceResult::Pending(rx)
+        } else {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+
+            let key_clone = key.clone();
+            let entries_spawn = Arc::clone(&self.entries);
+            let handle = tokio::spawn(async move {
+                tokio::time::sleep(window).await;
+                fire_debounced(&entries_spawn, &key_clone).await;
+            });
+
+            entries.insert(
+                key,
+                DebouncerEntry {
+                    messages: vec![message.to_owned()],
+                    timer_handle: handle,
+                    result_tx: Some(tx),
+                },
+            );
+
+            DebounceResult::Pending(rx)
+        }
+    }
+}
+
+/// Called when the debounce timer fires. Removes the entry, concatenates all
+/// accumulated messages, and sends the result through the oneshot channel.
+async fn fire_debounced(entries: &Mutex<HashMap<String, DebouncerEntry>>, key: &str) {
+    let mut map = entries.lock().await;
+    if let Some(entry) = map.remove(key) {
+        let combined = entry.messages.join("\n");
+        if let Some(tx) = entry.result_tx {
+            let _ = tx.send(combined);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn passthrough_when_disabled() {
+        let debouncer = MessageDebouncer::new(Duration::ZERO);
+        assert!(!debouncer.enabled());
+        match debouncer.debounce("user1", "hello").await {
+            DebounceResult::Passthrough(msg) => assert_eq!(msg, "hello"),
+            DebounceResult::Pending(_) => panic!("expected Passthrough"),
+        }
+    }
+
+    #[tokio::test]
+    async fn single_message_fires_after_window() {
+        let debouncer = MessageDebouncer::new(Duration::from_millis(50));
+        let rx = match debouncer.debounce("user1", "hello").await {
+            DebounceResult::Pending(rx) => rx,
+            DebounceResult::Passthrough(_) => panic!("expected Pending"),
+        };
+        let combined = rx.await.unwrap();
+        assert_eq!(combined, "hello");
+    }
+
+    #[tokio::test]
+    async fn multiple_messages_concatenated() {
+        let debouncer = MessageDebouncer::new(Duration::from_millis(100));
+
+        // First message
+        let _rx1 = match debouncer.debounce("user1", "hello").await {
+            DebounceResult::Pending(rx) => rx,
+            DebounceResult::Passthrough(_) => panic!("expected Pending"),
+        };
+
+        // Second message within window (resets timer)
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        let rx2 = match debouncer.debounce("user1", "world").await {
+            DebounceResult::Pending(rx) => rx,
+            DebounceResult::Passthrough(_) => panic!("expected Pending"),
+        };
+
+        // The first receiver is dropped (superseded), second gets the combined result
+        let combined = rx2.await.unwrap();
+        assert_eq!(combined, "hello\nworld");
+    }
+
+    #[tokio::test]
+    async fn different_senders_independent() {
+        let debouncer = MessageDebouncer::new(Duration::from_millis(50));
+
+        let rx_a = match debouncer.debounce("alice", "hi alice").await {
+            DebounceResult::Pending(rx) => rx,
+            DebounceResult::Passthrough(_) => panic!("expected Pending"),
+        };
+        let rx_b = match debouncer.debounce("bob", "hi bob").await {
+            DebounceResult::Pending(rx) => rx,
+            DebounceResult::Passthrough(_) => panic!("expected Pending"),
+        };
+
+        assert_eq!(rx_a.await.unwrap(), "hi alice");
+        assert_eq!(rx_b.await.unwrap(), "hi bob");
+    }
+}

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -18,6 +18,7 @@ pub mod acp_server;
 pub mod bluesky;
 pub mod clawdtalk;
 pub mod cli;
+pub mod debounce;
 pub mod dingtalk;
 pub mod discord;
 pub mod discord_history;
@@ -393,6 +394,7 @@ struct ChannelRuntimeContext {
     activated_tools: Option<std::sync::Arc<std::sync::Mutex<crate::tools::ActivatedToolSet>>>,
     cost_tracking: Option<ChannelCostTrackingState>,
     pacing: crate::config::PacingConfig,
+    debouncer: Arc<debounce::MessageDebouncer>,
 }
 
 #[derive(Clone)]
@@ -3242,6 +3244,67 @@ async fn process_channel_message(
     }
 }
 
+/// Shared worker body extracted so both the normal path and the debounce path
+/// can reuse the same in-flight tracking / cancellation / process logic.
+async fn dispatch_worker(
+    ctx: Arc<ChannelRuntimeContext>,
+    msg: traits::ChannelMessage,
+    in_flight: Arc<tokio::sync::Mutex<HashMap<String, InFlightSenderTaskState>>>,
+    task_sequence: Arc<AtomicU64>,
+    permit: tokio::sync::OwnedSemaphorePermit,
+) {
+    let _permit = permit;
+    let interrupt_enabled = ctx
+        .interrupt_on_new_message
+        .enabled_for_channel(msg.channel.as_str());
+    let sender_scope_key = interruption_scope_key(&msg);
+    let cancellation_token = CancellationToken::new();
+    let completion = Arc::new(InFlightTaskCompletion::new());
+    let task_id = task_sequence.fetch_add(1, Ordering::Relaxed) as u64;
+
+    let register_in_flight = msg.channel != "cli";
+
+    if register_in_flight {
+        let previous = {
+            let mut active = in_flight.lock().await;
+            active.insert(
+                sender_scope_key.clone(),
+                InFlightSenderTaskState {
+                    task_id,
+                    cancellation: cancellation_token.clone(),
+                    completion: Arc::clone(&completion),
+                },
+            )
+        };
+
+        if interrupt_enabled {
+            if let Some(previous) = previous {
+                tracing::info!(
+                    channel = %msg.channel,
+                    sender = %msg.sender,
+                    "Interrupting previous in-flight request for sender"
+                );
+                previous.cancellation.cancel();
+                previous.completion.wait().await;
+            }
+        }
+    }
+
+    process_channel_message(ctx, msg, cancellation_token).await;
+
+    if register_in_flight {
+        let mut active = in_flight.lock().await;
+        if active
+            .get(&sender_scope_key)
+            .is_some_and(|state| state.task_id == task_id)
+        {
+            active.remove(&sender_scope_key);
+        }
+    }
+
+    completion.mark_done();
+}
+
 async fn run_message_dispatch_loop(
     mut rx: tokio::sync::mpsc::Receiver<traits::ChannelMessage>,
     ctx: Arc<ChannelRuntimeContext>,
@@ -3299,6 +3362,61 @@ async fn run_message_dispatch_loop(
             continue;
         }
 
+        // ── Debounce: accumulate rapid messages per sender ──────────
+        // CLI messages bypass debouncing so the interactive loop stays responsive.
+        let msg = if msg.channel != "cli" && ctx.debouncer.enabled() {
+            let debounce_key = conversation_history_key(&msg);
+            match ctx.debouncer.debounce(&debounce_key, &msg.content).await {
+                debounce::DebounceResult::Pending(rx) => {
+                    // Spawn a lightweight task that waits for the debounce window
+                    // to expire, then feeds the combined message through the normal
+                    // worker path below.
+                    let debounce_ctx = Arc::clone(&ctx);
+                    let debounce_in_flight = Arc::clone(&in_flight_by_sender);
+                    let debounce_semaphore = Arc::clone(&semaphore);
+                    let debounce_task_seq = Arc::clone(&task_sequence);
+                    let mut debounce_msg = msg;
+                    workers.spawn(async move {
+                        let combined = match rx.await {
+                            Ok(combined) => combined,
+                            Err(_) => {
+                                // Receiver dropped — a newer message superseded this one.
+                                return;
+                            }
+                        };
+                        debounce_msg.content = combined;
+                        tracing::info!(
+                            channel = %debounce_msg.channel,
+                            sender = %debounce_msg.sender,
+                            "Debounced message ready — dispatching combined message"
+                        );
+
+                        let permit = match debounce_semaphore.acquire_owned().await {
+                            Ok(permit) => permit,
+                            Err(_) => return,
+                        };
+
+                        dispatch_worker(
+                            debounce_ctx,
+                            debounce_msg,
+                            debounce_in_flight,
+                            debounce_task_seq,
+                            permit,
+                        )
+                        .await;
+                    });
+                    continue;
+                }
+                debounce::DebounceResult::Passthrough(content) => {
+                    let mut m = msg;
+                    m.content = content;
+                    m
+                }
+            }
+        } else {
+            msg
+        };
+
         let permit = match Arc::clone(&semaphore).acquire_owned().await {
             Ok(permit) => permit,
             Err(_) => break,
@@ -3308,59 +3426,7 @@ async fn run_message_dispatch_loop(
         let in_flight = Arc::clone(&in_flight_by_sender);
         let task_sequence = Arc::clone(&task_sequence);
         workers.spawn(async move {
-            let _permit = permit;
-            let interrupt_enabled = worker_ctx
-                .interrupt_on_new_message
-                .enabled_for_channel(msg.channel.as_str());
-            let sender_scope_key = interruption_scope_key(&msg);
-            let cancellation_token = CancellationToken::new();
-            let completion = Arc::new(InFlightTaskCompletion::new());
-            let task_id = task_sequence.fetch_add(1, Ordering::Relaxed) as u64;
-
-            // Register all non-CLI tasks in the in-flight store so /stop can reach them.
-            // This is a deliberate broadening from the previous behaviour where only
-            // interrupt_enabled (Telegram/Slack) channels registered tasks.
-            let register_in_flight = msg.channel != "cli";
-
-            if register_in_flight {
-                let previous = {
-                    let mut active = in_flight.lock().await;
-                    active.insert(
-                        sender_scope_key.clone(),
-                        InFlightSenderTaskState {
-                            task_id,
-                            cancellation: cancellation_token.clone(),
-                            completion: Arc::clone(&completion),
-                        },
-                    )
-                };
-
-                if interrupt_enabled {
-                    if let Some(previous) = previous {
-                        tracing::info!(
-                            channel = %msg.channel,
-                            sender = %msg.sender,
-                            "Interrupting previous in-flight request for sender"
-                        );
-                        previous.cancellation.cancel();
-                        previous.completion.wait().await;
-                    }
-                }
-            }
-
-            process_channel_message(worker_ctx, msg, cancellation_token).await;
-
-            if register_in_flight {
-                let mut active = in_flight.lock().await;
-                if active
-                    .get(&sender_scope_key)
-                    .is_some_and(|state| state.task_id == task_id)
-                {
-                    active.remove(&sender_scope_key);
-                }
-            }
-
-            completion.mark_done();
+            dispatch_worker(worker_ctx, msg, in_flight, task_sequence, permit).await;
         });
 
         while let Some(result) = workers.try_join_next() {
@@ -5245,6 +5311,9 @@ pub async fn start_channels(config: Config) -> Result<()> {
             prices: Arc::new(config.cost.prices.clone()),
         }),
         pacing: config.pacing.clone(),
+        debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::from_millis(
+            config.channels_config.debounce_ms,
+        ))),
     });
 
     // Hydrate in-memory conversation histories from persisted JSONL session files.
@@ -5652,6 +5721,7 @@ mod tests {
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         };
 
         assert!(compact_sender_history(&ctx, &sender));
@@ -5771,6 +5841,7 @@ mod tests {
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         };
 
         append_sender_turn(&ctx, &sender, ChatMessage::user("hello"));
@@ -5846,6 +5917,7 @@ mod tests {
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         };
 
         assert!(rollback_orphan_user_turn(&ctx, &sender, "pending"));
@@ -5940,6 +6012,7 @@ mod tests {
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         };
 
         assert!(rollback_orphan_user_turn(
@@ -6484,6 +6557,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -6569,6 +6643,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -6668,6 +6743,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -6752,6 +6828,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -6846,6 +6923,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -6961,6 +7039,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -7057,6 +7136,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -7168,6 +7248,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -7267,6 +7348,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 loop_detection_enabled: false,
                 ..crate::config::PacingConfig::default()
             },
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -7356,6 +7438,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 loop_detection_enabled: false,
                 ..crate::config::PacingConfig::default()
             },
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -7560,6 +7643,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(4);
@@ -7667,6 +7751,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);
@@ -7789,6 +7874,7 @@ BTC is currently around $65,000 based on latest tool output."#
             cost_tracking: None,
             query_classification: crate::config::QueryClassificationConfig::default(),
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);
@@ -7908,6 +7994,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);
@@ -8009,6 +8096,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -8093,6 +8181,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -8874,6 +8963,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -9010,6 +9100,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -9187,6 +9278,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -9299,6 +9391,7 @@ BTC is currently around $65,000 based on latest tool output."#
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -9875,6 +9968,7 @@ This is an example JSON object for profile settings."#;
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         // Simulate a photo attachment message with [IMAGE:] marker.
@@ -9966,6 +10060,7 @@ This is an example JSON object for profile settings."#;
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -10133,6 +10228,7 @@ This is an example JSON object for profile settings."#;
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -10248,6 +10344,7 @@ This is an example JSON object for profile settings."#;
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -10355,6 +10452,7 @@ This is an example JSON object for profile settings."#;
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -10482,6 +10580,7 @@ This is an example JSON object for profile settings."#;
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         process_channel_message(
@@ -10750,6 +10849,7 @@ This is an example JSON object for profile settings."#;
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(Duration::ZERO)),
         });
 
         let (tx, rx) = tokio::sync::mpsc::channel::<traits::ChannelMessage>(8);

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6122,6 +6122,11 @@ pub struct ChannelsConfig {
     /// Auto-archive stale sessions older than this many hours. `0` disables. Default: `0`.
     #[serde(default)]
     pub session_ttl_hours: u32,
+    /// Inbound message debounce window in milliseconds. When a sender fires
+    /// multiple messages within this window, they are accumulated and dispatched
+    /// as a single concatenated message. `0` disables debouncing. Default: `0`.
+    #[serde(default)]
+    pub debounce_ms: u64,
 }
 
 impl ChannelsConfig {
@@ -6289,6 +6294,7 @@ impl Default for ChannelsConfig {
             session_persistence: true,
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
+            debounce_ms: 0,
         }
     }
 }
@@ -11341,6 +11347,7 @@ auto_save = true
                 session_persistence: true,
                 session_backend: default_session_backend(),
                 session_ttl_hours: 0,
+                debounce_ms: 0,
             },
             memory: MemoryConfig::default(),
             storage: StorageConfig::default(),
@@ -12364,6 +12371,7 @@ allowed_users = ["@ops:matrix.org"]
             session_persistence: true,
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
+            debounce_ms: 0,
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();
@@ -12730,6 +12738,7 @@ channel_ids = ["C123", "D456"]
             session_persistence: true,
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
+            debounce_ms: 0,
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();


### PR DESCRIPTION
## Summary

Adds unified inbound message debouncing across all channels, inspired by OpenClaw's `inbound-debounce-policy.ts`. When users type fast and send multiple messages rapidly, they're accumulated and dispatched as a single combined message to the agent — preventing wasted LLM calls.

- **Configurable window** via `[channels] debounce_ms = 2000`
- **Disabled by default** (`debounce_ms = 0`) for backward compatibility
- First message starts a timer; subsequent messages within the window append and reset
- When the timer fires, all accumulated messages are joined with `\n` and dispatched
- CLI messages always bypass debouncing
- 4 unit tests covering disabled, single, multi-message, and independent sender scenarios

## Usage

```toml
[channels]
debounce_ms = 2000  # 2-second debounce window
```

## Files

| File | Change |
|------|--------|
| `src/channels/debounce.rs` | New — `MessageDebouncer` with per-sender accumulation + 4 tests |
| `src/channels/mod.rs` | Wire debouncer into dispatch loop, extract `dispatch_worker()` |
| `src/config/schema.rs` | Add `debounce_ms` to `ChannelsConfig` |

## Test plan

- [ ] `debounce_ms = 0` — messages dispatched immediately (unchanged behavior)
- [ ] `debounce_ms = 2000` — rapid messages combined into single LLM call
- [ ] Different senders debounce independently
- [ ] CLI mode bypasses debouncing entirely