### PR TITLE
fix(gateway): echo Sec-WebSocket-Protocol in canvas WebSocket upgrade

### DIFF
--- a/src/gateway/canvas.rs
+++ b/src/gateway/canvas.rs
@@ -18,6 +18,9 @@ use axum::{
 use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
 
+/// Subprotocol expected by the Canvas frontend (`web/src/pages/Canvas.tsx`).
+const WS_CANVAS_PROTOCOL: &str = "zeroclaw.v1";
+
 /// POST /api/canvas/:id request body.
 #[derive(Deserialize)]
 pub struct CanvasPostBody {
@@ -194,6 +197,18 @@ pub async fn handle_ws_canvas(
                 .into_response();
         }
     }
+
+    // Echo Sec-WebSocket-Protocol if the client requests our sub-protocol (RFC 6455 §4.2.2).
+    let ws = if headers
+        .get("sec-websocket-protocol")
+        .and_then(|v| v.to_str().ok())
+        .map_or(false, |protos| {
+            protos.split(',').any(|p| p.trim() == WS_CANVAS_PROTOCOL)
+        }) {
+        ws.protocols([WS_CANVAS_PROTOCOL])
+    } else {
+        ws
+    };
 
     ws.on_upgrade(move |socket| handle_canvas_socket(socket, state, id))
         .into_response()


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: The Canvas WebSocket endpoint (`/ws/canvas/:id`) did not echo the `Sec-WebSocket-Protocol` header in its 101 Switching Protocols response. Per RFC 6455 §4.2.2, browsers reject the connection when the client sends a subprotocol but the server doesn't echo one back.
- Why it matters: The Canvas page is completely broken in all modern browsers — Chrome rejects with "Sent non-empty 'Sec-WebSocket-Protocol' header but no response was received".
- What changed: Added `ws.protocols(["zeroclaw.v1"])` echo logic to `handle_ws_canvas`, matching the existing pattern in `ws.rs` (chat WebSocket) and `nodes.rs` (node WebSocket).
- What did **not** change: Auth logic, socket handling, broadcast logic, frontend code — all untouched.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `gateway`
- Module labels: `gateway: canvas`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `gateway`

## Linked Issue

- Closes #5354
- Related: N/A
- Depends on: N/A
- Supersedes: N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A — not superseding any PR.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check     # ✅ clean
cargo clippy --all-targets -- -D warnings  # ✅ 0 warnings
cargo test                     # ✅ all passed
```

- Evidence provided: all three CI commands run locally and passed
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Confirmed the existing `ws.rs` and `nodes.rs` handlers use the identical `.protocols()` echo pattern; confirmed `Canvas.tsx` sends `zeroclaw.v1` subprotocol
- Edge cases checked: When client does NOT send subprotocol header, the `else` branch passes `ws` through unmodified — no regression for non-browser clients
- What was not verified: Live browser test (no running instance), but the fix is mechanically identical to the working chat/node WebSocket handlers

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Canvas WebSocket connections only
- Potential unintended effects: None — the protocol echo is additive and only triggers when the client requests `zeroclaw.v1`
- Guardrails/monitoring for early detection: Existing gateway logs will show WebSocket upgrade success/failure

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Read issue → identify root cause in `canvas.rs` → match existing pattern from `ws.rs`/`nodes.rs` → apply minimal fix → validate all CI checks
- Verification focus: Pattern consistency with other WebSocket handlers
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>` — single commit, single file
- Feature flags or config toggles: None needed
- Observable failure symptoms: Canvas page WebSocket connection failure in browser console

## Risks and Mitigations

- Risk: None — this is a 15-line additive fix matching an established pattern used by two other handlers in the same codebase.