### PR TITLE
fix: ignore generic API_KEY override for Bedrock to favor SigV4 fallback

### DIFF
--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -857,7 +857,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
                 if let Some(credential) = resolve_minimax_oauth_refresh_token(name) {
                     return Some(credential);
                 }
-            } else if name == "anthropic" || name == "openai" || name == "groq" {
+            } else if name == "anthropic" || name == "openai" || name == "groq" || name == "bedrock" || name == "aws-bedrock" {
                 // For well-known providers, prefer provider-specific env vars over the
                 // global api_key override, since the global key may belong to a different
                 // provider (e.g. a custom: gateway). This enables multi-provider setups
@@ -866,6 +866,7 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
                     "anthropic" => &["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"],
                     "openai" => &["OPENAI_API_KEY"],
                     "groq" => &["GROQ_API_KEY"],
+                    "bedrock" | "aws-bedrock" => &["BEDROCK_API_KEY"],
                     _ => &[],
                 };
                 for env_var in env_candidates {
@@ -876,6 +877,21 @@ fn resolve_provider_credential(name: &str, credential_override: Option<&str>) ->
                         }
                     }
                 }
+
+                // For Bedrock, we only use the override if it's NOT a generic generic API_KEY override.
+                // If it looks generic, we return None here to fall through to the internal
+                // SigV4 fallback logic.
+                if name == "bedrock" || name == "aws-bedrock" {
+                    let generic_vars = ["API_KEY", "ZEROCLAW_API_KEY"];
+                    let looks_generic = generic_vars.iter().any(|&var| {
+                        std::env::var(var).ok().map(|val| val.trim().to_string())
+                            == Some(trimmed_override.to_owned())
+                    });
+                    if looks_generic {
+                        return None;
+                    }
+                }
+
                 return Some(trimmed_override.to_owned());
             } else {
                 return Some(trimmed_override.to_owned());
@@ -2425,6 +2441,17 @@ mod tests {
         let resolved = resolve_provider_credential("minimax", Some(MINIMAX_OAUTH_PLACEHOLDER));
 
         assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn resolve_provider_credential_bedrock_ignores_generic_api_key_override() {
+        let _env_lock = env_lock();
+        let _generic_guard = EnvGuard::set("API_KEY", Some("generic-key"));
+        let _bedrock_guard = EnvGuard::set("BEDROCK_API_KEY", None);
+
+        // This is the bug! It currently returns Some("generic-key") instead of None.
+        let resolved = resolve_provider_credential("bedrock", Some("generic-key"));
+        assert!(resolved.is_none(), "Bedrock should have ignored the generic API_KEY override to fall back to SigV4, but got {:?}", resolved);
     }
 
     #[test]


### PR DESCRIPTION
When using provider = "bedrock", ZeroClaw currently reads the generic API_KEY or ZEROCLAW_API_KEY environment variables (which are often set for other providers like OpenAI or Anthropic) and attempts to use them as a bearer token for Bedrock requests.\n\nSince Bedrock typically authenticates via AWS SigV4 (AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY), sending a generic API key as a bearer token results in a 403 Forbidden error:\n'Bedrock API error (403 Forbidden): {"Message":"Invalid API Key format: Must start with pre-defined prefix"}'\n\nThis PR fixes the over-eager credential resolution for Bedrock by ignoring the generic API_KEY/ZEROCLAW_API_KEY override if it matches the environment variable. This allows the Bedrock provider to correctly fall back to SigV4 or BEDROCK_API_KEY as intended.\n\n### Fix Details:\n- Updated resolve_provider_credential to add 'bedrock' to the list of well-known providers.\n- Specifically check if the provided credential override for Bedrock is a generic one from the environment.\n- If it's generic, return None to trigger the SigV4 fallback logic.\n\nVerified by checking the credential resolution flow for both explicit Bedrock keys and generic environment overrides.