### PR TITLE
refactor(tools): delegate rate-limiting to RateLimitedTool in network/skill tools

### DIFF
--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -878,7 +878,7 @@ pub fn skills_to_tools(
         for tool in &skill.tools {
             match tool.kind.as_str() {
                 "shell" | "script" => {
-                    tools.push(Box::new(crate::tools::skill_tool::SkillShellTool::new(
+                    tools.push(Box::new(crate::tools::skill_tool::wrapped_skill_tool(
                         &skill.name,
                         tool,
                         security.clone(),

--- a/src/tools/browser.rs
+++ b/src/tools/browser.rs
@@ -1047,14 +1047,6 @@ impl Tool for BrowserTool {
             });
         }
 
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Action blocked: rate limit exceeded".into()),
-            });
-        }
-
         let backend = match self.resolve_backend().await {
             Ok(selected) => selected,
             Err(error) => {
@@ -2192,6 +2184,32 @@ fn host_matches_allowlist(host: &str, allowed: &[String]) -> bool {
             host == pattern || host.ends_with(&format!(".{pattern}"))
         }
     })
+}
+
+/// Construct a `BrowserTool` wrapped in a `RateLimitedTool`.
+pub fn wrapped_browser(
+    security: Arc<SecurityPolicy>,
+    allowed_domains: Vec<String>,
+    session_name: Option<String>,
+    backend: String,
+    native_headless: bool,
+    native_webdriver_url: String,
+    native_chrome_path: Option<String>,
+    computer_use: ComputerUseConfig,
+) -> super::wrappers::RateLimitedTool<BrowserTool> {
+    super::wrappers::RateLimitedTool::new(
+        BrowserTool::new_with_backend(
+            security.clone(),
+            allowed_domains,
+            session_name,
+            backend,
+            native_headless,
+            native_webdriver_url,
+            native_chrome_path,
+            computer_use,
+        ),
+        security,
+    )
 }
 
 #[cfg(test)]

--- a/src/tools/http_request.rs
+++ b/src/tools/http_request.rs
@@ -219,14 +219,6 @@ impl Tool for HttpRequestTool {
             });
         }
 
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Action blocked: rate limit exceeded".into()),
-            });
-        }
-
         let url = match self.validate_url(url) {
             Ok(v) => v,
             Err(e) => {
@@ -451,6 +443,26 @@ fn is_non_global_v6(v6: std::net::Ipv6Addr) -> bool {
         || (segs[0] & 0xffc0) == 0xfe80   // Link-local (fe80::/10)
         || (segs[0] == 0x2001 && segs[1] == 0x0db8) // Documentation (2001:db8::/32)
         || v6.to_ipv4_mapped().is_some_and(is_non_global_v4)
+}
+
+/// Construct an `HttpRequestTool` wrapped in a `RateLimitedTool`.
+pub fn wrapped_http_request(
+    security: Arc<SecurityPolicy>,
+    allowed_domains: Vec<String>,
+    max_response_size: usize,
+    timeout_secs: u64,
+    allow_private_hosts: bool,
+) -> super::wrappers::RateLimitedTool<HttpRequestTool> {
+    super::wrappers::RateLimitedTool::new(
+        HttpRequestTool::new(
+            security.clone(),
+            allowed_domains,
+            max_response_size,
+            timeout_secs,
+            allow_private_hosts,
+        ),
+        security,
+    )
 }
 
 #[cfg(test)]
@@ -714,13 +726,13 @@ mod tests {
             max_actions_per_hour: 0,
             ..SecurityPolicy::default()
         });
-        let tool = HttpRequestTool::new(security, vec!["example.com".into()], 1_000_000, 30, false);
+        let tool = wrapped_http_request(security, vec!["example.com".into()], 1_000_000, 30, false);
         let result = tool
             .execute(json!({"url": "https://example.com"}))
             .await
             .unwrap();
         assert!(!result.success);
-        assert!(result.error.unwrap().contains("rate limit"));
+        assert!(result.error.unwrap().contains("Rate limit"));
     }
 
     #[test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -115,7 +115,8 @@ pub mod wrappers;
 
 pub use ask_user::AskUserTool;
 pub use backup_tool::BackupTool;
-pub use browser::{BrowserTool, ComputerUseConfig};
+#[allow(unused_imports)]
+pub use browser::{BrowserTool, ComputerUseConfig, wrapped_browser};
 #[allow(unused_imports)]
 pub use browser_delegate::{BrowserDelegateConfig, BrowserDelegateTool};
 pub use browser_open::BrowserOpenTool;
@@ -154,7 +155,8 @@ pub use hardware_board_info::HardwareBoardInfoTool;
 pub use hardware_memory_map::HardwareMemoryMapTool;
 #[cfg(feature = "hardware")]
 pub use hardware_memory_read::HardwareMemoryReadTool;
-pub use http_request::HttpRequestTool;
+#[allow(unused_imports)]
+pub use http_request::{HttpRequestTool, wrapped_http_request};
 pub use image_gen::ImageGenTool;
 pub use image_info::ImageInfoTool;
 pub use jira_tool::JiraTool;
@@ -194,7 +196,7 @@ pub use shell::ShellTool;
 #[allow(unused_imports)]
 pub use skill_http::SkillHttpTool;
 #[allow(unused_imports)]
-pub use skill_tool::SkillShellTool;
+pub use skill_tool::{SkillShellTool, wrapped_skill_tool};
 pub use sop_advance::SopAdvanceTool;
 pub use sop_approve::SopApproveTool;
 pub use sop_execute::SopExecuteTool;
@@ -208,7 +210,8 @@ pub use traits::Tool;
 pub use traits::{ToolResult, ToolSpec};
 pub use verifiable_intent::VerifiableIntentTool;
 pub use weather_tool::WeatherTool;
-pub use web_fetch::WebFetchTool;
+#[allow(unused_imports)]
+pub use web_fetch::{WebFetchTool, wrapped_web_fetch};
 pub use web_search_tool::WebSearchTool;
 pub use workspace_tool::WorkspaceTool;
 pub use wrappers::{PathGuardedTool, RateLimitedTool};
@@ -506,7 +509,7 @@ pub fn all_tools_with_runtime(
             browser_config.allowed_domains.clone(),
         )));
         // Add full browser automation tool (pluggable backend)
-        tool_arcs.push(Arc::new(BrowserTool::new_with_backend(
+        tool_arcs.push(Arc::new(wrapped_browser(
             security.clone(),
             browser_config.allowed_domains.clone(),
             browser_config.session_name.clone(),
@@ -541,7 +544,7 @@ pub fn all_tools_with_runtime(
     }
 
     if http_config.enabled {
-        tool_arcs.push(Arc::new(HttpRequestTool::new(
+        tool_arcs.push(Arc::new(wrapped_http_request(
             security.clone(),
             http_config.allowed_domains.clone(),
             http_config.max_response_size,
@@ -551,7 +554,7 @@ pub fn all_tools_with_runtime(
     }
 
     if web_fetch_config.enabled {
-        tool_arcs.push(Arc::new(WebFetchTool::new(
+        tool_arcs.push(Arc::new(wrapped_web_fetch(
             security.clone(),
             web_fetch_config.allowed_domains.clone(),
             web_fetch_config.blocked_domains.clone(),

--- a/src/tools/skill_tool.rs
+++ b/src/tools/skill_tool.rs
@@ -99,15 +99,6 @@ impl Tool for SkillShellTool {
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
         let command = self.substitute_args(&args);
 
-        // Rate limit check
-        if self.security.is_rate_limited() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: too many actions in the last hour".into()),
-            });
-        }
-
         // Security validation — always requires explicit approval (approved=true)
         // since skill tools are user-defined and should be treated as medium-risk.
         match self.security.validate_command_execution(&command, true) {
@@ -126,14 +117,6 @@ impl Tool for SkillShellTool {
                 success: false,
                 output: String::new(),
                 error: Some(format!("Path blocked by security policy: {path}")),
-            });
-        }
-
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Rate limit exceeded: action budget exhausted".into()),
             });
         }
 
@@ -201,6 +184,18 @@ impl Tool for SkillShellTool {
             }),
         }
     }
+}
+
+/// Construct a `SkillShellTool` wrapped in a `RateLimitedTool`.
+pub fn wrapped_skill_tool(
+    skill_name: &str,
+    tool: &crate::skills::SkillTool,
+    security: Arc<SecurityPolicy>,
+) -> super::wrappers::RateLimitedTool<SkillShellTool> {
+    super::wrappers::RateLimitedTool::new(
+        SkillShellTool::new(skill_name, tool, security.clone()),
+        security,
+    )
 }
 
 #[cfg(test)]

--- a/src/tools/web_fetch.rs
+++ b/src/tools/web_fetch.rs
@@ -301,14 +301,6 @@ impl Tool for WebFetchTool {
             });
         }
 
-        if !self.security.record_action() {
-            return Ok(ToolResult {
-                success: false,
-                output: String::new(),
-                error: Some("Action blocked: rate limit exceeded".into()),
-            });
-        }
-
         let url = match self.validate_url(url) {
             Ok(v) => v,
             Err(e) => {
@@ -656,6 +648,30 @@ fn is_non_global_v6(v6: std::net::Ipv6Addr) -> bool {
         || v6.to_ipv4_mapped().is_some_and(is_non_global_v4)
 }
 
+/// Construct a `WebFetchTool` wrapped in a `RateLimitedTool`.
+pub fn wrapped_web_fetch(
+    security: Arc<SecurityPolicy>,
+    allowed_domains: Vec<String>,
+    blocked_domains: Vec<String>,
+    max_response_size: usize,
+    timeout_secs: u64,
+    firecrawl: crate::config::schema::FirecrawlConfig,
+    allowed_private_hosts: Vec<String>,
+) -> super::wrappers::RateLimitedTool<WebFetchTool> {
+    super::wrappers::RateLimitedTool::new(
+        WebFetchTool::new(
+            security.clone(),
+            allowed_domains,
+            blocked_domains,
+            max_response_size,
+            timeout_secs,
+            firecrawl,
+            allowed_private_hosts,
+        ),
+        security,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -952,7 +968,7 @@ mod tests {
             max_actions_per_hour: 0,
             ..SecurityPolicy::default()
         });
-        let tool = WebFetchTool::new(
+        let tool = wrapped_web_fetch(
             security,
             vec!["example.com".into()],
             vec![],
@@ -966,7 +982,7 @@ mod tests {
             .await
             .unwrap();
         assert!(!result.success);
-        assert!(result.error.unwrap().contains("rate limit"));
+        assert!(result.error.unwrap().contains("Rate limit"));
     }
 
     // ── Response truncation ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- Remove inline `record_action()` guards from `BrowserTool`, `HttpRequestTool`, `WebFetchTool`; remove both `is_rate_limited()` and `record_action()` from `SkillTool`
- Each tool now has a `wrapped_*` convenience constructor composing `RateLimitedTool` at the call site
- `mod.rs` and `skills/mod.rs` updated to use wrapped constructors
- Rate-limited test assertions updated from `"rate limit"` to `"Rate limit"` to match wrapper error message format
- `can_act()` (read-only mode guard) is preserved inline in `BrowserTool`, `HttpRequestTool`, and `WebFetchTool` since `RateLimitedTool` only handles rate-limiting, not read-only policy

**Note:** `GoogleWorkspaceTool` is intentionally excluded — its `record_action()` is placed after all parameter validation by design, to avoid charging the action budget on invalid API calls.

This is batch 7 of the tool-wrapper refactor series.

## Test plan

- [ ] `cargo test --lib -- browser` passes
- [ ] `cargo test --lib -- http_request` passes (rate-limited test now uses wrapper)
- [ ] `cargo test --lib -- web_fetch` passes (rate-limited test now uses wrapper)
- [ ] `cargo test --lib -- skill_tool` passes
- [ ] No new compile errors introduced (8 pre-existing errors remain unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)