### PR TITLE
docs(copilot): add setup guide and onboarding wizard support

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -89,6 +89,7 @@ Last refreshed: **February 18, 2026**.
 - [nextcloud-talk-setup.md](setup-guides/nextcloud-talk-setup.md)
 - [config-reference.md](reference/api/config-reference.md)
 - [custom-providers.md](contributing/custom-providers.md)
+- [copilot-provider.md](setup-guides/copilot-provider.md)
 - [zai-glm-setup.md](setup-guides/zai-glm-setup.md)
 - [langgraph-integration.md](contributing/langgraph-integration.md)
 

--- a/docs/reference/api/providers-reference.md
+++ b/docs/reference/api/providers-reference.md
@@ -138,7 +138,7 @@ For detailed setup guidance, see [Multi-Model Setup and Fallback Chains](/docs/g
 | `novita` | — | No | `NOVITA_API_KEY` |
 | `perplexity` | — | No | `PERPLEXITY_API_KEY` |
 | `cohere` | — | No | `COHERE_API_KEY` |
-| `copilot` | `github-copilot` | No | (use config/`API_KEY` fallback with GitHub token) |
+| `copilot` | `github-copilot` | No | OAuth device flow (no key needed); or `API_KEY` with a GitHub PAT. See [Copilot setup guide](../../setup-guides/copilot-provider.md). |
 | `lmstudio` | `lm-studio` | Yes | (optional; local by default) |
 | `llamacpp` | `llama.cpp` | Yes | `LLAMACPP_API_KEY` (optional; only if server auth is enabled) |
 | `sglang` | — | Yes | `SGLANG_API_KEY` (optional) |

--- a/docs/setup-guides/README.md
+++ b/docs/setup-guides/README.md
@@ -27,6 +27,11 @@ For first-time setup and quick orientation.
 - Ollama cloud models (`:cloud`) require a remote `api_url` and API key (for example `api_url = "https://ollama.com"`).
 - Validate environment: `zeroclaw status` + `zeroclaw doctor`
 
+## Provider-Specific Guides
+
+- [GitHub Copilot Provider](copilot-provider.md) — use your Copilot subscription with ZeroClaw (OAuth device flow)
+- [Z.AI GLM Setup](zai-glm-setup.md) — Z.AI/GLM models through OpenAI-compatible endpoints
+
 ## Next
 
 - Runtime operations: [../ops/README.md](../ops/README.md)

--- a/docs/setup-guides/copilot-provider.md
+++ b/docs/setup-guides/copilot-provider.md
@@ -1,0 +1,201 @@
+# GitHub Copilot Provider Setup
+
+ZeroClaw supports GitHub Copilot as a model provider using the same OAuth
+device-flow authentication that VS Code and other third-party Copilot
+integrations use.
+
+## Prerequisites
+
+- A GitHub account with an **active GitHub Copilot subscription**
+  (Individual, Business, or Enterprise).
+- A working internet connection (the device-flow requires browser access to
+  `github.com/login/device`).
+
+## Quick Start (Onboarding Wizard)
+
+```bash
+zeroclaw onboard --provider copilot
+```
+
+No API key is required. On first use, ZeroClaw will prompt you to visit
+GitHub's device authorization page and enter a one-time code.
+
+## Manual Configuration
+
+Edit `~/.zeroclaw/config.toml`:
+
+```toml
+default_provider = "copilot"
+default_model = "gpt-4o"
+default_temperature = 0.7
+```
+
+Then run any command (for example `zeroclaw agent -m "Hello!"`). The OAuth
+device-flow login will trigger automatically on first request.
+
+### Skipping Device Flow with a GitHub Token
+
+If you already have a GitHub personal access token (PAT) with Copilot
+access, you can supply it directly:
+
+```toml
+api_key = "ghp_YOUR_GITHUB_TOKEN"
+default_provider = "copilot"
+default_model = "gpt-4o"
+```
+
+Or via environment variable:
+
+```bash
+export API_KEY="ghp_YOUR_GITHUB_TOKEN"
+```
+
+When `api_key` is set, ZeroClaw skips the device-flow login and uses the
+token directly to obtain short-lived Copilot API keys.
+
+## How Authentication Works
+
+1. **Device code request** -- ZeroClaw requests a device code from GitHub
+   using the VS Code Copilot OAuth client ID.
+2. **User authorization** -- you visit `https://github.com/login/device` in
+   a browser and enter the displayed code.
+3. **Token exchange** -- once authorized, ZeroClaw receives a GitHub access
+   token and exchanges it for a short-lived Copilot API key via
+   `api.github.com/copilot_internal/v2/token`.
+4. **Token caching** -- the access token and API key are cached to
+   `~/.config/zeroclaw/copilot/` (with `0600` permissions on Unix) and
+   automatically refreshed before expiry.
+
+No secrets are stored in the ZeroClaw config file when using device-flow.
+
+## Obtaining a GitHub Token Manually
+
+If you prefer to supply a token instead of using device-flow:
+
+### From GitHub CLI
+
+```bash
+gh auth token
+```
+
+### From VS Code
+
+1. Open VS Code with the GitHub Copilot extension installed.
+2. Open the command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`).
+3. Run "GitHub Copilot: Sign In" if not already signed in.
+4. The token is stored in VS Code's secret storage -- use `gh auth token`
+   for a simpler extraction path.
+
+### From GitHub Settings
+
+1. Go to [github.com/settings/tokens](https://github.com/settings/tokens).
+2. Create a personal access token (classic) with the `read:user` scope.
+3. Use this token as the `api_key` value.
+
+Note: a PAT only works if your GitHub account has an active Copilot
+subscription. The token itself does not grant Copilot access.
+
+## Available Models
+
+The Copilot API serves models through `api.githubcopilot.com`. Commonly
+available models include:
+
+| Model | Description |
+|-------|-------------|
+| `gpt-4o` | GPT-4o (recommended default) |
+| `gpt-4o-mini` | GPT-4o mini (faster, lower cost) |
+| `gpt-4` | GPT-4 (previous generation) |
+| `claude-3.5-sonnet` | Claude 3.5 Sonnet (if enabled on your plan) |
+| `o1-preview` | o1 Preview (reasoning model, if available) |
+| `o1-mini` | o1 mini (reasoning, faster) |
+
+Model availability depends on your Copilot plan and GitHub's current
+model roster. GitHub may add or remove models at any time.
+
+## Provider Aliases
+
+ZeroClaw accepts both `copilot` and `github-copilot` as the provider name:
+
+```bash
+zeroclaw onboard --provider copilot
+zeroclaw onboard --provider github-copilot
+```
+
+## Verify Setup
+
+```bash
+# Test agent directly
+zeroclaw agent -m "Hello"
+
+# Check configuration status
+zeroclaw status
+```
+
+## Proxy Configuration
+
+If you need to route Copilot traffic through an HTTP proxy, set the
+`provider.copilot` proxy service key in your config or use the standard
+`HTTPS_PROXY` / `HTTP_PROXY` environment variables.
+
+## Troubleshooting
+
+### "Ensure your GitHub account has an active Copilot subscription"
+
+**Symptom:** 401 or 403 errors after authentication.
+
+**Cause:** Your GitHub account does not have Copilot enabled, or the
+subscription has expired.
+
+**Solution:**
+- Check your subscription at
+  [github.com/settings/copilot](https://github.com/settings/copilot).
+- If using a PAT, ensure the token belongs to an account with Copilot
+  access.
+- ZeroClaw automatically clears cached tokens on 401/403, so the next
+  request will re-trigger the device-flow.
+
+### "Timed out waiting for GitHub authorization"
+
+**Symptom:** The device-flow expires before you complete browser
+authorization.
+
+**Solution:**
+- You have 15 minutes to complete the authorization.
+- Ensure you are visiting the correct URL (`github.com/login/device`) and
+  entering the code exactly as shown.
+- Check that your browser is logged into the correct GitHub account.
+
+### "GitHub auth failed: access_denied"
+
+**Symptom:** You denied the authorization request in the browser.
+
+**Solution:**
+- Re-run the command and approve the authorization this time.
+
+### Token Cache Location
+
+Cached tokens are stored in:
+- Linux/macOS: `~/.config/zeroclaw/copilot/`
+- Windows: `%APPDATA%\zeroclaw\config\copilot\`
+
+To force re-authentication, delete the files in this directory:
+
+```bash
+rm -rf ~/.config/zeroclaw/copilot/
+```
+
+## Important Notes
+
+- The Copilot provider uses VS Code's OAuth client ID and editor headers.
+  This is the same approach used by LiteLLM, Codex CLI, and other
+  third-party Copilot integrations.
+- The Copilot token endpoint is private and undocumented. GitHub could
+  change or revoke third-party access at any time.
+- This provider does not support live model discovery (`zeroclaw doctor`
+  will report model probing as skipped for Copilot).
+
+## Related Documentation
+
+- [Providers Reference](../reference/api/providers-reference.md)
+- [Getting Started](README.md)
+- [Custom Provider Endpoints](../contributing/custom-providers.md)

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -876,6 +876,7 @@ fn default_model_for_provider(provider: &str) -> String {
         "ollama" => "llama3.2".into(),
         "llamacpp" => "ggml-org/gpt-oss-20b-GGUF".into(),
         "sglang" | "vllm" | "osaurus" | "opencode-go" => "default".into(),
+        "copilot" => "gpt-4o".into(),
         "gemini" => "gemini-2.5-pro".into(),
         "kimi-code" => "kimi-for-coding".into(),
         "bedrock" => "anthropic.claude-sonnet-4-5-20250929-v1:0".into(),
@@ -1301,6 +1302,24 @@ fn curated_models_for_provider(provider_name: &str) -> Vec<(String, String)> {
             (
                 "anthropic.claude-sonnet-4-5-20250929-v1:0".to_string(),
                 "Claude Sonnet 4.5".to_string(),
+            ),
+        ],
+        "copilot" => vec![
+            (
+                "gpt-4o".to_string(),
+                "GPT-4o (recommended default)".to_string(),
+            ),
+            (
+                "gpt-4o-mini".to_string(),
+                "GPT-4o mini (faster, lower cost)".to_string(),
+            ),
+            (
+                "claude-3.5-sonnet".to_string(),
+                "Claude 3.5 Sonnet (if enabled on your plan)".to_string(),
+            ),
+            (
+                "o1-mini".to_string(),
+                "o1 mini (reasoning model)".to_string(),
             ),
         ],
         "gemini" => vec![
@@ -2366,6 +2385,10 @@ async fn setup_provider(workspace_dir: &Path) -> Result<(String, String, String,
             (
                 "gemini",
                 "Google Gemini — Gemini 2.0 Flash & Pro (supports CLI auth)",
+            ),
+            (
+                "copilot",
+                "GitHub Copilot — use your Copilot subscription (OAuth device flow, no API key)",
             ),
         ],
         1 => vec![

--- a/src/providers/copilot.rs
+++ b/src/providers/copilot.rs
@@ -587,7 +587,10 @@ impl CopilotProvider {
 
             anyhow::bail!(
                 "Failed to get Copilot API key ({status}): {sanitized}. \
-                 Ensure your GitHub account has an active Copilot subscription."
+                 Ensure your GitHub account has an active Copilot subscription \
+                 (check https://github.com/settings/copilot). If using a personal access token, \
+                 verify it has the 'read:user' scope. To re-authenticate, delete the cached \
+                 tokens: rm -rf ~/.config/zeroclaw/copilot/"
             );
         }
 


### PR DESCRIPTION
## Summary

- **Problem:** Users can't figure out how to configure GitHub Copilot as a provider (#4851). The implementation exists but has no documentation or wizard entry.
- **Why it matters:** Copilot is a widely-used subscription that many developers already have. Making it discoverable reduces friction for new users.
- **What changed:**
  - Added `docs/setup-guides/copilot-provider.md` covering OAuth device flow, manual token setup, available models, and troubleshooting
  - Added Copilot to the onboarding wizard tier 0 (Recommended) provider list with curated model selection
  - Added default model (`gpt-4o`) and curated model list for Copilot in the wizard
  - Improved auth failure error message with actionable guidance (subscription URL, token scope, cache clear instructions)
  - Updated `providers-reference.md` table entry with link to setup guide
  - Updated `setup-guides/README.md` and `SUMMARY.md` indexes
- **What did not change (scope boundary):** No changes to the Copilot provider implementation itself, no changes to auth flow logic, no i18n translations (docs-only, English canonical)
- Base branch target: `master`

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `docs`, `onboard`, `provider`
- Module labels: `provider: copilot`
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `docs`
- Primary scope: `docs`

## Linked Issue

- Closes #4851

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass (no formatting issues)
cargo check                  # pass (pre-existing warnings only, no new errors)
```

- Clippy reports pre-existing errors in `src/tools/wrappers.rs` due to local Rust 1.93.0 vs CI Rust 1.92.0 toolchain mismatch. No new warnings introduced by this PR.
- Markdown files reviewed for broken links and formatting.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? Yes (new English docs and wizard text)
- Locale navigation parity updated? No (new setup guide, not a navigation architecture change)
- Localized runtime-contract docs updated? N/A (new doc, no existing translations to update)
- If any No/N.A.: This adds a new English-only setup guide. i18n translations can be added in a follow-up PR once the guide is reviewed and stable.

## Human Verification (required)

- Verified scenarios: Wizard provider list includes Copilot in tier 0, curated model list renders, default model set correctly
- Edge cases checked: Both `copilot` and `github-copilot` aliases work in wizard canonicalization
- What was not verified: Live OAuth device flow (requires active Copilot subscription)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Onboarding wizard (new provider option), docs site
- Potential unintended effects: None (additive changes only)
- Guardrails/monitoring: Standard CI checks

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: Code compilation, formatting, doc link integrity
- Confirmation: naming + architecture boundaries followed (AGENTS.md + CONTRIBUTING.md): Yes

## Rollback Plan (required)

- Fast rollback command/path: Revert the single commit
- Feature flags or config toggles: None needed
- Observable failure symptoms: Wizard crash on Copilot selection (would surface immediately in onboarding)

## Risks and Mitigations

- Risk: Copilot model names may change over time as GitHub updates its model roster
  - Mitigation: Models are presented as curated suggestions with a custom model option; the guide documents that availability depends on plan and GitHub's current roster