### PR TITLE
feat(channel): add LINE Messaging API channel with Reply/Push API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,15 @@ password = "..."
 phone_number = "+1234567890"
 ```
 
+**LINE:**
+```toml
+[channels_config.line]
+channel_secret = "your-channel-secret"
+channel_access_token = "your-channel-access-token"
+allowed_users = ["Uxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"]  # LINE user IDs, or ["*"] for all
+reply_mode = "reply_first"  # reply_first (default) | push_only | reply_only
+```
+
 ### Tunnel configuration
 
 ```toml

--- a/src/channels/line.rs
+++ b/src/channels/line.rs
@@ -1,0 +1,1061 @@
+use super::traits::{Channel, ChannelMessage, SendMessage};
+use anyhow::Result;
+use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose};
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use std::path::Path;
+
+pub use crate::config::schema::LineReplyMode;
+
+/// LINE Messaging API base URL
+const LINE_API_BASE: &str = "https://api.line.me/v2/bot";
+
+/// Maximum LINE text message length
+const LINE_MAX_TEXT_LEN: usize = 5000;
+
+/// LINE channel max image download size (10 MB)
+const LINE_MAX_IMAGE_BYTES: u64 = 10 * 1024 * 1024;
+
+// ── Signature verification ────────────────────────────────────────────────────
+
+/// Verify the `X-Line-Signature` header using HMAC-SHA256 + Base64.
+///
+/// The gateway calls this before processing any webhook body.
+pub fn verify_line_signature(channel_secret: &str, body: &str, signature: &str) -> bool {
+    if signature.is_empty() {
+        return false;
+    }
+    let Ok(mut mac) = Hmac::<Sha256>::new_from_slice(channel_secret.as_bytes()) else {
+        return false;
+    };
+    mac.update(body.as_bytes());
+    // Decode the incoming signature and verify with constant-time comparison
+    // (prevents timing-based side-channel attacks on the HMAC).
+    let Ok(sig_bytes) = general_purpose::STANDARD.decode(signature) else {
+        return false;
+    };
+    mac.verify_slice(&sig_bytes).is_ok()
+}
+
+// ── Incoming event structs ────────────────────────────────────────────────────
+
+/// Top-level webhook payload from LINE
+#[derive(Debug, serde::Deserialize)]
+struct LineWebhook {
+    events: Vec<LineEvent>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct LineEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    /// present on message events (renamed from replyToken in JSON)
+    #[serde(rename = "replyToken")]
+    token: Option<String>,
+    source: LineSource,
+    message: Option<LineMsg>,
+    /// milliseconds since epoch
+    timestamp: Option<u64>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct LineSource {
+    #[serde(rename = "type")]
+    source_type: String,
+    #[serde(rename = "userId")]
+    user_id: Option<String>,
+    #[serde(rename = "groupId")]
+    group_id: Option<String>,
+    #[serde(rename = "roomId")]
+    room_id: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct LineMsg {
+    id: String,
+    #[serde(rename = "type")]
+    msg_type: String,
+    /// text message body (present when msg_type == "text")
+    text: Option<String>,
+}
+
+// ── Outgoing message structs ──────────────────────────────────────────────────
+
+#[derive(Debug, serde::Serialize)]
+struct LinePushRequest<'a> {
+    to: &'a str,
+    messages: Vec<LineTextMsg>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct LineReplyRequest<'a> {
+    #[serde(rename = "replyToken")]
+    reply_token: &'a str,
+    messages: Vec<LineTextMsg>,
+}
+
+#[derive(Debug, serde::Serialize)]
+struct LineTextMsg {
+    #[serde(rename = "type")]
+    msg_type: &'static str,
+    text: String,
+}
+
+// ── LineChannel ───────────────────────────────────────────────────────────────
+
+/// LINE Messaging API channel — **webhook-based** (push-mode).
+///
+/// Messages are received via the gateway's `/line` endpoint.
+/// The `listen` method is a keepalive placeholder; real message handling
+/// happens in the gateway when LINE sends webhook events.
+///
+/// Incoming text messages and images from both 1:1 and group chats are
+/// supported.  Images are downloaded from the Content API, saved to
+/// `workspace/line_files/`, and represented as `[IMAGE:/path]` markers so
+/// the multimodal pipeline can process them.
+pub struct LineChannel {
+    /// LINE Channel Access Token (used for all outbound API calls)
+    channel_access_token: String,
+    /// Allowed LINE user IDs. `["*"]` accepts all users.
+    allowed_users: Vec<String>,
+    /// Optional directory for storing downloaded image files.
+    workspace_dir: Option<std::path::PathBuf>,
+    /// Outbound delivery mode (reply_first / push_only / reply_only).
+    reply_mode: LineReplyMode,
+    /// When `true`, group messages are ignored unless they @mention the bot.
+    /// 1:1 messages are always processed.
+    mention_only: bool,
+    /// Resolved bot display name used to detect `@<name>` mentions.
+    ///
+    /// Populated either from config (manual override) or fetched once from
+    /// `GET /v2/bot/info` at startup via `resolve_bot_display_name()`.
+    /// Uses `OnceCell` so the field is written once and then read without locks.
+    bot_display_name: tokio::sync::OnceCell<String>,
+    client: reqwest::Client,
+}
+
+impl LineChannel {
+    pub fn new(channel_access_token: String, allowed_users: Vec<String>) -> Self {
+        Self {
+            channel_access_token,
+            allowed_users,
+            workspace_dir: None,
+            reply_mode: LineReplyMode::default(),
+            mention_only: false,
+            bot_display_name: tokio::sync::OnceCell::new(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Set the outbound delivery mode.
+    pub fn with_reply_mode(mut self, mode: LineReplyMode) -> Self {
+        self.reply_mode = mode;
+        self
+    }
+
+    /// Attach a workspace directory for saving downloaded images.
+    pub fn with_workspace_dir(mut self, dir: std::path::PathBuf) -> Self {
+        self.workspace_dir = Some(dir);
+        self
+    }
+
+    /// Enable mention-only mode for group chats.
+    ///
+    /// When enabled the bot only responds in groups when `@<display_name>` appears
+    /// in the message text.  The `@<display_name>` prefix is stripped before the
+    /// content is forwarded to the agent.  1:1 messages are unaffected.
+    ///
+    /// `display_name_override` pre-seeds the bot name so no API call is needed.
+    /// If `None`, call `resolve_bot_display_name()` after construction to fetch
+    /// the name from LINE's Bot Info API.
+    pub fn with_mention_only(
+        mut self,
+        enabled: bool,
+        display_name_override: Option<String>,
+    ) -> Self {
+        self.mention_only = enabled;
+        if let Some(name) = display_name_override {
+            // Pre-seed — resolve_bot_display_name() will be a no-op.
+            let _ = self.bot_display_name.set(name);
+        }
+        self
+    }
+
+    /// Ensure `bot_display_name` is populated.
+    ///
+    /// Resolution order:
+    /// 1. Already set (config override) — returns immediately.
+    /// 2. Fetch `GET /v2/bot/info` and cache `displayName`.
+    /// 3. API failure — logs a warning; mention_only silently becomes a no-op
+    ///    until the next successful fetch (future webhook calls will retry via
+    ///    the `warn` path in `parse_webhook_payload`).
+    pub async fn resolve_bot_display_name(&self) {
+        if self.bot_display_name.initialized() {
+            return; // already set via config override
+        }
+
+        #[derive(serde::Deserialize)]
+        struct BotInfo {
+            #[serde(rename = "displayName")]
+            display_name: String,
+        }
+
+        let url = self.api_url("info");
+        match self
+            .client
+            .get(&url)
+            .bearer_auth(&self.channel_access_token)
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => match resp.json::<BotInfo>().await {
+                Ok(info) => {
+                    let name = info.display_name;
+                    tracing::info!("LINE: resolved bot display name = {name:?}");
+                    let _ = self.bot_display_name.set(name);
+                }
+                Err(e) => {
+                    tracing::warn!("LINE: failed to parse bot info response: {e}");
+                }
+            },
+            Ok(resp) => {
+                tracing::warn!(
+                    "LINE: GET /v2/bot/info returned {} — mention_only will be inactive",
+                    resp.status()
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "LINE: failed to reach /v2/bot/info: {e} — mention_only will be inactive"
+                );
+            }
+        }
+    }
+
+    // ── Permissions ───────────────────────────────────────────────────────────
+
+    fn is_user_allowed(&self, user_id: &str) -> bool {
+        self.allowed_users.iter().any(|u| u == "*" || u == user_id)
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn api_url(&self, path: &str) -> String {
+        format!("{LINE_API_BASE}/{path}")
+    }
+
+    /// Build the *reply_target* for a source.
+    ///
+    /// For 1:1 chats the target is the userId; for groups/rooms we use the
+    /// group/room ID so push messages land in the right conversation.
+    fn reply_target(source: &LineSource) -> Option<String> {
+        match source.source_type.as_str() {
+            "group" => source.group_id.clone(),
+            "room" => source.room_id.clone(),
+            "user" => source.user_id.clone(),
+            _ => None,
+        }
+    }
+
+    // ── Image handling ────────────────────────────────────────────────────────
+
+    /// Download a LINE image/video/audio message by its message ID and save it
+    /// to disk.  Returns the local file path on success.
+    async fn download_content(
+        &self,
+        message_id: &str,
+        ext: &str,
+        chat_id: &str,
+    ) -> Option<std::path::PathBuf> {
+        let workspace = self.workspace_dir.as_ref()?;
+        let save_dir = workspace.join("line_files");
+
+        if let Err(e) = tokio::fs::create_dir_all(&save_dir).await {
+            tracing::warn!("LINE: failed to create line_files dir: {e}");
+            return None;
+        }
+
+        let url = self.api_url(&format!("message/{message_id}/content"));
+        let resp = match self
+            .client
+            .get(&url)
+            .bearer_auth(&self.channel_access_token)
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("LINE: failed to fetch content for msg={message_id}: {e}");
+                return None;
+            }
+        };
+
+        if !resp.status().is_success() {
+            tracing::warn!(
+                "LINE: content API returned {} for msg={message_id}",
+                resp.status()
+            );
+            return None;
+        }
+
+        // Guard against enormous files
+        if let Some(len) = resp.content_length() {
+            if len > LINE_MAX_IMAGE_BYTES {
+                tracing::info!(
+                    "LINE: skipping content {message_id}: {len} bytes > {} MB limit",
+                    LINE_MAX_IMAGE_BYTES / (1024 * 1024)
+                );
+                return None;
+            }
+        }
+
+        let bytes = match resp.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!("LINE: failed to read content body: {e}");
+                return None;
+            }
+        };
+
+        // Guard against servers that omit Content-Length (checked above only when present).
+        if bytes.len() as u64 > LINE_MAX_IMAGE_BYTES {
+            tracing::warn!(
+                "LINE: skipping content {message_id}: body {} bytes > {} MB limit",
+                bytes.len(),
+                LINE_MAX_IMAGE_BYTES / (1024 * 1024)
+            );
+            return None;
+        }
+
+        // Sanitize IDs before using them as filename components to block path traversal.
+        let safe_chat_id = chat_id.replace(['-', ':'], "_");
+        let safe_msg_id: String = message_id
+            .chars()
+            .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_')
+            .collect();
+        if safe_msg_id.is_empty() {
+            tracing::warn!("LINE: invalid message_id {message_id:?}, skipping download");
+            return None;
+        }
+        let filename = format!("line_{safe_chat_id}_{safe_msg_id}.{ext}");
+        let local_path = save_dir.join(&filename);
+
+        if let Err(e) = tokio::fs::write(&local_path, &bytes).await {
+            tracing::warn!("LINE: failed to write {}: {e}", local_path.display());
+            return None;
+        }
+
+        Some(local_path)
+    }
+
+    /// Decide the file extension for a given LINE message type.
+    fn content_ext(msg_type: &str) -> &'static str {
+        match msg_type {
+            "image" => "jpg",
+            "video" => "mp4",
+            "audio" => "m4a",
+            _ => "bin",
+        }
+    }
+
+    /// Format a local file path into a content marker string.
+    fn format_content_marker(msg_type: &str, path: &Path) -> String {
+        let path_str = path.display().to_string();
+        match msg_type {
+            "image" => format!("[IMAGE:{path_str}]"),
+            "video" => format!("[VIDEO:{path_str}]"),
+            "audio" => format!("[AUDIO:{path_str}]"),
+            _ => format!("[FILE:{path_str}]"),
+        }
+    }
+
+    // ── Mention helpers ───────────────────────────────────────────────────────
+
+    /// Returns `true` when the source is a group or room chat.
+    fn is_group_source(source: &LineSource) -> bool {
+        matches!(source.source_type.as_str(), "group" | "room")
+    }
+
+    /// If `text` contains `@<bot_name>`, strips the tag (and surrounding
+    /// whitespace) and returns the cleaned text.  Returns `None` if not found.
+    fn strip_mention(text: &str, bot_name: &str) -> Option<String> {
+        let tag = format!("@{bot_name}");
+        if text.contains(&tag) {
+            let cleaned = text.replace(&tag, "");
+            Some(cleaned.trim().to_string())
+        } else {
+            None
+        }
+    }
+
+    // ── Parse webhook into channel messages ───────────────────────────────────
+
+    /// Parse the raw JSON webhook payload into zero or more `ChannelMessage`s.
+    ///
+    /// This is called by the gateway handler after signature verification.
+    pub async fn parse_webhook_payload(&self, raw: &serde_json::Value) -> Vec<ChannelMessage> {
+        let webhook: LineWebhook = match serde_json::from_value(raw.clone()) {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::warn!("LINE: failed to parse webhook JSON: {e}");
+                return vec![];
+            }
+        };
+
+        let mut out = Vec::new();
+
+        for event in webhook.events {
+            if event.event_type != "message" {
+                continue;
+            }
+
+            let Some(msg) = event.message else { continue };
+            let Some(reply_target) = Self::reply_target(&event.source) else {
+                continue;
+            };
+
+            // The sender is always the userId (even in groups)
+            let sender = match event.source.user_id.as_deref() {
+                Some(uid) => uid.to_string(),
+                None => continue,
+            };
+
+            if !self.is_user_allowed(&sender) {
+                tracing::debug!("LINE: ignoring msg from non-allowlisted user {sender}");
+                continue;
+            }
+
+            let timestamp = event.timestamp.unwrap_or(0) / 1000;
+
+            // mention_only: in group/room chats, require @BotName in text messages.
+            // Strip the tag before forwarding so the agent sees clean input.
+            let is_group = Self::is_group_source(&event.source);
+            let mut mention_stripped_text: Option<String> = None;
+            if self.mention_only && is_group {
+                // Resolve bot name lazily — handles the case where the startup
+                // API call failed.  OnceCell guarantees the fetch runs at most
+                // once even under concurrent webhook requests.
+                if !self.bot_display_name.initialized() {
+                    self.resolve_bot_display_name().await;
+                }
+                match self.bot_display_name.get() {
+                    Some(bot_name) => {
+                        if let Some(raw_text) = &msg.text {
+                            match Self::strip_mention(raw_text, bot_name) {
+                                Some(cleaned) => mention_stripped_text = Some(cleaned),
+                                None => {
+                                    tracing::debug!(
+                                        "LINE: mention_only — skipping group msg without @{bot_name}"
+                                    );
+                                    continue;
+                                }
+                            }
+                        } else {
+                            // Non-text message in a group while mention_only — skip silently.
+                            tracing::debug!(
+                                "LINE: mention_only — skipping non-text group msg (no @mention possible)"
+                            );
+                            continue;
+                        }
+                    }
+                    None => {
+                        // API still unreachable — fail-closed: drop the group message
+                        // rather than bypassing the mention filter.
+                        tracing::warn!(
+                            "LINE: mention_only is true but bot_display_name could not be resolved; \
+                             dropping group message (fail-closed)"
+                        );
+                        continue;
+                    }
+                }
+            }
+
+            let content: Option<String> = match msg.msg_type.as_str() {
+                "text" => mention_stripped_text.or_else(|| msg.text.clone()),
+
+                "image" | "video" | "audio" => {
+                    let ext = Self::content_ext(&msg.msg_type);
+                    if let Some(path) = self.download_content(&msg.id, ext, &reply_target).await {
+                        Some(Self::format_content_marker(&msg.msg_type, &path))
+                    } else {
+                        // Fall back to a text description so the agent knows something arrived
+                        Some(format!("[LINE {} received]", msg.msg_type))
+                    }
+                }
+
+                "sticker" => Some("[Sticker 🎭]".to_string()),
+
+                other => {
+                    tracing::debug!("LINE: unsupported message type '{other}', skipping");
+                    None
+                }
+            };
+
+            let Some(content) = content else { continue };
+
+            // Build a stable, deduplicated message ID using the LINE message ID
+            let id = format!("line_{}", msg.id);
+
+            // Store the replyToken in thread_ts so the gateway handler can pass it
+            // to send_with_reply_token() without changing the ChannelMessage schema.
+            // LINE reply tokens are one-time-use and expire after 1 minute.
+            let reply_token = event.token.filter(|t| !t.is_empty());
+
+            out.push(ChannelMessage {
+                id,
+                sender,
+                reply_target,
+                content,
+                channel: "line".to_string(),
+                timestamp,
+                thread_ts: reply_token,
+                interruption_scope_id: None,
+                attachments: vec![],
+            });
+        }
+
+        out
+    }
+
+    // ── Outbound: split long messages ─────────────────────────────────────────
+
+    /// Split a long reply into 5000-char chunks (LINE's per-message limit).
+    fn split_message(text: &str) -> Vec<String> {
+        if text.chars().count() <= LINE_MAX_TEXT_LEN {
+            return vec![text.to_string()];
+        }
+        let mut chunks = Vec::new();
+        let mut remaining = text;
+        while !remaining.is_empty() {
+            let end = remaining
+                .char_indices()
+                .nth(LINE_MAX_TEXT_LEN)
+                .map(|(i, _)| i)
+                .unwrap_or(remaining.len());
+            chunks.push(remaining[..end].to_string());
+            remaining = &remaining[end..];
+        }
+        chunks
+    }
+
+    // ── Outbound: Push API ────────────────────────────────────────────────────
+
+    /// Send via Push API (`/message/push`). Consumes Push quota.
+    async fn send_via_push(&self, to: &str, text: &str) -> Result<()> {
+        for chunk in Self::split_message(text) {
+            let payload = LinePushRequest {
+                to,
+                messages: vec![LineTextMsg {
+                    msg_type: "text",
+                    text: chunk,
+                }],
+            };
+            let resp = self
+                .client
+                .post(self.api_url("message/push"))
+                .bearer_auth(&self.channel_access_token)
+                .json(&payload)
+                .send()
+                .await?;
+            if !resp.status().is_success() {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                anyhow::bail!("LINE push API error: {status} — {body}");
+            }
+        }
+        Ok(())
+    }
+
+    // ── Outbound: Reply API ───────────────────────────────────────────────────
+
+    /// Send via Reply API (`/message/reply`). Free — no Push quota cost.
+    ///
+    /// LINE allows **at most 5 messages per reply token** and the token
+    /// expires after **1 minute**. Only the first call per token is valid;
+    /// subsequent calls with the same token will fail.
+    async fn send_via_reply(&self, reply_token: &str, text: &str) -> Result<()> {
+        let chunks = Self::split_message(text);
+        // Reply API accepts up to 5 messages per call — send all at once.
+        let messages: Vec<LineTextMsg> = chunks
+            .into_iter()
+            .map(|t| LineTextMsg {
+                msg_type: "text",
+                text: t,
+            })
+            .collect();
+        let payload = LineReplyRequest {
+            reply_token,
+            messages,
+        };
+        let resp = self
+            .client
+            .post(self.api_url("message/reply"))
+            .bearer_auth(&self.channel_access_token)
+            .json(&payload)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("LINE reply API error: {status} — {body}");
+        }
+        Ok(())
+    }
+
+    // ── Outbound: mode-aware dispatch ─────────────────────────────────────────
+
+    /// Send a reply honouring the configured [`LineReplyMode`].
+    ///
+    /// The `reply_token` comes from the incoming webhook event and is stored
+    /// in `ChannelMessage::thread_ts` by [`parse_webhook_payload`].
+    ///
+    /// | Mode | Behaviour |
+    /// |------|-----------|
+    /// | `reply_first` | Reply API when token present; fallback to Push on error (e.g. expired token) |
+    /// | `push_only`   | Always Push API |
+    /// | `reply_only`  | Reply API; error if token absent |
+    pub async fn send_with_reply_token(
+        &self,
+        message: &SendMessage,
+        reply_token: Option<&str>,
+    ) -> Result<()> {
+        match self.reply_mode {
+            LineReplyMode::ReplyFirst => {
+                if let Some(token) = reply_token.filter(|t| !t.is_empty()) {
+                    tracing::debug!("LINE: sending via Reply API");
+                    match self.send_via_reply(token, &message.content).await {
+                        Ok(()) => Ok(()),
+                        Err(e) => {
+                            tracing::warn!(
+                                "LINE: Reply API failed ({e:#}), falling back to Push API"
+                            );
+                            self.send_via_push(&message.recipient, &message.content)
+                                .await
+                        }
+                    }
+                } else {
+                    tracing::debug!("LINE: no reply token — falling back to Push API");
+                    self.send_via_push(&message.recipient, &message.content)
+                        .await
+                }
+            }
+            LineReplyMode::PushOnly => {
+                tracing::debug!("LINE: push_only mode — using Push API");
+                self.send_via_push(&message.recipient, &message.content)
+                    .await
+            }
+            LineReplyMode::ReplyOnly => {
+                let token = reply_token.filter(|t| !t.is_empty()).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "LINE reply_only mode but no replyToken available for recipient {}",
+                        message.recipient
+                    )
+                })?;
+                tracing::debug!("LINE: reply_only mode — using Reply API");
+                self.send_via_reply(token, &message.content).await
+            }
+        }
+    }
+}
+
+// ── Channel trait ─────────────────────────────────────────────────────────────
+
+#[async_trait]
+impl Channel for LineChannel {
+    fn name(&self) -> &str {
+        "line"
+    }
+
+    /// Send via Push API — generic trait implementation (no reply token context).
+    ///
+    /// The gateway LINE handler uses [`LineChannel::send_with_reply_token`] instead,
+    /// which honours the configured [`LineReplyMode`]. This trait impl is kept for
+    /// programmatic / proactive sends that have no incoming `replyToken`.
+    async fn send(&self, message: &SendMessage) -> Result<()> {
+        self.send_via_push(&message.recipient, &message.content)
+            .await
+    }
+
+    /// LINE is webhook-based — this loop is a keepalive placeholder only.
+    ///
+    /// Actual inbound messages are processed by the gateway's `/line` handler,
+    /// which calls `parse_webhook_payload`.
+    async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
+        tracing::info!("LINE channel active (webhook mode — gateway handles inbound events).");
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+        }
+    }
+
+    async fn health_check(&self) -> bool {
+        // Call getProfile on ourselves; any 200 from the API means the token works
+        let url = self.api_url("info");
+        match self
+            .client
+            .get(&url)
+            .bearer_auth(&self.channel_access_token)
+            .send()
+            .await
+        {
+            Ok(r) => r.status().is_success(),
+            Err(_) => false,
+        }
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_channel() -> LineChannel {
+        LineChannel::new("test-token".to_string(), vec!["U123".to_string()])
+    }
+
+    #[test]
+    fn verify_signature_correct() {
+        // Pre-computed: HMAC-SHA256("secret", "{\"events\":[]}") → base64
+        let body = "{\"events\":[]}";
+        let secret = "secret";
+        let sig = {
+            let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+            mac.update(body.as_bytes());
+            general_purpose::STANDARD.encode(mac.finalize().into_bytes())
+        };
+        assert!(verify_line_signature(secret, body, &sig));
+    }
+
+    #[test]
+    fn verify_signature_wrong() {
+        assert!(!verify_line_signature("secret", "body", "badsig"));
+        assert!(!verify_line_signature("secret", "body", ""));
+    }
+
+    #[test]
+    fn is_user_allowed_wildcard() {
+        let ch = LineChannel::new("tok".to_string(), vec!["*".to_string()]);
+        assert!(ch.is_user_allowed("anyone"));
+    }
+
+    #[test]
+    fn is_user_allowed_specific() {
+        let ch = make_channel();
+        assert!(ch.is_user_allowed("U123"));
+        assert!(!ch.is_user_allowed("U999"));
+    }
+
+    #[test]
+    fn split_message_short() {
+        let chunks = LineChannel::split_message("hello");
+        assert_eq!(chunks, vec!["hello"]);
+    }
+
+    #[test]
+    fn split_message_long() {
+        let long_text = "a".repeat(LINE_MAX_TEXT_LEN + 10);
+        let chunks = LineChannel::split_message(&long_text);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].len(), LINE_MAX_TEXT_LEN);
+    }
+
+    #[tokio::test]
+    async fn parse_empty_events() {
+        let ch = make_channel();
+        let raw = serde_json::json!({"events": []});
+        let msgs = ch.parse_webhook_payload(&raw).await;
+        assert!(msgs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn parse_text_message_allowed() {
+        let ch = make_channel();
+        let raw = serde_json::json!({
+            "events": [{
+                "type": "message",
+                "replyToken": "tok",
+                "timestamp": 1_700_000_000_000u64,
+                "source": { "type": "user", "userId": "U123" },
+                "message": { "id": "m1", "type": "text", "text": "hello bot" }
+            }]
+        });
+        let msgs = ch.parse_webhook_payload(&raw).await;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].content, "hello bot");
+        assert_eq!(msgs[0].sender, "U123");
+        assert_eq!(msgs[0].reply_target, "U123");
+        assert_eq!(msgs[0].channel, "line");
+    }
+
+    #[tokio::test]
+    async fn parse_text_message_denied() {
+        let ch = make_channel();
+        let raw = serde_json::json!({
+            "events": [{
+                "type": "message",
+                "replyToken": "tok",
+                "timestamp": 1_700_000_000_000u64,
+                "source": { "type": "user", "userId": "U_BLOCKED" },
+                "message": { "id": "m2", "type": "text", "text": "hack" }
+            }]
+        });
+        let msgs = ch.parse_webhook_payload(&raw).await;
+        assert!(msgs.is_empty(), "blocked user must not produce messages");
+    }
+
+    #[tokio::test]
+    async fn parse_group_message() {
+        let ch = LineChannel::new("tok".to_string(), vec!["*".to_string()]);
+        let raw = serde_json::json!({
+            "events": [{
+                "type": "message",
+                "replyToken": "tok",
+                "timestamp": 1_700_000_000_000u64,
+                "source": {
+                    "type": "group",
+                    "groupId": "C_GROUP",
+                    "userId": "U_MEMBER"
+                },
+                "message": { "id": "m3", "type": "text", "text": "group msg" }
+            }]
+        });
+        let msgs = ch.parse_webhook_payload(&raw).await;
+        assert_eq!(msgs.len(), 1);
+        // reply_target for groups must be the groupId, not the userId
+        assert_eq!(msgs[0].reply_target, "C_GROUP");
+        assert_eq!(msgs[0].sender, "U_MEMBER");
+    }
+
+    #[tokio::test]
+    async fn parse_sticker() {
+        let ch = LineChannel::new("tok".to_string(), vec!["*".to_string()]);
+        let raw = serde_json::json!({
+            "events": [{
+                "type": "message",
+                "replyToken": "tok",
+                "timestamp": 1_700_000_000_000u64,
+                "source": { "type": "user", "userId": "U999" },
+                "message": { "id": "m4", "type": "sticker" }
+            }]
+        });
+        let msgs = ch.parse_webhook_payload(&raw).await;
+        assert_eq!(msgs.len(), 1);
+        assert!(msgs[0].content.contains("Sticker"));
+    }
+
+    #[tokio::test]
+    async fn parse_non_message_event_ignored() {
+        let ch = make_channel();
+        let raw = serde_json::json!({
+            "events": [{
+                "type": "follow",
+                "timestamp": 1_700_000_000_000u64,
+                "source": { "type": "user", "userId": "U123" }
+            }]
+        });
+        let msgs = ch.parse_webhook_payload(&raw).await;
+        assert!(msgs.is_empty());
+    }
+
+    // ── reply_mode tests ──────────────────────────────────────────────────────
+
+    #[test]
+    fn default_reply_mode_is_reply_first() {
+        let ch = make_channel();
+        assert_eq!(ch.reply_mode, LineReplyMode::ReplyFirst);
+    }
+
+    #[test]
+    fn with_reply_mode_sets_mode() {
+        let ch = LineChannel::new("tok".to_string(), vec!["*".to_string()])
+            .with_reply_mode(LineReplyMode::PushOnly);
+        assert_eq!(ch.reply_mode, LineReplyMode::PushOnly);
+    }
+
+    #[tokio::test]
+    async fn parse_stores_reply_token_in_thread_ts() {
+        let ch = make_channel();
+        let raw = serde_json::json!({
+            "events": [{
+                "type": "message",
+                "replyToken": "my-reply-token",
+                "timestamp": 1_700_000_000_000u64,
+                "source": { "type": "user", "userId": "U123" },
+                "message": { "id": "m1", "type": "text", "text": "hi" }
+            }]
+        });
+        let msgs = ch.parse_webhook_payload(&raw).await;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].thread_ts.as_deref(), Some("my-reply-token"));
+    }
+
+    #[tokio::test]
+    async fn parse_empty_reply_token_stored_as_none() {
+        let ch = make_channel();
+        let raw = serde_json::json!({
+            "events": [{
+                "type": "message",
+                "replyToken": "",
+                "timestamp": 1_700_000_000_000u64,
+                "source": { "type": "user", "userId": "U123" },
+                "message": { "id": "m2", "type": "text", "text": "hi" }
+            }]
+        });
+        let msgs = ch.parse_webhook_payload(&raw).await;
+        assert_eq!(msgs.len(), 1);
+        assert!(
+            msgs[0].thread_ts.is_none(),
+            "empty token must be stored as None"
+        );
+    }
+
+    #[tokio::test]
+    async fn reply_only_mode_errors_without_token() {
+        let ch = LineChannel::new("tok".to_string(), vec!["*".to_string()])
+            .with_reply_mode(LineReplyMode::ReplyOnly);
+        let msg = crate::channels::traits::SendMessage::new("hello", "U999");
+        let result = ch.send_with_reply_token(&msg, None).await;
+        assert!(result.is_err(), "reply_only without token must return Err");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("reply_only mode but no replyToken")
+        );
+    }
+
+    // ── mention_only tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn strip_mention_found_returns_clean_text() {
+        let result = LineChannel::strip_mention("@ZeroClaw what is rust?", "ZeroClaw");
+        assert_eq!(result, Some("what is rust?".to_string()));
+    }
+
+    #[test]
+    fn strip_mention_not_found_returns_none() {
+        let result = LineChannel::strip_mention("just a normal message", "ZeroClaw");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn strip_mention_whitespace_trimmed() {
+        let result = LineChannel::strip_mention("  @ZeroClaw   hello  ", "ZeroClaw");
+        assert_eq!(result, Some("hello".to_string()));
+    }
+
+    #[test]
+    fn with_mention_only_sets_flag_and_name() {
+        let ch = LineChannel::new("tok".to_string(), vec!["*".to_string()])
+            .with_mention_only(true, Some("ZeroClaw".to_string()));
+        assert!(ch.mention_only);
+        assert_eq!(
+            ch.bot_display_name.get().map(|s| s.as_str()),
+            Some("ZeroClaw")
+        );
+    }
+
+    #[test]
+    fn with_mention_only_no_override_leaves_cell_empty() {
+        let ch = LineChannel::new("tok".to_string(), vec!["*".to_string()])
+            .with_mention_only(true, None);
+        assert!(ch.mention_only);
+        assert!(ch.bot_display_name.get().is_none());
+    }
+
+    #[test]
+    fn is_group_source_user_returns_false() {
+        let src = LineSource {
+            source_type: "user".to_string(),
+            user_id: Some("U1".to_string()),
+            group_id: None,
+            room_id: None,
+        };
+        assert!(!LineChannel::is_group_source(&src));
+    }
+
+    #[test]
+    fn is_group_source_group_returns_true() {
+        let src = LineSource {
+            source_type: "group".to_string(),
+            user_id: Some("U1".to_string()),
+            group_id: Some("C_GROUP".to_string()),
+            room_id: None,
+        };
+        assert!(LineChannel::is_group_source(&src));
+    }
+
+    #[tokio::test]
+    async fn mention_only_group_skips_message_without_tag() {
+        let ch = LineChannel::new("tok".to_string(), vec!["*".to_string()])
+            .with_mention_only(true, Some("ZeroClaw".to_string()));
+        let raw = serde_json::json!({
+            "events": [{
+                "type": "message",
+                "replyToken": "tok",
+                "timestamp": 1_700_000_000_000u64,
+                "source": { "type": "group", "groupId": "C_GROUP", "userId": "U_MEMBER" },
+                "message": { "id": "m10", "type": "text", "text": "hello everyone" }
+            }]
+        });
+        let msgs = ch.parse_webhook_payload(&raw).await;
+        assert!(msgs.is_empty(), "no @mention — must be skipped");
+    }
+
+    #[tokio::test]
+    async fn mention_only_group_processes_message_with_tag() {
+        let ch = LineChannel::new("tok".to_string(), vec!["*".to_string()])
+            .with_mention_only(true, Some("ZeroClaw".to_string()));
+        let raw = serde_json::json!({
+            "events": [{
+                "type": "message",
+                "replyToken": "tok",
+                "timestamp": 1_700_000_000_000u64,
+                "source": { "type": "group", "groupId": "C_GROUP", "userId": "U_MEMBER" },
+                "message": { "id": "m11", "type": "text", "text": "@ZeroClaw what is rust?" }
+            }]
+        });
+        let msgs = ch.parse_webhook_payload(&raw).await;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(
+            msgs[0].content, "what is rust?",
+            "@mention must be stripped"
+        );
+        assert_eq!(msgs[0].reply_target, "C_GROUP");
+    }
+
+    #[tokio::test]
+    async fn mention_only_direct_message_always_processed() {
+        let ch = LineChannel::new("tok".to_string(), vec!["*".to_string()])
+            .with_mention_only(true, Some("ZeroClaw".to_string()));
+        let raw = serde_json::json!({
+            "events": [{
+                "type": "message",
+                "replyToken": "tok",
+                "timestamp": 1_700_000_000_000u64,
+                "source": { "type": "user", "userId": "U_DM" },
+                "message": { "id": "m12", "type": "text", "text": "no tag needed in DM" }
+            }]
+        });
+        let msgs = ch.parse_webhook_payload(&raw).await;
+        assert_eq!(msgs.len(), 1, "1:1 DM must bypass mention_only filter");
+        assert_eq!(msgs[0].content, "no tag needed in DM");
+    }
+
+    #[tokio::test]
+    async fn mention_only_false_passes_group_messages_through() {
+        let ch = LineChannel::new("tok".to_string(), vec!["*".to_string()]);
+        let raw = serde_json::json!({
+            "events": [{
+                "type": "message",
+                "replyToken": "tok",
+                "timestamp": 1_700_000_000_000u64,
+                "source": { "type": "group", "groupId": "C_GROUP", "userId": "U_MEMBER" },
+                "message": { "id": "m13", "type": "text", "text": "no tag but mention_only off" }
+            }]
+        });
+        let msgs = ch.parse_webhook_payload(&raw).await;
+        assert_eq!(msgs.len(), 1, "mention_only=false must pass all messages");
+    }
+}

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -28,6 +28,7 @@ pub mod imessage;
 pub mod irc;
 #[cfg(feature = "channel-lark")]
 pub mod lark;
+pub mod line;
 pub mod link_enricher;
 pub mod linq;
 #[cfg(feature = "channel-matrix")]
@@ -77,6 +78,7 @@ pub use imessage::IMessageChannel;
 pub use irc::IrcChannel;
 #[cfg(feature = "channel-lark")]
 pub use lark::LarkChannel;
+pub use line::LineChannel;
 pub use linq::LinqChannel;
 #[cfg(feature = "channel-matrix")]
 pub use matrix::MatrixChannel;

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6102,6 +6102,8 @@ pub struct ChannelsConfig {
     pub signal: Option<SignalConfig>,
     /// WhatsApp channel configuration (Cloud API or Web mode).
     pub whatsapp: Option<WhatsAppConfig>,
+    /// LINE Messaging API channel configuration.
+    pub line: Option<LineConfig>,
     /// Linq Partner API channel configuration.
     pub linq: Option<LinqConfig>,
     /// WATI WhatsApp Business API channel configuration.
@@ -6215,6 +6217,10 @@ impl ChannelsConfig {
                 self.whatsapp.is_some(),
             ),
             (
+                Box::new(ConfigWrapper::new(self.line.as_ref())),
+                self.line.is_some(),
+            ),
+            (
                 Box::new(ConfigWrapper::new(self.linq.as_ref())),
                 self.linq.is_some(),
             ),
@@ -6319,6 +6325,7 @@ impl Default for ChannelsConfig {
             matrix: None,
             signal: None,
             whatsapp: None,
+            line: None,
             linq: None,
             wati: None,
             nextcloud_talk: None,
@@ -6857,6 +6864,61 @@ impl ChannelConfig for WhatsAppConfig {
     }
     fn desc() -> &'static str {
         "Business Cloud API"
+    }
+}
+
+/// Outbound message delivery mode for the LINE channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum LineReplyMode {
+    /// Use Reply API when a `replyToken` is available (free, no quota cost),
+    /// fall back to Push API when no token is present (e.g. proactive messages).
+    /// **This is the recommended default** — it conserves Push quota on free plans.
+    #[default]
+    ReplyFirst,
+    /// Always use Push API regardless of whether a `replyToken` is available.
+    /// Compatible with all message types but consumes Push quota every time.
+    PushOnly,
+    /// Always use Reply API. Fails for proactive/scheduled messages that have
+    /// no `replyToken`. Suitable when Push API is not available on the plan.
+    ReplyOnly,
+}
+
+/// LINE Messaging API channel configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct LineConfig {
+    /// LINE Channel Secret — used to verify `X-Line-Signature` webhook headers.
+    /// Can also be set via `ZEROCLAW_LINE_CHANNEL_SECRET` env var.
+    pub channel_secret: String,
+    /// LINE Channel Access Token — used for outbound push messages and content download.
+    pub channel_access_token: String,
+    /// Allowed LINE user IDs that the bot will respond to.
+    /// Use `["*"]` to allow all users (not recommended for public bots).
+    pub allowed_users: Vec<String>,
+    /// Outbound delivery mode: `reply_first` (default), `push_only`, or `reply_only`.
+    ///
+    /// - `reply_first` — Reply API when `replyToken` available, Push API as fallback.
+    /// - `push_only`   — Always Push API (current legacy behavior).
+    /// - `reply_only`  — Always Reply API; fails without a `replyToken`.
+    #[serde(default)]
+    pub reply_mode: LineReplyMode,
+    /// When `true`, the bot only responds in group chats when @mentioned by
+    /// `bot_display_name`.  1:1 messages are always processed regardless.
+    /// Defaults to `false`.
+    #[serde(default)]
+    pub mention_only: bool,
+    /// Display name the bot uses inside LINE groups (e.g. `"ZeroClaw"`).
+    /// Required when `mention_only = true`; ignored otherwise.
+    #[serde(default)]
+    pub bot_display_name: Option<String>,
+}
+
+impl ChannelConfig for LineConfig {
+    fn name() -> &'static str {
+        "LINE"
+    }
+    fn desc() -> &'static str {
+        "LINE Messaging API bot"
     }
 }
 
@@ -11509,6 +11571,7 @@ auto_save = true
                 matrix: None,
                 signal: None,
                 whatsapp: None,
+                line: None,
                 linq: None,
                 wati: None,
                 nextcloud_talk: None,
@@ -12549,6 +12612,7 @@ allowed_users = ["@ops:matrix.org"]
             }),
             signal: None,
             whatsapp: None,
+            line: None,
             linq: None,
             wati: None,
             nextcloud_talk: None,
@@ -12923,6 +12987,7 @@ channel_ids = ["C123", "D456"]
                 group_mention_patterns: vec![],
                 proxy_url: None,
             }),
+            line: None,
             linq: None,
             wati: None,
             nextcloud_talk: None,

--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -1626,6 +1626,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            line: None,
+            line_channel_secret: None,
             linq: None,
             linq_signing_secret: None,
             nextcloud_talk: None,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -23,8 +23,9 @@ pub mod tls;
 pub mod ws;
 
 use crate::channels::{
-    Channel, GmailPushChannel, LinqChannel, NextcloudTalkChannel, SendMessage, WatiChannel,
-    WhatsAppChannel, session_backend::SessionBackend, session_sqlite::SqliteSessionBackend,
+    Channel, GmailPushChannel, LineChannel, LinqChannel, NextcloudTalkChannel, SendMessage,
+    WatiChannel, WhatsAppChannel, session_backend::SessionBackend,
+    session_sqlite::SqliteSessionBackend,
 };
 use crate::config::Config;
 use crate::cost::CostTracker;
@@ -93,6 +94,10 @@ fn linq_memory_key(msg: &crate::channels::traits::ChannelMessage) -> String {
 
 fn wati_memory_key(msg: &crate::channels::traits::ChannelMessage) -> String {
     format!("wati_{}_{}", msg.sender, msg.id)
+}
+
+fn line_memory_key(msg: &crate::channels::traits::ChannelMessage) -> String {
+    format!("line_{}_{}", msg.sender, msg.id)
 }
 
 fn nextcloud_talk_memory_key(msg: &crate::channels::traits::ChannelMessage) -> String {
@@ -337,6 +342,10 @@ pub struct AppState {
     pub whatsapp: Option<Arc<WhatsAppChannel>>,
     /// `WhatsApp` app secret for webhook signature verification (`X-Hub-Signature-256`)
     pub whatsapp_app_secret: Option<Arc<str>>,
+    /// LINE Messaging API channel
+    pub line: Option<Arc<LineChannel>>,
+    /// LINE Channel Secret for `X-Line-Signature` verification
+    pub line_channel_secret: Option<Arc<str>>,
     pub linq: Option<Arc<LinqChannel>>,
     /// Linq webhook signing secret for signature verification
     pub linq_signing_secret: Option<Arc<str>>,
@@ -582,6 +591,45 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         })
         .map(Arc::from);
 
+    // LINE channel (if configured)
+    let line_channel: Option<Arc<LineChannel>> = if let Some(ln) =
+        config.channels_config.line.as_ref()
+    {
+        let mut ch = LineChannel::new(ln.channel_access_token.clone(), ln.allowed_users.clone())
+            .with_reply_mode(ln.reply_mode)
+            .with_mention_only(ln.mention_only, ln.bot_display_name.clone());
+        if let Some(ws_dir) = config.workspace_dir.parent() {
+            ch = ch.with_workspace_dir(ws_dir.join("workspace"));
+        }
+        let ch = Arc::new(ch);
+        // Resolve bot display name (no-op if already set via config override).
+        // Only needed when mention_only is enabled, but cheap to call regardless.
+        if ln.mention_only {
+            ch.resolve_bot_display_name().await;
+        }
+        Some(ch)
+    } else {
+        None
+    };
+
+    // LINE Channel Secret for webhook signature verification
+    // Priority: environment variable > config file
+    let line_channel_secret: Option<Arc<str>> = std::env::var("ZEROCLAW_LINE_CHANNEL_SECRET")
+        .ok()
+        .and_then(|s| {
+            let s = s.trim().to_owned();
+            (!s.is_empty()).then_some(s)
+        })
+        .or_else(|| {
+            config
+                .channels_config
+                .line
+                .as_ref()
+                .map(|ln| ln.channel_secret.trim().to_owned())
+                .filter(|s| !s.is_empty())
+        })
+        .map(Arc::from);
+
     // Linq channel (if configured)
     let linq_channel: Option<Arc<LinqChannel>> = config.channels_config.linq.as_ref().map(|lq| {
         Arc::new(LinqChannel::new(
@@ -768,6 +816,9 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
     if linq_channel.is_some() {
         println!("  POST {pfx}/linq      — Linq message webhook (iMessage/RCS/SMS)");
     }
+    if line_channel.is_some() {
+        println!("  POST {pfx}/line      — LINE message webhook");
+    }
     if wati_channel.is_some() {
         println!("  GET  {pfx}/wati      — WATI webhook verification");
         println!("  POST {pfx}/wati      — WATI message webhook");
@@ -834,6 +885,8 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         idempotency_store,
         whatsapp: whatsapp_channel,
         whatsapp_app_secret,
+        line: line_channel,
+        line_channel_secret,
         linq: linq_channel,
         linq_signing_secret,
         nextcloud_talk: nextcloud_talk_channel,
@@ -897,6 +950,7 @@ pub async fn run_gateway(host: &str, port: u16, config: Config) -> Result<()> {
         .route("/webhook", post(handle_webhook))
         .route("/whatsapp", get(handle_whatsapp_verify))
         .route("/whatsapp", post(handle_whatsapp_message))
+        .route("/line", post(handle_line_webhook))
         .route("/linq", post(handle_linq_webhook))
         .route("/wati", get(handle_wati_verify))
         .route("/wati", post(handle_wati_webhook))
@@ -1694,6 +1748,151 @@ async fn handle_whatsapp_message(
     (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
 }
 
+/// POST /line — incoming message webhook from LINE Messaging API
+async fn handle_line_webhook(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    let Some(ref line) = state.line else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "LINE not configured"})),
+        );
+    };
+
+    // ── Security: Body size limit ─────────────────────────────────────────────
+    if body.len() > MAX_BODY_SIZE {
+        tracing::warn!("LINE webhook body too large: {} bytes", body.len());
+        return (
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(serde_json::json!({"error": "Payload too large"})),
+        );
+    }
+
+    // ── Security: Require valid UTF-8 before signature check ─────────────────
+    let body_str = match std::str::from_utf8(&body) {
+        Ok(s) => s,
+        Err(_) => {
+            tracing::warn!("LINE webhook body is not valid UTF-8");
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "Invalid UTF-8 body"})),
+            );
+        }
+    };
+
+    // ── Security: Verify X-Line-Signature (mandatory) ────────────────────────
+    let Some(ref channel_secret) = state.line_channel_secret else {
+        tracing::error!("LINE channel_secret not configured — rejecting webhook");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "LINE channel_secret not configured"})),
+        );
+    };
+    let signature = headers
+        .get("X-Line-Signature")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if !crate::channels::line::verify_line_signature(channel_secret, body_str, signature) {
+        tracing::warn!(
+            "LINE webhook signature verification failed ({})",
+            if signature.is_empty() {
+                "missing"
+            } else {
+                "invalid"
+            }
+        );
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "Invalid signature"})),
+        );
+    }
+
+    // ── Parse JSON body ───────────────────────────────────────────────────────
+    let Ok(payload) = serde_json::from_str::<serde_json::Value>(body_str) else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "Invalid JSON payload"})),
+        );
+    };
+
+    // ── Parse and dispatch messages ───────────────────────────────────────────
+    let messages = line.parse_webhook_payload(&payload).await;
+
+    if messages.is_empty() {
+        // Acknowledge without processing (e.g. follow/join events)
+        return (StatusCode::OK, Json(serde_json::json!({"status": "ok"})));
+    }
+
+    for msg in messages {
+        tracing::info!(
+            "LINE message from {}: {}",
+            msg.sender,
+            truncate_with_ellipsis(&msg.content, 50)
+        );
+        let session_id = sender_session_id("line", &msg);
+
+        // Spawn everything (including memory save) so the webhook returns 200
+        // immediately — minimises reply-token expiry risk.
+        let state_clone = state.clone();
+        let line_clone = Arc::clone(line);
+        let content = msg.content.clone();
+        let reply_target = msg.reply_target.clone();
+        let reply_token = msg.thread_ts.clone();
+        tokio::spawn(async move {
+            // Auto-save to memory (non-blocking relative to HTTP response)
+            if state_clone.auto_save && !memory::should_skip_autosave_content(&content) {
+                let key = line_memory_key(&msg);
+                let _ = state_clone
+                    .mem
+                    .store(
+                        &key,
+                        &content,
+                        MemoryCategory::Conversation,
+                        Some(&session_id),
+                    )
+                    .await;
+            }
+
+            match Box::pin(run_gateway_chat_with_tools(
+                &state_clone,
+                &content,
+                Some(&session_id),
+            ))
+            .await
+            {
+                Ok(response) => {
+                    if let Err(e) = line_clone
+                        .send_with_reply_token(
+                            &SendMessage::new(response, &reply_target),
+                            reply_token.as_deref(),
+                        )
+                        .await
+                    {
+                        tracing::error!("Failed to send LINE reply: {e}");
+                    }
+                }
+                Err(e) => {
+                    tracing::error!("LLM error for LINE message: {e:#}");
+                    let _ = line_clone
+                        .send_with_reply_token(
+                            &SendMessage::new(
+                                "Sorry, I couldn't process your message right now.",
+                                &reply_target,
+                            ),
+                            reply_token.as_deref(),
+                        )
+                        .await;
+                }
+            }
+        });
+    }
+
+    // LINE expects HTTP 200 OK
+    (StatusCode::OK, Json(serde_json::json!({"status": "ok"})))
+}
+
 /// POST /linq — incoming message webhook (iMessage/RCS/SMS via Linq)
 async fn handle_linq_webhook(
     State(state): State<AppState>,
@@ -2323,6 +2522,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            line: None,
+            line_channel_secret: None,
             linq: None,
             linq_signing_secret: None,
             nextcloud_talk: None,
@@ -2391,6 +2592,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            line: None,
+            line_channel_secret: None,
             linq: None,
             linq_signing_secret: None,
             nextcloud_talk: None,
@@ -2785,6 +2988,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            line: None,
+            line_channel_secret: None,
             linq: None,
             linq_signing_secret: None,
             nextcloud_talk: None,
@@ -2863,6 +3068,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            line: None,
+            line_channel_secret: None,
             linq: None,
             linq_signing_secret: None,
             nextcloud_talk: None,
@@ -2953,6 +3160,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            line: None,
+            line_channel_secret: None,
             linq: None,
             linq_signing_secret: None,
             nextcloud_talk: None,
@@ -3015,6 +3224,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            line: None,
+            line_channel_secret: None,
             linq: None,
             linq_signing_secret: None,
             nextcloud_talk: None,
@@ -3082,6 +3293,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            line: None,
+            line_channel_secret: None,
             linq: None,
             linq_signing_secret: None,
             nextcloud_talk: None,
@@ -3154,6 +3367,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            line: None,
+            line_channel_secret: None,
             linq: None,
             linq_signing_secret: None,
             nextcloud_talk: None,
@@ -3223,6 +3438,8 @@ mod tests {
             idempotency_store: Arc::new(IdempotencyStore::new(Duration::from_secs(300), 1000)),
             whatsapp: None,
             whatsapp_app_secret: None,
+            line: None,
+            line_channel_secret: None,
             linq: None,
             linq_signing_secret: None,
             nextcloud_talk: Some(channel),


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: PR #5049 (re-open of #4822) fails the `Lint` check in both CI and Quality Gate workflows due to missing `cargo fmt` fix on `src/hardware/uf2.rs` and `src/peripherals/uno_q_bridge.rs` — these were fixed in the original branch (commit `99fea1e4`) but absent from the squashed re-open commit.
- Why it matters: LINE is a dominant messaging platform in Southeast Asia; many operators need it alongside Discord/Telegram. Free LINE OA plans cap Push API at 500 messages/month, so using Reply API (free, unlimited) by default is critical for cost control. The fmt gate must pass before merge.
- What changed: Carries forward all code from #4822 (LINE channel implementation) plus adds the missing `cargo fmt` fix to `src/hardware/uf2.rs` and `src/peripherals/uno_q_bridge.rs` test assertions so the formatting gate passes.
- What did **not** change: No logic changes beyond what was already reviewed and merged in #4822. No changes to existing channels, providers, memory, security policy, or `ChannelMessage` struct layout.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: L` (auto-managed)
- Scope labels: `channel, config, gateway, security, docs`
- Module labels: `channel: line`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: —

## Change Metadata

- Change type: `feature`
- Primary scope: `channel`

## Linked Issue

- Closes # — no prior issue; new channel integration (LINE Messaging API)
- Supersedes #5049
- Supersedes #4822

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors:
  - #5049 by @SimianAstronaut7
  - #4822 by @ninenox
- Integrated scope by source PR:
  - #4822: full LINE channel implementation (all commits), security hardening, mention_only mode, gateway handler — 100% carried forward
  - #5049: squashed re-open of #4822 — same code, missing only the fmt fix restored in this PR
- `Co-authored-by` trailers added for materially incorporated contributors? `Yes`
- Trailer format check: `Pass`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check    # pass
cargo clippy -- -D warnings   # pass (0 errors, 0 warnings)
cargo test --lib -- channels::line  # 28/28 passed
cargo test --locked           # 5820 passed, 2 pre-existing failures unrelated
```

- Evidence provided: 28 LINE-specific unit tests pass; `cargo fmt --check` passes locally after adding fmt fix commit.
- If any command is intentionally skipped, explain why: —

## Security Impact (required)

- New permissions/capabilities? `Yes` — gateway exposes new `POST /line` public endpoint.
- New external network calls? `Yes` — LINE Messaging API (push, reply, content, bot info).
- Secrets/tokens handling changed? `Yes` — `channel_access_token` Bearer header; `channel_secret` HMAC-only, never logged.
- File system access scope changed? `Yes` — media saved to `workspace/line_files/`, capped at 10 MB enforced unconditionally post-download.
- Risk and mitigation: HMAC-SHA256 constant-time signature verification on every webhook; user allowlist; path traversal sanitization on filenames; fail-closed on mention filter API failure; body size cap (64 KB) enforced before any processing; non-UTF-8 bodies rejected with 400.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No real user data. All test fixtures use project-scoped identifiers only.
- Neutral wording confirmation: Test fixtures use ZeroClaw-native identifiers only (`U123`, `U_MEMBER`, `C_GROUP`).

## Compatibility / Migration

- Backward compatible? `Yes` — `[channels_config.line]` is optional; existing configs unaffected.
- Config/env changes? `Yes` — new optional `[channels_config.line]` block with `LineReplyMode` enum.
- Migration needed? `No` — additive only.
- If yes, exact upgrade steps: —

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No` — README addition is English-only config example, not a runtime-contract doc.
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: Config example added to README.md only; locale parity for a new channel config block is out of scope for this PR.

## Human Verification (required)

- Verified scenarios: Live daemon with LINE config; `POST /line` webhook verified from LINE Developer Console (HTTP 200); inbound message dispatched; bot replied via Reply API in group; signature rejection confirmed (invalid sig → 401).
- Edge cases checked: expired replyToken fallback to Push; mention_only group filtering; fail-closed on bot name API failure; body > 64 KB rejected; non-UTF-8 body rejected.
- What was not verified: Media download path (requires real image from LINE).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `src/channels/` (new file), `src/gateway/mod.rs` (new route), `src/config/schema.rs` (new config keys), `src/hardware/uf2.rs` and `src/peripherals/uno_q_bridge.rs` (test formatting only — no logic change).
- Potential unintended effects: None expected; LINE channel is opt-in via config.
- Guardrails/monitoring for early detection: Existing CI gates; HMAC rejection logs visible in gateway stderr.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (claude-sonnet-4-6)
- Workflow/plan summary: Carried forward all commits from #4822; added missing fmt fix (originally commit `99fea1e4` in #4822) to unblock CI Lint gate; verified `cargo fmt --check` passes locally.
- Verification focus: Formatting gate; no logic drift from #4822.
- Confirmation: naming + architecture boundaries followed per `AGENTS.md` + `CONTRIBUTING.md`. Supersede attribution included per queue hygiene rules.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 95d02d03` — removes all LINE channel code (squashed main commit).
- Feature flags or config toggles: Remove `[channels_config.line]` from `config.toml` to disable at runtime without redeployment.
- Observable failure symptoms: Gateway startup logs missing `LINE channel registered`; `POST /line` returns 404.

## Risks and Mitigations

- Risk: fmt fix touches `src/hardware/uf2.rs` and `src/peripherals/uno_q_bridge.rs` which are unrelated to the LINE channel.
  - Mitigation: Changes are formatting-only in `#[cfg(test)]` test assertions (no logic change). This exact fix was already reviewed and accepted in #4822 commit `99fea1e4`. Files are not in high-risk tier per `AGENTS.md`.