### PR TITLE
feat(channels): configurable concurrency per channel and DM precheck skip

### DIFF
--- a/src/channels/bluesky.rs
+++ b/src/channels/bluesky.rs
@@ -253,6 +253,7 @@ impl BlueskyChannel {
             thread_ts: Some(notif.uri.clone()),
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: false,
         })
     }
 

--- a/src/channels/cli.rs
+++ b/src/channels/cli.rs
@@ -50,6 +50,7 @@ impl Channel for CliChannel {
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             };
 
             if tx.send(msg).await.is_err() {
@@ -119,6 +120,7 @@ mod tests {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
         assert_eq!(msg.id, "test-id");
         assert_eq!(msg.sender, "user");
@@ -140,6 +142,7 @@ mod tests {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
         let cloned = msg.clone();
         assert_eq!(cloned.id, msg.id);

--- a/src/channels/dingtalk.rs
+++ b/src/channels/dingtalk.rs
@@ -291,6 +291,7 @@ impl Channel for DingTalkChannel {
                         thread_ts: None,
                         interruption_scope_id: None,
                         attachments: vec![],
+                        is_dm: true,
                     };
 
                     if tx.send(channel_msg).await.is_err() {

--- a/src/channels/discord.rs
+++ b/src/channels/discord.rs
@@ -1215,7 +1215,8 @@ impl Channel for DiscordChannel {
                             .as_secs(),
                         thread_ts: None,
                         interruption_scope_id: None,
-                    attachments: vec![],
+                        attachments: vec![],
+                        is_dm,
                     };
 
                     if tx.send(channel_msg).await.is_err() {

--- a/src/channels/discord_history.rs
+++ b/src/channels/discord_history.rs
@@ -500,6 +500,7 @@ impl Channel for DiscordHistoryChannel {
                             thread_ts: None,
                             interruption_scope_id: None,
                             attachments: Vec::new(),
+                            is_dm: is_dm_event,
                         };
                         if tx.send(channel_msg).await.is_err() {
                             break;

--- a/src/channels/email_channel.rs
+++ b/src/channels/email_channel.rs
@@ -541,6 +541,7 @@ impl EmailChannel {
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: email.attachments,
+                is_dm: true,
             };
 
             if tx.send(msg).await.is_err() {

--- a/src/channels/gmail_push.rs
+++ b/src/channels/gmail_push.rs
@@ -495,6 +495,7 @@ impl GmailPushChannel {
                         thread_ts: Some(gmail_msg.thread_id),
                         interruption_scope_id: None,
                         attachments: Vec::new(),
+                        is_dm: true,
                     };
 
                     if tx.send(channel_msg).await.is_err() {

--- a/src/channels/imessage.rs
+++ b/src/channels/imessage.rs
@@ -296,6 +296,7 @@ end tell"#
                             thread_ts: None,
                             interruption_scope_id: None,
                             attachments: vec![],
+                            is_dm: true,
                         };
 
                         if tx.send(msg).await.is_err() {

--- a/src/channels/irc.rs
+++ b/src/channels/irc.rs
@@ -578,6 +578,7 @@ impl Channel for IrcChannel {
                         thread_ts: None,
                         interruption_scope_id: None,
                         attachments: vec![],
+                        is_dm: !is_channel,
                     };
 
                     if tx.send(channel_msg).await.is_err() {

--- a/src/channels/lark.rs
+++ b/src/channels/lark.rs
@@ -1028,7 +1028,8 @@ impl LarkChannel {
                             .as_secs(),
                         thread_ts: None,
                         interruption_scope_id: None,
-                    attachments: vec![],
+                        attachments: vec![],
+                        is_dm: true,
                     };
 
                     tracing::debug!("Lark WS: message in {}", lark_msg.chat_id);
@@ -1556,6 +1557,7 @@ impl LarkChannel {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         }]
     }
 
@@ -1772,6 +1774,7 @@ impl LarkChannel {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         });
 
         messages

--- a/src/channels/linq.rs
+++ b/src/channels/linq.rs
@@ -269,6 +269,7 @@ impl LinqChannel {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         });
 
         messages

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -1188,6 +1188,7 @@ impl Channel for MatrixChannel {
                     thread_ts: thread_ts.clone(),
                     interruption_scope_id: thread_ts,
                     attachments: vec![],
+                    is_dm: true,
                 };
 
                 let _ = tx.send(msg).await;

--- a/src/channels/mattermost.rs
+++ b/src/channels/mattermost.rs
@@ -465,6 +465,7 @@ impl MattermostChannel {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: false,
         })
     }
 }

--- a/src/channels/mochat.rs
+++ b/src/channels/mochat.rs
@@ -200,6 +200,7 @@ impl Channel for MochatChannel {
                                 thread_ts: None,
                                 interruption_scope_id: None,
                                 attachments: vec![],
+                                is_dm: true,
                             };
 
                             if tx.send(channel_msg).await.is_err() {

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -389,6 +389,8 @@ struct ChannelRuntimeContext {
     model_routes: Arc<Vec<crate::config::ModelRouteConfig>>,
     query_classification: crate::config::QueryClassificationConfig,
     ack_reactions: bool,
+    mention_only: bool,
+    reply_precheck: bool,
     show_tool_calls: bool,
     session_store: Option<Arc<session_store::SessionStore>>,
     /// Non-interactive approval manager for channel-driven runs.
@@ -2778,15 +2780,23 @@ async fn process_channel_message(
     }
 
     // ── Reply-intent precheck ────────────────────────────────────────
-    let reply_intent = classify_channel_reply_intent(
-        active_provider.as_ref(),
-        history[0].content.as_str(),
-        &history,
-        route.model.as_str(),
-        runtime_defaults.temperature,
-    )
-    .await
-    .unwrap_or(AssistantChannelOutcome::Reply(String::new()));
+    // DMs always get a reply — no precheck needed.
+    // Groups only run the precheck when `reply_precheck` is enabled in
+    // `[channels_config]`.  Without it, group behaviour depends solely
+    // on `mention_only` (upstream filtering) or replies to everything.
+    let reply_intent = if msg.is_dm || !ctx.reply_precheck {
+        AssistantChannelOutcome::Reply(String::new())
+    } else {
+        classify_channel_reply_intent(
+            active_provider.as_ref(),
+            history[0].content.as_str(),
+            &history,
+            route.model.as_str(),
+            runtime_defaults.temperature,
+        )
+        .await
+        .unwrap_or(AssistantChannelOutcome::Reply(String::new()))
+    };
 
     if let AssistantChannelOutcome::NoReply { reason } = reply_intent {
         let history_response = AssistantChannelOutcome::NoReply {
@@ -5568,6 +5578,8 @@ pub async fn start_channels(config: Config) -> Result<()> {
         model_routes: Arc::new(config.model_routes.clone()),
         query_classification: config.query_classification.clone(),
         ack_reactions: config.channels_config.ack_reactions,
+        mention_only: false,
+        reply_precheck: config.channels_config.reply_precheck,
         show_tool_calls: config.channels_config.show_tool_calls,
         session_store: if config.channels_config.session_persistence {
             match session_store::SessionStore::new(&config.workspace_dir) {
@@ -6022,6 +6034,8 @@ mod tests {
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -6146,6 +6160,8 @@ mod tests {
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -6227,6 +6243,8 @@ mod tests {
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -6325,6 +6343,8 @@ mod tests {
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: Some(Arc::clone(&store)),
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -6924,6 +6944,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -6949,6 +6971,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -7014,6 +7037,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -7039,6 +7064,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -7118,6 +7144,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -7143,6 +7171,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -7207,6 +7236,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -7232,6 +7263,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -7306,6 +7338,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -7331,6 +7365,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -7426,6 +7461,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -7451,6 +7488,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -7527,6 +7565,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -7552,6 +7592,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -7643,6 +7684,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -7668,6 +7711,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -7744,6 +7788,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -7772,6 +7818,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -7838,6 +7885,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -7866,6 +7915,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -8058,6 +8108,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -8082,6 +8134,7 @@ BTC is currently around $65,000 based on latest tool output."#
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         })
         .await
         .unwrap();
@@ -8095,6 +8148,7 @@ BTC is currently around $65,000 based on latest tool output."#
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         })
         .await
         .unwrap();
@@ -8170,6 +8224,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -8195,6 +8251,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             })
             .await
             .unwrap();
@@ -8209,6 +8266,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             })
             .await
             .unwrap();
@@ -8292,6 +8350,8 @@ BTC is currently around $65,000 based on latest tool output."#
                 matrix: false,
             },
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             multimodal: crate::config::MultimodalConfig::default(),
@@ -8326,6 +8386,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: Some("1741234567.100001".to_string()),
                 interruption_scope_id: Some("1741234567.100001".to_string()),
                 attachments: vec![],
+                is_dm: true,
             })
             .await
             .unwrap();
@@ -8340,6 +8401,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: Some("1741234567.100001".to_string()),
                 interruption_scope_id: Some("1741234567.100001".to_string()),
                 attachments: vec![],
+                is_dm: true,
             })
             .await
             .unwrap();
@@ -8429,6 +8491,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -8454,6 +8518,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             })
             .await
             .unwrap();
@@ -8468,6 +8533,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             })
             .await
             .unwrap();
@@ -8535,6 +8601,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -8560,6 +8628,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -8622,6 +8691,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -8647,6 +8718,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -8709,6 +8781,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -8734,6 +8808,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -9270,6 +9345,7 @@ BTC is currently around $65,000 based on latest tool output."#
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
 
         assert_eq!(conversation_memory_key(&msg), "slack_U123_msg_abc123");
@@ -9287,6 +9363,7 @@ BTC is currently around $65,000 based on latest tool output."#
             thread_ts: Some("1741234567.123456".into()),
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
 
         assert_eq!(
@@ -9307,6 +9384,7 @@ BTC is currently around $65,000 based on latest tool output."#
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
 
         assert_eq!(followup_thread_id(&msg).as_deref(), Some("msg_abc123"));
@@ -9324,6 +9402,7 @@ BTC is currently around $65,000 based on latest tool output."#
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
         let msg2 = traits::ChannelMessage {
             id: "msg_2".into(),
@@ -9335,6 +9414,7 @@ BTC is currently around $65,000 based on latest tool output."#
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
 
         assert_ne!(
@@ -9358,6 +9438,7 @@ BTC is currently around $65,000 based on latest tool output."#
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
         let msg2 = traits::ChannelMessage {
             id: "msg_2".into(),
@@ -9369,6 +9450,7 @@ BTC is currently around $65,000 based on latest tool output."#
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
 
         mem.store(
@@ -9501,6 +9583,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -9526,6 +9610,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -9543,6 +9628,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -9642,6 +9728,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -9667,6 +9755,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -9700,6 +9789,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -9739,6 +9829,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -9826,6 +9917,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -9851,6 +9944,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -9942,6 +10036,8 @@ BTC is currently around $65,000 based on latest tool output."#
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -9967,6 +10063,7 @@ BTC is currently around $65,000 based on latest tool output."#
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -10529,6 +10626,8 @@ This is an example JSON object for profile settings."#;
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -10555,6 +10654,7 @@ This is an example JSON object for profile settings."#;
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -10625,6 +10725,8 @@ This is an example JSON object for profile settings."#;
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -10650,6 +10752,7 @@ This is an example JSON object for profile settings."#;
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -10667,6 +10770,7 @@ This is an example JSON object for profile settings."#;
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -10753,6 +10857,8 @@ This is an example JSON object for profile settings."#;
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -10780,6 +10886,7 @@ This is an example JSON object for profile settings."#;
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -10797,6 +10904,7 @@ This is an example JSON object for profile settings."#;
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -10929,6 +11037,8 @@ This is an example JSON object for profile settings."#;
             model_routes: Arc::new(model_routes),
             query_classification: classification_config,
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -10954,6 +11064,7 @@ This is an example JSON object for profile settings."#;
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -11049,6 +11160,8 @@ This is an example JSON object for profile settings."#;
             model_routes: Arc::new(model_routes),
             query_classification: classification_config,
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -11074,6 +11187,7 @@ This is an example JSON object for profile settings."#;
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -11161,6 +11275,8 @@ This is an example JSON object for profile settings."#;
             model_routes: Arc::new(model_routes),
             query_classification: classification_config,
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -11186,6 +11302,7 @@ This is an example JSON object for profile settings."#;
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -11293,6 +11410,8 @@ This is an example JSON object for profile settings."#;
             model_routes: Arc::new(model_routes),
             query_classification: classification_config,
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -11318,6 +11437,7 @@ This is an example JSON object for profile settings."#;
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             },
             CancellationToken::new(),
         )
@@ -11476,6 +11596,7 @@ This is an example JSON object for profile settings."#;
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
         assert_eq!(interruption_scope_key(&msg), "matrix_room_alice");
     }
@@ -11492,6 +11613,7 @@ This is an example JSON object for profile settings."#;
             thread_ts: Some("$thread1".into()),
             interruption_scope_id: Some("$thread1".into()),
             attachments: vec![],
+            is_dm: true,
         };
         assert_eq!(interruption_scope_key(&msg), "matrix_room_alice_$thread1");
     }
@@ -11509,6 +11631,7 @@ This is an example JSON object for profile settings."#;
             thread_ts: Some("1234567890.000100".into()), // Slack top-level fallback
             interruption_scope_id: None,                 // but NOT a thread reply
             attachments: vec![],
+            is_dm: true,
         };
         assert_eq!(interruption_scope_key(&msg), "slack_C123_alice");
     }
@@ -11566,6 +11689,8 @@ This is an example JSON object for profile settings."#;
             model_routes: Arc::new(Vec::new()),
             query_classification: crate::config::QueryClassificationConfig::default(),
             ack_reactions: true,
+            mention_only: false,
+            reply_precheck: false,
             show_tool_calls: true,
             session_store: None,
             approval_manager: Arc::new(ApprovalManager::for_non_interactive(
@@ -11593,6 +11718,7 @@ This is an example JSON object for profile settings."#;
                 thread_ts: Some("1741234567.100001".to_string()),
                 interruption_scope_id: Some("1741234567.100001".to_string()),
                 attachments: vec![],
+                is_dm: true,
             })
             .await
             .unwrap();
@@ -11607,6 +11733,7 @@ This is an example JSON object for profile settings."#;
                 thread_ts: Some("1741234567.200002".to_string()),
                 interruption_scope_id: Some("1741234567.200002".to_string()),
                 attachments: vec![],
+                is_dm: true,
             })
             .await
             .unwrap();

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -2395,12 +2395,10 @@ fn spawn_supervised_listener_with_health_interval(
 }
 
 fn compute_max_in_flight_messages(channel_count: usize, per_channel: usize) -> usize {
-    channel_count
-        .saturating_mul(per_channel)
-        .clamp(
-            CHANNEL_MIN_IN_FLIGHT_MESSAGES,
-            CHANNEL_MAX_IN_FLIGHT_MESSAGES,
-        )
+    channel_count.saturating_mul(per_channel).clamp(
+        CHANNEL_MIN_IN_FLIGHT_MESSAGES,
+        CHANNEL_MAX_IN_FLIGHT_MESSAGES,
+    )
 }
 
 fn log_worker_join_result(result: Result<(), tokio::task::JoinError>) {

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -211,8 +211,7 @@ const MIN_CHANNEL_MESSAGE_TIMEOUT_SECS: u64 = 30;
 const CHANNEL_MESSAGE_TIMEOUT_SECS: u64 = 300;
 /// Cap timeout scaling so large max_tool_iterations values do not create unbounded waits.
 const CHANNEL_MESSAGE_TIMEOUT_SCALE_CAP: u64 = 4;
-const CHANNEL_PARALLELISM_PER_CHANNEL: usize = 4;
-const CHANNEL_MIN_IN_FLIGHT_MESSAGES: usize = 8;
+const CHANNEL_MIN_IN_FLIGHT_MESSAGES: usize = 2;
 const CHANNEL_MAX_IN_FLIGHT_MESSAGES: usize = 64;
 const CHANNEL_TYPING_REFRESH_INTERVAL_SECS: u64 = 4;
 const CHANNEL_HEALTH_HEARTBEAT_SECS: u64 = 30;
@@ -354,6 +353,7 @@ struct ChannelCostTrackingState {
 }
 
 #[derive(Clone)]
+#[allow(clippy::struct_excessive_bools)]
 struct ChannelRuntimeContext {
     channels_by_name: Arc<HashMap<String, Arc<dyn Channel>>>,
     provider: Arc<dyn Provider>,
@@ -2394,9 +2394,9 @@ fn spawn_supervised_listener_with_health_interval(
     })
 }
 
-fn compute_max_in_flight_messages(channel_count: usize) -> usize {
+fn compute_max_in_flight_messages(channel_count: usize, per_channel: usize) -> usize {
     channel_count
-        .saturating_mul(CHANNEL_PARALLELISM_PER_CHANNEL)
+        .saturating_mul(per_channel)
         .clamp(
             CHANNEL_MIN_IN_FLIGHT_MESSAGES,
             CHANNEL_MAX_IN_FLIGHT_MESSAGES,
@@ -5488,7 +5488,10 @@ pub async fn start_channels(config: Config) -> Result<()> {
         }
     }
 
-    let max_in_flight_messages = compute_max_in_flight_messages(channels.len());
+    let max_in_flight_messages = compute_max_in_flight_messages(
+        channels.len(),
+        config.channels_config.max_concurrent_per_channel,
+    );
 
     println!("  🚦 In-flight message limit: {max_in_flight_messages}");
 

--- a/src/channels/nextcloud_talk.rs
+++ b/src/channels/nextcloud_talk.rs
@@ -251,6 +251,7 @@ impl NextcloudTalkChannel {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         });
 
         messages
@@ -364,6 +365,7 @@ impl NextcloudTalkChannel {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         });
 
         messages

--- a/src/channels/nostr.rs
+++ b/src/channels/nostr.rs
@@ -255,6 +255,7 @@ impl Channel for NostrChannel {
                             thread_ts: None,
                             interruption_scope_id: None,
                             attachments: vec![],
+                            is_dm: true,
                         };
                         if tx.send(msg).await.is_err() {
                             tracing::info!("Nostr listener: message bus closed, stopping");

--- a/src/channels/notion.rs
+++ b/src/channels/notion.rs
@@ -362,6 +362,7 @@ impl Channel for NotionChannel {
                                 thread_ts: None,
                                 interruption_scope_id: None,
                                 attachments: vec![],
+                                is_dm: true,
                             })
                             .await
                             .is_err()

--- a/src/channels/qq.rs
+++ b/src/channels/qq.rs
@@ -1293,7 +1293,8 @@ impl Channel for QQChannel {
                                     .as_secs(),
                                 thread_ts: None,
                                 interruption_scope_id: None,
-                    attachments: vec![],
+                                attachments: vec![],
+                                is_dm: true,
                             };
 
                             if tx.send(channel_msg).await.is_err() {
@@ -1334,7 +1335,8 @@ impl Channel for QQChannel {
                                     .as_secs(),
                                 thread_ts: None,
                                 interruption_scope_id: None,
-                    attachments: vec![],
+                                attachments: vec![],
+                                is_dm: false,
                             };
 
                             if tx.send(channel_msg).await.is_err() {

--- a/src/channels/reddit.rs
+++ b/src/channels/reddit.rs
@@ -227,6 +227,8 @@ impl RedditChannel {
             thread_ts: item.parent_id.clone(),
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: item.message_type.as_deref() != Some("comment_reply")
+                && item.parent_id.is_none(),
         })
     }
 }

--- a/src/channels/signal.rs
+++ b/src/channels/signal.rs
@@ -281,6 +281,11 @@ impl SignalChannel {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: data_msg
+                .group_info
+                .as_ref()
+                .and_then(|g| g.group_id.as_deref())
+                .is_none(),
         })
     }
 }

--- a/src/channels/slack.rs
+++ b/src/channels/slack.rs
@@ -2507,6 +2507,7 @@ impl SlackChannel {
                 .map(str::to_string),
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: false,
         })
     }
 
@@ -2740,6 +2741,7 @@ impl SlackChannel {
                                         thread_ts,
                                         interruption_scope_id: scope_id,
                                         attachments: vec![],
+                                        is_dm: false,
                                     };
                                     tracing::info!(
                                         "Slack: :{cancel_emoji}: reaction from {user} \
@@ -2837,6 +2839,7 @@ impl SlackChannel {
                     },
                     interruption_scope_id: Self::inbound_interruption_scope_id(event, ts),
                     attachments: vec![],
+                    is_dm: !is_group_message,
                 };
 
                 // Track thread context so start_typing can set assistant status.
@@ -3839,6 +3842,7 @@ impl Channel for SlackChannel {
                             },
                             interruption_scope_id: Self::inbound_interruption_scope_id(msg, ts),
                             attachments: vec![],
+                            is_dm: !is_group_message,
                         };
 
                         if tx.send(channel_msg).await.is_err() {
@@ -3923,6 +3927,7 @@ impl Channel for SlackChannel {
                         thread_ts: Some(thread_ts.clone()),
                         interruption_scope_id: Some(thread_ts.clone()),
                         attachments: vec![],
+                        is_dm: false,
                     };
 
                     if tx.send(channel_msg).await.is_err() {
@@ -4935,6 +4940,7 @@ mod tests {
             thread_ts: None, // thread_replies=false → no fallback to ts
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
 
         let msg1 = make_msg("100.000");
@@ -4961,6 +4967,7 @@ mod tests {
             thread_ts: Some(ts.to_string()), // thread_replies=true → ts as thread_ts
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
 
         let msg1 = make_msg("100.000");

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -1171,6 +1171,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             thread_ts: thread_id,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: !Self::is_group_message(message),
         })
     }
 
@@ -1302,6 +1303,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             thread_ts: thread_id,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: !Self::is_group_message(message),
         })
     }
 
@@ -1507,6 +1509,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
             thread_ts: thread_id,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: !is_group,
         })
     }
 

--- a/src/channels/traits.rs
+++ b/src/channels/traits.rs
@@ -22,6 +22,8 @@ pub struct ChannelMessage {
     /// Channels populate this when they receive media alongside a text message.
     /// Defaults to empty — existing channels are unaffected.
     pub attachments: Vec<super::media_pipeline::MediaAttachment>,
+    /// Whether this is a direct message (true) or group chat message (false).
+    pub is_dm: bool,
 }
 
 /// Message to send through a channel
@@ -257,6 +259,7 @@ mod tests {
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             })
             .await
             .map_err(|e| anyhow::anyhow!(e.to_string()))
@@ -275,6 +278,7 @@ mod tests {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
 
         let cloned = message.clone();

--- a/src/channels/twitter.rs
+++ b/src/channels/twitter.rs
@@ -290,6 +290,7 @@ impl Channel for TwitterChannel {
                                     .map(|s| s.to_string()),
                                 interruption_scope_id: None,
                                 attachments: vec![],
+                                is_dm: false,
                             };
 
                             if tx.send(channel_msg).await.is_err() {

--- a/src/channels/voice_call.rs
+++ b/src/channels/voice_call.rs
@@ -367,6 +367,7 @@ impl VoiceCallChannel {
             thread_ts: Some(call_id.to_string()),
             interruption_scope_id: Some(call_id.to_string()),
             attachments: vec![],
+            is_dm: true,
         };
         tx.send(msg)
             .await

--- a/src/channels/voice_wake.rs
+++ b/src/channels/voice_wake.rs
@@ -240,6 +240,7 @@ impl Channel for VoiceWakeChannel {
                                         interruption_scope_id: None,
                                         attachments: vec![],
                                         observe_group: false,
+                                        is_dm: true,
                                     };
 
                                     if let Err(e) = tx.send(msg).await {

--- a/src/channels/wati.rs
+++ b/src/channels/wati.rs
@@ -212,6 +212,7 @@ impl WatiChannel {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         });
 
         messages
@@ -355,6 +356,7 @@ impl WatiChannel {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         });
 
         messages

--- a/src/channels/webhook.rs
+++ b/src/channels/webhook.rs
@@ -239,6 +239,7 @@ impl Channel for WebhookChannel {
                 thread_ts: payload.thread_id,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             };
 
             if state.tx.send(msg).await.is_err() {

--- a/src/channels/whatsapp.rs
+++ b/src/channels/whatsapp.rs
@@ -278,6 +278,7 @@ impl WhatsAppChannel {
                         thread_ts: None,
                         interruption_scope_id: None,
                         attachments: vec![],
+                        is_dm: !is_group,
                     });
                 }
             }

--- a/src/channels/whatsapp_web.rs
+++ b/src/channels/whatsapp_web.rs
@@ -1369,7 +1369,8 @@ impl Channel for WhatsAppWebChannel {
                                         timestamp: chrono::Utc::now().timestamp() as u64,
                                         thread_ts: None,
                                         interruption_scope_id: None,
-                    attachments: vec![],
+                                        attachments: vec![],
+                                        is_dm: !is_group,
                                     })
                                     .await
                                 {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6391,6 +6391,7 @@ impl Default for ChannelsConfig {
             session_ttl_hours: 0,
             debounce_ms: 0,
             reply_precheck: false,
+            max_concurrent_per_channel: default_max_concurrent_per_channel(),
         }
     }
 }
@@ -11596,6 +11597,7 @@ auto_save = true
                 session_ttl_hours: 0,
                 debounce_ms: 0,
                 reply_precheck: false,
+                max_concurrent_per_channel: default_max_concurrent_per_channel(),
             },
             memory: MemoryConfig::default(),
             storage: StorageConfig::default(),
@@ -12637,6 +12639,7 @@ allowed_users = ["@ops:matrix.org"]
             session_ttl_hours: 0,
             debounce_ms: 0,
             reply_precheck: false,
+            max_concurrent_per_channel: 4,
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();
@@ -13012,6 +13015,7 @@ channel_ids = ["C123", "D456"]
             session_ttl_hours: 0,
             debounce_ms: 0,
             reply_precheck: false,
+            max_concurrent_per_channel: 4,
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6207,6 +6207,12 @@ pub struct ChannelsConfig {
     /// Default: `false`.
     #[serde(default)]
     pub reply_precheck: bool,
+    /// Maximum concurrent LLM requests per channel. Controls how many messages
+    /// can be processed simultaneously. Lower values prevent saturating
+    /// backends with limited slots (e.g. llama.cpp `--parallel 3`).
+    /// Default: `4`.
+    #[serde(default = "default_max_concurrent_per_channel")]
+    pub max_concurrent_per_channel: usize,
 }
 
 impl ChannelsConfig {
@@ -6331,6 +6337,10 @@ impl ChannelsConfig {
 
 fn default_channel_message_timeout_secs() -> u64 {
     300
+}
+
+fn default_max_concurrent_per_channel() -> usize {
+    4
 }
 
 fn default_session_backend() -> String {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6197,6 +6197,16 @@ pub struct ChannelsConfig {
     /// as a single concatenated message. `0` disables debouncing. Default: `0`.
     #[serde(default)]
     pub debounce_ms: u64,
+    /// Run an LLM reply-intent precheck before responding in group conversations.
+    /// When `true`, the agent makes a lightweight classification call to decide
+    /// whether the latest group message warrants a reply (`REPLY` / `NO_REPLY`).
+    /// When `false`, group messages are handled based solely on `mention_only`:
+    /// if `mention_only` is enabled, only @-mentions get a reply; otherwise the
+    /// agent replies to every message.
+    /// Direct messages always get a reply regardless of this setting.
+    /// Default: `false`.
+    #[serde(default)]
+    pub reply_precheck: bool,
 }
 
 impl ChannelsConfig {
@@ -6370,6 +6380,7 @@ impl Default for ChannelsConfig {
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
             debounce_ms: 0,
+            reply_precheck: false,
         }
     }
 }
@@ -11574,6 +11585,7 @@ auto_save = true
                 session_backend: default_session_backend(),
                 session_ttl_hours: 0,
                 debounce_ms: 0,
+                reply_precheck: false,
             },
             memory: MemoryConfig::default(),
             storage: StorageConfig::default(),
@@ -12614,6 +12626,7 @@ allowed_users = ["@ops:matrix.org"]
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
             debounce_ms: 0,
+            reply_precheck: false,
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();
@@ -12988,6 +13001,7 @@ channel_ids = ["C123", "D456"]
             session_backend: default_session_backend(),
             session_ttl_hours: 0,
             debounce_ms: 0,
+            reply_precheck: false,
         };
         let toml_str = toml::to_string_pretty(&c).unwrap();
         let parsed: ChannelsConfig = toml::from_str(&toml_str).unwrap();

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -2630,6 +2630,7 @@ mod tests {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         };
 
         let key = whatsapp_memory_key(&msg);

--- a/src/tools/ask_user.rs
+++ b/src/tools/ask_user.rs
@@ -305,6 +305,7 @@ mod tests {
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             };
             let _ = tx.send(msg).await;
             Ok(())

--- a/src/tools/escalate.rs
+++ b/src/tools/escalate.rs
@@ -427,6 +427,7 @@ mod tests {
                 thread_ts: None,
                 interruption_scope_id: None,
                 attachments: vec![],
+                is_dm: true,
             };
             let _ = tx.send(msg).await;
             Ok(())

--- a/tests/integration/channel_matrix.rs
+++ b/tests/integration/channel_matrix.rs
@@ -131,6 +131,7 @@ impl Channel for MatrixTestChannel {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         })
         .await
         .map_err(|e| anyhow::anyhow!(e.to_string()))
@@ -627,6 +628,7 @@ fn channel_message_thread_ts_preserved_on_clone() {
         thread_ts: Some("1700000000.000001".into()),
         interruption_scope_id: None,
         attachments: vec![],
+        is_dm: true,
     };
 
     let cloned = msg.clone();
@@ -645,6 +647,7 @@ fn channel_message_none_thread_ts_preserved() {
         thread_ts: None,
         interruption_scope_id: None,
         attachments: vec![],
+        is_dm: true,
     };
 
     assert!(msg.clone().thread_ts.is_none());
@@ -700,6 +703,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "discord" => ChannelMessage {
             id: "dc_1".into(),
@@ -711,6 +715,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "slack" => ChannelMessage {
             id: "sl_1".into(),
@@ -722,6 +727,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: Some("1700000000.000001".into()),
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "imessage" => ChannelMessage {
             id: "im_1".into(),
@@ -733,6 +739,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "irc" => ChannelMessage {
             id: "irc_1".into(),
@@ -744,6 +751,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "email" => ChannelMessage {
             id: "email_1".into(),
@@ -755,6 +763,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "signal" => ChannelMessage {
             id: "sig_1".into(),
@@ -766,6 +775,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "mattermost" => ChannelMessage {
             id: "mm_1".into(),
@@ -777,6 +787,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: Some("root_msg_id".into()),
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "whatsapp" => ChannelMessage {
             id: "wa_1".into(),
@@ -788,6 +799,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "nextcloud_talk" => ChannelMessage {
             id: "nc_1".into(),
@@ -799,6 +811,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "wecom" => ChannelMessage {
             id: "wc_1".into(),
@@ -810,6 +823,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "dingtalk" => ChannelMessage {
             id: "dt_1".into(),
@@ -821,6 +835,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "qq" => ChannelMessage {
             id: "qq_1".into(),
@@ -832,6 +847,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "linq" => ChannelMessage {
             id: "lq_1".into(),
@@ -843,6 +859,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "wati" => ChannelMessage {
             id: "wt_1".into(),
@@ -854,6 +871,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         "cli" => ChannelMessage {
             id: "cli_1".into(),
@@ -865,6 +883,7 @@ fn make_platform_message(platform: &str) -> ChannelMessage {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         },
         _ => panic!("Unknown platform: {platform}"),
     }
@@ -1168,6 +1187,7 @@ fn channel_message_zero_timestamp() {
         thread_ts: None,
         interruption_scope_id: None,
         attachments: vec![],
+        is_dm: true,
     };
     assert_eq!(msg.timestamp, 0);
 }
@@ -1184,6 +1204,7 @@ fn channel_message_max_timestamp() {
         thread_ts: None,
         interruption_scope_id: None,
         attachments: vec![],
+        is_dm: true,
     };
     assert_eq!(msg.timestamp, u64::MAX);
 }

--- a/tests/integration/channel_routing.rs
+++ b/tests/integration/channel_routing.rs
@@ -27,6 +27,7 @@ fn channel_message_sender_field_holds_platform_user_id() {
         thread_ts: None,
         interruption_scope_id: None,
         attachments: vec![],
+        is_dm: true,
     };
 
     assert_eq!(msg.sender, "123456789");
@@ -51,6 +52,7 @@ fn channel_message_reply_target_distinct_from_sender() {
         thread_ts: None,
         interruption_scope_id: None,
         attachments: vec![],
+        is_dm: true,
     };
 
     assert_ne!(
@@ -73,6 +75,7 @@ fn channel_message_fields_not_swapped() {
         thread_ts: None,
         interruption_scope_id: None,
         attachments: vec![],
+        is_dm: true,
     };
 
     assert_eq!(
@@ -101,6 +104,7 @@ fn channel_message_preserves_all_fields_on_clone() {
         thread_ts: None,
         interruption_scope_id: None,
         attachments: vec![],
+        is_dm: true,
     };
 
     let cloned = original.clone();
@@ -196,6 +200,7 @@ impl Channel for CapturingChannel {
             thread_ts: None,
             interruption_scope_id: None,
             attachments: vec![],
+            is_dm: true,
         })
         .await
         .map_err(|e| anyhow::anyhow!(e.to_string()))


### PR DESCRIPTION
## Summary
- **perf:** Skip reply-intent precheck LLM call for direct messages — DMs always respond directly, saving one LLM round-trip per DM.
- **feat:** Add `max_concurrent_per_channel` to `[channels_config]` (default: 4) so deployments with limited LLM backend slots (e.g. llama.cpp `--parallel 3`) can throttle concurrent requests. Lower minimum in-flight floor from 8 to 2.
- **fix:** Suppress `clippy::struct_excessive_bools` on `ChannelRuntimeContext`.

## Config parameters
| Parameter | Default | Purpose |
|---|---|---|
| `reply_precheck` | `false` | LLM precheck before replying in groups |
| `max_concurrent_per_channel` | `4` | Max concurrent LLM requests per channel |

## Test plan
- [ ] Verify DMs skip precheck on all channel types
- [ ] Verify `max_concurrent_per_channel = 1` limits concurrent LLM calls
- [ ] `cargo clippy` and `cargo test` pass