### PR TITLE
fix(onboard): preserve existing channel config when re-configuring

### DIFF
--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -7926,7 +7926,7 @@ mod tests {
 
     #[test]
     fn channels_fresh_install_starts_empty() {
-        let config: ChannelsConfig = None.unwrap_or_default();
+        let config = ChannelsConfig::default();
         assert!(config.discord.is_none());
         assert!(config.matrix.is_none());
         assert!(config.telegram.is_none());


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `zeroclaw onboard --channels-only` overwrites entire channel config — re-configuring Matrix destroys Discord, and re-configuring any single field resets non-prompted fields to hardcoded defaults
- Why it matters: S1 data loss on production deployments. Users lose all channel configs when updating one token. Reported 3 times (#4655).
- What changed: Pass existing `ChannelsConfig` to `setup_channels()` so untouched channels survive. Pre-populate prompts with existing values for all 13 channels. Preserve non-prompted fields from existing config instead of hardcoding defaults.
- What did **not** change: Full `zeroclaw onboard` (intentionally replaces everything). `Config::save()` serialization. Secret encryption.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: M`
- Scope labels: `onboard, config`
- Module labels: `onboard: wizard`
- Contributor tier label: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #4655
- Supersedes #4689 (addresses cross-channel only, not intra-channel; unresponsive author)

## Validation Evidence (required)

```bash
cargo fmt --all -- --check     # clean
cargo clippy --all-targets -- -D warnings  # clean
cargo test --lib               # 5801 pass
```

- Evidence provided: 4 new tests — cross-channel preservation, intra-channel field preservation, fresh install defaults
- If any command is intentionally skipped: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? Yes — access tokens and recovery keys show "(Enter to keep existing)" with masked input; empty input preserves existing encrypted value
- File system access scope changed? No
- If Yes: Existing encrypted secrets are preserved when user presses Enter. No new exposure — same encryption path as before.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: Token prompts use `dialoguer::Password` (masked input)
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No — `setup_channels()` signature changed internally but external behavior is preserved
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (wizard text unchanged, only behavior)

## Human Verification (required)

- Verified scenarios: Pending deployment test
- Edge cases checked: Token keep-existing with empty input, non-prompted field preservation across all 13 channels
- What was not verified: Full onboard wizard flow with multiple channels configured

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `onboard/wizard.rs` — `setup_channels()` and all 13 channel setup blocks
- Potential unintended effects: Channels that were already configured show "✅ connected" from the start in the menu
- Guardrails/monitoring: Existing channel setup validation (connection tests)

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (Opus 4.6)
- Workflow/plan summary: Identified two levels of data loss (cross-channel, intra-channel). Applied Matrix preservation pattern to all 13 channels.
- Verification focus: No field loss on re-configuration
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: Revert commits, redeploy
- Feature flags or config toggles: None
- Observable failure symptoms: If reverted, `--channels-only` destroys other channels again

## Risks and Mitigations

- Risk: 13 channel setup blocks modified — large surface area
  - Mitigation: Each follows the same pattern. Existing tests + 4 new tests cover the invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)