### PR TITLE
feat(web): persist Agent Chat history across navigation and refresh

### DIFF
--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -1296,6 +1296,40 @@ pub async fn handle_api_sessions_list(
     Json(serde_json::json!({ "sessions": gw_sessions })).into_response()
 }
 
+/// GET /api/sessions/{id}/messages — load persisted gateway WebSocket chat transcript
+pub async fn handle_api_session_messages(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    if let Err(e) = require_auth(&state, &headers) {
+        return e.into_response();
+    }
+
+    let Some(ref backend) = state.session_backend else {
+        return Json(serde_json::json!({
+            "session_id": id,
+            "messages": [],
+            "session_persistence": false,
+        }))
+        .into_response();
+    };
+
+    let session_key = format!("gw_{id}");
+    let msgs = backend.load(&session_key);
+    let messages: Vec<serde_json::Value> = msgs
+        .into_iter()
+        .map(|m| serde_json::json!({ "role": m.role, "content": m.content }))
+        .collect();
+
+    Json(serde_json::json!({
+        "session_id": id,
+        "messages": messages,
+        "session_persistence": true,
+    }))
+    .into_response()
+}
+
 /// DELETE /api/sessions/{id} — delete a gateway session
 pub async fn handle_api_session_delete(
     State(state): State<AppState>,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -926,6 +926,10 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         .route("/api/cli-tools", get(api::handle_api_cli_tools))
         .route("/api/health", get(api::handle_api_health))
         .route("/api/sessions", get(api::handle_api_sessions_list))
+        .route(
+            "/api/sessions/{id}/messages",
+            get(api::handle_api_session_messages),
+        )
         .route("/api/sessions/{id}", delete(api::handle_api_session_delete).put(api::handle_api_session_rename))
         // ── Pairing + Device management API ──
         .route("/api/pairing/initiate", post(api_pairing::initiate_pairing))

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   HealthSnapshot,
   Session,
   ChannelDetail,
+  SessionMessagesResponse,
 } from '../types/api';
 import { clearToken, getToken, setToken } from './auth';
 import { apiOrigin, basePath } from './basePath';
@@ -305,6 +306,13 @@ export function getSessions(): Promise<Session[]> {
 
 export function getSession(id: string): Promise<Session> {
   return apiFetch<Session>(`/api/sessions/${encodeURIComponent(id)}`);
+}
+
+/** Load persisted gateway WebSocket chat transcript for the dashboard Agent Chat. */
+export function getSessionMessages(id: string): Promise<SessionMessagesResponse> {
+  return apiFetch<SessionMessagesResponse>(
+    `/api/sessions/${encodeURIComponent(id)}/messages`,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/chatHistoryStorage.ts
+++ b/web/src/lib/chatHistoryStorage.ts
@@ -1,0 +1,116 @@
+import type { SessionMessageRow } from '@/types/api';
+import { generateUUID } from '@/lib/uuid';
+
+const MAX_MESSAGES = 100;
+const PREFIX = 'zeroclaw_chat_history_v1:';
+
+export interface PersistedChatBubble {
+  id: string;
+  role: 'user' | 'agent';
+  content: string;
+  thinking?: string;
+  markdown?: boolean;
+  timestamp: string;
+}
+
+function storageKey(sessionId: string): string {
+  return `${PREFIX}${sessionId}`;
+}
+
+export function loadChatHistory(sessionId: string): PersistedChatBubble[] {
+  try {
+    const raw = localStorage.getItem(storageKey(sessionId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as { messages?: PersistedChatBubble[] };
+    if (!parsed.messages?.length) return [];
+    return parsed.messages;
+  } catch {
+    return [];
+  }
+}
+
+export function saveChatHistory(sessionId: string, messages: PersistedChatBubble[]): void {
+  try {
+    const slice = messages.slice(-MAX_MESSAGES);
+    localStorage.setItem(storageKey(sessionId), JSON.stringify({ messages: slice }));
+  } catch {
+    // QuotaExceeded or private mode
+  }
+}
+
+/** Map server-persisted rows into UI messages (timestamps are synthetic for ordering). */
+export function mapServerMessagesToPersisted(rows: SessionMessageRow[]): PersistedChatBubble[] {
+  const base = Date.now() - rows.length * 1000;
+  const out: PersistedChatBubble[] = [];
+  let idx = 0;
+  for (const row of rows) {
+    if (row.role === 'system') continue;
+    const ts = new Date(base + idx * 1000).toISOString();
+    idx += 1;
+    if (row.role === 'user') {
+      out.push({
+        id: generateUUID(),
+        role: 'user',
+        content: row.content,
+        timestamp: ts,
+      });
+    } else if (row.role === 'assistant') {
+      out.push({
+        id: generateUUID(),
+        role: 'agent',
+        content: row.content,
+        markdown: true,
+        timestamp: ts,
+      });
+    } else {
+      out.push({
+        id: generateUUID(),
+        role: 'agent',
+        content: row.content,
+        markdown: false,
+        timestamp: ts,
+      });
+    }
+  }
+  return out;
+}
+
+export function persistedToUiMessages(
+  rows: PersistedChatBubble[],
+): Array<{
+  id: string;
+  role: 'user' | 'agent';
+  content: string;
+  thinking?: string;
+  markdown?: boolean;
+  timestamp: Date;
+}> {
+  return rows.map((m) => ({
+    id: m.id,
+    role: m.role,
+    content: m.content,
+    thinking: m.thinking,
+    markdown: m.markdown,
+    timestamp: new Date(m.timestamp),
+  }));
+}
+
+export function uiMessagesToPersisted(
+  messages: Array<{
+    id: string;
+    role: 'user' | 'agent';
+    content: string;
+    thinking?: string;
+    markdown?: boolean;
+    timestamp: Date;
+  }>,
+): PersistedChatBubble[] {
+  return messages.map((m) => ({
+    id: m.id,
+    role: m.role,
+    content: m.content,
+    thinking: m.thinking,
+    markdown: m.markdown,
+    timestamp: m.timestamp.toISOString(),
+  }));
+}

--- a/web/src/lib/ws.ts
+++ b/web/src/lib/ws.ts
@@ -23,10 +23,10 @@ export interface WebSocketClientOptions {
 const DEFAULT_RECONNECT_DELAY = 1000;
 const MAX_RECONNECT_DELAY = 30000;
 
-const SESSION_STORAGE_KEY = 'zeroclaw_session_id';
+export const SESSION_STORAGE_KEY = 'zeroclaw_session_id';
 
 /** Return a stable session ID, persisted in sessionStorage across reconnects. */
-function getOrCreateSessionId(): string {
+export function getOrCreateSessionId(): string {
   let id = sessionStorage.getItem(SESSION_STORAGE_KEY);
   if (!id) {
     id = generateUUID();

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -3,10 +3,18 @@ import { Send, Bot, User, AlertCircle, Copy, Check } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { WsMessage } from '@/types/api';
-import { WebSocketClient } from '@/lib/ws';
+import { WebSocketClient, getOrCreateSessionId } from '@/lib/ws';
 import { generateUUID } from '@/lib/uuid';
 import { useDraft } from '@/hooks/useDraft';
 import { t } from '@/lib/i18n';
+import { getSessionMessages } from '@/lib/api';
+import {
+  loadChatHistory,
+  mapServerMessagesToPersisted,
+  persistedToUiMessages,
+  saveChatHistory,
+  uiMessagesToPersisted,
+} from '@/lib/chatHistoryStorage';
 
 interface ChatMessage {
   id: string;
@@ -20,8 +28,10 @@ interface ChatMessage {
 const DRAFT_KEY = 'agent-chat';
 
 export default function AgentChat() {
+  const sessionIdRef = useRef(getOrCreateSessionId());
   const { draft, saveDraft, clearDraft } = useDraft(DRAFT_KEY);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [historyReady, setHistoryReady] = useState(false);
   const [input, setInput] = useState(draft);
   const [typing, setTyping] = useState(false);
   const [connected, setConnected] = useState(false);
@@ -42,6 +52,50 @@ export default function AgentChat() {
   useEffect(() => {
     saveDraft(input);
   }, [input, saveDraft]);
+
+  // Hydrate chat from server (preferred) or localStorage fallback
+  useEffect(() => {
+    const sid = sessionIdRef.current;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const res = await getSessionMessages(sid);
+        if (cancelled) return;
+        if (res.session_persistence && res.messages.length > 0) {
+          setMessages((prev) =>
+            prev.length > 0 ? prev : persistedToUiMessages(mapServerMessagesToPersisted(res.messages)),
+          );
+        } else if (!res.session_persistence) {
+          setMessages((prev) => {
+            if (prev.length > 0) return prev;
+            const ls = loadChatHistory(sid);
+            return ls.length ? persistedToUiMessages(ls) : prev;
+          });
+        }
+      } catch {
+        if (!cancelled) {
+          setMessages((prev) => {
+            if (prev.length > 0) return prev;
+            const ls = loadChatHistory(sid);
+            return ls.length ? persistedToUiMessages(ls) : prev;
+          });
+        }
+      } finally {
+        if (!cancelled) setHistoryReady(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Mirror transcript to localStorage (bounded); server remains source of truth when persistence is on
+  useEffect(() => {
+    if (!historyReady) return;
+    saveChatHistory(sessionIdRef.current, uiMessagesToPersisted(messages));
+  }, [messages, historyReady]);
 
   useEffect(() => {
     const ws = new WebSocketClient();
@@ -64,6 +118,10 @@ export default function AgentChat() {
 
     ws.onMessage = (msg: WsMessage) => {
       switch (msg.type) {
+        case 'session_start':
+        case 'connected':
+          break;
+
         case 'thinking':
           setTyping(true);
           pendingThinkingRef.current += msg.content ?? '';

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -132,7 +132,17 @@ export interface SSEEvent {
 }
 
 export interface WsMessage {
-  type: 'message' | 'chunk' | 'chunk_reset' | 'thinking' | 'tool_call' | 'tool_result' | 'done' | 'error';
+  type:
+    | 'message'
+    | 'chunk'
+    | 'chunk_reset'
+    | 'thinking'
+    | 'tool_call'
+    | 'tool_result'
+    | 'done'
+    | 'error'
+    | 'session_start'
+    | 'connected';
   content?: string;
   full_response?: string;
   name?: string;
@@ -140,4 +150,19 @@ export interface WsMessage {
   output?: string;
   message?: string;
   code?: string;
+  session_id?: string;
+  resumed?: boolean;
+  message_count?: number;
+}
+
+/** Row from GET /api/sessions/{id}/messages */
+export interface SessionMessageRow {
+  role: string;
+  content: string;
+}
+
+export interface SessionMessagesResponse {
+  session_id: string;
+  messages: SessionMessageRow[];
+  session_persistence: boolean;
 }


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): **`master`**
- **Problem:** The web dashboard Agent Chat kept the conversation only in React state. Navigating away or refreshing the page cleared the transcript, even though the gateway already persisted WebSocket sessions server-side and reused the same `session_id` from `sessionStorage`.
- **Why it matters:** Users lose visible chat history and get a misleading “empty” UI while the backend may still hold context. This hurts trust and makes multi-turn support harder from the browser.
- **What changed:**
  - Added **`GET /api/sessions/{id}/messages`** (authenticated) to return the persisted gateway chat transcript (`gw_{id}`) as `{ role, content }` rows when `session_backend` is enabled; returns empty messages with `session_persistence: false` when persistence is off.
  - **Web:** Exported **`getOrCreateSessionId`** from `ws.ts` so the REST hydrate and WebSocket use the same session key.
  - **`AgentChat`** hydrates on mount from the API; falls back to **`localStorage`** when persistence is disabled or the request fails; mirrors updates to local storage (capped at **100** messages); avoids overwriting in-flight UI if the user sends before hydrate completes.
  - Extended **`WsMessage`** with **`session_start`** / **`connected`**; **`chatHistoryStorage.ts`** centralizes mapping and persistence helpers.
- **What did **not** change (scope boundary):** WebSocket streaming protocol for turns, agent logic, channel sessions outside `gw_` prefix, unrelated tooling, and local-only files (`.vscode`, `install.sh`, Tauri gen schemas) were left out of this branch.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): **`medium`** (new authenticated gateway endpoint exposing stored session text to paired clients)
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): **`S`**
- Scope labels: **`gateway`, `web`**
- Module labels: **`gateway: sessions`**, **`web: dashboard`**
- Contributor tier label: *(auto / leave blank)*
- If any auto-label is incorrect, note requested correction: *(none)*

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): **`feature`**
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): **`multi`** (gateway + web)

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution

- N/A (not superseding another PR)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -- -D warnings
cargo test
```

- **Run locally for this change:**
  - `cargo check -p zeroclawlabs` — **pass**
  - `cd web && npm run build` (tsc + vite) — **pass**
- **Evidence provided:** Build/typecheck logs for the touched Rust and web packages.
- **If any command is intentionally skipped, explain why:**
  - Full `cargo clippy -- -D warnings` and full `cargo test` were **not** re-run as a clean green baseline in this session; the repository currently reports unrelated pre-existing clippy items and unrelated failing tests elsewhere. The modified code paths compile and the web bundle builds successfully.

## Security Impact (required)

- New permissions/capabilities? **`No`** (same bearer pairing model as other `/api/sessions/*` routes)
- New external network calls? **`No`**
- Secrets/tokens handling changed? **`No`**
- File system access scope changed? **`No`**
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): **`pass`**
- Redaction/anonymization notes: Transcript is loaded only for the authenticated dashboard client; content is whatever was already persisted by the gateway session store (same trust boundary as server-side chat).
- Neutral wording confirmation: No personal identifiers added in code or test fixtures.

## Compatibility / Migration

- Backward compatible? **`Yes`** (additive API route and client behavior)
- Config/env changes? **`No`**
- Migration needed? **`No`**

## i18n Follow-Through

- i18n follow-through triggered? **`No`** (no new user-visible copy strings in this PR)
- Remaining template lines: **`N.A.`**

## Human Verification (required)

- **Verified scenarios (recommended before merge):** Paired token → Agent Chat → send messages → navigate to another dashboard page → return to chat (history visible); refresh browser tab (same tab, same `session_id`) → history visible when `gateway.session_persistence` is enabled.
- **Edge cases checked:** Hydrate completing after the user sends a message should not wipe the partial thread (guarded with functional `setMessages`).
- **What was not verified:** End-to-end run against a live production gateway with TLS and custom `basePath` (logic follows existing `apiFetch` / WS patterns).

## Side Effects / Blast Radius

- **Affected:** Web dashboard Agent Chat page; gateway session API surface.
- **Potential unintended effects:** Slightly larger initial load (one GET per chat mount); `localStorage` usage for transcript mirror (bounded).
- **Guardrails:** Auth required on new endpoint; message list capped on the client.

## Agent Collaboration Notes

- Implementation followed the “Web chat history” plan: server read path + client hydrate + optional local fallback.

## Rollback Plan

- **Rollback:** Revert this PR or remove the new route and client hydrate block; no migration.
- **Feature flags:** None.
- **Failure symptoms:** If the new GET fails, UI falls back to `localStorage` or empty state; chat streaming unchanged.

## Risks and Mitigations

- **Risk:** Authenticated clients can read persisted gateway session text for any session id they know.
  - **Mitigation:** Same as existing session list/delete/rename APIs — requires a valid paired bearer token; document that session ids should be treated as secrets in untrusted environments.

---

**Branch:** `fix/web-agent-chat-history`  
**Suggested compare:** `https://github.com/mehmet-zahid/zeroclaw/compare/zeroclaw-labs:master...fix/web-agent-chat-history` (adjust upstream if needed)
