### PR TITLE
refactor(tools): delegate rate-limiting to RateLimitedTool in AI CLI tools

### DIFF
--- a/src/tools/claude_code.rs
+++ b/src/tools/claude_code.rs
@@ -78,15 +78,6 @@ impl Tool for ClaudeCodeTool {
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
-        // Rate limit check
-        if self.security.is_rate_limited() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
-            });
-        }
-
         // Enforce act policy
         if let Err(error) = self
             .security
@@ -174,15 +165,6 @@ impl Tool for ClaudeCodeTool {
         } else {
             self.security.workspace_dir.clone()
         };
-
-        // Record action budget
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".into()),
-            });
-        }
 
         // Build CLI command
         let claude_bin = if cfg!(target_os = "windows") {
@@ -331,6 +313,14 @@ impl Tool for ClaudeCodeTool {
     }
 }
 
+/// Convenience constructor used in tests and in `mod.rs` assembly.
+pub fn wrapped_claude_code(
+    security: Arc<SecurityPolicy>,
+    config: ClaudeCodeConfig,
+) -> super::wrappers::RateLimitedTool<ClaudeCodeTool> {
+    super::wrappers::RateLimitedTool::new(ClaudeCodeTool::new(security.clone(), config), security)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -382,7 +372,7 @@ mod tests {
             workspace_dir: std::env::temp_dir(),
             ..SecurityPolicy::default()
         });
-        let tool = ClaudeCodeTool::new(security, test_config());
+        let tool = wrapped_claude_code(security, test_config());
         let result = tool
             .execute(json!({"prompt": "hello"}))
             .await

--- a/src/tools/codex_cli.rs
+++ b/src/tools/codex_cli.rs
@@ -60,15 +60,6 @@ impl Tool for CodexCliTool {
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
-        // Rate limit check
-        if self.security.is_rate_limited() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
-            });
-        }
-
         // Enforce act policy
         if let Err(error) = self
             .security
@@ -135,15 +126,6 @@ impl Tool for CodexCliTool {
         } else {
             self.security.workspace_dir.clone()
         };
-
-        // Record action budget
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".into()),
-            });
-        }
 
         // Build CLI command
         let codex_bin = if cfg!(target_os = "windows") {
@@ -236,6 +218,14 @@ impl Tool for CodexCliTool {
     }
 }
 
+/// Convenience constructor used in tests and in `mod.rs` assembly.
+pub fn wrapped_codex_cli(
+    security: Arc<SecurityPolicy>,
+    config: CodexCliConfig,
+) -> super::wrappers::RateLimitedTool<CodexCliTool> {
+    super::wrappers::RateLimitedTool::new(CodexCliTool::new(security.clone(), config), security)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -282,7 +272,7 @@ mod tests {
             workspace_dir: std::env::temp_dir(),
             ..SecurityPolicy::default()
         });
-        let tool = CodexCliTool::new(security, test_config());
+        let tool = wrapped_codex_cli(security, test_config());
         let result = tool
             .execute(json!({"prompt": "hello"}))
             .await

--- a/src/tools/gemini_cli.rs
+++ b/src/tools/gemini_cli.rs
@@ -60,15 +60,6 @@ impl Tool for GeminiCliTool {
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
-        // Rate limit check
-        if self.security.is_rate_limited() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
-            });
-        }
-
         // Enforce act policy
         if let Err(error) = self
             .security
@@ -135,15 +126,6 @@ impl Tool for GeminiCliTool {
         } else {
             self.security.workspace_dir.clone()
         };
-
-        // Record action budget
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".into()),
-            });
-        }
 
         // Build CLI command
         let gemini_bin = if cfg!(target_os = "windows") {
@@ -236,6 +218,14 @@ impl Tool for GeminiCliTool {
     }
 }
 
+/// Convenience constructor used in tests and in `mod.rs` assembly.
+pub fn wrapped_gemini_cli(
+    security: Arc<SecurityPolicy>,
+    config: GeminiCliConfig,
+) -> super::wrappers::RateLimitedTool<GeminiCliTool> {
+    super::wrappers::RateLimitedTool::new(GeminiCliTool::new(security.clone(), config), security)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -282,7 +272,7 @@ mod tests {
             workspace_dir: std::env::temp_dir(),
             ..SecurityPolicy::default()
         });
-        let tool = GeminiCliTool::new(security, test_config());
+        let tool = wrapped_gemini_cli(security, test_config());
         let result = tool
             .execute(json!({"prompt": "hello"}))
             .await

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -121,11 +121,13 @@ pub use browser_delegate::{BrowserDelegateConfig, BrowserDelegateTool};
 pub use browser_open::BrowserOpenTool;
 pub use calculator::CalculatorTool;
 pub use canvas::{CanvasStore, CanvasTool};
-pub use claude_code::ClaudeCodeTool;
+#[allow(unused_imports)]
+pub use claude_code::{ClaudeCodeTool, wrapped_claude_code};
 pub use claude_code_runner::ClaudeCodeRunnerTool;
 pub use cloud_ops::CloudOpsTool;
 pub use cloud_patterns::CloudPatternsTool;
-pub use codex_cli::CodexCliTool;
+#[allow(unused_imports)]
+pub use codex_cli::{CodexCliTool, wrapped_codex_cli};
 pub use composio::ComposioTool;
 pub use content_search::ContentSearchTool;
 pub use cron_add::CronAddTool;
@@ -144,7 +146,8 @@ pub use escalate::EscalateToHumanTool;
 pub use file_edit::FileEditTool;
 pub use file_read::FileReadTool;
 pub use file_write::FileWriteTool;
-pub use gemini_cli::GeminiCliTool;
+#[allow(unused_imports)]
+pub use gemini_cli::{GeminiCliTool, wrapped_gemini_cli};
 pub use git_operations::GitOperationsTool;
 pub use glob_search::GlobSearchTool;
 pub use google_workspace::GoogleWorkspaceTool;
@@ -175,7 +178,8 @@ pub use model_switch::ModelSwitchTool;
 #[allow(unused_imports)]
 pub use node_tool::NodeTool;
 pub use notion_tool::NotionTool;
-pub use opencode_cli::OpenCodeCliTool;
+#[allow(unused_imports)]
+pub use opencode_cli::{OpenCodeCliTool, wrapped_opencode_cli};
 pub use pdf_read::PdfReadTool;
 pub use poll::{ChannelMapHandle, PollTool};
 pub use project_intel::ProjectIntelTool;
@@ -687,7 +691,7 @@ pub fn all_tools_with_runtime(
 
     // Claude Code delegation tool
     if root_config.claude_code.enabled {
-        tool_arcs.push(Arc::new(ClaudeCodeTool::new(
+        tool_arcs.push(Arc::new(wrapped_claude_code(
             security.clone(),
             root_config.claude_code.clone(),
         )));
@@ -708,7 +712,7 @@ pub fn all_tools_with_runtime(
 
     // Codex CLI delegation tool
     if root_config.codex_cli.enabled {
-        tool_arcs.push(Arc::new(CodexCliTool::new(
+        tool_arcs.push(Arc::new(wrapped_codex_cli(
             security.clone(),
             root_config.codex_cli.clone(),
         )));
@@ -716,7 +720,7 @@ pub fn all_tools_with_runtime(
 
     // Gemini CLI delegation tool
     if root_config.gemini_cli.enabled {
-        tool_arcs.push(Arc::new(GeminiCliTool::new(
+        tool_arcs.push(Arc::new(wrapped_gemini_cli(
             security.clone(),
             root_config.gemini_cli.clone(),
         )));
@@ -724,7 +728,7 @@ pub fn all_tools_with_runtime(
 
     // OpenCode CLI delegation tool
     if root_config.opencode_cli.enabled {
-        tool_arcs.push(Arc::new(OpenCodeCliTool::new(
+        tool_arcs.push(Arc::new(wrapped_opencode_cli(
             security.clone(),
             root_config.opencode_cli.clone(),
         )));

--- a/src/tools/opencode_cli.rs
+++ b/src/tools/opencode_cli.rs
@@ -60,15 +60,6 @@ impl Tool for OpenCodeCliTool {
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
-        // Rate limit check
-        if self.security.is_rate_limited() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
-            });
-        }
-
         // Enforce act policy
         if let Err(error) = self
             .security
@@ -135,15 +126,6 @@ impl Tool for OpenCodeCliTool {
         } else {
             self.security.workspace_dir.clone()
         };
-
-        // Record action budget
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".into()),
-            });
-        }
 
         // Build CLI command
         let mut cmd = Command::new("opencode");
@@ -231,6 +213,14 @@ impl Tool for OpenCodeCliTool {
     }
 }
 
+/// Convenience constructor used in tests and in `mod.rs` assembly.
+pub fn wrapped_opencode_cli(
+    security: Arc<SecurityPolicy>,
+    config: OpenCodeCliConfig,
+) -> super::wrappers::RateLimitedTool<OpenCodeCliTool> {
+    super::wrappers::RateLimitedTool::new(OpenCodeCliTool::new(security.clone(), config), security)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -277,7 +267,7 @@ mod tests {
             workspace_dir: std::env::temp_dir(),
             ..SecurityPolicy::default()
         });
-        let tool = OpenCodeCliTool::new(security, test_config());
+        let tool = wrapped_opencode_cli(security, test_config());
         let result = tool
             .execute(json!({"prompt": "hello"}))
             .await


### PR DESCRIPTION
## Summary

- Remove inline `is_rate_limited()` / `record_action()` guards from `GeminiCliTool`, `ClaudeCodeTool`, `CodexCliTool`, and `OpenCodeCliTool`
- Each tool now has a `wrapped_*` convenience constructor that composes `RateLimitedTool` at the call site
- `mod.rs` updated to use the wrapped constructors in `all_tools_with_runtime()`
- Rate-limited test cases updated to instantiate tools via the wrapper

This is batch 5 of the tool-wrapper refactor series (following PRs for file tools, search tools, pdf/image tools, and cron tools).

## Test plan

- [ ] `cargo test --lib -- gemini_cli` passes (pre-existing unrelated compile errors excluded)
- [ ] `cargo test --lib -- claude_code` passes
- [ ] `cargo test --lib -- codex_cli` passes
- [ ] `cargo test --lib -- opencode_cli` passes
- [ ] No new compile errors introduced (8 pre-existing errors remain unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)