### PR TITLE
fix(skills): tighten agent-approved gate for PR reviews

### DIFF
--- a/.claude/skills/github-pr-review/SKILL.md
+++ b/.claude/skills/github-pr-review/SKILL.md
@@ -79,7 +79,7 @@ Every PR decision is governed by these — see `AGENTS.md` for full rationale:
 | Suggest documentation improvements | Act. Comment only, don't push. |
 | Skip draft PRs | Act. |
 | Skip high-risk path (non-docs) PRs | Act. |
-| Mark PR as ready to merge | Act. Apply `agent-approved` label. |
+| Mark PR as ready to merge | Act. Apply `agent-approved` label. **Only when there are zero findings of any severity — no `[blocking]`, no `[suggestion]`, no `[question]`.** Any outstanding feedback means "Needs author action", not approved. |
 | Push code to contributor branch | Never. |
 | Merge to master | Never. Human only. |
 | Close duplicate PRs autonomously | Never. Flag for maintainer. |

--- a/.claude/skills/github-pr-review/references/review-protocol.md
+++ b/.claude/skills/github-pr-review/references/review-protocol.md
@@ -1,4 +1,4 @@
-# PR Review Protocol — Full Reference
+  # PR Review Protocol — Full Reference
 
 This is the detailed, phase-by-phase review protocol. The SKILL.md provides the quick reference; this document is the authoritative procedure.
 
@@ -220,6 +220,7 @@ Before marking ready, re-read the PR page for:
 Use one of three outcomes per `reviewer-playbook.md` §3.4. Every verdict comment must open with the **PR comprehension summary** from §1.2 (what, why, blast radius) and include the **security/performance assessment** from §3.4.
 
 **Ready to merge:**
+- **Gate:** Only use this verdict when there are **zero** `[blocking]` findings AND **zero** `[suggestion]` findings. If there are any suggestions — even non-blocking ones — use "Needs author action" instead. The `agent-approved` label means "nothing left to do, just merge." Any outstanding feedback, however minor, means the PR is not ready.
 - Leave a comment that:
   - Thanks the contributor.
   - Opens with the comprehension summary (what this PR does and why).
@@ -231,11 +232,12 @@ Use one of three outcomes per `reviewer-playbook.md` §3.4. Every verdict commen
 - **Do NOT merge. Do NOT rebase and merge. A human maintainer will do this.**
 
 **Needs author action:**
+- **Gate:** Use this verdict when there are ANY findings — `[blocking]`, `[suggestion]`, or `[question]`. Even a single suggestion means the PR is not ready for blind merge.
 - Leave a comment that:
   - Thanks the contributor.
   - Opens with the comprehension summary.
   - Notes what is already good (avoid demoralizing contributors).
-  - Lists blocking issues in priority order, each with a severity tag (`[blocking]` or `[suggestion]`).
+  - Lists all issues in priority order, each with a severity tag (`[blocking]` or `[suggestion]`).
   - States clearly what must change before re-review.
 - Do not apply `agent-approved`.
 


### PR DESCRIPTION
## Summary
- Tightens the `agent-approved` label gate so it is only applied when there are **zero** findings of any severity (`[blocking]`, `[suggestion]`, or `[question]`)
- Any outstanding feedback — even non-blocking suggestions — now routes to "Needs author action" instead of marking ready to merge
- Prevents PRs with open suggestions from being rubber-stamped as merge-ready

## Test plan
- [ ] Trigger a PR review on a PR with only `[suggestion]` findings and verify verdict is "Needs author action", not "Ready to merge"
- [ ] Trigger a PR review on a clean PR with zero findings and verify `agent-approved` label is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)