### PR TITLE
docs(channel): clarify WhatsApp Web feature reinstall guidance

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -97,6 +97,8 @@ use zeroclaw_runtime::agent::loop_::{
     is_model_switch_requested, run_tool_call_loop, scope_thread_id, scrub_credentials,
 };
 use zeroclaw_runtime::approval::ApprovalManager;
+#[cfg(not(feature = "whatsapp-web"))]
+use zeroclaw_runtime::i18n;
 use zeroclaw_runtime::observability::traits::{ObserverEvent, ObserverMetric};
 use zeroclaw_runtime::observability::{self, Observer, runtime_trace};
 use zeroclaw_runtime::platform;
@@ -4920,11 +4922,22 @@ fn collect_configured_channels(
                             "WhatsApp Web backend requires 'whatsapp-web' feature. Build/run with --features whatsapp-web"
                         );
                         eprintln!(
-                            "  ⚠ WhatsApp Web is configured but the 'whatsapp-web' feature is not compiled in."
+                            "{}",
+                            i18n::get_required_cli_string(
+                                "channel-whatsapp-web-feature-missing-warning"
+                            )
                         );
-                        eprintln!("    Build/run with: cargo build --features whatsapp-web");
                         eprintln!(
-                            "    If installed to PATH, reinstall with: cargo install --path . --force --locked --features whatsapp-web"
+                            "{}",
+                            i18n::get_required_cli_string(
+                                "channel-whatsapp-web-feature-missing-build"
+                            )
+                        );
+                        eprintln!(
+                            "{}",
+                            i18n::get_required_cli_string(
+                                "channel-whatsapp-web-feature-missing-install"
+                            )
                         );
                     }
                 }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -4917,12 +4917,15 @@ fn collect_configured_channels(
                     #[cfg(not(feature = "whatsapp-web"))]
                     {
                         tracing::warn!(
-                            "WhatsApp Web backend requires 'whatsapp-web' feature. Enable with: cargo build --features whatsapp-web"
+                            "WhatsApp Web backend requires 'whatsapp-web' feature. Build/run with --features whatsapp-web"
                         );
                         eprintln!(
                             "  ⚠ WhatsApp Web is configured but the 'whatsapp-web' feature is not compiled in."
                         );
-                        eprintln!("    Rebuild with: cargo build --features whatsapp-web");
+                        eprintln!("    Build/run with: cargo build --features whatsapp-web");
+                        eprintln!(
+                            "    If installed to PATH, reinstall with: cargo install --path . --force --locked --features whatsapp-web"
+                        );
                     }
                 }
                 _ => {

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -10,6 +10,8 @@
 //! This channel requires the `whatsapp-web` feature flag:
 //! ```sh
 //! cargo build --features whatsapp-web
+//! # If installed to PATH:
+//! cargo install --path . --force --locked --features whatsapp-web
 //! ```
 //!
 //! # Configuration
@@ -1754,14 +1756,16 @@ impl Channel for WhatsAppWebChannel {
     async fn send(&self, _message: &SendMessage) -> Result<()> {
         anyhow::bail!(
             "WhatsApp Web channel requires the 'whatsapp-web' feature. \
-            Enable with: cargo build --features whatsapp-web"
+            Enable with: cargo build --features whatsapp-web \
+            (or, if installed to PATH: cargo install --path . --force --locked --features whatsapp-web)"
         );
     }
 
     async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
         anyhow::bail!(
             "WhatsApp Web channel requires the 'whatsapp-web' feature. \
-            Enable with: cargo build --features whatsapp-web"
+            Enable with: cargo build --features whatsapp-web \
+            (or, if installed to PATH: cargo install --path . --force --locked --features whatsapp-web)"
         );
     }
 
@@ -1772,14 +1776,16 @@ impl Channel for WhatsAppWebChannel {
     async fn start_typing(&self, _recipient: &str) -> Result<()> {
         anyhow::bail!(
             "WhatsApp Web channel requires the 'whatsapp-web' feature. \
-            Enable with: cargo build --features whatsapp-web"
+            Enable with: cargo build --features whatsapp-web \
+            (or, if installed to PATH: cargo install --path . --force --locked --features whatsapp-web)"
         );
     }
 
     async fn stop_typing(&self, _recipient: &str) -> Result<()> {
         anyhow::bail!(
             "WhatsApp Web channel requires the 'whatsapp-web' feature. \
-            Enable with: cargo build --features whatsapp-web"
+            Enable with: cargo build --features whatsapp-web \
+            (or, if installed to PATH: cargo install --path . --force --locked --features whatsapp-web)"
         );
     }
 }

--- a/crates/zeroclaw-channels/src/whatsapp_web.rs
+++ b/crates/zeroclaw-channels/src/whatsapp_web.rs
@@ -37,6 +37,8 @@ use std::sync::Arc;
 use tokio::select;
 use wa_rs_proto::whatsapp::device_props::PlatformType;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+#[cfg(not(feature = "whatsapp-web"))]
+use zeroclaw_runtime::i18n;
 
 /// WhatsApp Web channel using wa-rs with custom rusqlite storage
 ///
@@ -1754,19 +1756,15 @@ impl Channel for WhatsAppWebChannel {
     }
 
     async fn send(&self, _message: &SendMessage) -> Result<()> {
-        anyhow::bail!(
-            "WhatsApp Web channel requires the 'whatsapp-web' feature. \
-            Enable with: cargo build --features whatsapp-web \
-            (or, if installed to PATH: cargo install --path . --force --locked --features whatsapp-web)"
-        );
+        anyhow::bail!(i18n::get_required_cli_string(
+            "channel-whatsapp-web-feature-missing-error"
+        ));
     }
 
     async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
-        anyhow::bail!(
-            "WhatsApp Web channel requires the 'whatsapp-web' feature. \
-            Enable with: cargo build --features whatsapp-web \
-            (or, if installed to PATH: cargo install --path . --force --locked --features whatsapp-web)"
-        );
+        anyhow::bail!(i18n::get_required_cli_string(
+            "channel-whatsapp-web-feature-missing-error"
+        ));
     }
 
     async fn health_check(&self) -> bool {
@@ -1774,19 +1772,15 @@ impl Channel for WhatsAppWebChannel {
     }
 
     async fn start_typing(&self, _recipient: &str) -> Result<()> {
-        anyhow::bail!(
-            "WhatsApp Web channel requires the 'whatsapp-web' feature. \
-            Enable with: cargo build --features whatsapp-web \
-            (or, if installed to PATH: cargo install --path . --force --locked --features whatsapp-web)"
-        );
+        anyhow::bail!(i18n::get_required_cli_string(
+            "channel-whatsapp-web-feature-missing-error"
+        ));
     }
 
     async fn stop_typing(&self, _recipient: &str) -> Result<()> {
-        anyhow::bail!(
-            "WhatsApp Web channel requires the 'whatsapp-web' feature. \
-            Enable with: cargo build --features whatsapp-web \
-            (or, if installed to PATH: cargo install --path . --force --locked --features whatsapp-web)"
-        );
+        anyhow::bail!(i18n::get_required_cli_string(
+            "channel-whatsapp-web-feature-missing-error"
+        ));
     }
 }
 

--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -300,3 +300,8 @@ cli-desktop-long-about =
 # gateway has no model configured. Used by the gateway crate channel
 # webhook handlers (WhatsApp, Linq, WATI, Nextcloud Talk).
 channel-needs-onboarding-reply = This agent isn't fully set up yet. The operator needs to complete onboarding before I can reply.
+
+channel-whatsapp-web-feature-missing-warning =   ⚠ WhatsApp Web is configured but the 'whatsapp-web' feature is not compiled in.
+channel-whatsapp-web-feature-missing-build =     Build/run with: cargo build --features whatsapp-web
+channel-whatsapp-web-feature-missing-install =     If installed to PATH, reinstall with: cargo install --path . --force --locked --features whatsapp-web
+channel-whatsapp-web-feature-missing-error = WhatsApp Web channel requires the 'whatsapp-web' feature. Enable with: cargo build --features whatsapp-web (or, if installed to PATH: cargo install --path . --force --locked --features whatsapp-web)


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Clarifies the WhatsApp Web no-feature guidance for users who installed `zeroclaw` onto `PATH`.
  - Adds the PATH reinstall command with `--features whatsapp-web` so users do not accidentally replace a feature-enabled build with a feature-disabled install.
  - Moves the changed user-facing guidance through the Fluent CLI string path instead of embedding new English terminal/channel error text directly in Rust.
- **Scope boundary:** This does not change WhatsApp channel runtime behavior, pairing flow, session handling, or feature-gating semantics.
- **Blast radius:** WhatsApp Web users who configure the channel without compiling the `whatsapp-web` feature will see clearer setup guidance. No network, permission, storage, or config schema behavior changes.
- **Linked issue(s):** Closes #4846
- **Labels:** `bug`, `channel`, `channel:whatsapp`, `risk: medium`, `risk: manual`, `size: XS`

## Validation Evidence

```text
cargo fmt --all -- --check
Result: passed.

cargo check --locked
Result: passed on the PR branch.

GitHub Quality Gate at head 0e93140e3d7f4a1e10017c7528337c3c8f672ec3
Result: passed, including Lint, all feature/no-default-feature checks, platform builds, Test, Security, and CI Required Gate.

Reviewer local check:
git diff --check master...HEAD
Result: passed; no output.
```

- **Beyond CI — what did you manually verify?** Verified the changed warning/error guidance is now sourced from `crates/zeroclaw-runtime/locales/en/cli.ftl` through `i18n::get_required_cli_string`, and that the PR remains limited to the WhatsApp Web missing-feature guidance path.
- **If any command was intentionally skipped, why:** No live WhatsApp Web pairing test or local `cargo install` smoke test was run; the change is guidance/localization text only and CI covered compile/test health.

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N.A.`

## Compatibility

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`
- If `No` or `Yes` to either: exact upgrade steps for existing users: `N.A.`

## Rollback

- **Fast rollback command/path:** `git revert <squash-merge-sha>`
- **Feature flags or config toggles:** `None`
- **Observable failure symptoms:** Users who configured WhatsApp Web without compiling the feature still receive unclear or missing reinstall guidance.

## Supersede Attribution

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N.A.`
- Scope materially carried forward: `N.A.`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? `No`
- If `No`, why: No superseded PR was materially incorporated.
