### PR TITLE
fix(install): reopen /dev/tty for TUI when piped via curl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1435,11 +1435,16 @@ if [[ "$SKIP_ONBOARD" == false && -n "$ZEROCLAW_BIN" ]]; then
     else
       step_fail "Provider configuration failed — run zeroclaw onboard --tui to retry"
     fi
-  elif [[ -t 0 && -t 1 ]]; then
-    # Interactive terminal: launch TUI onboarding wizard
+  elif [[ -t 1 ]] && [[ -t 0 || -e /dev/tty ]]; then
+    # Interactive terminal: launch TUI onboarding wizard.
+    # When piped (curl | bash), stdin is not a TTY — reopen from /dev/tty.
     echo
     step_dot "Launching TUI onboarding wizard"
-    "$ZEROCLAW_BIN" onboard --tui || warn "TUI setup exited — run zeroclaw onboard --tui to retry"
+    if [[ -t 0 ]]; then
+      "$ZEROCLAW_BIN" onboard --tui || warn "TUI setup exited — run zeroclaw onboard --tui to retry"
+    else
+      "$ZEROCLAW_BIN" onboard --tui </dev/tty || warn "TUI setup exited — run zeroclaw onboard --tui to retry"
+    fi
   else
     step_dot "No API key provided — run zeroclaw onboard --tui to configure"
   fi


### PR DESCRIPTION
## Summary
- Fixes TUI onboarding wizard not launching when installed via `curl -fsSL https://zeroclawlabs.ai/install.sh | bash`
- When piped, stdin is the curl stream, not the terminal — `-t 0` fails and the TUI was skipped
- Now detects `/dev/tty` availability and redirects stdin from it so ratatui works in the pipe flow

## Test plan
- [ ] `curl -fsSL https://zeroclawlabs.ai/install.sh | bash` → TUI wizard launches after build
- [ ] `./install.sh` (direct run) → TUI wizard launches normally
- [ ] `./install.sh --api-key "sk-..." --provider openrouter` → non-interactive config, no TUI
- [ ] `./install.sh --skip-onboard` → skips onboarding entirely