### PR TITLE
fix: add git config for tag creation in release workflow

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -424,6 +424,8 @@ jobs:
         env:
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "zeroclaw $TAG"
           git push origin "$TAG"
 


### PR DESCRIPTION
## Summary
Add missing `git config user.name/email` before `git tag -a` in the release workflow's manual dispatch path.

## Problem
The `Publish Stable Release` job fails with `fatal: empty ident name` when creating an annotated tag via `workflow_dispatch`, because the runner has no git identity configured.

## Fix
Set `github-actions[bot]` identity before the `git tag -a` command.

## Test plan
- [ ] Re-trigger release-stable-manual for v0.6.7 after merge