### PR TITLE
feat(debug): add structured logging for tool calls, drafts, and responses

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -1992,7 +1992,6 @@ struct StreamedChatOutcome {
     forwarded_live_deltas: bool,
 }
 
-
 async fn consume_provider_streaming_response(
     provider: &dyn Provider,
     messages: &[ChatMessage],
@@ -3049,7 +3048,8 @@ pub(crate) async fn run_tool_call_loop(
 
             let signature = {
                 let canonical_args = canonicalize_json_for_tool_signature(&tool_args);
-                let args_json = serde_json::to_string(&canonical_args).unwrap_or_else(|_| "{}".to_string());
+                let args_json =
+                    serde_json::to_string(&canonical_args).unwrap_or_else(|_| "{}".to_string());
                 (tool_name.trim().to_ascii_lowercase(), args_json)
             };
             let dedup_exempt = dedup_exempt_tools.iter().any(|e| e == &tool_name);
@@ -3113,7 +3113,9 @@ pub(crate) async fn run_tool_call_loop(
                 let hint = {
                     let raw = match tool_name.as_str() {
                         "shell" => tool_args.get("command").and_then(|v| v.as_str()),
-                        "file_read" | "file_write" => tool_args.get("path").and_then(|v| v.as_str()),
+                        "file_read" | "file_write" => {
+                            tool_args.get("path").and_then(|v| v.as_str())
+                        }
                         _ => tool_args
                             .get("action")
                             .and_then(|v| v.as_str())
@@ -3132,6 +3134,12 @@ pub(crate) async fn run_tool_call_loop(
                 tracing::debug!(tool = %tool_name, "Sending progress start to draft");
                 let _ = tx.send(DraftEvent::Progress(progress)).await;
             }
+
+            tracing::debug!(
+                tool = %tool_name,
+                args = %truncate_with_ellipsis(&tool_args.to_string(), 500),
+                "Tool call request"
+            );
 
             executable_indices.push(idx);
             executable_calls.push(ParsedToolCall {
@@ -3166,6 +3174,14 @@ pub(crate) async fn run_tool_call_loop(
             .zip(executable_calls.iter())
             .zip(executed_outcomes.into_iter())
         {
+            tracing::debug!(
+                tool = %call.name,
+                success = outcome.success,
+                duration_ms = outcome.duration.as_millis() as u64,
+                output = %truncate_with_ellipsis(&scrub_credentials(&outcome.output), 500),
+                "Tool call result"
+            );
+
             runtime_trace::record_event(
                 "tool_call_result",
                 Some(channel_name),

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -634,6 +634,7 @@ fn build_channel_system_prompt(
     base_prompt: &str,
     channel_name: &str,
     reply_target: &str,
+    thread_ts: Option<&str>,
 ) -> String {
     let mut prompt = base_prompt.to_string();
 
@@ -665,12 +666,16 @@ fn build_channel_system_prompt(
     }
 
     if !reply_target.is_empty() {
+        let thread_part = thread_ts
+            .map(|ts| format!(", thread_ts={ts}"))
+            .unwrap_or_default();
         let context = format!(
             "\n\nChannel context: You are currently responding on channel={channel_name}, \
-             reply_target={reply_target}. When scheduling delayed messages or reminders \
+             reply_target={reply_target}{thread_part}. When scheduling delayed messages or reminders \
              via cron_add for this conversation, use delivery={{\"mode\":\"announce\",\
              \"channel\":\"{channel_name}\",\"to\":\"{reply_target}\"}} so the message \
-             reaches the user."
+             reaches the user. When uploading files to Slack, always include thread_ts={reply_target}{thread_part} \
+             to keep uploads in the current thread."
         );
         prompt.push_str(&context);
     }
@@ -2578,8 +2583,12 @@ async fn process_channel_message(
     } else {
         refreshed_new_session_system_prompt(ctx.as_ref())
     };
-    let mut system_prompt =
-        build_channel_system_prompt(&base_system_prompt, &msg.channel, &msg.reply_target);
+    let mut system_prompt = build_channel_system_prompt(
+        &base_system_prompt,
+        &msg.channel,
+        &msg.reply_target,
+        msg.thread_ts.as_deref(),
+    );
     if !memory_context.is_empty() {
         let _ = write!(system_prompt, "\n\n{memory_context}");
     }
@@ -2643,9 +2652,11 @@ async fn process_channel_message(
                 while let Some(event) = rx.recv().await {
                     match event {
                         DraftEvent::Clear => {
+                            tracing::debug!("Draft stream: clear");
                             accumulated.clear();
                         }
                         DraftEvent::Progress(text) => {
+                            tracing::debug!(text = %text.trim(), "Draft stream: progress");
                             if let Err(e) = channel
                                 .update_draft_progress(&reply_target, &draft_id, &text)
                                 .await
@@ -2654,6 +2665,11 @@ async fn process_channel_message(
                             }
                         }
                         DraftEvent::Content(text) => {
+                            tracing::debug!(
+                                chunk_len = text.len(),
+                                total_len = accumulated.len() + text.len(),
+                                "Draft stream: content chunk"
+                            );
                             accumulated.push_str(&text);
                             if let Err(e) = channel
                                 .update_draft(&reply_target, &draft_id, &accumulated)
@@ -2664,6 +2680,7 @@ async fn process_channel_message(
                         }
                     }
                 }
+                tracing::debug!(total_len = accumulated.len(), "Draft stream: complete");
             }))
         } else {
             None
@@ -3064,6 +3081,11 @@ async fn process_channel_message(
                 "  🤖 Reply ({}ms): {}",
                 started_at.elapsed().as_millis(),
                 truncate_with_ellipsis(&delivered_response, 80)
+            );
+            tracing::debug!(
+                response = %truncate_with_ellipsis(&delivered_response, 2000),
+                elapsed_ms = started_at.elapsed().as_millis() as u64,
+                "Full LLM response"
             );
             if let Some(channel) = target_channel.as_ref() {
                 if let Some(ref draft_id) = draft_message_id {


### PR DESCRIPTION
## Summary
- Logs tool call requests (name + args) and results (success, duration, output) at debug level
- Logs draft stream events: clear, progress, content chunks with lengths, stream completion
- Logs full LLM response text at debug level (truncated to 2000 chars)
- Passes `thread_ts` into the channel system prompt so the LLM knows its thread context

Previously there was no way to see what tool calls the agent made or what the LLM responded with in container logs — only a truncated 80-char summary was printed to stdout.

## Test plan
- [ ] Set `RUST_LOG=debug`, send a message that triggers tool calls
- [ ] Verify logs show `Tool call request`, `Tool call result`, `Draft stream:`, and `Full LLM response`
- [ ] Verify `thread_ts` appears in the channel context when responding in a thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)