### PR TITLE
fix: beta Android build and idempotent marketplace sync

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -210,10 +210,14 @@ jobs:
             artifact: zeroclaw
             ext: tar.gz
             ndk: true
+            experimental: true
+            # wa-rs crates don't compile for Android; exclude whatsapp-web
+            cargo_features: "channel-matrix,channel-lark"
           - os: windows-latest
             target: x86_64-pc-windows-msvc
             artifact: zeroclaw.exe
             ext: zip
+    continue-on-error: ${{ matrix.experimental || false }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -246,7 +250,8 @@ jobs:
           if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
             export "${{ matrix.linker_env }}=${{ matrix.linker }}"
           fi
-          cargo build --release --locked --features "${{ env.RELEASE_CARGO_FEATURES }}" --target ${{ matrix.target }}
+          FEATURES="${{ matrix.cargo_features || env.RELEASE_CARGO_FEATURES }}"
+          cargo build --release --locked --features "${FEATURES}" --target ${{ matrix.target }}
 
       - name: Check binary size
         shell: bash

--- a/.github/workflows/sync-marketplace-templates.yml
+++ b/.github/workflows/sync-marketplace-templates.yml
@@ -98,14 +98,21 @@ jobs:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
           BRANCH="zeroclaw/update-v${VERSION}"
-          git checkout -b "$BRANCH"
+          git fetch origin "$BRANCH" 2>/dev/null && git checkout "$BRANCH" && git pull origin "$BRANCH" || git checkout -b "$BRANCH"
           git add -A
           git diff --cached --quiet && echo "No changes" && exit 0
 
           git config user.name "ZeroClaw Bot"
           git config user.email "bot@zeroclaw.com"
           git commit -m "feat: add/update ZeroClaw service template (v${VERSION})"
-          git push -u origin "$BRANCH"
+          git push -u origin "$BRANCH" --force-with-lease
+
+          # Skip PR creation if one already exists
+          EXISTING_PR=$(gh pr list --repo coollabsio/coolify --head "zeroclaw-labs:${BRANCH}" --json url --jq '.[0].url' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR already exists: $EXISTING_PR"
+            exit 0
+          fi
 
           gh pr create \
             --repo coollabsio/coolify \
@@ -246,14 +253,21 @@ jobs:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
           BRANCH="zeroclaw/update-v${VERSION}"
-          git checkout -b "$BRANCH"
+          git fetch origin "$BRANCH" 2>/dev/null && git checkout "$BRANCH" && git pull origin "$BRANCH" || git checkout -b "$BRANCH"
           git add -A
           git diff --cached --quiet && echo "No changes" && exit 0
 
           git config user.name "ZeroClaw Bot"
           git config user.email "bot@zeroclaw.com"
           git commit -m "feat: add/update ZeroClaw template (v${VERSION})"
-          git push -u origin "$BRANCH"
+          git push -u origin "$BRANCH" --force-with-lease
+
+          # Skip PR creation if one already exists
+          EXISTING_PR=$(gh pr list --repo Dokploy/templates --head "zeroclaw-labs:${BRANCH}" --json url --jq '.[0].url' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR already exists: $EXISTING_PR"
+            exit 0
+          fi
 
           gh pr create \
             --repo Dokploy/templates \
@@ -479,14 +493,21 @@ jobs:
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
           BRANCH="zeroclaw/update-v${VERSION}"
-          git checkout -b "$BRANCH"
+          git fetch origin "$BRANCH" 2>/dev/null && git checkout "$BRANCH" && git pull origin "$BRANCH" || git checkout -b "$BRANCH"
           git add -A
           git diff --cached --quiet && echo "No changes" && exit 0
 
           git config user.name "ZeroClaw Bot"
           git config user.email "bot@zeroclaw.com"
           git commit -m "feat: add/update ZeroClaw template (v${VERSION})"
-          git push -u origin "$BRANCH"
+          git push -u origin "$BRANCH" --force-with-lease
+
+          # Skip PR creation if one already exists
+          EXISTING_PR=$(gh pr list --repo easypanel-io/templates --head "zeroclaw-labs:${BRANCH}" --json url --jq '.[0].url' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR already exists: $EXISTING_PR"
+            exit 0
+          fi
 
           gh pr create \
             --repo easypanel-io/templates \


### PR DESCRIPTION
## Summary
- Fix beta Android build: exclude `whatsapp-web` feature (wa-rs doesn't compile on Android), matching stable workflow
- Add per-target `cargo_features` override support in beta build step
- Mark Android as `experimental` with `continue-on-error`
- Make marketplace sync idempotent: handle existing branches with `--force-with-lease` and skip PR creation if PR already exists

## Fixes
- Release Beta / Build aarch64-linux-android — 186 compile errors from wa-rs crates
- Release Stable / Sync Marketplace Templates (Coolify, Dokploy, EasyPanel) — branch/PR conflicts on re-runs

## Also updated secrets
- `MARKETPLACE_PAT` — refreshed with new PAT
- `WEBSITE_REPO_PAT` — refreshed with new PAT

## Test plan
- [ ] Beta workflow Android build compiles with `channel-matrix,channel-lark` features only
- [ ] Marketplace sync succeeds when branches/PRs already exist (idempotent)
- [ ] Marketplace sync still creates new branches/PRs for fresh versions