### PR TITLE
fix(tooling): allow domain names in web_fetch.allowed_private_hosts to skip DNS check

### DIFF
--- a/src/tools/web_fetch.rs
+++ b/src/tools/web_fetch.rs
@@ -435,8 +435,7 @@ fn validate_target_url(
         anyhow::bail!("Host '{host}' is in {tool_name}.blocked_domains");
     }
 
-    let private_host_allowed =
-        is_private_or_local_host(&host) && host_matches_allowlist(&host, allowed_private_hosts);
+    let private_host_allowed = host_matches_allowlist(&host, allowed_private_hosts);
 
     if is_private_or_local_host(&host) && !private_host_allowed {
         anyhow::bail!(
@@ -447,7 +446,7 @@ fn validate_target_url(
 
     if private_host_allowed {
         tracing::warn!(
-            "{tool_name}: allowing private/local host '{host}' via allowed_private_hosts"
+            "{tool_name}: allowing host '{host}' via allowed_private_hosts"
         );
     }
 
@@ -919,6 +918,25 @@ mod tests {
         .unwrap_err()
         .to_string();
         assert!(err.contains("blocked_domains"));
+    }
+
+    #[test]
+    fn ssrf_allows_explicit_private_domain() {
+        let allowed = vec!["example.com".to_string()];
+        let private_allowed = vec!["local.internal".to_string()];
+        let blocked = vec![];
+
+        // This should pass if local.internal is in private_allowed, bypassing DNS check
+        assert!(
+            validate_target_url(
+                "https://local.internal/api",
+                &allowed,
+                &blocked,
+                &private_allowed,
+                "web_fetch"
+            )
+            .is_ok()
+        );
     }
 
     // ── Security policy ──────────────────────────────────────────


### PR DESCRIPTION
This PR resolves issue #5122 where domain names in `allowed_private_hosts` were still subject to DNS resolution checks that blocked private IP addresses.

### Problem
Previously, `private_host_allowed` was only set to `true` if a host was both in the `allowed_private_hosts` list AND recognized as a private/local host (literal IP, `.local`, or `localhost`). For regular domain names (e.g., `local.internal`), `is_private_or_local_host` returned `false`, causing the tool to fall through to `validate_resolved_host_is_public`, which bails if the domain resolves to a private IP.

### Solution
Simplified the `private_host_allowed` logic to depend solely on the `allowed_private_hosts` explicit allowlist. This allows the user to explicitly approve any host (including domain names) and bypass the public-IP-only enforcement.

### Changes
- Removed the `is_private_or_local_host` requirement for the private allowlist check.
- Added a regression test: `ssrf_allows_explicit_private_domain`.

Fixes #5122