### PR TITLE
fix(channels): rollback failed non-retryable turns from history

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -6016,7 +6016,7 @@ mod tests {
                 .any(|msg| msg.content.contains("trigger format error"))
             {
                 anyhow::bail!(
-                    "All providers/models failed. Attempts:\nprovider=custom:https://api.scnet.cn/api/llm/v1 model=MiniMax-M2.5 attempt 1/3: non_retryable; error=Custom API error (400 Bad Request): {{\"error\":{{\"message\":\"Format Error\",\"type\":\"invalid_request_error\",\"param\":null,\"code\":\"400\"}},\"request_id\":\"test-request-id\"}}"
+                    "All providers/models failed. Attempts:\nprovider=custom:https://example.invalid/v1 model=test-model attempt 1/3: non_retryable; error=Custom API error (400 Bad Request): {{\"error\":{{\"message\":\"Format Error\",\"type\":\"invalid_request_error\",\"param\":null,\"code\":\"400\"}},\"request_id\":\"test-request-id\"}}"
                 );
             }
 
@@ -10131,6 +10131,8 @@ This is an example JSON object for profile settings."#;
             activated_tools: None,
             cost_tracking: None,
             pacing: crate::config::PacingConfig::default(),
+            media_pipeline: crate::config::MediaPipelineConfig::default(),
+            transcription_config: crate::config::TranscriptionConfig::default(),
         });
 
         process_channel_message(
@@ -10144,6 +10146,7 @@ This is an example JSON object for profile settings."#;
                 timestamp: 1,
                 thread_ts: None,
                 interruption_scope_id: None,
+                attachments: vec![],
             },
             CancellationToken::new(),
         )
@@ -10160,6 +10163,7 @@ This is an example JSON object for profile settings."#;
                 timestamp: 2,
                 thread_ts: None,
                 interruption_scope_id: None,
+                attachments: vec![],
             },
             CancellationToken::new(),
         )


### PR DESCRIPTION
## Summary

This change prevents sender-history poisoning after non-retryable provider failures.

Previously, channel processing only rolled back the failed user turn for `ProviderCapabilityError(capability=vision)`. Other hard failures, such as provider-side `400 Bad Request` / `Format Error` request failures, still left the bad user turn in history. That caused later follow-up messages to inherit malformed context.

This patch broadens rollback behavior to include non-retryable failures detected by `providers::reliable::is_non_retryable(&err)`.

## What Changed

- added `should_rollback_failed_user_turn(...)` in `src/channels/mod.rs`
- preserved existing rollback behavior for vision capability failures
- extended rollback to non-retryable provider/request failures
- added regression test:
  - `e2e_failed_non_retryable_turn_does_not_poison_follow_up_text_turn`
- revalidated:
  - `e2e_failed_vision_turn_does_not_poison_follow_up_text_turn`

## Why

Appending a failure marker is enough to close normal failed turns structurally, but it is not sufficient when the failed user message itself is invalid for future provider requests.

In those cases, the failed user turn should be removed from sender history so subsequent messages start from clean context.

## Risk

Medium.

This changes channel-side history handling for a subset of failed requests. The main risk is rolling back a failed turn that some workflows may have expected to remain in history, but this behavior is more correct for non-retryable client/request failures.

## Validation

Ran:

```bash
cargo fmt --all -- --check
cargo test e2e_failed_non_retryable_turn_does_not_poison_follow_up_text_turn -- --nocapture
cargo test e2e_failed_vision_turn_does_not_poison_follow_up_text_turn -- --nocapture
```

Also manually verified the release build on server-side testing.

## Fixes

Fixes #4789

## Supersedes

Supersedes #4790 because that PR entered a stale compare state after the branch was rebased onto upstream `master`.
