### PR TITLE
fix(provider): filter empty content blocks in Bedrock message conversion

### DIFF
--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -605,26 +605,23 @@ impl BedrockProvider {
                     }
                 }
                 "assistant" => {
-                    if let Some(blocks) = Self::parse_assistant_tool_call_message(&msg.content) {
+                    if let Some(blocks) = Self::parse_assistant_tool_call_message(&msg.content)
+                        .filter(|b| !b.is_empty())
+                    {
                         converse_messages.push(ConverseMessage {
                             role: "assistant".to_string(),
                             content: blocks,
                         });
-                    } else {
-                        // Guard: never send an empty text block to Bedrock.
-                        // This can happen when a daemon restart interrupts a
-                        // streaming response, leaving a partially-persisted
-                        // assistant message with empty content.
-                        let text = if msg.content.trim().is_empty() {
-                            "(empty response)".to_string()
-                        } else {
-                            msg.content.clone()
-                        };
+                    } else if !msg.content.trim().is_empty() {
                         converse_messages.push(ConverseMessage {
                             role: "assistant".to_string(),
-                            content: vec![ContentBlock::Text(TextBlock { text })],
+                            content: vec![ContentBlock::Text(TextBlock {
+                                text: msg.content.clone(),
+                            })],
                         });
                     }
+                    // Empty assistant messages (e.g. from interrupted streaming)
+                    // are silently dropped — Bedrock rejects empty TextBlocks.
                 }
                 "tool" => {
                     let tool_result_msg = Self::parse_tool_result_message(&msg.content)
@@ -674,10 +671,12 @@ impl BedrockProvider {
                 }
                 _ => {
                     let content_blocks = Self::parse_user_content_blocks(&msg.content);
-                    converse_messages.push(ConverseMessage {
-                        role: "user".to_string(),
-                        content: content_blocks,
-                    });
+                    if !content_blocks.is_empty() {
+                        converse_messages.push(ConverseMessage {
+                            role: "user".to_string(),
+                            content: content_blocks,
+                        });
+                    }
                 }
             }
         }
@@ -828,13 +827,10 @@ impl BedrockProvider {
             }));
         }
 
-        if blocks.is_empty() {
-            let fallback = if content.trim().is_empty() {
-                "(empty)".to_string()
-            } else {
-                content.to_string()
-            };
-            blocks.push(ContentBlock::Text(TextBlock { text: fallback }));
+        if blocks.is_empty() && !content.trim().is_empty() {
+            blocks.push(ContentBlock::Text(TextBlock {
+                text: content.to_string(),
+            }));
         }
 
         blocks
@@ -1532,6 +1528,39 @@ mod tests {
         let (_, msgs) = BedrockProvider::convert_messages(&messages);
         assert_eq!(msgs.len(), 1);
         assert!(matches!(msgs[0].content[0], ContentBlock::Text(_)));
+    }
+
+    #[test]
+    fn convert_messages_drops_empty_assistant() {
+        let messages = vec![
+            ChatMessage::user("Hello"),
+            ChatMessage::assistant(""),
+            ChatMessage::assistant("   "),
+            ChatMessage::user("Follow-up"),
+        ];
+        let (_, msgs) = BedrockProvider::convert_messages(&messages);
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].role, "user");
+        assert_eq!(msgs[1].role, "user");
+    }
+
+    #[test]
+    fn convert_messages_drops_empty_user() {
+        let messages = vec![ChatMessage::user("")];
+        let (_, msgs) = BedrockProvider::convert_messages(&messages);
+        assert!(msgs.is_empty());
+    }
+
+    #[test]
+    fn convert_messages_assistant_empty_tool_calls_falls_back_to_text() {
+        // JSON with empty tool_calls and empty content: parsed blocks are empty
+        // so the filter drops them, but the raw JSON string is non-blank so it
+        // falls through to the plain-text branch (still valid for Bedrock).
+        let messages = vec![ChatMessage::assistant(r#"{"content":"","tool_calls":[]}"#)];
+        let (_, msgs) = BedrockProvider::convert_messages(&messages);
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "assistant");
+        assert!(matches!(&msgs[0].content[0], ContentBlock::Text(_)));
     }
 
     // ── Cache tests ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Bedrock Converse API returns 400 ("The text field in the ContentBlock object is blank") when empty text ContentBlocks are sent in conversation history. This occurs after daemon restarts (partially-received assistant messages persisted with empty content) or with attachment-only/bot messages.
- Why it matters: The conversation is permanently broken — every subsequent request fails with the same 400 because the empty message is stuck in history. Users must manually clear history or start a new conversation.
- What changed: Added empty/whitespace content filtering at four sites in `convert_messages()` and `parse_user_content_blocks()` to prevent empty TextBlocks from reaching the Bedrock API.
- What did **not** change: Tool result messages, system messages, non-Bedrock providers, streaming logic, history persistence. No config or API surface changes.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `provider`
- Module labels: `provider: bedrock`
- Contributor tier label: N/A (external)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `provider`

## Linked Issue

- Closes #5228

## Validation Evidence (required)

```bash
cargo fmt --all -- --check         # pass
cargo clippy --all-targets -- -D warnings  # pass (0 warnings)
cargo test --lib -- providers::bedrock::tests  # 50 passed; 0 failed (47 existing + 3 new)
```

- Evidence provided: All existing Bedrock tests pass, plus 3 new tests covering empty assistant, empty user, and empty-tool-calls-JSON messages.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Empty assistant message (empty string), whitespace-only assistant message, empty user message, assistant with empty tool_calls JSON, all existing convert_messages test cases.
- Edge cases checked: Whitespace-only content (trimmed check), JSON with empty tool_calls array (falls back to text since raw JSON is non-blank), structured tool call messages with empty blocks vector (filtered).
- What was not verified: Live Bedrock API call (no AWS credentials in test environment).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Bedrock provider message conversion only.
- Potential unintended effects: Empty messages are silently dropped from the conversation history sent to Bedrock. This means the Bedrock model won't see them, but they were already causing 400 errors so removing them is strictly better.
- Guardrails/monitoring for early detection: Existing Bedrock test suite covers the affected paths.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (research + implementation)
- Verification focus: All 50 Bedrock provider tests pass (47 existing + 3 new).
- Confirmation: naming + architecture boundaries followed (AGENTS.md + CONTRIBUTING.md): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <sha>`
- Feature flags or config toggles: None needed — pure bug fix
- Observable failure symptoms: If rollback needed, Bedrock 400 errors return for conversations with empty history messages.

## Risks and Mitigations

- Risk: Dropping empty messages could affect conversation turn order if Bedrock expects strict alternation.
  - Mitigation: Empty messages carry no semantic content and were already causing hard failures. The Bedrock API validates turn order independently, and consecutive same-role messages are handled elsewhere in the conversion logic.