### PR TITLE
fix(browser): remove double-escaped quotes in browser CSS selectors

### DIFF
--- a/src/tools/browser.rs
+++ b/src/tools/browser.rs
@@ -1566,10 +1566,10 @@ mod native_backend {
     fn selector_for_find(by: &str, value: &str) -> String {
         let escaped = css_attr_escape(value);
         match by {
-            "role" => format!(r#"[role=\"{escaped}\"]"#),
+            "role" => format!("[role=\"{escaped}\"]"),
             "label" => format!("label={value}"),
-            "placeholder" => format!(r#"[placeholder=\"{escaped}\"]"#),
-            "testid" => format!(r#"[data-testid=\"{escaped}\"]"#),
+            "placeholder" => format!("[placeholder=\"{escaped}\"]"),
+            "testid" => format!("[data-testid=\"{escaped}\"]"),
             _ => format!("text={value}"),
         }
     }
@@ -1657,7 +1657,7 @@ mod native_backend {
 
         if trimmed.starts_with('@') {
             let escaped = css_attr_escape(trimmed);
-            return SelectorKind::Css(format!(r#"[data-zc-ref=\"{escaped}\"]"#));
+            return SelectorKind::Css(format!("[data-zc-ref=\"{escaped}\"]"));
         }
 
         SelectorKind::Css(trimmed.to_string())


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: `parse_selector` and `selector_for_find` in the browser tool used `r#"..."#` raw string literals with `\"` inside, producing literal backslash-quote characters in CSS selectors (e.g., `[data-zc-ref=\"@e25\"]`) instead of valid attribute selectors (`[data-zc-ref="@e25"]`). This caused every `@`-ref based `click`, `fill`, and `hover` action to fail with `Failed to find element by CSS`, even though `snapshot` correctly injected `data-zc-ref` attributes into the DOM.
- Why it matters: The browser tool is completely unable to interact with any element via ref selectors. The agent loops retrying until it exhausts `max_iterations` (default 25), wasting tokens and providing no useful result.
- What changed: Replaced `r#"[attr=\"{v}\"]"#` with `"[attr=\"{v}\"]"` in `parse_selector` (for `@`-ref selectors) and `selector_for_find` (for `role`, `placeholder`, `testid` selectors) so the generated CSS is valid.
- What did **not** change (scope boundary): No changes to snapshot ref injection, tool schema, fill/click logic, or any other tool. Only the 4 format strings that produced invalid CSS.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `tool`
- Module labels: `tool: browser`
- Contributor tier label: N/A (first contribution)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `tool`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check   # pass (no diffs in browser.rs)
cargo clippy --all-targets -- -D warnings  # no warnings in browser.rs (pre-existing warnings elsewhere)
cargo check --all-targets    # pass — Finished dev profile
```

- Evidence provided: compilation verification, diff review, traced the original failure through 25-iteration agent log showing the exact CSS selector mismatch
- If any command is intentionally skipped, explain why: `cargo test` not run locally (browser tests require WebDriver); the fix is a string literal change with no logic branch differences

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: N/A

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No`

## Human Verification (required)

- Verified scenarios: Traced a full 25-iteration agent JSONL log where every `click`/`fill` via `@e` ref failed with `Failed to find element by CSS '[data-zc-ref=\"@e25\"]'`. Confirmed the `r#"..."#` raw string literal produces literal `\` characters. Confirmed the fix generates valid `[data-zc-ref="@e25"]`.
- Edge cases checked: `css_attr_escape` still properly escapes values containing `"`, `\`, or newlines for injection into the corrected format strings.
- What was not verified: Live browser fill/click (requires WebDriver runtime).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Browser tool — all ref-based element interactions (`click`, `fill`, `hover`, `select_option`) and `find` actions using `role`, `placeholder`, `testid`.
- Potential unintended effects: None — this is a strict bugfix. The previous selectors never matched anything, so no existing working behavior changes.
- Guardrails/monitoring for early detection: Any browser-based agent task exercising `click`/`fill` will immediately validate the fix.

## Agent Collaboration Notes (recommended)

- Agent tools used: VS Code Copilot (code analysis, root cause identification from agent log trace)
- Workflow/plan summary: Analyzed 25-iteration JSONL agent log → identified `snapshot` succeeded but `click`/`fill` always failed → traced to `parse_selector` producing invalid CSS from raw string escaping → applied minimal fix → verified compilation
- Verification focus: String literal semantics in Rust raw strings vs regular strings
