### PR TITLE
fix(anthropic): use configured max_tokens in stream_chat

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -10241,6 +10241,7 @@ This is an example JSON object for profile settings."#;
             pacing: crate::config::PacingConfig::default(),
             media_pipeline: crate::config::MediaPipelineConfig::default(),
             transcription_config: crate::config::TranscriptionConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(std::time::Duration::ZERO)),
         });
 
         process_channel_message(

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -610,6 +610,24 @@ impl AnthropicProvider {
                 .unwrap_or_default();
 
             match event_type {
+                "message_start" => {
+                    let model = event
+                        .get("message")
+                        .and_then(|m| m.get("model"))
+                        .and_then(|m| m.as_str())
+                        .unwrap_or("unknown");
+                    let input_tokens = event
+                        .get("message")
+                        .and_then(|m| m.get("usage"))
+                        .and_then(|u| u.get("input_tokens"))
+                        .and_then(|t| t.as_u64())
+                        .unwrap_or(0);
+                    tracing::debug!(
+                        model = %model,
+                        input_tokens = input_tokens,
+                        "Anthropic stream: message_start"
+                    );
+                }
                 "content_block_start" => {
                     if let Some(block) = event.get("content_block") {
                         let block_type = block
@@ -685,7 +703,32 @@ impl AnthropicProvider {
                             .await;
                     }
                 }
+                "message_delta" => {
+                    let stop_reason = event
+                        .get("delta")
+                        .and_then(|d| d.get("stop_reason"))
+                        .and_then(|s| s.as_str())
+                        .unwrap_or("none");
+                    let output_tokens = event
+                        .get("usage")
+                        .and_then(|u| u.get("output_tokens"))
+                        .and_then(|t| t.as_u64())
+                        .unwrap_or(0);
+                    if stop_reason == "max_tokens" {
+                        tracing::warn!(
+                            output_tokens = output_tokens,
+                            "Anthropic response truncated: hit max_tokens limit. Increase provider_max_tokens in config."
+                        );
+                    } else {
+                        tracing::debug!(
+                            stop_reason = %stop_reason,
+                            output_tokens = output_tokens,
+                            "Anthropic stream: message_delta"
+                        );
+                    }
+                }
                 "message_stop" => {
+                    tracing::debug!("Anthropic stream: message_stop");
                     let _ = tx.send(Ok(StreamEvent::Final)).await;
                     return;
                 }
@@ -728,6 +771,7 @@ impl Provider for AnthropicProvider {
             system
         };
 
+        tracing::debug!(max_tokens = self.max_tokens, model = %model, "Anthropic API request");
         let request = NativeChatRequest {
             model: model.to_string(),
             max_tokens: self.max_tokens,
@@ -805,6 +849,7 @@ impl Provider for AnthropicProvider {
         } else {
             system_prompt
         };
+        tracing::debug!(max_tokens = self.max_tokens, model = %model, "Anthropic streaming API request");
         let native_request = NativeChatRequest {
             model: model.to_string(),
             max_tokens: self.max_tokens,
@@ -958,9 +1003,10 @@ impl Provider for AnthropicProvider {
             system_prompt
         };
 
+        tracing::debug!(max_tokens = self.max_tokens, model = %model, "Anthropic stream_chat request");
         let native_request = NativeChatRequest {
             model: model.to_string(),
-            max_tokens: 4096,
+            max_tokens: self.max_tokens,
             system: system_prompt,
             messages,
             temperature,


### PR DESCRIPTION
## Summary
- `stream_chat()` was hardcoded to `max_tokens: 4096` instead of using `self.max_tokens` from provider config, causing silent response truncation
- Adds structured debug logging for SSE stream events (message_start, message_delta, message_stop)
- Logs WARN when `stop_reason=max_tokens` so truncation is visible in logs

## Test plan
- [x] Set `provider_max_tokens = 16384` in config, verify stream_chat uses it
- [x] Trigger a response that exceeds 4096 output tokens (e.g. tool call with large Python script), verify it completes
- [x] Check logs show `Anthropic stream: message_start/message_delta/message_stop` at debug level

🤖 Generated with [Claude Code](https://claude.com/claude-code)