### PR TITLE
feat(telegram): add per-channel debounce_window_ms config

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4215,6 +4215,7 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 )
                 .with_ack_reactions(ack)
                 .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
+                .with_debounce_window(std::time::Duration::from_millis(tg.debounce_window_ms))
                 .with_transcription(config.transcription.clone())
                 .with_tts(config.tts.clone())
                 .with_workspace_dir(config.workspace_dir.clone()),
@@ -4422,6 +4423,7 @@ fn collect_configured_channels(
                 )
                 .with_ack_reactions(ack)
                 .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
+                .with_debounce_window(std::time::Duration::from_millis(tg.debounce_window_ms))
                 .with_transcription(config.transcription.clone())
                 .with_tts(config.tts.clone())
                 .with_workspace_dir(config.workspace_dir.clone())
@@ -11264,6 +11266,7 @@ This is an example JSON object for profile settings."#;
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            debounce_window_ms: 0,
         });
         match build_channel_by_id(&config, "telegram") {
             Ok(channel) => assert_eq!(channel.name(), "telegram"),

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -340,6 +340,8 @@ pub struct TelegramChannel {
         Arc<std::sync::Mutex<std::collections::HashMap<String, (String, std::time::Instant)>>>,
     /// Per-channel proxy URL override.
     proxy_url: Option<String>,
+    /// Per-channel inbound message debouncer.
+    debouncer: super::debounce::MessageDebouncer,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -384,7 +386,14 @@ impl TelegramChannel {
             voice_chats: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
             pending_voice: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             proxy_url: None,
+            debouncer: super::debounce::MessageDebouncer::new(Duration::ZERO),
         }
+    }
+
+    /// Set the per-channel debounce window. A zero duration disables debouncing.
+    pub fn with_debounce_window(mut self, window: Duration) -> Self {
+        self.debouncer = super::debounce::MessageDebouncer::new(window);
+        self
     }
 
     /// Configure whether Telegram-native acknowledgement reactions are sent.
@@ -2950,6 +2959,37 @@ Ensure only one `zeroclaw` process is using this bot token."
                         .send()
                         .await; // Ignore errors for typing indicator
 
+                    // ── Per-channel debounce ──────────────────────────
+                    if self.debouncer.enabled() {
+                        let debounce_key = format!("{}::{}", msg.sender, msg.reply_target);
+                        match self.debouncer.debounce(&debounce_key, &msg.content).await {
+                            super::debounce::DebounceResult::Pending(rx) => {
+                                // Spawn a lightweight task that waits for the debounce
+                                // window to expire, then forwards the combined message.
+                                let tx_clone = tx.clone();
+                                let mut debounce_msg = msg;
+                                tokio::spawn(async move {
+                                    if let Ok(combined) = rx.await {
+                                        debounce_msg.content = combined;
+                                        let _ = tx_clone.send(debounce_msg).await;
+                                    }
+                                    // RecvError means superseded — do nothing.
+                                });
+                                continue;
+                            }
+                            super::debounce::DebounceResult::Passthrough(content) => {
+                                // Window is zero; should not happen since we check
+                                // `enabled()`, but handle gracefully.
+                                let mut m = msg;
+                                m.content = content;
+                                if tx.send(m).await.is_err() {
+                                    return Ok(());
+                                }
+                                continue;
+                            }
+                        }
+                    }
+
                     if tx.send(msg).await.is_err() {
                         return Ok(());
                     }
@@ -5096,5 +5136,27 @@ mod tests {
         let photo_content = "[IMAGE:/tmp/photo.jpg]".to_string();
         let content = format!("{attr}{photo_content}");
         assert_eq!(content, "[Forwarded from @bob] [IMAGE:/tmp/photo.jpg]");
+    }
+
+    // ── Debounce integration tests ──────────────────────────────
+
+    #[test]
+    fn with_debounce_window_sets_enabled() {
+        let ch = TelegramChannel::new("tok".into(), vec!["*".into()], false)
+            .with_debounce_window(Duration::from_millis(500));
+        assert!(ch.debouncer.enabled());
+    }
+
+    #[test]
+    fn with_debounce_window_zero_is_disabled() {
+        let ch = TelegramChannel::new("tok".into(), vec!["*".into()], false)
+            .with_debounce_window(Duration::ZERO);
+        assert!(!ch.debouncer.enabled());
+    }
+
+    #[test]
+    fn default_debouncer_is_disabled() {
+        let ch = TelegramChannel::new("tok".into(), vec!["*".into()], false);
+        assert!(!ch.debouncer.enabled());
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -64,6 +64,7 @@ mod tests {
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            debounce_window_ms: 0,
         };
 
         let discord = DiscordConfig {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6408,6 +6408,13 @@ pub struct TelegramConfig {
     /// Overrides the global `[proxy]` setting for this channel only.
     #[serde(default)]
     pub proxy_url: Option<String>,
+    /// Debounce window in milliseconds for rapid inbound messages.
+    /// When set to a positive value, rapid messages from the same sender within
+    /// this window are accumulated and dispatched as a single concatenated message.
+    /// `0` or absent disables per-channel debouncing (falls through to global
+    /// `debounce_ms` if configured). Default: `0`.
+    #[serde(default)]
+    pub debounce_window_ms: u64,
 }
 
 impl ChannelConfig for TelegramConfig {
@@ -11499,6 +11506,7 @@ auto_save = true
                     mention_only: false,
                     ack_reactions: None,
                     proxy_url: None,
+                    debounce_window_ms: 0,
                 }),
                 discord: None,
                 discord_history: None,
@@ -12314,6 +12322,7 @@ default_temperature = 0.7
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            debounce_window_ms: 200,
         };
         let json = serde_json::to_string(&tc).unwrap();
         let parsed: TelegramConfig = serde_json::from_str(&json).unwrap();
@@ -12322,6 +12331,7 @@ default_temperature = 0.7
         assert_eq!(parsed.stream_mode, StreamMode::Partial);
         assert_eq!(parsed.draft_update_interval_ms, 500);
         assert!(parsed.interrupt_on_new_message);
+        assert_eq!(parsed.debounce_window_ms, 200);
     }
 
     #[test]
@@ -12331,6 +12341,7 @@ default_temperature = 0.7
         assert_eq!(parsed.stream_mode, StreamMode::Off);
         assert_eq!(parsed.draft_update_interval_ms, 1000);
         assert!(!parsed.interrupt_on_new_message);
+        assert_eq!(parsed.debounce_window_ms, 0);
     }
 
     #[test]
@@ -15189,6 +15200,7 @@ require_otp_to_resume = true
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            debounce_window_ms: 0,
         });
 
         // Save (triggers encryption)

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -930,6 +930,7 @@ mod tests {
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            debounce_window_ms: 0,
         });
         assert!(has_supervised_channels(&config));
     }
@@ -1055,6 +1056,7 @@ mod tests {
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            debounce_window_ms: 0,
         });
 
         let target = resolve_heartbeat_delivery(&config).unwrap();
@@ -1073,6 +1075,7 @@ mod tests {
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            debounce_window_ms: 0,
         });
 
         let target = resolve_heartbeat_delivery(&config).unwrap();

--- a/src/integrations/registry.rs
+++ b/src/integrations/registry.rs
@@ -842,6 +842,7 @@ mod tests {
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            debounce_window_ms: 0,
         });
         let entries = all_integrations();
         let tg = entries.iter().find(|e| e.name == "Telegram").unwrap();

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -3876,6 +3876,7 @@ fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
                     mention_only: existing_tg.map(|t| t.mention_only).unwrap_or(false),
                     ack_reactions: existing_tg.and_then(|t| t.ack_reactions),
                     proxy_url: existing_tg.and_then(|t| t.proxy_url.clone()),
+                    debounce_window_ms: existing_tg.map(|t| t.debounce_window_ms).unwrap_or(0),
                 });
             }
             ChannelMenuChoice::Discord => {


### PR DESCRIPTION
## Summary
- Wires the existing `MessageDebouncer` into the Telegram channel's `listen()` loop so rapid inbound messages from the same sender are accumulated within a configurable time window and dispatched as a single concatenated message
- Adds `debounce_window_ms` field to `TelegramConfig` (default `0` = disabled), independent of the global `channels_config.debounce_ms`
- Adds builder method `with_debounce_window` on `TelegramChannel` and three unit tests for the integration

## Changes
| File | What |
|------|------|
| `src/config/schema.rs` | Add `debounce_window_ms: u64` to `TelegramConfig` |
| `src/channels/telegram.rs` | Store `MessageDebouncer` on channel, builder method, debounce in `listen()`, 3 tests |
| `src/channels/mod.rs` | Wire `debounce_window_ms` into both `TelegramChannel` construction sites |
| `src/config/mod.rs` | Add field to test struct literal |
| `src/daemon/mod.rs` | Add field to test struct literals |
| `src/integrations/registry.rs` | Add field to test struct literal |
| `src/onboard/wizard.rs` | Preserve existing `debounce_window_ms` during onboard |

## Test plan
- [x] `cargo test --lib -- debounce` — all 7 tests pass (4 existing + 3 new)
- [x] `cargo test --lib -- telegram_config` — all 8 tests pass
- [x] `cargo build` succeeds
- [x] `cargo fmt --all` clean
- [ ] CI gate (clippy errors are pre-existing, unrelated to this change)