### PR TITLE
fix(observability): use local timezone for runtime_trace timestamps

### DIFF
--- a/src/observability/runtime_trace.rs
+++ b/src/observability/runtime_trace.rs
@@ -1,6 +1,6 @@
 use crate::config::ObservabilityConfig;
 use anyhow::Result;
-use chrono::Utc;
+use chrono::{Local, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fs::{self, OpenOptions};
@@ -213,7 +213,7 @@ pub fn record_event(
 
     let event = RuntimeTraceEvent {
         id: Uuid::new_v4().to_string(),
-        timestamp: Utc::now().to_rfc3339(),
+        timestamp: Local::now().to_rfc3339(),
         event_type: event_type.to_string(),
         channel: channel.map(str::to_string),
         provider: provider.map(str::to_string),


### PR DESCRIPTION
## Summary
- Replace `Utc::now()` with `Local::now()` in `record_event()` so runtime trace timestamps match the device's local timezone instead of UTC
- This aligns trace logs with system logs and `date` output, making debugging time-sensitive issues straightforward

## Changes
- `src/observability/runtime_trace.rs`: Import `chrono::Local`, use `Local::now().to_rfc3339()` for event timestamps
- Internal-only uses (temp file naming) remain `Utc` for consistency

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --lib observability::runtime_trace` — all 4 tests pass
- [x] Verified `Local::now().to_rfc3339()` includes timezone offset in output

Closes #4816