### PR TITLE
refactor(tools): apply RateLimitedTool+PathGuardedTool to search tools

### DIFF
--- a/src/tools/content_search.rs
+++ b/src/tools/content_search.rs
@@ -161,54 +161,6 @@ impl Tool for ContentSearchTool {
             .unwrap_or(MAX_RESULTS)
             .min(MAX_RESULTS);
 
-        // --- Rate limit check ---
-        if self.security.is_rate_limited() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
-            });
-        }
-
-        // --- Path security checks ---
-        // Reject absolute paths unless they fall under an explicit allowed root.
-        if std::path::Path::new(search_path).is_absolute()
-            && !self.security.is_under_allowed_root(search_path)
-        {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Absolute paths are not allowed. Use a relative path.".into()),
-            });
-        }
-
-        if search_path.contains("../") || search_path.contains("..\\") || search_path == ".." {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Path traversal ('..') is not allowed.".into()),
-            });
-        }
-
-        if !self.security.is_path_allowed(search_path) {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some(format!(
-                    "Path '{search_path}' is not allowed by security policy."
-                )),
-            });
-        }
-
-        // Record action to consume rate limit budget
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".into()),
-            });
-        }
-
         // --- Resolve search directory ---
         let resolved_path = self.security.resolve_tool_path(search_path);
 
@@ -658,6 +610,7 @@ fn truncate_utf8(input: &str, max_bytes: usize) -> &str {
 mod tests {
     use super::*;
     use crate::security::{AutonomyLevel, SecurityPolicy};
+    use crate::tools::{PathGuardedTool, RateLimitedTool};
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -680,6 +633,15 @@ mod tests {
             max_actions_per_hour,
             ..SecurityPolicy::default()
         })
+    }
+
+    fn wrapped_content_search(
+        security: Arc<SecurityPolicy>,
+    ) -> RateLimitedTool<PathGuardedTool<ContentSearchTool>> {
+        RateLimitedTool::new(
+            PathGuardedTool::new(ContentSearchTool::new(security.clone()), security.clone()),
+            security,
+        )
     }
 
     fn create_test_files(dir: &TempDir) {
@@ -888,26 +850,26 @@ mod tests {
 
     #[tokio::test]
     async fn content_search_rejects_absolute_path() {
-        let tool = ContentSearchTool::new(test_security(std::env::temp_dir()));
+        let tool = wrapped_content_search(test_security(std::env::temp_dir()));
         let result = tool
             .execute(json!({"pattern": "test", "path": "/etc"}))
             .await
             .unwrap();
 
         assert!(!result.success);
-        assert!(result.error.as_ref().unwrap().contains("Absolute paths"));
+        assert!(result.error.as_ref().unwrap().contains("blocked"));
     }
 
     #[tokio::test]
     async fn content_search_rejects_path_traversal() {
-        let tool = ContentSearchTool::new(test_security(std::env::temp_dir()));
+        let tool = wrapped_content_search(test_security(std::env::temp_dir()));
         let result = tool
             .execute(json!({"pattern": "test", "path": "../../../etc"}))
             .await
             .unwrap();
 
         assert!(!result.success);
-        assert!(result.error.as_ref().unwrap().contains("Path traversal"));
+        assert!(result.error.as_ref().unwrap().contains("blocked"));
     }
 
     #[tokio::test]
@@ -915,7 +877,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("file.txt"), "test content\n").unwrap();
 
-        let tool = ContentSearchTool::new(test_security_with(
+        let tool = wrapped_content_search(test_security_with(
             dir.path().to_path_buf(),
             AutonomyLevel::Supervised,
             0,

--- a/src/tools/glob_search.rs
+++ b/src/tools/glob_search.rs
@@ -48,15 +48,6 @@ impl Tool for GlobSearchTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing 'pattern' parameter"))?;
 
-        // Rate limit check (fast path)
-        if self.security.is_rate_limited() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
-            });
-        }
-
         // Security: reject absolute paths unless under an explicit allowed root.
         if (pattern.starts_with('/') || pattern.starts_with('\\'))
             && !self.security.is_under_allowed_root(pattern)
@@ -74,15 +65,6 @@ impl Tool for GlobSearchTool {
                 success: false,
                 output: String::new(),
                 error: Some("Path traversal ('..') is not allowed in glob patterns.".into()),
-            });
-        }
-
-        // Record action to consume rate limit budget
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".into()),
             });
         }
 
@@ -181,6 +163,7 @@ impl Tool for GlobSearchTool {
 mod tests {
     use super::*;
     use crate::security::{AutonomyLevel, SecurityPolicy};
+    use crate::tools::RateLimitedTool;
     use std::path::PathBuf;
     use tempfile::TempDir;
 
@@ -203,6 +186,10 @@ mod tests {
             max_actions_per_hour,
             ..SecurityPolicy::default()
         })
+    }
+
+    fn wrapped_glob_search(security: Arc<SecurityPolicy>) -> RateLimitedTool<GlobSearchTool> {
+        RateLimitedTool::new(GlobSearchTool::new(security.clone()), security)
     }
 
     #[test]
@@ -364,7 +351,7 @@ mod tests {
         let dir = TempDir::new().unwrap();
         std::fs::write(dir.path().join("file.txt"), "").unwrap();
 
-        let tool = GlobSearchTool::new(test_security_with(
+        let tool = wrapped_glob_search(test_security_with(
             dir.path().to_path_buf(),
             AutonomyLevel::Supervised,
             0,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -300,8 +300,14 @@ pub fn default_tools_with_runtime(
         Box::new(FileReadTool::new(security.clone())),
         Box::new(FileWriteTool::new(security.clone())),
         Box::new(FileEditTool::new(security.clone())),
-        Box::new(GlobSearchTool::new(security.clone())),
-        Box::new(ContentSearchTool::new(security)),
+        Box::new(RateLimitedTool::new(
+            GlobSearchTool::new(security.clone()),
+            security.clone(),
+        )),
+        Box::new(RateLimitedTool::new(
+            PathGuardedTool::new(ContentSearchTool::new(security.clone()), security.clone()),
+            security,
+        )),
     ]
 }
 
@@ -421,8 +427,14 @@ pub fn all_tools_with_runtime(
         Arc::new(FileReadTool::new(security.clone())),
         Arc::new(FileWriteTool::new(security.clone())),
         Arc::new(FileEditTool::new(security.clone())),
-        Arc::new(GlobSearchTool::new(security.clone())),
-        Arc::new(ContentSearchTool::new(security.clone())),
+        Arc::new(RateLimitedTool::new(
+            GlobSearchTool::new(security.clone()),
+            security.clone(),
+        )),
+        Arc::new(RateLimitedTool::new(
+            PathGuardedTool::new(ContentSearchTool::new(security.clone()), security.clone()),
+            security.clone(),
+        )),
         Arc::new(CronAddTool::new(config.clone(), security.clone())),
         Arc::new(CronListTool::new(config.clone())),
         Arc::new(CronRemoveTool::new(config.clone(), security.clone())),


### PR DESCRIPTION
## Summary

- Remove inlined `is_rate_limited()` / `record_action()` guard blocks from `GlobSearchTool` and `ContentSearchTool`
- Remove `is_path_allowed()` guard from `ContentSearchTool`; wrap with `RateLimitedTool<PathGuardedTool<ContentSearchTool>>`
- `GlobSearchTool` uses a custom pattern-path validator (`is_under_allowed_root` + pattern-specific traversal error), so only `RateLimitedTool` is applied; custom path guards remain in the tool

## Notes on `GlobSearchTool` design

The glob pattern field is special: `"../foo/**"` needs a glob-specific error message and the absolute-path check uses `is_under_allowed_root` (not just `is_path_allowed`). Applying `PathGuardedTool` would change error message semantics observed by callers. Rate-limiting is the clean win here; path logic stays inline.

## Test plan

- [ ] `glob_search_rate_limited` — uses `wrapped_glob_search()` helper (rate limit from `RateLimitedTool`)
- [ ] `content_search_rejects_absolute_path` — uses `wrapped_content_search()`, asserts `"blocked"` (from `PathGuardedTool`)
- [ ] `content_search_rejects_path_traversal` — same
- [ ] `content_search_rate_limited` — uses `wrapped_content_search()`

## Context

Third PR in the series applying wrappers from `src/tools/wrappers.rs`. Previous PRs: ShellTool (#4828), file tools (#4944). Next: `PdfReadTool`, `ImageInfoTool`, cron tools, AI-CLI tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)