### PR TITLE
fix(tool): collapse JSON Schema type arrays to single string for llama.cpp

### DIFF
--- a/src/tools/schema.rs
+++ b/src/tools/schema.rs
@@ -465,7 +465,11 @@ impl SchemaCleanr {
         })
     }
 
-    /// Clean type array, removing null.
+    /// Clean type array by removing null and collapsing to a single type string.
+    ///
+    /// Many LLM backends (llama.cpp, Gemini, etc.) do not support JSON Schema
+    /// type arrays and will error when `"type"` is not a plain string.
+    /// When multiple non-null types remain, the first one is used.
     fn clean_type_array(value: Value) -> Value {
         if let Value::Array(types) = value {
             let non_null: Vec<Value> = types
@@ -475,11 +479,11 @@ impl SchemaCleanr {
 
             match non_null.len() {
                 0 => Value::String("null".to_string()),
-                1 => non_null
+                // One or more: always collapse to a single string type.
+                _ => non_null
                     .into_iter()
                     .next()
                     .unwrap_or(Value::String("null".to_string())),
-                _ => Value::Array(non_null),
             }
         } else {
             value
@@ -776,6 +780,20 @@ mod tests {
         let cleaned = SchemaCleanr::clean_for_gemini(schema);
 
         assert_eq!(cleaned["type"], "null");
+    }
+
+    #[test]
+    fn test_type_array_multi_collapses_to_first() {
+        let schema = json!({
+            "type": ["string", "integer"]
+        });
+
+        // All strategies should collapse multi-type arrays to the first type.
+        let cleaned_openai = SchemaCleanr::clean_for_openai(schema.clone());
+        assert_eq!(cleaned_openai["type"], "string");
+
+        let cleaned_gemini = SchemaCleanr::clean_for_gemini(schema);
+        assert_eq!(cleaned_gemini["type"], "string");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: llama.cpp with gemma4 model returns 500 Internal Server Error because its Jinja template applies `| upper` filter to tool parameter `type` values, which crashes when `type` is a JSON array (e.g., `["string", "integer"]`) instead of a plain string.
- Why it matters: Users running llama.cpp with gemma4 (and potentially other models) are completely blocked — every request fails with a 500 error.
- What changed: `SchemaCleanr::clean_type_array()` now always collapses multi-type arrays to the first non-null type string, instead of only collapsing single-type-plus-null arrays. This ensures `type` is always a plain string in cleaned schemas.
- What did **not** change (scope boundary): No changes to tool definitions, provider logic, or any other schema cleaning methods. The `oneOf`/`anyOf` simplification logic is untouched.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `tool`
- Module labels: `tool: schema`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `tool`

## Linked Issue

- Closes #5256

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # ✓ clean
cargo clippy --all-targets -- -D warnings   # ✓ clean
cargo test --lib -- --skip gateway   # ✓ 5785 passed, 0 failed
cargo test --bin zeroclaw -- --skip gateway   # ✓ 5762 passed, 0 failed
```

- Evidence provided: 1 new unit test (`test_type_array_multi_collapses_to_first`) verifying multi-type arrays are collapsed to a single type for both OpenAI and Gemini strategies.
- If any command is intentionally skipped, explain why: `gateway::tests` skipped — pre-existing timeout issue on local environment, unrelated to this change.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No personal data involved.
- Neutral wording confirmation: Confirmed.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: `["string", "null"]` → `"string"` (existing behavior preserved); `["null"]` → `"null"` (preserved); `["string", "integer"]` → `"string"` (new behavior); plain `"string"` → `"string"` (passthrough unchanged).
- Edge cases checked: Empty array (cannot occur — JSON Schema requires at least one type); all-null array `["null"]` → `"null"`.
- What was not verified: Live llama.cpp + gemma4 end-to-end (requires local model setup).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: All providers that use `SchemaCleanr` for tool schema cleaning (compatible/llamacpp, ollama, gemini, anthropic, openai).
- Potential unintended effects: Tools with genuinely multi-typed parameters (e.g., `["string", "integer"]`) will now only advertise the first type. In practice, no existing tool schemas use multi-type arrays without null, so this has no real impact.
- Guardrails/monitoring for early detection: Existing tool calling tests cover schema cleaning; any regression would surface as tool call failures.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Traced the error from llama.cpp Jinja template through the compatible provider to SchemaCleanr; identified that `clean_type_array` left multi-type arrays intact; applied minimal fix.
- Verification focus: Schema cleaning correctness across all strategies.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>` — single commit, single file changed.
- Feature flags or config toggles: None needed.
- Observable failure symptoms: llama.cpp 500 errors with "filter 'upper' for type Array" message.

## Risks and Mitigations

- Risk: Loss of type precision for multi-type parameters (e.g., `["string", "integer"]` becomes `"string"`).
  - Mitigation: No existing tool schemas use multi-type arrays without null. If needed in the future, a provider-specific cleaning strategy can be added.