### PR TITLE
revert: roll back #5215 and #5217 — tightening review standards for AI-generated PRs

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2133,7 +2133,6 @@ pub(crate) async fn agent_turn(
     dedup_exempt_tools: &[String],
     activated_tools: Option<&std::sync::Arc<std::sync::Mutex<crate::tools::ActivatedToolSet>>>,
     model_switch_callback: Option<ModelSwitchCallback>,
-    force_xml_tools: bool,
 ) -> Result<String> {
     run_tool_call_loop(
         provider,
@@ -2160,7 +2159,6 @@ pub(crate) async fn agent_turn(
         0,    // max_tool_result_chars: 0 = disabled (legacy callers)
         0,    // context_token_budget: 0 = disabled (legacy callers)
         None, // shared_budget: no shared budget for legacy callers
-        force_xml_tools,
     )
     .await
 }
@@ -2299,10 +2297,6 @@ pub(crate) async fn run_tool_call_loop(
     max_tool_result_chars: usize,
     context_token_budget: usize,
     shared_budget: Option<Arc<std::sync::atomic::AtomicUsize>>,
-    // When true, native tool calling is disabled regardless of provider capability.
-    // Respects `[agent] tool_dispatcher = "xml"` in config.toml, forcing the model
-    // to use `<tool_call>` XML format injected via the system prompt instead.
-    force_xml_tools: bool,
 ) -> Result<String> {
     let max_iterations = if max_tool_iterations == 0 {
         DEFAULT_MAX_TOOL_ITERATIONS
@@ -2420,8 +2414,7 @@ pub(crate) async fn run_tool_call_loop(
                 }
             }
         }
-        let use_native_tools =
-            !force_xml_tools && provider.supports_native_tools() && !tool_specs.is_empty();
+        let use_native_tools = provider.supports_native_tools() && !tool_specs.is_empty();
 
         let image_marker_count = multimodal::count_image_markers(history);
 
@@ -3826,10 +3819,7 @@ pub async fn run(
     } else {
         None
     };
-    // Respect [agent] tool_dispatcher = "xml" in config: force XML-based tool
-    // calling even when the provider reports native tool support.
-    let force_xml_tools = config.agent.tool_dispatcher == "xml";
-    let native_tools = !force_xml_tools && provider.supports_native_tools();
+    let native_tools = provider.supports_native_tools();
     let mut system_prompt = crate::channels::build_system_prompt_with_mode_and_autonomy(
         &config.workspace_dir,
         &model_name,
@@ -3990,7 +3980,6 @@ pub async fn run(
                 config.agent.max_tool_result_chars,
                 config.agent.max_context_tokens,
                 None, // shared_budget
-                force_xml_tools,
             )
             .await
             {
@@ -4297,7 +4286,6 @@ pub async fn run(
                     config.agent.max_tool_result_chars,
                     config.agent.max_context_tokens,
                     None, // shared_budget
-                    force_xml_tools,
                 )
                 .await
                 {
@@ -4704,12 +4692,7 @@ pub async fn process_message(
     } else {
         None
     };
-    // Respect [agent] tool_dispatcher = "xml" in config: force XML-based tool
-    // calling even when the provider reports native tool support. This is needed
-    // for models that accept tool specs but output raw JSON text instead of proper
-    // native function calls (e.g. some models via OpenRouter or Venice).
-    let force_xml_tools = config.agent.tool_dispatcher == "xml";
-    let native_tools = !force_xml_tools && provider.supports_native_tools();
+    let native_tools = provider.supports_native_tools();
     let mut system_prompt = crate::channels::build_system_prompt_with_mode_and_autonomy(
         &config.workspace_dir,
         &model_name,
@@ -4807,7 +4790,6 @@ pub async fn process_message(
         &config.agent.tool_call_dedup_exempt,
         activated_handle_pm.as_ref(),
         None,
-        force_xml_tools,
     )
     .await
 }
@@ -5817,7 +5799,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect_err("provider without vision support should fail");
@@ -5873,7 +5854,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect_err("oversized payload must fail");
@@ -5923,7 +5903,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("valid multimodal payload should pass");
@@ -5972,7 +5951,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect_err("should fail without vision_provider config");
@@ -6028,7 +6006,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect_err("should fail when vision provider cannot be created");
@@ -6084,7 +6061,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("text-only messages should succeed with default provider");
@@ -6141,7 +6117,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect_err("should fail due to nonexistent vision provider");
@@ -6196,7 +6171,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("empty image markers should not trigger vision routing");
@@ -6251,7 +6225,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect_err("should attempt vision provider creation for multiple images");
@@ -6389,7 +6362,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("parallel execution should complete");
@@ -6464,7 +6436,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("cron_add delivery defaults should be injected");
@@ -6531,7 +6502,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("explicit delivery mode should be preserved");
@@ -6593,7 +6563,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("loop should finish after deduplicating repeated calls");
@@ -6667,7 +6636,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("non-interactive shell should succeed for low-risk command");
@@ -6732,7 +6700,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("loop should finish with exempt tool executing twice");
@@ -6817,7 +6784,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("loop should complete");
@@ -6879,7 +6845,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("native fallback id flow should complete");
@@ -6965,7 +6930,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("native tool-call text should be relayed through on_delta");
@@ -7035,7 +6999,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("streaming provider should complete");
@@ -7107,7 +7070,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("streaming tool loop should execute tool and finish");
@@ -7183,7 +7145,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("native streaming events should preserve tool loop semantics");
@@ -7268,7 +7229,6 @@ mod tests {
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("routed streaming provider should complete");
@@ -7355,7 +7315,6 @@ mod tests {
                 &[],
                 Some(&activated),
                 None,
-                false, // force_xml_tools
             )
             .await
             .expect("wrapper path should execute activated tools");
@@ -9283,7 +9242,6 @@ Let me check the result."#;
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("tool loop should complete");
@@ -9441,7 +9399,6 @@ Let me check the result."#;
                     0,
                     0,
                     None,
-                    false, // force_xml_tools
                 ),
             )
             .await
@@ -9524,7 +9481,6 @@ Let me check the result."#;
                     0,
                     0,
                     None,
-                    false, // force_xml_tools
                 ),
             )
             .await
@@ -9583,7 +9539,6 @@ Let me check the result."#;
             0,
             0,
             None,
-            false, // force_xml_tools
         )
         .await
         .expect("should succeed without cost scope");

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3034,7 +3034,6 @@ async fn process_channel_message(
                         ctx.max_tool_result_chars,
                         ctx.context_token_budget,
                         None, // shared_budget
-                        ctx.prompt_config.agent.tool_dispatcher == "xml", // force_xml_tools
                     ),
                     ),
                     ),

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -1169,10 +1169,9 @@ impl DelegateTool {
                 None,
                 None,
                 &crate::config::PacingConfig::default(),
-                0,     // max_tool_result_chars: inherit from parent config in future
-                0,     // context_token_budget: 0 = disabled for subagents
-                None,  // shared_budget: TODO thread from parent in future
-                false, // force_xml_tools: subagents inherit provider capabilities
+                0,    // max_tool_result_chars: inherit from parent config in future
+                0,    // context_token_budget: 0 = disabled for subagents
+                None, // shared_budget: TODO thread from parent in future
             ),
         )
         .await;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -305,38 +305,9 @@ export function getCost(): Promise<CostSummary> {
 // Sessions
 // ---------------------------------------------------------------------------
 
-/** Gateway session row shape returned by GET /api/sessions */
-interface GatewaySessionRow {
-  session_id?: string;
-  id?: string;
-  created_at?: string;
-  last_activity?: string;
-  message_count?: number;
-  name?: string;
-  channel?: string;
-  status?: 'active' | 'idle' | 'closed';
-}
-
 export function getSessions(): Promise<Session[]> {
-  return apiFetch<GatewaySessionRow[] | { sessions: GatewaySessionRow[] }>('/api/sessions').then(
-    (data) => {
-      const rows = unwrapField(data, 'sessions');
-      if (!Array.isArray(rows)) return [];
-      return rows
-        .map((row): Session | null => {
-          const id = row.session_id ?? row.id;
-          if (!id) return null;
-          return {
-            id,
-            channel: row.channel ?? row.name ?? 'gateway',
-            started_at: row.created_at ?? new Date().toISOString(),
-            last_activity: row.last_activity ?? row.created_at ?? new Date().toISOString(),
-            status: row.status ?? 'active',
-            message_count: row.message_count ?? 0,
-          };
-        })
-        .filter((s): s is Session => s !== null);
-    },
+  return apiFetch<Session[] | { sessions: Session[] }>('/api/sessions').then((data) =>
+    unwrapField(data, 'sessions'),
   );
 }
 


### PR DESCRIPTION
## Summary

Reverts #5215 and #5217. Both PRs contained issues that should have been caught during review. This revert restores main to a known-good state while we re-address the underlying bugs properly.

## Why

### #5217 — `fix(web): normalize gateway session list`
The `GatewaySessionRow` interface references fields (`session_id`, `last_activity`, `channel`, `status`, `message_count`) that the `GET /api/sessions` endpoint **does not return**. The actual API returns `{ id, name, created_at, updated_at }` — see `SessionDto` in `crates/api-gateway`. The normalization layer maps phantom fields and papers over the mismatch with hardcoded defaults. The original crash (#4918) is real and still needs a proper fix.

### #5215 — `fix(agent): respect tool_dispatcher = "xml"`
The bug is real (#4083), but the fix threads a `force_xml_tools: bool` through `run_tool_call_loop` — a function that already has **25 positional parameters**. Adding a 26th boolean deepens an existing architectural problem. Additionally, sub-agent delegation hardcodes `false`, which means sub-agents will still break for users who set `tool_dispatcher = "xml"`. This needs a design that doesn't grow the parameter list.

## Going forward

Both of these PRs were AI-generated and approved quickly. As we grow, we need to hold AI-assisted contributions to the **same standard** as human-written code — especially verifying that interfaces match actual API contracts and that architectural patterns are preserved. This isn't about slowing down; it's about making sure what lands on main is solid.

A few things that would have caught these:
- **Check the backend source** when a PR claims to describe an API shape
- **Question new parameters** on functions that already have too many
- **Test against a running instance** when the PR's own test plan is manual-only

The underlying bugs (#4918, #4083) are real and should be re-addressed with fixes that match the actual API and respect the framework's goal of staying thin.

## Reverted commits

- `7c54334` — #5215
- `9e22745` — #5217