### PR TITLE
fix(config): handle Windows ACCESS_DENIED when fsyncing directories

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -10960,8 +10960,22 @@ async fn sync_directory(path: &Path) -> Result<()> {
             .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
             .open(path)
             .with_context(|| format!("Failed to open directory for fsync: {}", path.display()))?;
-        dir.sync_all()
-            .with_context(|| format!("Failed to fsync directory metadata: {}", path.display()))?;
+        // FlushFileBuffers on directory handles returns ERROR_ACCESS_DENIED on
+        // Windows (OS Error 5). This is expected — NTFS does not support
+        // flushing directory metadata the same way Unix does. The individual
+        // files have already been synced, so it is safe to ignore this error.
+        if let Err(e) = dir.sync_all() {
+            if e.raw_os_error() == Some(5) {
+                tracing::trace!(
+                    "Ignoring expected ACCESS_DENIED when fsyncing directory on Windows: {}",
+                    path.display()
+                );
+            } else {
+                return Err(e).with_context(|| {
+                    format!("Failed to fsync directory metadata: {}", path.display())
+                });
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: On Windows, `FlushFileBuffers` on a directory handle returns `ERROR_ACCESS_DENIED` (OS Error 5), causing `zeroclaw onboard` to fail at the final step despite all config files being written successfully.
- Why it matters: Blocks Windows users from completing onboarding without hitting a confusing error.
- What changed: The Windows `sync_directory` path now catches OS Error 5 specifically and logs a trace-level message instead of propagating it as a fatal error.
- What did **not** change: Unix and other-platform behavior is untouched. Non-ACCESS_DENIED errors are still propagated.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `config`, `onboard`
- Module labels: `config: schema`
- Contributor tier label: n/a
- If any auto-label is incorrect, note requested correction: n/a

## Change Metadata

- Change type: `bug`
- Primary scope: `config`

## Linked Issue

- Closes #5258

## Supersede Attribution (required when `Supersedes #` is used)

n/a

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # ✓ clean
cargo clippy --all-targets -- -D warnings   # ✓ no warnings
cargo test   # ✓ all tests pass (5910 unit + 159 integration + 5 system)
```

- Evidence provided: full test suite pass on macOS; CI running on Linux, macOS, and Windows targets
- If any command is intentionally skipped, explain why: n/a

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: n/a
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: `sync_directory_handles_existing_directory` test passes; full test suite passes locally
- Edge cases checked: only OS Error 5 is caught; all other errors still propagate as before
- What was not verified: actual Windows runtime (CI Windows build is in progress and will cover this)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `sync_directory` in `src/config/schema.rs` — Windows `#[cfg(windows)]` path only
- Potential unintended effects: None. The error was always benign on NTFS; individual files are already synced before this call.
- Guardrails/monitoring for early detection: trace-level log emitted when the error is suppressed

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: correctness of OS error code matching, no regressions on Unix path, full test suite pass
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`)

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: none
- Observable failure symptoms: Windows onboarding would fail again with "Access is denied" at the final step

## Risks and Mitigations

- Risk: Silencing a legitimate error on a future Windows version where error 5 means something different for directory handles.
  - Mitigation: Only error code 5 is suppressed; all other errors propagate. A trace log is emitted for observability.