### PR TITLE
fix(config): support env var overrides for Slack channel tokens

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -10388,6 +10388,35 @@ impl Config {
                 }
             }
         }
+        // Channel tokens: allow credentials to be supplied via environment
+        // variables so they don't need to be hardcoded in config.toml.
+        if let Some(ref mut sl) = self.channels_config.slack {
+            if let Ok(bot_token) = std::env::var("SLACK_BOT_TOKEN") {
+                if !bot_token.is_empty() {
+                    sl.bot_token = bot_token;
+                }
+            }
+            if let Ok(app_token) = std::env::var("SLACK_APP_TOKEN") {
+                if !app_token.is_empty() {
+                    sl.app_token = Some(app_token);
+                }
+            }
+        }
+        if let Some(ref mut dc) = self.channels_config.discord {
+            if let Ok(bot_token) = std::env::var("DISCORD_BOT_TOKEN") {
+                if !bot_token.is_empty() {
+                    dc.bot_token = bot_token;
+                }
+            }
+        }
+        if let Some(ref mut tg) = self.channels_config.telegram {
+            if let Ok(bot_token) = std::env::var("TELEGRAM_BOT_TOKEN") {
+                if !bot_token.is_empty() {
+                    tg.bot_token = bot_token;
+                }
+            }
+        }
+
         // Proxy enabled flag: ZEROCLAW_PROXY_ENABLED
         let explicit_proxy_enabled = std::env::var("ZEROCLAW_PROXY_ENABLED")
             .ok()


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Slack (and other channel) bot tokens cannot be supplied via environment variables. The `${env:VAR}` syntax is not valid TOML and no post-parse expansion exists, forcing users to hardcode credentials in config.toml.
- Why it matters: S1 — blocks anyone who wants to follow security best practices by keeping secrets out of config files.
- What changed: Added env var override support in `apply_env_overrides()` for `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `DISCORD_BOT_TOKEN`, and `TELEGRAM_BOT_TOKEN`. Env vars take precedence over config.toml values when set and non-empty.
- What did **not** change: Config parsing, TOML schema, encryption/decryption flow, channel initialization logic.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `config`, `channel`
- Module labels: `channel: slack`, `channel: discord`, `channel: telegram`
- Contributor tier label: n/a
- If any auto-label is incorrect, note requested correction: n/a

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #5183

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # ✓ clean
cargo clippy --all-targets -- -D warnings   # ✓ no warnings
cargo test   # ✓ 12,148 passed, 0 failed
```

- Evidence provided: full test suite pass

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? Yes — channel tokens can now be supplied via env vars
- File system access scope changed? No
- If any `Yes`, describe risk and mitigation: This is a security improvement — env vars are the standard way to supply secrets without persisting them in config files.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: no PII involved
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes — env vars only override when set; existing config.toml values work unchanged
- Config/env changes? Yes — new optional env vars: `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `DISCORD_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN`
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: full test suite pass, fmt, clippy clean
- Edge cases checked: empty env vars are ignored; missing env vars fall through to config.toml values
- What was not verified: live Slack/Discord/Telegram bot authentication with env vars

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `apply_env_overrides()` in config schema — channel token fields only
- Potential unintended effects: none — follows the same precedence model as `ZEROCLAW_API_KEY`
- Guardrails/monitoring for early detection: env var names are channel-specific and unlikely to collide

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: none
- Observable failure symptoms: channel tokens would revert to config.toml-only behavior

## Risks and Mitigations

- Risk: Users with stale env vars may inadvertently override their config.toml tokens.
  - Mitigation: Same precedence model as `ZEROCLAW_API_KEY`. Env var wins when set and non-empty.