### PR TITLE
fix(whatsapp-web): resolve LID reply target in self_chat_mode

### DIFF
--- a/src/channels/whatsapp_web.rs
+++ b/src/channels/whatsapp_web.rs
@@ -1145,6 +1145,12 @@ impl Channel for WhatsAppWebChannel {
 
                                 let is_group = info.source.is_group;
 
+                                // Phone-based reply target for self-chat.
+                                // LID JIDs (e.g. 76188559093817@lid) are internal
+                                // identifiers that cannot receive messages; replies
+                                // must go to the phone JID (digits@s.whatsapp.net).
+                                let mut reply_target = chat.clone();
+
                                 // ── Personal-mode chat-type policy filtering ──
                                 if wa_mode == crate::config::WhatsAppWebMode::Personal {
                                     // Self-chat: the chat JID user part matches
@@ -1164,7 +1170,23 @@ impl Channel for WhatsAppWebChannel {
                                             );
                                             return;
                                         }
-                                        // self_chat_mode=true: always process, skip further policy checks
+                                        // self_chat_mode=true: always process, skip further policy checks.
+                                        //
+                                        // When the chat JID is LID-based, replies
+                                        // won't be delivered. Convert to a phone
+                                        // JID so the reply shows up in the self-chat.
+                                        if info.source.chat.is_lid() {
+                                            let phone_digits = normalized
+                                                .as_ref()
+                                                .map(|n| n.chars().filter(|c| c.is_ascii_digit()).collect::<String>())
+                                                .filter(|d| !d.is_empty());
+                                            if let Some(digits) = phone_digits {
+                                                reply_target = format!("{digits}@s.whatsapp.net");
+                                                tracing::debug!(
+                                                    "WhatsApp Web: self-chat LID→phone reply target: {reply_target}"
+                                                );
+                                            }
+                                        }
                                     } else if is_group {
                                         match wa_group_policy {
                                             crate::config::WhatsAppChatPolicy::Ignore => {
@@ -1340,7 +1362,9 @@ impl Channel for WhatsAppWebChannel {
                                         channel: "whatsapp".to_string(),
                                         sender: normalized.clone(),
                                         // Reply to the originating chat JID (DM or group).
-                                        reply_target: chat,
+                                        // For self-chat with LID JIDs, this is the
+                                        // resolved phone JID (see above).
+                                        reply_target,
                                         content,
                                         timestamp: chrono::Utc::now().timestamp() as u64,
                                         thread_ts: None,


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: WhatsApp self-chat replies are silently dropped when the chat JID uses LID format (Multi-Device protocol). Users see typing dots but never receive the bot's response.
- Why it matters: `self_chat_mode` is unusable — the bot processes messages and generates replies but they never arrive in WhatsApp.
- What changed: When `self_chat_mode=true` and the chat JID is LID-based (e.g. `76188559093817@lid`), convert the `reply_target` to a phone-based JID (`digits@s.whatsapp.net`) using the normalized phone from the sender's allowlist match.
- What did **not** change: Non-self-chat message routing, group/DM policy logic, allowlist behavior, typing indicator logic.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`
- Module labels: `channel: whatsapp`
- Contributor tier label: auto-managed
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #5260
- Related: N/A
- Depends on: N/A
- Supersedes: N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A — not superseding another PR.

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check    # ✅ clean
cargo clippy --all-targets -- -D warnings  # ✅ no warnings
cargo test                    # ✅ all unit + system tests pass
```

- Evidence provided: all three commands pass locally on rustc 1.93.1
- If any command is intentionally skipped: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: no personal data in the change; test data uses synthetic phone numbers
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No (code-only, no user-facing wording)

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: code review confirms LID JID detection triggers phone-based JID conversion only in self-chat path; non-self-chat paths are unaffected
- Edge cases checked: `normalized` is `None` (no allowlist match) — gracefully falls back to original chat JID; chat JID is already phone-based — `is_lid()` returns false, no conversion applied
- What was not verified: end-to-end WhatsApp self-chat delivery (requires live WhatsApp session)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: WhatsApp Web channel self-chat reply routing only
- Potential unintended effects: none — the LID→phone conversion is gated behind `is_self_chat && info.source.chat.is_lid()`, so it cannot fire for DM/group messages
- Guardrails/monitoring: debug log `WhatsApp Web: self-chat LID→phone reply target: ...` emitted when conversion triggers

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: traced the message flow from `listen()` → `ChannelMessage` → `process_channel_message` → `send()`, identified that `reply_target` carried the LID JID through to `send_message()` where WhatsApp silently dropped it
- Verification focus: ensure fix is narrowly scoped to self-chat + LID path, no impact on other routing
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`)

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>` — single commit, no migration
- Feature flags or config toggles: existing `self_chat_mode = false` disables the entire self-chat path
- Observable failure symptoms: self-chat replies not appearing in WhatsApp (same as the original bug)

## Risks and Mitigations

- Risk: if a user's phone number is not in `allowed_numbers`, the LID→phone conversion has no digits to use and falls back to the original LID JID (reply still won't be delivered).
  - Mitigation: `self_chat_mode` documentation already requires the user's own number in `allowed_numbers`. A follow-up could add a warning log when the fallback triggers.