### PR TITLE
fix(transcription): allow OpenAI STT env key fallback

### DIFF
--- a/src/channels/transcription.rs
+++ b/src/channels/transcription.rs
@@ -229,7 +229,22 @@ impl OpenAiWhisperProvider {
             .map(str::trim)
             .filter(|v| !v.is_empty())
             .map(ToOwned::to_owned)
-            .context("Missing OpenAI STT API key: set [transcription.openai].api_key")?;
+            .or_else(|| {
+                std::env::var("TRANSCRIPTION_API_KEY")
+                    .ok()
+                    .map(|v| v.trim().to_string())
+                    .filter(|v| !v.is_empty())
+            })
+            .or_else(|| {
+                std::env::var("OPENAI_API_KEY")
+                    .ok()
+                    .map(|v| v.trim().to_string())
+                    .filter(|v| !v.is_empty())
+            })
+            .context(
+                "Missing OpenAI STT API key: set [transcription.openai].api_key, \
+                 TRANSCRIPTION_API_KEY, or OPENAI_API_KEY",
+            )?;
 
         Ok(Self {
             api_key,
@@ -883,6 +898,42 @@ pub async fn transcribe_audio(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::OnceLock;
+    use tokio::sync::Mutex;
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(value) = &self.previous {
+                std::env::set_var(self.key, value);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
 
     #[tokio::test]
     async fn rejects_oversized_audio() {
@@ -900,10 +951,10 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_missing_api_key() {
-        // Ensure all candidate keys are absent for this test.
-        std::env::remove_var("GROQ_API_KEY");
-        std::env::remove_var("OPENAI_API_KEY");
-        std::env::remove_var("TRANSCRIPTION_API_KEY");
+        let _lock = env_lock().lock().await;
+        let _groq = EnvVarGuard::unset("GROQ_API_KEY");
+        let _openai = EnvVarGuard::unset("OPENAI_API_KEY");
+        let _transcription = EnvVarGuard::unset("TRANSCRIPTION_API_KEY");
 
         let data = vec![0u8; 100];
         let config = TranscriptionConfig::default();
@@ -919,7 +970,8 @@ mod tests {
 
     #[tokio::test]
     async fn uses_config_api_key_without_groq_env() {
-        std::env::remove_var("GROQ_API_KEY");
+        let _lock = env_lock().lock().await;
+        let _groq = EnvVarGuard::unset("GROQ_API_KEY");
 
         let data = vec![0u8; 100];
         let mut config = TranscriptionConfig::default();
@@ -937,6 +989,10 @@ mod tests {
 
     #[tokio::test]
     async fn openai_default_provider_uses_openai_config() {
+        let _lock = env_lock().lock().await;
+        let _transcription = EnvVarGuard::unset("TRANSCRIPTION_API_KEY");
+        let _openai = EnvVarGuard::unset("OPENAI_API_KEY");
+
         let data = vec![0u8; 100];
         let mut config = TranscriptionConfig::default();
         config.default_provider = "openai".to_string();
@@ -949,9 +1005,39 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
-            err.to_string().contains("[transcription.openai].api_key"),
+            err.to_string().contains("TRANSCRIPTION_API_KEY"),
             "expected openai-specific missing-key error, got: {err}"
         );
+    }
+
+    #[test]
+    fn openai_provider_uses_transcription_api_key_env_fallback() {
+        let _lock = env_lock().blocking_lock();
+        let _openai = EnvVarGuard::unset("OPENAI_API_KEY");
+        let _transcription = EnvVarGuard::set("TRANSCRIPTION_API_KEY", "stt-env-key");
+
+        let provider = OpenAiWhisperProvider::from_config(&crate::config::OpenAiSttConfig {
+            api_key: None,
+            model: "whisper-1".to_string(),
+        })
+        .expect("provider should use TRANSCRIPTION_API_KEY fallback");
+
+        assert_eq!(provider.api_key, "stt-env-key");
+    }
+
+    #[test]
+    fn openai_provider_uses_openai_api_key_env_fallback() {
+        let _lock = env_lock().blocking_lock();
+        let _transcription = EnvVarGuard::unset("TRANSCRIPTION_API_KEY");
+        let _openai = EnvVarGuard::set("OPENAI_API_KEY", "openai-env-key");
+
+        let provider = OpenAiWhisperProvider::from_config(&crate::config::OpenAiSttConfig {
+            api_key: None,
+            model: "whisper-1".to_string(),
+        })
+        .expect("provider should use OPENAI_API_KEY fallback");
+
+        assert_eq!(provider.api_key, "openai-env-key");
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -1231,6 +1231,7 @@ pub struct ToolFilterGroup {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct OpenAiSttConfig {
     /// OpenAI API key for Whisper transcription.
+    /// Falls back to `TRANSCRIPTION_API_KEY`, then `OPENAI_API_KEY`.
     #[serde(default)]
     pub api_key: Option<String>,
     /// Whisper model name (default: "whisper-1").


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: `transcription.openai` only accepted `[transcription.openai].api_key`, while other transcription paths already support environment-based secret resolution.
- Why it matters: operators cannot keep shared OpenAI STT credentials out of agent-visible TOML, and OpenAI/Groq transcription providers behave inconsistently.
- What changed: `OpenAiWhisperProvider::from_config()` now falls back to `TRANSCRIPTION_API_KEY` and then `OPENAI_API_KEY`; schema docs and focused tests were updated.
- What did **not** change (scope boundary): no provider defaults changed, no network behavior changed, and no non-transcription credential handling was modified.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): expected `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `config,provider,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `provider: transcription`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `provider`

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` ⚠️ failed in pre-existing Bedrock tests: `providers::bedrock::tests::bearer_token_from_env` and `providers::bedrock::tests::chat_fails_without_credentials`
- Additional targeted validation: `cargo test --lib channels::transcription -- --nocapture` ✅ (`39 passed`)
- Evidence provided (test/log/trace/screenshot/perf): command logs from local validation
- If any command is intentionally skipped, explain why: none

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `Yes`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: OpenAI STT now accepts env-based secret resolution, matching existing Groq-style operational patterns. Precedence still prefers explicit config, and no secret is surfaced to the shell by this patch.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no real tokens or identity-like test data added
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `Yes`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: optional only; operators may now omit `[transcription.openai].api_key` when `TRANSCRIPTION_API_KEY` or `OPENAI_API_KEY` is already present

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: explicit OpenAI STT config still works; missing-key path now mentions env fallbacks; `TRANSCRIPTION_API_KEY` fallback works; `OPENAI_API_KEY` fallback works
- Edge cases checked: env-dependent tests are serialized with a local mutex to avoid parallel test races; empty env values are ignored
- What was not verified: live OpenAI API calls with real credentials

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: transcription provider initialization; transcription test module
- Potential unintended effects: environments that accidentally export `OPENAI_API_KEY` may now satisfy STT auth where they previously failed fast
- Guardrails/monitoring for early detection: explicit config still has highest precedence; targeted tests cover fallback order and missing-key behavior

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local shell, git, GitHub CLI
- Workflow/plan summary (if any): isolated the OpenAI-only inconsistency, applied the minimal provider/schema/test patch, then validated on `upstream/master`
- Verification focus: fallback precedence, deterministic env tests, no scope expansion outside transcription
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed

## Rollback Plan (required)

- Fast rollback command/path: revert this PR commit from `master`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: unexpected OpenAI STT credential resolution from environment instead of failing on missing config

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: operators with a generic `OPENAI_API_KEY` in process env may observe OpenAI STT initializing where it previously required explicit config.
  - Mitigation: explicit `[transcription.openai].api_key` still wins, and tests lock in the fallback order and missing-key messaging.
