### PR TITLE
fix(mcp): warn on misconfigured MCP and add setup guide

### DIFF
--- a/docs/setup-guides/README.md
+++ b/docs/setup-guides/README.md
@@ -27,6 +27,10 @@ For first-time setup and quick orientation.
 - Ollama cloud models (`:cloud`) require a remote `api_url` and API key (for example `api_url = "https://ollama.com"`).
 - Validate environment: `zeroclaw status` + `zeroclaw doctor`
 
+## Integrations
+
+- MCP tool servers: [mcp-servers.md](mcp-servers.md)
+
 ## Next
 
 - Runtime operations: [../ops/README.md](../ops/README.md)

--- a/docs/setup-guides/mcp-servers.md
+++ b/docs/setup-guides/mcp-servers.md
@@ -1,0 +1,196 @@
+# MCP Server Configuration
+
+Connect external [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers to ZeroClaw so the agent can use tools provided by those servers.
+
+## Prerequisites
+
+- ZeroClaw installed and working (`zeroclaw status` passes)
+- One or more MCP-compatible tool servers (stdio, HTTP, or SSE)
+
+## Quick Start
+
+Add the following to your `config.toml`:
+
+```toml
+[mcp]
+enabled = true
+
+[[mcp.servers]]
+name = "filesystem"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/documents"]
+```
+
+Restart ZeroClaw. Verify with:
+
+```bash
+zeroclaw status
+```
+
+The agent will discover tools advertised by connected MCP servers and make them available during conversations.
+
+## Configuration Reference
+
+### `[mcp]` section
+
+| Key                | Type     | Default | Description |
+|--------------------|----------|---------|-------------|
+| `enabled`          | bool     | `false` | Master switch. Must be `true` for MCP servers to connect. |
+| `deferred_loading` | bool     | `true`  | When `true`, only tool names are listed in the system prompt. The LLM calls `tool_search` to fetch full schemas on demand, reducing context window usage. When `false`, all MCP tool schemas are loaded eagerly. |
+
+### `[[mcp.servers]]` entries
+
+Each entry configures one MCP server connection.
+
+| Key                 | Type              | Default  | Description |
+|---------------------|-------------------|----------|-------------|
+| `name`              | string (required) | —        | Unique display name. Used as tool prefix: `<name>__<tool>`. |
+| `transport`         | string            | `"stdio"`| Transport type: `"stdio"`, `"http"`, or `"sse"`. |
+| `command`           | string            | `""`     | Executable to spawn (stdio transport only). |
+| `args`              | string array      | `[]`     | Arguments passed to the command (stdio transport only). |
+| `env`               | key-value map     | `{}`     | Environment variables set for the spawned process (stdio only). |
+| `url`               | string            | —        | Server URL (required for `http` and `sse` transports). |
+| `headers`           | key-value map     | `{}`     | HTTP headers sent with requests (`http`/`sse` only). |
+| `tool_timeout_secs` | integer           | `180`    | Per-call timeout in seconds. Hard cap: 600. |
+
+## Transport Types
+
+### Stdio (default)
+
+Spawns a local process and communicates over stdin/stdout using JSON-RPC 2.0.
+
+```toml
+[[mcp.servers]]
+name = "filesystem"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/docs"]
+```
+
+### HTTP
+
+Connects to a remote MCP server via HTTP POST.
+
+```toml
+[[mcp.servers]]
+name = "remote-tools"
+transport = "http"
+url = "https://mcp.example.com/rpc"
+headers = { Authorization = "Bearer sk-..." }
+```
+
+### SSE (Server-Sent Events)
+
+Connects via HTTP with Server-Sent Events for streaming responses.
+
+```toml
+[[mcp.servers]]
+name = "streaming-tools"
+transport = "sse"
+url = "https://mcp.example.com/events"
+```
+
+## Examples
+
+### Multiple servers
+
+```toml
+[mcp]
+enabled = true
+
+[[mcp.servers]]
+name = "filesystem"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem", "/home/user/projects"]
+
+[[mcp.servers]]
+name = "github"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+env = { GITHUB_PERSONAL_ACCESS_TOKEN = "ghp_..." }
+
+[[mcp.servers]]
+name = "postgres"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-postgres", "postgresql://localhost/mydb"]
+```
+
+### Eager loading (disable deferred)
+
+By default, MCP tool schemas are loaded on demand via `tool_search`. To load all schemas upfront (useful when you have few MCP tools):
+
+```toml
+[mcp]
+enabled = true
+deferred_loading = false
+```
+
+### Custom timeout
+
+For long-running tools (e.g., database queries):
+
+```toml
+[[mcp.servers]]
+name = "slow-db"
+transport = "stdio"
+command = "/usr/local/bin/mcp-db-server"
+tool_timeout_secs = 300
+```
+
+## How Tools Appear to the Agent
+
+Each MCP tool is prefixed with the server name to prevent collisions:
+
+- Server `filesystem` advertising tool `read_file` becomes `filesystem__read_file`
+- Server `github` advertising tool `list_repos` becomes `github__list_repos`
+
+When **deferred loading** is enabled (the default), the agent sees tool names in the system prompt and calls `tool_search` to activate them before first use. When disabled, all tool schemas are included in the LLM context window from the start.
+
+## Troubleshooting
+
+### "MCP servers are configured but mcp.enabled is false"
+
+You have `[[mcp.servers]]` entries but forgot the master switch:
+
+```toml
+[mcp]
+enabled = true   # <-- add this
+```
+
+### "All configured MCP server(s) failed to connect"
+
+Check that:
+
+1. The `command` exists and is executable (`which npx`, `which node`, etc.)
+2. The MCP server package is installed or the `npx -y` auto-install works
+3. For HTTP/SSE: the `url` is reachable and correct
+4. Run with `RUST_LOG=debug` for detailed error output:
+   ```bash
+   RUST_LOG=debug zeroclaw run
+   ```
+
+### "mcp.enabled is true but no servers are configured"
+
+Add at least one `[[mcp.servers]]` entry. See the examples above.
+
+### Tools not appearing in conversations
+
+- Verify `mcp.enabled = true` in your config
+- Check that `deferred_loading` matches your expectation:
+  - If `true` (default): the agent must call `tool_search` to activate tools
+  - If `false`: tools should appear immediately in the tool list
+- Look for connection errors in logs: `zeroclaw run 2>&1 | grep -i mcp`
+
+### Server name conflicts
+
+Each server `name` must be unique (case-insensitive). Duplicate names cause a validation error at startup.
+
+## Further Reading
+
+- [MCP specification](https://modelcontextprotocol.io/)
+- [Config reference](../reference/config-reference.md)
+- [CLI commands](../reference/cli/commands-reference.md)

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -4065,6 +4065,13 @@ fn service_selector_matches(selector: &str, service_key: &str) -> bool {
 const MCP_MAX_TOOL_TIMEOUT_SECS: u64 = 600;
 
 fn validate_mcp_config(config: &McpConfig) -> Result<()> {
+    if config.servers.is_empty() {
+        tracing::warn!(
+            "mcp.enabled is true but no servers are configured — \
+             add [[mcp.servers]] entries in config.toml to connect MCP tool servers"
+        );
+        return Ok(());
+    }
     let mut seen_names = std::collections::HashSet::new();
     for (i, server) in config.servers.iter().enumerate() {
         let name = server.name.trim();
@@ -9783,6 +9790,12 @@ impl Config {
         // MCP
         if self.mcp.enabled {
             validate_mcp_config(&self.mcp)?;
+        } else if !self.mcp.servers.is_empty() {
+            tracing::warn!(
+                "MCP servers are configured ({} server(s)) but mcp.enabled is false — \
+                 set `mcp.enabled = true` in config.toml to activate them",
+                self.mcp.servers.len()
+            );
         }
 
         // Knowledge graph
@@ -15476,6 +15489,17 @@ require_otp_to_resume = true
         let cfg = McpConfig::default();
         assert!(!cfg.enabled);
         assert!(cfg.servers.is_empty());
+    }
+
+    #[test]
+    async fn validate_mcp_config_enabled_no_servers_succeeds() {
+        // enabled=true with no servers should succeed (warning is logged, not an error)
+        let cfg = McpConfig {
+            enabled: true,
+            servers: vec![],
+            ..Default::default()
+        };
+        assert!(validate_mcp_config(&cfg).is_ok());
     }
 
     #[test]

--- a/src/tools/mcp_client.rs
+++ b/src/tools/mcp_client.rs
@@ -241,6 +241,22 @@ impl McpRegistry {
             }
         }
 
+        if !configs.is_empty() && servers.is_empty() {
+            tracing::warn!(
+                "All {} configured MCP server(s) failed to connect — \
+                 check server commands/URLs and ensure the MCP processes are reachable. \
+                 Run with RUST_LOG=debug for detailed connection errors.",
+                configs.len()
+            );
+        } else if !configs.is_empty() && servers.len() < configs.len() {
+            tracing::warn!(
+                "Only {}/{} MCP server(s) connected successfully — \
+                 check logs above for connection failures",
+                servers.len(),
+                configs.len()
+            );
+        }
+
         Ok(Self {
             servers,
             tool_index,


### PR DESCRIPTION
## Summary

- **Problem:** MCP servers are silently ignored when configured without `mcp.enabled = true`, making users think MCP detection is broken (#4848)
- **Why it matters:** Users configure `[[mcp.servers]]` entries but get zero feedback that the master switch is off
- **What changed:**
  - Config validation now warns when servers are defined but `mcp.enabled` is false
  - Config validation warns when `mcp.enabled = true` but no servers are listed
  - `McpRegistry::connect_all` logs warnings when all or some servers fail to connect
  - New `docs/setup-guides/mcp-servers.md` with full configuration reference, transport examples, and troubleshooting
- **What did not change:** MCP client/protocol/transport logic, tool registration, deferred loading behavior

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `config`, `tool`, `docs`
- Module labels: `tool: mcp`, `config: schema`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: n/a

## Change Metadata

- Change type: `bug`
- Primary scope: `config`

## Linked Issue

- Closes #4848

## Supersede Attribution (required when `Supersedes #` is used)

n/a

## Validation Evidence (required)

```bash
cargo fmt --all -- --check    # pass
cargo clippy --all-targets    # pass (no new warnings)
cargo test --lib -- mcp       # 104 passed; 0 failed
```

- Evidence provided: all 104 MCP-related tests pass including the new `validate_mcp_config_enabled_no_servers_succeeds` test
- No commands skipped

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: n/a
- Neutral wording confirmation: yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No (existing configs continue to work; new warnings are informational only)
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (new English-only setup guide; no existing i18n equivalents to update)

## Human Verification (required)

- Verified scenarios: configured servers with enabled=false produces warning; enabled=true with empty servers produces warning; all servers failing produces warning
- Edge cases checked: empty config, single failure among multiple servers, validation test for new path
- What was not verified: live MCP server connection (requires external process)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: config validation (adds tracing::warn calls), MCP registry initialization
- Potential unintended effects: none — warnings are purely informational
- Guardrails/monitoring for early detection: n/a

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: compilation, clippy, all MCP tests
- Confirmation: naming + architecture boundaries followed (AGENTS.md + CONTRIBUTING.md)

## Rollback Plan (required)

- Fast rollback command/path: revert single commit
- Feature flags or config toggles: n/a
- Observable failure symptoms: n/a (additive warnings only)

## Risks and Mitigations

- Risk: None — purely additive warnings and documentation