### PR TITLE
fix: resolve clippy warnings in tools/wrappers.rs

### DIFF
--- a/src/tools/web_search_tool.rs
+++ b/src/tools/web_search_tool.rs
@@ -419,10 +419,11 @@ impl Tool for WebSearchTool {
         }
 
         let result = match resolution.route {
-            WebSearchProviderRoute::DuckDuckGo => self.search_duckduckgo(query).await?,
+            WebSearchProviderRoute::DuckDuckGo | WebSearchProviderRoute::Tavily => {
+                self.search_duckduckgo(query).await?
+            } // TODO: implement Tavily search
             WebSearchProviderRoute::Brave => self.search_brave(query).await?,
             WebSearchProviderRoute::SearXNG => self.search_searxng(query).await?,
-            WebSearchProviderRoute::Tavily => self.search_duckduckgo(query).await?, // TODO: implement Tavily search
         };
 
         Ok(ToolResult {

--- a/src/tools/wrappers.rs
+++ b/src/tools/wrappers.rs
@@ -27,6 +27,9 @@ use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use std::sync::Arc;
 
+/// Type alias to reduce complexity of the optional path-extraction closure.
+type ValueExtractor = Box<dyn Fn(&serde_json::Value) -> Option<String> + Send + Sync>;
+
 // ── RateLimitedTool ───────────────────────────────────────────────────────────
 
 /// Wraps any [`Tool`] and enforces the [`SecurityPolicy`] rate limit.
@@ -96,7 +99,7 @@ pub struct PathGuardedTool<T: Tool> {
     inner: T,
     security: Arc<SecurityPolicy>,
     /// Optional override: extract a path string from the args JSON.
-    extractor: Option<Box<dyn Fn(&serde_json::Value) -> Option<String> + Send + Sync>>,
+    extractor: Option<ValueExtractor>,
 }
 
 impl<T: Tool> PathGuardedTool<T> {
@@ -117,7 +120,7 @@ impl<T: Tool> PathGuardedTool<T> {
         self
     }
 
-    fn extract_path_string<'a>(&self, args: &'a serde_json::Value) -> Option<String> {
+    fn extract_path_string(&self, args: &serde_json::Value) -> Option<String> {
         if let Some(ref f) = self.extractor {
             return f(args);
         }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Three clippy lints (`match_same_arms`, `type_complexity`, `needless_lifetimes`) in `src/tools/wrappers.rs` and `src/tools/web_search_tool.rs` fail CI with `-D warnings` on Rust 1.93.0, blocking all open PRs.
- Why it matters: Every PR targeting master inherits these lint failures from the base branch, making CI red for all contributors.
- What changed: Fixed all three lint violations with minimal, behavior-preserving edits.
- What did **not** change (scope boundary): No logic, tests, or other files touched. Only the three offending patterns were corrected.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): risk: low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): size: XS
- Scope labels: tool
- Module labels: tool: web_search, tool: wrappers
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: bug
- Primary scope: tool (lint fix)

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # three target lints resolved
```

- Evidence provided: local clippy run confirms the three target lints no longer fire.
- If any command is intentionally skipped, explain why: `cargo test` skipped — no behavior change, lint-only fix. CI will run the full suite.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: clippy no longer fires `match_same_arms`, `type_complexity`, or `needless_lifetimes` on the changed files
- Edge cases checked: Tavily route still dispatches to `search_duckduckgo` (behavior preserved)
- What was not verified: full CI run (will run on PR)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: none — pure lint fix
- Potential unintended effects: none
- Guardrails/monitoring for early detection: CI clippy gate

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: clippy lint resolution
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: none
- Observable failure symptoms: clippy lint failures return

## Risks and Mitigations

None — behavior-preserving lint fixes only.