### PR TITLE
fix(matrix): bootstrap E2EE cross-signing and backup on first-time setup

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -4,6 +4,7 @@ use matrix_sdk::{
     Client as MatrixSdkClient, LoopCtrl, Room, RoomState, SessionMeta, SessionTokens,
     authentication::matrix::MatrixSession,
     config::SyncSettings,
+    encryption::{BackupDownloadStrategy, EncryptionSettings},
     ruma::{
         OwnedEventId, OwnedRoomId, OwnedUserId,
         api::client::receipt::create_receipt,
@@ -580,7 +581,13 @@ impl MatrixChannel {
                     }
                 };
 
-                let mut client_builder = MatrixSdkClient::builder().homeserver_url(&self.homeserver);
+                let mut client_builder = MatrixSdkClient::builder()
+                    .homeserver_url(&self.homeserver)
+                    .with_encryption_settings(EncryptionSettings {
+                        auto_enable_cross_signing: true,
+                        auto_enable_backups: true,
+                        backup_download_strategy: BackupDownloadStrategy::AfterDecryptionFailure,
+                    });
 
                 if let Some(store_dir) = self.matrix_store_dir() {
                     tokio::fs::create_dir_all(&store_dir).await.map_err(|error| {
@@ -608,6 +615,16 @@ impl MatrixChannel {
 
                 client.restore_session(session).await?;
                 tracing::debug!("Matrix session restored for device");
+
+                // Wait for the SDK's E2EE initialization tasks to complete.
+                // With the encryption settings above, this bootstraps
+                // cross-signing (so other devices will share room keys with
+                // us) and creates a key backup if none exists yet.
+                client
+                    .encryption()
+                    .wait_for_e2ee_initialization_tasks()
+                    .await;
+                tracing::debug!("Matrix E2EE initialization tasks completed");
 
                 // Attempt E2EE key recovery if a recovery key is configured
                 if let Some(ref key) = self.recovery_key {
@@ -774,20 +791,17 @@ impl MatrixChannel {
 
         if client.encryption().backups().are_enabled().await {
             tracing::info!("Matrix room-key backup is enabled for this device.");
+        } else if self.recovery_key.is_some() {
+            tracing::info!(
+                "Matrix room-key backup is not active on this device, but a recovery key is configured. \
+                 Room keys will be restored from server backup on startup."
+            );
         } else {
-            let _ = client.encryption().backups().disable().await;
-            if self.recovery_key.is_some() {
-                tracing::info!(
-                    "Matrix room-key backup is not active on this device, but a recovery key is configured. \
-                     Room keys will be restored from server backup on startup."
-                );
-            } else {
-                tracing::warn!(
-                    "Matrix room-key backup is not enabled for this device. \
-                     To automatically restore room keys after a device reset, set recovery_key in your Matrix config. \
-                     See docs/security/matrix-e2ee-guide.md section 4I."
-                );
-            }
+            tracing::warn!(
+                "Matrix room-key backup is not enabled for this device. \
+                 To automatically restore room keys after a device reset, set recovery_key in your Matrix config. \
+                 See docs/security/matrix-e2ee-guide.md section 4I."
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Matrix E2E encryption fails on first-time setup because cross-signing is never bootstrapped and no key backup is created. Without cross-signing, other devices do not trust the bot device and will not share Megolm room keys via to-device messages, causing "Can't find the room key to decrypt the event" errors.
- Why it matters: All encrypted Matrix rooms are unreadable on a fresh deployment until another client manually shares keys.
- What changed: Enabled matrix-sdk's built-in E2EE auto-bootstrap (cross-signing + key backup + backup-on-decryption-failure), wait for initialization before first sync, and removed an erroneous `backups().disable()` call.
- What did **not** change (scope boundary): No changes to config schema, Matrix API calls outside the SDK, or any other channel.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: matrix`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: n/a

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #5144
- Related #5097

## Supersede Attribution (required when `Supersedes #` is used)

n/a

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass (no formatting changes)
```

Compilation and CI validation deferred to CI runners (local build hit disk space limits on Windows worktree). The change uses only public, stable matrix-sdk 0.16 APIs (`EncryptionSettings`, `BackupDownloadStrategy`, `wait_for_e2ee_initialization_tasks`) verified against the vendored source.

- Evidence provided: API cross-reference against matrix-sdk 0.16.0 source
- If any command is intentionally skipped, explain why: `cargo clippy` and `cargo test` deferred to CI due to local disk space constraint on worktree

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (cross-signing bootstrap uses existing SDK plumbing that was already compiled in but not activated)
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: n/a
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No — existing installs gain automatic cross-signing bootstrap on next startup; the local crypto store is additive

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Reviewed matrix-sdk 0.16.0 source to confirm `EncryptionSettings` fields, `with_encryption_settings` builder method, `spawn_initialization_task` call chain from `restore_session`, and `wait_for_e2ee_initialization_tasks` public API
- Edge cases checked: Recovery key configured but no server-side backup yet (auto_enable_backups creates one); no recovery key configured (cross-signing still bootstraps so to-device key sharing works); existing installs with backup already active (no-op)
- What was not verified: End-to-end runtime test against a live homeserver (deferred to reporter validation)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Matrix channel E2EE initialization path only
- Potential unintended effects: First startup after this change may take slightly longer due to cross-signing key upload and backup creation
- Guardrails/monitoring for early detection: Existing E2EE diagnostic logs will report cross-signing and backup status

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Traced the matrix-sdk 0.16 `restore_session` -> `set_session` -> `spawn_initialization_task` call chain and identified that `EncryptionSettings` defaults left `auto_enable_cross_signing` and `auto_enable_backups` as `false`, preventing E2EE bootstrap on first run
- Verification focus: API compatibility with matrix-sdk 0.16.0
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): yes

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit; E2EE will revert to manual-only cross-signing setup
- Feature flags or config toggles (if any): None
- Observable failure symptoms: "Can't find the room key to decrypt the event" log messages return

## Risks and Mitigations

- Risk: `bootstrap_cross_signing_if_needed` requires UIAA on servers without MSC3967 support
  - Mitigation: The SDK passes `None` for auth_data from `restore_session`, which works on servers that support MSC3967 (most modern homeservers). On older servers, the bootstrap will fail gracefully with an error log, and behavior reverts to the pre-fix state (manual cross-signing setup required). No regression.