### PR TITLE
fix(status): read cost limits from [cost] config and show dynamic usage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1241,9 +1241,37 @@ async fn main() -> Result<()> {
                 config.autonomy.max_actions_per_hour
             );
             println!(
-                "  Max cost/day:      ${:.2}",
-                f64::from(config.autonomy.max_cost_per_day_cents) / 100.0
+                "  Cost tracking:     {}",
+                if config.cost.enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                }
             );
+            println!("  Max cost/day:      ${:.2}", config.cost.daily_limit_usd);
+            println!("  Max cost/month:    ${:.2}", config.cost.monthly_limit_usd);
+            if config.cost.enabled {
+                match cost::CostTracker::new(config.cost.clone(), &config.workspace_dir) {
+                    Ok(tracker) => match tracker.get_summary() {
+                        Ok(summary) => {
+                            println!(
+                                "  Spent today:       ${:.4} / ${:.2}",
+                                summary.daily_cost_usd, config.cost.daily_limit_usd
+                            );
+                            println!(
+                                "  Spent this month:  ${:.4} / ${:.2}",
+                                summary.monthly_cost_usd, config.cost.monthly_limit_usd
+                            );
+                        }
+                        Err(e) => {
+                            eprintln!("  ⚠ Could not load cost usage: {e}");
+                        }
+                    },
+                    Err(e) => {
+                        eprintln!("  ⚠ Could not init cost tracker: {e}");
+                    }
+                }
+            }
             println!("  OTP enabled:       {}", config.security.otp.enabled);
             println!("  E-stop enabled:    {}", config.security.estop.enabled);
             println!();


### PR DESCRIPTION
## Summary

- `zeroclaw status` was reading `max_cost_per_day_cents` from the legacy `[autonomy]` block (default $5.00) instead of `daily_limit_usd` from the `[cost]` block that `CostTracker` actually enforces at runtime
- Users setting `[cost].daily_limit_usd = 1.0` still saw "Max cost/day: $5.00" — the displayed limit didn't match what was enforced
- Now reads from `config.cost`, shows cost tracking enabled/disabled, daily + monthly limits, and **dynamic spend vs limit** from persistent storage

### Before
```
  Max cost/day:      $5.00
```

### After
```
  Cost tracking:     enabled
  Max cost/day:      $1.00
  Max cost/month:    $40.00
  Spent today:       $0.3200 / $1.00
  Spent this month:  $12.4500 / $40.00
```

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes (1 pre-existing failure in `seatbelt::tests::generate_policy_restricts_network` also fails on master)
- [ ] Manual: set `[cost].daily_limit_usd = 1.0` in config, run `zeroclaw status`, confirm it shows `$1.00` and current usage
- [ ] Manual: set `[cost].enabled = false`, confirm usage lines are hidden

Closes the issue reported by Saleh in Discord regarding cost limits not updating in status output.