### PR TITLE
chore: rename dokploy-templates → dokploy

### DIFF
--- a/.github/workflows/sync-marketplace-templates.yml
+++ b/.github/workflows/sync-marketplace-templates.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Checkout Dokploy templates fork
         uses: actions/checkout@v4
         with:
-          repository: zeroclaw-labs/dokploy-templates
+          repository: zeroclaw-labs/dokploy
           token: ${{ secrets.MARKETPLACE_PAT }}
           ref: main
           path: templates

--- a/marketplace/sync-marketplace-templates.yml
+++ b/marketplace/sync-marketplace-templates.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Checkout Dokploy templates fork
         uses: actions/checkout@v4
         with:
-          repository: zeroclaw-labs/dokploy-templates
+          repository: zeroclaw-labs/dokploy
           token: ${{ secrets.MARKETPLACE_PAT }}
           ref: main
           path: templates


### PR DESCRIPTION
## Summary
- Renamed `zeroclaw-labs/dokploy-templates` → `zeroclaw-labs/dokploy`
- Updated workflow references

🤖 Generated with [Claude Code](https://claude.com/claude-code)