### PR TITLE
docs(auth): clarify codex setup and service logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ One TOML file at `~/.zeroclaw/config.toml`. Pointers:
 - [Security overview](docs/book/src/security/overview.md) — autonomy, sandboxing, tool receipts
 - [Full config reference](docs/book/src/reference/config.md) — generated from the live schema; every key documented
 
+For standard OpenAI Codex subscription auth, keep `config.toml` minimal:
+
+```toml
+default_provider = "openai-codex"
+default_model = "gpt-5-codex"
+```
+
+Notes:
+
+- Normal OpenAI Codex subscription auth uses stored auth profiles, not top-level `api_key` / `api_url`.
+- Only set `api_key` / `api_url` when intentionally targeting a custom OpenAI-compatible gateway or endpoint.
+- If you see `provider streaming failed, falling back to non-streaming chat`, ZeroClaw retries the same request in non-streaming mode. Check `zeroclaw auth status` before changing provider config.
+
 ## Architecture
 
 ```

--- a/docs/book/src/ops/troubleshooting.md
+++ b/docs/book/src/ops/troubleshooting.md
@@ -113,6 +113,35 @@ ln -s "$HOMEBREW_PREFIX/var/zeroclaw" ~/.zeroclaw
 
 ## Runtime
 
+### OpenAI Codex subscription auth warns about config or streaming
+
+Symptoms:
+
+- `default_provider = "openai-codex"` is set, but runs still feel misconfigured
+- Config loading warns about unknown top-level `api_key` / `api_url`
+- Agent logs `provider streaming failed, falling back to non-streaming chat`
+
+Checks:
+
+```bash
+zeroclaw auth status
+zeroclaw auth login --provider openai-codex --device-code
+zeroclaw agent --provider openai-codex -m "hello"
+```
+
+Use this minimal `config.toml` shape for normal subscription auth:
+
+```toml
+default_provider = "openai-codex"
+default_model = "gpt-5-codex"
+```
+
+Notes:
+
+- Standard OpenAI Codex subscription auth uses stored auth profiles, so top-level `api_key` / `api_url` should usually stay unset.
+- `api_key` / `api_url` are only needed for custom OpenAI-compatible gateways or other explicit endpoint overrides.
+- The streaming fallback warning by itself is not an auth failure; ZeroClaw retries the request in non-streaming mode.
+
 ### Daemon starts, then immediately exits
 
 Check journald / the platform log (see [Logs & observability](./observability.md)) for the actual error. Common causes:
@@ -234,6 +263,12 @@ Playwright downloads Chromium (~150 MB) on first launch. Let it finish. If it ke
 zeroclaw service start
 zeroclaw service status
 ```
+
+Use `zeroclaw service logs` to tail the installed service logs. Add `--follow` to stream new entries or `--lines <count>` to change how much history is shown. If the wrapper is unavailable or you need to inspect the platform directly, use:
+
+- Linux: `journalctl --user -u zeroclaw.service -f`
+- macOS: `log stream --predicate 'process == "zeroclaw"'`
+- If you are running `zeroclaw daemon` directly in a terminal, use that foreground output instead of service log commands.
 
 If that succeeds interactively but the service dies in the background, it's almost always config or permissions — read the journal:
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: OpenAI Codex subscription-auth setup was documented too loosely, and issue `#4863` showed users adding top-level `api_key` / `api_url` while also needing clearer service-log troubleshooting guidance.
- Why it matters: This creates avoidable setup churn, misleading config warnings, and dead-end troubleshooting for a common subscription-auth path.
- What changed: Added a minimal `config.toml` example plus subscription-auth notes to `README.md`, and added a troubleshooting section that clarifies profile-based Codex auth, the non-streaming fallback warning, and the correct service-log alternatives.
- What did **not** change (scope boundary): No provider/runtime behavior, no auth flow code, no service implementation, and no locale/i18n sync in this narrow docs fix.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `docs`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `N/A`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `N/A`
- If any auto-label is incorrect, note requested correction: stale `provider`, `service`, `provider: openai_codex`, and `service: core` labels should be removed because the refreshed head is docs-only.

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `docs`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `docs`

## Linked Issue

- Related #4863
- Depends on # (if stacked): `none`
- Supersedes # (if replacing older PR): `none`

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Integrated scope by source PR (what was materially carried forward): `N/A`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `N/A`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): `N/A`
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `N/A`

## Validation Evidence (required)

Commands and result summary:

```text
scripts/ci/docs_quality_gate.sh
Result: passed in maintainer review after rerunning outside the sandbox DNS restriction; markdownlint-cli2 reported 0 errors for README.md and docs/book/src/ops/troubleshooting.md.

git diff --check origin/master...HEAD
Result: passed with no output.
```

- Evidence provided (test/log/trace/screenshot/perf): GitHub CI is green on the refreshed docs-only head; maintainer review verified the changed docs against the current CLI/service/auth definitions.
- If any command is intentionally skipped, explain why: Cargo commands were skipped because this PR is docs-only and does not change Rust code. `lychee` was not installed in the maintainer environment, so the offline link check was not rerun there.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: `N/A`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: No user secrets or personal data were added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N/A`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `Yes`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `No`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `No`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `No`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: No follow-up issue is linked; this PR is limited to the English docs unblock for `#4863`, and maintainers accepted the localization follow-through as separate from this narrow docs fix.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Reviewed the exact markdown diff; verified the new troubleshooting section and README guidance are consistent with existing CLI/auth commands.
- Edge cases checked: Confirmed `zeroclaw service logs` is a real CLI command in the current tree; confirmed the changed docs path is `docs/book/src/ops/troubleshooting.md`.
- What was not verified: End-to-end interactive OpenAI Codex auth on macOS was not reproduced in this run.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: README subscription-auth guidance; troubleshooting docs for runtime/service triage.
- Potential unintended effects: Readers may still need localized docs parity later because this PR updates English docs only.
- Guardrails/monitoring for early detection: Maintainer review of wording; link/lint checks on the changed troubleshooting file.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local worktrees, GitHub CLI, markdownlint via `npx`, `lychee`.
- Workflow/plan summary (if any): narrowed the issue pool to a docs-only carrier after excluding lines with existing open PRs; patched docs in a dedicated worktree; re-reviewed in a separate review worktree before opening.
- Verification focus: command accuracy, scope containment, and docs-only validation evidence.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: revert the landed squash commit after merge, or close this PR before merge.
- Feature flags or config toggles (if any): `None`
- Observable failure symptoms: Incorrect docs wording around OpenAI Codex setup or service-log troubleshooting.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: English-only docs update may temporarily diverge from localized docs.
  - Mitigation: Scope is explicitly documented in the PR body; follow-up localization can be handled separately.
