### PR TITLE
fix(provider): clean tool schemas before sending to llama.cpp/Ollama

### DIFF
--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -446,12 +446,13 @@ impl OpenAiCompatibleProvider {
         tools
             .iter()
             .map(|tool| {
+                let params = crate::tools::SchemaCleanr::clean_for_openai(tool.parameters.clone());
                 serde_json::json!({
                     "type": "function",
                     "function": {
                         "name": tool.name,
                         "description": tool.description,
-                        "parameters": tool.parameters
+                        "parameters": params
                     }
                 })
             })
@@ -1390,12 +1391,14 @@ impl OpenAiCompatibleProvider {
             items
                 .iter()
                 .map(|tool| {
+                    let params =
+                        crate::tools::SchemaCleanr::clean_for_openai(tool.parameters.clone());
                     serde_json::json!({
                         "type": "function",
                         "function": {
                             "name": tool.name,
                             "description": tool.description,
-                            "parameters": tool.parameters,
+                            "parameters": params,
                         }
                     })
                 })

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -846,12 +846,14 @@ impl Provider for OllamaProvider {
                 let tools: Vec<serde_json::Value> = specs
                     .iter()
                     .map(|s| {
+                        let params =
+                            crate::tools::SchemaCleanr::clean_for_openai(s.parameters.clone());
                         serde_json::json!({
                             "type": "function",
                             "function": {
                                 "name": s.name,
                                 "description": s.description,
-                                "parameters": s.parameters
+                                "parameters": params
                             }
                         })
                     })


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: llama.cpp with gemma4 crashes when tool parameter schemas contain `"type": ["string", "null"]` (JSON array). The Jinja chat template calls `| upper` on the type field, which fails on arrays.
- Why it matters: completely blocks generation for all llama.cpp + gemma4 users with tool calling enabled (S1 severity).
- What changed: apply `SchemaCleanr::clean_for_openai()` to tool parameter schemas before serializing them in all three OpenAI-compatible tool-spec conversion points (`tool_specs_to_openai_format`, `convert_tool_specs` in compatible.rs, and the Ollama tool spec builder).
- What did **not** change: tool schema definitions themselves, SchemaCleanr implementation, non-tool-calling API paths.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `provider`
- Module labels: `provider: compatible`, `provider: ollama`
- Contributor tier label: auto-managed
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `provider`

## Linked Issue

- Closes #5224
- Related: N/A
- Depends on: N/A
- Supersedes: N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check    # ✅ clean
cargo clippy --all-targets -- -D warnings  # ✅ no warnings
cargo test                    # ✅ all tests pass (5907 lib + 191 integration + 159 benches + 5 system)
```

- Evidence provided: all commands pass locally on rustc 1.93.1
- If any command is intentionally skipped: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes — schemas are cleaned to a more standard form; existing working setups are unaffected
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: confirmed `SchemaCleanr::clean_type_array()` converts `["string", "null"]` → `"string"` (existing test `test_type_array_null_removal`); verified all three conversion points now apply cleaning
- Edge cases checked: schemas with no type arrays pass through unchanged; schemas with `["string"]` (single-element array) are reduced to `"string"`
- What was not verified: end-to-end with llama.cpp + gemma4 (requires GPU setup)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: OpenAI-compatible provider (llama.cpp, LM Studio, vLLM, etc.) and Ollama provider tool-calling paths
- Potential unintended effects: minimal — `clean_for_openai` is the most permissive strategy, only removing `null` from type arrays and resolving `$ref`s
- Guardrails/monitoring: existing `test_type_array_null_removal` test validates the core transformation

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: traced the issue from the gemma4 Jinja template error → type array in tool schema → raw schema serialization in provider code → existing but unused SchemaCleanr infrastructure
- Verification focus: ensure cleaning is applied consistently across all provider tool-spec paths
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>` — single commit, no migration
- Feature flags or config toggles: N/A
- Observable failure symptoms: same error as #5224 (llama.cpp 500 with Jinja upper filter error)

## Risks and Mitigations

- Risk: `clean_for_openai` might remove schema information needed by some providers
  - Mitigation: OpenAI strategy is the most permissive — only removes `null` from type arrays and resolves `$ref`s. The transformation is well-tested and matches what providers expect.