### PR TITLE
fix(provider): sanitize llama.cpp gemma4 tool schemas

### DIFF
--- a/crates/zeroclaw-providers/src/llamacpp.rs
+++ b/crates/zeroclaw-providers/src/llamacpp.rs
@@ -226,7 +226,7 @@ impl LlamaCppProvider {
 
     fn should_sanitize_tool_schema(model: &str) -> bool {
         let lower = model.to_ascii_lowercase();
-        lower.contains("gemma-4") || lower.contains("gemma4")
+        model.is_empty() || lower.contains("gemma-4") || lower.contains("gemma4")
     }
 
     fn sanitize_tool_payload_for_model(
@@ -1117,6 +1117,18 @@ mod tool_schema_tests {
         let specs = vec![ref_tool_spec()];
         let tools = LlamaCppProvider::convert_tools(Some(&specs), "gemma4:27b")
             .expect("tools should be present");
+        let params = &tools[0]["parameters"];
+
+        assert!(params.get("$defs").is_none());
+        assert!(params.get("additionalProperties").is_none());
+        assert_eq!(params["properties"]["command"]["type"], "string");
+    }
+
+    #[test]
+    fn empty_model_sanitizes_tool_schema() {
+        let specs = vec![ref_tool_spec()];
+        let tools =
+            LlamaCppProvider::convert_tools(Some(&specs), "").expect("tools should be present");
         let params = &tools[0]["parameters"];
 
         assert!(params.get("$defs").is_none());

--- a/crates/zeroclaw-providers/src/llamacpp.rs
+++ b/crates/zeroclaw-providers/src/llamacpp.rs
@@ -224,11 +224,46 @@ impl LlamaCppProvider {
         })
     }
 
+    fn should_sanitize_tool_schema(model: &str) -> bool {
+        let lower = model.to_ascii_lowercase();
+        lower.contains("gemma-4") || lower.contains("gemma4")
+    }
+
+    fn sanitize_tool_payload_for_model(
+        tools: Vec<serde_json::Value>,
+        model: &str,
+    ) -> Vec<serde_json::Value> {
+        if !Self::should_sanitize_tool_schema(model) {
+            return tools;
+        }
+
+        tools
+            .into_iter()
+            .map(|mut tool| {
+                let Some(raw_parameters) = tool.get("parameters").cloned() else {
+                    return tool;
+                };
+
+                let cleaned_parameters = zeroclaw_api::schema::SchemaCleanr::clean(
+                    raw_parameters,
+                    zeroclaw_api::schema::CleaningStrategy::Conservative,
+                );
+
+                if let Some(tool_obj) = tool.as_object_mut() {
+                    tool_obj.insert("parameters".to_string(), cleaned_parameters);
+                }
+
+                tool
+            })
+            .collect()
+    }
+
     fn convert_tools(
         tools: Option<&[zeroclaw_api::tool::ToolSpec]>,
+        model: &str,
     ) -> Option<Vec<serde_json::Value>> {
         tools.map(|items| {
-            items
+            let converted = items
                 .iter()
                 .map(|tool| {
                     let params = zeroclaw_api::schema::SchemaCleanr::clean_for_openai(
@@ -241,7 +276,9 @@ impl LlamaCppProvider {
                         "parameters": params,
                     })
                 })
-                .collect()
+                .collect::<Vec<_>>();
+
+            Self::sanitize_tool_payload_for_model(converted, model)
         })
     }
 
@@ -453,6 +490,7 @@ impl Provider for LlamaCppProvider {
                 }))
             })
             .collect();
+        let converted = Self::sanitize_tool_payload_for_model(converted, model);
         let tools_opt = if converted.is_empty() {
             None
         } else {
@@ -467,7 +505,7 @@ impl Provider for LlamaCppProvider {
         model: &str,
         temperature: Option<f64>,
     ) -> anyhow::Result<ProviderChatResponse> {
-        let tools = Self::convert_tools(request.tools);
+        let tools = Self::convert_tools(request.tools, model);
         self.do_chat(request.messages, model, temperature, tools)
             .await
     }
@@ -491,7 +529,7 @@ impl Provider for LlamaCppProvider {
             return stream::once(async { Ok(StreamEvent::Final) }).boxed();
         }
         let messages = request.messages.to_vec();
-        let tools = Self::convert_tools(request.tools);
+        let tools = Self::convert_tools(request.tools, model);
         self.do_stream(messages, model, temperature, tools, options.count_tokens)
     }
 
@@ -1034,6 +1072,70 @@ mod url_tests {
             provider("http://localhost:8080/openai/v1").responses_url(),
             "http://localhost:8080/openai/v1/responses"
         );
+    }
+}
+
+#[cfg(test)]
+mod tool_schema_tests {
+    use super::LlamaCppProvider;
+
+    fn ref_tool_spec() -> zeroclaw_api::tool::ToolSpec {
+        zeroclaw_api::tool::ToolSpec {
+            name: "shell".to_string(),
+            description: "Run shell command".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "command": { "$ref": "#/$defs/Cmd" }
+                },
+                "required": ["command"],
+                "additionalProperties": false,
+                "$defs": {
+                    "Cmd": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            }),
+        }
+    }
+
+    #[test]
+    fn gemma4_sanitizes_tool_schema() {
+        let specs = vec![ref_tool_spec()];
+        let tools = LlamaCppProvider::convert_tools(Some(&specs), "gemma-4-27b-it")
+            .expect("tools should be present");
+        let params = &tools[0]["parameters"];
+
+        assert!(params.get("$defs").is_none());
+        assert!(params.get("additionalProperties").is_none());
+        assert_eq!(params["properties"]["command"]["type"], "string");
+    }
+
+    #[test]
+    fn gemma4_alias_sanitizes_tool_schema() {
+        let specs = vec![ref_tool_spec()];
+        let tools = LlamaCppProvider::convert_tools(Some(&specs), "gemma4:27b")
+            .expect("tools should be present");
+        let params = &tools[0]["parameters"];
+
+        assert!(params.get("$defs").is_none());
+        assert!(params.get("additionalProperties").is_none());
+        assert_eq!(params["properties"]["command"]["type"], "string");
+    }
+
+    #[test]
+    fn non_gemma_models_keep_openai_cleaned_tool_schema() {
+        let specs = vec![ref_tool_spec()];
+        let tools = LlamaCppProvider::convert_tools(Some(&specs), "llama-3.3-70b")
+            .expect("tools should be present");
+        let params = &tools[0]["parameters"];
+
+        let expected =
+            zeroclaw_api::schema::SchemaCleanr::clean_for_openai(specs[0].parameters.clone());
+
+        assert_eq!(params, &expected);
+        assert_eq!(params["additionalProperties"], serde_json::json!(false));
     }
 }
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: llama.cpp with Gemma 4 can reject ZeroClaw native tool schemas during generation because stricter local schema handling chokes on unresolved / expanded JSON Schema constructs.
- Why it matters: tool-calling conversations fail for affected local llama.cpp + Gemma 4 setups even though the same tools work with other providers.
- What changed: sanitize native tool `function.parameters` conservatively for `llama.cpp` when the selected model name is empty or matches `gemma-4` / `gemma4`, and cover the scoped behavior with focused tests.
- What did **not** change (scope boundary): no change to non-Gemma llama.cpp models, no broad schema rewrite for other providers, and no channel/runtime/tool behavior changes outside provider request shaping.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `provider,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `provider: compatible`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `provider`

## Linked Issue

- Related #5224
- Depends on # (if stacked): N/A
- Supersedes # (if replacing older PR): N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): `No`
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): no supersede / no direct carry-over
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): `Pass`

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
  - `cargo fmt --all -- --check` — pass
  - GitHub CI `Test` on head `9dd5b891` — pass, covering the current focused tests in `llamacpp::tool_schema_tests::*`
  - Current focused test targets: `llamacpp::tool_schema_tests::gemma4_sanitizes_tool_schema`, `llamacpp::tool_schema_tests::gemma4_alias_sanitizes_tool_schema`, `llamacpp::tool_schema_tests::empty_model_sanitizes_tool_schema`, and `llamacpp::tool_schema_tests::non_gemma_models_keep_openai_cleaned_tool_schema`
  - Independent reviewer `PASS` on the scoped diff before PR creation
- If any command is intentionally skipped, explain why:
  - `cargo clippy --all-targets -- -D warnings` skipped in this lane to keep fill risk/latency bounded after the first test build took several minutes.
  - Full local `cargo test` skipped for the same reason; this PR only adds a narrow provider-only request-shaping change plus focused unit coverage, and GitHub CI is green on the current head.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: no user data or secret material added
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): `No`
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): `N.A.`
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): `N.A.`
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A because no docs or user-facing wording changed

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Gemma 4 + llama.cpp native tool schema now gets conservatively cleaned before request serialization; empty-model llama.cpp requests take the same sanitizer path; non-Gemma llama.cpp keeps the original schema shape.
- Edge cases checked: sanitizer is gated on empty model strings or Gemma 4-like model names, and it is applied on `chat()`, `stream_chat()`, and `chat_with_tools()` request-building paths.
- What was not verified: live llama.cpp server repro against a real Gemma 4 endpoint; broader provider regression sweep.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: OpenAI-compatible provider request shaping for llama.cpp Gemma 4 or empty-model tool calls only.
- Potential unintended effects: over-sanitizing a Gemma 4 or empty-model schema could drop constraints that some local setups actually accept.
- Guardrails/monitoring for early detection: focused unit tests added for sanitized vs unsanitized behavior; scope gate limits impact to the known provider/model family and the empty-model llama.cpp repro shape.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): one worker implementation agent, one independent reviewer agent
- Workflow/plan summary (if any): fill-mode issue-pool scan found #5224 as the first safe unoccupied narrow lane; worker patched provider request shaping; reviewer returned `PASS`; main thread reran focused validation and opened PR.
- Verification focus: provider-specific schema sanitization scope, regression boundary for non-Gemma llama.cpp, and request-path coverage.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed

## Rollback Plan (required)

- Fast rollback command/path: after merge, revert the squash commit for PR #5254; before merge, revert the branch commits with `git revert 9dd5b891acc1326343fc94c354b7f9a2d6d7f528 ffc621738fcc5267171b4d097d9bc6ca8a32aed3`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: Gemma 4 + llama.cpp tool-calling regressions would reappear, or unexpected schema-cleaning side effects would show up only on llama.cpp Gemma 4 / empty-model requests.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: conservative cleaning could remove a schema detail that an affected llama.cpp deployment would have accepted.
  - Mitigation: the cleaning is restricted to `llama.cpp` plus Gemma 4-like model names or the empty-model repro path, while non-Gemma llama.cpp keeps the original schema intact and is covered by a boundary test.
