### PR TITLE
[codex] guard empty cargo feature args in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1299,7 +1299,11 @@ if [[ "$SKIP_BUILD" == false ]]; then
   fi
 
   step_dot "Building release binary"
-  cargo build --release --locked "${CARGO_FEATURE_ARGS[@]}"
+  if [[ ${#CARGO_FEATURE_ARGS[@]} -gt 0 ]]; then
+    cargo build --release --locked "${CARGO_FEATURE_ARGS[@]}"
+  else
+    cargo build --release --locked
+  fi
   step_ok "Release binary built"
 else
   step_dot "Skipping build"
@@ -1318,7 +1322,11 @@ if [[ "$SKIP_INSTALL" == false ]]; then
     fi
   fi
 
-  cargo install --path "$WORK_DIR" --force --locked "${CARGO_FEATURE_ARGS[@]}"
+  if [[ ${#CARGO_FEATURE_ARGS[@]} -gt 0 ]]; then
+    cargo install --path "$WORK_DIR" --force --locked "${CARGO_FEATURE_ARGS[@]}"
+  else
+    cargo install --path "$WORK_DIR" --force --locked
+  fi
   step_ok "ZeroClaw installed"
 
   # Sync binary to ~/.local/bin so PATH lookups find the fresh version


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: `./install.sh --install-system-deps --install-rust` aborts under `set -u` when no cargo feature flags are present.
- Why it matters: this blocks a documented first-time install path on a supported platform.
- What changed: guard the `cargo build` and `cargo install` invocations so empty feature args are only expanded when present.
- What did **not** change (scope boundary): no installer behavior changes outside the empty-feature-args case.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `scripts, onboarding`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `scripts: install`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): `trusted contributor`
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi`

## Linked Issue

- Closes #5299
- Related # none
- Depends on # none
- Supersedes # none

## Validation Evidence (required)

Commands and result summary:

```bash
bash -n install.sh
```

- Evidence provided (test/log/trace/screenshot/perf): installer reproduction log from local run, plus shell syntax validation
- If any command is intentionally skipped, explain why: `cargo fmt`, `cargo clippy`, and `cargo test` were not rerun because this is a shell-only installer fix and the repo has unrelated local changes in the worktree outside the PR scope.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- If any `Yes`, describe risk and mitigation: none

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: reproduction uses no secrets
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): pass

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: none

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: local installer no longer aborts at the cargo build/install step when no feature flags are configured
- Edge cases checked: empty cargo feature args under `set -u`
- What was not verified: full end-to-end installer completion after the patch on a fresh host

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: bootstrap installer path
- Potential unintended effects: none expected; only changes the empty-args path
- Guardrails/monitoring for early detection: rerun `./install.sh --install-system-deps --install-rust` on a clean macOS host

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local shell, GitHub CLI
- Workflow/plan summary (if any): reproduced installer failure, patched `install.sh`, validated syntax, created issue and PR
- Verification focus: bash strict-mode array expansion
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): yes

## Rollback Plan (required)

- Fast rollback command/path: revert commit `232de3ed`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: installer aborts with `CARGO_FEATURE_ARGS[@]: unbound variable`

## Risks and Mitigations

- Risk: accidental change to installer command line in non-empty feature cases
  - Mitigation: retained existing `cargo build`/`cargo install` arguments when features are present
