### PR TITLE
fix(browser): add missing return in native snapshot script

### DIFF
--- a/src/tools/browser.rs
+++ b/src/tools/browser.rs
@@ -1727,7 +1727,7 @@ mod native_backend {
             .unwrap_or_else(|| "null".to_string());
 
         format!(
-            r#"(() => {{
+            r#"return (() => {{
   const interactiveOnly = {interactive_only};
   const compact = {compact};
   const maxDepth = {depth_literal};


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The `rust_native` browser backend's `snapshot_script()` generates a JavaScript IIFE passed to WebDriver's `ExecuteScript` command. Per the W3C WebDriver spec, `ExecuteScript` wraps the provided script in an anonymous function body, so the script must use an explicit `return` to pass back its result. Without it, the IIFE executes but its return value is discarded — `ExecuteScript` always returns `null`.
- Why it matters: Every `rust_native` snapshot call returns `{"data": null}`, completely breaking page content extraction. The agent cannot see any page content and reports "the page didn't load" even though Chrome successfully navigated and rendered the page.
- What changed: Added `return` keyword before the IIFE in `snapshot_script()` so the anonymous wrapper function returns the snapshot result to the WebDriver client.
- What did **not** change (scope boundary): No other browser actions, no other backends (`agent_browser`, `computer_use`), no snapshot script logic or DOM walking behavior. Only the single missing `return` keyword.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `tool`
- Module labels: `tool: browser`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `tool`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check     # PASS
cargo clippy --all-targets -- -D warnings  # PASS
cargo check --all-targets      # PASS
cargo test                     # Blocked by Windows linker issue (pre-existing); CI will validate
```

- Evidence provided: Verified via chromedriver verbose logs that the snapshot JS executes successfully (`document.readyState === "complete"`, page URL confirmed) but `RESPONSE ExecuteScript null` due to the missing `return`. After the fix, the script returns the snapshot object instead of `undefined`.
- If any command is intentionally skipped, explain why: `cargo test` could not complete locally due to a pre-existing Windows linker stack overflow on the debug test binary. CI will run tests.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- If any Yes, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Reproduced the bug in a live K8s deployment with `zenika/alpine-chrome:with-chromedriver`. Chromedriver verbose logs confirm: page navigates successfully (`readyState: complete`), `ExecuteScript` receives the snapshot IIFE, Chrome evaluates it (DOM walking runs), but the WebDriver response is `{"status":0,"value":null}` because the outer function wrapper has no `return` statement.
- Edge cases checked: `snapshot_script()` is only called from `BrowserAction::Snapshot` via `client.execute()`, which always goes through WebDriver `ExecuteScript`. The `return` keyword is required in all WebDriver execution contexts.
- TI did test it and it does get snapshots successfully after the fix.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `rust_native` browser backend snapshot action only
- Potential unintended effects: None — this is a pure bugfix. The snapshot was always returning `null`; now it returns the intended DOM snapshot object.
- Guardrails/monitoring for early detection: Existing runtime trace logs show snapshot `data` field — non-null values confirm the fix is working.

## Agent Collaboration Notes (recommended)

- Agent tools used: GitHub Copilot (root cause analysis from chromedriver logs, fix implementation, PR creation)
- Workflow/plan summary: User reported browser returning "page didn't load". Analyzed runtime traces showing snapshot returning `{"data": null}` in 50ms. Read `snapshot_script()` source and identified the W3C WebDriver `ExecuteScript` contract mismatch. Confirmed via chromedriver verbose logs showing `RESPONSE ExecuteScript null`. Applied one-word fix.
- Verification focus: WebDriver ExecuteScript semantics, chromedriver log analysis
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: Revert this single commit
- Feature flags or config toggles (if any): Users can switch to `backend = "agent_browser"` as a workaround
- Observable failure symptoms: `rust_native` browser snapshots returning `{"data": null}` (same as current broken state)

## Risks and Mitigations

None — single-keyword fix restoring intended behavior.