### PR TITLE
fix: resolve clippy inefficient_to_string for &&str receivers

### DIFF
--- a/src/agent/context_analyzer.rs
+++ b/src/agent/context_analyzer.rs
@@ -32,7 +32,7 @@ pub fn analyze_turn_context(
     if let Some(last_assistant) = history.iter().rev().find(|m| m.role == "assistant") {
         for word in last_assistant.content.split_whitespace() {
             for tool_name in tools_for_keyword(word) {
-                tools.insert(tool_name.to_string());
+                tools.insert(String::from(*tool_name));
             }
         }
     }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -11511,7 +11511,10 @@ auto_approve = ["my_custom_tool", "another_tool"]
             "web_fetch",
         ] {
             assert!(
-                parsed.autonomy.auto_approve.contains(&default_tool.to_string()),
+                parsed
+                    .autonomy
+                    .auto_approve
+                    .contains(&String::from(*default_tool)),
                 "default tool '{default_tool}' must be present in auto_approve even when user provides custom list"
             );
         }

--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -1152,7 +1152,7 @@ impl Provider for ReliableProvider {
 
             // Try the first model in the chain for streaming
             let current_model = match self.model_chain(model).first() {
-                Some(m) => m.to_string(),
+                Some(m) => (*m).to_string(),
                 None => model.to_string(),
             };
 
@@ -1219,7 +1219,7 @@ impl Provider for ReliableProvider {
             let provider_clone = provider_name.clone();
 
             let current_model = match self.model_chain(model).first() {
-                Some(m) => m.to_string(),
+                Some(m) => (*m).to_string(),
                 None => model.to_string(),
             };
 

--- a/src/providers/router.rs
+++ b/src/providers/router.rs
@@ -376,7 +376,7 @@ mod tests {
             .zip(mocks.iter())
             .map(|((name, _), mock)| {
                 (
-                    name.to_string(),
+                    (*name).to_string(),
                     Box::new(Arc::clone(mock)) as Box<dyn Provider>,
                 )
             })
@@ -386,10 +386,10 @@ mod tests {
             .iter()
             .map(|(hint, provider_name, model)| {
                 (
-                    hint.to_string(),
+                    (*hint).to_string(),
                     Route {
-                        provider_name: provider_name.to_string(),
-                        model: model.to_string(),
+                        provider_name: (*provider_name).to_string(),
+                        model: (*model).to_string(),
                     },
                 )
             })

--- a/src/security/leak_detector.rs
+++ b/src/security/leak_detector.rs
@@ -126,7 +126,7 @@ impl LeakDetector {
 
         for (regex, name) in regexes {
             if regex.is_match(content) {
-                patterns.push(name.to_string());
+                patterns.push(String::from(*name));
                 *redacted = regex
                     .replace_all(redacted, "[REDACTED_API_KEY]")
                     .to_string();
@@ -160,7 +160,7 @@ impl LeakDetector {
 
         for (regex, name) in regexes {
             if regex.is_match(content) {
-                patterns.push(name.to_string());
+                patterns.push(String::from(*name));
                 *redacted = regex
                     .replace_all(redacted, "[REDACTED_AWS_CREDENTIAL]")
                     .to_string();
@@ -195,7 +195,7 @@ impl LeakDetector {
 
         for (regex, name) in regexes {
             if regex.is_match(content) && self.sensitivity > 0.5 {
-                patterns.push(name.to_string());
+                patterns.push(String::from(*name));
                 *redacted = regex.replace_all(redacted, "[REDACTED_SECRET]").to_string();
             }
         }
@@ -286,7 +286,7 @@ impl LeakDetector {
 
         for (regex, name) in regexes {
             if regex.is_match(content) {
-                patterns.push(name.to_string());
+                patterns.push(String::from(*name));
                 *redacted = regex
                     .replace_all(redacted, "[REDACTED_DATABASE_URL]")
                     .to_string();

--- a/src/tools/tool_search.rs
+++ b/src/tools/tool_search.rs
@@ -152,7 +152,7 @@ impl ToolSearchTool {
                 Some(spec) => {
                     if !guard.is_activated(name) {
                         if let Some(tool) = self.deferred.activate(name) {
-                            guard.activate(name.to_string(), Arc::from(tool));
+                            guard.activate(String::from(*name), Arc::from(tool));
                             activated_count += 1;
                         }
                     }


### PR DESCRIPTION
Dereference double references before String conversion so ToString uses the str specialization instead of the slower blanket &T impl.

## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: Clippy’s `inefficient_to_string` fires when `to_string()` is called on `&&str`; the receiver should be `&str` so `ToString` uses the specialized path for `str` instead of the slower blanket impl for `&T`.
- Why it matters: Keeps `cargo clippy --all-targets -- -D warnings` green and avoids a minor allocation/performance footgun in hot paths and tests.
- What changed: Dereference double references (`*x`) or use `String::from(*x)` before converting to `String` in agent context analysis, config tests, reliable streaming model selection, router test helpers, leak detector pattern names, and tool search activation.
- What did **not** change (scope boundary): No behavior change intended beyond equivalent string construction; no API, config schema, or security policy changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `core`, `agent`, `config`, `provider`, `security`, `tool`, `tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `agent: context`, `config: schema`, `provider: reliable`, `provider: router`, `security: leak_detector`, `tool: tool_search`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): (auto)
- If any auto-label is incorrect, note requested correction: (none)

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `chore` (lint-driven cleanup; alternatively `refactor`)
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

_(Leave issue numbers empty or fill if applicable.)_

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test -p zeroclawlabs
```

- Evidence provided (test/log/trace/screenshot/perf):
  - `cargo fmt --all -- --check`: pass
  - `cargo clippy --all-targets -- -D warnings`: pass
  - `cargo test -p zeroclawlabs`: 5749 passed; 2 failed in unrelated tests (`channels::mattermost::tests::mattermost_manager_none_and_warn_on_init_failure`, `security::seatbelt::tests::generate_policy_restricts_network`). Failures are not caused by this diff (string construction only). Recommend relying on CI for full suite.
- If any command is intentionally skipped, explain why: none

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): N/A

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `cargo clippy -p zeroclawlabs --all-targets -- -D warnings` after edits
- Edge cases checked: N/A (mechanical dereference)
- What was not verified: full `cargo test` green locally due to two unrelated failing tests on this machine

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: none beyond equivalent `String` construction
- Potential unintended effects: none expected
- Guardrails/monitoring for early detection: CI clippy should match local

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local `cargo fmt`, `cargo clippy`, `cargo test`
- Workflow/plan summary (if any): N/A
- Verification focus: clippy `-D warnings`
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): yes

## Rollback Plan (required)

- Fast rollback command/path: revert this commit on the branch or `git revert <sha>`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: none expected; if issues arise, revert

## Risks and Mitigations

List real risks in this PR (or write `None`).

- None — mechanical lint fix with no intended semantic change.

---

## Files touched

- `src/agent/context_analyzer.rs`
- `src/config/schema.rs`
- `src/providers/reliable.rs`
- `src/providers/router.rs`
- `src/security/leak_detector.rs`
- `src/tools/tool_search.rs`