### PR TITLE
chore: update copyright year to 2025-2026

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 ZeroClaw
-Copyright 2025 ZeroClaw Labs
+Copyright 2025-2026 ZeroClaw Labs
 
 This product includes software developed at ZeroClaw Labs (https://github.com/zeroclaw-labs).
 


### PR DESCRIPTION
## Summary

- Updates the NOTICE file copyright from `2025` to `2025-2026`
- Removed stray `web/dist/logo.png` change from previous revision

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `docs`
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `chore`
- Primary scope: `docs`

## Validation Evidence (required)

- `cargo fmt --all -- --check`: N/A (no code changes)
- `cargo clippy --all-targets`: N/A (no code changes)
- `cargo test --lib`: N/A (no code changes)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Confirmed NOTICE file has correct `2025-2026` range
- Edge cases checked: N/A
- What was not verified: N/A

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: None — NOTICE file only
- Potential unintended effects: None
- Guardrails/monitoring: N/A

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None
- Observable failure symptoms: N/A