### PR TITLE
fix(channel): whatsapp-web feature flag wiring and error messaging

### DIFF
--- a/.github/workflows/cross-platform-build-manual.yml
+++ b/.github/workflows/cross-platform-build-manual.yml
@@ -79,4 +79,4 @@ jobs:
           if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
             export "${{ matrix.linker_env }}=${{ matrix.linker }}"
           fi
-          cargo build --release --locked --features channel-matrix,channel-lark --target ${{ matrix.target }}
+          cargo build --release --locked --features channel-matrix,channel-lark,whatsapp-web --target ${{ matrix.target }}

--- a/docs/i18n/vi/channels-reference.md
+++ b/docs/i18n/vi/channels-reference.md
@@ -236,7 +236,8 @@ allowed_numbers = ["*"]
 
 Lưu ý:
 
-- Build với `cargo build --features whatsapp-web` (hoặc lệnh run tương đương).
+- Các bản phát hành dựng sẵn (stable và beta) đã bao gồm `whatsapp-web` mặc định; không cần thêm bước nào.
+- Khi build từ mã nguồn, bật với `cargo build --features whatsapp-web` (hoặc `ZEROCLAW_CARGO_FEATURES=whatsapp-web` cho `install.sh`).
 - Giữ `session_path` trên bộ nhớ lưu trữ bền vững để tránh phải liên kết lại sau khi khởi động lại.
 - Định tuyến trả lời sử dụng JID của chat nguồn, vì vậy cả trả lời trực tiếp và nhóm đều hoạt động đúng.
 

--- a/docs/i18n/zh-CN/reference/api/channels-reference.zh-CN.md
+++ b/docs/i18n/zh-CN/reference/api/channels-reference.zh-CN.md
@@ -255,7 +255,8 @@ allowed_numbers = [\"*\"]
 
 注意事项：
 
-- 使用 `cargo build --features whatsapp-web` 构建（或等效的运行命令）。
+- 预构建的发布二进制文件（stable 和 beta）默认包含 `whatsapp-web`，无需额外步骤。
+- 从源代码构建时，使用 `cargo build --features whatsapp-web` 启用（或在 `install.sh` 中设置 `ZEROCLAW_CARGO_FEATURES=whatsapp-web`）。
 - 将 `session_path` 保留在持久存储上，以避免重启后重新链接。
 - 回复路由使用发起聊天的 JID，因此直接和群组回复都能正常工作。
 

--- a/docs/reference/api/channels-reference.md
+++ b/docs/reference/api/channels-reference.md
@@ -282,7 +282,8 @@ interrupt_on_new_message = false   # optional: cancel in-flight same-sender same
 
 Notes:
 
-- Build with `cargo build --features whatsapp-web` (or equivalent run command).
+- Prebuilt release binaries (stable and beta) include `whatsapp-web` by default; no extra steps needed.
+- When building from source, enable with `cargo build --features whatsapp-web` (or `ZEROCLAW_CARGO_FEATURES=whatsapp-web` for `install.sh`).
 - Keep `session_path` on persistent storage to avoid relinking after restart.
 - Reply routing uses the originating chat JID, so direct and group replies work correctly.
 - `mention_only = true` makes the bot ignore group messages unless the bot is @-mentioned. Direct messages are always processed. Bot identity is seeded from `pair_phone` and updated from the device store on connect.

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4341,7 +4341,12 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
             }
             #[cfg(not(feature = "whatsapp-web"))]
             {
-                anyhow::bail!("WhatsApp channel requires the `whatsapp-web` feature");
+                anyhow::bail!(
+                    "WhatsApp channel requires the `whatsapp-web` compile-time feature, \
+                     but this binary was built without it. \
+                     Install a prebuilt release binary (includes whatsapp-web) or \
+                     rebuild from source with: cargo build --features whatsapp-web"
+                );
             }
         }
         "qq" => {
@@ -4637,13 +4642,22 @@ fn collect_configured_channels(
                 }
                 #[cfg(not(feature = "whatsapp-web"))]
                 {
-                    tracing::warn!(
-                        "WhatsApp Web backend requires 'whatsapp-web' feature. Enable with: cargo build --features whatsapp-web"
+                    tracing::error!(
+                        "WhatsApp Web backend requires the 'whatsapp-web' compile-time feature, \
+                         but this binary was built without it. \
+                         Prebuilt release binaries include this feature — \
+                         reinstall from a release asset or rebuild from source with: \
+                         cargo build --features whatsapp-web"
                     );
                     eprintln!(
-                        "  ⚠ WhatsApp Web is configured but the 'whatsapp-web' feature is not compiled in."
+                        "  ✖ WhatsApp Web is configured but the 'whatsapp-web' feature is not compiled into this binary."
                     );
-                    eprintln!("    Rebuild with: cargo build --features whatsapp-web");
+                    eprintln!(
+                        "    Option 1: Install a prebuilt release binary (includes whatsapp-web by default)."
+                    );
+                    eprintln!(
+                        "    Option 2: Rebuild from source with: cargo build --features whatsapp-web"
+                    );
                 }
             }
             _ => {

--- a/src/channels/whatsapp_web.rs
+++ b/src/channels/whatsapp_web.rs
@@ -1630,15 +1630,17 @@ impl Channel for WhatsAppWebChannel {
 
     async fn send(&self, _message: &SendMessage) -> Result<()> {
         anyhow::bail!(
-            "WhatsApp Web channel requires the 'whatsapp-web' feature. \
-            Enable with: cargo build --features whatsapp-web"
+            "WhatsApp Web channel requires the 'whatsapp-web' compile-time feature, \
+            but this binary was built without it. \
+            Install a prebuilt release binary or rebuild with: cargo build --features whatsapp-web"
         );
     }
 
     async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
         anyhow::bail!(
-            "WhatsApp Web channel requires the 'whatsapp-web' feature. \
-            Enable with: cargo build --features whatsapp-web"
+            "WhatsApp Web channel requires the 'whatsapp-web' compile-time feature, \
+            but this binary was built without it. \
+            Install a prebuilt release binary or rebuild with: cargo build --features whatsapp-web"
         );
     }
 
@@ -1648,15 +1650,17 @@ impl Channel for WhatsAppWebChannel {
 
     async fn start_typing(&self, _recipient: &str) -> Result<()> {
         anyhow::bail!(
-            "WhatsApp Web channel requires the 'whatsapp-web' feature. \
-            Enable with: cargo build --features whatsapp-web"
+            "WhatsApp Web channel requires the 'whatsapp-web' compile-time feature, \
+            but this binary was built without it. \
+            Install a prebuilt release binary or rebuild with: cargo build --features whatsapp-web"
         );
     }
 
     async fn stop_typing(&self, _recipient: &str) -> Result<()> {
         anyhow::bail!(
-            "WhatsApp Web channel requires the 'whatsapp-web' feature. \
-            Enable with: cargo build --features whatsapp-web"
+            "WhatsApp Web channel requires the 'whatsapp-web' compile-time feature, \
+            but this binary was built without it. \
+            Install a prebuilt release binary or rebuild with: cargo build --features whatsapp-web"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: WhatsApp Web channel fails with a confusing error even when users believe they built with `--features whatsapp-web`. The `cross-platform-build-manual.yml` workflow omits `whatsapp-web` from its feature list, producing binaries without WhatsApp Web support. Error messages do not distinguish compile-time feature gating from runtime issues and do not mention prebuilt release binaries as an alternative.
- Why it matters: Users following the docs cannot use WhatsApp Web unless they use a release binary or build from source with the correct flags. The error messaging sends them on a wild goose chase.
- What changed: (1) Added `whatsapp-web` to `cross-platform-build-manual.yml` features. (2) Upgraded error messages in `mod.rs` and `whatsapp_web.rs` stub to clearly state this is a compile-time feature, explain that prebuilt release binaries include it, and give the source-build command. (3) Updated docs in en/zh-CN/vi locales to note that prebuilt binaries include the feature by default.
- What did **not** change (scope boundary): No changes to feature flag wiring in `Cargo.toml`, no changes to the `whatsapp-web` implementation itself, no changes to release workflows (stable/beta already include the feature).

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels: `channel`, `ci`, `docs`
- Module labels: `channel: whatsapp-web`
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi` (channel + ci + docs)

## Linked Issue

- Closes #4846

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings   # pre-existing failures in unrelated files (schema.rs, multimodal.rs, wrappers.rs); no new warnings from this PR
```

- Evidence provided: formatting clean, no new clippy warnings introduced
- If any command is intentionally skipped, explain why: `cargo test` not run locally as the changed code paths are behind `cfg(not(feature = "whatsapp-web"))` stubs that are not exercised in the default test suite

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? Yes
- Locale navigation parity updated? N/A (no navigation changes)
- Localized runtime-contract docs updated? Yes (zh-CN and vi channels-reference updated)
- Vietnamese canonical docs synced? Yes

## Human Verification (required)

- Verified scenarios: Confirmed `cross-platform-build-manual.yml` was missing `whatsapp-web`; confirmed stable/beta release workflows already include it; confirmed error messages are improved
- Edge cases checked: Verified the `#[cfg(not(feature = "whatsapp-web"))]` stub Channel impl error messages are also updated
- What was not verified: Runtime behavior with a live WhatsApp Web session (requires wa-rs dependencies)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `cross-platform-build-manual.yml` now builds larger binaries (includes wa-rs); WhatsApp Web error messages changed
- Potential unintended effects: wa-rs may not compile on all targets in the cross-platform matrix (but stable/beta already include it for the same targets)
- Guardrails/monitoring for early detection: CI will validate compilation

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Investigated feature flag wiring across Cargo.toml, channel mod.rs, whatsapp_web.rs stubs, CI workflows, and docs
- Verification focus: Ensuring no new clippy/fmt regressions
- Confirmation: naming + architecture boundaries followed (AGENTS.md + CONTRIBUTING.md)

## Rollback Plan (required)

- Fast rollback command/path: Revert commit
- Feature flags or config toggles: N/A
- Observable failure symptoms: WhatsApp Web channel not registering at startup

## Risks and Mitigations

- Risk: wa-rs crates may not compile on some cross-platform targets
  - Mitigation: The cross-platform-build-manual.yml matrix can be adjusted per-target like the stable release workflow does for Android