### PR TITLE
chore: rename easypanel-templates → easypanel

### DIFF
--- a/.github/workflows/sync-marketplace-templates.yml
+++ b/.github/workflows/sync-marketplace-templates.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Checkout EasyPanel templates fork
         uses: actions/checkout@v4
         with:
-          repository: zeroclaw-labs/easypanel-templates
+          repository: zeroclaw-labs/easypanel
           token: ${{ secrets.MARKETPLACE_PAT }}
           ref: main
           path: easypanel

--- a/marketplace/sync-marketplace-templates.yml
+++ b/marketplace/sync-marketplace-templates.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Checkout EasyPanel templates fork
         uses: actions/checkout@v4
         with:
-          repository: zeroclaw-labs/easypanel-templates
+          repository: zeroclaw-labs/easypanel
           token: ${{ secrets.MARKETPLACE_PAT }}
           ref: main
           path: easypanel


### PR DESCRIPTION
## Summary
- Renamed `zeroclaw-labs/easypanel-templates` → `zeroclaw-labs/easypanel`
- Updated workflow references

🤖 Generated with [Claude Code](https://claude.com/claude-code)