### PR TITLE
fix(tui): reopen /dev/tty natively when stdin is a pipe

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1437,14 +1437,10 @@ if [[ "$SKIP_ONBOARD" == false && -n "$ZEROCLAW_BIN" ]]; then
     fi
   elif [[ -t 1 ]] && [[ -t 0 || -e /dev/tty ]]; then
     # Interactive terminal: launch TUI onboarding wizard.
-    # When piped (curl | bash), stdin is not a TTY — reopen from /dev/tty.
+    # The TUI binary handles /dev/tty reopening internally when stdin is a pipe.
     echo
     step_dot "Launching TUI onboarding wizard"
-    if [[ -t 0 ]]; then
-      "$ZEROCLAW_BIN" onboard --tui || warn "TUI setup exited — run zeroclaw onboard --tui to retry"
-    else
-      "$ZEROCLAW_BIN" onboard --tui </dev/tty || warn "TUI setup exited — run zeroclaw onboard --tui to retry"
-    fi
+    "$ZEROCLAW_BIN" onboard --tui || warn "TUI setup exited — run zeroclaw onboard --tui to retry"
   else
     step_dot "No API key provided — run zeroclaw onboard --tui to configure"
   fi

--- a/src/tui/onboarding.rs
+++ b/src/tui/onboarding.rs
@@ -12,7 +12,8 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Paragraph},
 };
-use std::io;
+use std::io::{self, IsTerminal};
+
 
 use crate::config::Config;
 use crate::config::schema::{
@@ -570,6 +571,24 @@ impl App {
 // ── Public entry point ──────────────────────────────────────────────
 
 pub async fn run_tui_onboarding() -> Result<()> {
+    // When launched via `curl | bash`, stdin is a pipe, not a TTY.
+    // Crossterm reads terminal events from stdin, so we must reopen
+    // stdin from /dev/tty before entering raw mode.
+    #[cfg(unix)]
+    if !io::stdin().is_terminal() {
+        use std::fs::File;
+        let tty = File::open("/dev/tty").context("Failed to open /dev/tty for TUI input")?;
+        let fd = std::os::unix::io::IntoRawFd::into_raw_fd(tty);
+        // Safety: we just opened this fd and are replacing stdin (fd 0) with it.
+        unsafe {
+            if libc::dup2(fd, 0) == -1 {
+                libc::close(fd);
+                anyhow::bail!("Failed to redirect stdin from /dev/tty");
+            }
+            libc::close(fd);
+        }
+    }
+
     enable_raw_mode().context("Failed to enable raw mode")?;
     io::stdout()
         .execute(EnterAlternateScreen)


### PR DESCRIPTION
## Summary
- Fixes `Error: Failed to read event / Failed to initialize input reader` when TUI runs via `curl -fsSL https://zeroclawlabs.ai/install.sh | bash`
- Crossterm reads events from stdin, which is a pipe in the curl flow — `dup2()` reopens stdin from `/dev/tty` before crossterm init
- Simplifies install.sh — removes the bash `</dev/tty` redirect since the binary handles it

## Test plan
- [ ] `curl -fsSL https://zeroclawlabs.ai/install.sh | bash` → TUI launches after build
- [ ] `zeroclaw onboard --tui` (direct) → TUI works normally
- [ ] `echo "" | zeroclaw onboard --tui` (piped stdin) → TUI reopens from /dev/tty