### PR TITLE
fix(agent): add per-route context_window override and block memory auto_save snowball

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -269,6 +269,10 @@ struct ChannelRouteSelection {
     /// the global `api_key` in [`ChannelRuntimeContext`] when creating the
     /// provider for this route.
     api_key: Option<String>,
+    /// Route-specific context window override (in tokens). When set, takes
+    /// precedence over the global `context_token_budget` for preemptive
+    /// trimming and proactive compression.
+    context_window: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1029,6 +1033,7 @@ fn default_route_selection(ctx: &ChannelRuntimeContext) -> ChannelRouteSelection
         provider: defaults.default_provider,
         model: defaults.model,
         api_key: None,
+        context_window: None,
     }
 }
 
@@ -1812,8 +1817,10 @@ async fn handle_runtime_command_if_needed(
                     current.provider = route.provider.clone();
                     current.model = route.model.clone();
                     current.api_key = route.api_key.clone();
+                    current.context_window = route.context_window;
                 } else {
                     current.model = model.clone();
+                    current.context_window = None;
                 }
                 set_route_selection(ctx, &sender_key, current.clone());
 
@@ -2550,9 +2557,15 @@ async fn process_channel_message(
                 provider: matched_route.provider.clone(),
                 model: matched_route.model.clone(),
                 api_key: matched_route.api_key.clone(),
+                context_window: matched_route.context_window,
             };
         }
     }
+
+    // Use route-specific context window when available, otherwise fall back
+    // to the global max_context_tokens config. This lets large-context models
+    // (e.g. 200k+ behind litellm) avoid aggressive preemptive trimming.
+    let effective_context_budget = route.context_window.unwrap_or(ctx.context_token_budget);
 
     let runtime_defaults = runtime_defaults_snapshot(ctx.as_ref());
     let mut active_provider = match get_or_create_provider(
@@ -2753,7 +2766,7 @@ async fn process_channel_message(
         let cc_config = ctx.prompt_config.agent.context_compression.clone();
         let compressor = crate::agent::context_compressor::ContextCompressor::new(
             cc_config,
-            ctx.context_token_budget,
+            effective_context_budget,
         )
         .with_memory(Arc::clone(&ctx.memory));
         match compressor
@@ -3032,7 +3045,7 @@ async fn process_channel_message(
                         Some(model_switch_callback.clone()),
                         &ctx.pacing,
                         ctx.max_tool_result_chars,
-                        ctx.context_token_budget,
+                        effective_context_budget,
                         None, // shared_budget
                     ),
                     ),
@@ -7380,6 +7393,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 provider: "openrouter".to_string(),
                 model: "route-model".to_string(),
                 api_key: None,
+                context_window: None,
             },
         );
 
@@ -10884,6 +10898,7 @@ This is an example JSON object for profile settings."#;
             provider: "vision-provider".into(),
             model: "gpt-4-vision".into(),
             api_key: None,
+            context_window: None,
         }];
 
         let runtime_ctx = Arc::new(ChannelRuntimeContext {
@@ -11004,6 +11019,7 @@ This is an example JSON object for profile settings."#;
             provider: "vision-provider".into(),
             model: "gpt-4-vision".into(),
             api_key: None,
+            context_window: None,
         }];
 
         let runtime_ctx = Arc::new(ChannelRuntimeContext {
@@ -11116,6 +11132,7 @@ This is an example JSON object for profile settings."#;
             provider: "vision-provider".into(),
             model: "gpt-4-vision".into(),
             api_key: None,
+            context_window: None,
         }];
 
         let runtime_ctx = Arc::new(ChannelRuntimeContext {
@@ -11241,12 +11258,14 @@ This is an example JSON object for profile settings."#;
                 provider: "fast-provider".into(),
                 model: "fast-model".into(),
                 api_key: None,
+                context_window: None,
             },
             crate::config::ModelRouteConfig {
                 hint: "code".into(),
                 provider: "code-provider".into(),
                 model: "code-model".into(),
                 api_key: None,
+                context_window: None,
             },
         ];
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -5649,6 +5649,12 @@ pub struct ModelRouteConfig {
     /// Optional API key override for this route's provider
     #[serde(default)]
     pub api_key: Option<String>,
+    /// Optional context window size (in tokens) for this route's model.
+    /// When set, overrides `agent.max_context_tokens` for channel messages
+    /// routed through this model, preventing aggressive preemptive trimming
+    /// on large-context models (e.g. 200k+ token windows).
+    #[serde(default)]
+    pub context_window: Option<usize>,
 }
 
 // ── Embedding routing ───────────────────────────────────────────

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -1166,6 +1166,7 @@ mod tests {
             provider: "groq".into(),
             model: String::new(),
             api_key: None,
+            context_window: None,
         }];
         let mut items = Vec::new();
         check_config_semantics(&config, &mut items);

--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -1716,6 +1716,7 @@ mod tests {
             provider: "openrouter".to_string(),
             model: "anthropic/claude-sonnet-4.6".to_string(),
             api_key: Some("route-model-key".to_string()),
+            context_window: None,
         }];
         cfg.embedding_routes = vec![crate::config::schema::EmbeddingRouteConfig {
             hint: "semantic".to_string(),
@@ -1854,12 +1855,14 @@ mod tests {
                 provider: "openrouter".to_string(),
                 model: "anthropic/claude-sonnet-4.6".to_string(),
                 api_key: Some("route-model-key-1".to_string()),
+                context_window: None,
             },
             crate::config::schema::ModelRouteConfig {
                 hint: "fast".to_string(),
                 provider: "openrouter".to_string(),
                 model: "openai/gpt-4.1-mini".to_string(),
                 api_key: Some("route-model-key-2".to_string()),
+                context_window: None,
             },
         ];
         current.embedding_routes = vec![
@@ -2006,12 +2009,14 @@ mod tests {
                 provider: "openrouter".to_string(),
                 model: "anthropic/claude-sonnet-4.6".to_string(),
                 api_key: Some("route-model-key-1".to_string()),
+                context_window: None,
             },
             crate::config::schema::ModelRouteConfig {
                 hint: "fast".to_string(),
                 provider: "openrouter".to_string(),
                 model: "openai/gpt-4.1-mini".to_string(),
                 api_key: Some("route-model-key-2".to_string()),
+                context_window: None,
             },
         ];
         current.embedding_routes = vec![
@@ -2041,6 +2046,7 @@ mod tests {
                 provider: "openai".to_string(),
                 model: "gpt-4.1".to_string(),
                 api_key: Some(MASKED_SECRET.to_string()),
+                context_window: None,
             });
         incoming
             .embedding_routes

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -113,6 +113,7 @@ pub fn should_skip_autosave_content(content: &str) -> bool {
     lowered.starts_with("[cron:")
         || lowered.starts_with("[heartbeat task")
         || lowered.starts_with("[distilled_")
+        || lowered.starts_with("[memory context]")
         || lowered.contains("distilled_index_sig:")
 }
 
@@ -444,6 +445,9 @@ mod tests {
         ));
         assert!(should_skip_autosave_content(
             "[Heartbeat Task | high] Execute scheduled patrol"
+        ));
+        assert!(should_skip_autosave_content(
+            "[Memory context]\n- user_name: alice\n- project: zeroclaw\n[/Memory context]"
         ));
         assert!(!should_skip_autosave_content(
             "User prefers concise answers."

--- a/src/tools/model_routing_config.rs
+++ b/src/tools/model_routing_config.rs
@@ -534,6 +534,7 @@ impl ModelRoutingConfigTool {
             provider: provider.clone(),
             model: model.clone(),
             api_key: None,
+            context_window: None,
         });
 
         next_route.hint = hint.clone();


### PR DESCRIPTION
## Summary
- Add optional `context_window` field to `[[model_routes]]` for per-route context window override (tokens). Useful to cap context on backends with limited VRAM.
- Block `[Memory context]` auto_save from snowballing across turns (#4916).

## Test plan
- [ ] Verify per-route `context_window` override applies correctly
- [ ] Verify memory context auto_save no longer snowballs
- [ ] `cargo test` passes