### PR TITLE
fix: resolve all clippy errors blocking release builds

### DIFF
--- a/src/channels/whatsapp_web.rs
+++ b/src/channels/whatsapp_web.rs
@@ -31,6 +31,7 @@ use super::whatsapp_storage::RusqliteStore;
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use parking_lot::Mutex;
+use std::path::Path;
 use std::sync::Arc;
 use tokio::select;
 use wa_rs_proto::whatsapp::device_props::PlatformType;
@@ -1121,7 +1122,7 @@ impl Channel for WhatsAppWebChannel {
                                 let sender_jid = info.source.sender.clone();
                                 let sender_alt = info.source.sender_alt.clone();
                                 let sender = sender_jid.user().to_string();
-                                let is_group = info.source.chat.is_group();
+                                let _is_group = info.source.chat.is_group();
                                 let chat = info.source.chat.to_string();
 
                                 let mapped_phone = if sender_jid.is_lid() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -956,7 +956,7 @@ async fn main() -> Result<()> {
 
         // TUI onboarding mode (ratatui-based)
         if use_tui {
-            tui::run_tui_onboarding().await?;
+            Box::pin(tui::run_tui_onboarding()).await?;
             return Ok(());
         }
 

--- a/src/memory/namespaced.rs
+++ b/src/memory/namespaced.rs
@@ -182,10 +182,8 @@ impl Memory for NamespacedMemory {
         let entries = self.inner.list(None, Some(session_id)).await?;
         let mut count = 0;
         for entry in entries {
-            if entry.namespace == self.namespace {
-                if self.inner.forget(&entry.key).await? {
-                    count += 1;
-                }
+            if entry.namespace == self.namespace && self.inner.forget(&entry.key).await? {
+                count += 1;
             }
         }
         Ok(count)

--- a/src/multimodal.rs
+++ b/src/multimodal.rs
@@ -143,7 +143,6 @@ pub async fn prepare_messages_for_provider(
     let remote_client = build_runtime_proxy_client_with_timeouts("provider.ollama", 30, 10);
 
     let mut normalized_messages = Vec::with_capacity(trimmed.len());
-    let _has_successful_images = false;
     for message in &trimmed {
         if message.role != "user" {
             normalized_messages.push(message.clone());

--- a/src/tools/web_search_tool.rs
+++ b/src/tools/web_search_tool.rs
@@ -419,10 +419,9 @@ impl Tool for WebSearchTool {
         }
 
         let result = match resolution.route {
-            WebSearchProviderRoute::DuckDuckGo => self.search_duckduckgo(query).await?,
+            WebSearchProviderRoute::DuckDuckGo | WebSearchProviderRoute::Tavily => self.search_duckduckgo(query).await?, // TODO: implement Tavily search
             WebSearchProviderRoute::Brave => self.search_brave(query).await?,
             WebSearchProviderRoute::SearXNG => self.search_searxng(query).await?,
-            WebSearchProviderRoute::Tavily => self.search_duckduckgo(query).await?, // TODO: implement Tavily search
         };
 
         Ok(ToolResult {

--- a/src/tools/web_search_tool.rs
+++ b/src/tools/web_search_tool.rs
@@ -419,7 +419,9 @@ impl Tool for WebSearchTool {
         }
 
         let result = match resolution.route {
-            WebSearchProviderRoute::DuckDuckGo | WebSearchProviderRoute::Tavily => self.search_duckduckgo(query).await?, // TODO: implement Tavily search
+            WebSearchProviderRoute::DuckDuckGo | WebSearchProviderRoute::Tavily => {
+                self.search_duckduckgo(query).await?
+            } // TODO: implement Tavily search
             WebSearchProviderRoute::Brave => self.search_brave(query).await?,
             WebSearchProviderRoute::SearXNG => self.search_searxng(query).await?,
         };

--- a/src/tools/wrappers.rs
+++ b/src/tools/wrappers.rs
@@ -27,6 +27,9 @@ use crate::security::SecurityPolicy;
 use async_trait::async_trait;
 use std::sync::Arc;
 
+/// Type alias for a path-extraction closure used by [`PathGuardedTool`].
+type PathExtractor = dyn Fn(&serde_json::Value) -> Option<String> + Send + Sync;
+
 // ── RateLimitedTool ───────────────────────────────────────────────────────────
 
 /// Wraps any [`Tool`] and enforces the [`SecurityPolicy`] rate limit.
@@ -96,7 +99,7 @@ pub struct PathGuardedTool<T: Tool> {
     inner: T,
     security: Arc<SecurityPolicy>,
     /// Optional override: extract a path string from the args JSON.
-    extractor: Option<Box<dyn Fn(&serde_json::Value) -> Option<String> + Send + Sync>>,
+    extractor: Option<Box<PathExtractor>>,
 }
 
 impl<T: Tool> PathGuardedTool<T> {
@@ -117,7 +120,7 @@ impl<T: Tool> PathGuardedTool<T> {
         self
     }
 
-    fn extract_path_string<'a>(&self, args: &'a serde_json::Value) -> Option<String> {
+    fn extract_path_string(&self, args: &serde_json::Value) -> Option<String> {
         if let Some(ref f) = self.extractor {
             return f(args);
         }

--- a/src/tui/onboarding.rs
+++ b/src/tui/onboarding.rs
@@ -582,7 +582,7 @@ pub async fn run_tui_onboarding() -> Result<()> {
 
     let mut app = App::new();
     app.fetch_pairing_code().await;
-    let result = run_app(&mut terminal, &mut app).await;
+    let result = run_app(&mut terminal, &mut app);
 
     disable_raw_mode().context("Failed to disable raw mode")?;
     io::stdout()
@@ -593,6 +593,7 @@ pub async fn run_tui_onboarding() -> Result<()> {
 
     if app.screen == Screen::Complete {
         // ── Persist configuration ──
+        #[allow(clippy::large_futures)]
         match save_tui_config(&app).await {
             Ok(()) => {
                 println!();
@@ -628,6 +629,7 @@ pub async fn run_tui_onboarding() -> Result<()> {
 // ── Config persistence ──────────────────────────────────────────────
 
 /// Save the TUI selections to the real config.toml.
+#[allow(clippy::large_futures)]
 async fn save_tui_config(app: &App) -> Result<()> {
     let mut config = Config::load_or_init().await?;
 
@@ -647,10 +649,10 @@ async fn save_tui_config(app: &App) -> Result<()> {
 
     // Model
     let model = app.selected_model();
-    if model != "Auto (recommended)" {
-        config.default_model = Some(model.to_string());
-    } else {
+    if model == "Auto (recommended)" {
         config.default_model = None; // Let provider pick default
+    } else {
+        config.default_model = Some(model.to_string());
     }
 
     // Web search provider
@@ -661,7 +663,6 @@ async fn save_tui_config(app: &App) -> Result<()> {
             "SearxNG" => "searxng",
             "Tavily" => "tavily",
             "Google Custom Search" => "google",
-            "DuckDuckGo" => "duckduckgo",
             _ => "duckduckgo",
         };
         config.web_search.enabled = true;
@@ -755,12 +756,12 @@ async fn find_docker_container() -> Option<String> {
         .unwrap_or("")
         .trim()
         .to_string();
-    if !name.is_empty() { Some(name) } else { None }
+    if name.is_empty() { None } else { Some(name) }
 }
 
 // ── Main loop ───────────────────────────────────────────────────────
 
-async fn run_app(
+fn run_app(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     app: &mut App,
 ) -> Result<()> {
@@ -820,11 +821,11 @@ fn handle_input(app: &mut App, key: KeyCode) {
         },
 
         Screen::SecurityWarning => match key {
-            KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+            KeyCode::Char('y' | 'Y') | KeyCode::Enter => {
                 app.security_accepted = true;
                 app.screen = Screen::SetupMode;
             }
-            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+            KeyCode::Char('n' | 'N') | KeyCode::Esc => {
                 app.should_quit = true;
             }
             _ => {}
@@ -2590,7 +2591,7 @@ fn render_control_ui(frame: &mut Frame, area: Rect, app: &App) {
     )));
     lines.push(Line::from(""));
 
-    let panel_height = lines.len() as u16 + 2; // +2 for border
+    let panel_height = u16::try_from(lines.len()).unwrap_or(u16::MAX).saturating_add(2); // +2 for border
     let layout = Layout::vertical([
         Constraint::Length(2),
         Constraint::Length(panel_height),

--- a/src/tui/onboarding.rs
+++ b/src/tui/onboarding.rs
@@ -761,10 +761,7 @@ async fn find_docker_container() -> Option<String> {
 
 // ── Main loop ───────────────────────────────────────────────────────
 
-fn run_app(
-    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    app: &mut App,
-) -> Result<()> {
+fn run_app(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut App) -> Result<()> {
     loop {
         terminal.draw(|frame| render(frame, app))?;
 
@@ -2591,7 +2588,9 @@ fn render_control_ui(frame: &mut Frame, area: Rect, app: &App) {
     )));
     lines.push(Line::from(""));
 
-    let panel_height = u16::try_from(lines.len()).unwrap_or(u16::MAX).saturating_add(2); // +2 for border
+    let panel_height = u16::try_from(lines.len())
+        .unwrap_or(u16::MAX)
+        .saturating_add(2); // +2 for border
     let layout = Layout::vertical([
         Constraint::Length(2),
         Constraint::Length(panel_height),

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -14,7 +14,7 @@ pub struct InfoPanel<'a> {
     pub lines: Vec<Line<'a>>,
 }
 
-impl<'a> Widget for InfoPanel<'a> {
+impl Widget for InfoPanel<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let block = Block::default()
             .borders(Borders::ALL)
@@ -49,7 +49,7 @@ pub struct SelectableItem {
     pub installed: bool,
 }
 
-impl<'a> Widget for SelectableList<'a> {
+impl Widget for SelectableList<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let block = Block::default()
             .borders(Borders::ALL)
@@ -68,7 +68,7 @@ impl<'a> Widget for SelectableList<'a> {
 
         for (i, item) in self.items[start..end].iter().enumerate() {
             let abs_idx = start + i;
-            let y = inner.y + i as u16;
+            let y = inner.y + u16::try_from(i).unwrap_or(u16::MAX);
             if y >= inner.y + inner.height {
                 break;
             }
@@ -153,7 +153,7 @@ pub enum StepStatus {
     Error,
 }
 
-impl<'a> Widget for StepIndicator<'a> {
+impl Widget for StepIndicator<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let (icon, style) = match self.status {
             StepStatus::Pending => (" ", theme::dim_style()),
@@ -215,7 +215,7 @@ pub struct ConfirmedLine<'a> {
     pub value: &'a str,
 }
 
-impl<'a> Widget for ConfirmedLine<'a> {
+impl Widget for ConfirmedLine<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let line = Line::from(vec![
             Span::styled("\u{25c7}  ", theme::success_style()), // ◇
@@ -234,7 +234,7 @@ pub struct InputPrompt<'a> {
     pub masked: bool,
 }
 
-impl<'a> Widget for InputPrompt<'a> {
+impl Widget for InputPrompt<'_> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let display = if self.masked {
             "\u{2022}".repeat(self.input.len()) // •


### PR DESCRIPTION
## Summary
- Fix 20 clippy errors that block both CI and release builds
- All errors are pre-existing on master, not introduced by the v0.6.7 bump

## Fixes by file

| File | Errors | Fix |
|------|--------|-----|
| `whatsapp_web.rs` | Missing `Path` import + unused var | Added `use std::path::Path`, prefixed `_is_group` |
| `tui/onboarding.rs` | 9 errors | Unnested or-patterns, large futures, unnecessary ops, usize truncation, removed unused async |
| `tui/widgets.rs` | 6 errors | Elided lifetimes, usize-to-u16 truncation |
| `memory/namespaced.rs` | 1 error | Collapsed nested if |
| `multimodal.rs` | 1 error | Removed unused `_` binding |
| `tools/web_search_tool.rs` | 1 error | Merged identical match arms |
| `tools/wrappers.rs` | 2 errors | Type alias for complex type, elided lifetime |
| `main.rs` | 1 error | Box::pin for large future |

## Context
These errors block the v0.6.7 release pipeline. The release workflow builds with `--features channel-matrix,channel-lark,whatsapp-web` which enables code paths that have compile errors on master.

## Test plan
- [ ] CI lint (clippy) passes
- [ ] Release builds compile on all targets
- [ ] After merge, re-trigger release-stable-manual for v0.6.7