### PR TITLE
fix(gateway): keep websocket steering additive and persist committed streamed output

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -37,6 +37,19 @@ pub enum TurnEvent {
     ToolResult { name: String, output: String },
 }
 
+#[derive(Debug)]
+pub(crate) struct StreamedTurnSuccess {
+    pub(crate) response: String,
+    pub(crate) consumed_messages: Vec<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct StreamedTurnError {
+    pub(crate) error: anyhow::Error,
+    pub(crate) committed_response: String,
+    pub(crate) consumed_messages: Vec<String>,
+}
+
 pub struct Agent {
     provider: Box<dyn Provider>,
     tools: Vec<Box<dyn Tool>>,
@@ -729,6 +742,57 @@ impl Agent {
         self.model_name.clone()
     }
 
+    fn encode_transcript_for_cache_key(messages: &[crate::providers::ChatMessage]) -> String {
+        let mut transcript = String::new();
+        for message in messages.iter().filter(|m| m.role != "system") {
+            transcript.push_str("role=");
+            transcript.push_str(&message.role.len().to_string());
+            transcript.push(':');
+            transcript.push_str(&message.role);
+            transcript.push_str(";content=");
+            transcript.push_str(&message.content.len().to_string());
+            transcript.push(':');
+            transcript.push_str(&message.content);
+            transcript.push('\n');
+        }
+        transcript
+    }
+
+    fn response_cache_key_for_messages(
+        &self,
+        messages: &[crate::providers::ChatMessage],
+        effective_model: &str,
+    ) -> Option<String> {
+        if self.temperature != 0.0 || self.response_cache.is_none() {
+            return None;
+        }
+
+        let system = messages
+            .iter()
+            .find(|m| m.role == "system")
+            .map(|m| m.content.as_str());
+        let transcript = Self::encode_transcript_for_cache_key(messages);
+
+        Some(crate::memory::response_cache::ResponseCache::cache_key(
+            effective_model,
+            system,
+            &transcript,
+        ))
+    }
+
+    fn commit_assistant_output(&mut self, assistant_text: &str, accumulated_response: &mut String) {
+        if assistant_text.is_empty() {
+            return;
+        }
+
+        self.history
+            .push(ConversationMessage::Chat(ChatMessage::assistant(
+                assistant_text.to_string(),
+            )));
+        self.trim_history();
+        accumulated_response.push_str(assistant_text);
+    }
+
     pub async fn turn(&mut self, user_message: &str) -> Result<String> {
         if self.history.is_empty() {
             let system_prompt = self.build_system_prompt()?;
@@ -738,40 +802,7 @@ impl Agent {
                 )));
         }
 
-        let context = self
-            .memory_loader
-            .load_context(
-                self.memory.as_ref(),
-                user_message,
-                self.memory_session_id.as_deref(),
-            )
-            .await
-            .unwrap_or_default();
-
-        if self.auto_save {
-            let _ = self
-                .memory
-                .store(
-                    "user_msg",
-                    user_message,
-                    MemoryCategory::Conversation,
-                    self.memory_session_id.as_deref(),
-                )
-                .await;
-        }
-
-        let now = chrono::Local::now();
-        let (year, month, day) = (now.year(), now.month(), now.day());
-        let (hour, minute, second) = (now.hour(), now.minute(), now.second());
-        let tz = now.format("%Z");
-        let date_str =
-            format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02} {tz}");
-
-        let enriched = if context.is_empty() {
-            format!("[CURRENT DATE & TIME: {date_str}]\n\n{user_message}")
-        } else {
-            format!("[CURRENT DATE & TIME: {date_str}]\n\n{context}\n\n{user_message}")
-        };
+        let enriched = self.build_enriched_user_message(user_message).await;
 
         self.history
             .push(ConversationMessage::Chat(ChatMessage::user(enriched)));
@@ -781,27 +812,8 @@ impl Agent {
         for _ in 0..self.config.max_tool_iterations {
             let messages = self.tool_dispatcher.to_provider_messages(&self.history);
 
-            // Response cache: check before LLM call (only for deterministic, text-only prompts)
-            let cache_key = if self.temperature == 0.0 {
-                self.response_cache.as_ref().map(|_| {
-                    let last_user = messages
-                        .iter()
-                        .rfind(|m| m.role == "user")
-                        .map(|m| m.content.as_str())
-                        .unwrap_or("");
-                    let system = messages
-                        .iter()
-                        .find(|m| m.role == "system")
-                        .map(|m| m.content.as_str());
-                    crate::memory::response_cache::ResponseCache::cache_key(
-                        &effective_model,
-                        system,
-                        last_user,
-                    )
-                })
-            } else {
-                None
-            };
+            // Response cache: key on the full provider-visible transcript.
+            let cache_key = self.response_cache_key_for_messages(&messages, &effective_model);
 
             if let (Some(cache), Some(key)) = (&self.response_cache, &cache_key) {
                 if let Ok(Some(cached)) = cache.get(key) {
@@ -909,74 +921,62 @@ impl Agent {
         user_message: &str,
         event_tx: tokio::sync::mpsc::Sender<TurnEvent>,
     ) -> Result<String> {
-        // ── Preamble (identical to turn) ───────────────────────────────
+        let (response, _) = self
+            .turn_streamed_with_steering(user_message, event_tx, None)
+            .await?;
+        Ok(response)
+    }
+
+    pub async fn turn_streamed_with_steering(
+        &mut self,
+        user_message: &str,
+        event_tx: tokio::sync::mpsc::Sender<TurnEvent>,
+        steering_rx: Option<&mut tokio::sync::mpsc::Receiver<String>>,
+    ) -> Result<(String, Vec<String>)> {
+        match self
+            .turn_streamed_with_steering_state(user_message, event_tx, steering_rx)
+            .await
+        {
+            Ok(outcome) => Ok((outcome.response, outcome.consumed_messages)),
+            Err(err) => Err(err.error),
+        }
+    }
+
+    pub(crate) async fn turn_streamed_with_steering_state(
+        &mut self,
+        user_message: &str,
+        event_tx: tokio::sync::mpsc::Sender<TurnEvent>,
+        mut steering_rx: Option<&mut tokio::sync::mpsc::Receiver<String>>,
+    ) -> std::result::Result<StreamedTurnSuccess, StreamedTurnError> {
         if self.history.is_empty() {
-            let system_prompt = self.build_system_prompt()?;
+            let system_prompt = self
+                .build_system_prompt()
+                .map_err(|error| StreamedTurnError {
+                    error,
+                    committed_response: String::new(),
+                    consumed_messages: Vec::new(),
+                })?;
             self.history
                 .push(ConversationMessage::Chat(ChatMessage::system(
                     system_prompt,
                 )));
         }
 
-        let context = self
-            .memory_loader
-            .load_context(
-                self.memory.as_ref(),
-                user_message,
-                self.memory_session_id.as_deref(),
-            )
-            .await
-            .unwrap_or_default();
-
-        if self.auto_save {
-            let _ = self
-                .memory
-                .store(
-                    "user_msg",
-                    user_message,
-                    MemoryCategory::Conversation,
-                    self.memory_session_id.as_deref(),
-                )
-                .await;
-        }
-
-        let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S %Z");
-        let enriched = if context.is_empty() {
-            format!("[{now}] {user_message}")
-        } else {
-            format!("{context}[{now}] {user_message}")
-        };
-
-        self.history
-            .push(ConversationMessage::Chat(ChatMessage::user(enriched)));
-
+        self.append_user_message_to_history(user_message).await;
+        let mut consumed_messages = vec![user_message.to_string()];
         let effective_model = self.classify_model(user_message);
+        let mut accumulated_assistant_response = String::new();
 
-        // ── Turn loop ──────────────────────────────────────────────────
         for _ in 0..self.config.max_tool_iterations {
-            let messages = self.tool_dispatcher.to_provider_messages(&self.history);
+            if let Some(steering_rx) = steering_rx.as_mut() {
+                while let Ok(message) = steering_rx.try_recv() {
+                    self.append_user_message_to_history(&message).await;
+                    consumed_messages.push(message);
+                }
+            }
 
-            // Response cache check (same as turn)
-            let cache_key = if self.temperature == 0.0 {
-                self.response_cache.as_ref().map(|_| {
-                    let last_user = messages
-                        .iter()
-                        .rfind(|m| m.role == "user")
-                        .map(|m| m.content.as_str())
-                        .unwrap_or("");
-                    let system = messages
-                        .iter()
-                        .find(|m| m.role == "system")
-                        .map(|m| m.content.as_str());
-                    crate::memory::response_cache::ResponseCache::cache_key(
-                        &effective_model,
-                        system,
-                        last_user,
-                    )
-                })
-            } else {
-                None
-            };
+            let messages = self.tool_dispatcher.to_provider_messages(&self.history);
+            let cache_key = self.response_cache_key_for_messages(&messages, &effective_model);
 
             if let (Some(cache), Some(key)) = (&self.response_cache, &cache_key) {
                 if let Ok(Some(cached)) = cache.get(key) {
@@ -989,16 +989,21 @@ impl Agent {
                             cached.clone(),
                         )));
                     self.trim_history();
-                    return Ok(cached);
+                    let full_response = if accumulated_assistant_response.is_empty() {
+                        cached.clone()
+                    } else {
+                        format!("{}{}", accumulated_assistant_response, cached)
+                    };
+                    return Ok(StreamedTurnSuccess {
+                        response: full_response,
+                        consumed_messages,
+                    });
                 }
                 self.observer.record_event(&ObserverEvent::CacheMiss {
                     cache_type: "response".into(),
                 });
             }
 
-            // ── Streaming LLM call ────────────────────────────────────
-            // Try streaming first; if the provider returns content we
-            // forward deltas.  Otherwise fall back to non-streaming chat.
             use futures_util::StreamExt;
 
             let stream_opts = crate::providers::traits::StreamOptions::new(true);
@@ -1058,7 +1063,6 @@ impl Agent {
                                     args: serde_json::from_str(&args).unwrap_or_default(),
                                 })
                                 .await;
-                            // NOT pushed to streamed_tool_calls — already executed by proxy
                         }
                         crate::providers::traits::StreamEvent::PreExecutedToolResult {
                             name,
@@ -1071,13 +1075,9 @@ impl Agent {
                     Err(_) => break,
                 }
             }
-            // Drop the stream so we release the borrow on provider.
             drop(stream);
 
-            // If streaming produced text, use it as the response and
-            // check for tool calls via the dispatcher.
             let response = if got_stream {
-                // Build a synthetic ChatResponse from streamed text
                 crate::providers::ChatResponse {
                     text: Some(streamed_text),
                     tool_calls: streamed_tool_calls,
@@ -1085,7 +1085,6 @@ impl Agent {
                     reasoning_content: None,
                 }
             } else {
-                // Fall back to non-streaming chat
                 match self
                     .provider
                     .chat(
@@ -1103,7 +1102,13 @@ impl Agent {
                     .await
                 {
                     Ok(resp) => resp,
-                    Err(err) => return Err(err),
+                    Err(error) => {
+                        return Err(StreamedTurnError {
+                            error,
+                            committed_response: accumulated_assistant_response,
+                            consumed_messages,
+                        });
+                    }
                 }
             };
 
@@ -1115,7 +1120,24 @@ impl Agent {
                     text
                 };
 
-                // Store in response cache
+                if let Some(steering_rx) = steering_rx.as_mut() {
+                    let mut drained_any = false;
+                    while let Ok(message) = steering_rx.try_recv() {
+                        if !drained_any {
+                            self.commit_assistant_output(
+                                &final_text,
+                                &mut accumulated_assistant_response,
+                            );
+                            drained_any = true;
+                        }
+                        self.append_user_message_to_history(&message).await;
+                        consumed_messages.push(message);
+                    }
+                    if drained_any {
+                        continue;
+                    }
+                }
+
                 if let (Some(cache), Some(key)) = (&self.response_cache, &cache_key) {
                     let token_count = response
                         .usage
@@ -1126,7 +1148,6 @@ impl Agent {
                     let _ = cache.put(key, &effective_model, &final_text, token_count as u32);
                 }
 
-                // If we didn't stream, send the full response as a single chunk
                 if !got_stream && !final_text.is_empty() {
                     let _ = event_tx
                         .send(TurnEvent::Chunk {
@@ -1141,15 +1162,25 @@ impl Agent {
                     )));
                 self.trim_history();
 
-                return Ok(final_text);
+                let full_response = if accumulated_assistant_response.is_empty() {
+                    final_text.clone()
+                } else {
+                    format!("{}{}", accumulated_assistant_response, final_text)
+                };
+                return Ok(StreamedTurnSuccess {
+                    response: full_response,
+                    consumed_messages,
+                });
             }
 
-            // ── Tool calls ─────────────────────────────────────────────
             if !text.is_empty() {
                 self.history
                     .push(ConversationMessage::Chat(ChatMessage::assistant(
                         text.clone(),
                     )));
+                if got_stream {
+                    accumulated_assistant_response.push_str(&text);
+                }
             }
 
             self.history.push(ConversationMessage::AssistantToolCalls {
@@ -1158,7 +1189,6 @@ impl Agent {
                 reasoning_content: response.reasoning_content.clone(),
             });
 
-            // Notify about each tool call
             for call in &calls {
                 let _ = event_tx
                     .send(TurnEvent::ToolCall {
@@ -1170,7 +1200,6 @@ impl Agent {
 
             let results = self.execute_tools(&calls).await;
 
-            // Notify about each tool result
             for result in &results {
                 let _ = event_tx
                     .send(TurnEvent::ToolResult {
@@ -1185,10 +1214,58 @@ impl Agent {
             self.trim_history();
         }
 
-        anyhow::bail!(
-            "Agent exceeded maximum tool iterations ({})",
-            self.config.max_tool_iterations
-        )
+        Err(StreamedTurnError {
+            error: anyhow::anyhow!(
+                "Agent exceeded maximum tool iterations ({})",
+                self.config.max_tool_iterations
+            ),
+            committed_response: accumulated_assistant_response,
+            consumed_messages,
+        })
+    }
+
+    async fn build_enriched_user_message(&self, user_message: &str) -> String {
+        let context = self
+            .memory_loader
+            .load_context(
+                self.memory.as_ref(),
+                user_message,
+                self.memory_session_id.as_deref(),
+            )
+            .await
+            .unwrap_or_default();
+
+        if self.auto_save {
+            let _ = self
+                .memory
+                .store(
+                    "user_msg",
+                    user_message,
+                    MemoryCategory::Conversation,
+                    self.memory_session_id.as_deref(),
+                )
+                .await;
+        }
+
+        let now = chrono::Local::now();
+        let (year, month, day) = (now.year(), now.month(), now.day());
+        let (hour, minute, second) = (now.hour(), now.minute(), now.second());
+        let tz = now.format("%Z");
+        let date_str =
+            format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02} {tz}");
+
+        if context.is_empty() {
+            format!("[CURRENT DATE & TIME: {date_str}]\n\n{user_message}")
+        } else {
+            format!("[CURRENT DATE & TIME: {date_str}]\n\n{context}\n\n{user_message}")
+        }
+    }
+
+    async fn append_user_message_to_history(&mut self, user_message: &str) {
+        let enriched = self.build_enriched_user_message(user_message).await;
+
+        self.history
+            .push(ConversationMessage::Chat(ChatMessage::user(enriched)));
     }
 
     pub async fn run_single(&mut self, message: &str) -> Result<String> {
@@ -1718,6 +1795,145 @@ mod tests {
             matches!(&history[2], ConversationMessage::Chat(m) if m.role == "assistant" && m.content == "hi there")
         );
         assert_eq!(history.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn build_enriched_user_message_keeps_turn_prompt_format_for_streamed_path() {
+        let provider = Box::new(MockProvider {
+            responses: Mutex::new(vec![]),
+        });
+
+        let memory_cfg = crate::config::MemoryConfig {
+            backend: "none".into(),
+            ..crate::config::MemoryConfig::default()
+        };
+        let mem: Arc<dyn Memory> = Arc::from(
+            crate::memory::create_memory(&memory_cfg, std::path::Path::new("/tmp"), None)
+                .expect("memory creation should succeed with valid config"),
+        );
+
+        let observer: Arc<dyn Observer> = Arc::from(crate::observability::NoopObserver {});
+        let agent = Agent::builder()
+            .provider(provider)
+            .tools(vec![Box::new(MockTool)])
+            .memory(mem)
+            .observer(observer)
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(std::path::PathBuf::from("/tmp"))
+            .build()
+            .expect("agent builder should succeed with valid config");
+
+        let enriched = agent.build_enriched_user_message("hello").await;
+        assert!(enriched.starts_with("[CURRENT DATE & TIME: "));
+        assert!(enriched.ends_with("\n\nhello"));
+    }
+
+    #[test]
+    fn response_cache_key_distinguishes_structurally_different_transcripts() {
+        let single_message = vec![
+            crate::providers::ChatMessage::system("system"),
+            crate::providers::ChatMessage::assistant(
+                "first line
+user:second line",
+            ),
+        ];
+        let split_messages = vec![
+            crate::providers::ChatMessage::system("system"),
+            crate::providers::ChatMessage::assistant("first line"),
+            crate::providers::ChatMessage::user("second line"),
+        ];
+
+        let single_transcript = Agent::encode_transcript_for_cache_key(&single_message);
+        let split_transcript = Agent::encode_transcript_for_cache_key(&split_messages);
+
+        assert_ne!(single_transcript, split_transcript);
+    }
+
+    #[tokio::test]
+    async fn response_cache_keeps_structurally_different_transcripts_distinct() {
+        let unique = format!(
+            "zeroclaw-response-cache-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after unix epoch")
+                .as_nanos()
+        );
+        let workspace_dir = std::env::temp_dir().join(unique);
+        std::fs::create_dir_all(&workspace_dir).expect("workspace dir should be created");
+
+        let cache = Arc::new(
+            crate::memory::response_cache::ResponseCache::new(&workspace_dir, 5, 32)
+                .expect("response cache should initialize"),
+        );
+
+        let build_memory = || {
+            let memory_cfg = crate::config::MemoryConfig {
+                backend: "none".into(),
+                ..crate::config::MemoryConfig::default()
+            };
+            Arc::from(
+                crate::memory::create_memory(&memory_cfg, &workspace_dir, None)
+                    .expect("memory creation should succeed with valid config"),
+            ) as Arc<dyn Memory>
+        };
+
+        let build_observer =
+            || Arc::from(crate::observability::NoopObserver {}) as Arc<dyn Observer>;
+
+        let mut first_agent = Agent::builder()
+            .provider(Box::new(MockProvider {
+                responses: Mutex::new(vec![crate::providers::ChatResponse {
+                    text: Some("cached-one".into()),
+                    tool_calls: vec![],
+                    usage: None,
+                    reasoning_content: None,
+                }]),
+            }))
+            .tools(vec![Box::new(MockTool)])
+            .memory(build_memory())
+            .observer(build_observer())
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(workspace_dir.clone())
+            .temperature(0.0)
+            .response_cache(Some(cache.clone()))
+            .build()
+            .expect("agent builder should succeed with valid config");
+        first_agent.seed_history(&[crate::providers::ChatMessage::assistant(
+            "first line
+user:second line",
+        )]);
+
+        let mut second_agent = Agent::builder()
+            .provider(Box::new(MockProvider {
+                responses: Mutex::new(vec![crate::providers::ChatResponse {
+                    text: Some("cached-two".into()),
+                    tool_calls: vec![],
+                    usage: None,
+                    reasoning_content: None,
+                }]),
+            }))
+            .tools(vec![Box::new(MockTool)])
+            .memory(build_memory())
+            .observer(build_observer())
+            .tool_dispatcher(Box::new(NativeToolDispatcher))
+            .workspace_dir(workspace_dir.clone())
+            .temperature(0.0)
+            .response_cache(Some(cache))
+            .build()
+            .expect("agent builder should succeed with valid config");
+        second_agent.seed_history(&[
+            crate::providers::ChatMessage::assistant("first line"),
+            crate::providers::ChatMessage::user("second line"),
+        ]);
+
+        let first = first_agent.turn("follow up").await.unwrap();
+        let second = second_agent.turn("follow up").await.unwrap();
+
+        assert_eq!(first, "cached-one");
+        assert_eq!(second, "cached-two");
+
+        let _ = std::fs::remove_dir_all(&workspace_dir);
     }
 
     /// Mock provider that captures whether tool specs were passed to `stream_chat`

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -200,14 +200,12 @@ async fn handle_socket(
             agent.seed_history(&messages);
             resumed = true;
         }
-        // Set session name if provided (non-empty) on connect
         if let Some(ref name) = session_name {
             if !name.is_empty() {
                 let _ = backend.set_session_name(&session_key, name);
                 effective_name = Some(name.clone());
             }
         }
-        // If no name was provided via query param, load the stored name
         if effective_name.is_none() {
             effective_name = backend.get_session_name(&session_key).unwrap_or(None);
         }
@@ -227,176 +225,254 @@ async fn handle_socket(
         .send(Message::Text(session_start.to_string().into()))
         .await;
 
-    // ── Optional connect handshake ──────────────────────────────────
-    // The first message may be a `{"type":"connect",...}` frame carrying
-    // connection parameters.  If it is, we extract the params, send an
-    // ack, and proceed to the normal message loop.  If the first message
-    // is a regular `{"type":"message",...}` frame, we fall through and
-    // process it immediately (backward-compatible).
-    let mut first_msg_fallback: Option<String> = None;
+    let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel::<Message>(64);
+    let writer_handle = tokio::spawn(async move {
+        while let Some(message) = outbound_rx.recv().await {
+            if sender.send(message).await.is_err() {
+                break;
+            }
+        }
+    });
 
+    let (steering_tx, mut steering_rx) = tokio::sync::mpsc::channel::<String>(64);
+
+    // Optional connect handshake: if the first frame is `{"type":"connect",...}`
+    // we acknowledge it and keep waiting for queued chat messages. If the first
+    // frame is already a normal `{"type":"message",...}` payload, route it
+    // through the same acceptance path used for all later steering messages.
     if let Some(first) = receiver.next().await {
         match first {
             Ok(Message::Text(text)) => {
-                if let Ok(cp) = serde_json::from_str::<ConnectParams>(&text) {
-                    if cp.msg_type == "connect" {
-                        debug!(
-                            session_id = ?cp.session_id,
-                            device_name = ?cp.device_name,
-                            capabilities = ?cp.capabilities,
-                            "WebSocket connect params received"
-                        );
-                        // Override session_id if provided in connect params
-                        if let Some(sid) = &cp.session_id {
-                            agent.set_memory_session_id(Some(sid.clone()));
-                        }
-                        let ack = serde_json::json!({
-                            "type": "connected",
-                            "message": "Connection established"
-                        });
-                        let _ = sender.send(Message::Text(ack.to_string().into())).await;
-                    } else {
-                        // Not a connect message — fall through to normal processing
-                        first_msg_fallback = Some(text.to_string());
+                if let Some(connect_params) = parse_connect_frame(&text) {
+                    debug!(
+                        session_id = ?connect_params.session_id,
+                        device_name = ?connect_params.device_name,
+                        capabilities = ?connect_params.capabilities,
+                        "WebSocket connect params received"
+                    );
+                    if let Some(sid) = &connect_params.session_id {
+                        agent.set_memory_session_id(Some(sid.clone()));
                     }
-                } else {
-                    // Not parseable as ConnectParams — fall through
-                    first_msg_fallback = Some(text.to_string());
+                    let ack = serde_json::json!({
+                        "type": "connected",
+                        "message": "Connection established"
+                    });
+                    let _ = outbound_tx
+                        .send(Message::Text(ack.to_string().into()))
+                        .await;
+                } else if accept_user_text_frame(&text, &steering_tx, &outbound_tx)
+                    .await
+                    .is_err()
+                {
+                    let _ = writer_handle.await;
+                    return;
                 }
             }
-            Ok(Message::Close(_)) | Err(_) => return,
+            Ok(Message::Close(_)) | Err(_) => {
+                drop(outbound_tx);
+                let _ = writer_handle.await;
+                return;
+            }
             _ => {}
         }
     }
 
-    // Process the first message if it was not a connect frame
-    if let Some(ref text) = first_msg_fallback {
-        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(text) {
-            if parsed["type"].as_str() == Some("message") {
-                let content = parsed["content"].as_str().unwrap_or("").to_string();
-                if !content.is_empty() {
-                    // Persist user message
-                    if let Some(ref backend) = state.session_backend {
-                        let user_msg = crate::providers::ChatMessage::user(&content);
-                        let _ = backend.append(&session_key, &user_msg);
+    // Spawn a dedicated reader so inbound websocket frames keep flowing while
+    // the coordinator is busy driving a steered turn.
+    let reader_outbound_tx = outbound_tx.clone();
+    let reader_steering_tx = steering_tx.clone();
+    let reader_handle = tokio::spawn(async move {
+        while let Some(msg) = receiver.next().await {
+            match msg {
+                Ok(Message::Text(text)) => {
+                    if accept_user_text_frame(&text, &reader_steering_tx, &reader_outbound_tx)
+                        .await
+                        .is_err()
+                    {
+                        break;
                     }
-                    process_chat_message(&state, &mut agent, &mut sender, &content, &session_key)
-                        .await;
                 }
-            } else {
-                let unknown_type = parsed["type"].as_str().unwrap_or("unknown");
-                let err = serde_json::json!({
-                    "type": "error",
-                    "message": format!(
-                        "Unsupported message type \"{unknown_type}\". Send {{\"type\":\"message\",\"content\":\"your text\"}}"
-                    )
-                });
-                let _ = sender.send(Message::Text(err.to_string().into())).await;
+                Ok(Message::Close(_)) | Err(_) => break,
+                _ => {}
             }
-        } else {
-            let err = serde_json::json!({
-                "type": "error",
-                "message": "Invalid JSON. Send {\"type\":\"message\",\"content\":\"your text\"}"
-            });
-            let _ = sender.send(Message::Text(err.to_string().into())).await;
         }
-    }
+    });
+    drop(steering_tx);
 
     // Subscribe to the shared broadcast channel so cron/heartbeat events
-    // are forwarded to this WebSocket client.
+    // and other gateway broadcasts are forwarded to this WebSocket client.
     let mut broadcast_rx = state.event_tx.subscribe();
-
-    loop {
-        tokio::select! {
-            // ── Client message ────────────────────────────────────────
-            client_msg = receiver.next() => {
-                let Some(msg) = client_msg else { break };
-                let msg = match msg {
-                    Ok(Message::Text(text)) => text,
-                    Ok(Message::Close(_)) | Err(_) => break,
-                    _ => continue,
-                };
-
-                // Parse incoming message
-                let parsed: serde_json::Value = match serde_json::from_str(&msg) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        let err = serde_json::json!({
-                            "type": "error",
-                            "message": format!("Invalid JSON: {}", e),
-                            "code": "INVALID_JSON"
-                        });
-                        let _ = sender.send(Message::Text(err.to_string().into())).await;
-                        continue;
+    let broadcast_outbound_tx = outbound_tx.clone();
+    let broadcast_handle = tokio::spawn(async move {
+        loop {
+            match broadcast_rx.recv().await {
+                Ok(event) => {
+                    if broadcast_outbound_tx
+                        .send(Message::Text(event.to_string().into()))
+                        .await
+                        .is_err()
+                    {
+                        break;
                     }
-                };
-
-                let msg_type = parsed["type"].as_str().unwrap_or("");
-                if msg_type != "message" {
-                    let err = serde_json::json!({
-                        "type": "error",
-                        "message": format!(
-                            "Unsupported message type \"{msg_type}\". Send {{\"type\":\"message\",\"content\":\"your text\"}}"
-                        ),
-                        "code": "UNKNOWN_MESSAGE_TYPE"
-                    });
-                    let _ = sender.send(Message::Text(err.to_string().into())).await;
-                    continue;
                 }
-
-                let content = parsed["content"].as_str().unwrap_or("").to_string();
-                if content.is_empty() {
-                    let err = serde_json::json!({
-                        "type": "error",
-                        "message": "Message content cannot be empty",
-                        "code": "EMPTY_CONTENT"
-                    });
-                    let _ = sender.send(Message::Text(err.to_string().into())).await;
-                    continue;
-                }
-
-                // Acquire session lock to serialize concurrent turns
-                let _session_guard = match state.session_queue.acquire(&session_key).await {
-                    Ok(guard) => guard,
-                    Err(e) => {
-                        let err = serde_json::json!({
-                            "type": "error",
-                            "message": e.to_string(),
-                            "code": "SESSION_BUSY"
-                        });
-                        let _ = sender.send(Message::Text(err.to_string().into())).await;
-                        continue;
-                    }
-                };
-
-                // Persist user message
-                if let Some(ref backend) = state.session_backend {
-                    let user_msg = crate::providers::ChatMessage::user(&content);
-                    let _ = backend.append(&session_key, &user_msg);
-                }
-
-                process_chat_message(&state, &mut agent, &mut sender, &content, &session_key).await;
-            }
-
-            // ── Broadcast event (cron/heartbeat results) ──────────────
-            event = broadcast_rx.recv() => {
-                if let Ok(event) = event {
-                    let _ = sender.send(Message::Text(event.to_string().into())).await;
-                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
             }
         }
+    });
+
+    // The per-session queue still serializes top-level turns only. Steering
+    // happens inside one active turn through the connection-local inbox above.
+    while let Some(content) = steering_rx.recv().await {
+        let _session_guard = match state.session_queue.acquire(&session_key).await {
+            Ok(guard) => guard,
+            Err(error) => {
+                let _ = outbound_tx.send(session_queue_error_message(&error)).await;
+                continue;
+            }
+        };
+
+        process_chat_turn_with_steering(
+            &state,
+            &mut agent,
+            &outbound_tx,
+            &content,
+            &mut steering_rx,
+            &session_key,
+        )
+        .await;
+    }
+
+    reader_handle.abort();
+    broadcast_handle.abort();
+    drop(outbound_tx);
+    let _ = writer_handle.await;
+}
+
+/// Parse the optional first-frame websocket connect handshake.
+fn parse_connect_frame(text: &str) -> Option<ConnectParams> {
+    let connect = serde_json::from_str::<ConnectParams>(text).ok()?;
+    (connect.msg_type == "connect").then_some(connect)
+}
+
+fn inbound_error(message: String, code: &str) -> Message {
+    Message::Text(
+        serde_json::json!({
+            "type": "error",
+            "message": message,
+            "code": code,
+        })
+        .to_string()
+        .into(),
+    )
+}
+
+/// Validate websocket chat messages so the first fallback frame and later
+/// steering frames share exactly one acceptance path.
+fn parse_user_message_content(text: &str) -> Result<String, Message> {
+    let parsed: serde_json::Value = serde_json::from_str(text)
+        .map_err(|e| inbound_error(format!("Invalid JSON: {e}"), "INVALID_JSON"))?;
+
+    let msg_type = parsed["type"].as_str().unwrap_or("");
+    if msg_type != "message" {
+        return Err(inbound_error(
+            format!(
+                "Unsupported message type \"{msg_type}\". Send {{\"type\":\"message\",\"content\":\"your text\"}}"
+            ),
+            "UNKNOWN_MESSAGE_TYPE",
+        ));
+    }
+
+    let content = parsed["content"].as_str().unwrap_or("").to_string();
+    if content.trim().is_empty() {
+        return Err(inbound_error(
+            "Message content cannot be empty".to_string(),
+            "EMPTY_CONTENT",
+        ));
+    }
+
+    Ok(content)
+}
+
+async fn accept_user_text_frame(
+    text: &str,
+    steering_tx: &tokio::sync::mpsc::Sender<String>,
+    outbound_tx: &tokio::sync::mpsc::Sender<Message>,
+) -> Result<(), ()> {
+    let content = match parse_user_message_content(text) {
+        Ok(content) => content,
+        Err(message) => {
+            let _ = outbound_tx.send(message).await;
+            return Ok(());
+        }
+    };
+
+    match steering_tx.try_send(content) {
+        Ok(()) => Ok(()),
+        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+            let _ = outbound_tx
+                .send(inbound_error(
+                    "Steering queue is full for this websocket connection".to_string(),
+                    "STEERING_QUEUE_FULL",
+                ))
+                .await;
+            Ok(())
+        }
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => Err(()),
     }
 }
 
-/// Process a single chat message through the agent and send the response.
-///
-/// Uses [`Agent::turn_streamed`] so that intermediate text chunks, tool calls,
-/// and tool results are forwarded to the WebSocket client in real time.
-async fn process_chat_message(
+/// Flatten all user text consumed during one admitted turn into the same
+/// lossy plain-text shape used by other consolidation callers. This is not a
+/// machine-recoverable message boundary encoding.
+fn flatten_consolidation_input(consumed_messages: &[String]) -> String {
+    consumed_messages.join("\n\n")
+}
+
+fn persist_turn_transcript(
+    session_backend: Option<&std::sync::Arc<dyn crate::channels::session_backend::SessionBackend>>,
+    session_key: &str,
+    consumed_messages: &[String],
+    assistant_response: Option<&str>,
+) {
+    let Some(backend) = session_backend else {
+        return;
+    };
+
+    for message in consumed_messages {
+        let user_msg = crate::providers::ChatMessage::user(message);
+        let _ = backend.append(session_key, &user_msg);
+    }
+
+    if let Some(response) = assistant_response.filter(|response| !response.is_empty()) {
+        let assistant_msg = crate::providers::ChatMessage::assistant(response);
+        let _ = backend.append(session_key, &assistant_msg);
+    }
+}
+
+fn session_queue_error_message(
+    error: &crate::gateway::session_queue::SessionQueueError,
+) -> Message {
+    match error {
+        crate::gateway::session_queue::SessionQueueError::QueueFull { .. } => inbound_error(
+            "Session already has the maximum number of queued turns".to_string(),
+            "SESSION_QUEUE_FULL",
+        ),
+        crate::gateway::session_queue::SessionQueueError::Timeout { .. } => inbound_error(
+            "Timed out waiting for the active session turn to finish".to_string(),
+            "SESSION_QUEUE_TIMEOUT",
+        ),
+    }
+}
+
+/// Process one top-level websocket turn while continuing to absorb queued
+/// steering messages at the agent's safe drain boundaries.
+async fn process_chat_turn_with_steering(
     state: &AppState,
     agent: &mut crate::agent::Agent,
-    sender: &mut futures_util::stream::SplitSink<WebSocket, Message>,
+    outbound_tx: &tokio::sync::mpsc::Sender<Message>,
     content: &str,
+    steering_rx: &mut tokio::sync::mpsc::Receiver<String>,
     session_key: &str,
 ) {
     use crate::agent::TurnEvent;
@@ -408,33 +484,26 @@ async fn process_chat_message(
         .clone()
         .unwrap_or_else(|| "unknown".to_string());
 
-    // Broadcast agent_start event
     let _ = state.event_tx.send(serde_json::json!({
         "type": "agent_start",
         "provider": provider_label,
         "model": state.model,
     }));
 
-    // Set session state to running
     let turn_id = uuid::Uuid::new_v4().to_string();
     if let Some(ref backend) = state.session_backend {
         let _ = backend.set_session_state(session_key, "running", Some(&turn_id));
     }
 
-    // Channel for streaming turn events from the agent.
     let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(64);
-
-    // Run the streamed turn concurrently: the agent produces events
-    // while we forward them to the WebSocket below.  We cannot move
-    // `agent` into a spawned task (it is `&mut`), so we use a join
-    // instead — `turn_streamed` writes to the channel and we drain it
-    // from the other branch.
     let content_owned = content.to_string();
-    let turn_fut = async { agent.turn_streamed(&content_owned, event_tx).await };
-
-    // Drive both futures concurrently: the agent turn produces events
-    // and we relay them over WebSocket.
-    let forward_fut = async {
+    let turn_fut = async {
+        agent
+            .turn_streamed_with_steering_state(&content_owned, event_tx, Some(steering_rx))
+            .await
+    };
+    let outbound_tx_clone = outbound_tx.clone();
+    let forward_fut = async move {
         while let Some(event) = event_rx.recv().await {
             let ws_msg = match event {
                 TurnEvent::Chunk { delta } => {
@@ -450,27 +519,35 @@ async fn process_chat_message(
                     serde_json::json!({ "type": "tool_result", "name": name, "output": output })
                 }
             };
-            let _ = sender.send(Message::Text(ws_msg.to_string().into())).await;
+            if outbound_tx_clone
+                .send(Message::Text(ws_msg.to_string().into()))
+                .await
+                .is_err()
+            {
+                break;
+            }
         }
     };
 
     let (result, ()) = tokio::join!(turn_fut, forward_fut);
 
     match result {
-        Ok(response) => {
-            // Persist assistant response
-            if let Some(ref backend) = state.session_backend {
-                let assistant_msg = crate::providers::ChatMessage::assistant(&response);
-                let _ = backend.append(session_key, &assistant_msg);
-            }
+        Ok(outcome) => {
+            let response = outcome.response;
+            let consumed_messages = outcome.consumed_messages;
 
-            // Fire-and-forget memory consolidation so facts from WS sessions
-            // are extracted to long-term memory (Daily + Core categories).
+            persist_turn_transcript(
+                state.session_backend.as_ref(),
+                session_key,
+                &consumed_messages,
+                Some(&response),
+            );
+
             if state.auto_save {
                 let mem = state.mem.clone();
                 let provider = state.provider.clone();
                 let model = state.model.clone();
-                let user_msg = content.to_string();
+                let user_msg = flatten_consolidation_input(&consumed_messages);
                 let assistant_resp = response.clone();
                 tokio::spawn(async move {
                     if let Err(e) = crate::memory::consolidation::consolidate_turn(
@@ -487,37 +564,38 @@ async fn process_chat_message(
                 });
             }
 
-            // Send chunk_reset so the client clears any accumulated draft
-            // before the authoritative done message.
-            let reset = serde_json::json!({ "type": "chunk_reset" });
-            let _ = sender.send(Message::Text(reset.to_string().into())).await;
-
             let done = serde_json::json!({
                 "type": "done",
                 "full_response": response,
             });
-            let _ = sender.send(Message::Text(done.to_string().into())).await;
+            let _ = outbound_tx
+                .send(Message::Text(done.to_string().into()))
+                .await;
 
-            // Set session state to idle
             if let Some(ref backend) = state.session_backend {
                 let _ = backend.set_session_state(session_key, "idle", None);
             }
 
-            // Broadcast agent_end event
             let _ = state.event_tx.send(serde_json::json!({
                 "type": "agent_end",
                 "provider": provider_label,
                 "model": state.model,
             }));
         }
-        Err(e) => {
-            // Set session state to error
+        Err(failure) => {
+            persist_turn_transcript(
+                state.session_backend.as_ref(),
+                session_key,
+                &failure.consumed_messages,
+                Some(&failure.committed_response),
+            );
+
             if let Some(ref backend) = state.session_backend {
                 let _ = backend.set_session_state(session_key, "error", Some(&turn_id));
             }
 
-            tracing::error!(error = %e, "Agent turn failed");
-            let sanitized = crate::providers::sanitize_api_error(&e.to_string());
+            tracing::error!(error = %failure.error, "Agent turn failed");
+            let sanitized = crate::providers::sanitize_api_error(&failure.error.to_string());
             let error_code = if sanitized.to_lowercase().contains("api key")
                 || sanitized.to_lowercase().contains("authentication")
                 || sanitized.to_lowercase().contains("unauthorized")
@@ -535,9 +613,10 @@ async fn process_chat_message(
                 "message": sanitized,
                 "code": error_code,
             });
-            let _ = sender.send(Message::Text(err.to_string().into())).await;
+            let _ = outbound_tx
+                .send(Message::Text(err.to_string().into()))
+                .await;
 
-            // Broadcast error event
             let _ = state.event_tx.send(serde_json::json!({
                 "type": "error",
                 "component": "ws_chat",
@@ -550,7 +629,23 @@ async fn process_chat_message(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::http::HeaderMap;
+    use crate::channels::session_backend::SessionBackend;
+    use axum::{
+        Json, Router,
+        extract::State as AxumState,
+        http::{HeaderMap, StatusCode},
+        response::{
+            IntoResponse,
+            sse::{Event, Sse},
+        },
+        routing::{get, post},
+    };
+    use futures_util::{SinkExt, StreamExt};
+    use serde_json::Value;
+    use std::{sync::Arc, time::Duration};
+    use tokio::net::TcpListener;
+    use tokio_stream::wrappers::ReceiverStream;
+    use tokio_tungstenite::{connect_async, tungstenite::Message as ClientMessage};
 
     #[test]
     fn extract_ws_token_from_authorization_header() {
@@ -626,5 +721,627 @@ mod tests {
             "zeroclaw.v1, bearer.zc_tok, other".parse().unwrap(),
         );
         assert_eq!(extract_ws_token(&headers, None), Some("zc_tok"));
+    }
+
+    #[derive(Clone)]
+    struct MockProviderServerState {
+        requests: Arc<parking_lot::Mutex<Vec<Value>>>,
+        first_done_delay: Duration,
+        first_delta: &'static str,
+        later_delta: &'static str,
+        fail_on_call: Option<usize>,
+    }
+
+    async fn mock_chat_completions(
+        AxumState(state): AxumState<MockProviderServerState>,
+        Json(body): Json<Value>,
+    ) -> axum::response::Response {
+        let call_index = {
+            let mut requests = state.requests.lock();
+            requests.push(body);
+            requests.len()
+        };
+
+        if state.fail_on_call == Some(call_index) {
+            return (StatusCode::BAD_GATEWAY, "mock provider failure").into_response();
+        }
+
+        let delta = if call_index == 1 {
+            state.first_delta
+        } else {
+            state.later_delta
+        };
+        let first_done_delay = state.first_done_delay;
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, axum::Error>>(4);
+        tokio::spawn(async move {
+            let chunk = serde_json::json!({
+                "choices": [{"delta": {"content": delta}}]
+            })
+            .to_string();
+            let _ = tx.send(Ok(Event::default().data(chunk))).await;
+            if call_index == 1 {
+                tokio::time::sleep(first_done_delay).await;
+            }
+            let _ = tx.send(Ok(Event::default().data("[DONE]"))).await;
+        });
+
+        Sse::new(ReceiverStream::new(rx)).into_response()
+    }
+
+    async fn start_mock_provider_server(
+        state: MockProviderServerState,
+    ) -> (
+        String,
+        tokio::task::JoinHandle<()>,
+        Arc<parking_lot::Mutex<Vec<Value>>>,
+    ) {
+        let requests = state.requests.clone();
+        let app = Router::new()
+            .route("/v1/chat/completions", post(mock_chat_completions))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{addr}/v1"), handle, requests)
+    }
+
+    fn build_ws_test_state(
+        provider_url: &str,
+        session_backend: Option<Arc<dyn SessionBackend>>,
+    ) -> crate::gateway::AppState {
+        build_ws_test_state_with_queue(
+            provider_url,
+            session_backend,
+            Arc::new(crate::gateway::session_queue::SessionActorQueue::new(
+                8, 30, 600,
+            )),
+        )
+    }
+
+    fn build_ws_test_state_with_queue(
+        provider_url: &str,
+        session_backend: Option<Arc<dyn SessionBackend>>,
+        session_queue: Arc<crate::gateway::session_queue::SessionActorQueue>,
+    ) -> crate::gateway::AppState {
+        let mut config = crate::config::Config::default();
+        let workspace_dir =
+            std::env::temp_dir().join(format!("zeroclaw-ws-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&workspace_dir).unwrap();
+        config.workspace_dir = workspace_dir.clone();
+        config.config_path = workspace_dir.join("config.toml");
+        config.api_key = Some("test-key".to_string());
+        config.default_provider = Some(format!("custom:{provider_url}"));
+        config.default_model = Some("test-model".to_string());
+        config.memory.backend = "none".to_string();
+        config.memory.auto_save = false;
+
+        let provider: Arc<dyn crate::providers::Provider> = Arc::from(
+            crate::providers::create_provider(&format!("custom:{provider_url}"), Some("test-key"))
+                .unwrap(),
+        );
+
+        crate::gateway::AppState {
+            config: Arc::new(parking_lot::Mutex::new(config)),
+            provider,
+            model: "test-model".into(),
+            temperature: 0.0,
+            mem: Arc::from(
+                crate::memory::create_memory(
+                    &crate::config::MemoryConfig {
+                        backend: "none".into(),
+                        ..crate::config::MemoryConfig::default()
+                    },
+                    &workspace_dir,
+                    None,
+                )
+                .unwrap(),
+            ),
+            auto_save: false,
+            webhook_secret_hash: None,
+            pairing: Arc::new(crate::security::PairingGuard::new(false, &[])),
+            trust_forwarded_headers: false,
+            rate_limiter: Arc::new(crate::gateway::GatewayRateLimiter::new(100, 100, 100)),
+            auth_limiter: Arc::new(crate::gateway::auth_rate_limit::AuthRateLimiter::new()),
+            idempotency_store: Arc::new(crate::gateway::IdempotencyStore::new(
+                Duration::from_secs(300),
+                1000,
+            )),
+            whatsapp: None,
+            whatsapp_app_secret: None,
+            linq: None,
+            linq_signing_secret: None,
+            nextcloud_talk: None,
+            nextcloud_talk_webhook_secret: None,
+            wati: None,
+            gmail_push: None,
+            observer: Arc::new(crate::observability::NoopObserver),
+            tools_registry: Arc::new(Vec::new()),
+            cost_tracker: None,
+            event_tx: tokio::sync::broadcast::channel(16).0,
+            event_buffer: Arc::new(crate::gateway::sse::EventBuffer::new(16)),
+            shutdown_tx: tokio::sync::watch::channel(false).0,
+            node_registry: Arc::new(crate::gateway::nodes::NodeRegistry::new(16)),
+            path_prefix: String::new(),
+            session_backend,
+            session_queue,
+            device_registry: None,
+            pending_pairings: None,
+            canvas_store: crate::tools::canvas::CanvasStore::new(),
+            #[cfg(feature = "webauthn")]
+            webauthn: None,
+        }
+    }
+
+    async fn start_ws_test_server(
+        state: crate::gateway::AppState,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new()
+            .route("/ws/chat", get(handle_ws_chat))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("ws://{addr}/ws/chat"), handle)
+    }
+
+    async fn recv_json(
+        ws: &mut tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+    ) -> Value {
+        loop {
+            match ws
+                .next()
+                .await
+                .expect("websocket frame")
+                .expect("websocket message")
+            {
+                ClientMessage::Text(text) => return serde_json::from_str(&text).unwrap(),
+                ClientMessage::Close(frame) => panic!("unexpected close: {frame:?}"),
+                _ => {}
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct MockSessionBackend {
+        messages: parking_lot::Mutex<
+            std::collections::HashMap<String, Vec<crate::providers::ChatMessage>>,
+        >,
+    }
+
+    impl crate::channels::session_backend::SessionBackend for MockSessionBackend {
+        fn load(&self, session_key: &str) -> Vec<crate::providers::ChatMessage> {
+            self.messages
+                .lock()
+                .get(session_key)
+                .cloned()
+                .unwrap_or_default()
+        }
+
+        fn append(
+            &self,
+            session_key: &str,
+            message: &crate::providers::ChatMessage,
+        ) -> std::io::Result<()> {
+            self.messages
+                .lock()
+                .entry(session_key.to_string())
+                .or_default()
+                .push(message.clone());
+            Ok(())
+        }
+
+        fn remove_last(&self, _session_key: &str) -> std::io::Result<bool> {
+            Ok(false)
+        }
+
+        fn list_sessions(&self) -> Vec<String> {
+            self.messages.lock().keys().cloned().collect()
+        }
+    }
+
+    #[test]
+    fn flatten_consolidation_input_matches_existing_plain_text_shape() {
+        let rendered = flatten_consolidation_input(&["first".into(), "second".into()]);
+        assert_eq!(rendered, "first\n\nsecond");
+    }
+
+    #[test]
+    fn parse_user_message_content_rejects_unknown_message_type() {
+        let err = parse_user_message_content(r#"{"type":"connect"}"#).unwrap_err();
+        let Message::Text(payload) = err else {
+            panic!("expected text error message");
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(parsed["code"], "UNKNOWN_MESSAGE_TYPE");
+    }
+
+    #[test]
+    fn parse_user_message_content_preserves_original_whitespace() {
+        let content =
+            parse_user_message_content("{\"type\":\"message\",\"content\":\"  first  \"}")
+                .expect("message should be accepted");
+        assert_eq!(content, "  first  ");
+    }
+
+    #[tokio::test]
+    async fn accept_user_text_frame_enqueues_messages_and_reports_overflow() {
+        let (steering_tx, mut steering_rx) = tokio::sync::mpsc::channel::<String>(1);
+        let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel::<Message>(4);
+
+        accept_user_text_frame(
+            r#"{"type":"message","content":"first"}"#,
+            &steering_tx,
+            &outbound_tx,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(steering_rx.recv().await.as_deref(), Some("first"));
+
+        steering_tx.try_send("already queued".into()).unwrap();
+        accept_user_text_frame(
+            r#"{"type":"message","content":"overflow"}"#,
+            &steering_tx,
+            &outbound_tx,
+        )
+        .await
+        .unwrap();
+
+        let Some(Message::Text(payload)) = outbound_rx.recv().await else {
+            panic!("expected outbound error");
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(parsed["code"], "STEERING_QUEUE_FULL");
+    }
+
+    #[tokio::test]
+    async fn websocket_steering_integration_reuses_first_message_enqueue_path() {
+        let provider_state = MockProviderServerState {
+            requests: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            first_done_delay: Duration::from_millis(250),
+            first_delta: "draft",
+            later_delta: "final answer",
+            fail_on_call: None,
+        };
+        let (provider_url, provider_handle, requests) =
+            start_mock_provider_server(provider_state).await;
+        let backend_impl = Arc::new(MockSessionBackend::default());
+        let backend: Arc<dyn SessionBackend> = backend_impl.clone();
+        let state = build_ws_test_state(&provider_url, Some(backend));
+        let (ws_base_url, ws_handle) = start_ws_test_server(state).await;
+        let ws_url = format!("{ws_base_url}?session_id=steering-it");
+
+        let (mut ws, _) = connect_async(&ws_url).await.unwrap();
+        let session_start = recv_json(&mut ws).await;
+        assert_eq!(session_start["type"], "session_start");
+
+        ws.send(ClientMessage::Text(
+            r#"{"type":"message","content":"first"}"#.into(),
+        ))
+        .await
+        .unwrap();
+
+        let mut sent_second = false;
+        let mut done_count = 0;
+        let mut saw_final_chunk = false;
+
+        let final_response = loop {
+            let payload = recv_json(&mut ws).await;
+            match payload["type"].as_str().unwrap() {
+                "chunk" if payload["content"] == "draft" && !sent_second => {
+                    ws.send(ClientMessage::Text(
+                        r#"{"type":"message","content":"second"}"#.into(),
+                    ))
+                    .await
+                    .unwrap();
+                    sent_second = true;
+                }
+                "chunk" if payload["content"] == "final answer" => {
+                    saw_final_chunk = true;
+                }
+                "chunk_reset" => panic!("websocket steering must not emit chunk_reset"),
+                "done" => {
+                    done_count += 1;
+                    break payload["full_response"].as_str().unwrap().to_string();
+                }
+                _ => {}
+            }
+        };
+
+        assert!(sent_second);
+        assert_eq!(done_count, 1);
+        assert!(saw_final_chunk);
+        assert_eq!(final_response, "draftfinal answer");
+
+        let requests = requests.lock().clone();
+        assert_eq!(requests.len(), 2);
+        let first_user_contents: Vec<_> = requests[0]["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|msg| msg["role"] == "user")
+            .map(|msg| msg["content"].to_string())
+            .collect();
+        let second_user_contents: Vec<_> = requests[1]["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|msg| msg["role"] == "user")
+            .map(|msg| msg["content"].to_string())
+            .collect();
+        let second_assistant_contents: Vec<_> = requests[1]["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|msg| msg["role"] == "assistant")
+            .map(|msg| msg["content"].to_string())
+            .collect();
+        assert_eq!(first_user_contents.len(), 1);
+        assert!(first_user_contents[0].contains("first"));
+        assert_eq!(second_user_contents.len(), 2);
+        assert!(second_user_contents[0].contains("first"));
+        assert!(second_user_contents[1].contains("second"));
+        assert!(
+            second_assistant_contents
+                .iter()
+                .any(|content| content.contains("draft"))
+        );
+
+        let transcript = backend_impl.load("gw_steering-it");
+        assert_eq!(transcript.len(), 3);
+        assert_eq!(transcript[0].role, "user");
+        assert_eq!(transcript[0].content, "first");
+        assert_eq!(transcript[1].role, "user");
+        assert_eq!(transcript[1].content, "second");
+        assert_eq!(transcript[2].role, "assistant");
+        assert_eq!(transcript[2].content, "draftfinal answer");
+
+        ws.close(None).await.unwrap();
+        provider_handle.abort();
+        ws_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn websocket_steering_overflow_returns_error_and_skips_persistence() {
+        let provider_state = MockProviderServerState {
+            requests: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            first_done_delay: Duration::from_millis(400),
+            first_delta: "draft",
+            later_delta: "settled",
+            fail_on_call: None,
+        };
+        let (provider_url, provider_handle, _requests) =
+            start_mock_provider_server(provider_state).await;
+        let backend_impl = Arc::new(MockSessionBackend::default());
+        let backend: Arc<dyn SessionBackend> = backend_impl.clone();
+        let state = build_ws_test_state(&provider_url, Some(backend));
+        let (ws_base_url, ws_handle) = start_ws_test_server(state).await;
+        let ws_url = format!("{ws_base_url}?session_id=overflow-it");
+
+        let (mut ws, _) = connect_async(&ws_url).await.unwrap();
+        let _ = recv_json(&mut ws).await;
+
+        ws.send(ClientMessage::Text(
+            r#"{"type":"message","content":"first"}"#.into(),
+        ))
+        .await
+        .unwrap();
+
+        loop {
+            let payload = recv_json(&mut ws).await;
+            if payload["type"] == "chunk" && payload["content"] == "draft" {
+                break;
+            }
+        }
+
+        for idx in 0..80 {
+            ws.send(ClientMessage::Text(
+                format!(r#"{{"type":"message","content":"overflow-{idx}"}}"#).into(),
+            ))
+            .await
+            .unwrap();
+        }
+
+        let mut saw_queue_full = false;
+        loop {
+            let payload = recv_json(&mut ws).await;
+            match payload["type"].as_str().unwrap() {
+                "error" if payload["code"] == "STEERING_QUEUE_FULL" => saw_queue_full = true,
+                "done" => break,
+                _ => {}
+            }
+        }
+
+        assert!(saw_queue_full);
+        let transcript = backend_impl.load("gw_overflow-it");
+        let user_messages: Vec<_> = transcript.iter().filter(|msg| msg.role == "user").collect();
+        assert_eq!(user_messages.len(), 65);
+        assert!(user_messages.iter().any(|msg| msg.content == "overflow-63"));
+        assert!(user_messages.iter().all(|msg| msg.content != "overflow-79"));
+
+        ws.close(None).await.unwrap();
+        provider_handle.abort();
+        ws_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn websocket_session_queue_full_returns_error_without_persisting_turn() {
+        let provider_state = MockProviderServerState {
+            requests: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            first_done_delay: Duration::from_millis(300),
+            first_delta: "draft",
+            later_delta: "settled",
+            fail_on_call: None,
+        };
+        let (provider_url, provider_handle, _requests) =
+            start_mock_provider_server(provider_state).await;
+        let backend_impl = Arc::new(MockSessionBackend::default());
+        let backend: Arc<dyn SessionBackend> = backend_impl.clone();
+        let session_queue = Arc::new(crate::gateway::session_queue::SessionActorQueue::new(
+            1, 1, 600,
+        ));
+        let state = build_ws_test_state_with_queue(&provider_url, Some(backend), session_queue);
+        let (ws_base_url, ws_handle) = start_ws_test_server(state).await;
+        let ws_url = format!("{ws_base_url}?session_id=queue-full-it");
+
+        let (mut ws1, _) = connect_async(&ws_url).await.unwrap();
+        let _ = recv_json(&mut ws1).await;
+        ws1.send(ClientMessage::Text(
+            r#"{"type":"message","content":"first"}"#.into(),
+        ))
+        .await
+        .unwrap();
+        loop {
+            let payload = recv_json(&mut ws1).await;
+            if payload["type"] == "chunk" && payload["content"] == "draft" {
+                break;
+            }
+        }
+
+        let (mut ws2, _) = connect_async(&ws_url).await.unwrap();
+        let _ = recv_json(&mut ws2).await;
+        ws2.send(ClientMessage::Text(
+            r#"{"type":"message","content":"blocked"}"#.into(),
+        ))
+        .await
+        .unwrap();
+
+        loop {
+            let payload = recv_json(&mut ws2).await;
+            if payload["type"] == "error" {
+                assert_eq!(payload["code"], "SESSION_QUEUE_FULL");
+                break;
+            }
+        }
+
+        loop {
+            let payload = recv_json(&mut ws1).await;
+            if payload["type"] == "done" {
+                break;
+            }
+        }
+
+        let transcript = backend_impl.load("gw_queue-full-it");
+        assert!(
+            transcript
+                .iter()
+                .any(|msg| msg.role == "user" && msg.content == "first")
+        );
+        assert!(transcript.iter().all(|msg| msg.content != "blocked"));
+
+        ws1.close(None).await.unwrap();
+        ws2.close(None).await.unwrap();
+        provider_handle.abort();
+        ws_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn websocket_session_queue_timeout_returns_error_without_persisting_turn() {
+        let provider_state = MockProviderServerState {
+            requests: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            first_done_delay: Duration::from_millis(50),
+            first_delta: "draft",
+            later_delta: "settled",
+            fail_on_call: None,
+        };
+        let (provider_url, provider_handle, _requests) =
+            start_mock_provider_server(provider_state).await;
+        let backend_impl = Arc::new(MockSessionBackend::default());
+        let backend: Arc<dyn SessionBackend> = backend_impl.clone();
+        let session_queue = Arc::new(crate::gateway::session_queue::SessionActorQueue::new(
+            2, 1, 600,
+        ));
+        let guard = session_queue.acquire("gw_timeout-it").await.unwrap();
+        let state = build_ws_test_state_with_queue(&provider_url, Some(backend), session_queue);
+        let (ws_base_url, ws_handle) = start_ws_test_server(state).await;
+        let ws_url = format!("{ws_base_url}?session_id=timeout-it");
+
+        let (mut ws, _) = connect_async(&ws_url).await.unwrap();
+        let _ = recv_json(&mut ws).await;
+        ws.send(ClientMessage::Text(
+            r#"{"type":"message","content":"blocked"}"#.into(),
+        ))
+        .await
+        .unwrap();
+
+        loop {
+            let payload = recv_json(&mut ws).await;
+            if payload["type"] == "error" {
+                assert_eq!(payload["code"], "SESSION_QUEUE_TIMEOUT");
+                break;
+            }
+        }
+
+        drop(guard);
+        assert!(backend_impl.load("gw_timeout-it").is_empty());
+
+        ws.close(None).await.unwrap();
+        provider_handle.abort();
+        ws_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn websocket_error_persists_committed_partial_assistant_output() {
+        let provider_state = MockProviderServerState {
+            requests: Arc::new(parking_lot::Mutex::new(Vec::new())),
+            first_done_delay: Duration::from_millis(250),
+            first_delta: "draft",
+            later_delta: "unused",
+            fail_on_call: Some(2),
+        };
+        let (provider_url, provider_handle, _requests) =
+            start_mock_provider_server(provider_state).await;
+        let backend_impl = Arc::new(MockSessionBackend::default());
+        let backend: Arc<dyn SessionBackend> = backend_impl.clone();
+        let state = build_ws_test_state(&provider_url, Some(backend));
+        let (ws_base_url, ws_handle) = start_ws_test_server(state).await;
+        let ws_url = format!("{ws_base_url}?session_id=partial-it");
+
+        let (mut ws, _) = connect_async(&ws_url).await.unwrap();
+        let _ = recv_json(&mut ws).await;
+
+        ws.send(ClientMessage::Text(
+            r#"{"type":"message","content":"first"}"#.into(),
+        ))
+        .await
+        .unwrap();
+
+        let mut sent_second = false;
+        loop {
+            let payload = recv_json(&mut ws).await;
+            match payload["type"].as_str().unwrap() {
+                "chunk" if payload["content"] == "draft" && !sent_second => {
+                    ws.send(ClientMessage::Text(
+                        r#"{"type":"message","content":"second"}"#.into(),
+                    ))
+                    .await
+                    .unwrap();
+                    sent_second = true;
+                }
+                "error" => break,
+                _ => {}
+            }
+        }
+
+        assert!(sent_second);
+        let transcript = backend_impl.load("gw_partial-it");
+        assert_eq!(transcript.len(), 3);
+        assert_eq!(transcript[0].role, "user");
+        assert_eq!(transcript[0].content, "first");
+        assert_eq!(transcript[1].role, "user");
+        assert_eq!(transcript[1].content, "second");
+        assert_eq!(transcript[2].role, "assistant");
+        assert_eq!(transcript[2].content, "draft");
+
+        ws.close(None).await.unwrap();
+        provider_handle.abort();
+        ws_handle.abort();
     }
 }


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: WebSocket steering needed to remain additive without invalidating already-streamed output, while keeping transcript/session persistence correct under steering, queue pressure, and mid-turn failure.
- Why it matters: In shared OSS runtime behavior, websocket/direct flows must preserve committed output semantics and transcript integrity, and queue admission errors must be explicit/non-persistent.
- What changed:
  - Added steering-aware streamed turn path in agent (`turn_streamed_with_steering_state`) that:
    - drains accepted steering messages at safe boundaries,
    - treats already-streamed assistant text as committed,
    - returns both full response and consumed user messages,
    - preserves additive continuation semantics.
  - Updated gateway websocket loop to:
    - route first and subsequent `message` frames through a shared validation/enqueue path,
    - keep steering connection-local via inbox queue,
    - serialize only top-level turns via session queue,
    - map queue admission failures to explicit websocket error codes.
  - Centralized transcript persistence for admitted turns:
    - accepted user messages persisted as separate entries,
    - assistant output persisted once on success,
    - committed partial assistant output persisted on failure.
  - Updated response cache keying to use full provider-visible transcript encoding (not last-user-only keying).
  - Added focused tests for steering semantics, queue behavior, partial-output persistence, and cache-key structural separation.
- What did **not** change (scope boundary):
  - No `chunk_reset` behavior reintroduced.
  - No changes to auth model, permissions, or gateway security boundaries.
  - No schema/config migrations required.
  - No steering support added to non-websocket channel types.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high` (touches `src/gateway/**`)
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): _auto-managed (expected: `size: L`)_
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `agent,gateway,tests,memory`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `gateway: websocket`, `agent: streaming`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): _auto-managed_
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi` (agent + gateway)

## Linked Issue

- Closes #N/A
- Related #N/A
- Depends on #N/A (if stacked)
- Supersedes #N/A (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): local command output; websocket integration tests in `src/gateway/ws.rs` and agent cache/streaming tests in `src/agent/agent.rs` pass in `cargo test`.
- If any command is intentionally skipped, explain why: `./dev/ci.sh all` was not used here due local Docker credential helper setup; equivalent Rust validation commands were run directly.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No` (existing provider calls only)
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: tests and fixtures use neutral synthetic values.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - Steering continuation remains additive across streamed partial output.
  - Accepted steering messages persist as separate transcript entries.
  - Rejected queue-overflow messages are not persisted.
  - Session queue full/timeout produce explicit websocket errors and do not persist rejected turns.
  - Committed partial assistant output persists when later continuation fails.
- Edge cases checked:
  - First-frame `message` path equals later-frame acceptance path.
  - No `chunk_reset` in steering flow.
  - Structurally different transcripts do not collide under updated response-cache transcript encoding.
- What was not verified:
  - Live provider credentials/end-to-end external live tests.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: websocket gateway chat loop, streamed agent turn handling, response cache key construction, websocket integration tests.
- Potential unintended effects: broader response-cache key behavior affects all agent turns (intentional but wider than websocket-only path).
- Guardrails/monitoring for early detection: websocket error codes (`STEERING_QUEUE_FULL`, `SESSION_QUEUE_FULL`, `SESSION_QUEUE_TIMEOUT`) and existing event broadcast logs (`agent_start`, `agent_end`, `error`).

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local git/status/diff + cargo validation commands.
- Workflow/plan summary (if any): review-first iteration focused on websocket steering semantics, transcript persistence, and queue behavior; added/updated tests to prove corrected behavior.
- Verification focus: additive streaming semantics, persistence correctness, queue admission boundaries, cache-key structural correctness.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: revert this PR commit(s) (`git revert <commit>`), redeploy.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: websocket turn stalls, incorrect transcript persistence (missing/extra user entries), assistant output mismatch between streamed chunks and persisted transcript.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: Response-cache key logic now depends on full transcript encoding and affects all agent paths.
  - Mitigation: deterministic encoding helper + unit and behavior-level tests for structurally distinct transcripts.
- Risk: Websocket coordination complexity (reader/writer/inbox/session-queue) could regress ordering.
  - Mitigation: integration tests cover happy path, overflow, queue full/timeout, and partial-output-on-error persistence.
