### PR TITLE
docs: add new config parameters across all references and templates

### DIFF
--- a/dev/config.template.toml
+++ b/dev/config.template.toml
@@ -6,6 +6,15 @@ default_provider = "ollama"
 default_model = "llama3.2"
 default_temperature = 0.7
 
+[channels_config]
+message_timeout_secs = 300
+reply_precheck = false
+max_concurrent_per_channel = 4
+
+[skills]
+open_skills_enabled = false
+whitelist = []
+
 [gateway]
 port = 42617
 host = "[::]"

--- a/docs/i18n/vi/channels-reference.md
+++ b/docs/i18n/vi/channels-reference.md
@@ -146,8 +146,11 @@ interrupt_on_new_message = false  # tùy chọn: hủy yêu cầu đang xử lý
 
 Lưu ý về Telegram:
 
+- `stream_mode = "partial"` gửi tin nhắn nháp có thể chỉnh sửa, cập nhật từng token khi LLM streaming, sau đó hoàn tất với văn bản đầy đủ. Tiến trình gọi tool (ví dụ "🤔 Thinking...", "🔧 Running shell...") được hiển thị trong quá trình thực thi tool.
+- `draft_update_interval_ms` điều khiển giới hạn tần suất chỉnh sửa trong chế độ partial (mặc định: 1000ms).
 - `interrupt_on_new_message = true` giữ lại các lượt người dùng bị gián đoạn trong lịch sử hội thoại, sau đó khởi động lại việc tạo nội dung với tin nhắn mới nhất.
 - Phạm vi gián đoạn rất chặt chẽ: cùng người gửi trong cùng chat. Tin nhắn từ các chat khác nhau được xử lý độc lập.
+- **Chế độ giọng nói**: Khi người dùng gửi tin nhắn thoại với `[transcription]` được bật, agent sẽ chuyển đổi (STT), trả lời bằng văn bản và cũng gửi phản hồi giọng nói TTS (yêu cầu `[tts]` được bật). Chế độ giọng nói được kích hoạt theo chat khi nhận tin nhắn thoại và tắt khi người dùng gửi văn bản. Phản hồi ngắn hơn 40 ký tự không được tổng hợp.
 
 ### 4.2 Discord
 

--- a/docs/i18n/vi/config-reference.md
+++ b/docs/i18n/vi/config-reference.md
@@ -136,6 +136,8 @@ Lưu ý:
 |---|---|---|
 | `open_skills_enabled` | `false` | Cho phép tải/đồng bộ kho `open-skills` cộng đồng |
 | `open_skills_dir` | chưa đặt | Đường dẫn cục bộ cho `open-skills` (mặc định `$HOME/open-skills` khi bật) |
+| `prompt_injection_mode` | `full` | Độ chi tiết prompt skill: `full` (nội tuyến) hoặc `compact` (chỉ tên/mô tả) |
+| `whitelist` | `[]` | Danh sách trắng tên skill. Rỗng = tải tất cả (mặc định). Không rỗng = chỉ tải skill được chỉ định. Hữu ích để giảm kích thước system prompt trên model ngữ cảnh thấp. |
 
 Lưu ý:
 
@@ -349,6 +351,7 @@ Route hint giúp tên tích hợp ổn định khi model ID thay đổi.
 | `provider` | _bắt buộc_ | Provider đích (phải khớp tên provider đã biết) |
 | `model` | _bắt buộc_ | Model sử dụng với provider đó |
 | `api_key` | chưa đặt | API key tùy chỉnh cho provider của route này (tùy chọn) |
+| `context_window` | chưa đặt | Kích thước context window tùy chỉnh cho route này (token). Hữu ích để giới hạn context trên backend có VRAM hạn chế. |
 
 ### `[[embedding_routes]]`
 
@@ -426,6 +429,8 @@ Cấu hình kênh cấp cao nằm dưới `channels_config`.
 | Khóa | Mặc định | Mục đích |
 |---|---|---|
 | `message_timeout_secs` | `300` | Thời gian chờ cơ bản (giây) cho xử lý tin nhắn kênh; runtime tự điều chỉnh theo độ sâu tool-loop (lên đến 4x) |
+| `reply_precheck` | `false` | Chạy kiểm tra ý định trả lời LLM trước khi phản hồi trong cuộc trò chuyện nhóm. Khi `true`, agent thực hiện cuộc gọi phân loại nhẹ để quyết định có nên trả lời không. Tin nhắn trực tiếp luôn bỏ qua kiểm tra này. |
+| `max_concurrent_per_channel` | `4` | Số request LLM đồng thời tối đa cho mỗi kênh. Giá trị thấp hơn ngăn bão hòa backend có slot hạn chế (ví dụ llama.cpp `--parallel 3`). |
 
 Ví dụ:
 

--- a/docs/i18n/zh-CN/reference/api/channels-reference.zh-CN.md
+++ b/docs/i18n/zh-CN/reference/api/channels-reference.zh-CN.md
@@ -160,8 +160,11 @@ interrupt_on_new_message = false  # 可选: 取消同一发送者同一聊天中
 
 Telegram 注意事项：
 
+- `stream_mode = "partial"` 发送一条可编辑的草稿消息，随着 LLM 流式输出逐 token 更新，最后以完整文本定稿。工具调用期间显示进度（如"🤔 Thinking..."、"🔧 Running shell..."）。
+- `draft_update_interval_ms` 控制部分模式下的编辑节流（默认：1000ms）。
 - `interrupt_on_new_message = true` 会在对话历史中保留被中断的用户轮次，然后在最新消息上重新开始生成。
 - 中断范围是严格的：同一聊天中的同一发送者。来自不同聊天的消息独立处理。
+- **语音模式**：当用户在启用 `[transcription]` 的情况下发送语音消息时，代理会转录（STT）并回复文本，同时发送 TTS 语音回复（需要启用 `[tts]`）。语音模式在收到语音消息时按聊天激活，当用户发送文本时停用。短于 40 个字符的回复不会被合成。
 
 ### 4.2 Discord
 

--- a/docs/i18n/zh-CN/reference/api/config-reference.zh-CN.md
+++ b/docs/i18n/zh-CN/reference/api/config-reference.zh-CN.md
@@ -194,6 +194,7 @@ temperature = 0.2
 | `open_skills_enabled` | `false` | 选择加入社区 `open-skills` 仓库的加载/同步 |
 | `open_skills_dir` | 未设置 | `open-skills` 的可选本地路径（启用时默认为 `$HOME/open-skills`） |
 | `prompt_injection_mode` | `full` | 技能提示详细程度：`full`（内联指令/工具）或 `compact`（仅名称/描述/位置） |
+| `whitelist` | `[]` | 技能名称白名单。空列表加载所有技能（默认）。非空时仅加载指定技能。适用于减少低上下文模型的系统提示大小。 |
 
 注意事项：
 
@@ -423,6 +424,7 @@ allowed_roots = [\"~/Desktop/projects\", \"/opt/shared-repo\"]
 | `provider` | _必填_ | 要路由到的提供商（必须匹配已知提供商名称） |
 | `model` | _必填_ | 与该提供商一起使用的模型 |
 | `api_key` | 未设置 | 此路由提供商的可选 API 密钥覆盖 |
+| `context_window` | 未设置 | 此路由的可选上下文窗口大小覆盖（token 数）。适用于限制 VRAM 有限后端的上下文。 |
 
 ### `[[embedding_routes]]`
 
@@ -511,6 +513,8 @@ priority = 5
 | 键 | 默认值 | 用途 |
 |---|---|---|
 | `message_timeout_secs` | `300` | 渠道消息处理的基本超时（秒）；运行时会根据工具循环深度扩展（最多 4 倍） |
+| `reply_precheck` | `false` | 在群组对话中回复前运行 LLM 回复意图预检。为 `true` 时，代理会进行轻量分类调用以决定是否回复。私聊始终绕过此检查。 |
+| `max_concurrent_per_channel` | `4` | 每个渠道的最大并发 LLM 请求数。较低的值可防止后端 slot 饱和（例如 llama.cpp `--parallel 3`）。 |
 
 示例：
 

--- a/docs/reference/api/channels-reference.md
+++ b/docs/reference/api/channels-reference.md
@@ -160,8 +160,11 @@ interrupt_on_new_message = false  # optional: cancel in-flight same-sender same-
 
 Telegram notes:
 
+- `stream_mode = "partial"` sends an editable draft message that updates token-by-token as the LLM streams its response, then finalizes with the complete text. Tool-call progress (e.g. "🤔 Thinking...", "🔧 Running shell...") is shown during tool execution.
+- `draft_update_interval_ms` controls edit throttling in partial mode (default: 1000ms).
 - `interrupt_on_new_message = true` preserves interrupted user turns in conversation history, then restarts generation on the newest message.
 - Interruption scope is strict: same sender in the same chat. Messages from different chats are processed independently.
+- **Voice mode**: When a user sends a voice note with `[transcription]` enabled, the agent transcribes it (STT), responds with text, and also sends a TTS voice note reply (requires `[tts]` enabled). Voice mode activates per-chat on incoming voice notes and deactivates when the user sends text. Responses shorter than 40 characters are not synthesized.
 
 ### 4.2 Discord
 

--- a/docs/reference/api/config-reference.md
+++ b/docs/reference/api/config-reference.md
@@ -331,6 +331,7 @@ Notes:
 | `open_skills_enabled` | `false` | Opt-in loading/sync of community `open-skills` repository |
 | `open_skills_dir` | unset | Optional local path for `open-skills` (defaults to `$HOME/open-skills` when enabled) |
 | `prompt_injection_mode` | `full` | Skill prompt verbosity: `full` (inline instructions/tools) or `compact` (name/description/location only) |
+| `whitelist` | `[]` | Skill name allowlist. Empty loads all skills (default). Non-empty loads only the named skills. Useful to reduce system prompt size on low-context models. |
 
 Notes:
 
@@ -583,6 +584,7 @@ Use route hints so integrations can keep stable names while model IDs evolve.
 | `provider` | _required_ | Provider to route to (must match a known provider name) |
 | `model` | _required_ | Model to use with that provider |
 | `api_key` | unset | Optional API key override for this route's provider |
+| `context_window` | unset | Optional context window size override for this route (tokens). Useful to cap context on backends with limited VRAM. |
 
 ### `[[embedding_routes]]`
 
@@ -671,6 +673,8 @@ Top-level channel options are configured under `channels_config`.
 | Key | Default | Purpose |
 |---|---|---|
 | `message_timeout_secs` | `300` | Base timeout in seconds for channel message processing; runtime scales this with tool-loop depth (up to 4x, overridable via `[pacing].message_timeout_scale_max`) |
+| `reply_precheck` | `false` | Run an LLM reply-intent precheck before responding in group conversations. When `true`, the agent makes a lightweight classification call to decide whether the latest group message warrants a reply. DMs always bypass this. |
+| `max_concurrent_per_channel` | `4` | Maximum concurrent LLM requests per channel. Lower values prevent saturating backends with limited slots (e.g. llama.cpp `--parallel 3`). |
 
 Examples:
 

--- a/scripts/rpi-config.toml
+++ b/scripts/rpi-config.toml
@@ -360,6 +360,7 @@ open_skills_enabled = false
 trusted_skill_roots = []
 allow_scripts = false
 prompt_injection_mode = "full"
+whitelist = []
 
 [query_classification]
 enabled = false
@@ -382,6 +383,8 @@ max_steps_per_cycle = 3
 [channels_config]
 cli = true
 message_timeout_secs = 300
+reply_precheck = false
+max_concurrent_per_channel = 4
 
 [channels_config.webhook]
 port = 8080


### PR DESCRIPTION
## Summary
- Document new config parameters (`context_window`, `max_concurrent_per_channel`, `whitelist`) across all reference docs, i18n translations, and RPi template
- Sync `config.template.toml` with latest schema additions

## Dependencies
- Depends on #5417 (`context_window` field)
- Depends on #5418 (`max_concurrent_per_channel` field)

Merge after #5417 and #5418 are merged.

## Test plan
- [ ] Verify docs render correctly
- [ ] Verify config template matches schema defaults