### PR TITLE
fix: route webhook requests through tool loop

### DIFF
--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1452,7 +1452,7 @@ async fn handle_webhook(
             messages_count: 1,
         });
 
-    match run_gateway_chat_simple(&state, message).await {
+    match run_gateway_chat_with_tools(&state, message, session_id.as_deref()).await {
         Ok(response) => {
             let duration = started_at.elapsed();
             state


### PR DESCRIPTION
## Summary
- route webhook requests through the tool-enabled chat path
- keep webhook behavior aligned with interactive tool execution

## Testing
- cargo test webhook_body_requires_message_field -- --exact