### PR TITLE
fix(channels): invoke ContextCompressor in daemon/channel path

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3178,6 +3178,77 @@ async fn process_channel_message(
                 strip_old_tool_context(ctx.as_ref(), &history_key, keep_tool_turns);
             }
 
+            // Post-turn context compression: summarize older history so
+            // channel conversations preserve long-context signal instead
+            // of losing everything beyond the most recent N messages.
+            // Mirrors the CLI interactive loop compression (#4880).
+            {
+                let cc_config = ctx.prompt_config.agent.context_compression.clone();
+                if cc_config.enabled {
+                    let compressor = crate::agent::context_compressor::ContextCompressor::new(
+                        cc_config,
+                        ctx.context_token_budget,
+                    )
+                    .with_memory(Arc::clone(&ctx.memory));
+
+                    // Build a temporary history vec from the stored sender
+                    // turns so the compressor can operate on it.
+                    let mut sender_history = {
+                        let mut guard = ctx
+                            .conversation_histories
+                            .lock()
+                            .unwrap_or_else(|e| e.into_inner());
+                        guard.get(&history_key).cloned().unwrap_or_default()
+                    };
+
+                    if !sender_history.is_empty() {
+                        // Prepend the system prompt so the compressor can
+                        // correctly identify protected head messages.
+                        sender_history.insert(0, ChatMessage::system(&base_system_prompt));
+
+                        match compressor
+                            .compress_if_needed(
+                                &mut sender_history,
+                                active_provider.as_ref(),
+                                route.model.as_str(),
+                            )
+                            .await
+                        {
+                            Ok(result) if result.compressed => {
+                                // Strip the synthetic system prompt before
+                                // writing back to the sender store.
+                                if sender_history.first().is_some_and(|m| m.role == "system") {
+                                    sender_history.remove(0);
+                                }
+                                let mut guard = ctx
+                                    .conversation_histories
+                                    .lock()
+                                    .unwrap_or_else(|e| e.into_inner());
+                                if let Some(turns) = guard.get_mut(&history_key) {
+                                    *turns = sender_history;
+                                }
+                                tracing::info!(
+                                    channel = %msg.channel,
+                                    sender = %msg.sender,
+                                    tokens_before = result.tokens_before,
+                                    tokens_after = result.tokens_after,
+                                    passes = result.passes_used,
+                                    "Post-turn context compression applied"
+                                );
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    error = %e,
+                                    "Post-turn context compression failed, \
+                                     relying on history trim"
+                                );
+                            }
+                            _ => {} // No compression needed
+                        }
+                    }
+                }
+            }
+
             // Fire-and-forget LLM-driven memory consolidation.
             if ctx.auto_save_memory && msg.content.chars().count() >= AUTOSAVE_MIN_MESSAGE_CHARS {
                 let provider = Arc::clone(&ctx.provider);
@@ -3260,7 +3331,84 @@ async fn process_channel_message(
                     }
                 }
             } else if is_context_window_overflow_error(&e) {
-                let compacted = compact_sender_history(ctx.as_ref(), &history_key);
+                // Attempt LLM-driven compression before falling back to
+                // the naive compact_sender_history (#4880).
+                let mut compressed_ok = false;
+                {
+                    let cc_config = ctx.prompt_config.agent.context_compression.clone();
+                    if cc_config.enabled {
+                        let mut compressor =
+                            crate::agent::context_compressor::ContextCompressor::new(
+                                cc_config,
+                                ctx.context_token_budget,
+                            )
+                            .with_memory(Arc::clone(&ctx.memory));
+
+                        let mut sender_history = {
+                            let mut guard = ctx
+                                .conversation_histories
+                                .lock()
+                                .unwrap_or_else(|err| err.into_inner());
+                            guard.get(&history_key).cloned().unwrap_or_default()
+                        };
+
+                        if !sender_history.is_empty() {
+                            sender_history.insert(0, ChatMessage::system(&base_system_prompt));
+
+                            let error_msg = format!("{e}");
+                            match compressor
+                                .compress_on_error(
+                                    &mut sender_history,
+                                    active_provider.as_ref(),
+                                    route.model.as_str(),
+                                    &error_msg,
+                                )
+                                .await
+                            {
+                                Ok(true) => {
+                                    if sender_history.first().is_some_and(|m| m.role == "system") {
+                                        sender_history.remove(0);
+                                    }
+                                    let mut guard = ctx
+                                        .conversation_histories
+                                        .lock()
+                                        .unwrap_or_else(|err| err.into_inner());
+                                    if let Some(turns) = guard.get_mut(&history_key) {
+                                        *turns = sender_history;
+                                    }
+                                    compressed_ok = true;
+                                    tracing::info!(
+                                        channel = %msg.channel,
+                                        sender = %msg.sender,
+                                        "Context recovered via \
+                                         compress_on_error"
+                                    );
+                                }
+                                Ok(false) => {
+                                    tracing::warn!(
+                                        "compress_on_error ran but \
+                                         couldn't reduce enough"
+                                    );
+                                }
+                                Err(compress_err) => {
+                                    tracing::warn!(
+                                        error = %compress_err,
+                                        "compress_on_error failed, \
+                                         falling back to compact"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Fall back to naive compaction when compression is
+                // disabled or failed.
+                let compacted = if compressed_ok {
+                    true
+                } else {
+                    compact_sender_history(ctx.as_ref(), &history_key)
+                };
                 let error_text = if compacted {
                     "⚠️ Context window exceeded for this conversation. I compacted recent history and kept the latest context. Please resend your last message."
                 } else {


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `compress_if_needed` and `compress_on_error` were only called in the CLI interactive loop (`src/agent/loop_.rs`). Daemon/channel conversations dispatched through `run_tool_call_loop` which only performed preemptive history pruning (hard drop of old messages). The `ContextCompressor` was never invoked for channel conversations.
- Why it matters: Channel conversations lose all context beyond the most recent N messages instead of being summarized, degrading response quality over long sessions.
- What changed: Added two `ContextCompressor` call-sites in `process_channel_message`: (1) post-turn `compress_if_needed` after the response is persisted to sender history, and (2) `compress_on_error` when context-window-exceeded errors occur, falling back to the existing `compact_sender_history` if compression fails or is disabled.
- What did **not** change: The pre-LLM proactive compression (already present at L2680-2710), the CLI loop compression paths, and the `compact_sender_history` fallback are all preserved.

## Label Snapshot (required)

- Risk label: `risk: high`
- Size label: `size: S`
- Scope labels: `channel`, `agent`
- Module labels: `channel: all`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #4880

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo check                  # pass (2 pre-existing warnings in multimodal.rs)
```

- Evidence provided: `cargo check` compiles cleanly; `cargo fmt` produces no diffs.
- If any command is intentionally skipped: `cargo test` not run locally due to pre-existing type inference failures in `src/config/schema.rs` tests (known issue per project memory). CI will validate.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (compression uses the existing provider already in scope)
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No (uses existing `[agent.context_compression]` config)
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Code review of both insertion points; confirmed `base_system_prompt`, `active_provider`, `route`, `history_key` are in scope; confirmed LRU cache `get()` requires `&mut self`.
- Edge cases checked: Empty sender history (no-op), compression disabled (skipped via `cc_config.enabled` check), compression failure (falls back to `compact_sender_history`).
- What was not verified: End-to-end daemon run with a real channel (requires running instance).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Channel message processing in daemon mode.
- Potential unintended effects: Post-turn compression adds an LLM call after each channel turn when compression is enabled and the context exceeds the threshold. This increases latency slightly but only fires after the response has already been delivered.
- Guardrails/monitoring for early detection: Existing tracing spans log compression passes, token counts, and failures. The `compress_if_needed` threshold prevents unnecessary calls.

## Rollback Plan (required)

- Fast rollback command/path: Revert this single commit. Alternatively, set `[agent.context_compression] enabled = false` in config to disable at runtime.
- Feature flags or config toggles: `[agent.context_compression] enabled` (existing flag)
- Observable failure symptoms: Compression errors logged at WARN level; falls back to existing naive trim.

## Risks and Mitigations

- Risk: Post-turn compression holds the conversation_histories mutex lock for the duration of the clone, releases it, then re-acquires to write back. A concurrent message for the same sender could interleave.
  - Mitigation: The existing architecture already processes one message per sender at a time (in-flight task cancellation). The clone-compress-writeback pattern avoids holding the mutex across the async compression call.

- Risk: LLM-driven compression could produce poor summaries or hallucinate.
  - Mitigation: This is the same ContextCompressor already trusted in the CLI loop. The compress_on_error path falls back to compact_sender_history if compression fails.