### PR TITLE
chore: update marketplace workflow for renamed fork repos

### DIFF
--- a/.github/workflows/sync-marketplace-templates.yml
+++ b/.github/workflows/sync-marketplace-templates.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Checkout Dokploy templates fork
         uses: actions/checkout@v4
         with:
-          repository: zeroclaw-labs/templates
+          repository: zeroclaw-labs/dokploy-templates
           token: ${{ secrets.MARKETPLACE_PAT }}
           ref: main
           path: templates
@@ -297,7 +297,7 @@ jobs:
       - name: Checkout EasyPanel templates fork
         uses: actions/checkout@v4
         with:
-          repository: zeroclaw-labs/templates-1
+          repository: zeroclaw-labs/easypanel-templates
           token: ${{ secrets.MARKETPLACE_PAT }}
           ref: main
           path: easypanel

--- a/marketplace/sync-marketplace-templates.yml
+++ b/marketplace/sync-marketplace-templates.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Checkout Dokploy templates fork
         uses: actions/checkout@v4
         with:
-          repository: zeroclaw-labs/templates
+          repository: zeroclaw-labs/dokploy-templates
           token: ${{ secrets.MARKETPLACE_PAT }}
           ref: main
           path: templates
@@ -297,7 +297,7 @@ jobs:
       - name: Checkout EasyPanel templates fork
         uses: actions/checkout@v4
         with:
-          repository: zeroclaw-labs/templates-1
+          repository: zeroclaw-labs/easypanel-templates
           token: ${{ secrets.MARKETPLACE_PAT }}
           ref: main
           path: easypanel


### PR DESCRIPTION
## Summary
- Renamed GitHub repos: `templates` → `dokploy-templates`, `templates-1` → `easypanel-templates`
- Updated references in both copies of `sync-marketplace-templates.yml`

## Test plan
- [x] Repos renamed via GitHub API
- [x] Both workflow files reference correct new names
- [x] No stale `templates-1` or bare `templates` references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)