### PR TITLE
feat(delegate): add per-agent skill pinning

### DIFF
--- a/docs/reference/api/config-reference.md
+++ b/docs/reference/api/config-reference.md
@@ -277,6 +277,7 @@ Delegate sub-agent configurations. Each key under `[agents]` defines a named sub
 | `timeout_secs` | `120` | Timeout in seconds for non-agentic provider calls (1–3600) |
 | `agentic_timeout_secs` | `300` | Timeout in seconds for agentic sub-agent loops (1–3600) |
 | `skills_directory` | unset | Optional skills directory path (workspace-relative) for scoped skill loading |
+| `pinned_skills` | unset | Optional list of skill names always loaded for this agent regardless of keyword matching |
 
 Notes:
 
@@ -285,6 +286,7 @@ Notes:
 - The `delegate` tool is excluded from sub-agent allowlists to prevent re-entrant delegation loops.
 - Sub-agents receive an enriched system prompt containing: tools section (allowed tools with parameters), skills section (from scoped or default directory), workspace path, current date/time, safety constraints, and shell policy when `shell` is in the effective tool list.
 - When `skills_directory` is unset or empty, the sub-agent loads skills from the default workspace `skills/` directory. When set, skills are loaded exclusively from that directory (relative to workspace root), enabling per-agent scoped skill sets.
+- When `pinned_skills` is set, only the listed skill names are included in the agent's prompt. When unset, all skills from the effective directory are loaded.
 
 ```toml
 [agents.researcher]
@@ -310,6 +312,7 @@ system_prompt = "You are an expert code reviewer focused on security and perform
 agentic = true
 allowed_tools = ["file_read", "shell"]
 skills_directory = "skills/code-review"
+pinned_skills = ["lint-check", "security-scan"]
 ```
 
 ## `[runtime]`

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -591,6 +591,10 @@ pub struct DelegateAgentConfig {
     /// preventing cross-contamination with memory from other agents.
     #[serde(default)]
     pub memory_namespace: Option<String>,
+    /// Optional list of skill names that are always loaded for this agent regardless of
+    /// keyword matching. Skills are resolved from the effective skills directory.
+    #[serde(default)]
+    pub pinned_skills: Option<Vec<String>>,
 }
 
 fn default_delegate_timeout_secs() -> u64 {
@@ -12184,6 +12188,7 @@ default_temperature = 0.7
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
 

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -1287,6 +1287,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         config.agents.insert(
@@ -1305,6 +1306,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
 

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -1026,7 +1026,15 @@ impl DelegateTool {
             .filter(|s| !s.trim().is_empty())
             .map(|dir| workspace_dir.join(dir))
             .unwrap_or_else(|| crate::skills::skills_dir(workspace_dir));
-        let skills = crate::skills::load_skills_from_directory(&skills_dir, false);
+        let mut skills = crate::skills::load_skills_from_directory(&skills_dir, false);
+
+        // When pinned_skills is set, filter to only the pinned skill names so the
+        // agent receives a deterministic, curated skill set.
+        if let Some(ref pinned) = agent_config.pinned_skills {
+            let pinned_set: std::collections::HashSet<&str> =
+                pinned.iter().map(|s| s.as_str()).collect();
+            skills.retain(|s| pinned_set.contains(s.name.as_str()));
+        }
 
         // Determine shell policy instructions when the `shell` tool is in the
         // effective tool list.
@@ -1287,6 +1295,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         agents.insert(
@@ -1305,6 +1314,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         agents
@@ -1462,6 +1472,7 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
+            pinned_skills: None,
         }
     }
 
@@ -1578,6 +1589,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         let tool = DelegateTool::new(agents, None, test_security());
@@ -1692,6 +1704,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         let tool = DelegateTool::new(agents, None, test_security());
@@ -1733,6 +1746,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         let tool = DelegateTool::new(agents, None, test_security());
@@ -2022,6 +2036,7 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
+            pinned_skills: None,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
@@ -2076,6 +2091,7 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
+            pinned_skills: None,
         };
 
         struct MockShellTool;
@@ -2147,6 +2163,7 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
+            pinned_skills: None,
         };
         assert_eq!(
             config.timeout_secs.unwrap_or(DEFAULT_DELEGATE_TIMEOUT_SECS),
@@ -2176,6 +2193,7 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
+            pinned_skills: None,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
@@ -2210,6 +2228,7 @@ mod tests {
             agentic_timeout_secs: Some(600),
             skills_directory: None,
             memory_namespace: None,
+            pinned_skills: None,
         };
         assert_eq!(
             config.timeout_secs.unwrap_or(DEFAULT_DELEGATE_TIMEOUT_SECS),
@@ -2266,6 +2285,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         let err = config.validate().unwrap_err();
@@ -2294,6 +2314,7 @@ mod tests {
                 agentic_timeout_secs: Some(0),
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         let err = config.validate().unwrap_err();
@@ -2322,6 +2343,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         let err = config.validate().unwrap_err();
@@ -2350,6 +2372,7 @@ mod tests {
                 agentic_timeout_secs: Some(5000),
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         let err = config.validate().unwrap_err();
@@ -2378,6 +2401,7 @@ mod tests {
                 agentic_timeout_secs: Some(3600),
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         assert!(config.validate().is_ok());
@@ -2402,6 +2426,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         assert!(config.validate().is_ok());
@@ -2435,6 +2460,7 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: Some("skills/code-review".to_string()),
             memory_namespace: None,
+            pinned_skills: None,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
@@ -2482,6 +2508,7 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
+            pinned_skills: None,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
@@ -2496,6 +2523,119 @@ mod tests {
         assert!(
             prompt.contains("deploy"),
             "should contain skills from default workspace skills/ directory"
+        );
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn enriched_prompt_filters_skills_to_pinned_set() {
+        let workspace = std::env::temp_dir().join(format!(
+            "zeroclaw_delegate_pinned_test_{}",
+            uuid::Uuid::new_v4()
+        ));
+        let skills_dir = workspace.join("skills");
+        // Create two skills: "lint" and "deploy".
+        for name in &["lint", "deploy"] {
+            std::fs::create_dir_all(skills_dir.join(name)).unwrap();
+            std::fs::write(
+                skills_dir.join(format!("{name}/SKILL.toml")),
+                format!(
+                    "[skill]\nname = \"{name}\"\ndescription = \"Skill {name}\"\nversion = \"1.0.0\"\n"
+                ),
+            )
+            .unwrap();
+        }
+
+        let config = DelegateAgentConfig {
+            provider: "openrouter".to_string(),
+            model: "test-model".to_string(),
+            system_prompt: None,
+            api_key: None,
+            temperature: None,
+            max_depth: 3,
+            agentic: true,
+            allowed_tools: vec!["echo_tool".to_string()],
+            max_iterations: 10,
+            timeout_secs: None,
+            agentic_timeout_secs: None,
+            skills_directory: None,
+            memory_namespace: None,
+            pinned_skills: Some(vec!["lint".to_string()]),
+        };
+
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
+
+        let tool = DelegateTool::new(HashMap::new(), None, test_security())
+            .with_workspace_dir(workspace.clone());
+
+        let prompt = tool
+            .build_enriched_system_prompt(&config, &tools, &workspace)
+            .unwrap();
+
+        assert!(
+            prompt.contains("lint"),
+            "should contain pinned skill 'lint'"
+        );
+        assert!(
+            !prompt.contains("Skill deploy"),
+            "should NOT contain non-pinned skill 'deploy'"
+        );
+
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn enriched_prompt_loads_all_skills_when_pinned_is_none() {
+        let workspace = std::env::temp_dir().join(format!(
+            "zeroclaw_delegate_no_pin_test_{}",
+            uuid::Uuid::new_v4()
+        ));
+        let skills_dir = workspace.join("skills");
+        for name in &["alpha", "beta"] {
+            std::fs::create_dir_all(skills_dir.join(name)).unwrap();
+            std::fs::write(
+                skills_dir.join(format!("{name}/SKILL.toml")),
+                format!(
+                    "[skill]\nname = \"{name}\"\ndescription = \"Skill {name}\"\nversion = \"1.0.0\"\n"
+                ),
+            )
+            .unwrap();
+        }
+
+        let config = DelegateAgentConfig {
+            provider: "openrouter".to_string(),
+            model: "test-model".to_string(),
+            system_prompt: None,
+            api_key: None,
+            temperature: None,
+            max_depth: 3,
+            agentic: true,
+            allowed_tools: vec!["echo_tool".to_string()],
+            max_iterations: 10,
+            timeout_secs: None,
+            agentic_timeout_secs: None,
+            skills_directory: None,
+            memory_namespace: None,
+            pinned_skills: None,
+        };
+
+        let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
+
+        let tool = DelegateTool::new(HashMap::new(), None, test_security())
+            .with_workspace_dir(workspace.clone());
+
+        let prompt = tool
+            .build_enriched_system_prompt(&config, &tools, &workspace)
+            .unwrap();
+
+        assert!(
+            prompt.contains("alpha"),
+            "should contain skill 'alpha' when pinned_skills is None"
+        );
+        assert!(
+            prompt.contains("beta"),
+            "should contain skill 'beta' when pinned_skills is None"
         );
 
         let _ = std::fs::remove_dir_all(workspace);

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1301,6 +1301,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
 

--- a/src/tools/model_routing_config.rs
+++ b/src/tools/model_routing_config.rs
@@ -709,6 +709,7 @@ impl ModelRoutingConfigTool {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             });
 
         next_agent.provider = provider;

--- a/src/tools/swarm.rs
+++ b/src/tools/swarm.rs
@@ -570,6 +570,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         agents.insert(
@@ -588,6 +589,7 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                pinned_skills: None,
             },
         );
         agents


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Delegate agents load all skills from their skills directory, with no way to curate a specific subset for a given agent.
- Why it matters: Agents with specialized roles (e.g. code reviewer, security auditor) should receive only relevant skills, reducing prompt size and preventing skill-mismatch behavior.
- What changed: Added `pinned_skills: Option<Vec<String>>` to `DelegateAgentConfig`. When set, only listed skill names are retained from the loaded skills. When unset, behavior is unchanged.
- What did **not** change: Skill loading, skill directory resolution, and all other delegate agent behavior remain identical.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `config`, `tool`, `skills`
- Module labels: `tool: delegate`
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `config`

## Linked Issue

- Related: N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pre-existing failures only (wrappers.rs, multimodal.rs)
cargo test --lib "tools::delegate::tests"   # 61 passed, 1 pre-existing flaky failure
```

- Evidence provided: Two new unit tests (`enriched_prompt_filters_skills_to_pinned_set`, `enriched_prompt_loads_all_skills_when_pinned_is_none`)
- If any command is intentionally skipped, explain why: Full clippy has pre-existing errors in unrelated modules.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes — `pinned_skills` defaults to `None` via `#[serde(default)]`
- Config/env changes? New optional config key `pinned_skills` under `[agents.<name>]`
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (docs change is reference-only, English config-reference)

## Human Verification (required)

- Verified scenarios: pinned_skills filters correctly, None loads all skills, empty skills dir returns empty
- Edge cases checked: pinned skill name not in directory (silently omitted)
- What was not verified: Integration with live agent execution

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: delegate agent prompt construction
- Potential unintended effects: None — additive field with `serde(default)`
- Guardrails/monitoring: Existing skill loading tests cover regression

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: Test coverage for filter-vs-passthrough behavior
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: Revert commit, field is ignored by serde if removed
- Feature flags or config toggles: `pinned_skills` being `None` preserves prior behavior
- Observable failure symptoms: Skills missing from agent prompt when incorrectly pinned

## Risks and Mitigations

- Risk: Operator pins a skill name that doesn't exist in the directory, getting zero skills.
  - Mitigation: This is intentional behavior — the agent simply has no skills, same as an empty skills directory.