### PR TITLE
feat(docs): add GitHub Pages deployment with mdBook

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,53 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - "book.toml"
+      - ".github/workflows/deploy-docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: "latest"
+
+      - name: Build documentation
+        run: mdbook build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./book
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ playground/
 
 # Temporary rustc output
 rust_out
+
+# mdBook build output
+/book

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,16 @@
+[book]
+title = "ZeroClaw Documentation"
+description = "Documentation for ZeroClaw — Personal AI Assistant"
+authors = ["ZeroClaw Labs"]
+language = "en"
+src = "docs"
+
+[build]
+build-dir = "book"
+
+[output.html]
+default-theme = "navy"
+preferred-dark-theme = "navy"
+git-repository-url = "https://github.com/zeroclaw-labs/zeroclaw"
+edit-url-template = "https://github.com/zeroclaw-labs/zeroclaw/edit/master/docs/{path}"
+site-url = "/zeroclaw/"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,110 +1,80 @@
-# ZeroClaw Docs Summary (Unified TOC)
+# Summary
 
-This file is the canonical table of contents for the documentation system.
+[Introduction](README.md)
 
-Last refreshed: **February 18, 2026**.
+---
 
-## Language Entry
+# Getting Started
 
-- Docs Structure Map (language/part/function): [structure/README.md](maintainers/structure-README.md)
-- English README: [../README.md](../README.md)
-- Arabic: [i18n/ar/README.md](i18n/ar/README.md) · [SUMMARY](i18n/ar/SUMMARY.md)
-- Bengali: [i18n/bn/README.md](i18n/bn/README.md) · [SUMMARY](i18n/bn/SUMMARY.md)
-- Czech: [i18n/cs/README.md](i18n/cs/README.md) · [SUMMARY](i18n/cs/SUMMARY.md)
-- Danish: [i18n/da/README.md](i18n/da/README.md) · [SUMMARY](i18n/da/SUMMARY.md)
-- German: [i18n/de/README.md](i18n/de/README.md) · [SUMMARY](i18n/de/SUMMARY.md)
-- Greek: [i18n/el/README.md](i18n/el/README.md) · [SUMMARY](i18n/el/SUMMARY.md)
-- Spanish: [i18n/es/README.md](i18n/es/README.md) · [SUMMARY](i18n/es/SUMMARY.md)
-- Finnish: [i18n/fi/README.md](i18n/fi/README.md) · [SUMMARY](i18n/fi/SUMMARY.md)
-- French: [i18n/fr/README.md](i18n/fr/README.md) · [SUMMARY](i18n/fr/SUMMARY.md)
-- Hebrew: [i18n/he/README.md](i18n/he/README.md) · [SUMMARY](i18n/he/SUMMARY.md)
-- Hindi: [i18n/hi/README.md](i18n/hi/README.md) · [SUMMARY](i18n/hi/SUMMARY.md)
-- Hungarian: [i18n/hu/README.md](i18n/hu/README.md) · [SUMMARY](i18n/hu/SUMMARY.md)
-- Indonesian: [i18n/id/README.md](i18n/id/README.md) · [SUMMARY](i18n/id/SUMMARY.md)
-- Italian: [i18n/it/README.md](i18n/it/README.md) · [SUMMARY](i18n/it/SUMMARY.md)
-- Japanese: [i18n/ja/README.md](i18n/ja/README.md) · [SUMMARY](i18n/ja/SUMMARY.md)
-- Korean: [i18n/ko/README.md](i18n/ko/README.md) · [SUMMARY](i18n/ko/SUMMARY.md)
-- Norwegian Bokmål: [i18n/nb/README.md](i18n/nb/README.md) · [SUMMARY](i18n/nb/SUMMARY.md)
-- Dutch: [i18n/nl/README.md](i18n/nl/README.md) · [SUMMARY](i18n/nl/SUMMARY.md)
-- Polish: [i18n/pl/README.md](i18n/pl/README.md) · [SUMMARY](i18n/pl/SUMMARY.md)
-- Portuguese: [i18n/pt/README.md](i18n/pt/README.md) · [SUMMARY](i18n/pt/SUMMARY.md)
-- Romanian: [i18n/ro/README.md](i18n/ro/README.md) · [SUMMARY](i18n/ro/SUMMARY.md)
-- Russian: [i18n/ru/README.md](i18n/ru/README.md) · [SUMMARY](i18n/ru/SUMMARY.md)
-- Swedish: [i18n/sv/README.md](i18n/sv/README.md) · [SUMMARY](i18n/sv/SUMMARY.md)
-- Thai: [i18n/th/README.md](i18n/th/README.md) · [SUMMARY](i18n/th/SUMMARY.md)
-- Tagalog: [i18n/tl/README.md](i18n/tl/README.md) · [SUMMARY](i18n/tl/SUMMARY.md)
-- Turkish: [i18n/tr/README.md](i18n/tr/README.md) · [SUMMARY](i18n/tr/SUMMARY.md)
-- Ukrainian: [i18n/uk/README.md](i18n/uk/README.md) · [SUMMARY](i18n/uk/SUMMARY.md)
-- Urdu: [i18n/ur/README.md](i18n/ur/README.md) · [SUMMARY](i18n/ur/SUMMARY.md)
-- Vietnamese: [i18n/vi/README.md](i18n/vi/README.md) · [SUMMARY](i18n/vi/SUMMARY.md)
-- Chinese (Simplified): [i18n/zh-CN/README.md](i18n/zh-CN/README.md) · [SUMMARY](i18n/zh-CN/SUMMARY.md)
-- English Docs Hub: [README.md](README.md)
-- i18n Docs Index: [i18n/README.md](i18n/README.md)
-- i18n Coverage Map: [i18n-coverage.md](maintainers/i18n-coverage.md)
+- [Setup Guides](setup-guides/README.md)
+  - [One-Click Bootstrap](setup-guides/one-click-bootstrap.md)
+  - [macOS Update & Uninstall](setup-guides/macos-update-uninstall.md)
+  - [Windows Setup](setup-guides/windows-setup.md)
+  - [Nextcloud Talk Setup](setup-guides/nextcloud-talk-setup.md)
+  - [Mattermost Setup](setup-guides/mattermost-setup.md)
+  - [ZAI GLM Setup](setup-guides/zai-glm-setup.md)
+- [Browser Setup](browser-setup.md)
 
-## Collections
+# References
 
-### 1) Getting Started
+- [Reference Overview](reference/README.md)
+  - [CLI Commands](reference/cli/commands-reference.md)
+  - [Configuration](reference/api/config-reference.md)
+  - [Providers](reference/api/providers-reference.md)
+  - [Channels](reference/api/channels-reference.md)
 
-- [setup-guides/README.md](setup-guides/README.md)
-- [macos-update-uninstall.md](setup-guides/macos-update-uninstall.md)
-- [one-click-bootstrap.md](setup-guides/one-click-bootstrap.md)
+# Architecture
 
-### 2) Command/Config References & Integrations
+- [Aardvark Integration](aardvark-integration.md)
+- [OpenAI Temperature Compatibility](openai-temperature-compatibility.md)
 
-- [reference/README.md](reference/README.md)
-- [commands-reference.md](reference/cli/commands-reference.md)
-- [providers-reference.md](reference/api/providers-reference.md)
-- [channels-reference.md](reference/api/channels-reference.md)
-- [nextcloud-talk-setup.md](setup-guides/nextcloud-talk-setup.md)
-- [config-reference.md](reference/api/config-reference.md)
-- [custom-providers.md](contributing/custom-providers.md)
-- [zai-glm-setup.md](setup-guides/zai-glm-setup.md)
-- [langgraph-integration.md](contributing/langgraph-integration.md)
+# Operations & Deployment
 
-### 3) Operations & Deployment
+- [Operations Overview](ops/README.md)
+  - [Operations Runbook](ops/operations-runbook.md)
+  - [Troubleshooting](ops/troubleshooting.md)
+  - [Network Deployment](ops/network-deployment.md)
+  - [Proxy Agent Playbook](ops/proxy-agent-playbook.md)
+  - [Resource Limits](ops/resource-limits.md)
 
-- [ops/README.md](ops/README.md)
-- [operations-runbook.md](ops/operations-runbook.md)
-- [release-process.md](contributing/release-process.md)
-- [troubleshooting.md](ops/troubleshooting.md)
-- [network-deployment.md](ops/network-deployment.md)
-- [mattermost-setup.md](setup-guides/mattermost-setup.md)
+# Security
 
-### 4) Security Design & Proposals
+- [Security Overview](security/README.md)
+  - [Agnostic Security](security/agnostic-security.md)
+  - [Frictionless Security](security/frictionless-security.md)
+  - [Sandboxing](security/sandboxing.md)
+  - [Audit Logging](security/audit-logging.md)
+  - [Matrix E2EE Guide](security/matrix-e2ee-guide.md)
+  - [Security Roadmap](security/security-roadmap.md)
 
-- [security/README.md](security/README.md)
-- [agnostic-security.md](security/agnostic-security.md)
-- [frictionless-security.md](security/frictionless-security.md)
-- [sandboxing.md](security/sandboxing.md)
-- [resource-limits.md](ops/resource-limits.md)
-- [audit-logging.md](security/audit-logging.md)
-- [security-roadmap.md](security/security-roadmap.md)
+# Hardware & Peripherals
 
-### 5) Hardware & Peripherals
+- [Hardware Overview](hardware/README.md)
+  - [Hardware Peripherals Design](hardware/hardware-peripherals-design.md)
+  - [Nucleo Setup](hardware/nucleo-setup.md)
+  - [Arduino Uno Q Setup](hardware/arduino-uno-q-setup.md)
+  - [Android Setup](hardware/android-setup.md)
+  - [Nucleo F401RE Datasheet](hardware/datasheets/nucleo-f401re.md)
+  - [Arduino Uno Datasheet](hardware/datasheets/arduino-uno.md)
+  - [ESP32 Datasheet](hardware/datasheets/esp32.md)
 
-- [hardware/README.md](hardware/README.md)
-- [hardware-peripherals-design.md](hardware/hardware-peripherals-design.md)
-- [adding-boards-and-tools.md](contributing/adding-boards-and-tools.md)
-- [nucleo-setup.md](hardware/nucleo-setup.md)
-- [arduino-uno-q-setup.md](hardware/arduino-uno-q-setup.md)
-- [datasheets/nucleo-f401re.md](hardware/datasheets/nucleo-f401re.md)
-- [datasheets/arduino-uno.md](hardware/datasheets/arduino-uno.md)
-- [datasheets/esp32.md](hardware/datasheets/esp32.md)
+# Contributing
 
-### 6) Contribution & CI
+- [Contributing Overview](contributing/README.md)
+  - [PR Workflow](contributing/pr-workflow.md)
+  - [Reviewer Playbook](contributing/reviewer-playbook.md)
+  - [CI Map](contributing/ci-map.md)
+  - [Testing](contributing/testing.md)
+  - [Release Process](contributing/release-process.md)
+  - [Custom Providers](contributing/custom-providers.md)
+  - [Adding Boards & Tools](contributing/adding-boards-and-tools.md)
+  - [Extension Examples](contributing/extension-examples.md)
+  - [Actions Source Policy](contributing/actions-source-policy.md)
+  - [CLA](contributing/cla.md)
 
-- [contributing/README.md](contributing/README.md)
-- [../CONTRIBUTING.md](../CONTRIBUTING.md)
-- [pr-workflow.md](contributing/pr-workflow.md)
-- [reviewer-playbook.md](contributing/reviewer-playbook.md)
-- [ci-map.md](contributing/ci-map.md)
-- [actions-source-policy.md](contributing/actions-source-policy.md)
-- [extension-examples.md](contributing/extension-examples.md)
-- [testing.md](contributing/testing.md)
+# Project Status
 
-### 7) Project Status & Snapshot
-
-- [maintainers/README.md](maintainers/README.md)
-- [project-triage-snapshot-2026-02-18.md](maintainers/project-triage-snapshot-2026-02-18.md)
-- [docs-inventory.md](maintainers/docs-inventory.md)
+- [Maintainers Overview](maintainers/README.md)
+  - [Project Triage Snapshot](maintainers/project-triage-snapshot-2026-02-18.md)
+  - [Docs Inventory](maintainers/docs-inventory.md)
+  - [Trademark](maintainers/trademark.md)


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow (`deploy-docs.yml`) to build and deploy the `docs/` directory to GitHub Pages using **mdBook**
- Adds `book.toml` configuration for mdBook with ZeroClaw branding, edit links, and navy theme
- Restructures `docs/SUMMARY.md` into proper mdBook format with nested chapters covering all doc sections (getting started, references, ops, security, hardware, contributing, maintainers)
- Adds `/book` to `.gitignore` for local mdBook builds

## How it works

- On push to `master` (when docs change) or manual dispatch, the workflow builds the docs with mdBook and deploys via `actions/deploy-pages`
- The site will be available at `https://zeroclaw-labs.github.io/zeroclaw/`

## After merging

You'll need to **enable GitHub Pages** in the repo settings:
1. Go to Settings > Pages
2. Under "Build and deployment", select **GitHub Actions** as the source
3. Trigger the workflow manually (or push a docs change) to deploy

## Test plan

- [x] Verified mdBook builds successfully locally with no errors
- [ ] After merging, verify GitHub Pages deployment succeeds
- [ ] Verify the site renders correctly at the Pages URL