### PR TITLE
fix(cost): scope cost tracking context for CLI, cron, and gateway agents

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -47,6 +47,7 @@ pub struct Agent {
     tool_dispatcher: Box<dyn ToolDispatcher>,
     memory_loader: Box<dyn MemoryLoader>,
     config: crate::config::AgentConfig,
+    provider_name: String,
     model_name: String,
     temperature: f64,
     workspace_dir: std::path::PathBuf,
@@ -82,6 +83,7 @@ pub struct AgentBuilder {
     tool_dispatcher: Option<Box<dyn ToolDispatcher>>,
     memory_loader: Option<Box<dyn MemoryLoader>>,
     config: Option<crate::config::AgentConfig>,
+    provider_name: Option<String>,
     model_name: Option<String>,
     temperature: Option<f64>,
     workspace_dir: Option<std::path::PathBuf>,
@@ -112,6 +114,7 @@ impl AgentBuilder {
             tool_dispatcher: None,
             memory_loader: None,
             config: None,
+            provider_name: None,
             model_name: None,
             temperature: None,
             workspace_dir: None,
@@ -169,6 +172,11 @@ impl AgentBuilder {
 
     pub fn config(mut self, config: crate::config::AgentConfig) -> Self {
         self.config = Some(config);
+        self
+    }
+
+    pub fn provider_name(mut self, provider_name: String) -> Self {
+        self.provider_name = Some(provider_name);
         self
     }
 
@@ -301,6 +309,7 @@ impl AgentBuilder {
                 .memory_loader
                 .unwrap_or_else(|| Box::new(DefaultMemoryLoader::default())),
             config: self.config.unwrap_or_default(),
+            provider_name: self.provider_name.unwrap_or_else(|| "unknown".into()),
             model_name: self
                 .model_name
                 .unwrap_or_else(|| "anthropic/claude-sonnet-4-20250514".into()),
@@ -540,6 +549,7 @@ impl Agent {
             )))
             .prompt_builder(SystemPromptBuilder::with_defaults())
             .config(config.agent.clone())
+            .provider_name(provider_name.to_string())
             .model_name(model_name)
             .temperature(config.default_temperature)
             .workspace_dir(config.workspace_dir.clone())
@@ -841,6 +851,15 @@ impl Agent {
                 Err(err) => return Err(err),
             };
 
+            // Record cost via task-local tracker (no-op when not scoped)
+            let _ = response.usage.as_ref().and_then(|usage| {
+                super::cost::record_tool_loop_cost_usage(
+                    &self.provider_name,
+                    &effective_model,
+                    usage,
+                )
+            });
+
             let (text, calls) = self.tool_dispatcher.parse_response(&response);
             if calls.is_empty() {
                 let final_text = if text.is_empty() {
@@ -1106,6 +1125,15 @@ impl Agent {
                     Err(err) => return Err(err),
                 }
             };
+
+            // Record cost via task-local tracker (no-op when not scoped)
+            let _ = response.usage.as_ref().and_then(|usage| {
+                super::cost::record_tool_loop_cost_usage(
+                    &self.provider_name,
+                    &effective_model,
+                    usage,
+                )
+            });
 
             let (text, calls) = self.tool_dispatcher.parse_response(&response);
             if calls.is_empty() {

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -3861,6 +3861,16 @@ pub async fn run(
         }
     });
 
+    // ── Cost tracking ────────────────────────────────────────────
+    let cost_tracking_context =
+        crate::cost::CostTracker::get_or_init_global(config.cost.clone(), &config.workspace_dir)
+            .map(|tracker| {
+                ToolLoopCostTrackingContext::new(
+                    tracker,
+                    std::sync::Arc::new(config.cost.prices.clone()),
+                )
+            });
+
     // ── Execute ──────────────────────────────────────────────────
     let start = Instant::now();
 
@@ -3955,33 +3965,37 @@ pub async fn run(
         #[allow(unused_assignments)]
         let mut response = String::new();
         loop {
-            match run_tool_call_loop(
-                provider.as_ref(),
-                &mut history,
-                &tools_registry,
-                observer.as_ref(),
-                &provider_name,
-                &model_name,
-                effective_temperature,
-                false,
-                approval_manager.as_ref(),
-                channel_name,
-                None,
-                &config.multimodal,
-                config.agent.max_tool_iterations,
-                None,
-                None,
-                None,
-                &excluded_tools,
-                &config.agent.tool_call_dedup_exempt,
-                activated_handle.as_ref(),
-                Some(model_switch_callback.clone()),
-                &config.pacing,
-                config.agent.max_tool_result_chars,
-                config.agent.max_context_tokens,
-                None, // shared_budget
-            )
-            .await
+            match TOOL_LOOP_COST_TRACKING_CONTEXT
+                .scope(
+                    cost_tracking_context.clone(),
+                    run_tool_call_loop(
+                        provider.as_ref(),
+                        &mut history,
+                        &tools_registry,
+                        observer.as_ref(),
+                        &provider_name,
+                        &model_name,
+                        effective_temperature,
+                        false,
+                        approval_manager.as_ref(),
+                        channel_name,
+                        None,
+                        &config.multimodal,
+                        config.agent.max_tool_iterations,
+                        None,
+                        None,
+                        None,
+                        &excluded_tools,
+                        &config.agent.tool_call_dedup_exempt,
+                        activated_handle.as_ref(),
+                        Some(model_switch_callback.clone()),
+                        &config.pacing,
+                        config.agent.max_tool_result_chars,
+                        config.agent.max_context_tokens,
+                        None, // shared_budget
+                    ),
+                )
+                .await
             {
                 Ok(resp) => {
                     response = resp;
@@ -4261,33 +4275,37 @@ pub async fn run(
             });
 
             let response = loop {
-                match run_tool_call_loop(
-                    provider.as_ref(),
-                    &mut history,
-                    &tools_registry,
-                    observer.as_ref(),
-                    &provider_name,
-                    &model_name,
-                    turn_temperature,
-                    true,
-                    approval_manager.as_ref(),
-                    channel_name,
-                    None,
-                    &config.multimodal,
-                    config.agent.max_tool_iterations,
-                    Some(cancel_token.clone()),
-                    Some(delta_tx.clone()),
-                    None,
-                    &excluded_tools,
-                    &config.agent.tool_call_dedup_exempt,
-                    activated_handle.as_ref(),
-                    Some(model_switch_callback.clone()),
-                    &config.pacing,
-                    config.agent.max_tool_result_chars,
-                    config.agent.max_context_tokens,
-                    None, // shared_budget
-                )
-                .await
+                match TOOL_LOOP_COST_TRACKING_CONTEXT
+                    .scope(
+                        cost_tracking_context.clone(),
+                        run_tool_call_loop(
+                            provider.as_ref(),
+                            &mut history,
+                            &tools_registry,
+                            observer.as_ref(),
+                            &provider_name,
+                            &model_name,
+                            turn_temperature,
+                            true,
+                            approval_manager.as_ref(),
+                            channel_name,
+                            None,
+                            &config.multimodal,
+                            config.agent.max_tool_iterations,
+                            Some(cancel_token.clone()),
+                            Some(delta_tx.clone()),
+                            None,
+                            &excluded_tools,
+                            &config.agent.tool_call_dedup_exempt,
+                            activated_handle.as_ref(),
+                            Some(model_switch_callback.clone()),
+                            &config.pacing,
+                            config.agent.max_tool_result_chars,
+                            config.agent.max_context_tokens,
+                            None, // shared_budget
+                        ),
+                    )
+                    .await
                 {
                     Ok(resp) => break resp,
                     Err(e) => {

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -421,6 +421,19 @@ async fn process_chat_message(
         let _ = backend.set_session_state(session_key, "running", Some(&turn_id));
     }
 
+    // Set up cost tracking context so LLM costs are recorded.
+    let config_snapshot = state.config.lock().clone();
+    let cost_tracking_context = crate::cost::CostTracker::get_or_init_global(
+        config_snapshot.cost.clone(),
+        &config_snapshot.workspace_dir,
+    )
+    .map(|tracker| {
+        crate::agent::loop_::ToolLoopCostTrackingContext::new(
+            tracker,
+            std::sync::Arc::new(config_snapshot.cost.prices.clone()),
+        )
+    });
+
     // Channel for streaming turn events from the agent.
     let (event_tx, mut event_rx) = tokio::sync::mpsc::channel::<TurnEvent>(64);
 
@@ -430,7 +443,10 @@ async fn process_chat_message(
     // instead — `turn_streamed` writes to the channel and we drain it
     // from the other branch.
     let content_owned = content.to_string();
-    let turn_fut = async { agent.turn_streamed(&content_owned, event_tx).await };
+    let turn_fut = crate::agent::loop_::TOOL_LOOP_COST_TRACKING_CONTEXT
+        .scope(cost_tracking_context, async {
+            agent.turn_streamed(&content_owned, event_tx).await
+        });
 
     // Drive both futures concurrently: the agent turn produces events
     // and we relay them over WebSocket.


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: LLM cost tracking only worked for channel-based agents (Telegram, Discord, Slack). Costs were not recorded when using CLI, cron schedules, or the WebSocket gateway because the task-local `ToolLoopCostTrackingContext` was never scoped in those code paths.
- Why it matters: Users cannot track API spend for schedules, command-line, and web agent interactions — the most common non-channel usage modes.
- What changed: Initialize and scope the cost tracking context in `agent::run()` (CLI + cron), add `record_tool_loop_cost_usage` calls in `Agent::turn()`/`turn_streamed()` (gateway WS), and scope the context in `gateway/ws.rs`.
- What did **not** change: Channel-based cost tracking (already working), delegate sub-agents (inherit parent context automatically), cost storage/reporting infrastructure.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `agent`, `gateway`, `config`
- Module labels: `agent: cost`, `gateway: ws`
- Contributor tier label: n/a
- If any auto-label is incorrect, note requested correction: n/a

## Change Metadata

- Change type: `bug`
- Primary scope: `multi` (agent + gateway)

## Linked Issue

- Closes #5221

## Supersede Attribution (required when `Supersedes #` is used)

n/a

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # ✓ clean
cargo clippy --all-targets -- -D warnings   # ✓ no warnings
cargo test --lib --tests   # ✓ all tests pass (5910 unit + 159 integration + 5 system)
```

- Evidence provided: full test suite pass locally; one pre-existing doctest failure (stale .rlib artifact, reproduces on master)
- If any command is intentionally skipped, explain why: `--doc` tests skipped due to pre-existing build artifact issue on master

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: n/a
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: all existing cost tracking tests pass; channels path unchanged; CLI/cron/gateway paths now initialize and scope cost context
- Edge cases checked: no cost config = `None` context = no-op (same as before); delegate inherits parent task-local automatically
- What was not verified: live end-to-end cost recording with a real provider (CI should validate)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `agent::run()` (CLI + cron), `Agent::turn()`/`turn_streamed()` (gateway WS), `gateway/ws.rs`
- Potential unintended effects: Slightly more work per LLM call (cost recording + pricing lookup), but this is the intended behavior
- Guardrails/monitoring for early detection: existing `cost_tracking_records_usage_when_scoped` and `cost_tracking_is_noop_without_scope` tests validate the mechanism

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: correct scoping of task-local context, no regressions in existing tests
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`)

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: none (cost tracking is already config-gated via `[cost]` section)
- Observable failure symptoms: costs would stop being recorded for non-channel agents (silent regression, same as current bug)

## Risks and Mitigations

- Risk: Adding `provider_name` field to `Agent` struct could break external consumers using the builder pattern without setting it.
  - Mitigation: Field defaults to `"unknown"` via `unwrap_or_else` in builder — fully backward compatible.