### PR TITLE
fix(telegram): TTS voice reply and streaming progress for partial mode

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -643,7 +643,10 @@ impl TelegramChannel {
     /// Check whether a voice reply should be queued for the given recipient and
     /// content. This is shared between `send()` and `finalize_draft()` so the
     /// TTS voice-reply path works regardless of `stream_mode`.
-    fn try_queue_voice_reply(&self, recipient: &str, content: &str) {
+    ///
+    /// When `immediate` is `true` (called from `finalize_draft`), the 10-second
+    /// debounce is skipped and `synthesize_and_send_voice` is called directly.
+    fn try_queue_voice_reply(&self, recipient: &str, content: &str, immediate: bool) {
         let is_voice_chat = self
             .voice_chats
             .lock()
@@ -681,6 +684,42 @@ impl TelegramChannel {
             return;
         }
 
+        let (chat_id, thread_id) = Self::parse_reply_target(recipient);
+        let voice_chats = self.voice_chats.clone();
+        let api_base = self.api_base.clone();
+        let bot_token = self.bot_token.clone();
+        let tts_config = self.tts_config.clone().unwrap();
+
+        if immediate {
+            tracing::debug!("TTS: immediate voice reply triggered");
+
+            let text = content.to_string();
+            let recipient = recipient.to_string();
+            tokio::spawn(async move {
+                if let Ok(mut vc) = voice_chats.lock() {
+                    vc.remove(&recipient);
+                }
+                match Self::synthesize_and_send_voice(
+                    &api_base,
+                    &bot_token,
+                    &chat_id,
+                    thread_id.as_deref(),
+                    &text,
+                    &tts_config,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        tracing::info!("Telegram: voice reply sent ({} chars)", text.len());
+                    }
+                    Err(e) => {
+                        tracing::warn!("Telegram: TTS voice reply failed: {e}");
+                    }
+                }
+            });
+            return;
+        }
+
         if let Ok(mut pv) = self.pending_voice.lock() {
             pv.insert(
                 recipient.to_string(),
@@ -694,13 +733,8 @@ impl TelegramChannel {
             "TTS voice reply queued"
         );
 
-        let (chat_id, thread_id) = Self::parse_reply_target(recipient);
         let pending = self.pending_voice.clone();
-        let voice_chats = self.voice_chats.clone();
-        let api_base = self.api_base.clone();
-        let bot_token = self.bot_token.clone();
         let recipient = recipient.to_string();
-        let tts_config = self.tts_config.clone().unwrap();
         tokio::spawn(async move {
             // Wait 10 seconds — long enough for the agent to finish its
             // full tool chain and send the final answer.
@@ -2586,7 +2620,7 @@ impl Channel for TelegramChannel {
         let (chat_id, thread_id) = Self::parse_reply_target(recipient);
 
         // Queue TTS voice reply when streaming mode finalises a draft
-        self.try_queue_voice_reply(recipient, text);
+        self.try_queue_voice_reply(recipient, text, true);
 
         // Clean up rate-limit tracking for this chat
         self.last_draft_edit.lock().remove(&chat_id);
@@ -2783,7 +2817,7 @@ impl Channel for TelegramChannel {
 
         // Voice chat mode: send text normally AND queue a voice note of the
         // final answer. Text in → text out. Voice in → text + voice out.
-        self.try_queue_voice_reply(&message.recipient, &content);
+        self.try_queue_voice_reply(&message.recipient, &content, false);
 
         // Always send text reply (voice chat gets both text and voice)
         let (text_without_markers, attachments) = parse_attachment_markers(&content);

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -445,7 +445,10 @@ impl TelegramChannel {
     /// Configure text-to-speech for outgoing voice replies.
     pub fn with_tts(mut self, config: crate::config::TtsConfig) -> Self {
         if config.enabled {
+            tracing::info!("Telegram TTS enabled: provider={}", config.default_provider);
             self.tts_config = Some(config);
+        } else {
+            tracing::debug!("Telegram TTS disabled (enabled=false)");
         }
         self
     }
@@ -635,6 +638,107 @@ impl TelegramChannel {
 
         tracing::info!("Telegram TTS: sent voice note ({audio_len} bytes)");
         Ok(())
+    }
+
+    /// Check whether a voice reply should be queued for the given recipient and
+    /// content. This is shared between `send()` and `finalize_draft()` so the
+    /// TTS voice-reply path works regardless of `stream_mode`.
+    fn try_queue_voice_reply(&self, recipient: &str, content: &str) {
+        let is_voice_chat = self
+            .voice_chats
+            .lock()
+            .map(|vs| vs.contains(recipient))
+            .unwrap_or(false);
+
+        tracing::debug!(
+            is_voice_chat,
+            tts_config_present = self.tts_config.is_some(),
+            recipient = %recipient,
+            "TTS voice reply check"
+        );
+
+        if !is_voice_chat || self.tts_config.is_none() {
+            return;
+        }
+
+        // Only queue substantive natural-language replies for voice.
+        // Skip tool outputs: URLs, JSON, code blocks, errors, short status.
+        let is_substantive = content.len() > 40
+            && !content.starts_with("http")
+            && !content.starts_with('{')
+            && !content.starts_with('[')
+            && !content.starts_with("Error")
+            && !content.contains("```")
+            && !content.contains("tool_call")
+            && !content.contains("wttr.in");
+
+        if !is_substantive {
+            tracing::debug!(
+                recipient = %recipient,
+                content_len = content.len(),
+                "TTS voice reply skipped: content not substantive"
+            );
+            return;
+        }
+
+        if let Ok(mut pv) = self.pending_voice.lock() {
+            pv.insert(
+                recipient.to_string(),
+                (content.to_string(), std::time::Instant::now()),
+            );
+        }
+
+        tracing::debug!(
+            recipient = %recipient,
+            content_len = content.len(),
+            "TTS voice reply queued"
+        );
+
+        let (chat_id, thread_id) = Self::parse_reply_target(recipient);
+        let pending = self.pending_voice.clone();
+        let voice_chats = self.voice_chats.clone();
+        let api_base = self.api_base.clone();
+        let bot_token = self.bot_token.clone();
+        let recipient = recipient.to_string();
+        let tts_config = self.tts_config.clone().unwrap();
+        tokio::spawn(async move {
+            // Wait 10 seconds — long enough for the agent to finish its
+            // full tool chain and send the final answer.
+            tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+
+            // Atomic check-and-remove: only one task gets the value
+            let to_voice = pending.lock().ok().and_then(|mut pv| {
+                if let Some((_, ts)) = pv.get(&recipient) {
+                    if ts.elapsed().as_secs() >= 8 {
+                        return pv.remove(&recipient).map(|(text, _)| text);
+                    }
+                }
+                None
+            });
+
+            if let Some(text) = to_voice {
+                if let Ok(mut vc) = voice_chats.lock() {
+                    vc.remove(&recipient);
+                }
+                match Self::synthesize_and_send_voice(
+                    &api_base,
+                    &bot_token,
+                    &chat_id,
+                    thread_id.as_deref(),
+                    &text,
+                    &tts_config,
+                )
+                .await
+                {
+                    Ok(()) => {
+                        tracing::info!("Telegram: voice reply sent ({} chars)", text.len());
+                    }
+                    Err(e) => {
+                        tracing::warn!("Telegram: TTS voice reply failed: {e}");
+                    }
+                }
+            }
+        });
     }
 
     async fn classify_edit_message_response(resp: reqwest::Response) -> EditMessageResult {
@@ -2459,6 +2563,19 @@ impl Channel for TelegramChannel {
         Ok(())
     }
 
+    async fn update_draft_progress(
+        &self,
+        recipient: &str,
+        message_id: &str,
+        text: &str,
+    ) -> anyhow::Result<()> {
+        if self.stream_mode == StreamMode::Partial {
+            self.update_draft(recipient, message_id, text).await
+        } else {
+            Ok(())
+        }
+    }
+
     async fn finalize_draft(
         &self,
         recipient: &str,
@@ -2467,6 +2584,9 @@ impl Channel for TelegramChannel {
     ) -> anyhow::Result<()> {
         let text = &strip_tool_call_tags(text);
         let (chat_id, thread_id) = Self::parse_reply_target(recipient);
+
+        // Queue TTS voice reply when streaming mode finalises a draft
+        self.try_queue_voice_reply(recipient, text);
 
         // Clean up rate-limit tracking for this chat
         self.last_draft_edit.lock().remove(&chat_id);
@@ -2663,80 +2783,7 @@ impl Channel for TelegramChannel {
 
         // Voice chat mode: send text normally AND queue a voice note of the
         // final answer. Text in → text out. Voice in → text + voice out.
-        let is_voice_chat = self
-            .voice_chats
-            .lock()
-            .map(|vs| vs.contains(&message.recipient))
-            .unwrap_or(false);
-
-        if is_voice_chat && self.tts_config.is_some() {
-            // Only queue substantive natural-language replies for voice.
-            // Skip tool outputs: URLs, JSON, code blocks, errors, short status.
-            let is_substantive = content.len() > 40
-                && !content.starts_with("http")
-                && !content.starts_with('{')
-                && !content.starts_with('[')
-                && !content.starts_with("Error")
-                && !content.contains("```")
-                && !content.contains("tool_call")
-                && !content.contains("wttr.in");
-
-            if is_substantive {
-                if let Ok(mut pv) = self.pending_voice.lock() {
-                    pv.insert(
-                        message.recipient.clone(),
-                        (content.clone(), std::time::Instant::now()),
-                    );
-                }
-
-                let pending = self.pending_voice.clone();
-                let voice_chats = self.voice_chats.clone();
-                let api_base = self.api_base.clone();
-                let bot_token = self.bot_token.clone();
-                let chat_id_owned = chat_id.to_string();
-                let thread_id_owned = thread_id.map(str::to_string);
-                let recipient = message.recipient.clone();
-                let tts_config = self.tts_config.clone().unwrap();
-                tokio::spawn(async move {
-                    // Wait 10 seconds — long enough for the agent to finish its
-                    // full tool chain and send the final answer.
-                    tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
-
-                    // Atomic check-and-remove: only one task gets the value
-                    let to_voice = pending.lock().ok().and_then(|mut pv| {
-                        if let Some((_, ts)) = pv.get(&recipient) {
-                            if ts.elapsed().as_secs() >= 8 {
-                                return pv.remove(&recipient).map(|(text, _)| text);
-                            }
-                        }
-                        None
-                    });
-
-                    if let Some(text) = to_voice {
-                        if let Ok(mut vc) = voice_chats.lock() {
-                            vc.remove(&recipient);
-                        }
-                        match Self::synthesize_and_send_voice(
-                            &api_base,
-                            &bot_token,
-                            &chat_id_owned,
-                            thread_id_owned.as_deref(),
-                            &text,
-                            &tts_config,
-                        )
-                        .await
-                        {
-                            Ok(()) => {
-                                tracing::info!("Telegram: voice reply sent ({} chars)", text.len());
-                            }
-                            Err(e) => {
-                                tracing::warn!("Telegram: TTS voice reply failed: {e}");
-                            }
-                        }
-                    }
-                });
-            }
-        }
+        self.try_queue_voice_reply(&message.recipient, &content);
 
         // Always send text reply (voice chat gets both text and voice)
         let (text_without_markers, attachments) = parse_attachment_markers(&content);


### PR DESCRIPTION
## Summary
- **fix:** TTS voice reply not working with `stream_mode=partial` — responses went through `finalize_draft()` which lacked TTS logic. Extracted into `try_queue_voice_reply()` helper called from both `send()` and `finalize_draft()`.
- **perf:** Skip 10-second TTS debounce when called from `finalize_draft` (immediate mode) since it only fires once with the final text.
- **feat:** Implement `update_draft_progress` for Telegram so tool-call progress ("Thinking...", "Got 2 tool calls...") is shown during streaming instead of the message freezing.

## Test plan
- [ ] Verify TTS voice reply works with `stream_mode=partial`
- [ ] Verify TTS fires immediately in streaming mode (no 10s delay)
- [ ] Verify tool-call progress shown during streaming
- [ ] `cargo test` passes