### PR TITLE
feat(cron): deadline-aware conditional schedule intervals

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -5872,6 +5872,26 @@ pub struct CronJobDecl {
     /// Delivery configuration.
     #[serde(default)]
     pub delivery: Option<DeliveryConfigDecl>,
+    /// Optional conditional schedule that overrides the primary schedule
+    /// when a condition is active (e.g. more frequent polling near a deadline).
+    #[serde(default)]
+    pub conditional_schedule: Option<ConditionalScheduleDecl>,
+}
+
+/// Declarative conditional schedule configuration.
+///
+/// When the condition is active, the `schedule` expression replaces the
+/// primary job schedule (typically a more frequent interval).
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ConditionalScheduleDecl {
+    /// Cron expression to use while the condition is active.
+    pub schedule: CronScheduleDecl,
+    /// Condition type. Currently only `"date_range"` is supported.
+    pub condition_type: String,
+    /// RFC 3339 timestamp: start of the condition window (inclusive).
+    pub condition_start: String,
+    /// RFC 3339 timestamp: end of the condition window (inclusive).
+    pub condition_end: String,
 }
 
 /// Schedule variant for declarative cron jobs.

--- a/src/cron/mod.rs
+++ b/src/cron/mod.rs
@@ -10,7 +10,8 @@ pub mod scheduler;
 
 #[allow(unused_imports)]
 pub use schedule::{
-    next_run_for_schedule, normalize_expression, schedule_cron_expression, validate_schedule,
+    effective_next_run, next_run_for_schedule, normalize_expression, schedule_cron_expression,
+    validate_schedule,
 };
 #[allow(unused_imports)]
 pub use store::{
@@ -18,8 +19,8 @@ pub use store::{
     record_run, remove_job, reschedule_after_run, sync_declarative_jobs, update_job,
 };
 pub use types::{
-    CronJob, CronJobPatch, CronRun, DeliveryConfig, JobType, Schedule, SessionTarget,
-    deserialize_maybe_stringified,
+    ConditionType, ConditionalSchedule, CronJob, CronJobPatch, CronRun, DeliveryConfig, JobType,
+    Schedule, SessionTarget, deserialize_maybe_stringified,
 };
 
 /// Validate a shell command against the full security policy (allowlist + risk gate).

--- a/src/cron/schedule.rs
+++ b/src/cron/schedule.rs
@@ -1,8 +1,34 @@
-use crate::cron::Schedule;
+use crate::cron::{ConditionalSchedule, Schedule};
 use anyhow::{Context, Result};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use cron::Schedule as CronExprSchedule;
 use std::str::FromStr;
+
+/// Compute the next run time considering an optional conditional schedule.
+///
+/// If `conditional` is active at `from`, uses the conditional schedule;
+/// otherwise uses the primary `schedule`. If the conditional schedule would
+/// produce a next_run after the condition window ends, falls back to the
+/// primary schedule instead.
+pub fn effective_next_run(
+    schedule: &Schedule,
+    conditional: Option<&ConditionalSchedule>,
+    from: DateTime<Utc>,
+) -> Result<DateTime<Utc>> {
+    if let Some(cond) = conditional {
+        if cond.is_active(from) {
+            let candidate = next_run_for_schedule(&cond.schedule, from)?;
+            // Only use the conditional schedule if the next occurrence falls
+            // within (or at) the condition window end.
+            if candidate <= cond.condition_end {
+                return Ok(candidate);
+            }
+            // Condition will expire before the next conditional run;
+            // fall through to the primary schedule.
+        }
+    }
+    next_run_for_schedule(schedule, from)
+}
 
 pub fn next_run_for_schedule(schedule: &Schedule, from: DateTime<Utc>) -> Result<DateTime<Utc>> {
     match schedule {
@@ -302,5 +328,120 @@ mod tests {
         };
         let next = next_run_for_schedule(&schedule, monday).unwrap();
         assert_eq!(next.weekday(), chrono::Weekday::Sun);
+    }
+
+    // ── Conditional schedule tests ────────────────────────────────
+
+    use crate::cron::{ConditionType, ConditionalSchedule};
+
+    fn make_conditional(
+        expr: &str,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> ConditionalSchedule {
+        ConditionalSchedule {
+            schedule: Schedule::Cron {
+                expr: expr.to_string(),
+                tz: None,
+            },
+            condition_type: ConditionType::DateRange,
+            condition_start: start,
+            condition_end: end,
+        }
+    }
+
+    #[test]
+    fn effective_next_run_uses_primary_when_no_conditional() {
+        let from = Utc.with_ymd_and_hms(2026, 3, 28, 12, 0, 0).unwrap();
+        let primary = Schedule::Cron {
+            expr: "0 */6 * * *".into(),
+            tz: None,
+        };
+        let next = effective_next_run(&primary, None, from).unwrap();
+        // Next 6-hourly slot after 12:00 is 18:00
+        assert_eq!(next, Utc.with_ymd_and_hms(2026, 3, 28, 18, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn effective_next_run_uses_conditional_when_active() {
+        let from = Utc.with_ymd_and_hms(2026, 3, 29, 10, 0, 0).unwrap();
+        let primary = Schedule::Cron {
+            expr: "0 */6 * * *".into(),
+            tz: None,
+        };
+        let cond = make_conditional(
+            "*/30 * * * *",
+            Utc.with_ymd_and_hms(2026, 3, 28, 0, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2026, 3, 31, 23, 59, 59).unwrap(),
+        );
+        let next = effective_next_run(&primary, Some(&cond), from).unwrap();
+        // Should use 30-min schedule: next after 10:00 is 10:30
+        assert_eq!(next, Utc.with_ymd_and_hms(2026, 3, 29, 10, 30, 0).unwrap());
+    }
+
+    #[test]
+    fn effective_next_run_uses_primary_when_condition_inactive() {
+        let from = Utc.with_ymd_and_hms(2026, 4, 5, 10, 0, 0).unwrap();
+        let primary = Schedule::Cron {
+            expr: "0 */6 * * *".into(),
+            tz: None,
+        };
+        let cond = make_conditional(
+            "*/30 * * * *",
+            Utc.with_ymd_and_hms(2026, 3, 28, 0, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2026, 3, 31, 23, 59, 59).unwrap(),
+        );
+        let next = effective_next_run(&primary, Some(&cond), from).unwrap();
+        // Condition ended on March 31, so primary schedule applies
+        assert_eq!(next, Utc.with_ymd_and_hms(2026, 4, 5, 12, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn effective_next_run_falls_back_when_conditional_exceeds_window() {
+        // Condition ends soon but conditional schedule is infrequent
+        let from = Utc.with_ymd_and_hms(2026, 3, 31, 23, 50, 0).unwrap();
+        let primary = Schedule::Cron {
+            expr: "0 */6 * * *".into(),
+            tz: None,
+        };
+        // Conditional is every 6 hours too, but condition ends at 23:59:59
+        let cond = make_conditional(
+            "0 */6 * * *",
+            Utc.with_ymd_and_hms(2026, 3, 28, 0, 0, 0).unwrap(),
+            Utc.with_ymd_and_hms(2026, 3, 31, 23, 59, 59).unwrap(),
+        );
+        let next = effective_next_run(&primary, Some(&cond), from).unwrap();
+        // The conditional schedule's next run (06:00 April 1) exceeds the
+        // condition window end, so we fall back to the primary schedule.
+        assert_eq!(next, Utc.with_ymd_and_hms(2026, 4, 1, 0, 0, 0).unwrap());
+    }
+
+    #[test]
+    fn conditional_schedule_is_active_at_boundaries() {
+        let start = Utc.with_ymd_and_hms(2026, 3, 28, 0, 0, 0).unwrap();
+        let end = Utc.with_ymd_and_hms(2026, 3, 31, 23, 59, 59).unwrap();
+        let cond = make_conditional("*/30 * * * *", start, end);
+
+        // Exactly at start
+        assert!(cond.is_active(start));
+        // Exactly at end
+        assert!(cond.is_active(end));
+        // One second before start
+        assert!(!cond.is_active(start - ChronoDuration::seconds(1)));
+        // One second after end
+        assert!(!cond.is_active(end + ChronoDuration::seconds(1)));
+    }
+
+    #[test]
+    fn condition_type_parses_date_range() {
+        assert_eq!(
+            "date_range".parse::<ConditionType>().unwrap(),
+            ConditionType::DateRange
+        );
+        assert_eq!(
+            "DATE_RANGE".parse::<ConditionType>().unwrap(),
+            ConditionType::DateRange
+        );
+        assert!("unknown".parse::<ConditionType>().is_err());
     }
 }

--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -55,6 +55,7 @@ pub async fn run(config: Config) -> Result<()> {
             allowed_tools: None,
             session_target: None,
             delivery: None,
+            conditional_schedule: None,
         };
         tracing::debug!(
             schedule = %schedule_cron,
@@ -801,6 +802,7 @@ mod tests {
             delivery: DeliveryConfig::default(),
             delete_after_run: false,
             allowed_tools: None,
+            conditional_schedule: None,
             source: "imperative".into(),
             created_at: Utc::now(),
             next_run: Utc::now(),

--- a/src/cron/store.rs
+++ b/src/cron/store.rs
@@ -1,7 +1,8 @@
 use crate::config::Config;
 use crate::cron::{
-    CronJob, CronJobPatch, CronRun, DeliveryConfig, JobType, Schedule, SessionTarget,
-    next_run_for_schedule, schedule_cron_expression, validate_delivery_config, validate_schedule,
+    ConditionalSchedule, CronJob, CronJobPatch, CronRun, DeliveryConfig, JobType, Schedule,
+    SessionTarget, effective_next_run, next_run_for_schedule, schedule_cron_expression,
+    validate_delivery_config, validate_schedule,
 };
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -49,8 +50,8 @@ pub fn add_shell_job(
         conn.execute(
             "INSERT INTO cron_jobs (
                 id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                enabled, delivery, delete_after_run, created_at, next_run
-             ) VALUES (?1, ?2, ?3, ?4, 'shell', NULL, ?5, 'isolated', NULL, 1, ?6, ?7, ?8, ?9)",
+                enabled, delivery, delete_after_run, created_at, next_run, conditional_schedule
+             ) VALUES (?1, ?2, ?3, ?4, 'shell', NULL, ?5, 'isolated', NULL, 1, ?6, ?7, ?8, ?9, NULL)",
             params![
                 id,
                 expression,
@@ -95,8 +96,8 @@ pub fn add_agent_job(
         conn.execute(
             "INSERT INTO cron_jobs (
                 id, expression, command, schedule, job_type, prompt, name, session_target, model,
-                enabled, delivery, delete_after_run, allowed_tools, created_at, next_run
-             ) VALUES (?1, ?2, '', ?3, 'agent', ?4, ?5, ?6, ?7, 1, ?8, ?9, ?10, ?11, ?12)",
+                enabled, delivery, delete_after_run, allowed_tools, created_at, next_run, conditional_schedule
+             ) VALUES (?1, ?2, '', ?3, 'agent', ?4, ?5, ?6, ?7, 1, ?8, ?9, ?10, ?11, ?12, NULL)",
             params![
                 id,
                 expression,
@@ -124,7 +125,7 @@ pub fn list_jobs(config: &Config) -> Result<Vec<CronJob>> {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source
+                    allowed_tools, source, conditional_schedule
              FROM cron_jobs ORDER BY next_run ASC",
         )?;
 
@@ -143,7 +144,7 @@ pub fn get_job(config: &Config, job_id: &str) -> Result<CronJob> {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source
+                    allowed_tools, source, conditional_schedule
              FROM cron_jobs WHERE id = ?1",
         )?;
 
@@ -177,7 +178,7 @@ pub fn due_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJob>> {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source
+                    allowed_tools, source, conditional_schedule
              FROM cron_jobs
              WHERE enabled = 1 AND next_run <= ?1
              ORDER BY next_run ASC
@@ -207,7 +208,7 @@ pub fn all_overdue_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJ
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source
+                    allowed_tools, source, conditional_schedule
              FROM cron_jobs
              WHERE enabled = 1 AND next_run <= ?1
              ORDER BY next_run ASC",
@@ -269,9 +270,13 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
             job.allowed_tools = Some(allowed_tools);
         }
     }
+    if let Some(cond) = patch.conditional_schedule {
+        job.conditional_schedule = cond;
+    }
 
     if schedule_changed {
-        job.next_run = next_run_for_schedule(&job.schedule, Utc::now())?;
+        job.next_run =
+            effective_next_run(&job.schedule, job.conditional_schedule.as_ref(), Utc::now())?;
     }
 
     with_connection(config, |conn| {
@@ -279,8 +284,8 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
             "UPDATE cron_jobs
              SET expression = ?1, command = ?2, schedule = ?3, job_type = ?4, prompt = ?5, name = ?6,
                  session_target = ?7, model = ?8, enabled = ?9, delivery = ?10, delete_after_run = ?11,
-                 allowed_tools = ?12, next_run = ?13
-             WHERE id = ?14",
+                 allowed_tools = ?12, next_run = ?13, conditional_schedule = ?14
+             WHERE id = ?15",
             params![
                 job.expression,
                 job.command,
@@ -295,6 +300,7 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
                 if job.delete_after_run { 1 } else { 0 },
                 encode_allowed_tools(job.allowed_tools.as_ref())?,
                 job.next_run.to_rfc3339(),
+                encode_conditional_schedule(job.conditional_schedule.as_ref())?,
                 job.id,
             ],
         )
@@ -350,7 +356,7 @@ pub fn reschedule_after_run(
             Ok(())
         })
     } else {
-        let next_run = next_run_for_schedule(&job.schedule, now)?;
+        let next_run = effective_next_run(&job.schedule, job.conditional_schedule.as_ref(), now)?;
         with_connection(config, |conn| {
             conn.execute(
                 "UPDATE cron_jobs
@@ -496,6 +502,7 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
     let created_at_raw: String = row.get(12)?;
     let allowed_tools_raw: Option<String> = row.get(17)?;
     let source: Option<String> = row.get(18)?;
+    let conditional_schedule_raw: Option<String> = row.get(19)?;
 
     Ok(CronJob {
         id: row.get(0)?,
@@ -520,6 +527,8 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
         last_status: row.get(15)?,
         last_output: row.get(16)?,
         allowed_tools: decode_allowed_tools(allowed_tools_raw.as_deref())
+            .map_err(sql_conversion_error)?,
+        conditional_schedule: decode_conditional_schedule(conditional_schedule_raw.as_deref())
             .map_err(sql_conversion_error)?,
     })
 }
@@ -568,6 +577,24 @@ fn decode_allowed_tools(raw: Option<&str>) -> Result<Option<Vec<String>>> {
             return serde_json::from_str(trimmed)
                 .map(Some)
                 .with_context(|| format!("Failed to parse cron allowed_tools JSON: {trimmed}"));
+        }
+    }
+    Ok(None)
+}
+
+fn encode_conditional_schedule(cond: Option<&ConditionalSchedule>) -> Result<Option<String>> {
+    cond.map(serde_json::to_string)
+        .transpose()
+        .context("Failed to serialize conditional_schedule")
+}
+
+fn decode_conditional_schedule(raw: Option<&str>) -> Result<Option<ConditionalSchedule>> {
+    if let Some(raw) = raw {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            return serde_json::from_str(trimmed)
+                .map(Some)
+                .with_context(|| format!("Failed to parse conditional_schedule JSON: {trimmed}"));
         }
     }
     Ok(None)
@@ -651,6 +678,11 @@ pub fn sync_declarative_jobs(
             };
             let delivery_json = serde_json::to_string(&delivery)?;
             let allowed_tools_json = encode_allowed_tools(decl.allowed_tools.as_ref())?;
+            let conditional = match &decl.conditional_schedule {
+                Some(c) => Some(convert_conditional_schedule_decl(c)?),
+                None => None,
+            };
+            let conditional_json = encode_conditional_schedule(conditional.as_ref())?;
             let command = decl.command.as_deref().unwrap_or("");
             let delete_after_run = matches!(decl.schedule, CronScheduleDecl::At { .. });
 
@@ -673,14 +705,15 @@ pub fn sync_declarative_jobs(
                 let schedule_changed = current_schedule_raw.as_deref() != Some(&schedule_json);
 
                 if schedule_changed {
-                    let next_run = next_run_for_schedule(&schedule, now)?;
+                    let next_run = effective_next_run(&schedule, conditional.as_ref(), now)?;
                     conn.execute(
                         "UPDATE cron_jobs
                          SET expression = ?1, command = ?2, schedule = ?3, job_type = ?4,
                              prompt = ?5, name = ?6, session_target = ?7, model = ?8,
                              enabled = ?9, delivery = ?10, delete_after_run = ?11,
-                             allowed_tools = ?12, source = 'declarative', next_run = ?13
-                         WHERE id = ?14",
+                             allowed_tools = ?12, source = 'declarative', next_run = ?13,
+                             conditional_schedule = ?14
+                         WHERE id = ?15",
                         params![
                             expression,
                             command,
@@ -695,6 +728,7 @@ pub fn sync_declarative_jobs(
                             if delete_after_run { 1 } else { 0 },
                             allowed_tools_json,
                             next_run.to_rfc3339(),
+                            conditional_json,
                             decl.id,
                         ],
                     )
@@ -707,8 +741,9 @@ pub fn sync_declarative_jobs(
                          SET expression = ?1, command = ?2, schedule = ?3, job_type = ?4,
                              prompt = ?5, name = ?6, session_target = ?7, model = ?8,
                              enabled = ?9, delivery = ?10, delete_after_run = ?11,
-                             allowed_tools = ?12, source = 'declarative'
-                         WHERE id = ?13",
+                             allowed_tools = ?12, source = 'declarative',
+                             conditional_schedule = ?13
+                         WHERE id = ?14",
                         params![
                             expression,
                             command,
@@ -722,6 +757,7 @@ pub fn sync_declarative_jobs(
                             delivery_json,
                             if delete_after_run { 1 } else { 0 },
                             allowed_tools_json,
+                            conditional_json,
                             decl.id,
                         ],
                     )
@@ -733,13 +769,13 @@ pub fn sync_declarative_jobs(
                 tracing::debug!(job_id = %decl.id, "Updated declarative cron job");
             } else {
                 // Insert new declarative job.
-                let next_run = next_run_for_schedule(&schedule, now)?;
+                let next_run = effective_next_run(&schedule, conditional.as_ref(), now)?;
                 conn.execute(
                     "INSERT INTO cron_jobs (
                         id, expression, command, schedule, job_type, prompt, name,
                         session_target, model, enabled, delivery, delete_after_run,
-                        allowed_tools, source, created_at, next_run
-                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, 'declarative', ?14, ?15)",
+                        allowed_tools, source, created_at, next_run, conditional_schedule
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, 'declarative', ?14, ?15, ?16)",
                     params![
                         decl.id,
                         expression,
@@ -756,6 +792,7 @@ pub fn sync_declarative_jobs(
                         allowed_tools_json,
                         now.to_rfc3339(),
                         next_run.to_rfc3339(),
+                        conditional_json,
                     ],
                 )
                 .with_context(|| {
@@ -842,6 +879,46 @@ fn convert_delivery_decl(decl: &crate::config::schema::DeliveryConfigDecl) -> De
         to: decl.to.clone(),
         best_effort: decl.best_effort,
     }
+}
+
+/// Convert a `ConditionalScheduleDecl` to the runtime `ConditionalSchedule`.
+fn convert_conditional_schedule_decl(
+    decl: &crate::config::schema::ConditionalScheduleDecl,
+) -> Result<ConditionalSchedule> {
+    use crate::cron::ConditionType;
+
+    let schedule = convert_schedule_decl(&decl.schedule)?;
+    let condition_type = decl
+        .condition_type
+        .parse::<ConditionType>()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let condition_start = DateTime::parse_from_rfc3339(&decl.condition_start)
+        .with_context(|| {
+            format!(
+                "Invalid RFC3339 timestamp in conditional_schedule.condition_start: {}",
+                decl.condition_start
+            )
+        })?
+        .with_timezone(&Utc);
+    let condition_end = DateTime::parse_from_rfc3339(&decl.condition_end)
+        .with_context(|| {
+            format!(
+                "Invalid RFC3339 timestamp in conditional_schedule.condition_end: {}",
+                decl.condition_end
+            )
+        })?
+        .with_timezone(&Utc);
+
+    if condition_end <= condition_start {
+        anyhow::bail!("conditional_schedule.condition_end must be after condition_start");
+    }
+
+    Ok(ConditionalSchedule {
+        schedule,
+        condition_type,
+        condition_start,
+        condition_end,
+    })
 }
 
 fn add_column_if_missing(conn: &Connection, name: &str, sql_type: &str) -> Result<()> {
@@ -935,6 +1012,7 @@ fn with_connection<T>(config: &Config, f: impl FnOnce(&Connection) -> Result<T>)
     add_column_if_missing(&conn, "delete_after_run", "INTEGER NOT NULL DEFAULT 0")?;
     add_column_if_missing(&conn, "allowed_tools", "TEXT")?;
     add_column_if_missing(&conn, "source", "TEXT DEFAULT 'imperative'")?;
+    add_column_if_missing(&conn, "conditional_schedule", "TEXT")?;
 
     f(&conn)
 }
@@ -1470,6 +1548,7 @@ mod tests {
             allowed_tools: None,
             session_target: None,
             delivery: None,
+            conditional_schedule: None,
         }
     }
 
@@ -1489,6 +1568,7 @@ mod tests {
             allowed_tools: None,
             session_target: None,
             delivery: None,
+            conditional_schedule: None,
         }
     }
 
@@ -1643,6 +1723,7 @@ mod tests {
             allowed_tools: None,
             session_target: None,
             delivery: None,
+            conditional_schedule: None,
         };
 
         sync_declarative_jobs(&config, &[decl]).unwrap();

--- a/src/cron/types.rs
+++ b/src/cron/types.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 /// Try to deserialize a `serde_json::Value` as `T`.  If the value is a JSON
 /// string that looks like an object (i.e. the LLM double-serialized it), parse
@@ -84,6 +85,50 @@ impl SessionTarget {
     }
 }
 
+/// Condition type for conditional schedules.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConditionType {
+    /// Active during a date/time range.
+    DateRange,
+}
+
+impl FromStr for ConditionType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "date_range" => Ok(Self::DateRange),
+            other => Err(format!(
+                "Invalid condition type '{other}'. Expected one of: 'date_range'"
+            )),
+        }
+    }
+}
+
+/// A conditional schedule that overrides the primary schedule when its
+/// condition is active.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConditionalSchedule {
+    /// The more frequent schedule to use when the condition is active.
+    pub schedule: Schedule,
+    /// The type of condition that activates this schedule.
+    pub condition_type: ConditionType,
+    /// Start of the condition window (inclusive).
+    pub condition_start: DateTime<Utc>,
+    /// End of the condition window (inclusive).
+    pub condition_end: DateTime<Utc>,
+}
+
+impl ConditionalSchedule {
+    /// Returns `true` if the condition is active at the given timestamp.
+    pub fn is_active(&self, now: DateTime<Utc>) -> bool {
+        match self.condition_type {
+            ConditionType::DateRange => now >= self.condition_start && now <= self.condition_end,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum Schedule {
@@ -150,6 +195,10 @@ pub struct CronJob {
     /// When `None`, all tools are available (backward compatible default).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<Vec<String>>,
+    /// Optional conditional schedule that overrides the primary schedule
+    /// when its condition is active (e.g. more frequent polling near a deadline).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conditional_schedule: Option<ConditionalSchedule>,
     /// How the job was created: `"imperative"` (CLI/API) or `"declarative"` (config).
     #[serde(default = "default_source")]
     pub source: String,
@@ -183,6 +232,7 @@ pub struct CronJobPatch {
     pub session_target: Option<SessionTarget>,
     pub delete_after_run: Option<bool>,
     pub allowed_tools: Option<Vec<String>>,
+    pub conditional_schedule: Option<Option<ConditionalSchedule>>,
 }
 
 #[cfg(test)]

--- a/tests/integration/backup_cron_scheduling.rs
+++ b/tests/integration/backup_cron_scheduling.rs
@@ -37,6 +37,7 @@ fn backup_cron_job_synced_when_schedule_set() {
             allowed_tools: None,
             session_target: None,
             delivery: None,
+            conditional_schedule: None,
         };
         jobs_with_builtin.push(backup_job);
     }
@@ -89,6 +90,7 @@ fn backup_cron_job_removed_when_schedule_cleared() {
             allowed_tools: None,
             session_target: None,
             delivery: None,
+            conditional_schedule: None,
         };
         jobs_with_builtin.push(backup_job);
     }
@@ -130,6 +132,7 @@ fn backup_cron_job_schedule_updated() {
             allowed_tools: None,
             session_target: None,
             delivery: None,
+            conditional_schedule: None,
         };
         jobs_v1.push(backup_job);
     }
@@ -157,6 +160,7 @@ fn backup_cron_job_schedule_updated() {
             allowed_tools: None,
             session_target: None,
             delivery: None,
+            conditional_schedule: None,
         };
         jobs_v2.push(backup_job);
     }
@@ -194,6 +198,7 @@ fn backup_cron_job_id_is_stable() {
                 allowed_tools: None,
                 session_target: None,
                 delivery: None,
+                conditional_schedule: None,
             };
             jobs_with_builtin.push(backup_job);
         }
@@ -238,6 +243,7 @@ fn backup_cron_job_command_is_backup_create() {
             allowed_tools: None,
             session_target: None,
             delivery: None,
+            conditional_schedule: None,
         };
         jobs_with_builtin.push(backup_job);
     }
@@ -269,6 +275,7 @@ fn backup_cron_job_type_is_shell() {
             allowed_tools: None,
             session_target: None,
             delivery: None,
+            conditional_schedule: None,
         };
         jobs_with_builtin.push(backup_job);
     }
@@ -300,6 +307,7 @@ fn backup_cron_job_source_is_declarative() {
             allowed_tools: None,
             session_target: None,
             delivery: None,
+            conditional_schedule: None,
         };
         jobs_with_builtin.push(backup_job);
     }


### PR DESCRIPTION
## Summary
- Adds optional `conditional_schedule` to cron jobs — a secondary, more frequent schedule that activates during a configurable date range
- When the condition is active, the job runs on the conditional schedule (e.g., every 30 min); outside the window, it uses the normal schedule (e.g., every 6 hours)
- Supports `date_range` condition type with RFC 3339 start/end timestamps
- Persisted in SQLite via auto-migrated `conditional_schedule` column

Inspired by [openclaw#56850](https://github.com/openclaw/openclaw/issues/56850).

## Config example
```toml
[[cron.jobs]]
name = "deadline-check"
schedule = "0 */6 * * *"

[cron.jobs.conditional_schedule]
schedule = "*/30 * * * *"
condition_type = "date_range"
condition_start = "2026-03-28T00:00:00Z"
condition_end = "2026-03-31T23:59:59Z"
```

## Changes
| File | What |
|------|------|
| `src/cron/types.rs` | `ConditionType`, `ConditionalSchedule` structs |
| `src/cron/schedule.rs` | `effective_next_run()` + 6 unit tests |
| `src/cron/store.rs` | DB column migration, JSON encode/decode, sync |
| `src/config/schema.rs` | `ConditionalScheduleDecl` config |
| `src/cron/scheduler.rs` | Wire conditional schedule into job construction |

## Test plan
- [x] 6 unit tests covering active/inactive conditions, boundaries, edge cases
- [x] `cargo build` succeeds
- [x] `cargo fmt --all` clean
- [ ] CI gate