### PR TITLE
fix(clippy): lift shared warning blockers

### DIFF
--- a/src/tools/web_search_tool.rs
+++ b/src/tools/web_search_tool.rs
@@ -420,8 +420,8 @@ impl Tool for WebSearchTool {
 
         let result = match resolution.route {
             WebSearchProviderRoute::DuckDuckGo | WebSearchProviderRoute::Tavily => {
-                self.search_duckduckgo(query).await?
-            } // TODO: implement Tavily search
+                self.search_duckduckgo(query).await? // TODO: implement Tavily search
+            }
             WebSearchProviderRoute::Brave => self.search_brave(query).await?,
             WebSearchProviderRoute::SearXNG => self.search_searxng(query).await?,
         };


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: shared clippy warning debt in core Rust files was failing `Lint` on PR `#5077` and previously blocked PR `#5075`
- Why it matters: unrelated docs PRs should not stay blocked on behavior-preserving warning cleanups outside their diffs
- What changed: lifted four warning sites in `src/memory/namespaced.rs`, `src/multimodal.rs`, `src/tools/web_search_tool.rs`, and `src/tools/wrappers.rs` into a clean-base maintenance carrier
- What did **not** change (scope boundary): no docs content, no config keys, no dependency/security changes, no test logic changes

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `memory,tool`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `memory: namespaced`, `tool: web_search`, `tool: wrappers`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `experienced contributor`
- If any auto-label is incorrect, note requested correction: `none`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `chore`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #
- Related #5075
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N.A.`
- Integrated scope by source PR (what was materially carried forward): `N.A.`
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): `No superseded PR on this carrier.`
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): `worker and independent reviewer both ran cargo fmt --all -- --check and cargo clippy --all-targets -- -D warnings on commit 17228c26; both passed`
- If any command is intentionally skipped, explain why: `cargo test was skipped for this narrow lint-only maintenance PR; the reviewer confirmed fmt+clippy is sufficient for scope and no behavior changes are intended`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: `N.A.`

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: `No user data or secrets added.`
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): `Confirmed.`

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: `N.A.`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `N.A.`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N.A.`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N.A.`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: `Code-only clippy cleanup; no user-facing wording changed.`

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `independent worker and reviewer both confirmed the four-file cleanup leaves behavior intact while satisfying clippy`
- Edge cases checked: `Path extractor alias type, namespaced purge counting, and Tavily fallback routing remained semantically unchanged`
- What was not verified: `full cargo test suite and broader repo-wide blockers outside this PR (security audit, all-features build, gateway test failures)`

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `memory namespacing, multimodal message normalization, web search provider routing, tool path wrapper typing, PR lint gates`
- Potential unintended effects: `low; all touched hunks are simplifications or type-alias extraction`
- Guardrails/monitoring for early detection: `CI lint gates on this carrier and downstream reruns on #5075/#5077`

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `worker + independent reviewer worktrees`
- Workflow/plan summary (if any): `triaged #5075/#5077 as external-blocked docs PRs, then split their shared clippy blocker into a clean-base maintenance carrier`
- Verification focus: `behavior-preserving clippy cleanup only`
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: `revert commit 17228c26188ae29ff694f682b027815508b42240`
- Feature flags or config toggles (if any): `None`
- Observable failure symptoms: `unexpected runtime behavior in namespaced purge, multimodal normalization, or web search wrapper path extraction`

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: `A behavior-preserving cleanup could accidentally alter a code path through branch merging or type alias extraction.`
  - Mitigation: `Diff is limited to four files, independent reviewer pass completed, and both fmt+clippy passed on the clean-base branch.`
