### PR TITLE
feat(tools): add headers support in SkillHttpTool

### DIFF
--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -58,6 +58,8 @@ pub struct SkillTool {
     pub command: String,
     #[serde(default)]
     pub args: HashMap<String, String>,
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
 }
 
 /// Skill manifest parsed from SKILL.toml

--- a/src/tools/skill_http.rs
+++ b/src/tools/skill_http.rs
@@ -20,6 +20,7 @@ pub struct SkillHttpTool {
     tool_description: String,
     url_template: String,
     args: HashMap<String, String>,
+    headers: HashMap<String, String>,
 }
 
 impl SkillHttpTool {
@@ -33,6 +34,7 @@ impl SkillHttpTool {
             tool_description: tool.description.clone(),
             url_template: tool.command.clone(),
             args: tool.args.clone(),
+            headers: tool.headers.clone(),
         }
     }
 
@@ -106,7 +108,23 @@ impl Tool for SkillHttpTool {
             .build()
             .map_err(|e| anyhow::anyhow!("Failed to build HTTP client: {e}"))?;
 
-        let response = match client.get(&url).send().await {
+        let mut request = client.get(&url);
+        for (key, value) in &self.headers {
+            let value_substituted = {
+                let mut v = value.clone();
+                if let Some(obj) = args.as_object() {
+                    for (arg_key, arg_val) in obj {
+                        let placeholder = format!("{{{{{}}}}}", arg_key);
+                        let replacement = arg_val.as_str().unwrap_or_default();
+                        v = v.replace(&placeholder, replacement);
+                    }
+                }
+                v
+            };
+            request = request.header(key, value_substituted);
+        }
+
+        let response = match request.send().await {
             Ok(resp) => resp,
             Err(e) => {
                 return Ok(ToolResult {


### PR DESCRIPTION
## Summary
- add  support to  manifest model
- plumb headers into 
- apply configured headers on outgoing HTTP requests

## Testing
- not run (local  was canceled)

## Risk
- medium (touches HTTP tool execution path)
