### PR TITLE
refactor(tools): apply wrappers to PdfReadTool and ImageInfoTool

### DIFF
--- a/src/tools/image_info.rs
+++ b/src/tools/image_info.rs
@@ -3,7 +3,6 @@ use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use serde_json::json;
 use std::fmt::Write;
-use std::path::Path;
 use std::sync::Arc;
 
 /// Maximum file size we will read and base64-encode (5 MB).
@@ -156,20 +155,9 @@ impl Tool for ImageInfoTool {
             .and_then(serde_json::Value::as_bool)
             .unwrap_or(false);
 
-        let path = Path::new(path_str);
+        let full_path = self.security.resolve_tool_path(path_str);
 
-        // Restrict reads to workspace directory to prevent arbitrary file exfiltration
-        if !self.security.is_path_allowed(path_str) {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some(format!(
-                    "Path not allowed: {path_str} (must be within workspace)"
-                )),
-            });
-        }
-
-        if !path.exists() {
+        if !full_path.exists() {
             return Ok(ToolResult {
                 success: false,
                 output: String::new(),
@@ -177,7 +165,7 @@ impl Tool for ImageInfoTool {
             });
         }
 
-        let metadata = tokio::fs::metadata(path)
+        let metadata = tokio::fs::metadata(&full_path)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to read file metadata: {e}"))?;
 
@@ -193,7 +181,7 @@ impl Tool for ImageInfoTool {
             });
         }
 
-        let bytes = tokio::fs::read(path)
+        let bytes = tokio::fs::read(&full_path)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to read image file: {e}"))?;
 
@@ -232,6 +220,7 @@ impl Tool for ImageInfoTool {
 mod tests {
     use super::*;
     use crate::security::{AutonomyLevel, SecurityPolicy};
+    use crate::tools::PathGuardedTool;
 
     fn test_security() -> Arc<SecurityPolicy> {
         Arc::new(SecurityPolicy {
@@ -241,6 +230,10 @@ mod tests {
             forbidden_paths: vec![],
             ..SecurityPolicy::default()
         })
+    }
+
+    fn wrapped_image_info(security: Arc<SecurityPolicy>) -> PathGuardedTool<ImageInfoTool> {
+        PathGuardedTool::new(ImageInfoTool::new(security.clone()), security)
     }
 
     #[test]
@@ -489,5 +482,22 @@ mod tests {
         assert!(result.output.contains("data:image/png;base64,"));
 
         let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    // ── PathGuardedTool integration ─────────────────────────────
+
+    #[tokio::test]
+    async fn image_info_blocked_path_returns_error() {
+        let security = Arc::new(SecurityPolicy {
+            autonomy: AutonomyLevel::Full,
+            workspace_dir: std::env::temp_dir(),
+            workspace_only: false,
+            forbidden_paths: vec!["/etc/shadow".to_string()],
+            ..SecurityPolicy::default()
+        });
+        let tool = wrapped_image_info(security);
+        let result = tool.execute(json!({"path": "/etc/shadow"})).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_ref().unwrap().contains("blocked"));
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -731,11 +731,17 @@ pub fn all_tools_with_runtime(
     }
 
     // PDF extraction (feature-gated at compile time via rag-pdf)
-    tool_arcs.push(Arc::new(PdfReadTool::new(security.clone())));
+    tool_arcs.push(Arc::new(RateLimitedTool::new(
+        PathGuardedTool::new(PdfReadTool::new(security.clone()), security.clone()),
+        security.clone(),
+    )));
 
     // Vision tools are always available
     tool_arcs.push(Arc::new(ScreenshotTool::new(security.clone())));
-    tool_arcs.push(Arc::new(ImageInfoTool::new(security.clone())));
+    tool_arcs.push(Arc::new(PathGuardedTool::new(
+        ImageInfoTool::new(security.clone()),
+        security.clone(),
+    )));
 
     // Session-to-session messaging tools (always available when sessions dir exists)
     if let Ok(session_store) = crate::channels::session_store::SessionStore::new(workspace_dir) {

--- a/src/tools/pdf_read.rs
+++ b/src/tools/pdf_read.rs
@@ -75,31 +75,6 @@ impl Tool for PdfReadTool {
             })
             .unwrap_or(DEFAULT_MAX_CHARS);
 
-        if self.security.is_rate_limited() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
-            });
-        }
-
-        if !self.security.is_path_allowed(path) {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some(format!("Path not allowed by security policy: {path}")),
-            });
-        }
-
-        // Record action before canonicalization so path-probing still consumes budget.
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".into()),
-            });
-        }
-
         let full_path = self.security.resolve_tool_path(path);
 
         let resolved_path = match tokio::fs::canonicalize(&full_path).await {
@@ -232,6 +207,7 @@ impl Tool for PdfReadTool {
 mod tests {
     use super::*;
     use crate::security::{AutonomyLevel, SecurityPolicy};
+    use crate::tools::{PathGuardedTool, RateLimitedTool};
     use tempfile::TempDir;
 
     fn test_security(workspace: std::path::PathBuf) -> Arc<SecurityPolicy> {
@@ -252,6 +228,15 @@ mod tests {
             max_actions_per_hour: max_actions,
             ..SecurityPolicy::default()
         })
+    }
+
+    fn wrapped_pdf_read(
+        security: Arc<SecurityPolicy>,
+    ) -> RateLimitedTool<PathGuardedTool<PdfReadTool>> {
+        RateLimitedTool::new(
+            PathGuardedTool::new(PdfReadTool::new(security.clone()), security.clone()),
+            security,
+        )
     }
 
     #[test]
@@ -294,34 +279,22 @@ mod tests {
 
     #[tokio::test]
     async fn absolute_path_is_blocked() {
-        let tool = PdfReadTool::new(test_security(std::env::temp_dir()));
+        let tool = wrapped_pdf_read(test_security(std::env::temp_dir()));
         let result = tool.execute(json!({"path": "/etc/passwd"})).await.unwrap();
         assert!(!result.success);
-        assert!(
-            result
-                .error
-                .as_deref()
-                .unwrap_or("")
-                .contains("not allowed")
-        );
+        assert!(result.error.as_deref().unwrap_or("").contains("blocked"));
     }
 
     #[tokio::test]
     async fn path_traversal_is_blocked() {
         let tmp = TempDir::new().unwrap();
-        let tool = PdfReadTool::new(test_security(tmp.path().to_path_buf()));
+        let tool = wrapped_pdf_read(test_security(tmp.path().to_path_buf()));
         let result = tool
             .execute(json!({"path": "../../../etc/passwd"}))
             .await
             .unwrap();
         assert!(!result.success);
-        assert!(
-            result
-                .error
-                .as_deref()
-                .unwrap_or("")
-                .contains("not allowed")
-        );
+        assert!(result.error.as_deref().unwrap_or("").contains("blocked"));
     }
 
     #[tokio::test]
@@ -345,7 +318,7 @@ mod tests {
     #[tokio::test]
     async fn rate_limit_blocks_request() {
         let tmp = TempDir::new().unwrap();
-        let tool = PdfReadTool::new(test_security_with_limit(tmp.path().to_path_buf(), 0));
+        let tool = wrapped_pdf_read(test_security_with_limit(tmp.path().to_path_buf(), 0));
         let result = tool.execute(json!({"path": "any.pdf"})).await.unwrap();
         assert!(!result.success);
         assert!(result.error.as_deref().unwrap_or("").contains("Rate limit"));
@@ -355,7 +328,7 @@ mod tests {
     async fn probing_nonexistent_consumes_rate_limit_budget() {
         let tmp = TempDir::new().unwrap();
         // Allow 2 actions; both will fail on missing file but must consume budget.
-        let tool = PdfReadTool::new(test_security_with_limit(tmp.path().to_path_buf(), 2));
+        let tool = wrapped_pdf_read(test_security_with_limit(tmp.path().to_path_buf(), 2));
 
         let r1 = tool.execute(json!({"path": "a.pdf"})).await.unwrap();
         assert!(!r1.success);


### PR DESCRIPTION
## Summary

- **PdfReadTool**: remove `is_rate_limited()` / `record_action()` / `is_path_allowed()` inline guards; wrap with `RateLimitedTool<PathGuardedTool<PdfReadTool>>`
- **ImageInfoTool**: remove `is_path_allowed()` inline guard; wrap with `PathGuardedTool<ImageInfoTool>` (no rate-limiting calls were present in this tool)

## Test plan

- [ ] `absolute_path_is_blocked` (pdf_read) — uses `wrapped_pdf_read()`, asserts `"blocked"`
- [ ] `path_traversal_is_blocked` (pdf_read) — same
- [ ] `rate_limit_blocks_request` (pdf_read) — uses `wrapped_pdf_read()`
- [ ] `probing_nonexistent_consumes_rate_limit_budget` (pdf_read) — uses `wrapped_pdf_read()`
- [ ] `image_info_blocked_path_returns_error` (image_info) — **new test** covering the added `PathGuardedTool` wrapper

## Context

Fourth PR in the series applying `RateLimitedTool` / `PathGuardedTool` from `src/tools/wrappers.rs`. Previous: ShellTool (#4828), file tools (#4944), search tools (#4947). Next: cron tools, AI-CLI tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)