### PR TITLE
feat(channel): add inbound image support for Discord

### DIFF
--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -1,5 +1,6 @@
 use super::traits::{Channel, ChannelMessage, SendMessage};
 use async_trait::async_trait;
+use base64::Engine as _;
 use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex;
 use reqwest::multipart::{Form, Part};
@@ -121,11 +122,38 @@ impl DiscordChannel {
     }
 }
 
+/// Maximum image attachment size (bytes) that will be downloaded and inlined.
+const DISCORD_IMAGE_MAX_BYTES: usize = 5 * 1024 * 1024;
+
+/// MIME types accepted for inline image attachments.
+const DISCORD_IMAGE_MIME_TYPES: &[&str] = &[
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+    "image/gif",
+    "image/bmp",
+];
+
+/// Check if a content type is a supported image MIME type.
+fn is_supported_image_mime(content_type: &str) -> bool {
+    let normalized = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim();
+    DISCORD_IMAGE_MIME_TYPES
+        .iter()
+        .any(|&m| m.eq_ignore_ascii_case(normalized))
+}
+
 /// Process Discord message attachments and return a string to append to the
 /// agent message context.
 ///
-/// Only `text/*` MIME types are fetched and inlined. All other types are
-/// silently skipped. Fetch errors are logged as warnings.
+/// - `text/*` MIME types are fetched and inlined as text.
+/// - `image/*` MIME types (png, jpeg, webp, gif, bmp) are fetched, base64-encoded,
+///   and emitted as `[IMAGE:data:<mime>;base64,<data>]` markers for the multimodal
+///   pipeline.
+/// - All other types are silently skipped. Fetch errors are logged as warnings.
 async fn process_attachments(
     attachments: &[serde_json::Value],
     client: &reqwest::Client,
@@ -156,6 +184,38 @@ async fn process_attachments(
                 }
                 Err(e) => {
                     tracing::warn!(name, error = %e, "discord attachment fetch error");
+                }
+            }
+        } else if is_supported_image_mime(ct) {
+            match client.get(url).send().await {
+                Ok(resp) if resp.status().is_success() => match resp.bytes().await {
+                    Ok(bytes) => {
+                        if bytes.len() > DISCORD_IMAGE_MAX_BYTES {
+                            tracing::warn!(
+                                name,
+                                size = bytes.len(),
+                                max = DISCORD_IMAGE_MAX_BYTES,
+                                "discord: image attachment too large, skipping"
+                            );
+                            continue;
+                        }
+                        let mime = ct.split(';').next().unwrap_or(ct).trim();
+                        let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                        parts.push(format!("[IMAGE:data:{mime};base64,{encoded}]"));
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            name,
+                            error = %e,
+                            "discord: failed to read image attachment bytes"
+                        );
+                    }
+                },
+                Ok(resp) => {
+                    tracing::warn!(name, status = %resp.status(), "discord image attachment fetch failed");
+                }
+                Err(e) => {
+                    tracing::warn!(name, error = %e, "discord image attachment fetch error");
                 }
             }
         } else {
@@ -2182,6 +2242,38 @@ mod tests {
         })];
         let result = process_attachments(&attachments, &client).await;
         assert!(result.is_empty());
+    }
+
+    // is_supported_image_mime tests
+
+    #[test]
+    fn is_supported_image_mime_accepts_known_types() {
+        assert!(is_supported_image_mime("image/png"));
+        assert!(is_supported_image_mime("image/jpeg"));
+        assert!(is_supported_image_mime("image/webp"));
+        assert!(is_supported_image_mime("image/gif"));
+        assert!(is_supported_image_mime("image/bmp"));
+    }
+
+    #[test]
+    fn is_supported_image_mime_strips_charset_params() {
+        assert!(is_supported_image_mime("image/png; charset=utf-8"));
+        assert!(is_supported_image_mime("image/jpeg; boundary=something"));
+    }
+
+    #[test]
+    fn is_supported_image_mime_rejects_unsupported() {
+        assert!(!is_supported_image_mime("image/svg+xml"));
+        assert!(!is_supported_image_mime("image/tiff"));
+        assert!(!is_supported_image_mime("application/pdf"));
+        assert!(!is_supported_image_mime("text/plain"));
+        assert!(!is_supported_image_mime(""));
+    }
+
+    #[test]
+    fn is_supported_image_mime_case_insensitive() {
+        assert!(is_supported_image_mime("Image/PNG"));
+        assert!(is_supported_image_mime("IMAGE/JPEG"));
     }
 
     #[test]


### PR DESCRIPTION
Discord's `process_attachments()` previously only handled `text/*` MIME types, silently discarding image attachments with a debug log. This meant users sending images on Discord got no visual understanding from the agent.

Add support for `image/png`, `image/jpeg`, `image/webp`, `image/gif`, and `image/bmp` attachments by downloading, base64-encoding, and emitting `[IMAGE:data:...]` markers that feed into the existing multimodal pipeline.

- Add `DISCORD_IMAGE_MAX_BYTES` (5 MB) constant and `DISCORD_IMAGE_MIME_TYPES` list
- Add `is_supported_image_mime()` helper with charset-param stripping
- Extend `process_attachments()` with an image branch matching Slack's pattern
- Add 4 unit tests for `is_supported_image_mime()`

## Summary

- Base branch target: `master`
- Problem: Discord's `process_attachments()` silently discarded image attachments, logging only a debug message. Vision-capable providers never saw images sent on Discord.
- Why it matters: Telegram and Slack already support inbound images through the multimodal pipeline. Discord users were getting a degraded experience despite the infrastructure being in place.
- What changed: Added an image-handling branch in `process_attachments()` that downloads supported image attachments, enforces a 5 MB size limit, base64-encodes the bytes, and emits `[IMAGE:data:<mime>;base64,<data>]` markers. Added a helper function and 4 unit tests.
- What did **not** change (scope boundary): Outbound image handling, other channels, the multimodal pipeline, provider image processing. Only the inbound attachment path in `discord.rs` was modified.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `channel`
- Module labels: `channel: discord`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A — not superseding any PR.

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check          # PASS
cargo clippy --all-targets -- -D warnings  # PASS (pre-existing warnings in schema.rs only; none from this change)
cargo check --all-targets           # PASS
cargo test                          # Could not complete locally (see note below)
```

- Evidence provided: `cargo check --all-targets`, `clippy`, and `fmt` all pass. 4 new unit tests for `is_supported_image_mime()` compile successfully.
- If any command is intentionally skipped, explain why: `cargo test` could not finish locally — the Windows debug test binary hits `STATUS_STACK_BUFFER_OVERRUN` during linking (a known Windows/MSVC stack-size issue unrelated to this change). Tests are verified to compile via `cargo check --all-targets`. CI will run them.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (uses the same `reqwest::Client` already used for text attachment fetches)
- Secrets/tokens handling changed? No
- File system access scope changed? No (images are base64-encoded in memory, never written to disk)
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: Image data is ephemeral — base64-encoded in memory and passed through the multimodal pipeline, same as Telegram and Slack.
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Code review of the full diff; `cargo check`/`clippy`/`fmt` pass; marker format matches what `parse_image_markers()` in `multimodal.rs` expects.
- Edge cases checked: Oversized images (>5 MB) are skipped with a warning. Unsupported MIME types (`image/svg+xml`, `image/tiff`) are rejected. Charset parameters in content-type headers are stripped before matching. MIME comparison is case-insensitive.
- I did test it end-to-end, after the fix I can send an image to the zeroclaw agent in discord and ask it to describe the contents of a photo and it did a good job

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Discord channel inbound message processing only.
- Potential unintended effects: Slightly higher memory usage when processing messages with image attachments (~33% expansion from base64). Bounded by the 5 MB per-attachment limit.
- Guardrails/monitoring for early detection: `tracing::warn` logs on oversized images and fetch failures. The multimodal pipeline's `max_images` and `max_image_size_mb` config settings provide downstream limits.

## Agent Collaboration Notes (recommended)

- Agent tools used: GitHub Copilot (code implementation)
- Workflow/plan summary: Diagnosed bug (Discord silently dropping images) → studied Slack's working `download_private_image_as_marker()` approach → implemented matching pattern for Discord → added unit tests → validated with check/clippy/fmt
- Verification focus: MIME type matching correctness, size limit enforcement, marker format compatibility with `multimodal.rs`
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles (if any): None added; existing `multimodal.max_images` and `multimodal.max_image_size_mb` config provide implicit control.
- Observable failure symptoms: Discord image messages would stop being understood by vision providers; agent would respond as if no image was attached.

## Risks and Mitigations

- Risk: Large images temporarily increase memory usage during base64 encoding.
  - Mitigation: 5 MB hard limit per attachment (`DISCORD_IMAGE_MAX_BYTES`), matching Slack's limit. Downstream multimodal config caps provide additional protection.