### PR TITLE
fix(matrix): download room keys from backup after E2EE recovery

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -614,8 +614,12 @@ impl MatrixChannel {
                     match client.encryption().recovery().recover(key).await {
                         Ok(()) => {
                             tracing::info!(
-                                "Matrix E2EE recovery successful — room keys and cross-signing secrets restored from server backup."
+                                "Matrix E2EE recovery successful — cross-signing secrets restored from server backup."
                             );
+
+                            // After cross-signing recovery, download megolm room keys
+                            // from server-side backup so encrypted rooms are readable.
+                            Self::download_room_keys_from_backup(&client).await;
                         }
                         Err(error) => {
                             tracing::warn!(
@@ -633,6 +637,69 @@ impl MatrixChannel {
             .await?;
 
         Ok(client.clone())
+    }
+
+    /// Download megolm room keys from server-side key backup for all joined rooms.
+    ///
+    /// This is called after cross-signing recovery succeeds. Without this step,
+    /// encrypted rooms are unreadable after a crypto store reset because
+    /// `recovery().recover()` only restores cross-signing secrets, not the
+    /// per-room megolm session keys.
+    async fn download_room_keys_from_backup(client: &MatrixSdkClient) {
+        let backups = client.encryption().backups();
+
+        // Check whether a server-side key backup actually exists.
+        let backup_exists = match backups.fetch_exists_on_server().await {
+            Ok(exists) => exists,
+            Err(error) => {
+                tracing::warn!(
+                    "Matrix: could not check for server-side key backup: {error}. \
+                     Skipping room-key download."
+                );
+                return;
+            }
+        };
+
+        if !backup_exists {
+            tracing::info!(
+                "Matrix: no server-side key backup found. \
+                 Skipping room-key download."
+            );
+            return;
+        }
+
+        let joined = client.joined_rooms();
+        if joined.is_empty() {
+            tracing::debug!("Matrix: no joined rooms — nothing to download.");
+            return;
+        }
+
+        tracing::info!(
+            "Downloading room keys from backup for {} joined room(s)...",
+            joined.len()
+        );
+
+        let mut ok_count: usize = 0;
+        let mut err_count: usize = 0;
+
+        for room in &joined {
+            match backups.download_room_keys_for_room(room.room_id()).await {
+                Ok(()) => ok_count += 1,
+                Err(error) => {
+                    tracing::warn!(
+                        "Matrix: failed to download room keys for {}: {error}",
+                        room.room_id()
+                    );
+                    err_count += 1;
+                }
+            }
+        }
+
+        tracing::info!(
+            "Matrix room-key download complete: {ok_count} succeeded, {err_count} failed \
+             (out of {} rooms).",
+            joined.len()
+        );
     }
 
     async fn resolve_room_id(&self) -> anyhow::Result<String> {


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: `recovery().recover()` only imports cross-signing secrets. It never downloads megolm room keys from server-side backup. After a crypto store reset, encrypted rooms are completely broken — messages cannot be decrypted.
- Why it matters: Any Matrix deployment that resets its crypto store (or starts on a new device) loses the ability to read encrypted rooms, even when a recovery key and server-side key backup are properly configured.
- What changed: After successful cross-signing recovery, a new helper `download_room_keys_from_backup()` checks if a server-side key backup exists and downloads room keys for every joined room.
- What did **not** change (scope boundary): No changes to cross-signing recovery itself, no changes to backup creation/upload, no new config options.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): risk: low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): size: S
- Scope labels: channel
- Module labels: channel: matrix
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): channel

## Linked Issue

- Closes #4878

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo check --features channel-matrix   # pass (warnings are pre-existing in multimodal.rs)
```

- Evidence provided: compilation check with `channel-matrix` feature
- If any command is intentionally skipped, explain why: `cargo test` — the existing Matrix tests are unit tests on pure helper functions; the new method requires a live Matrix SDK client connected to a homeserver, which is not testable without a mock server integration harness that does not exist in this codebase.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No — uses existing SDK backup API calls that were already available but not invoked
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Compilation with `channel-matrix` feature gate, reviewed matrix-sdk 0.16 API for `fetch_exists_on_server()`, `joined_rooms()`, and `download_room_keys_for_room()`
- Edge cases checked: no backup exists on server (early return), no joined rooms (early return), individual room key download failure (warns and continues)
- What was not verified: end-to-end test against a live Matrix homeserver with encrypted rooms

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Matrix channel startup (E2EE recovery path only)
- Potential unintended effects: Slightly slower startup when many rooms are joined (one HTTP request per room). This only runs once during session restore when a recovery key is configured.
- Guardrails/monitoring for early detection: Per-room errors are logged as warnings; summary line logs success/failure counts.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Identified the gap in `recovery().recover()` call site, added `download_room_keys_from_backup()` helper that checks backup existence then iterates joined rooms
- Verification focus: API compatibility with matrix-sdk 0.16, graceful error handling
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): yes

## Rollback Plan (required)

- Fast rollback command/path: Revert the single commit
- Feature flags or config toggles: Feature-gated behind `channel-matrix` (existing gate)
- Observable failure symptoms: Warnings in logs if backup check or room key download fails; encrypted rooms still unreadable (same as before the fix)

## Risks and Mitigations

- Risk: Startup latency increases proportional to number of joined rooms
  - Mitigation: Only runs once during session restore when a recovery key is present; per-room failures do not block remaining downloads