### PR TITLE
feat(slack): reaction-based cancellation and finalize_draft thread fix

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4114,7 +4114,8 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 .with_workspace_dir(config.workspace_dir.clone())
                 .with_markdown_blocks(sl.use_markdown_blocks)
                 .with_transcription(config.transcription.clone())
-                .with_streaming(sl.stream_drafts, sl.draft_update_interval_ms),
+                .with_streaming(sl.stream_drafts, sl.draft_update_interval_ms)
+                .with_cancel_reaction(sl.cancel_reaction.clone()),
             ))
         }
         "mattermost" => {
@@ -4346,7 +4347,8 @@ fn collect_configured_channels(
                 .with_markdown_blocks(sl.use_markdown_blocks)
                 .with_proxy_url(sl.proxy_url.clone())
                 .with_transcription(config.transcription.clone())
-                .with_streaming(sl.stream_drafts, sl.draft_update_interval_ms),
+                .with_streaming(sl.stream_drafts, sl.draft_update_interval_ms)
+                .with_cancel_reaction(sl.cancel_reaction.clone()),
             ),
         });
     }
@@ -10241,6 +10243,7 @@ This is an example JSON object for profile settings."#;
             pacing: crate::config::PacingConfig::default(),
             media_pipeline: crate::config::MediaPipelineConfig::default(),
             transcription_config: crate::config::TranscriptionConfig::default(),
+            debouncer: Arc::new(debounce::MessageDebouncer::new(std::time::Duration::ZERO)),
         });
 
         process_channel_message(

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -51,6 +51,8 @@ pub struct SlackChannel {
     /// `send_draft` returns a placeholder without posting; the real message
     /// is created on the first `update_draft` call.
     lazy_draft_ts: tokio::sync::Mutex<HashMap<String, String>>,
+    /// Emoji reaction name (without colons) that cancels an in-flight request.
+    cancel_reaction: Option<String>,
 }
 
 const SLACK_HISTORY_MAX_RETRIES: u32 = 3;
@@ -179,6 +181,7 @@ impl SlackChannel {
             draft_update_interval_ms: SLACK_DRAFT_UPDATE_INTERVAL_MS,
             last_draft_edit: Mutex::new(HashMap::new()),
             lazy_draft_ts: tokio::sync::Mutex::new(HashMap::new()),
+            cancel_reaction: None,
         }
     }
 
@@ -244,6 +247,12 @@ impl SlackChannel {
         if interval_ms > 0 {
             self.draft_update_interval_ms = interval_ms;
         }
+        self
+    }
+
+    /// Set the emoji reaction name that cancels an in-flight request.
+    pub fn with_cancel_reaction(mut self, reaction: Option<String>) -> Self {
+        self.cancel_reaction = reaction;
         self
     }
 
@@ -2690,6 +2699,63 @@ impl SlackChannel {
                     continue;
                 }
 
+                // Handle reaction-based cancellation.
+                if event_type == "reaction_added" {
+                    if let Some(ref cancel_emoji) = self.cancel_reaction {
+                        let reaction = event
+                            .get("reaction")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default();
+                        if reaction == cancel_emoji.as_str() {
+                            let user = event
+                                .get("user")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or_default();
+                            if !user.is_empty() && self.is_user_allowed(user) {
+                                let item = event.get("item");
+                                let item_channel = item
+                                    .and_then(|i| i.get("channel"))
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or_default();
+                                let item_ts = item
+                                    .and_then(|i| i.get("ts"))
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or_default();
+                                if !item_channel.is_empty() && !item_ts.is_empty() {
+                                    // Build a synthetic /stop message scoped to the
+                                    // thread of the reacted message so the dispatch
+                                    // loop cancels the correct in-flight task.
+                                    let thread_ts = Some(item_ts.to_string());
+                                    let scope_id = Some(item_ts.to_string());
+                                    let sender = self.resolve_sender_identity(user).await;
+                                    let cancel_msg = ChannelMessage {
+                                        id: format!("slack_{item_channel}_{item_ts}_cancel"),
+                                        sender,
+                                        reply_target: item_channel.to_string(),
+                                        content: "/stop".to_string(),
+                                        channel: "slack".to_string(),
+                                        timestamp: std::time::SystemTime::now()
+                                            .duration_since(std::time::UNIX_EPOCH)
+                                            .unwrap_or_default()
+                                            .as_secs(),
+                                        thread_ts,
+                                        interruption_scope_id: scope_id,
+                                        attachments: vec![],
+                                    };
+                                    tracing::info!(
+                                        "Slack: :{cancel_emoji}: reaction from {user} \
+                                         on {item_channel}/{item_ts} — sending /stop"
+                                    );
+                                    if tx.send(cancel_msg).await.is_err() {
+                                        return Ok(());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    continue;
+                }
+
                 if event_type != "message" {
                     continue;
                 }
@@ -3440,19 +3506,29 @@ impl Channel for SlackChannel {
             .expect("last_draft_edit lock")
             .remove(recipient);
 
+        // Extract thread_ts from the lazy draft ID ("lazy:{channel}:{thread_ts}")
+        // so fallback sends preserve thread context.
+        let draft_thread_ts = message_id
+            .strip_prefix(LAZY_DRAFT_PREFIX)
+            .and_then(|rest| rest.find(':').map(|pos| &rest[pos + 1..]))
+            .filter(|ts| !ts.is_empty())
+            .map(String::from);
+
         let real_ts = self.resolve_draft_ts(message_id).await;
         // Clean up lazy mapping
         self.lazy_draft_ts.lock().await.remove(message_id);
 
         let Some(real_ts) = real_ts else {
             // Draft was never materialized — just send as a fresh message
-            return self.send(&SendMessage::new(text, recipient)).await;
+            let msg = SendMessage::new(text, recipient).in_thread(draft_thread_ts);
+            return self.send(&msg).await;
         };
 
         // If text exceeds Slack limit, delete draft and send as regular message
         if text.len() > SLACK_MESSAGE_MAX_CHARS {
             let _ = self.delete_message(recipient, &real_ts).await;
-            return self.send(&SendMessage::new(text, recipient)).await;
+            let msg = SendMessage::new(text, recipient).in_thread(draft_thread_ts);
+            return self.send(&msg).await;
         }
 
         // Edit the draft with the final formatted content
@@ -3491,7 +3567,8 @@ impl Channel for SlackChannel {
         tracing::debug!("Slack chat.update (finalize) failed: {err}; falling back to delete+send");
 
         let _ = self.delete_message(recipient, &real_ts).await;
-        self.send(&SendMessage::new(text, recipient)).await
+        let msg = SendMessage::new(text, recipient).in_thread(draft_thread_ts);
+        self.send(&msg).await
     }
 
     async fn cancel_draft(&self, recipient: &str, message_id: &str) -> anyhow::Result<()> {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6494,6 +6494,11 @@ pub struct SlackConfig {
     /// Minimum interval (ms) between draft message edits to avoid Slack rate limits.
     #[serde(default = "default_slack_draft_update_interval_ms")]
     pub draft_update_interval_ms: u64,
+    /// Emoji reaction name (without colons) that cancels an in-flight request.
+    /// For example, `"x"` means reacting with `:x:` cancels the task.
+    /// Leave unset to disable reaction-based cancellation.
+    #[serde(default)]
+    pub cancel_reaction: Option<String>,
 }
 
 fn default_slack_draft_update_interval_ms() -> u64 {

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -4078,6 +4078,7 @@ fn setup_channels() -> Result<ChannelsConfig> {
                     proxy_url: None,
                     stream_drafts: false,
                     draft_update_interval_ms: 1200,
+                    cancel_reaction: None,
                 });
             }
             ChannelMenuChoice::IMessage => {


### PR DESCRIPTION
## Summary
- Adds `cancel_reaction` config option to SlackConfig — react with the configured emoji (e.g. `:x:`) to cancel an in-flight request
- Intercepts `reaction_added` events in Socket Mode, synthesizes a `/stop` message scoped to the correct thread
- Fixes `finalize_draft` fallback paths to preserve `thread_ts` — previously when `chat.update` failed, fallback sends lost thread context and posted to channel root

## Config
```toml
[channels_config.slack]
cancel_reaction = "x"
```

## Test plan
- [ ] Set `cancel_reaction = "x"` in Slack config
- [ ] Send a message that triggers a long-running response
- [ ] React with `:x:` on the bot's draft message — verify it cancels
- [ ] Trigger a finalize_draft fallback (e.g. very long response) — verify message stays in thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)