### PR TITLE
style: fix rustfmt lint failures in uf2 and uno_q_bridge tests

### DIFF
--- a/src/hardware/uf2.rs
+++ b/src/hardware/uf2.rs
@@ -364,7 +364,10 @@ mod tests {
         // Either succeeds (real UF2) or fails with a clear placeholder message.
         match result {
             Ok(dir) => {
-                assert!(dir.exists(), "firmware dir should exist after ensure_firmware_dir");
+                assert!(
+                    dir.exists(),
+                    "firmware dir should exist after ensure_firmware_dir"
+                );
                 assert!(dir.ends_with("pico"), "firmware dir should end with 'pico'");
             }
             Err(e) => {
@@ -416,7 +419,10 @@ mod tests {
 
         let port = std::path::Path::new("/dev/ttyACM_fake_test");
         let result = deploy_main_py(port, firmware_dir).await;
-        assert!(result.is_err(), "deploy should fail when main.py is missing");
+        assert!(
+            result.is_err(),
+            "deploy should fail when main.py is missing"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("main.py not found"),

--- a/src/peripherals/uno_q_bridge.rs
+++ b/src/peripherals/uno_q_bridge.rs
@@ -208,7 +208,10 @@ mod tests {
         let tool = UnoQGpioReadTool;
         let result = tool.execute(json!({"pin": 13})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.is_some(), "should report bridge connection error");
+        assert!(
+            result.error.is_some(),
+            "should report bridge connection error"
+        );
     }
 
     // ── UnoQGpioWriteTool ───────────────────────────────────────────────
@@ -277,7 +280,10 @@ mod tests {
         let tool = UnoQGpioWriteTool;
         let result = tool.execute(json!({"pin": 13, "value": 1})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.is_some(), "should report bridge connection error");
+        assert!(
+            result.error.is_some(),
+            "should report bridge connection error"
+        );
     }
 
     // ── Constants ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: `cargo fmt --all -- --check` fails on `master` — 4 `assert!` macro calls have lines exceeding the configured max width
- Why it matters: CI format-check gate is broken on master, blocking contributor PRs
- What changed: Ran `cargo fmt` to reformat 4 `assert!` calls across 2 files (`src/hardware/uf2.rs`, `src/peripherals/uno_q_bridge.rs`)
- What did **not** change (scope boundary): No logic, no test behavior, no production code, no non-formatting edits

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `tests`
- Module labels: N/A (cross-module formatting fix)
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `chore`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes # N/A
- Related # N/A
- Depends on # N/A
- Supersedes # N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A — not superseding any PR.

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check   # ✅ pass after fix (was failing before)
```

- Evidence provided: `cargo fmt --all -- --check` returns exit code 0 after the fix
- If any command is intentionally skipped, explain why: `cargo clippy` and `cargo test` skipped — this is a whitespace-only formatting change with zero semantic impact

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A — no data changes
- Neutral wording confirmation: N/A

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Confirmed `cargo fmt --all -- --check` passes after fix
- Edge cases checked: N/A — formatting only
- What was not verified: Full `cargo test` / `cargo clippy` (not relevant for whitespace-only change)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: None — whitespace-only
- Potential unintended effects: None
- Guardrails/monitoring for early detection: CI format check will validate

## Agent Collaboration Notes (recommended)

- Agent tools used: GitHub Copilot (VS Code)
- Workflow/plan summary: Identified format failures via `cargo fmt --all -- --check`, applied `cargo fmt --all`, committed and pushed
- Verification focus: Format lint pass
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`)

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None
- Observable failure symptoms: `cargo fmt --all -- --check` would fail again

## Risks and Mitigations

None — whitespace-only formatting change.
