### PR TITLE
feat(reliability): circuit breaker for model provider fallback

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -5529,6 +5529,16 @@ pub struct ReliabilityConfig {
     /// Max retries for cron job execution attempts.
     #[serde(default = "default_scheduler_retries")]
     pub scheduler_retries: u32,
+    /// Enable circuit breaker for provider failover (default: true).
+    /// When enabled, providers that fail repeatedly are temporarily skipped.
+    #[serde(default = "default_circuit_breaker_enabled")]
+    pub circuit_breaker_enabled: Option<bool>,
+    /// Consecutive failures before the circuit breaker opens (default: 3).
+    #[serde(default = "default_circuit_breaker_failure_threshold")]
+    pub circuit_breaker_failure_threshold: Option<u32>,
+    /// Seconds to keep a circuit open before allowing a recovery probe (default: 60).
+    #[serde(default = "default_circuit_breaker_recovery_secs")]
+    pub circuit_breaker_recovery_secs: Option<u64>,
 }
 
 fn default_provider_retries() -> u32 {
@@ -5555,6 +5565,18 @@ fn default_scheduler_retries() -> u32 {
     2
 }
 
+fn default_circuit_breaker_enabled() -> Option<bool> {
+    Some(true)
+}
+
+fn default_circuit_breaker_failure_threshold() -> Option<u32> {
+    Some(3)
+}
+
+fn default_circuit_breaker_recovery_secs() -> Option<u64> {
+    Some(60)
+}
+
 impl Default for ReliabilityConfig {
     fn default() -> Self {
         Self {
@@ -5567,6 +5589,9 @@ impl Default for ReliabilityConfig {
             channel_max_backoff_secs: default_channel_backoff_max_secs(),
             scheduler_poll_secs: default_scheduler_poll_secs(),
             scheduler_retries: default_scheduler_retries(),
+            circuit_breaker_enabled: default_circuit_breaker_enabled(),
+            circuit_breaker_failure_threshold: default_circuit_breaker_failure_threshold(),
+            circuit_breaker_recovery_secs: default_circuit_breaker_recovery_secs(),
         }
     }
 }

--- a/src/providers/circuit_breaker.rs
+++ b/src/providers/circuit_breaker.rs
@@ -1,0 +1,270 @@
+//! Circuit breaker for provider failover.
+//!
+//! Tracks per-provider failure state and short-circuits requests to providers
+//! that are currently failing, allowing the fallback chain to skip them
+//! immediately instead of wasting retries.
+//!
+//! State machine:
+//! - **Closed** (healthy): requests pass through normally.
+//! - **Open** (failing): requests are skipped; transitions to HalfOpen after
+//!   `recovery_window` elapses.
+//! - **HalfOpen** (probing): one test request is allowed through. Success
+//!   closes the circuit; failure reopens it.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Circuit breaker state for a single provider.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CircuitState {
+    /// Healthy — requests pass through.
+    Closed,
+    /// Failing — skip this provider until `opened_at + recovery_window`.
+    Open { opened_at: Instant },
+    /// Recovery probe — allow one request, then decide.
+    HalfOpen,
+}
+
+/// Per-provider failure tracking.
+#[derive(Debug)]
+struct ProviderCircuit {
+    state: CircuitState,
+    consecutive_failures: u32,
+}
+
+impl ProviderCircuit {
+    fn new() -> Self {
+        Self {
+            state: CircuitState::Closed,
+            consecutive_failures: 0,
+        }
+    }
+}
+
+/// Thread-safe circuit breaker that tracks failure state per provider name.
+#[derive(Debug, Clone)]
+pub struct CircuitBreaker {
+    inner: Arc<Mutex<HashMap<String, ProviderCircuit>>>,
+    failure_threshold: u32,
+    recovery_window: Duration,
+}
+
+impl CircuitBreaker {
+    /// Create a new circuit breaker.
+    ///
+    /// - `failure_threshold`: consecutive failures before opening the circuit.
+    /// - `recovery_window`: how long a circuit stays open before transitioning
+    ///   to half-open.
+    pub fn new(failure_threshold: u32, recovery_window: Duration) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            failure_threshold: failure_threshold.max(1),
+            recovery_window,
+        }
+    }
+
+    /// Check whether a provider is available for requests.
+    ///
+    /// Returns `true` if the request should proceed (Closed or HalfOpen),
+    /// `false` if the circuit is Open and the provider should be skipped.
+    pub fn should_allow(&self, provider: &str) -> bool {
+        let mut map = self.inner.lock().unwrap();
+        let circuit = map
+            .entry(provider.to_string())
+            .or_insert_with(ProviderCircuit::new);
+
+        match &circuit.state {
+            CircuitState::Closed | CircuitState::HalfOpen => true,
+            CircuitState::Open { opened_at } => {
+                if opened_at.elapsed() >= self.recovery_window {
+                    // Transition to half-open: allow one probe request.
+                    circuit.state = CircuitState::HalfOpen;
+                    tracing::info!(
+                        provider,
+                        "Circuit breaker transitioning to half-open (recovery probe)"
+                    );
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// Record a successful request for a provider.
+    /// Resets failure count and closes the circuit.
+    pub fn record_success(&self, provider: &str) {
+        let mut map = self.inner.lock().unwrap();
+        let circuit = map
+            .entry(provider.to_string())
+            .or_insert_with(ProviderCircuit::new);
+
+        let was_half_open = circuit.state == CircuitState::HalfOpen;
+        circuit.consecutive_failures = 0;
+        circuit.state = CircuitState::Closed;
+
+        if was_half_open {
+            tracing::info!(
+                provider,
+                "Circuit breaker closed (recovery probe succeeded)"
+            );
+        }
+    }
+
+    /// Record a failed request for a provider.
+    /// Increments failure count and may open the circuit.
+    pub fn record_failure(&self, provider: &str) {
+        let mut map = self.inner.lock().unwrap();
+        let circuit = map
+            .entry(provider.to_string())
+            .or_insert_with(ProviderCircuit::new);
+
+        circuit.consecutive_failures += 1;
+
+        match circuit.state {
+            CircuitState::HalfOpen => {
+                // Probe failed — reopen immediately.
+                circuit.state = CircuitState::Open {
+                    opened_at: Instant::now(),
+                };
+                tracing::warn!(provider, "Circuit breaker reopened (recovery probe failed)");
+            }
+            CircuitState::Closed => {
+                if circuit.consecutive_failures >= self.failure_threshold {
+                    circuit.state = CircuitState::Open {
+                        opened_at: Instant::now(),
+                    };
+                    tracing::warn!(
+                        provider,
+                        consecutive_failures = circuit.consecutive_failures,
+                        threshold = self.failure_threshold,
+                        "Circuit breaker opened"
+                    );
+                }
+            }
+            CircuitState::Open { .. } => {
+                // Already open, nothing to do.
+            }
+        }
+    }
+
+    /// Get the current state of a provider's circuit (for diagnostics).
+    pub fn state(&self, provider: &str) -> CircuitState {
+        let map = self.inner.lock().unwrap();
+        map.get(provider)
+            .map(|c| c.state.clone())
+            .unwrap_or(CircuitState::Closed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn starts_closed() {
+        let cb = CircuitBreaker::new(3, Duration::from_secs(60));
+        assert_eq!(cb.state("test-provider"), CircuitState::Closed);
+        assert!(cb.should_allow("test-provider"));
+    }
+
+    #[test]
+    fn opens_after_threshold_failures() {
+        let cb = CircuitBreaker::new(3, Duration::from_secs(60));
+
+        cb.record_failure("p1");
+        assert_eq!(cb.state("p1"), CircuitState::Closed);
+        assert!(cb.should_allow("p1"));
+
+        cb.record_failure("p1");
+        assert_eq!(cb.state("p1"), CircuitState::Closed);
+
+        cb.record_failure("p1");
+        assert!(matches!(cb.state("p1"), CircuitState::Open { .. }));
+        assert!(!cb.should_allow("p1"));
+    }
+
+    #[test]
+    fn success_resets_failure_count() {
+        let cb = CircuitBreaker::new(3, Duration::from_secs(60));
+
+        cb.record_failure("p1");
+        cb.record_failure("p1");
+        // Two failures, one more would open — but success resets.
+        cb.record_success("p1");
+        assert_eq!(cb.state("p1"), CircuitState::Closed);
+
+        // Now need 3 fresh failures to open.
+        cb.record_failure("p1");
+        assert_eq!(cb.state("p1"), CircuitState::Closed);
+    }
+
+    #[test]
+    fn transitions_to_half_open_after_recovery_window() {
+        let cb = CircuitBreaker::new(1, Duration::from_millis(0));
+
+        cb.record_failure("p1");
+        assert!(matches!(cb.state("p1"), CircuitState::Open { .. }));
+
+        // Recovery window is 0ms, so should_allow transitions to HalfOpen.
+        assert!(cb.should_allow("p1"));
+        assert_eq!(cb.state("p1"), CircuitState::HalfOpen);
+    }
+
+    #[test]
+    fn half_open_success_closes_circuit() {
+        let cb = CircuitBreaker::new(1, Duration::from_millis(0));
+
+        cb.record_failure("p1");
+        // Transition to half-open.
+        assert!(cb.should_allow("p1"));
+        assert_eq!(cb.state("p1"), CircuitState::HalfOpen);
+
+        cb.record_success("p1");
+        assert_eq!(cb.state("p1"), CircuitState::Closed);
+    }
+
+    #[test]
+    fn half_open_failure_reopens_circuit() {
+        let cb = CircuitBreaker::new(1, Duration::from_millis(0));
+
+        cb.record_failure("p1");
+        assert!(cb.should_allow("p1")); // transitions to HalfOpen
+        assert_eq!(cb.state("p1"), CircuitState::HalfOpen);
+
+        cb.record_failure("p1");
+        assert!(matches!(cb.state("p1"), CircuitState::Open { .. }));
+    }
+
+    #[test]
+    fn independent_providers_have_separate_circuits() {
+        let cb = CircuitBreaker::new(2, Duration::from_secs(60));
+
+        cb.record_failure("p1");
+        cb.record_failure("p1");
+        assert!(matches!(cb.state("p1"), CircuitState::Open { .. }));
+
+        // p2 is unaffected.
+        assert_eq!(cb.state("p2"), CircuitState::Closed);
+        assert!(cb.should_allow("p2"));
+    }
+
+    #[test]
+    fn threshold_clamped_to_at_least_one() {
+        let cb = CircuitBreaker::new(0, Duration::from_secs(60));
+        // Threshold of 0 is clamped to 1.
+        cb.record_failure("p1");
+        assert!(matches!(cb.state("p1"), CircuitState::Open { .. }));
+    }
+
+    #[test]
+    fn open_circuit_stays_open_before_recovery_window() {
+        let cb = CircuitBreaker::new(1, Duration::from_secs(3600));
+
+        cb.record_failure("p1");
+        assert!(!cb.should_allow("p1"));
+        // Still open — recovery window is 1 hour.
+        assert!(!cb.should_allow("p1"));
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -19,6 +19,7 @@
 pub mod anthropic;
 pub mod azure_openai;
 pub mod bedrock;
+pub mod circuit_breaker;
 pub mod claude_code;
 pub mod compatible;
 pub mod copilot;
@@ -1783,13 +1784,22 @@ pub fn create_resilient_provider_with_options(
         }
     }
 
-    let reliable = ReliableProvider::new(
+    let mut reliable = ReliableProvider::new(
         providers,
         reliability.provider_retries,
         reliability.provider_backoff_ms,
     )
     .with_api_keys(reliability.api_keys.clone())
     .with_model_fallbacks(reliability.model_fallbacks.clone());
+
+    if reliability.circuit_breaker_enabled.unwrap_or(true) {
+        let threshold = reliability.circuit_breaker_failure_threshold.unwrap_or(3);
+        let recovery_secs = reliability.circuit_breaker_recovery_secs.unwrap_or(60);
+        reliable = reliable.with_circuit_breaker(circuit_breaker::CircuitBreaker::new(
+            threshold,
+            std::time::Duration::from_secs(recovery_secs),
+        ));
+    }
 
     Ok(Box::new(reliable))
 }
@@ -3213,6 +3223,9 @@ mod tests {
             channel_max_backoff_secs: 60,
             scheduler_poll_secs: 15,
             scheduler_retries: 2,
+            circuit_breaker_enabled: None,
+            circuit_breaker_failure_threshold: None,
+            circuit_breaker_recovery_secs: None,
         };
 
         let provider = create_resilient_provider(
@@ -3252,6 +3265,9 @@ mod tests {
             channel_max_backoff_secs: 60,
             scheduler_poll_secs: 15,
             scheduler_retries: 2,
+            circuit_breaker_enabled: None,
+            circuit_breaker_failure_threshold: None,
+            circuit_breaker_recovery_secs: None,
         };
 
         // Primary uses a ZAI key; fallbacks (lmstudio, ollama) should NOT
@@ -3274,6 +3290,9 @@ mod tests {
             channel_max_backoff_secs: 60,
             scheduler_poll_secs: 15,
             scheduler_retries: 2,
+            circuit_breaker_enabled: None,
+            circuit_breaker_failure_threshold: None,
+            circuit_breaker_recovery_secs: None,
         };
 
         let provider =
@@ -3300,6 +3319,9 @@ mod tests {
             channel_max_backoff_secs: 60,
             scheduler_poll_secs: 15,
             scheduler_retries: 2,
+            circuit_breaker_enabled: None,
+            circuit_breaker_failure_threshold: None,
+            circuit_breaker_recovery_secs: None,
         };
 
         let provider = create_resilient_provider("zai", Some("zai-test-key"), None, &reliability);
@@ -3332,6 +3354,9 @@ mod tests {
             channel_max_backoff_secs: 60,
             scheduler_poll_secs: 15,
             scheduler_retries: 2,
+            circuit_breaker_enabled: None,
+            circuit_breaker_failure_threshold: None,
+            circuit_breaker_recovery_secs: None,
         };
 
         let provider = create_resilient_provider("zai", Some("zai-test-key"), None, &reliability);
@@ -3630,6 +3655,9 @@ mod tests {
             channel_max_backoff_secs: 60,
             scheduler_poll_secs: 15,
             scheduler_retries: 2,
+            circuit_breaker_enabled: None,
+            circuit_breaker_failure_threshold: None,
+            circuit_breaker_recovery_secs: None,
         };
 
         // openai-codex resolves its own OAuth credential; it should not
@@ -3659,6 +3687,9 @@ mod tests {
             channel_max_backoff_secs: 60,
             scheduler_poll_secs: 15,
             scheduler_retries: 2,
+            circuit_breaker_enabled: None,
+            circuit_breaker_failure_threshold: None,
+            circuit_breaker_recovery_secs: None,
         };
 
         let provider = create_resilient_provider("ollama", None, None, &reliability);

--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -1,4 +1,5 @@
 use super::Provider;
+use super::circuit_breaker::CircuitBreaker;
 use super::traits::{
     ChatMessage, ChatRequest, ChatResponse, StreamChunk, StreamEvent, StreamOptions, StreamResult,
 };
@@ -335,7 +336,7 @@ fn push_failure(
 // Loop invariant: `failures` accumulates every failed attempt so the final
 // error message gives operators a complete diagnostic trail.
 
-/// Provider wrapper with retry, fallback, auth rotation, and model failover.
+/// Provider wrapper with retry, fallback, auth rotation, model failover, and circuit breaker.
 pub struct ReliableProvider {
     providers: Vec<(String, Box<dyn Provider>)>,
     max_retries: u32,
@@ -345,6 +346,8 @@ pub struct ReliableProvider {
     key_index: AtomicUsize,
     /// Per-model fallback chains: model_name → [fallback_model_1, fallback_model_2, ...]
     model_fallbacks: HashMap<String, Vec<String>>,
+    /// Circuit breaker for skipping providers that are currently failing.
+    circuit_breaker: Option<CircuitBreaker>,
 }
 
 impl ReliableProvider {
@@ -360,6 +363,7 @@ impl ReliableProvider {
             api_keys: Vec::new(),
             key_index: AtomicUsize::new(0),
             model_fallbacks: HashMap::new(),
+            circuit_breaker: None,
         }
     }
 
@@ -372,6 +376,12 @@ impl ReliableProvider {
     /// Set per-model fallback chains.
     pub fn with_model_fallbacks(mut self, fallbacks: HashMap<String, Vec<String>>) -> Self {
         self.model_fallbacks = fallbacks;
+        self
+    }
+
+    /// Enable circuit breaker with the given configuration.
+    pub fn with_circuit_breaker(mut self, breaker: CircuitBreaker) -> Self {
+        self.circuit_breaker = Some(breaker);
         self
     }
 
@@ -391,6 +401,27 @@ impl ReliableProvider {
         }
         let idx = self.key_index.fetch_add(1, Ordering::Relaxed) % self.api_keys.len();
         Some(&self.api_keys[idx])
+    }
+
+    /// Check if the circuit breaker allows a request to the given provider.
+    fn cb_should_allow(&self, provider_name: &str) -> bool {
+        self.circuit_breaker
+            .as_ref()
+            .map_or(true, |cb| cb.should_allow(provider_name))
+    }
+
+    /// Record a successful request in the circuit breaker.
+    fn cb_record_success(&self, provider_name: &str) {
+        if let Some(cb) = &self.circuit_breaker {
+            cb.record_success(provider_name);
+        }
+    }
+
+    /// Record a failed request in the circuit breaker.
+    fn cb_record_failure(&self, provider_name: &str) {
+        if let Some(cb) = &self.circuit_breaker {
+            cb.record_failure(provider_name);
+        }
     }
 
     /// Compute backoff duration, respecting Retry-After if present.
@@ -432,6 +463,14 @@ impl Provider for ReliableProvider {
         // retryable error, sleep with exponential backoff and retry.
         for current_model in &models {
             for (provider_name, provider) in &self.providers {
+                if !self.cb_should_allow(provider_name) {
+                    tracing::info!(
+                        provider = provider_name,
+                        model = *current_model,
+                        "Circuit breaker open, skipping provider"
+                    );
+                    continue;
+                }
                 let mut backoff_ms = self.base_backoff_ms;
 
                 for attempt in 0..=self.max_retries {
@@ -464,6 +503,7 @@ impl Provider for ReliableProvider {
                                     current_model,
                                 );
                             }
+                            self.cb_record_success(provider_name);
                             return Ok(resp);
                         }
                         Err(e) => {
@@ -550,6 +590,7 @@ impl Provider for ReliableProvider {
                     model = *current_model,
                     "Exhausted retries, trying next provider/model"
                 );
+                self.cb_record_failure(provider_name);
             }
 
             if *current_model != model {
@@ -580,6 +621,14 @@ impl Provider for ReliableProvider {
 
         for current_model in &models {
             for (provider_name, provider) in &self.providers {
+                if !self.cb_should_allow(provider_name) {
+                    tracing::info!(
+                        provider = provider_name,
+                        model = *current_model,
+                        "Circuit breaker open, skipping provider"
+                    );
+                    continue;
+                }
                 let mut backoff_ms = self.base_backoff_ms;
 
                 for attempt in 0..=self.max_retries {
@@ -614,6 +663,7 @@ impl Provider for ReliableProvider {
                                     current_model,
                                 );
                             }
+                            self.cb_record_success(provider_name);
                             return Ok(resp);
                         }
                         Err(e) => {
@@ -714,6 +764,7 @@ impl Provider for ReliableProvider {
                     model = *current_model,
                     "Exhausted retries, trying next provider/model"
                 );
+                self.cb_record_failure(provider_name);
             }
         }
 
@@ -750,6 +801,14 @@ impl Provider for ReliableProvider {
 
         for current_model in &models {
             for (provider_name, provider) in &self.providers {
+                if !self.cb_should_allow(provider_name) {
+                    tracing::info!(
+                        provider = provider_name,
+                        model = *current_model,
+                        "Circuit breaker open, skipping provider"
+                    );
+                    continue;
+                }
                 let mut backoff_ms = self.base_backoff_ms;
 
                 for attempt in 0..=self.max_retries {
@@ -784,6 +843,7 @@ impl Provider for ReliableProvider {
                                     current_model,
                                 );
                             }
+                            self.cb_record_success(provider_name);
                             return Ok(resp);
                         }
                         Err(e) => {
@@ -884,6 +944,7 @@ impl Provider for ReliableProvider {
                     model = *current_model,
                     "Exhausted retries, trying next provider/model"
                 );
+                self.cb_record_failure(provider_name);
             }
         }
 
@@ -906,6 +967,14 @@ impl Provider for ReliableProvider {
 
         for current_model in &models {
             for (provider_name, provider) in &self.providers {
+                if !self.cb_should_allow(provider_name) {
+                    tracing::info!(
+                        provider = provider_name,
+                        model = *current_model,
+                        "Circuit breaker open, skipping provider"
+                    );
+                    continue;
+                }
                 let mut backoff_ms = self.base_backoff_ms;
 
                 for attempt in 0..=self.max_retries {
@@ -941,6 +1010,7 @@ impl Provider for ReliableProvider {
                                     current_model,
                                 );
                             }
+                            self.cb_record_success(provider_name);
                             return Ok(resp);
                         }
                         Err(e) => {
@@ -1041,6 +1111,7 @@ impl Provider for ReliableProvider {
                     model = *current_model,
                     "Exhausted retries, trying next provider/model"
                 );
+                self.cb_record_failure(provider_name);
             }
 
             if *current_model != model {
@@ -1078,6 +1149,10 @@ impl Provider for ReliableProvider {
         let needs_tool_events = request.tools.is_some_and(|tools| !tools.is_empty());
 
         for (provider_name, provider) in &self.providers {
+            if !self.cb_should_allow(provider_name) {
+                continue;
+            }
+
             if !provider.supports_streaming() || !options.enabled {
                 continue;
             }
@@ -1143,6 +1218,10 @@ impl Provider for ReliableProvider {
         // Try each provider/model combination for streaming
         // For streaming, we use the first provider that supports it and has streaming enabled
         for (provider_name, provider) in &self.providers {
+            if !self.cb_should_allow(provider_name) {
+                continue;
+            }
+
             if !provider.supports_streaming() || !options.enabled {
                 continue;
             }
@@ -1212,6 +1291,10 @@ impl Provider for ReliableProvider {
         // Mirrors stream_chat_with_system but delegates to the underlying
         // provider's stream_chat_with_history, preserving the full conversation.
         for (provider_name, provider) in &self.providers {
+            if !self.cb_should_allow(provider_name) {
+                continue;
+            }
+
             if !provider.supports_streaming() || !options.enabled {
                 continue;
             }


### PR DESCRIPTION
## Summary
- Adds a `CircuitBreaker` state machine that quarantines failing model providers instead of retrying them on every request
- Three states: Closed (healthy) → Open (skip provider) → HalfOpen (probe once to test recovery)
- Integrated into all 7 provider iteration loops in `ReliableProvider`
- Configurable via `[reliability]`: `circuit_breaker_enabled`, `circuit_breaker_failure_threshold`, `circuit_breaker_recovery_secs`

Inspired by [openclaw#56851](https://github.com/openclaw/openclaw/issues/56851).

## Changes
| File | What |
|------|------|
| `src/providers/circuit_breaker.rs` | New — state machine with Arc<Mutex> thread safety, 9 unit tests |
| `src/providers/reliable.rs` | Integrate CB checks into provider iteration loops |
| `src/providers/mod.rs` | Wire CB at construction site |
| `src/config/schema.rs` | Add 3 config fields to ReliabilityConfig |

## Test plan
- [x] 9 unit tests covering all state transitions (closed→open, open→halfopen, halfopen→closed, halfopen→open)
- [x] `cargo build` succeeds
- [x] `cargo fmt --all` clean
- [ ] CI gate