### PR TITLE
fix(channels): refresh stale Qwen OAuth token in channel provider cache

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1445,7 +1445,18 @@ async fn get_or_create_provider(
 ) -> anyhow::Result<Arc<dyn Provider>> {
     let cache_key = provider_cache_key(provider_name, route_api_key);
 
-    if let Some(existing) = ctx
+    // For Qwen OAuth providers, check whether the cached token has expired.
+    // If stale, evict the cached entry so a fresh provider is created below
+    // (which triggers token refresh via `resolve_qwen_oauth_context`).
+    let qwen_stale =
+        providers::is_qwen_oauth_alias(provider_name) && providers::is_qwen_oauth_token_stale();
+
+    if qwen_stale {
+        ctx.provider_cache
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&cache_key);
+    } else if let Some(existing) = ctx
         .provider_cache
         .lock()
         .unwrap_or_else(|e| e.into_inner())
@@ -1457,8 +1468,9 @@ async fn get_or_create_provider(
 
     // Only return the pre-built default provider when there is no
     // route-specific credential override — otherwise the default was
-    // created with the global key and would be wrong.
-    if route_api_key.is_none() && provider_name == ctx.default_provider.as_str() {
+    // created with the global key and would be wrong.  Also skip when
+    // the OAuth token is stale so we recreate with refreshed credentials.
+    if !qwen_stale && route_api_key.is_none() && provider_name == ctx.default_provider.as_str() {
         return Ok(Arc::clone(&ctx.provider));
     }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -152,6 +152,17 @@ pub(crate) fn is_qwen_oauth_alias(name: &str) -> bool {
     matches!(name, "qwen-code" | "qwen-oauth" | "qwen_oauth")
 }
 
+/// Returns `true` when the cached Qwen OAuth token is expired (or missing)
+/// and the provider should be recreated so that
+/// [`resolve_qwen_oauth_context`] can refresh it.
+pub(crate) fn is_qwen_oauth_token_stale() -> bool {
+    match read_qwen_oauth_cached_credentials() {
+        Some(creds) => qwen_oauth_token_expired(&creds),
+        // No cached credentials — provider creation will attempt a refresh.
+        None => true,
+    }
+}
+
 pub(crate) fn is_bailian_alias(name: &str) -> bool {
     matches!(name, "bailian" | "aliyun-bailian" | "aliyun")
 }


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The channel subsystem (Discord, Telegram, etc.) caches provider instances at daemon startup and never refreshes Qwen OAuth tokens. After the token expires (a few hours), all channel-originated requests fail with auth errors while the CLI continues to work.
- Why it matters: Qwen OAuth users cannot use ZeroClaw through any channel after token expiry — S0 severity since it breaks the primary interaction path.
- What changed: Added `is_qwen_oauth_token_stale()` in `src/providers/mod.rs` and modified `get_or_create_provider()` in `src/channels/mod.rs` to evict cached providers when the Qwen OAuth token is expired, forcing recreation with refreshed credentials.
- What did **not** change: CLI behavior, non-Qwen provider caching, provider creation logic, token refresh mechanism itself.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`, `provider`
- Module labels: `provider: qwen`
- Contributor tier label: n/a
- If any auto-label is incorrect, note requested correction: n/a

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #5219

## Supersede Attribution (required when `Supersedes #` is used)

n/a

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # ✓ clean
cargo clippy --all-targets -- -D warnings   # ✓ no warnings
cargo test   # ✓ 12,153 passed, 0 failed, 13 ignored
```

- Evidence provided: full test suite pass

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (existing refresh mechanism is reused)
- Secrets/tokens handling changed? No (credential flow is unchanged; only cache eviction timing changed)
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: n/a

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: no PII involved
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: full test suite (12,153 tests), fmt, clippy all pass
- Edge cases checked: (1) non-Qwen providers unaffected — `is_qwen_oauth_alias` gate ensures only Qwen OAuth hits the new path; (2) when no cached credentials exist, `is_qwen_oauth_token_stale` returns true so provider is recreated allowing refresh attempt; (3) default provider shortcut also gated to avoid returning stale Arc
- What was not verified: live Qwen OAuth token expiry on Discord (requires real Qwen OAuth credentials + Discord bot setup)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `get_or_create_provider()` in channels — only for Qwen OAuth provider names
- Potential unintended effects: slightly more provider instantiations for Qwen OAuth when token expires (one-time cost per expiry cycle)
- Guardrails/monitoring for early detection: existing provider warmup warnings will log if the fresh provider fails

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: investigated OAuth flow divergence between CLI and channels; identified cache as root cause; added expiry check to cache lookup
- Verification focus: correctness of cache eviction logic, no regression for non-OAuth providers
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: none
- Observable failure symptoms: Qwen OAuth channels would fail again after token expiry

## Risks and Mitigations

- Risk: File I/O on every channel message for Qwen OAuth providers (reading cached credentials to check expiry).
  - Mitigation: `read_qwen_oauth_cached_credentials` reads a small JSON file — negligible latency. Only called for Qwen OAuth aliases, not all providers.