### PR TITLE
feat(security): add config option to disable high-entropy token redaction

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2009,7 +2009,11 @@ fn extract_tool_context_summary(history: &[ChatMessage], start_index: usize) -> 
     format!("[Used tools: {}]", tool_names.join(", "))
 }
 
-fn sanitize_channel_response(response: &str, tools: &[Box<dyn Tool>]) -> String {
+fn sanitize_channel_response(
+    response: &str,
+    tools: &[Box<dyn Tool>],
+    disable_high_entropy_redaction: bool,
+) -> String {
     let known_tool_names: HashSet<String> = tools
         .iter()
         .map(|tool| tool.name().to_ascii_lowercase())
@@ -2026,7 +2030,10 @@ fn sanitize_channel_response(response: &str, tools: &[Box<dyn Tool>]) -> String 
     let sanitized = strip_tool_narration(&stripped_json);
 
     // Scan for credential leaks before returning to caller
-    match crate::security::LeakDetector::new().scan(&sanitized) {
+    match crate::security::LeakDetector::new()
+        .with_high_entropy_disabled(disable_high_entropy_redaction)
+        .scan(&sanitized)
+    {
         crate::security::LeakResult::Clean => sanitized,
         crate::security::LeakResult::Detected { patterns, redacted } => {
             tracing::warn!(
@@ -3107,8 +3114,11 @@ async fn process_channel_message(
                 }
             }
 
-            let sanitized_response =
-                sanitize_channel_response(&outbound_response, ctx.tools_registry.as_ref());
+            let sanitized_response = sanitize_channel_response(
+                &outbound_response,
+                ctx.tools_registry.as_ref(),
+                ctx.prompt_config.security.disable_high_entropy_redaction,
+            );
             let mut delivered_response = if sanitized_response.is_empty()
                 && !outbound_response.trim().is_empty()
             {
@@ -5788,7 +5798,7 @@ mod tests {
         // Issue #4478: response with leading whitespace before [Used tools: ...]
         let input = "  [Used tools: web_search_tool]\nHere is the search result.";
 
-        let result = sanitize_channel_response(input, &tools);
+        let result = sanitize_channel_response(input, &tools, false);
 
         assert!(!result.contains("[Used tools:"));
         assert!(result.contains("Here is the search result."));
@@ -11529,7 +11539,7 @@ This is an example JSON object for profile settings."#;
         let tools: Vec<Box<dyn Tool>> = Vec::new();
         let leaked = "Temporary key: AKIAABCDEFGHIJKLMNOP"; // gitleaks:allow
 
-        let result = sanitize_channel_response(leaked, &tools);
+        let result = sanitize_channel_response(leaked, &tools, false);
 
         assert!(!result.contains("AKIAABCDEFGHIJKLMNOP")); // gitleaks:allow
         assert!(result.contains("[REDACTED"));
@@ -11540,7 +11550,7 @@ This is an example JSON object for profile settings."#;
         let tools: Vec<Box<dyn Tool>> = Vec::new();
         let clean_text = "This is a normal message with no credentials.";
 
-        let result = sanitize_channel_response(clean_text, &tools);
+        let result = sanitize_channel_response(clean_text, &tools, false);
 
         assert_eq!(result, clean_text);
     }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -7252,6 +7252,16 @@ pub struct SecurityConfig {
     /// WebAuthn / FIDO2 hardware key authentication configuration.
     #[serde(default)]
     pub webauthn: WebAuthnConfig,
+
+    /// Disable the high-entropy token redaction heuristic in the leak detector.
+    ///
+    /// When `true`, the `LeakDetector` skips Shannon-entropy-based token
+    /// flagging while all pattern-based checks (API keys, AWS credentials,
+    /// private keys, JWTs, database URLs, generic secrets) remain active.
+    /// Useful when outbound content regularly contains legitimate high-entropy
+    /// strings such as base64-encoded payloads or API usage examples.
+    #[serde(default)]
+    pub disable_high_entropy_redaction: bool,
 }
 
 /// WebAuthn / FIDO2 hardware key authentication configuration (`[security.webauthn]`).

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -451,8 +451,14 @@ impl RedactedOutput {
 
 /// Scan cron job output for credential leaks and return redacted output if leaks are detected.
 /// Logs a warning with channel, target, and detected patterns when credentials are found.
-fn scan_and_redact_output(channel: &str, target: &str, output: &str) -> RedactedOutput {
-    let leak_detector = crate::security::LeakDetector::new();
+fn scan_and_redact_output(
+    channel: &str,
+    target: &str,
+    output: &str,
+    disable_high_entropy_redaction: bool,
+) -> RedactedOutput {
+    let leak_detector = crate::security::LeakDetector::new()
+        .with_high_entropy_disabled(disable_high_entropy_redaction);
     let leak_check = leak_detector.scan(output);
 
     match leak_check {
@@ -476,7 +482,12 @@ pub(crate) async fn deliver_announcement(
     output: &str,
 ) -> Result<()> {
     // Scan for credential leaks before delivering cron job output to channel.
-    let safe_output = scan_and_redact_output(channel, target, output);
+    let safe_output = scan_and_redact_output(
+        channel,
+        target,
+        output,
+        config.security.disable_high_entropy_redaction,
+    );
 
     match channel.to_ascii_lowercase().as_str() {
         "telegram" => {
@@ -1432,7 +1443,7 @@ mod tests {
     fn scan_and_redact_output_redacts_credentials() {
         let leaked_output = "Deployment key: sk_test_FAKE1234567890abcdefgh"; // gitleaks:allow
 
-        let redacted = scan_and_redact_output("telegram", "123456", leaked_output);
+        let redacted = scan_and_redact_output("telegram", "123456", leaked_output, false);
 
         assert!(
             !redacted.as_str().contains("sk_test_FAKE1234567890abcdefgh"), // gitleaks:allow
@@ -1445,7 +1456,7 @@ mod tests {
     fn scan_and_redact_output_preserves_clean_output() {
         let clean_output = "Deployment completed successfully at 2024-03-15 10:00:00";
 
-        let redacted = scan_and_redact_output("telegram", "123456", clean_output);
+        let redacted = scan_and_redact_output("telegram", "123456", clean_output, false);
 
         assert_eq!(redacted.as_str(), clean_output);
     }

--- a/src/security/leak_detector.rs
+++ b/src/security/leak_detector.rs
@@ -32,6 +32,8 @@ pub enum LeakResult {
 pub struct LeakDetector {
     /// Sensitivity threshold (0.0-1.0, higher = more aggressive detection).
     sensitivity: f64,
+    /// When `true`, skip the high-entropy token heuristic entirely.
+    skip_high_entropy: bool,
 }
 
 impl Default for LeakDetector {
@@ -43,14 +45,27 @@ impl Default for LeakDetector {
 impl LeakDetector {
     /// Create a new leak detector with default sensitivity.
     pub fn new() -> Self {
-        Self { sensitivity: 0.7 }
+        Self {
+            sensitivity: 0.7,
+            skip_high_entropy: false,
+        }
     }
 
     /// Create a detector with custom sensitivity.
     pub fn with_sensitivity(sensitivity: f64) -> Self {
         Self {
             sensitivity: sensitivity.clamp(0.0, 1.0),
+            skip_high_entropy: false,
         }
+    }
+
+    /// Disable the high-entropy token heuristic.
+    ///
+    /// When set, [`scan`](Self::scan) skips Shannon-entropy-based detection
+    /// while all pattern-based checks remain active.
+    pub fn with_high_entropy_disabled(mut self, disabled: bool) -> Self {
+        self.skip_high_entropy = disabled;
+        self
     }
 
     /// Scan content for potential credential leaks.
@@ -65,7 +80,9 @@ impl LeakDetector {
         self.check_private_keys(content, &mut patterns, &mut redacted);
         self.check_jwt_tokens(content, &mut patterns, &mut redacted);
         self.check_database_urls(content, &mut patterns, &mut redacted);
-        self.check_high_entropy_tokens(content, &mut patterns, &mut redacted);
+        if !self.skip_high_entropy {
+            self.check_high_entropy_tokens(content, &mut patterns, &mut redacted);
+        }
 
         if patterns.is_empty() {
             LeakResult::Clean
@@ -571,6 +588,33 @@ MIIEowIBAAKCAQEA0ZPr5JeyVDonXsKhfq...
             LeakResult::Clean => {
                 panic!("Should still detect high-entropy tokens outside media markers")
             }
+        }
+    }
+
+    #[test]
+    fn high_entropy_disabled_skips_entropy_check() {
+        let detector = LeakDetector::new().with_high_entropy_disabled(true);
+        // This token would normally be flagged as high-entropy.
+        let content = "Found credential: aB3xK9mW2pQ7vL4nR8sT1yU6hD0jF5cG";
+        let result = detector.scan(content);
+        assert!(
+            matches!(result, LeakResult::Clean),
+            "High-entropy detection should be skipped when disabled"
+        );
+    }
+
+    #[test]
+    fn high_entropy_disabled_still_detects_pattern_based_leaks() {
+        let detector = LeakDetector::new().with_high_entropy_disabled(true);
+        // Pattern-based detection (Stripe key) must still work.
+        let content = "My Stripe key is sk_test_1234567890abcdefghijklmnop";
+        let result = detector.scan(content);
+        match result {
+            LeakResult::Detected { patterns, redacted } => {
+                assert!(patterns.iter().any(|p| p.contains("Stripe")));
+                assert!(redacted.contains("[REDACTED"));
+            }
+            LeakResult::Clean => panic!("Pattern-based leaks should still be detected"),
         }
     }
 


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The LeakDetector's high-entropy token redaction heuristic sometimes redacts legitimate content (base64 payloads, API usage examples in docs, etc.)
- Why it matters: False-positive redaction corrupts outbound messages that contain legitimate high-entropy strings
- What changed: Added `disable_high_entropy_redaction` boolean to `[security]` config; wired it through `LeakDetector`, channel sanitization, and cron output redaction
- What did **not** change (scope boundary): All pattern-based leak detection (API keys, AWS credentials, private keys, JWTs, database URLs, generic secrets) remains unconditionally active

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels: `config`, `security`
- Module labels: `security: leak_detector`
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `security`

## Linked Issue

- Closes #4832

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings  # pre-existing failures only (unrelated files)
cargo test --lib security::leak_detector   # 21/21 pass (2 new tests)
```

- Evidence provided: All 21 leak_detector unit tests pass including 2 new tests for the disabled-entropy path
- If any command is intentionally skipped, explain why: Full clippy has 7 pre-existing errors in unrelated files (schema.rs, multimodal.rs, namespaced.rs, web_search_tool.rs, wrappers.rs) due to local Rust 1.93 vs CI Rust 1.92 lint differences

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? Yes — high-entropy heuristic can be disabled via config
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: The option only disables the Shannon-entropy heuristic; all pattern-based detectors (Stripe, AWS, OpenAI, GitHub, private keys, JWTs, database URLs, generic secrets) remain unconditionally active. Default is `false` (no behavior change).

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes — default `false` preserves existing behavior
- Config/env changes? Yes — new optional `[security].disable_high_entropy_redaction` field (defaults to `false`)
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Enabled flag skips entropy detection; disabled flag preserves all detection; pattern-based detection unaffected by flag
- Edge cases checked: Builder pattern chaining, default values, sensitivity interaction
- What was not verified: Full integration test with running channels

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Channel outbound sanitization, cron job output redaction
- Potential unintended effects: None — opt-in only, default preserves existing behavior
- Guardrails/monitoring for early detection: Pattern-based detectors remain active as safety net

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Read LeakDetector impl, add config field, add builder method, wire through call sites, add tests
- Verification focus: Unit tests for new behavior, no regressions in existing tests
- Confirmation: naming + architecture boundaries followed (AGENTS.md + CONTRIBUTING.md): Yes

## Rollback Plan (required)

- Fast rollback command/path: Revert commit; or set `disable_high_entropy_redaction = false` in config
- Feature flags or config toggles: The config field itself acts as the toggle
- Observable failure symptoms: If misconfigured, high-entropy tokens would not be redacted (visible in audit logs)

## Risks and Mitigations

- Risk: User enables the flag without understanding that high-entropy credentials will pass through unredacted
  - Mitigation: All pattern-based detectors remain active; doc comment explains the trade-off; default is `false`