### PR TITLE
fix(memory): reject clear on append-only markdown backend

### DIFF
--- a/crates/zeroclaw-runtime/locales/en/cli.ftl
+++ b/crates/zeroclaw-runtime/locales/en/cli.ftl
@@ -129,6 +129,7 @@ cli-memory-list-about = List memory entries with optional filters
 cli-memory-get-about = Get a specific memory entry by key
 cli-memory-stats-about = Show memory backend statistics and health
 cli-memory-clear-about = Clear memories by category, by key, or clear all
+cli-memory-clear-unsupported-backend = memory clear is unsupported for append-only backend '{$backend}'; switch to a deletable backend (sqlite, lucid, or postgres)
 
 cli-estop-status-about = Print current estop status
 cli-estop-resume-about = Resume from an engaged estop level

--- a/src/memory/cli.rs
+++ b/src/memory/cli.rs
@@ -215,6 +215,18 @@ async fn handle_clear(
     category: Option<String>,
     yes: bool,
 ) -> Result<()> {
+    let backend = effective_memory_backend_name(
+        &config.memory.backend,
+        Some(&config.storage.provider.config),
+    );
+    if matches!(
+        classify_memory_backend(&backend),
+        MemoryBackendKind::Markdown
+    ) {
+        bail!(
+            "memory clear is unsupported for append-only backend 'markdown'; switch to a deletable backend (sqlite, lucid, postgres, or qdrant)"
+        );
+    }
     let mem = create_cli_memory(config)?;
 
     // Single-key deletion (exact or prefix match).
@@ -329,6 +341,7 @@ fn truncate_content(s: &str, max_len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     #[test]
     fn parse_category_known_variants() {
@@ -367,5 +380,67 @@ mod tests {
     #[test]
     fn truncate_content_empty_string() {
         assert_eq!(truncate_content("", 10), "");
+    }
+
+    #[tokio::test]
+    async fn clear_rejects_append_only_markdown_backend() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.workspace_dir = tmp.path().to_path_buf();
+        config.memory.backend = "markdown".into();
+
+        let err = handle_command(
+            crate::MemoryCommands::Clear {
+                key: None,
+                category: None,
+                yes: true,
+            },
+            &config,
+        )
+        .await
+        .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(msg.contains("append-only backend 'markdown'"));
+        assert!(msg.contains("switch to a deletable backend"));
+    }
+
+    #[tokio::test]
+    async fn clear_does_not_reject_qdrant_backend_constructed_as_markdown() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.workspace_dir = tmp.path().to_path_buf();
+        config.memory.backend = "qdrant".into();
+
+        handle_command(
+            crate::MemoryCommands::Clear {
+                key: None,
+                category: None,
+                yes: true,
+            },
+            &config,
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn clear_does_not_reject_storage_configured_qdrant_backend() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = Config::default();
+        config.workspace_dir = tmp.path().to_path_buf();
+        config.memory.backend = "markdown".into();
+        config.storage.provider.config.provider = "qdrant".into();
+
+        handle_command(
+            crate::MemoryCommands::Clear {
+                key: None,
+                category: None,
+                yes: true,
+            },
+            &config,
+        )
+        .await
+        .unwrap();
     }
 }

--- a/src/memory/cli.rs
+++ b/src/memory/cli.rs
@@ -6,6 +6,7 @@ use super::{
 use crate::config::Config;
 use anyhow::{Result, bail};
 use console::style;
+use zeroclaw_runtime::i18n;
 
 /// Handle `zeroclaw memory <subcommand>` CLI commands.
 pub async fn handle_command(command: crate::MemoryCommands, config: &Config) -> Result<()> {
@@ -215,17 +216,15 @@ async fn handle_clear(
     category: Option<String>,
     yes: bool,
 ) -> Result<()> {
-    let backend = effective_memory_backend_name(
-        &config.memory.backend,
-        Some(&config.storage.provider.config),
-    );
+    let backend = backend_kind_from_dotted(&config.memory.backend);
     if matches!(
         classify_memory_backend(&backend),
         MemoryBackendKind::Markdown | MemoryBackendKind::Qdrant
     ) {
-        bail!(
-            "memory clear is unsupported for append-only backend '{backend}'; switch to a deletable backend (sqlite, lucid, or postgres)"
-        );
+        bail!(i18n::get_required_cli_string_with_args(
+            "cli-memory-clear-unsupported-backend",
+            &[("backend", &backend)]
+        ));
     }
     let mem = create_cli_memory(config)?;
 
@@ -386,7 +385,7 @@ mod tests {
     async fn clear_rejects_append_only_markdown_backend() {
         let tmp = TempDir::new().unwrap();
         let mut config = Config::default();
-        config.workspace_dir = tmp.path().to_path_buf();
+        config.data_dir = tmp.path().to_path_buf();
         config.memory.backend = "markdown".into();
 
         let err = handle_command(
@@ -409,7 +408,7 @@ mod tests {
     async fn clear_rejects_qdrant_backend_constructed_as_markdown() {
         let tmp = TempDir::new().unwrap();
         let mut config = Config::default();
-        config.workspace_dir = tmp.path().to_path_buf();
+        config.data_dir = tmp.path().to_path_buf();
         config.memory.backend = "qdrant".into();
 
         let err = handle_command(
@@ -429,12 +428,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn clear_rejects_storage_configured_qdrant_backend() {
+    async fn clear_rejects_dotted_qdrant_backend() {
         let tmp = TempDir::new().unwrap();
         let mut config = Config::default();
-        config.workspace_dir = tmp.path().to_path_buf();
-        config.memory.backend = "markdown".into();
-        config.storage.provider.config.provider = "qdrant".into();
+        config.data_dir = tmp.path().to_path_buf();
+        config.memory.backend = "qdrant.default".into();
 
         let err = handle_command(
             crate::MemoryCommands::Clear {

--- a/src/memory/cli.rs
+++ b/src/memory/cli.rs
@@ -221,10 +221,10 @@ async fn handle_clear(
     );
     if matches!(
         classify_memory_backend(&backend),
-        MemoryBackendKind::Markdown
+        MemoryBackendKind::Markdown | MemoryBackendKind::Qdrant
     ) {
         bail!(
-            "memory clear is unsupported for append-only backend 'markdown'; switch to a deletable backend (sqlite, lucid, postgres, or qdrant)"
+            "memory clear is unsupported for append-only backend '{backend}'; switch to a deletable backend (sqlite, lucid, or postgres)"
         );
     }
     let mem = create_cli_memory(config)?;
@@ -406,13 +406,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn clear_does_not_reject_qdrant_backend_constructed_as_markdown() {
+    async fn clear_rejects_qdrant_backend_constructed_as_markdown() {
         let tmp = TempDir::new().unwrap();
         let mut config = Config::default();
         config.workspace_dir = tmp.path().to_path_buf();
         config.memory.backend = "qdrant".into();
 
-        handle_command(
+        let err = handle_command(
             crate::MemoryCommands::Clear {
                 key: None,
                 category: None,
@@ -421,18 +421,22 @@ mod tests {
             &config,
         )
         .await
-        .unwrap();
+        .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(msg.contains("append-only backend 'qdrant'"));
+        assert!(!msg.contains("or qdrant"));
     }
 
     #[tokio::test]
-    async fn clear_does_not_reject_storage_configured_qdrant_backend() {
+    async fn clear_rejects_storage_configured_qdrant_backend() {
         let tmp = TempDir::new().unwrap();
         let mut config = Config::default();
         config.workspace_dir = tmp.path().to_path_buf();
         config.memory.backend = "markdown".into();
         config.storage.provider.config.provider = "qdrant".into();
 
-        handle_command(
+        let err = handle_command(
             crate::MemoryCommands::Clear {
                 key: None,
                 category: None,
@@ -441,6 +445,10 @@ mod tests {
             &config,
         )
         .await
-        .unwrap();
+        .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(msg.contains("append-only backend 'qdrant'"));
+        assert!(!msg.contains("or qdrant"));
     }
 }

--- a/src/memory/cli.rs
+++ b/src/memory/cli.rs
@@ -214,10 +214,10 @@ async fn handle_stats(config: &Config) -> Result<()> {
 fn unsupported_clear_backend_message(backend: &str) -> String {
     #[cfg(feature = "agent-runtime")]
     {
-        return i18n::get_required_cli_string_with_args(
+        i18n::get_required_cli_string_with_args(
             "cli-memory-clear-unsupported-backend",
             &[("backend", backend)],
-        );
+        )
     }
 
     #[cfg(not(feature = "agent-runtime"))]

--- a/src/memory/cli.rs
+++ b/src/memory/cli.rs
@@ -6,6 +6,7 @@ use super::{
 use crate::config::Config;
 use anyhow::{Result, bail};
 use console::style;
+#[cfg(feature = "agent-runtime")]
 use zeroclaw_runtime::i18n;
 
 /// Handle `zeroclaw memory <subcommand>` CLI commands.
@@ -210,6 +211,23 @@ async fn handle_stats(config: &Config) -> Result<()> {
     Ok(())
 }
 
+fn unsupported_clear_backend_message(backend: &str) -> String {
+    #[cfg(feature = "agent-runtime")]
+    {
+        return i18n::get_required_cli_string_with_args(
+            "cli-memory-clear-unsupported-backend",
+            &[("backend", backend)],
+        );
+    }
+
+    #[cfg(not(feature = "agent-runtime"))]
+    {
+        format!(
+            "memory clear is unsupported for append-only backend '{backend}'; switch to a deletable backend (sqlite, lucid, or postgres)"
+        )
+    }
+}
+
 async fn handle_clear(
     config: &Config,
     key: Option<String>,
@@ -221,10 +239,7 @@ async fn handle_clear(
         classify_memory_backend(&backend),
         MemoryBackendKind::Markdown | MemoryBackendKind::Qdrant
     ) {
-        bail!(i18n::get_required_cli_string_with_args(
-            "cli-memory-clear-unsupported-backend",
-            &[("backend", &backend)]
-        ));
+        bail!(unsupported_clear_backend_message(&backend));
     }
     let mem = create_cli_memory(config)?;
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Make `zeroclaw memory clear` fail fast when the configured memory backend kind is append-only `markdown` or `qdrant`, instead of listing entries and reporting `Cleared 0/N`.
  - Normalize dotted backend references such as `qdrant.default` before the clear guard so storage-routed qdrant configs hit the same unsupported-backend path.
  - Move the default-build unsupported-backend message into the CLI Fluent resources, while keeping the no-default-features build compiling without the runtime i18n dependency.
  - Add focused regressions for markdown, bare qdrant, and dotted qdrant clear attempts.
- **Scope boundary:** This PR does not implement deletion semantics for append-only backends and does not change `memory list`, `memory get`, `memory stats`, or `memory reindex`.
- **Blast radius:** `zeroclaw memory clear` now returns an explicit unsupported-backend error for markdown/qdrant configs. This PR only changes the early rejection path for markdown/qdrant; deletable backend behavior is not intentionally changed.
- **Linked issue(s):** Fixes #5113.
- **Labels:** `bug`, `risk: medium`, `size: S`, `memory`.

## Validation Evidence (required)

```text
GitHub CI on head f153eae6:
- Apply path labels: success
- Lint: success
- Build aarch64-apple-darwin: success
- Build x86_64-pc-windows-msvc: success
- Build x86_64-unknown-linux-gnu: success
- Check (32-bit): success
- Check (all features): success
- Check (no default features): success
- Benchmarks Compile: success
- Test: success
- Security: success
- CI Required Gate: success

Maintainer validation:
- git diff --check origin/master...HEAD: passed
- cargo test -p zeroclawlabs memory::cli::tests::clear_rejects -- --nocapture: passed; the three new clear rejection tests passed in both the root lib and binary test harnesses
```

- **Beyond CI — what did you manually verify?** Reviewed the current diff against the prior Audacity88 blockers, linked issue #5113, the memory backend classification path, and the CLI Fluent lookup path. Verified the default build uses the new Fluent key and the no-default-features path keeps a feature-gated fallback.
- **If any command was intentionally skipped, why:** No broad local workspace clippy or CI-shaped nextest was run for this review pass; GitHub CI is green, and the local run targeted the behavior regressions added by this small two-file PR.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes`
- If `No` or `Yes` to either: Existing markdown/qdrant users now receive an explicit unsupported-backend error from `zeroclaw memory clear` instead of a misleading zero-deletion success message. Users who need clear/delete behavior should use a deletable backend such as sqlite, lucid, or postgres.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Revert the merge commit for this PR.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `zeroclaw memory clear` on markdown/qdrant no longer emits the unsupported-backend error, or clear operations on sqlite/lucid/postgres regress unexpectedly.
