### PR TITLE
refactor(tools): delegate rate-limiting to RateLimitedTool in ClaudeCodeRunnerTool

### DIFF
--- a/src/tools/claude_code_runner.rs
+++ b/src/tools/claude_code_runner.rs
@@ -105,15 +105,6 @@ impl Tool for ClaudeCodeRunnerTool {
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
-        // Rate limit check
-        if self.security.is_rate_limited() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
-            });
-        }
-
         // Enforce act policy
         if let Err(error) = self
             .security
@@ -182,15 +173,6 @@ impl Tool for ClaudeCodeRunnerTool {
             .get("slack_channel")
             .and_then(|v| v.as_str())
             .map(String::from);
-
-        // Record action budget
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".into()),
-            });
-        }
 
         // Generate a unique session ID
         let session_id = uuid::Uuid::new_v4().to_string()[..8].to_string();
@@ -330,6 +312,18 @@ impl Tool for ClaudeCodeRunnerTool {
     }
 }
 
+/// Convenience constructor used in tests and in `mod.rs` assembly.
+pub fn wrapped_claude_code_runner(
+    security: Arc<SecurityPolicy>,
+    config: ClaudeCodeRunnerConfig,
+    gateway_url: String,
+) -> super::wrappers::RateLimitedTool<ClaudeCodeRunnerTool> {
+    super::wrappers::RateLimitedTool::new(
+        ClaudeCodeRunnerTool::new(security.clone(), config, gateway_url),
+        security,
+    )
+}
+
 /// Minimal shell escaping for values embedded in tmux send-keys.
 fn shell_escape(s: &str) -> String {
     if s.chars()
@@ -437,7 +431,7 @@ mod tests {
             ..SecurityPolicy::default()
         });
         let tool =
-            ClaudeCodeRunnerTool::new(security, test_config(), "http://localhost:3000".into());
+            wrapped_claude_code_runner(security, test_config(), "http://localhost:3000".into());
         let result = tool
             .execute(json!({"prompt": "hello"}))
             .await

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -122,7 +122,8 @@ pub use browser_open::BrowserOpenTool;
 pub use calculator::CalculatorTool;
 pub use canvas::{CanvasStore, CanvasTool};
 pub use claude_code::ClaudeCodeTool;
-pub use claude_code_runner::ClaudeCodeRunnerTool;
+#[allow(unused_imports)]
+pub use claude_code_runner::{ClaudeCodeRunnerTool, wrapped_claude_code_runner};
 pub use cloud_ops::CloudOpsTool;
 pub use cloud_patterns::CloudPatternsTool;
 pub use codex_cli::CodexCliTool;
@@ -699,7 +700,7 @@ pub fn all_tools_with_runtime(
             "http://{}:{}",
             root_config.gateway.host, root_config.gateway.port
         );
-        tool_arcs.push(Arc::new(ClaudeCodeRunnerTool::new(
+        tool_arcs.push(Arc::new(wrapped_claude_code_runner(
             security.clone(),
             root_config.claude_code_runner.clone(),
             gateway_url,


### PR DESCRIPTION
## Summary

- Remove inline `is_rate_limited()` / `record_action()` guards from `ClaudeCodeRunnerTool`
- Add `wrapped_claude_code_runner()` convenience constructor composing `RateLimitedTool`
- `mod.rs` updated to use the wrapped constructor in `all_tools_with_runtime()`
- Rate-limited test case updated to instantiate tool via the wrapper

This is batch 6 of the tool-wrapper refactor series.

## Test plan

- [ ] `cargo test --lib -- claude_code_runner` passes
- [ ] No new compile errors introduced (8 pre-existing errors remain unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)