### PR TITLE
refactor(tools): apply RateLimitedTool to CronAddTool, CronRemoveTool, CronUpdateTool

### DIFF
--- a/src/tools/cron_add.rs
+++ b/src/tools/cron_add.rs
@@ -29,22 +29,6 @@ impl CronAddTool {
             });
         }
 
-        if self.security.is_rate_limited() {
-            return Some(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".to_string()),
-            });
-        }
-
-        if !self.security.record_action() {
-            return Some(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".to_string()),
-            });
-        }
-
         None
     }
 }
@@ -379,6 +363,7 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::security::AutonomyLevel;
+    use crate::tools::RateLimitedTool;
     use tempfile::TempDir;
 
     async fn test_config(tmp: &TempDir) -> Arc<Config> {
@@ -398,6 +383,13 @@ mod tests {
             &cfg.autonomy,
             &cfg.workspace_dir,
         ))
+    }
+
+    fn wrapped_cron_add(
+        cfg: Arc<Config>,
+        security: Arc<SecurityPolicy>,
+    ) -> RateLimitedTool<CronAddTool> {
+        RateLimitedTool::new(CronAddTool::new(cfg, security.clone()), security)
     }
 
     #[tokio::test]
@@ -516,7 +508,7 @@ mod tests {
         config.autonomy.max_actions_per_hour = 0;
         std::fs::create_dir_all(&config.workspace_dir).unwrap();
         let cfg = Arc::new(config);
-        let tool = CronAddTool::new(cfg.clone(), test_security(&cfg));
+        let tool = wrapped_cron_add(cfg.clone(), test_security(&cfg));
 
         let result = tool
             .execute(json!({

--- a/src/tools/cron_remove.rs
+++ b/src/tools/cron_remove.rs
@@ -27,22 +27,6 @@ impl CronRemoveTool {
             });
         }
 
-        if self.security.is_rate_limited() {
-            return Some(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".to_string()),
-            });
-        }
-
-        if !self.security.record_action() {
-            return Some(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".to_string()),
-            });
-        }
-
         None
     }
 }
@@ -111,6 +95,7 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::security::AutonomyLevel;
+    use crate::tools::RateLimitedTool;
     use tempfile::TempDir;
 
     async fn test_config(tmp: &TempDir) -> Arc<Config> {
@@ -130,6 +115,13 @@ mod tests {
             &cfg.autonomy,
             &cfg.workspace_dir,
         ))
+    }
+
+    fn wrapped_cron_remove(
+        cfg: Arc<Config>,
+        security: Arc<SecurityPolicy>,
+    ) -> RateLimitedTool<CronRemoveTool> {
+        RateLimitedTool::new(CronRemoveTool::new(cfg, security.clone()), security)
     }
 
     #[tokio::test]
@@ -192,7 +184,7 @@ mod tests {
         std::fs::create_dir_all(&config.workspace_dir).unwrap();
         let cfg = Arc::new(config);
         let job = cron::add_job(&cfg, "*/5 * * * *", "echo ok").unwrap();
-        let tool = CronRemoveTool::new(cfg.clone(), test_security(&cfg));
+        let tool = wrapped_cron_remove(cfg.clone(), test_security(&cfg));
 
         let result = tool.execute(json!({"job_id": job.id})).await.unwrap();
         assert!(!result.success);

--- a/src/tools/cron_update.rs
+++ b/src/tools/cron_update.rs
@@ -27,22 +27,6 @@ impl CronUpdateTool {
             });
         }
 
-        if self.security.is_rate_limited() {
-            return Some(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".to_string()),
-            });
-        }
-
-        if !self.security.record_action() {
-            return Some(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".to_string()),
-            });
-        }
-
         None
     }
 }
@@ -246,6 +230,7 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::security::AutonomyLevel;
+    use crate::tools::RateLimitedTool;
     use tempfile::TempDir;
 
     async fn test_config(tmp: &TempDir) -> Arc<Config> {
@@ -265,6 +250,13 @@ mod tests {
             &cfg.autonomy,
             &cfg.workspace_dir,
         ))
+    }
+
+    fn wrapped_cron_update(
+        cfg: Arc<Config>,
+        security: Arc<SecurityPolicy>,
+    ) -> RateLimitedTool<CronUpdateTool> {
+        RateLimitedTool::new(CronUpdateTool::new(cfg, security.clone()), security)
     }
 
     #[tokio::test]
@@ -493,7 +485,7 @@ mod tests {
         std::fs::create_dir_all(&config.workspace_dir).unwrap();
         let cfg = Arc::new(config);
         let job = cron::add_job(&cfg, "*/5 * * * *", "echo ok").unwrap();
-        let tool = CronUpdateTool::new(cfg.clone(), test_security(&cfg));
+        let tool = wrapped_cron_update(cfg.clone(), test_security(&cfg));
 
         let result = tool
             .execute(json!({

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -423,10 +423,19 @@ pub fn all_tools_with_runtime(
         Arc::new(FileEditTool::new(security.clone())),
         Arc::new(GlobSearchTool::new(security.clone())),
         Arc::new(ContentSearchTool::new(security.clone())),
-        Arc::new(CronAddTool::new(config.clone(), security.clone())),
+        Arc::new(RateLimitedTool::new(
+            CronAddTool::new(config.clone(), security.clone()),
+            security.clone(),
+        )),
         Arc::new(CronListTool::new(config.clone())),
-        Arc::new(CronRemoveTool::new(config.clone(), security.clone())),
-        Arc::new(CronUpdateTool::new(config.clone(), security.clone())),
+        Arc::new(RateLimitedTool::new(
+            CronRemoveTool::new(config.clone(), security.clone()),
+            security.clone(),
+        )),
+        Arc::new(RateLimitedTool::new(
+            CronUpdateTool::new(config.clone(), security.clone()),
+            security.clone(),
+        )),
         Arc::new(CronRunTool::new(config.clone(), security.clone())),
         Arc::new(CronRunsTool::new(config.clone())),
         Arc::new(MemoryStoreTool::new(memory.clone(), security.clone())),


### PR DESCRIPTION
## Summary

- Remove `is_rate_limited()` + `record_action()` from `enforce_mutation_allowed()` in `CronAddTool`, `CronRemoveTool`, `CronUpdateTool`; wrap each with `RateLimitedTool` at construction time
- `can_act()` (read-only mode check) remains in `enforce_mutation_allowed()` — it is not part of `RateLimitedTool`

## Why CronRunTool is excluded

`CronRunTool::execute()` positions `record_action()` _after_ job retrieval and command validation. This is intentional: non-existent job IDs and command-policy rejections should not consume rate-limit budget. Applying `RateLimitedTool` (which calls `record_action()` before `execute()`) would change this semantic. `CronRunTool` is left unchanged.

## Test plan

- [ ] `blocks_add_when_rate_limited` — uses `wrapped_cron_add()`
- [ ] `blocks_remove_when_rate_limited` — uses `wrapped_cron_remove()`  
- [ ] `blocks_update_when_rate_limited` — uses `wrapped_cron_update()`

## Context

Fifth PR in the series. Previous: ShellTool (#4828), file tools (#4944), search tools (#4947), PDF/image tools (#4948). Next: AI-CLI tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)