### PR TITLE
feat(tools): wire session tools to composite backend for gateway visibility

### DIFF
--- a/src/channels/session_backend.rs
+++ b/src/channels/session_backend.rs
@@ -133,6 +133,63 @@ pub struct SessionState {
     pub turn_started_at: Option<DateTime<Utc>>,
 }
 
+/// A read-only session backend that merges listings from two backends.
+///
+/// Channel sessions live in JSONL files; gateway sessions live in SQLite.
+/// This wrapper lets session tools see both. Primary wins on key conflicts;
+/// writes delegate to primary only.
+pub struct CompositeSessionBackend {
+    primary: std::sync::Arc<dyn SessionBackend>,
+    secondary: std::sync::Arc<dyn SessionBackend>,
+}
+
+impl CompositeSessionBackend {
+    pub fn new(
+        primary: std::sync::Arc<dyn SessionBackend>,
+        secondary: std::sync::Arc<dyn SessionBackend>,
+    ) -> Self {
+        Self { primary, secondary }
+    }
+}
+
+impl SessionBackend for CompositeSessionBackend {
+    fn load(&self, session_key: &str) -> Vec<ChatMessage> {
+        let msgs = self.primary.load(session_key);
+        if !msgs.is_empty() {
+            return msgs;
+        }
+        self.secondary.load(session_key)
+    }
+
+    fn append(&self, session_key: &str, message: &ChatMessage) -> std::io::Result<()> {
+        self.primary.append(session_key, message)
+    }
+
+    fn remove_last(&self, session_key: &str) -> std::io::Result<bool> {
+        self.primary.remove_last(session_key)
+    }
+
+    fn list_sessions(&self) -> Vec<String> {
+        let mut keys: std::collections::HashSet<String> =
+            self.primary.list_sessions().into_iter().collect();
+        keys.extend(self.secondary.list_sessions());
+        keys.into_iter().collect()
+    }
+
+    fn list_sessions_with_metadata(&self) -> Vec<SessionMetadata> {
+        let primary_meta = self.primary.list_sessions_with_metadata();
+        let mut seen: std::collections::HashSet<String> =
+            primary_meta.iter().map(|m| m.key.clone()).collect();
+        let mut result = primary_meta;
+        for meta in self.secondary.list_sessions_with_metadata() {
+            if seen.insert(meta.key.clone()) {
+                result.push(meta);
+            }
+        }
+        result
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -155,5 +212,130 @@ mod tests {
         let q = SessionQuery::default();
         assert!(q.keyword.is_none());
         assert!(q.limit.is_none());
+    }
+
+    // ── CompositeSessionBackend tests ─────────────────────────────
+
+    use crate::channels::session_sqlite::SqliteSessionBackend;
+    use crate::channels::session_store::SessionStore;
+
+    #[test]
+    fn composite_merges_sessions_from_both_dirs() {
+        let dir_a = tempfile::TempDir::new().unwrap();
+        let dir_b = tempfile::TempDir::new().unwrap();
+
+        let store_a = SessionStore::new(dir_a.path()).unwrap();
+        store_a
+            .append("telegram__alice", &ChatMessage::user("hi"))
+            .unwrap();
+
+        let store_b = SessionStore::new(dir_b.path()).unwrap();
+        store_b
+            .append("gw_project-abc", &ChatMessage::user("hello"))
+            .unwrap();
+
+        let composite = CompositeSessionBackend::new(
+            std::sync::Arc::new(store_a),
+            std::sync::Arc::new(store_b),
+        );
+        let sessions = composite.list_sessions();
+        assert_eq!(sessions.len(), 2);
+    }
+
+    #[test]
+    fn composite_primary_wins_on_load_conflict() {
+        let dir_a = tempfile::TempDir::new().unwrap();
+        let dir_b = tempfile::TempDir::new().unwrap();
+
+        let store_a = SessionStore::new(dir_a.path()).unwrap();
+        store_a
+            .append("shared", &ChatMessage::user("primary"))
+            .unwrap();
+
+        let store_b = SessionStore::new(dir_b.path()).unwrap();
+        store_b
+            .append("shared", &ChatMessage::user("secondary"))
+            .unwrap();
+
+        let composite = CompositeSessionBackend::new(
+            std::sync::Arc::new(store_a),
+            std::sync::Arc::new(store_b),
+        );
+        let msgs = composite.load("shared");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].content, "primary");
+
+        // Deduplicated in listing
+        assert_eq!(composite.list_sessions().len(), 1);
+    }
+
+    #[test]
+    fn composite_falls_through_to_secondary() {
+        let dir_a = tempfile::TempDir::new().unwrap();
+        let dir_b = tempfile::TempDir::new().unwrap();
+
+        let store_a = SessionStore::new(dir_a.path()).unwrap();
+        let store_b = SessionStore::new(dir_b.path()).unwrap();
+        store_b
+            .append("gw_session", &ChatMessage::user("from gateway"))
+            .unwrap();
+
+        let composite = CompositeSessionBackend::new(
+            std::sync::Arc::new(store_a),
+            std::sync::Arc::new(store_b),
+        );
+        let msgs = composite.load("gw_session");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].content, "from gateway");
+    }
+
+    #[test]
+    fn composite_jsonl_plus_sqlite_with_overlapping_keys() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // JSONL backend: channel session
+        let jsonl = SessionStore::new(dir.path()).unwrap();
+        jsonl
+            .append("telegram__alice", &ChatMessage::user("channel msg"))
+            .unwrap();
+        // Overlapping key in JSONL
+        jsonl
+            .append("shared_session", &ChatMessage::user("jsonl version"))
+            .unwrap();
+
+        // SQLite backend: gateway sessions
+        let sqlite = SqliteSessionBackend::new(dir.path()).unwrap();
+        sqlite
+            .append("gw_project-abc", &ChatMessage::user("gateway msg"))
+            .unwrap();
+        // Overlapping key in SQLite
+        sqlite
+            .append("shared_session", &ChatMessage::user("sqlite version"))
+            .unwrap();
+
+        let composite =
+            CompositeSessionBackend::new(std::sync::Arc::new(jsonl), std::sync::Arc::new(sqlite));
+
+        // Both unique sessions visible
+        let sessions = composite.list_sessions();
+        assert!(sessions.contains(&"telegram__alice".to_string()));
+        assert!(sessions.contains(&"gw_project-abc".to_string()));
+        assert!(sessions.contains(&"shared_session".to_string()));
+        assert_eq!(sessions.len(), 3);
+
+        // Primary (JSONL) wins on overlapping key
+        let msgs = composite.load("shared_session");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].content, "jsonl version");
+
+        // Gateway-only session loads from secondary
+        let gw_msgs = composite.load("gw_project-abc");
+        assert_eq!(gw_msgs.len(), 1);
+        assert_eq!(gw_msgs[0].content, "gateway msg");
+
+        // Metadata listing also deduplicates
+        let meta = composite.list_sessions_with_metadata();
+        let keys: Vec<&str> = meta.iter().map(|m| m.key.as_str()).collect();
+        assert_eq!(keys.iter().filter(|k| **k == "shared_session").count(), 1);
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -750,10 +750,30 @@ pub fn all_tools_with_runtime(
     tool_arcs.push(Arc::new(ScreenshotTool::new(security.clone())));
     tool_arcs.push(Arc::new(ImageInfoTool::new(security.clone())));
 
-    // Session-to-session messaging tools (always available when sessions dir exists)
+    // Session-to-session messaging tools (always available when sessions dir exists).
+    // Build a composite backend that merges channel sessions (JSONL file store)
+    // with gateway sessions (SQLite) so the agent can see all sessions regardless
+    // of which persistence layer stores them.
     if let Ok(session_store) = crate::channels::session_store::SessionStore::new(workspace_dir) {
-        let backend: Arc<dyn crate::channels::session_backend::SessionBackend> =
+        let file_backend: Arc<dyn crate::channels::session_backend::SessionBackend> =
             Arc::new(session_store);
+
+        let backend: Arc<dyn crate::channels::session_backend::SessionBackend> =
+            if let Ok(sqlite_backend) =
+                crate::channels::session_sqlite::SqliteSessionBackend::new(workspace_dir)
+            {
+                let sqlite_arc: Arc<dyn crate::channels::session_backend::SessionBackend> =
+                    Arc::new(sqlite_backend);
+                Arc::new(
+                    crate::channels::session_backend::CompositeSessionBackend::new(
+                        file_backend,
+                        sqlite_arc,
+                    ),
+                )
+            } else {
+                file_backend
+            };
+
         tool_arcs.push(Arc::new(SessionsListTool::new(backend.clone())));
         tool_arcs.push(Arc::new(SessionsHistoryTool::new(
             backend.clone(),


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `sessions_list`, `sessions_history`, and `sessions_send` tools are wired to the JSONL file store only. Gateway sessions (web dashboard, WebSocket chat) live in SQLite and are invisible to the tools.
- Why it matters: Agents that only receive messages through the gateway see "No active sessions found" even though sessions exist.
- What changed: Added `CompositeSessionBackend` that merges session listings from both the JSONL file store and the SQLite backend, deduplicating by session key. Wired it into the session tools when `sessions.db` exists; falls back to file-only when it doesn't.
- What did **not** change: Session storage format, gateway code, channel implementations. No new dependencies.

> Re-land of #4852 (merged, then reverted in the batch rollback). Identical code, rebased on current master (v0.6.7).

## Label Snapshot (required)

- Risk label: risk: low
- Size label: size: S
- Scope labels: tool
- Module labels: tool: sessions

## Change Metadata

- Change type: bug
- Primary scope: tool

## Linked Issue

- Supersedes #4852 (reverted in batch rollback)

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass (our files)
cargo clippy --lib -- -D warnings   # pass
cargo test --lib   # 5753+ passed, pre-existing seatbelt failure only
```

- 4 unit tests covering merge, dedup, fallback, and mixed JSONL+SQLite with overlapping keys

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified: provisioned ZeroClaw instance with gateway-only sessions confirmed invisible before fix, visible after
- Edge cases: both backends empty, overlapping keys (primary wins), secondary-only sessions

## Side Effects / Blast Radius (required)

- Affected: `sessions_list`, `sessions_history`, `sessions_send` tools
- Potential: agents with both channel + gateway sessions now see both (intended)

## Rollback Plan (required)

- Fast rollback: `git revert <commit>` — single commit, 2 files
- Observable failure: `sessions_list` returns empty or errors

## Risks and Mitigations

- Risk: Second SQLite connection to sessions.db alongside gateway's
  - Mitigation: SQLite WAL mode supports concurrent readers. Tools only read.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>