### PR TITLE
Fix #5228: skip empty text ContentBlocks to avoid 400 errors

### DIFF
--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -610,7 +610,7 @@ impl BedrockProvider {
                             role: "assistant".to_string(),
                             content: blocks,
                         });
-                    } else {
+                    } else if !msg.content.trim().is_empty() {
                         converse_messages.push(ConverseMessage {
                             role: "assistant".to_string(),
                             content: vec![ContentBlock::Text(TextBlock {
@@ -800,7 +800,7 @@ impl BedrockProvider {
             }));
         }
 
-        if blocks.is_empty() {
+        if blocks.is_empty() && !content.trim().is_empty() {
             blocks.push(ContentBlock::Text(TextBlock {
                 text: content.to_string(),
             }));


### PR DESCRIPTION
## Summary

Fixes #5228

## Changes

When content is empty or whitespace-only (e.g., daemon restart mid-response, attachment-only messages), Bedrock API returns 400 error if a TextBlock with empty content is sent.

Changes:
- `parse_user_content_blocks`: only create fallback TextBlock when content is not empty/whitespace
- Assistant message handling: skip creating TextBlock when content is empty/whitespace

## Testing

- Built and tested locally (Rust build succeeds)
- Issue describes the problem: after daemon restart, empty text ContentBlocks cause 400 errors