### PR TITLE
fix: use RELEASE_TOKEN for tag push in publish step

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -363,6 +363,8 @@ jobs:
       url: https://github.com/${{ github.repository }}/releases/tag/v${{ needs.validate.outputs.version }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:


### PR DESCRIPTION
## Problem
The Publish Stable Release step fails with `GH013: Repository rule violations` when pushing the v0.6.7 tag because the checkout uses `GITHUB_TOKEN`, which doesn't have permission to bypass tag protection rules.

## Fix
Use `RELEASE_TOKEN` (PAT with tag creation permissions) for the checkout step in the publish job, so `git push origin "$TAG"` succeeds.

## Test plan
- [ ] Re-trigger release after merge — tag push should succeed