### PR TITLE
feat(agents): real multi-agent system with workspace definitions (#3502)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4424,6 +4424,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4766,6 +4786,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4b1eb7788f3824c629b1116a7a9060d6e898c358ebff59070093d51103dcc3c"
 dependencies = [
  "typewit",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -5933,6 +5973,33 @@ dependencies = [
  "nostr-relay-pool",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.0",
+ "filetime",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -13018,6 +13085,7 @@ dependencies = [
  "mime_guess",
  "nanohtml2text",
  "nostr-sdk",
+ "notify",
  "nusb",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,6 +3167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5983,6 +5992,7 @@ checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
 dependencies = [
  "bitflags 2.11.0",
  "filetime",
+ "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tokio-util = { version = "0.7", default-features = false }
 tokio-stream = { version = "0.1.18", default-features = false, features = ["fs", "sync"] }
 
 # File system watcher for hot-reload (workspace agents)
-notify = { version = "7", default-features = false, features = ["macos_kqueue"] }
+notify = "7"
 
 # HTTP client - minimal features
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "multipart", "stream", "socks"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ tokio = { version = "1.50", default-features = false, features = ["rt-multi-thre
 tokio-util = { version = "0.7", default-features = false }
 tokio-stream = { version = "0.1.18", default-features = false, features = ["fs", "sync"] }
 
+# File system watcher for hot-reload (workspace agents)
+notify = { version = "7", default-features = false, features = ["macos_kqueue"] }
+
 # HTTP client - minimal features
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "blocking", "multipart", "stream", "socks"] }
 

--- a/docs/reference/api/config-reference.md
+++ b/docs/reference/api/config-reference.md
@@ -277,6 +277,8 @@ Delegate sub-agent configurations. Each key under `[agents]` defines a named sub
 | `timeout_secs` | `120` | Timeout in seconds for non-agentic provider calls (1–3600) |
 | `agentic_timeout_secs` | `300` | Timeout in seconds for agentic sub-agent loops (1–3600) |
 | `skills_directory` | unset | Optional skills directory path (workspace-relative) for scoped skill loading |
+| `max_context_tokens` | unset | Cap on the total tokens sent in the sub-agent context window; truncates oldest messages when exceeded |
+| `max_tool_result_chars` | unset | Maximum characters retained from each tool result; longer outputs are truncated with a summary marker |
 
 Notes:
 

--- a/docs/reference/api/config-reference.md
+++ b/docs/reference/api/config-reference.md
@@ -314,6 +314,27 @@ allowed_tools = ["file_read", "shell"]
 skills_directory = "skills/code-review"
 ```
 
+## `[delegate]`
+
+Concurrency controls for sub-agent execution.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_concurrent_subagents` | int | `0` | Maximum concurrent sub-agents. `0` = unlimited. Prevents LLM slot saturation on capacity-limited backends. |
+
+Notes:
+
+- When `max_concurrent_subagents > 0`, a shared semaphore limits the total number of simultaneously executing sub-agents across both `delegate` and `spawn_agent` invocations.
+- Excess requests wait for a permit rather than failing.
+- Recommended values: `1` for 1-2 LLM slots, `2` for 3-4 slots, `3-4` for 5+ slots, `0` (unlimited) for cloud APIs.
+
+Example:
+
+```toml
+[delegate]
+max_concurrent_subagents = 2
+```
+
 ## `[runtime]`
 
 | Key | Default | Purpose |

--- a/docs/reference/api/subagent-architecture.md
+++ b/docs/reference/api/subagent-architecture.md
@@ -182,13 +182,15 @@ Sub-agents do NOT share:
 
 ## Invocation
 
-### From the main agent (LLM decides):
+### From the main agent (LLM decides)
+
 ```
 delegate(agent="researcher", prompt="Find info about X")
 spawn_agent(name="helper", system_prompt="...", prompt="Do Y")
 ```
 
-### Background execution:
+### Background execution
+
 ```
 delegate(agent="researcher", prompt="...", background=true)
 spawn_agent(name="helper", ..., mode="background")

--- a/docs/reference/api/subagent-architecture.md
+++ b/docs/reference/api/subagent-architecture.md
@@ -1,0 +1,209 @@
+# Sub-Agent Architecture
+
+ZeroClaw supports dynamic multi-agent orchestration through two complementary mechanisms: **workspace agents** (file-based, persistent) and **ad-hoc agents** (inline, ephemeral). Both share a common execution engine and can coexist.
+
+## Overview
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Main Agent                         │
+│                                                      │
+│  ┌──────────────┐  ┌──────────────┐                 │
+│  │  delegate     │  │ spawn_agent  │                 │
+│  │  (pre-defined)│  │ (ad-hoc)     │                 │
+│  └──────┬───────┘  └──────┬───────┘                 │
+│         │                  │                         │
+│         ▼                  ▼                         │
+│  ┌─────────────────────────────────┐                │
+│  │   Shared Agent Registry          │                │
+│  │   Arc<RwLock<HashMap>>           │                │
+│  ├─────────────────────────────────┤                │
+│  │ config.toml [agents.*]           │                │
+│  │ workspace/agents/*/config.toml   │  ◄── hot-reload│
+│  │ ephemeral (spawn_agent)          │                │
+│  └──────────────┬──────────────────┘                │
+│                 │                                    │
+│                 ▼                                    │
+│  ┌─────────────────────────────────┐                │
+│  │   run_tool_call_loop()           │                │
+│  │   (isolated context per agent)   │                │
+│  └─────────────────────────────────┘                │
+└─────────────────────────────────────────────────────┘
+```
+
+## Workspace Agents (Definition-Based)
+
+Workspace agents are defined as folders under `workspace/agents/`:
+
+```
+workspace/agents/
+├── researcher/
+│   ├── config.toml       # Agent configuration
+│   ├── IDENTITY.md       # System prompt / persona
+│   ├── TOOLS.md          # Tool usage guidelines (optional)
+│   └── skills/           # Agent-scoped skills
+│       └── deep_search.md
+├── coder/
+│   ├── config.toml
+│   └── IDENTITY.md
+└── common/               # Shared across all agents
+    ├── SAFETY.md
+    └── skills/
+        └── memory_ops.md
+```
+
+### Agent config.toml
+
+Each agent folder contains a `config.toml` with these fields:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `provider` | string | global default | LLM provider (e.g. "openai", "anthropic", "ollama") |
+| `model` | string | global default | Model name |
+| `temperature` | float | global default | Sampling temperature |
+| `agentic` | bool | `true` | Enable multi-turn tool-call loop |
+| `allowed_tools` | string[] | all safe tools | Tool allowlist |
+| `max_iterations` | int | `10` | Max tool-call iterations |
+| `max_depth` | int | `3` | Max nested delegation depth |
+| `timeout_secs` | int | `120` | Non-agentic call timeout |
+| `agentic_timeout_secs` | int | `300` | Agentic run timeout |
+| `memory_namespace` | string | agent name | Memory isolation key |
+| `max_context_tokens` | int | `0` (unlimited) | Context window budget |
+| `max_tool_result_chars` | int | `0` (unlimited) | Tool result truncation |
+
+### Identity and Prompt Construction
+
+The system prompt for a workspace agent is assembled from:
+
+1. **common/*.md** — Shared context (safety rules, guidelines)
+2. **IDENTITY.md** — Agent persona and instructions
+3. **TOOLS.md** — Tool usage guidelines (optional)
+4. **Skills** — From `skills/` + `common/skills/`
+5. **Tool schemas** — Auto-injected based on `allowed_tools`
+
+### Hot-Reload
+
+A file watcher monitors `workspace/agents/` for changes:
+- **Create/Modify** `.toml` or `.md` → agent reloaded automatically
+- **Delete** agent folder → agent removed from registry
+- **common/ changes** → all workspace agents reloaded
+- Config-defined agents (`[agents.*]`) are never overwritten by workspace agents
+
+## Ad-Hoc Agents (spawn_agent)
+
+The `spawn_agent` tool creates ephemeral agents on the fly:
+
+```json
+{
+  "name": "temp-researcher",
+  "system_prompt": "You are a research specialist...",
+  "prompt": "Find information about X",
+  "provider": "openai",
+  "model": "gpt-4o",
+  "allowed_tools": ["web_search", "web_fetch"],
+  "mode": "sync",
+  "save": false
+}
+```
+
+### Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `name` | yes | — | Unique agent identifier |
+| `system_prompt` | yes | — | Agent persona and instructions |
+| `prompt` | yes | — | Task to execute |
+| `provider` | no | global default | LLM provider override |
+| `model` | no | global default | Model override |
+| `allowed_tools` | no | safe defaults | Tool allowlist |
+| `context` | no | — | Context prepended to prompt |
+| `mode` | no | `"sync"` | `"sync"` or `"background"` |
+| `save` | no | `false` | Persist to workspace after execution |
+
+### Persistence
+
+When `save: true`, the agent is written to `workspace/agents/<name>/`:
+- `config.toml` — provider, model, tools, settings
+- `IDENTITY.md` — system_prompt content
+
+The file watcher picks it up automatically, making it a permanent workspace agent.
+
+## Static Agents (config.toml)
+
+Agents can also be defined in the main `config.toml`:
+
+```toml
+[agents.summarizer]
+provider = "openai"
+model = "gpt-4o-mini"
+system_prompt = "You are a concise summarizer."
+agentic = true
+allowed_tools = ["file_read", "web_fetch"]
+max_iterations = 5
+max_context_tokens = 8000
+```
+
+Static agents take priority over workspace agents with the same name.
+
+## Concurrency Control
+
+Sub-agents share LLM backend capacity with the main agent. To prevent slot saturation:
+
+```toml
+[delegate]
+max_concurrent_subagents = 2  # 0 = unlimited (default)
+```
+
+When set, a shared semaphore limits how many sub-agents (delegate + spawn) execute simultaneously. Excess requests wait for a permit rather than failing.
+
+**Recommended settings by backend capacity:**
+
+| LLM Slots | Recommended `max_concurrent_subagents` |
+|-----------|---------------------------------------|
+| 1-2       | 1                                     |
+| 3-4       | 2                                     |
+| 5+        | 3-4                                   |
+| Cloud API | 0 (unlimited)                         |
+
+## Context Isolation
+
+Each sub-agent runs with its own:
+- **History** — Independent conversation context
+- **System prompt** — Built from its own IDENTITY.md + tools
+- **Skills** — Loaded from its own `skills/` directory
+- **Memory namespace** — Isolated from other agents
+- **Context budget** — Per-agent `max_context_tokens`
+- **Tool set** — Filtered by `allowed_tools`
+
+Sub-agents do NOT share:
+- Conversation history with the main agent
+- Each other's memory namespaces
+- Tool execution state
+
+## Invocation
+
+### From the main agent (LLM decides):
+```
+delegate(agent="researcher", prompt="Find info about X")
+spawn_agent(name="helper", system_prompt="...", prompt="Do Y")
+```
+
+### Background execution:
+```
+delegate(agent="researcher", prompt="...", background=true)
+spawn_agent(name="helper", ..., mode="background")
+```
+
+Background tasks return a `task_id`. Results are retrieved with:
+```
+delegate(action="check_result", task_id="<uuid>")
+delegate(action="list_results")
+```
+
+## Security
+
+- Sub-agents inherit the root `SecurityPolicy`
+- `workspace_only = true` restricts file access to the workspace
+- Sub-agents run without an `ApprovalManager` (tools execute directly)
+- The `allowed_tools` allowlist is the primary access control
+- `"delegate"` and `"spawn_agent"` are excluded from sub-agent tool sets to prevent recursive spawning

--- a/examples/workspace-agents/README.md
+++ b/examples/workspace-agents/README.md
@@ -28,6 +28,12 @@ workspace/agents/
 │   ├── TOOLS.md            # Tool usage guidelines (optional)
 │   └── skills/             # Agent-scoped skills
 │       └── summarize.md
+├── researcher/             # An example research-focused agent
+│   ├── config.toml         # Tuned for web research (generous timeouts, research tools)
+│   ├── IDENTITY.md         # Research specialist persona with structured output format
+│   ├── TOOLS.md            # Guidelines for web_search, web_fetch, and memory tools
+│   └── skills/             # Agent-scoped skills
+│       └── deep_search.md  # Multi-source deep research with citation tracking
 ├── common/                 # Shared across ALL workspace agents
 │   ├── SAFETY.md           # Shared safety rules
 │   └── skills/
@@ -44,6 +50,30 @@ workspace/agents/
 3. Add an `IDENTITY.md` with the agent's role and instructions
 4. Optionally add `TOOLS.md` and a `skills/` directory
 5. The agent is immediately available via the `delegate` or `spawn_agent` tools
+
+## Per-Agent Context Configuration
+
+Two fields in `config.toml` let you control how much data each agent processes, which is especially useful for agents that consume large tool outputs (e.g. web pages) or run on models with smaller context windows:
+
+| Field | Default | Purpose |
+|---|---|---|
+| `max_context_tokens` | unset (global limit) | Cap on total tokens sent in the agent context window. Oldest messages are truncated when the limit is exceeded. |
+| `max_tool_result_chars` | unset (global limit) | Maximum characters retained from each tool result. Longer outputs are truncated with a summary marker. |
+
+Example — a researcher agent with conservative context limits:
+
+```toml
+# researcher/config.toml
+max_context_tokens = 32000
+max_tool_result_chars = 5000
+
+agentic = true
+max_iterations = 20
+allowed_tools = ["web_search", "web_fetch", "file_read", "file_write"]
+agentic_timeout_secs = 600
+```
+
+These settings override the global values from your main `config.toml` for that agent only.
 
 ## Using Agents
 

--- a/examples/workspace-agents/README.md
+++ b/examples/workspace-agents/README.md
@@ -1,0 +1,60 @@
+# Workspace Agent Examples
+
+This directory contains example agent definitions for the ZeroClaw workspace agent system.
+
+## Quick Start
+
+1. Copy an agent folder to your workspace:
+   ```bash
+   cp -r examples/workspace-agents/assistant /your-workspace/agents/assistant
+   cp -r examples/workspace-agents/common /your-workspace/agents/common
+   ```
+
+2. Customize `config.toml` with your provider and model preferences.
+
+3. Edit `IDENTITY.md` to define the agent's persona and behavior.
+
+4. (Optional) Add agent-specific skills in the `skills/` subfolder.
+
+5. ZeroClaw will detect the new agent automatically via hot-reload.
+
+## Structure
+
+```
+workspace/agents/
+├── assistant/              # An example general-purpose agent
+│   ├── config.toml         # Agent configuration (provider, model, tools)
+│   ├── IDENTITY.md         # System prompt / persona
+│   ├── TOOLS.md            # Tool usage guidelines (optional)
+│   └── skills/             # Agent-scoped skills
+│       └── summarize.md
+├── common/                 # Shared across ALL workspace agents
+│   ├── SAFETY.md           # Shared safety rules
+│   └── skills/
+│       └── memory_ops.md   # Shared skills
+└── <your-agent>/           # Create your own!
+    ├── config.toml
+    └── IDENTITY.md
+```
+
+## Creating a New Agent
+
+1. Create a new folder under `workspace/agents/`
+2. Add a `config.toml` (copy from `assistant/config.toml` as template)
+3. Add an `IDENTITY.md` with the agent's role and instructions
+4. Optionally add `TOOLS.md` and a `skills/` directory
+5. The agent is immediately available via the `delegate` or `spawn_agent` tools
+
+## Using Agents
+
+Once defined, agents can be invoked by the main agent:
+
+```
+delegate(agent="assistant", prompt="Summarize the README.md file")
+```
+
+Or created on-the-fly and persisted:
+
+```
+spawn_agent(name="researcher", system_prompt="...", prompt="...", save=true)
+```

--- a/examples/workspace-agents/assistant/IDENTITY.md
+++ b/examples/workspace-agents/assistant/IDENTITY.md
@@ -1,0 +1,16 @@
+# Assistant Agent
+
+You are a helpful general-purpose assistant. You can read and write files, search the web, and execute shell commands.
+
+## Guidelines
+
+- Be concise and direct in your responses
+- Verify information before presenting it as fact
+- When modifying files, read them first to understand context
+- Use memory to track important findings across tasks
+
+## Safety
+
+- Never execute destructive commands without explicit confirmation
+- Do not modify files outside the workspace directory
+- Prefer non-destructive operations (e.g. `trash` over `rm`)

--- a/examples/workspace-agents/assistant/TOOLS.md
+++ b/examples/workspace-agents/assistant/TOOLS.md
@@ -1,0 +1,15 @@
+# Tool Usage Guidelines
+
+## File Operations
+- Always read a file before editing it
+- Use `file_edit` for targeted changes, `file_write` for new files
+- Verify changes after writing
+
+## Shell Commands
+- Prefer simple, non-interactive commands
+- Quote paths that may contain spaces
+- Avoid long-running processes without timeout
+
+## Web Research
+- Use `web_search` to find information, then `web_fetch` for details
+- Always cite sources when presenting web-sourced information

--- a/examples/workspace-agents/assistant/TOOLS.md
+++ b/examples/workspace-agents/assistant/TOOLS.md
@@ -1,15 +1,18 @@
 # Tool Usage Guidelines
 
 ## File Operations
+
 - Always read a file before editing it
 - Use `file_edit` for targeted changes, `file_write` for new files
 - Verify changes after writing
 
 ## Shell Commands
+
 - Prefer simple, non-interactive commands
 - Quote paths that may contain spaces
 - Avoid long-running processes without timeout
 
 ## Web Research
+
 - Use `web_search` to find information, then `web_fetch` for details
 - Always cite sources when presenting web-sourced information

--- a/examples/workspace-agents/assistant/config.toml
+++ b/examples/workspace-agents/assistant/config.toml
@@ -1,0 +1,36 @@
+# Workspace Agent Configuration
+# Copy this folder to your workspace/agents/ directory and customize.
+#
+# All fields are optional — unset values fall back to the global defaults
+# from your main config.toml.
+
+# Provider override (e.g. "openai", "anthropic", "ollama")
+# provider = "openai"
+
+# Model override
+# model = "gpt-4o"
+
+# Enable multi-turn tool-call loop (default: true)
+agentic = true
+
+# Maximum tool-call iterations in agentic mode
+max_iterations = 15
+
+# Tools this agent can use (empty = all safe tools)
+allowed_tools = [
+    "file_read",
+    "file_write",
+    "file_edit",
+    "shell",
+    "memory_recall",
+    "memory_store",
+    "web_search",
+    "web_fetch",
+    "calculator",
+]
+
+# Max recursion depth for nested delegation
+max_depth = 3
+
+# Memory namespace isolation (default: agent folder name)
+# memory_namespace = "assistant"

--- a/examples/workspace-agents/assistant/skills/summarize.md
+++ b/examples/workspace-agents/assistant/skills/summarize.md
@@ -1,0 +1,12 @@
+---
+name: summarize
+description: Summarize text or file contents concisely
+---
+
+When asked to summarize, follow these steps:
+
+1. Read the full content (file or provided text)
+2. Identify the key points and main themes
+3. Write a concise summary (aim for ~20% of original length)
+4. Include any critical details, numbers, or conclusions
+5. Format with bullet points for easy scanning

--- a/examples/workspace-agents/common/SAFETY.md
+++ b/examples/workspace-agents/common/SAFETY.md
@@ -1,0 +1,9 @@
+# Shared Safety Guidelines
+
+These rules apply to ALL workspace agents.
+
+- Never expose API keys, tokens, or credentials in outputs
+- Do not access files outside the designated workspace
+- Log significant actions for audit trail
+- Respect rate limits on external APIs
+- When in doubt, ask for confirmation before proceeding

--- a/examples/workspace-agents/common/skills/memory_ops.md
+++ b/examples/workspace-agents/common/skills/memory_ops.md
@@ -1,0 +1,14 @@
+---
+name: memory_ops
+description: Standard memory operations shared across all agents
+---
+
+## Storing Memories
+- Use descriptive keys that include context
+- Tag memories with the current task for retrieval
+- Keep stored values concise — store references, not full documents
+
+## Recalling Memories
+- Search with relevant keywords before starting new research
+- Check for existing context before making external calls
+- Update stale memories when you find newer information

--- a/examples/workspace-agents/common/skills/memory_ops.md
+++ b/examples/workspace-agents/common/skills/memory_ops.md
@@ -4,11 +4,13 @@ description: Standard memory operations shared across all agents
 ---
 
 ## Storing Memories
+
 - Use descriptive keys that include context
 - Tag memories with the current task for retrieval
 - Keep stored values concise — store references, not full documents
 
 ## Recalling Memories
+
 - Search with relevant keywords before starting new research
 - Check for existing context before making external calls
 - Update stale memories when you find newer information

--- a/examples/workspace-agents/researcher/IDENTITY.md
+++ b/examples/workspace-agents/researcher/IDENTITY.md
@@ -1,0 +1,43 @@
+# Researcher Agent
+
+You are a dedicated research specialist. Your job is to find, verify, and synthesize information from multiple sources.
+
+## Core Principles
+
+- **Accuracy first**: Always verify claims across multiple sources before presenting them as fact
+- **Source attribution**: Cite every source with URL and date accessed
+- **Structured output**: Present findings in clear, organized formats (bullet points, tables, sections)
+- **Depth over breadth**: It's better to deeply understand 3 sources than to skim 10
+
+## Research Workflow
+
+1. **Understand the query**: Break down what information is actually needed
+2. **Search broadly**: Use web_search to find relevant sources
+3. **Read deeply**: Use web_fetch to read the most promising results
+4. **Cross-reference**: Verify key facts across at least 2 independent sources
+5. **Synthesize**: Combine findings into a coherent, well-structured response
+6. **Store findings**: Save important discoveries to memory for future reference
+
+## Output Format
+
+Always structure your research output as:
+
+### Summary
+Brief 2-3 sentence overview of findings.
+
+### Key Findings
+- Finding 1 (source: [URL])
+- Finding 2 (source: [URL])
+
+### Details
+Expanded analysis with supporting evidence.
+
+### Sources
+Numbered list of all sources consulted.
+
+## Limitations
+
+- Do not present speculation as fact
+- Clearly mark uncertain or conflicting information
+- If you cannot find reliable information, say so explicitly
+- Do not fabricate sources or URLs

--- a/examples/workspace-agents/researcher/IDENTITY.md
+++ b/examples/workspace-agents/researcher/IDENTITY.md
@@ -23,16 +23,20 @@ You are a dedicated research specialist. Your job is to find, verify, and synthe
 Always structure your research output as:
 
 ### Summary
+
 Brief 2-3 sentence overview of findings.
 
 ### Key Findings
+
 - Finding 1 (source: [URL])
 - Finding 2 (source: [URL])
 
 ### Details
+
 Expanded analysis with supporting evidence.
 
 ### Sources
+
 Numbered list of all sources consulted.
 
 ## Limitations

--- a/examples/workspace-agents/researcher/TOOLS.md
+++ b/examples/workspace-agents/researcher/TOOLS.md
@@ -1,23 +1,27 @@
 # Research Tool Guidelines
 
 ## Web Search
+
 - Start with broad queries, then narrow down
 - Use specific technical terms when searching for technical topics
 - Try multiple search queries if the first doesn't yield good results
 - Prefer recent results for time-sensitive topics
 
 ## Web Fetch
+
 - Read the full page before extracting information
 - Look for author, date, and credibility indicators
 - Extract relevant quotes for citation
 - Note if the page is behind a paywall or requires authentication
 
 ## Memory
+
 - Store research findings with descriptive keys: "research:<topic>:<date>"
 - Check memory before starting new research — previous findings may be relevant
 - Update stale findings when you discover newer information
 
 ## File Operations
+
 - Save detailed research reports to files when requested
 - Use markdown format for readability
 - Include all sources and citations in saved reports

--- a/examples/workspace-agents/researcher/TOOLS.md
+++ b/examples/workspace-agents/researcher/TOOLS.md
@@ -1,0 +1,23 @@
+# Research Tool Guidelines
+
+## Web Search
+- Start with broad queries, then narrow down
+- Use specific technical terms when searching for technical topics
+- Try multiple search queries if the first doesn't yield good results
+- Prefer recent results for time-sensitive topics
+
+## Web Fetch
+- Read the full page before extracting information
+- Look for author, date, and credibility indicators
+- Extract relevant quotes for citation
+- Note if the page is behind a paywall or requires authentication
+
+## Memory
+- Store research findings with descriptive keys: "research:<topic>:<date>"
+- Check memory before starting new research — previous findings may be relevant
+- Update stale findings when you discover newer information
+
+## File Operations
+- Save detailed research reports to files when requested
+- Use markdown format for readability
+- Include all sources and citations in saved reports

--- a/examples/workspace-agents/researcher/config.toml
+++ b/examples/workspace-agents/researcher/config.toml
@@ -1,0 +1,33 @@
+# Researcher Agent — optimized for web research tasks
+#
+# Uses the default provider/model from the main config.
+# Uncomment to override:
+# provider = "openai"
+# model = "pakllm"
+
+# Context and truncation
+max_context_tokens = 32000
+max_tool_result_chars = 5000
+
+# Behavior
+agentic = true
+max_iterations = 20
+max_depth = 2
+
+# Tools: focused on research capabilities
+allowed_tools = [
+    "web_search",
+    "web_fetch",
+    "file_read",
+    "file_write",
+    "memory_recall",
+    "memory_store",
+    "calculator",
+]
+
+# Memory isolation
+# memory_namespace = "researcher"
+
+# Timeouts (generous for web research)
+timeout_secs = 120
+agentic_timeout_secs = 600

--- a/examples/workspace-agents/researcher/skills/deep_search.md
+++ b/examples/workspace-agents/researcher/skills/deep_search.md
@@ -1,0 +1,23 @@
+---
+name: deep_search
+description: Multi-source deep research with cross-referencing and citation
+---
+
+When performing deep research:
+
+1. Generate 3-5 different search queries for the topic
+2. For each query, examine the top 3 results
+3. Fetch and read the most relevant pages (up to 5 total)
+4. Cross-reference key facts across sources
+5. Build a citation map linking claims to sources
+6. Synthesize into a structured report with:
+   - Executive summary (3-5 sentences)
+   - Key findings (bullet points with inline citations)
+   - Detailed analysis (organized by subtopic)
+   - Confidence assessment (high/medium/low per finding)
+   - Complete source list with URLs
+
+Quality checks:
+- Every factual claim must have at least one citation
+- Conflicting information must be noted explicitly
+- Recency of sources must be considered for time-sensitive topics

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -15,6 +15,7 @@ pub mod personality;
 pub mod prompt;
 pub mod thinking;
 pub mod tool_execution;
+pub mod workspace_agents;
 
 #[cfg(test)]
 mod tests;

--- a/src/agent/workspace_agents.rs
+++ b/src/agent/workspace_agents.rs
@@ -300,6 +300,8 @@ impl WorkspaceAgentManager {
             timeout_secs: delegate.timeout_secs,
             agentic_timeout_secs: delegate.agentic_timeout_secs,
             memory_namespace: delegate.memory_namespace.clone(),
+            max_context_tokens: delegate.max_context_tokens,
+            max_tool_result_chars: delegate.max_tool_result_chars,
         };
 
         let toml_str =

--- a/src/agent/workspace_agents.rs
+++ b/src/agent/workspace_agents.rs
@@ -560,6 +560,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
 
@@ -668,6 +670,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
 
@@ -701,6 +705,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: Some("saved_bot".into()),
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
 

--- a/src/agent/workspace_agents.rs
+++ b/src/agent/workspace_agents.rs
@@ -560,8 +560,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
 
@@ -670,8 +670,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
 

--- a/src/agent/workspace_agents.rs
+++ b/src/agent/workspace_agents.rs
@@ -128,7 +128,7 @@ impl WorkspaceAgentManager {
     /// On `Create`/`Modify` events for `config.toml` or `.md` files the
     /// affected agent is reloaded.  On `Remove` events the agent is removed
     /// from the registry (only if it was workspace-loaded, never config-defined).
-    pub fn startwatcher_handle(&mut self) -> Result<()> {
+    pub fn start_watcher(&mut self) -> Result<()> {
         let agents_dir = self.workspace_dir.join("agents");
         if !agents_dir.is_dir() {
             std::fs::create_dir_all(&agents_dir)

--- a/src/agent/workspace_agents.rs
+++ b/src/agent/workspace_agents.rs
@@ -1,0 +1,730 @@
+//! Workspace-based agent definitions with hot-reload via file watcher.
+//!
+//! Agents are defined as folders under `workspace/agents/<name>/` containing a
+//! `config.toml` (parsed as [`WorkspaceAgentConfig`]), an optional `IDENTITY.md`
+//! system prompt, optional `TOOLS.md` tool guidance, and an optional `skills/`
+//! subdirectory.  A sibling `common/` folder provides shared `.md` context and
+//! skills inherited by all workspace agents.
+//!
+//! The [`WorkspaceAgentManager`] loads these on startup and optionally watches
+//! for file-system changes to hot-reload agent definitions at runtime.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use parking_lot::RwLock;
+use tracing::{debug, error, info, warn};
+
+use crate::config::schema::{DelegateAgentConfig, WorkspaceAgentConfig};
+
+/// Manages workspace-folder-based agent definitions with optional hot-reload.
+pub struct WorkspaceAgentManager {
+    /// Shared mutable agent registry (config agents + workspace agents + ad-hoc ephemeral).
+    agents: Arc<RwLock<HashMap<String, DelegateAgentConfig>>>,
+    /// Workspace root path (parent of `agents/`).
+    workspace_dir: PathBuf,
+    /// Global config defaults.
+    default_provider: String,
+    default_model: String,
+    /// Names of agents defined in the static TOML config (protected from overwrite).
+    config_agent_names: HashSet<String>,
+    /// File watcher handle (kept alive so watcher doesn't drop).
+    _watcher: Option<RecommendedWatcher>,
+}
+
+impl WorkspaceAgentManager {
+    /// Create a new manager, seeding the registry with `config_agents` and then
+    /// scanning `workspace_dir/agents/` for folder-based definitions.
+    ///
+    /// Config-defined agents take priority: a workspace agent whose name
+    /// collides with a config agent is silently skipped.
+    pub fn new(
+        workspace_dir: PathBuf,
+        config_agents: HashMap<String, DelegateAgentConfig>,
+        default_provider: String,
+        default_model: String,
+    ) -> Self {
+        let config_agent_names: HashSet<String> = config_agents.keys().cloned().collect();
+        let mut agents = config_agents;
+
+        let agents_dir = workspace_dir.join("agents");
+        let common_dir = agents_dir.join("common");
+
+        // Ensure workspace agent directories exist on boot.
+        for dir in [&agents_dir, &common_dir] {
+            if !dir.is_dir() {
+                if let Err(e) = std::fs::create_dir_all(dir) {
+                    warn!(path = %dir.display(), error = %e, "failed to create workspace agent directory");
+                } else {
+                    info!(path = %dir.display(), "created workspace agent directory");
+                }
+            }
+        }
+
+        let mut workspace_count = 0u32;
+
+        if agents_dir.is_dir() {
+            if let Ok(entries) = std::fs::read_dir(&agents_dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if !path.is_dir() {
+                        continue;
+                    }
+                    let name = match path.file_name().and_then(|n| n.to_str()) {
+                        Some(n) => n.to_owned(),
+                        None => continue,
+                    };
+                    // Skip the `common` directory — it holds shared context, not an agent.
+                    if name == "common" {
+                        continue;
+                    }
+                    // Config agents take priority.
+                    if config_agent_names.contains(&name) {
+                        debug!(
+                            agent = %name,
+                            "workspace agent skipped: config-defined agent has priority"
+                        );
+                        continue;
+                    }
+                    if !path.join("config.toml").exists() {
+                        continue;
+                    }
+                    match load_workspace_agent(
+                        &path,
+                        &common_dir,
+                        &default_provider,
+                        &default_model,
+                    ) {
+                        Ok(delegate) => {
+                            info!(agent = %name, "loaded workspace agent");
+                            agents.insert(name, delegate);
+                            workspace_count += 1;
+                        }
+                        Err(e) => {
+                            warn!(agent = %name, error = %e, "failed to load workspace agent");
+                        }
+                    }
+                }
+            }
+        }
+
+        info!(count = workspace_count, "workspace agents loaded");
+
+        Self {
+            agents: Arc::new(RwLock::new(agents)),
+            workspace_dir,
+            default_provider,
+            default_model,
+            config_agent_names,
+            _watcher: None,
+        }
+    }
+
+    /// Start a recursive file watcher on `workspace_dir/agents/`.
+    ///
+    /// On `Create`/`Modify` events for `config.toml` or `.md` files the
+    /// affected agent is reloaded.  On `Remove` events the agent is removed
+    /// from the registry (only if it was workspace-loaded, never config-defined).
+    pub fn start_watcher(&mut self) -> Result<()> {
+        let agents_dir = self.workspace_dir.join("agents");
+        if !agents_dir.is_dir() {
+            std::fs::create_dir_all(&agents_dir)
+                .with_context(|| format!("creating agents directory: {}", agents_dir.display()))?;
+        }
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<notify::Event>(100);
+
+        let mut watcher = RecommendedWatcher::new(
+            move |res: Result<notify::Event, notify::Error>| {
+                if let Ok(event) = res {
+                    let _ = tx.blocking_send(event);
+                }
+            },
+            notify::Config::default(),
+        )
+        .context("creating file watcher")?;
+
+        watcher
+            .watch(agents_dir.as_ref(), RecursiveMode::Recursive)
+            .with_context(|| format!("watching directory: {}", agents_dir.display()))?;
+
+        let agents_clone = Arc::clone(&self.agents);
+        let config_names = self.config_agent_names.clone();
+        let common_dir = agents_dir.join("common");
+        let agents_root = agents_dir.clone();
+        let default_provider = self.default_provider.clone();
+        let default_model = self.default_model.clone();
+
+        // Guard against missing Tokio runtime (e.g. in non-async tests).
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            warn!("no Tokio runtime available — workspace agent watcher disabled");
+            self._watcher = Some(watcher);
+            return Ok(());
+        };
+        handle.spawn(async move {
+            while let Some(event) = rx.recv().await {
+                let dominated_by_relevant_path = event.paths.iter().any(|p| {
+                    if let Some(ext) = p.extension().and_then(|e| e.to_str()) {
+                        ext == "toml" || ext == "md"
+                    } else {
+                        false
+                    }
+                });
+                if !dominated_by_relevant_path {
+                    continue;
+                }
+
+                match event.kind {
+                    EventKind::Create(_) | EventKind::Modify(_) => {
+                        for path in &event.paths {
+                            let agent_name =
+                                match extract_agent_name_from_path(path, &agents_root) {
+                                    Some(n) => n,
+                                    None => continue,
+                                };
+                            if agent_name == "common" {
+                                // Common dir changed — reload all workspace agents.
+                                debug!("common directory changed, reloading all workspace agents");
+                                reload_all_workspace_agents(
+                                    &agents_clone,
+                                    &agents_root,
+                                    &common_dir,
+                                    &config_names,
+                                    &default_provider,
+                                    &default_model,
+                                );
+                                break;
+                            }
+                            if config_names.contains(&agent_name) {
+                                debug!(
+                                    agent = %agent_name,
+                                    "ignoring watcher event for config-defined agent"
+                                );
+                                continue;
+                            }
+                            let agent_dir = agents_root.join(&agent_name);
+                            if !agent_dir.join("config.toml").exists() {
+                                continue;
+                            }
+                            match load_workspace_agent(
+                                &agent_dir,
+                                &common_dir,
+                                &default_provider,
+                                &default_model,
+                            ) {
+                                Ok(delegate) => {
+                                    info!(agent = %agent_name, "reloaded workspace agent");
+                                    agents_clone
+                                        .write()
+                                        .insert(agent_name, delegate);
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        agent = %agent_name,
+                                        error = %e,
+                                        "failed to reload workspace agent"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    EventKind::Remove(_) => {
+                        for path in &event.paths {
+                            let agent_name =
+                                match extract_agent_name_from_path(path, &agents_root) {
+                                    Some(n) => n,
+                                    None => continue,
+                                };
+                            if config_names.contains(&agent_name) {
+                                continue;
+                            }
+                            let agent_dir = agents_root.join(&agent_name);
+                            if !agent_dir.join("config.toml").exists() {
+                                info!(agent = %agent_name, "removed workspace agent");
+                                agents_clone.write().remove(&agent_name);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        self._watcher = Some(watcher);
+        info!(
+            path = %agents_dir.display(),
+            "workspace agent file watcher started"
+        );
+        Ok(())
+    }
+
+    /// Returns a clone of the shared agent registry handle.
+    pub fn agents(&self) -> Arc<RwLock<HashMap<String, DelegateAgentConfig>>> {
+        Arc::clone(&self.agents)
+    }
+
+    /// Register an ephemeral (ad-hoc) agent that is not persisted to disk.
+    pub fn register_ephemeral(&self, name: String, config: DelegateAgentConfig) {
+        info!(agent = %name, "registered ephemeral agent");
+        self.agents.write().insert(name, config);
+    }
+
+    /// Persist an agent from the registry to `workspace_dir/agents/<name>/`.
+    ///
+    /// Writes `config.toml` from the delegate config fields and `IDENTITY.md`
+    /// from the system prompt.  The file watcher will pick up the new files
+    /// automatically.
+    pub async fn save_agent(&self, name: &str) -> Result<()> {
+        let delegate = {
+            let lock = self.agents.read();
+            lock.get(name)
+                .cloned()
+                .with_context(|| format!("agent '{name}' not found in registry"))?
+        };
+
+        let agent_dir = self.workspace_dir.join("agents").join(name);
+        tokio::fs::create_dir_all(&agent_dir)
+            .await
+            .with_context(|| format!("creating agent directory: {}", agent_dir.display()))?;
+
+        // Build a WorkspaceAgentConfig for serialization.
+        let ws_config = WorkspaceAgentConfig {
+            provider: Some(delegate.provider.clone()),
+            model: Some(delegate.model.clone()),
+            temperature: delegate.temperature,
+            agentic: delegate.agentic,
+            allowed_tools: delegate.allowed_tools.clone(),
+            max_iterations: delegate.max_iterations,
+            max_depth: delegate.max_depth,
+            timeout_secs: delegate.timeout_secs,
+            agentic_timeout_secs: delegate.agentic_timeout_secs,
+            memory_namespace: delegate.memory_namespace.clone(),
+        };
+
+        let toml_str =
+            toml::to_string_pretty(&ws_config).context("serializing workspace agent config")?;
+        let config_path = agent_dir.join("config.toml");
+        tokio::fs::write(&config_path, toml_str)
+            .await
+            .with_context(|| format!("writing config: {}", config_path.display()))?;
+
+        if let Some(prompt) = &delegate.system_prompt {
+            let identity_path = agent_dir.join("IDENTITY.md");
+            tokio::fs::write(&identity_path, prompt)
+                .await
+                .with_context(|| format!("writing identity: {}", identity_path.display()))?;
+        }
+
+        info!(agent = %name, path = %agent_dir.display(), "saved workspace agent to disk");
+        Ok(())
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/// Load a single workspace agent from its folder.
+///
+/// Reads `config.toml`, optional `IDENTITY.md`, optional `TOOLS.md`, and
+/// shared `.md` files from the `common_dir`, then assembles them into a
+/// [`DelegateAgentConfig`].
+fn load_workspace_agent(
+    agent_dir: &Path,
+    common_dir: &Path,
+    default_provider: &str,
+    default_model: &str,
+) -> Result<DelegateAgentConfig> {
+    let agent_name = agent_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+
+    // Parse config.toml
+    let config_path = agent_dir.join("config.toml");
+    let config_text = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("reading {}", config_path.display()))?;
+    let workspace_config: WorkspaceAgentConfig = toml::from_str(&config_text)
+        .with_context(|| format!("parsing {}", config_path.display()))?;
+
+    // Read optional markdown files
+    let identity = read_optional_file(&agent_dir.join("IDENTITY.md"));
+    let tools_guidance = read_optional_file(&agent_dir.join("TOOLS.md"));
+
+    // Read shared context from common_dir (top-level .md files only)
+    let shared_context = read_common_md_files(common_dir);
+
+    // Assemble system prompt: shared + identity + tools
+    let mut prompt_parts: Vec<String> = Vec::new();
+    if !shared_context.is_empty() {
+        prompt_parts.push(shared_context);
+    }
+    if let Some(id) = identity {
+        prompt_parts.push(id);
+    }
+    if let Some(tools) = tools_guidance {
+        prompt_parts.push(tools);
+    }
+
+    let system_prompt = if prompt_parts.is_empty() {
+        None
+    } else {
+        Some(prompt_parts.join("\n\n"))
+    };
+
+    let skills_directory = format!("agents/{agent_name}/skills");
+
+    Ok(workspace_config.into_delegate_config(
+        agent_name,
+        system_prompt,
+        Some(skills_directory),
+        default_provider,
+        default_model,
+    ))
+}
+
+/// Read a file and return its contents, or `None` if the file doesn't exist
+/// or can't be read.
+fn read_optional_file(path: &Path) -> Option<String> {
+    match std::fs::read_to_string(path) {
+        Ok(s) if !s.trim().is_empty() => Some(s),
+        _ => None,
+    }
+}
+
+/// Read all top-level `.md` files from a directory and concatenate them
+/// (sorted by filename for deterministic ordering).
+fn read_common_md_files(common_dir: &Path) -> String {
+    let mut parts: Vec<(String, String)> = Vec::new();
+    let entries = match std::fs::read_dir(common_dir) {
+        Ok(e) => e,
+        Err(_) => return String::new(),
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let ext = path.extension().and_then(|e| e.to_str());
+        if ext != Some("md") {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            if !content.trim().is_empty() {
+                parts.push((name, content));
+            }
+        }
+    }
+
+    // Sort by filename for deterministic ordering.
+    parts.sort_by(|a, b| a.0.cmp(&b.0));
+    parts
+        .into_iter()
+        .map(|(_, content)| content)
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+/// Extract the agent name from a filesystem event path.
+///
+/// Given `agents_root = /workspace/agents` and
+/// `path = /workspace/agents/researcher/config.toml`, returns `Some("researcher")`.
+fn extract_agent_name_from_path(path: &Path, agents_root: &Path) -> Option<String> {
+    let relative = path.strip_prefix(agents_root).ok()?;
+    let first_component = relative.components().next()?;
+    match first_component {
+        std::path::Component::Normal(name) => Some(name.to_string_lossy().to_string()),
+        _ => None,
+    }
+}
+
+/// Reload all workspace agents from disk (used when the `common/` directory changes).
+fn reload_all_workspace_agents(
+    agents: &Arc<RwLock<HashMap<String, DelegateAgentConfig>>>,
+    agents_root: &Path,
+    common_dir: &Path,
+    config_names: &HashSet<String>,
+    default_provider: &str,
+    default_model: &str,
+) {
+    let entries = match std::fs::read_dir(agents_root) {
+        Ok(e) => e,
+        Err(e) => {
+            error!(error = %e, "failed to read agents directory during reload");
+            return;
+        }
+    };
+
+    let mut lock = agents.write();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_owned(),
+            None => continue,
+        };
+        if name == "common" || config_names.contains(&name) {
+            continue;
+        }
+        if !path.join("config.toml").exists() {
+            continue;
+        }
+        match load_workspace_agent(&path, common_dir, default_provider, default_model) {
+            Ok(delegate) => {
+                info!(agent = %name, "reloaded workspace agent (common changed)");
+                lock.insert(name, delegate);
+            }
+            Err(e) => {
+                warn!(agent = %name, error = %e, "failed to reload workspace agent");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Helper: write a minimal workspace agent folder.
+    fn write_agent(base: &Path, name: &str, toml_content: &str, identity: Option<&str>) {
+        let dir = base.join("agents").join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("config.toml"), toml_content).unwrap();
+        if let Some(id) = identity {
+            std::fs::write(dir.join("IDENTITY.md"), id).unwrap();
+        }
+    }
+
+    fn write_common_md(base: &Path, filename: &str, content: &str) {
+        let dir = base.join("agents").join("common");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(filename), content).unwrap();
+    }
+
+    #[test]
+    fn loads_workspace_agents_on_new() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        write_agent(base, "researcher", "agentic = true\n", Some("You are a researcher."));
+
+        let mgr = WorkspaceAgentManager::new(
+            base.to_path_buf(),
+            HashMap::new(),
+            "openai".into(),
+            "gpt-4".into(),
+        );
+
+        let agents = mgr.agents.read();
+        assert!(agents.contains_key("researcher"));
+        let cfg = &agents["researcher"];
+        assert!(cfg.agentic);
+        assert_eq!(cfg.provider, "openai");
+        assert!(cfg.system_prompt.as_deref().unwrap().contains("researcher"));
+    }
+
+    #[test]
+    fn config_agents_take_priority() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        write_agent(base, "coder", "agentic = false\n", None);
+
+        let mut config_agents = HashMap::new();
+        config_agents.insert(
+            "coder".into(),
+            DelegateAgentConfig {
+                provider: "anthropic".into(),
+                model: "claude-3".into(),
+                system_prompt: Some("config-defined".into()),
+                api_key: None,
+                temperature: None,
+                max_depth: 3,
+                agentic: true,
+                allowed_tools: vec![],
+                max_iterations: 10,
+                timeout_secs: None,
+                agentic_timeout_secs: None,
+                skills_directory: None,
+                memory_namespace: None,
+            },
+        );
+
+        let mgr = WorkspaceAgentManager::new(
+            base.to_path_buf(),
+            config_agents,
+            "openai".into(),
+            "gpt-4".into(),
+        );
+
+        let agents = mgr.agents.read();
+        let cfg = &agents["coder"];
+        // Should be the config-defined version, not the workspace one.
+        assert_eq!(cfg.provider, "anthropic");
+        assert!(cfg.agentic);
+        assert_eq!(cfg.system_prompt.as_deref(), Some("config-defined"));
+    }
+
+    #[test]
+    fn common_md_files_included_in_prompt() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        write_common_md(base, "SAFETY.md", "Be safe.");
+        write_agent(base, "helper", "agentic = true\n", Some("I help."));
+
+        let mgr = WorkspaceAgentManager::new(
+            base.to_path_buf(),
+            HashMap::new(),
+            "openai".into(),
+            "gpt-4".into(),
+        );
+
+        let agents = mgr.agents.read();
+        let prompt = agents["helper"].system_prompt.as_deref().unwrap();
+        assert!(prompt.contains("Be safe."));
+        assert!(prompt.contains("I help."));
+        // Common context comes first.
+        assert!(prompt.find("Be safe.").unwrap() < prompt.find("I help.").unwrap());
+    }
+
+    #[test]
+    fn skips_dirs_without_config_toml() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        // Create a directory without config.toml
+        std::fs::create_dir_all(base.join("agents").join("incomplete")).unwrap();
+        std::fs::write(
+            base.join("agents").join("incomplete").join("IDENTITY.md"),
+            "no config",
+        )
+        .unwrap();
+
+        let mgr = WorkspaceAgentManager::new(
+            base.to_path_buf(),
+            HashMap::new(),
+            "openai".into(),
+            "gpt-4".into(),
+        );
+
+        let agents = mgr.agents.read();
+        assert!(!agents.contains_key("incomplete"));
+    }
+
+    #[test]
+    fn extract_agent_name_works() {
+        let root = Path::new("/workspace/agents");
+        let path = Path::new("/workspace/agents/researcher/config.toml");
+        assert_eq!(
+            extract_agent_name_from_path(path, root),
+            Some("researcher".into())
+        );
+
+        let deep = Path::new("/workspace/agents/coder/skills/search.toml");
+        assert_eq!(
+            extract_agent_name_from_path(deep, root),
+            Some("coder".into())
+        );
+
+        let outside = Path::new("/other/path/file.toml");
+        assert_eq!(extract_agent_name_from_path(outside, root), None);
+    }
+
+    #[tokio::test]
+    async fn register_ephemeral_adds_agent() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = WorkspaceAgentManager::new(
+            tmp.path().to_path_buf(),
+            HashMap::new(),
+            "openai".into(),
+            "gpt-4".into(),
+        );
+
+        mgr.register_ephemeral(
+            "temp_agent".into(),
+            DelegateAgentConfig {
+                provider: "test".into(),
+                model: "test-model".into(),
+                system_prompt: None,
+                api_key: None,
+                temperature: None,
+                max_depth: 1,
+                agentic: false,
+                allowed_tools: vec![],
+                max_iterations: 5,
+                timeout_secs: None,
+                agentic_timeout_secs: None,
+                skills_directory: None,
+                memory_namespace: None,
+            },
+        );
+
+        let agents = mgr.agents.read();
+        assert!(agents.contains_key("temp_agent"));
+    }
+
+    #[tokio::test]
+    async fn save_agent_writes_files() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = WorkspaceAgentManager::new(
+            tmp.path().to_path_buf(),
+            HashMap::new(),
+            "openai".into(),
+            "gpt-4".into(),
+        );
+
+        mgr.register_ephemeral(
+            "saved_bot".into(),
+            DelegateAgentConfig {
+                provider: "anthropic".into(),
+                model: "claude-3".into(),
+                system_prompt: Some("You are a saved bot.".into()),
+                api_key: None,
+                temperature: Some(0.7),
+                max_depth: 2,
+                agentic: true,
+                allowed_tools: vec!["shell".into()],
+                max_iterations: 8,
+                timeout_secs: Some(60),
+                agentic_timeout_secs: None,
+                skills_directory: None,
+                memory_namespace: Some("saved_bot".into()),
+            },
+        );
+
+        mgr.save_agent("saved_bot").await.unwrap();
+
+        let agent_dir = tmp.path().join("agents").join("saved_bot");
+        assert!(agent_dir.join("config.toml").exists());
+        assert!(agent_dir.join("IDENTITY.md").exists());
+
+        let config_text = std::fs::read_to_string(agent_dir.join("config.toml")).unwrap();
+        assert!(config_text.contains("anthropic"));
+        assert!(config_text.contains("claude-3"));
+        assert!(config_text.contains("shell"));
+
+        let identity_text = std::fs::read_to_string(agent_dir.join("IDENTITY.md")).unwrap();
+        assert_eq!(identity_text, "You are a saved bot.");
+    }
+
+    #[tokio::test]
+    async fn save_agent_not_found_errors() {
+        let tmp = TempDir::new().unwrap();
+        let mgr = WorkspaceAgentManager::new(
+            tmp.path().to_path_buf(),
+            HashMap::new(),
+            "openai".into(),
+            "gpt-4".into(),
+        );
+
+        let result = mgr.save_agent("nonexistent").await;
+        assert!(result.is_err());
+    }
+}

--- a/src/agent/workspace_agents.rs
+++ b/src/agent/workspace_agents.rs
@@ -32,7 +32,7 @@ pub struct WorkspaceAgentManager {
     /// Names of agents defined in the static TOML config (protected from overwrite).
     config_agent_names: HashSet<String>,
     /// File watcher handle (kept alive so watcher doesn't drop).
-    _watcher: Option<RecommendedWatcher>,
+    watcher_handle: Option<RecommendedWatcher>,
 }
 
 impl WorkspaceAgentManager {
@@ -119,7 +119,7 @@ impl WorkspaceAgentManager {
             default_provider,
             default_model,
             config_agent_names,
-            _watcher: None,
+            watcher_handle: None,
         }
     }
 
@@ -128,7 +128,7 @@ impl WorkspaceAgentManager {
     /// On `Create`/`Modify` events for `config.toml` or `.md` files the
     /// affected agent is reloaded.  On `Remove` events the agent is removed
     /// from the registry (only if it was workspace-loaded, never config-defined).
-    pub fn start_watcher(&mut self) -> Result<()> {
+    pub fn startwatcher_handle(&mut self) -> Result<()> {
         let agents_dir = self.workspace_dir.join("agents");
         if !agents_dir.is_dir() {
             std::fs::create_dir_all(&agents_dir)
@@ -161,7 +161,7 @@ impl WorkspaceAgentManager {
         // Guard against missing Tokio runtime (e.g. in non-async tests).
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
             warn!("no Tokio runtime available — workspace agent watcher disabled");
-            self._watcher = Some(watcher);
+            self.watcher_handle = Some(watcher);
             return Ok(());
         };
         handle.spawn(async move {
@@ -180,11 +180,11 @@ impl WorkspaceAgentManager {
                 match event.kind {
                     EventKind::Create(_) | EventKind::Modify(_) => {
                         for path in &event.paths {
-                            let agent_name =
-                                match extract_agent_name_from_path(path, &agents_root) {
-                                    Some(n) => n,
-                                    None => continue,
-                                };
+                            let agent_name = match extract_agent_name_from_path(path, &agents_root)
+                            {
+                                Some(n) => n,
+                                None => continue,
+                            };
                             if agent_name == "common" {
                                 // Common dir changed — reload all workspace agents.
                                 debug!("common directory changed, reloading all workspace agents");
@@ -217,9 +217,7 @@ impl WorkspaceAgentManager {
                             ) {
                                 Ok(delegate) => {
                                     info!(agent = %agent_name, "reloaded workspace agent");
-                                    agents_clone
-                                        .write()
-                                        .insert(agent_name, delegate);
+                                    agents_clone.write().insert(agent_name, delegate);
                                 }
                                 Err(e) => {
                                     warn!(
@@ -233,11 +231,11 @@ impl WorkspaceAgentManager {
                     }
                     EventKind::Remove(_) => {
                         for path in &event.paths {
-                            let agent_name =
-                                match extract_agent_name_from_path(path, &agents_root) {
-                                    Some(n) => n,
-                                    None => continue,
-                                };
+                            let agent_name = match extract_agent_name_from_path(path, &agents_root)
+                            {
+                                Some(n) => n,
+                                None => continue,
+                            };
                             if config_names.contains(&agent_name) {
                                 continue;
                             }
@@ -253,7 +251,7 @@ impl WorkspaceAgentManager {
             }
         });
 
-        self._watcher = Some(watcher);
+        self.watcher_handle = Some(watcher);
         info!(
             path = %agents_dir.display(),
             "workspace agent file watcher started"
@@ -515,7 +513,12 @@ mod tests {
     fn loads_workspace_agents_on_new() {
         let tmp = TempDir::new().unwrap();
         let base = tmp.path();
-        write_agent(base, "researcher", "agentic = true\n", Some("You are a researcher."));
+        write_agent(
+            base,
+            "researcher",
+            "agentic = true\n",
+            Some("You are a researcher."),
+        );
 
         let mgr = WorkspaceAgentManager::new(
             base.to_path_buf(),

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -12313,6 +12313,8 @@ default_temperature = 0.7
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -597,6 +597,14 @@ pub struct DelegateAgentConfig {
     /// preventing cross-contamination with memory from other agents.
     #[serde(default)]
     pub memory_namespace: Option<String>,
+    /// Maximum context window in tokens for this agent.
+    /// When `None` or `0`, the sub-agent runs without a context budget limit.
+    #[serde(default)]
+    pub max_context_tokens: Option<usize>,
+    /// Maximum characters per tool result for this agent.
+    /// When `None` or `0`, tool results are not truncated.
+    #[serde(default)]
+    pub max_tool_result_chars: Option<usize>,
 }
 
 fn default_delegate_timeout_secs() -> u64 {
@@ -647,6 +655,12 @@ pub struct WorkspaceAgentConfig {
     /// Optional memory namespace for isolation (defaults to agent name).
     #[serde(default)]
     pub memory_namespace: Option<String>,
+    /// Maximum context window in tokens for this agent.
+    #[serde(default)]
+    pub max_context_tokens: Option<usize>,
+    /// Maximum characters per tool result for this agent.
+    #[serde(default)]
+    pub max_tool_result_chars: Option<usize>,
 }
 
 fn default_workspace_agent_agentic() -> bool {
@@ -680,6 +694,8 @@ impl WorkspaceAgentConfig {
             memory_namespace: self
                 .memory_namespace
                 .or_else(|| Some(agent_name.to_owned())),
+            max_context_tokens: self.max_context_tokens,
+            max_tool_result_chars: self.max_tool_result_chars,
         }
     }
 }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -607,6 +607,83 @@ fn default_delegate_agentic_timeout_secs() -> u64 {
     DEFAULT_DELEGATE_AGENTIC_TIMEOUT_SECS
 }
 
+// ── Workspace Agents ───────────────────────────────────────────
+
+/// Agent definition loaded from `workspace/agents/<name>/config.toml`.
+///
+/// Fields with `Option` fall back to the global defaults (`default_provider`,
+/// `default_model`) when not set.  The system prompt is assembled externally
+/// by reading the accompanying `IDENTITY.md` / `TOOLS.md` files, so it does
+/// not appear here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceAgentConfig {
+    /// Provider name override (falls back to `default_provider`).
+    #[serde(default)]
+    pub provider: Option<String>,
+    /// Model name override (falls back to `default_model`).
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Temperature override.
+    #[serde(default)]
+    pub temperature: Option<f64>,
+    /// Enable agentic sub-agent mode (multi-turn tool-call loop).
+    #[serde(default = "default_workspace_agent_agentic")]
+    pub agentic: bool,
+    /// Allowlist of tool names available to this agent in agentic mode.
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+    /// Maximum tool-call iterations in agentic mode.
+    #[serde(default = "default_max_tool_iterations")]
+    pub max_iterations: usize,
+    /// Max recursion depth for nested delegation.
+    #[serde(default = "default_max_depth")]
+    pub max_depth: u32,
+    /// Optional timeout in seconds for non-agentic calls.
+    #[serde(default)]
+    pub timeout_secs: Option<u64>,
+    /// Optional timeout in seconds for agentic runs.
+    #[serde(default)]
+    pub agentic_timeout_secs: Option<u64>,
+    /// Optional memory namespace for isolation (defaults to agent name).
+    #[serde(default)]
+    pub memory_namespace: Option<String>,
+}
+
+fn default_workspace_agent_agentic() -> bool {
+    true
+}
+
+impl WorkspaceAgentConfig {
+    /// Convert into a `DelegateAgentConfig`, filling in defaults and the
+    /// concatenated system prompt assembled from the agent's folder files.
+    pub fn into_delegate_config(
+        self,
+        agent_name: &str,
+        system_prompt: Option<String>,
+        skills_directory: Option<String>,
+        default_provider: &str,
+        default_model: &str,
+    ) -> DelegateAgentConfig {
+        DelegateAgentConfig {
+            provider: self.provider.unwrap_or_else(|| default_provider.to_owned()),
+            model: self.model.unwrap_or_else(|| default_model.to_owned()),
+            system_prompt,
+            api_key: None,
+            temperature: self.temperature,
+            max_depth: self.max_depth,
+            agentic: self.agentic,
+            allowed_tools: self.allowed_tools,
+            max_iterations: self.max_iterations,
+            timeout_secs: self.timeout_secs,
+            agentic_timeout_secs: self.agentic_timeout_secs,
+            skills_directory,
+            memory_namespace: self
+                .memory_namespace
+                .or_else(|| Some(agent_name.to_owned())),
+        }
+    }
+}
+
 // ── Swarms ──────────────────────────────────────────────────────
 
 /// Orchestration strategy for a swarm of agents.

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -539,6 +539,11 @@ pub struct DelegateToolConfig {
     /// Default: 300 seconds.
     #[serde(default = "default_delegate_agentic_timeout_secs")]
     pub agentic_timeout_secs: u64,
+    /// Maximum number of sub-agents (delegate + spawn) that can run concurrently.
+    /// Prevents slot saturation on LLM backends with limited capacity (e.g. llama.cpp).
+    /// `0` means unlimited (default).
+    #[serde(default)]
+    pub max_concurrent_subagents: usize,
 }
 
 impl Default for DelegateToolConfig {
@@ -546,6 +551,7 @@ impl Default for DelegateToolConfig {
         Self {
             timeout_secs: DEFAULT_DELEGATE_TIMEOUT_SECS,
             agentic_timeout_secs: DEFAULT_DELEGATE_AGENTIC_TIMEOUT_SECS,
+            max_concurrent_subagents: 0,
         }
     }
 }
@@ -12313,8 +12319,8 @@ default_temperature = 0.7
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
 

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -1287,6 +1287,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         config.agents.insert(
@@ -1305,6 +1307,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
 

--- a/src/doctor/mod.rs
+++ b/src/doctor/mod.rs
@@ -1287,8 +1287,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         config.agents.insert(
@@ -1307,8 +1307,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
 

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -1309,7 +1309,7 @@ impl Observer for SubagentObserver {
                 tracing::info!(
                     agent = %self.agent_name,
                     tool = %tool,
-                    duration_ms = duration.as_millis() as u64,
+                    duration_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
                     success = success,
                     "◀ [subagent] tool done"
                 );
@@ -1336,13 +1336,13 @@ impl Observer for SubagentObserver {
                 if *success {
                     tracing::info!(
                         agent = %self.agent_name,
-                        duration_ms = duration.as_millis() as u64,
+                        duration_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
                         "✓ [subagent] LLM response"
                     );
                 } else {
                     tracing::warn!(
                         agent = %self.agent_name,
-                        duration_ms = duration.as_millis() as u64,
+                        duration_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
                         error = ?error_message,
                         "✗ [subagent] LLM error"
                     );

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -1195,9 +1195,9 @@ impl DelegateTool {
                 None,
                 None,
                 &crate::config::PacingConfig::default(),
-                0,    // max_tool_result_chars: inherit from parent config in future
-                0,    // context_token_budget: 0 = disabled for subagents
-                None, // shared_budget: TODO thread from parent in future
+                agent_config.max_tool_result_chars.unwrap_or(0),
+                agent_config.max_context_tokens.unwrap_or(0),
+                None, // shared_budget
             ),
         )
         .await;

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -76,6 +76,9 @@ pub struct DelegateTool {
     /// Skills prompt injection mode inherited from root config.
     /// Fixes #5155: sub-agents now respect the global `skills.prompt_injection_mode`.
     skills_prompt_mode: crate::config::SkillsPromptInjectionMode,
+    /// Optional concurrency semaphore shared with SpawnAgentTool.
+    /// When set, limits how many sub-agents run simultaneously.
+    subagent_semaphore: Option<Arc<tokio::sync::Semaphore>>,
 }
 
 impl DelegateTool {
@@ -111,6 +114,7 @@ impl DelegateTool {
             cancellation_token: CancellationToken::new(),
             memory: None,
             skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
+            subagent_semaphore: None,
         }
     }
 
@@ -152,6 +156,7 @@ impl DelegateTool {
             cancellation_token: CancellationToken::new(),
             memory: None,
             skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
+            subagent_semaphore: None,
         }
     }
 
@@ -219,6 +224,12 @@ impl DelegateTool {
         agents: Arc<RwLock<HashMap<String, DelegateAgentConfig>>>,
     ) -> Self {
         self.agents = agents;
+        self
+    }
+
+    /// Attach a shared concurrency semaphore for sub-agent execution.
+    pub fn with_subagent_semaphore(mut self, sem: Arc<tokio::sync::Semaphore>) -> Self {
+        self.subagent_semaphore = Some(sem);
         self
     }
 
@@ -407,6 +418,16 @@ impl DelegateTool {
             .and_then(|v| v.as_str())
             .map(str::trim)
             .unwrap_or("");
+
+        // Acquire concurrency permit if semaphore is configured.
+        let _permit = match &self.subagent_semaphore {
+            Some(sem) => Some(
+                sem.acquire()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("subagent semaphore closed"))?,
+            ),
+            None => None,
+        };
 
         // Look up agent config
         let agent_config = match self.agents.read().get(agent_name).cloned() {
@@ -676,6 +697,7 @@ impl DelegateTool {
                 cancellation_token: child_token.clone(),
                 memory: None,
                 skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
+                subagent_semaphore: None,
             };
 
             let args_inner = json!({
@@ -835,6 +857,7 @@ impl DelegateTool {
                     cancellation_token,
                     memory: None,
                     skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
+                    subagent_semaphore: None,
                 };
                 let result = Box::pin(inner.execute_sync(&agent_name, &prompt, &args_clone)).await;
                 (agent_name, result)
@@ -1313,8 +1336,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         agents.insert(
@@ -1333,8 +1356,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         agents
@@ -1492,8 +1515,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
-        max_context_tokens: None,
-        max_tool_result_chars: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
         }
     }
 
@@ -1610,8 +1633,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         let tool = DelegateTool::new(agents, None, test_security());
@@ -1726,8 +1749,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         let tool = DelegateTool::new(agents, None, test_security());
@@ -1769,8 +1792,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         let tool = DelegateTool::new(agents, None, test_security());
@@ -2060,8 +2083,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
-        max_context_tokens: None,
-        max_tool_result_chars: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
@@ -2116,8 +2139,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
-        max_context_tokens: None,
-        max_tool_result_chars: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
         };
 
         struct MockShellTool;
@@ -2189,8 +2212,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
-        max_context_tokens: None,
-        max_tool_result_chars: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
         };
         assert_eq!(
             config.timeout_secs.unwrap_or(DEFAULT_DELEGATE_TIMEOUT_SECS),
@@ -2220,8 +2243,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
-        max_context_tokens: None,
-        max_tool_result_chars: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
@@ -2256,8 +2279,8 @@ mod tests {
             agentic_timeout_secs: Some(600),
             skills_directory: None,
             memory_namespace: None,
-        max_context_tokens: None,
-        max_tool_result_chars: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
         };
         assert_eq!(
             config.timeout_secs.unwrap_or(DEFAULT_DELEGATE_TIMEOUT_SECS),
@@ -2314,8 +2337,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         let err = config.validate().unwrap_err();
@@ -2344,8 +2367,8 @@ mod tests {
                 agentic_timeout_secs: Some(0),
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         let err = config.validate().unwrap_err();
@@ -2374,8 +2397,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         let err = config.validate().unwrap_err();
@@ -2404,8 +2427,8 @@ mod tests {
                 agentic_timeout_secs: Some(5000),
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         let err = config.validate().unwrap_err();
@@ -2434,8 +2457,8 @@ mod tests {
                 agentic_timeout_secs: Some(3600),
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         assert!(config.validate().is_ok());
@@ -2460,8 +2483,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         assert!(config.validate().is_ok());
@@ -2495,8 +2518,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: Some("skills/code-review".to_string()),
             memory_namespace: None,
-        max_context_tokens: None,
-        max_tool_result_chars: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
@@ -2544,8 +2567,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
-        max_context_tokens: None,
-        max_tool_result_chars: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -53,7 +53,7 @@ pub enum BackgroundTaskStatus {
 /// Background results are persisted to `workspace/delegate_results/{task_id}.json`
 /// and can be retrieved via `action: "check_result"`.
 pub struct DelegateTool {
-    agents: Arc<HashMap<String, DelegateAgentConfig>>,
+    agents: Arc<RwLock<HashMap<String, DelegateAgentConfig>>>,
     security: Arc<SecurityPolicy>,
     /// Global credential fallback (from config.api_key)
     fallback_credential: Option<String>,
@@ -73,6 +73,9 @@ pub struct DelegateTool {
     cancellation_token: CancellationToken,
     /// Optional memory instance for namespace isolation on delegate agents.
     memory: Option<Arc<dyn Memory>>,
+    /// Skills prompt injection mode inherited from root config.
+    /// Fixes #5155: sub-agents now respect the global `skills.prompt_injection_mode`.
+    skills_prompt_mode: crate::config::SkillsPromptInjectionMode,
 }
 
 impl DelegateTool {
@@ -96,7 +99,7 @@ impl DelegateTool {
         provider_runtime_options: providers::ProviderRuntimeOptions,
     ) -> Self {
         Self {
-            agents: Arc::new(agents),
+            agents: Arc::new(RwLock::new(agents)),
             security,
             fallback_credential,
             provider_runtime_options,
@@ -107,6 +110,7 @@ impl DelegateTool {
             workspace_dir: PathBuf::new(),
             cancellation_token: CancellationToken::new(),
             memory: None,
+            skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
         }
     }
 
@@ -136,7 +140,7 @@ impl DelegateTool {
         provider_runtime_options: providers::ProviderRuntimeOptions,
     ) -> Self {
         Self {
-            agents: Arc::new(agents),
+            agents: Arc::new(RwLock::new(agents)),
             security,
             fallback_credential,
             provider_runtime_options,
@@ -147,6 +151,7 @@ impl DelegateTool {
             workspace_dir: PathBuf::new(),
             cancellation_token: CancellationToken::new(),
             memory: None,
+            skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
         }
     }
 
@@ -198,6 +203,25 @@ impl DelegateTool {
         self
     }
 
+    /// Set the skills prompt injection mode for sub-agent system prompts.
+    /// Fixes #5155: propagates `skills.prompt_injection_mode` from root config.
+    pub fn with_skills_prompt_mode(
+        mut self,
+        mode: crate::config::SkillsPromptInjectionMode,
+    ) -> Self {
+        self.skills_prompt_mode = mode;
+        self
+    }
+
+    /// Inject a pre-existing shared agent registry (used by WorkspaceAgentManager).
+    pub fn with_shared_agents(
+        mut self,
+        agents: Arc<RwLock<HashMap<String, DelegateAgentConfig>>>,
+    ) -> Self {
+        self.agents = agents;
+        self
+    }
+
     /// Wrap memory with namespace isolation if configured for the given agent.
     /// Returns the namespaced memory if memory_namespace is set, otherwise returns
     /// the original memory.
@@ -242,7 +266,7 @@ impl Tool for DelegateTool {
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
-        let agent_names: Vec<&str> = self.agents.keys().map(|s: &String| s.as_str()).collect();
+        let agent_names: Vec<String> = self.agents.read().keys().cloned().collect();
         json!({
             "type": "object",
             "additionalProperties": false,
@@ -263,7 +287,7 @@ impl Tool for DelegateTool {
                         if agent_names.is_empty() {
                             "(none configured)".to_string()
                         } else {
-                            agent_names.join(", ")
+                            agent_names.iter().map(|s| s.as_str()).collect::<Vec<_>>().join(", ")
                         }
                     )
                 },
@@ -385,11 +409,11 @@ impl DelegateTool {
             .unwrap_or("");
 
         // Look up agent config
-        let agent_config = match self.agents.get(agent_name) {
+        let agent_config = match self.agents.read().get(agent_name).cloned() {
             Some(cfg) => cfg,
             None => {
-                let available: Vec<&str> =
-                    self.agents.keys().map(|s: &String| s.as_str()).collect();
+                let available: Vec<String> =
+                    self.agents.read().keys().cloned().collect::<Vec<String>>();
                 return Ok(ToolResult {
                     success: false,
                     output: String::new(),
@@ -470,7 +494,7 @@ impl DelegateTool {
             return self
                 .execute_agentic(
                     agent_name,
-                    agent_config,
+                    &agent_config,
                     &*provider,
                     &full_prompt,
                     temperature,
@@ -480,7 +504,7 @@ impl DelegateTool {
 
         // Build enriched system prompt for non-agentic sub-agent.
         let enriched_system_prompt =
-            self.build_enriched_system_prompt(agent_config, &[], &self.workspace_dir);
+            self.build_enriched_system_prompt(&agent_config, &[], &self.workspace_dir);
         let system_prompt_ref = enriched_system_prompt.as_deref();
 
         // Wrap the provider call in a timeout to prevent indefinite blocking
@@ -549,11 +573,11 @@ impl DelegateTool {
         args: &serde_json::Value,
     ) -> anyhow::Result<ToolResult> {
         // Validate agent exists and check depth/security before spawning
-        let agent_config = match self.agents.get(agent_name) {
-            Some(cfg) => cfg.clone(),
+        let agent_config = match self.agents.read().get(agent_name).cloned() {
+            Some(cfg) => cfg,
             None => {
-                let available: Vec<&str> =
-                    self.agents.keys().map(|s: &String| s.as_str()).collect();
+                let available: Vec<String> =
+                    self.agents.read().keys().cloned().collect::<Vec<String>>();
                 return Ok(ToolResult {
                     success: false,
                     output: String::new(),
@@ -651,6 +675,7 @@ impl DelegateTool {
                 workspace_dir: workspace_dir.clone(),
                 cancellation_token: child_token.clone(),
                 memory: None,
+                skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
             };
 
             let args_inner = json!({
@@ -761,9 +786,9 @@ impl DelegateTool {
 
         // Validate all agents exist before starting any
         for name in &agent_names {
-            if !self.agents.contains_key(name) {
-                let available: Vec<&str> =
-                    self.agents.keys().map(|s: &String| s.as_str()).collect();
+            if !self.agents.read().contains_key(name) {
+                let available: Vec<String> =
+                    self.agents.read().keys().cloned().collect::<Vec<String>>();
                 return Ok(ToolResult {
                     success: false,
                     output: String::new(),
@@ -809,6 +834,7 @@ impl DelegateTool {
                     workspace_dir,
                     cancellation_token,
                     memory: None,
+                    skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
                 };
                 let result = Box::pin(inner.execute_sync(&agent_name, &prompt, &args_clone)).await;
                 (agent_name, result)
@@ -1048,7 +1074,7 @@ impl DelegateTool {
             model_name: &agent_config.model,
             tools: sub_tools,
             skills: &skills,
-            skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
+            skills_prompt_mode: self.skills_prompt_mode,
             identity_config: None,
             dispatcher_instructions: "",
             tool_descriptions: None,

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -1313,6 +1313,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         agents.insert(
@@ -1331,6 +1333,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         agents
@@ -1488,6 +1492,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
+        max_context_tokens: None,
+        max_tool_result_chars: None,
         }
     }
 
@@ -1604,6 +1610,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         let tool = DelegateTool::new(agents, None, test_security());
@@ -1718,6 +1726,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         let tool = DelegateTool::new(agents, None, test_security());
@@ -1759,6 +1769,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         let tool = DelegateTool::new(agents, None, test_security());
@@ -2048,6 +2060,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
+        max_context_tokens: None,
+        max_tool_result_chars: None,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
@@ -2102,6 +2116,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
+        max_context_tokens: None,
+        max_tool_result_chars: None,
         };
 
         struct MockShellTool;
@@ -2173,6 +2189,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
+        max_context_tokens: None,
+        max_tool_result_chars: None,
         };
         assert_eq!(
             config.timeout_secs.unwrap_or(DEFAULT_DELEGATE_TIMEOUT_SECS),
@@ -2202,6 +2220,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
+        max_context_tokens: None,
+        max_tool_result_chars: None,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
@@ -2236,6 +2256,8 @@ mod tests {
             agentic_timeout_secs: Some(600),
             skills_directory: None,
             memory_namespace: None,
+        max_context_tokens: None,
+        max_tool_result_chars: None,
         };
         assert_eq!(
             config.timeout_secs.unwrap_or(DEFAULT_DELEGATE_TIMEOUT_SECS),
@@ -2292,6 +2314,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         let err = config.validate().unwrap_err();
@@ -2320,6 +2344,8 @@ mod tests {
                 agentic_timeout_secs: Some(0),
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         let err = config.validate().unwrap_err();
@@ -2348,6 +2374,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         let err = config.validate().unwrap_err();
@@ -2376,6 +2404,8 @@ mod tests {
                 agentic_timeout_secs: Some(5000),
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         let err = config.validate().unwrap_err();
@@ -2404,6 +2434,8 @@ mod tests {
                 agentic_timeout_secs: Some(3600),
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         assert!(config.validate().is_ok());
@@ -2428,6 +2460,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         assert!(config.validate().is_ok());
@@ -2461,6 +2495,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: Some("skills/code-review".to_string()),
             memory_namespace: None,
+        max_context_tokens: None,
+        max_tool_result_chars: None,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
@@ -2508,6 +2544,8 @@ mod tests {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: None,
+        max_context_tokens: None,
+        max_tool_result_chars: None,
         };
 
         let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -1189,7 +1189,9 @@ impl DelegateTool {
         }
         history.push(ChatMessage::user(full_prompt.to_string()));
 
-        let noop_observer = SubagentObserver { agent_name: agent_name.to_string() };
+        let noop_observer = SubagentObserver {
+            agent_name: agent_name.to_string(),
+        };
 
         let agentic_timeout_secs = agent_config
             .agentic_timeout_secs
@@ -1299,7 +1301,11 @@ impl Observer for SubagentObserver {
             ObserverEvent::ToolCallStart { tool, .. } => {
                 tracing::info!(agent = %self.agent_name, tool = %tool, "▶ [subagent] tool start");
             }
-            ObserverEvent::ToolCall { tool, duration, success } => {
+            ObserverEvent::ToolCall {
+                tool,
+                duration,
+                success,
+            } => {
                 tracing::info!(
                     agent = %self.agent_name,
                     tool = %tool,
@@ -1308,7 +1314,11 @@ impl Observer for SubagentObserver {
                     "◀ [subagent] tool done"
                 );
             }
-            ObserverEvent::LlmRequest { provider, model, messages_count } => {
+            ObserverEvent::LlmRequest {
+                provider,
+                model,
+                messages_count,
+            } => {
                 tracing::info!(
                     agent = %self.agent_name,
                     provider = %provider,
@@ -1317,7 +1327,12 @@ impl Observer for SubagentObserver {
                     "🔄 [subagent] LLM request"
                 );
             }
-            ObserverEvent::LlmResponse { duration, success, error_message, .. } => {
+            ObserverEvent::LlmResponse {
+                duration,
+                success,
+                error_message,
+                ..
+            } => {
                 if *success {
                     tracing::info!(
                         agent = %self.agent_name,

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -1189,7 +1189,7 @@ impl DelegateTool {
         }
         history.push(ChatMessage::user(full_prompt.to_string()));
 
-        let noop_observer = NoopObserver;
+        let noop_observer = SubagentObserver { agent_name: agent_name.to_string() };
 
         let agentic_timeout_secs = agent_config
             .agentic_timeout_secs
@@ -1288,15 +1288,59 @@ impl Tool for ToolArcRef {
     }
 }
 
-struct NoopObserver;
+/// Observer that logs sub-agent events via tracing so they appear in journalctl.
+struct SubagentObserver {
+    agent_name: String,
+}
 
-impl Observer for NoopObserver {
-    fn record_event(&self, _event: &ObserverEvent) {}
+impl Observer for SubagentObserver {
+    fn record_event(&self, event: &ObserverEvent) {
+        match event {
+            ObserverEvent::ToolCallStart { tool, .. } => {
+                tracing::info!(agent = %self.agent_name, tool = %tool, "▶ [subagent] tool start");
+            }
+            ObserverEvent::ToolCall { tool, duration, success } => {
+                tracing::info!(
+                    agent = %self.agent_name,
+                    tool = %tool,
+                    duration_ms = duration.as_millis() as u64,
+                    success = success,
+                    "◀ [subagent] tool done"
+                );
+            }
+            ObserverEvent::LlmRequest { provider, model, messages_count } => {
+                tracing::info!(
+                    agent = %self.agent_name,
+                    provider = %provider,
+                    model = %model,
+                    messages = messages_count,
+                    "🔄 [subagent] LLM request"
+                );
+            }
+            ObserverEvent::LlmResponse { duration, success, error_message, .. } => {
+                if *success {
+                    tracing::info!(
+                        agent = %self.agent_name,
+                        duration_ms = duration.as_millis() as u64,
+                        "✓ [subagent] LLM response"
+                    );
+                } else {
+                    tracing::warn!(
+                        agent = %self.agent_name,
+                        duration_ms = duration.as_millis() as u64,
+                        error = ?error_message,
+                        "✗ [subagent] LLM error"
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
 
     fn record_metric(&self, _metric: &ObserverMetric) {}
 
     fn name(&self) -> &str {
-        "noop"
+        "subagent-tracing"
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1314,6 +1314,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -97,11 +97,11 @@ pub mod shell;
 pub mod skill_http;
 pub mod skill_tool;
 pub mod sop_advance;
-pub mod spawn_agent;
 pub mod sop_approve;
 pub mod sop_execute;
 pub mod sop_list;
 pub mod sop_status;
+pub mod spawn_agent;
 pub mod swarm;
 pub mod text_browser;
 pub mod tool_search;
@@ -198,11 +198,11 @@ pub use skill_http::SkillHttpTool;
 pub use skill_tool::SkillShellTool;
 pub use sop_advance::SopAdvanceTool;
 pub use sop_approve::SopApproveTool;
-#[allow(unused_imports)]
-pub use spawn_agent::SpawnAgentTool;
 pub use sop_execute::SopExecuteTool;
 pub use sop_list::SopListTool;
 pub use sop_status::SopStatusTool;
+#[allow(unused_imports)]
+pub use spawn_agent::SpawnAgentTool;
 pub use swarm::SwarmTool;
 pub use text_browser::TextBrowserTool;
 pub use tool_search::ToolSearchTool;
@@ -915,13 +915,12 @@ pub fn all_tools_with_runtime(
         .iter()
         .map(|(name, cfg)| (name.clone(), cfg.clone()))
         .collect();
-    let mut workspace_agent_manager =
-        crate::agent::workspace_agents::WorkspaceAgentManager::new(
-            workspace_dir.to_path_buf(),
-            delegate_agents,
-            root_config.default_provider.clone().unwrap_or_default(),
-            root_config.default_model.clone().unwrap_or_default(),
-        );
+    let mut workspace_agent_manager = crate::agent::workspace_agents::WorkspaceAgentManager::new(
+        workspace_dir.to_path_buf(),
+        delegate_agents,
+        root_config.default_provider.clone().unwrap_or_default(),
+        root_config.default_model.clone().unwrap_or_default(),
+    );
     // Start file watcher for hot-reload of workspace agent definitions.
     if let Err(e) = workspace_agent_manager.start_watcher() {
         tracing::warn!("workspace agent file watcher failed to start: {e}");

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -97,6 +97,7 @@ pub mod shell;
 pub mod skill_http;
 pub mod skill_tool;
 pub mod sop_advance;
+pub mod spawn_agent;
 pub mod sop_approve;
 pub mod sop_execute;
 pub mod sop_list;
@@ -197,6 +198,8 @@ pub use skill_http::SkillHttpTool;
 pub use skill_tool::SkillShellTool;
 pub use sop_advance::SopAdvanceTool;
 pub use sop_approve::SopApproveTool;
+#[allow(unused_imports)]
+pub use spawn_agent::SpawnAgentTool;
 pub use sop_execute::SopExecuteTool;
 pub use sop_list::SopListTool;
 pub use sop_status::SopStatusTool;
@@ -898,7 +901,7 @@ pub fn all_tools_with_runtime(
         }
     }
 
-    // Add delegation tool when agents are configured
+    // Add delegation + spawn tools with workspace agent support
     let delegate_fallback_credential = fallback_api_key.and_then(|value| {
         let trimmed_value = value.trim();
         (!trimmed_value.is_empty()).then(|| trimmed_value.to_owned())
@@ -906,28 +909,65 @@ pub fn all_tools_with_runtime(
     let provider_runtime_options =
         crate::providers::provider_runtime_options_from_config(root_config);
 
-    let delegate_handle: Option<DelegateParentToolsHandle> = if agents.is_empty() {
+    // Create WorkspaceAgentManager — merges config agents + workspace/agents/ folder.
+    // Creates workspace/agents/ and workspace/agents/common/ directories if missing.
+    let delegate_agents: HashMap<String, DelegateAgentConfig> = agents
+        .iter()
+        .map(|(name, cfg)| (name.clone(), cfg.clone()))
+        .collect();
+    let mut workspace_agent_manager =
+        crate::agent::workspace_agents::WorkspaceAgentManager::new(
+            workspace_dir.to_path_buf(),
+            delegate_agents,
+            root_config.default_provider.clone().unwrap_or_default(),
+            root_config.default_model.clone().unwrap_or_default(),
+        );
+    // Start file watcher for hot-reload of workspace agent definitions.
+    if let Err(e) = workspace_agent_manager.start_watcher() {
+        tracing::warn!("workspace agent file watcher failed to start: {e}");
+    }
+    let shared_agents = workspace_agent_manager.agents();
+    // Keep the manager alive for the process lifetime (owns the file watcher).
+    std::mem::forget(workspace_agent_manager);
+
+    let parent_tools = Arc::new(RwLock::new(tool_arcs.clone()));
+    let delegate_handle: Option<DelegateParentToolsHandle> = if shared_agents.read().is_empty() {
         None
     } else {
-        let delegate_agents: HashMap<String, DelegateAgentConfig> = agents
-            .iter()
-            .map(|(name, cfg)| (name.clone(), cfg.clone()))
-            .collect();
-        let parent_tools = Arc::new(RwLock::new(tool_arcs.clone()));
         let delegate_tool = DelegateTool::new_with_options(
-            delegate_agents,
+            HashMap::new(), // empty — using shared_agents instead
             delegate_fallback_credential.clone(),
             security.clone(),
             provider_runtime_options.clone(),
         )
+        .with_shared_agents(Arc::clone(&shared_agents))
         .with_parent_tools(Arc::clone(&parent_tools))
         .with_multimodal_config(root_config.multimodal.clone())
         .with_delegate_config(root_config.delegate.clone())
         .with_workspace_dir(workspace_dir.to_path_buf())
-        .with_memory(memory.clone());
+        .with_memory(memory.clone())
+        .with_skills_prompt_mode(root_config.skills.prompt_injection_mode);
         tool_arcs.push(Arc::new(delegate_tool));
-        Some(parent_tools)
+        Some(Arc::clone(&parent_tools))
     };
+
+    // Always add spawn_agent tool — allows ad-hoc agent creation even without pre-configured agents.
+    let spawn_tool = spawn_agent::SpawnAgentTool::new(
+        Arc::clone(&shared_agents),
+        delegate_fallback_credential.clone(),
+        security.clone(),
+        provider_runtime_options.clone(),
+    )
+    .with_parent_tools(Arc::clone(&parent_tools))
+    .with_multimodal_config(root_config.multimodal.clone())
+    .with_delegate_config(root_config.delegate.clone())
+    .with_workspace_dir(workspace_dir.to_path_buf())
+    .with_skills_prompt_mode(root_config.skills.prompt_injection_mode)
+    .with_defaults(
+        root_config.default_provider.clone().unwrap_or_default(),
+        root_config.default_model.clone().unwrap_or_default(),
+    );
+    tool_arcs.push(Arc::new(spawn_tool.with_memory(memory.clone())));
 
     // Add swarm tool when swarms are configured
     if !root_config.swarms.is_empty() {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -929,11 +929,21 @@ pub fn all_tools_with_runtime(
     // Keep the manager alive for the process lifetime (owns the file watcher).
     std::mem::forget(workspace_agent_manager);
 
+    // Build optional concurrency semaphore for sub-agent execution.
+    // 0 = unlimited (default), N = at most N sub-agents running concurrently.
+    let subagent_semaphore = if root_config.delegate.max_concurrent_subagents > 0 {
+        Some(Arc::new(tokio::sync::Semaphore::new(
+            root_config.delegate.max_concurrent_subagents,
+        )))
+    } else {
+        None
+    };
+
     let parent_tools = Arc::new(RwLock::new(tool_arcs.clone()));
     let delegate_handle: Option<DelegateParentToolsHandle> = if shared_agents.read().is_empty() {
         None
     } else {
-        let delegate_tool = DelegateTool::new_with_options(
+        let mut delegate_tool = DelegateTool::new_with_options(
             HashMap::new(), // empty — using shared_agents instead
             delegate_fallback_credential.clone(),
             security.clone(),
@@ -946,12 +956,15 @@ pub fn all_tools_with_runtime(
         .with_workspace_dir(workspace_dir.to_path_buf())
         .with_memory(memory.clone())
         .with_skills_prompt_mode(root_config.skills.prompt_injection_mode);
+        if let Some(ref sem) = subagent_semaphore {
+            delegate_tool = delegate_tool.with_subagent_semaphore(Arc::clone(sem));
+        }
         tool_arcs.push(Arc::new(delegate_tool));
         Some(Arc::clone(&parent_tools))
     };
 
     // Always add spawn_agent tool — allows ad-hoc agent creation even without pre-configured agents.
-    let spawn_tool = spawn_agent::SpawnAgentTool::new(
+    let mut spawn_tool = spawn_agent::SpawnAgentTool::new(
         Arc::clone(&shared_agents),
         delegate_fallback_credential.clone(),
         security.clone(),
@@ -966,6 +979,9 @@ pub fn all_tools_with_runtime(
         root_config.default_provider.clone().unwrap_or_default(),
         root_config.default_model.clone().unwrap_or_default(),
     );
+    if let Some(ref sem) = subagent_semaphore {
+        spawn_tool = spawn_tool.with_subagent_semaphore(Arc::clone(sem));
+    }
     tool_arcs.push(Arc::new(spawn_tool.with_memory(memory.clone())));
 
     // Add swarm tool when swarms are configured
@@ -1314,8 +1330,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
 

--- a/src/tools/model_routing_config.rs
+++ b/src/tools/model_routing_config.rs
@@ -709,6 +709,8 @@ impl ModelRoutingConfigTool {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             });
 
         next_agent.provider = provider;

--- a/src/tools/spawn_agent.rs
+++ b/src/tools/spawn_agent.rs
@@ -1,0 +1,736 @@
+use super::traits::{Tool, ToolResult};
+use crate::agent::loop_::run_tool_call_loop;
+use crate::agent::prompt::{PromptContext, SystemPromptBuilder};
+use crate::config::{DelegateAgentConfig, DelegateToolConfig, SkillsPromptInjectionMode};
+use crate::memory::{Memory, NamespacedMemory};
+use crate::observability::traits::{Observer, ObserverEvent, ObserverMetric};
+use crate::providers::{self, ChatMessage, Provider};
+use crate::security::SecurityPolicy;
+use crate::security::policy::ToolOperation;
+use async_trait::async_trait;
+use parking_lot::RwLock;
+use serde_json::json;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{info, warn};
+
+use super::delegate::{BackgroundDelegateResult, BackgroundTaskStatus};
+
+/// Tool that creates and runs ad-hoc sub-agents with inline specifications.
+///
+/// Unlike [`DelegateTool`](super::DelegateTool) which requires pre-configured
+/// agents in `[agents.<name>]` config, `SpawnAgentTool` lets the LLM create
+/// ephemeral agents on the fly with custom personas, tool sets, and execution
+/// modes. Agents can optionally be persisted to the workspace for reuse.
+pub struct SpawnAgentTool {
+    /// Shared mutable agent registry (also used by DelegateTool and WorkspaceAgentManager).
+    agents: Arc<RwLock<HashMap<String, DelegateAgentConfig>>>,
+    /// Security policy.
+    security: Arc<SecurityPolicy>,
+    /// Global credential fallback (from config.api_key).
+    fallback_credential: Option<String>,
+    /// Provider runtime options inherited from root config.
+    provider_runtime_options: providers::ProviderRuntimeOptions,
+    /// Parent tool registry for filtering sub-agent tools.
+    parent_tools: Arc<RwLock<Vec<Arc<dyn Tool>>>>,
+    /// Inherited multimodal handling config for sub-agent loops.
+    multimodal_config: crate::config::MultimodalConfig,
+    /// Global delegate tool config providing default timeout values.
+    delegate_config: DelegateToolConfig,
+    /// Workspace directory inherited from the root agent context.
+    workspace_dir: PathBuf,
+    /// Skills prompt injection mode inherited from root config.
+    skills_prompt_mode: SkillsPromptInjectionMode,
+    /// Optional memory instance for namespace isolation on spawned agents.
+    memory: Option<Arc<dyn Memory>>,
+    /// Default provider name for agents that don't specify one.
+    default_provider: String,
+    /// Default model name.
+    default_model: String,
+}
+
+impl SpawnAgentTool {
+    pub fn new(
+        agents: Arc<RwLock<HashMap<String, DelegateAgentConfig>>>,
+        fallback_credential: Option<String>,
+        security: Arc<SecurityPolicy>,
+        provider_runtime_options: providers::ProviderRuntimeOptions,
+    ) -> Self {
+        Self {
+            agents,
+            security,
+            fallback_credential,
+            provider_runtime_options,
+            parent_tools: Arc::new(RwLock::new(Vec::new())),
+            multimodal_config: crate::config::MultimodalConfig::default(),
+            delegate_config: DelegateToolConfig::default(),
+            workspace_dir: PathBuf::new(),
+            skills_prompt_mode: SkillsPromptInjectionMode::Full,
+            memory: None,
+            default_provider: "anthropic".into(),
+            default_model: "claude-sonnet-4-20250514".into(),
+        }
+    }
+
+    pub fn with_parent_tools(mut self, parent_tools: Arc<RwLock<Vec<Arc<dyn Tool>>>>) -> Self {
+        self.parent_tools = parent_tools;
+        self
+    }
+
+    pub fn with_multimodal_config(mut self, config: crate::config::MultimodalConfig) -> Self {
+        self.multimodal_config = config;
+        self
+    }
+
+    pub fn with_delegate_config(mut self, config: DelegateToolConfig) -> Self {
+        self.delegate_config = config;
+        self
+    }
+
+    pub fn with_workspace_dir(mut self, workspace_dir: PathBuf) -> Self {
+        self.workspace_dir = workspace_dir;
+        self
+    }
+
+    pub fn with_skills_prompt_mode(mut self, mode: SkillsPromptInjectionMode) -> Self {
+        self.skills_prompt_mode = mode;
+        self
+    }
+
+    pub fn with_memory(mut self, memory: Arc<dyn Memory>) -> Self {
+        self.memory = Some(memory);
+        self
+    }
+
+    pub fn with_defaults(mut self, provider: String, model: String) -> Self {
+        self.default_provider = provider;
+        self.default_model = model;
+        self
+    }
+
+    /// Wrap memory with namespace isolation if configured for the given agent.
+    fn get_agent_memory(&self, agent_config: &DelegateAgentConfig) -> Option<Arc<dyn Memory>> {
+        self.memory.as_ref().map(|mem| {
+            if let Some(namespace) = &agent_config.memory_namespace {
+                Arc::new(NamespacedMemory::new(mem.clone(), namespace.clone())) as Arc<dyn Memory>
+            } else {
+                mem.clone()
+            }
+        })
+    }
+
+    /// Directory where background delegate results are stored.
+    fn results_dir(&self) -> PathBuf {
+        self.workspace_dir.join("delegate_results")
+    }
+
+    /// Build an enriched system prompt for a spawned sub-agent by composing structured
+    /// operational sections (tools, skills, workspace, datetime, shell policy)
+    /// with the operator-configured `system_prompt` string.
+    fn build_enriched_system_prompt(
+        &self,
+        agent_config: &DelegateAgentConfig,
+        sub_tools: &[Box<dyn Tool>],
+        workspace_dir: &Path,
+    ) -> Option<String> {
+        let skills_dir = agent_config
+            .skills_directory
+            .as_ref()
+            .filter(|s| !s.trim().is_empty())
+            .map(|dir| workspace_dir.join(dir))
+            .unwrap_or_else(|| crate::skills::skills_dir(workspace_dir));
+        let skills = crate::skills::load_skills_from_directory(&skills_dir, false);
+
+        let has_shell = sub_tools.iter().any(|t| t.name() == "shell");
+        let shell_policy = if has_shell {
+            "## Shell Policy\n\n\
+             - Prefer non-destructive commands. Use `trash` over `rm` where possible.\n\
+             - Do not run commands that exfiltrate data or modify system-critical paths.\n\
+             - Avoid interactive commands that block on stdin.\n\
+             - Quote paths that may contain spaces."
+                .to_string()
+        } else {
+            String::new()
+        };
+
+        let ctx = PromptContext {
+            workspace_dir,
+            model_name: &agent_config.model,
+            tools: sub_tools,
+            skills: &skills,
+            skills_prompt_mode: self.skills_prompt_mode,
+            identity_config: None,
+            dispatcher_instructions: "",
+            tool_descriptions: None,
+            security_summary: None,
+            autonomy_level: crate::security::AutonomyLevel::default(),
+        };
+
+        let builder = SystemPromptBuilder::default()
+            .add_section(Box::new(crate::agent::prompt::ToolsSection))
+            .add_section(Box::new(crate::agent::prompt::SafetySection))
+            .add_section(Box::new(crate::agent::prompt::SkillsSection))
+            .add_section(Box::new(crate::agent::prompt::WorkspaceSection))
+            .add_section(Box::new(crate::agent::prompt::DateTimeSection));
+
+        let mut enriched = builder.build(&ctx).unwrap_or_default();
+
+        if !shell_policy.is_empty() {
+            enriched.push_str(&shell_policy);
+            enriched.push_str("\n\n");
+        }
+
+        if let Some(operator_prompt) = agent_config.system_prompt.as_ref() {
+            enriched.push_str(operator_prompt);
+            enriched.push('\n');
+        }
+
+        let trimmed = enriched.trim().to_string();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    }
+
+    /// Execute the spawned agent's task using the agentic tool-call loop.
+    async fn execute_agent_task(
+        &self,
+        name: &str,
+        agent_config: &DelegateAgentConfig,
+        full_prompt: &str,
+    ) -> anyhow::Result<String> {
+        // Create provider
+        let provider_credential_owned = agent_config
+            .api_key
+            .clone()
+            .or_else(|| self.fallback_credential.clone());
+        #[allow(clippy::option_as_ref_deref)]
+        let provider_credential = provider_credential_owned.as_ref().map(String::as_str);
+
+        let provider: Box<dyn Provider> = providers::create_provider_with_options(
+            &agent_config.provider,
+            provider_credential,
+            &self.provider_runtime_options,
+        )?;
+
+        // Filter parent tools by allowlist, excluding delegate and spawn_agent
+        let allowed = agent_config
+            .allowed_tools
+            .iter()
+            .map(|name| name.trim())
+            .filter(|name| !name.is_empty())
+            .collect::<std::collections::HashSet<_>>();
+
+        let sub_tools: Vec<Box<dyn Tool>> = {
+            let parent_tools = self.parent_tools.read();
+            parent_tools
+                .iter()
+                .filter(|tool| allowed.contains(tool.name()))
+                .filter(|tool| tool.name() != "delegate" && tool.name() != "spawn_agent")
+                .map(|tool| Box::new(ToolArcRef::new(tool.clone())) as Box<dyn Tool>)
+                .collect()
+        };
+
+        if sub_tools.is_empty() {
+            anyhow::bail!(
+                "Spawned agent '{name}' has no executable tools after filtering allowlist ({})",
+                agent_config.allowed_tools.join(", ")
+            );
+        }
+
+        // Build enriched system prompt
+        let enriched_system_prompt =
+            self.build_enriched_system_prompt(agent_config, &sub_tools, &self.workspace_dir);
+
+        let mut history = Vec::new();
+        if let Some(system_prompt) = enriched_system_prompt.as_ref() {
+            history.push(ChatMessage::system(system_prompt.clone()));
+        }
+        history.push(ChatMessage::user(full_prompt.to_string()));
+
+        let noop_observer = NoopObserver;
+        let temperature = agent_config.temperature.unwrap_or(0.7);
+
+        let agentic_timeout_secs = agent_config
+            .agentic_timeout_secs
+            .unwrap_or(self.delegate_config.agentic_timeout_secs);
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(agentic_timeout_secs),
+            run_tool_call_loop(
+                &*provider,
+                &mut history,
+                &sub_tools,
+                &noop_observer,
+                &agent_config.provider,
+                &agent_config.model,
+                temperature,
+                true,  // silent
+                None,  // approval
+                "spawn_agent",
+                None,  // channel_reply_target
+                &self.multimodal_config,
+                agent_config.max_iterations,
+                None,  // cancellation_token
+                None,  // on_delta
+                None,  // hooks
+                &[],   // excluded_tools
+                &[],   // dedup_exempt_tools
+                None,  // activated_tools
+                None,  // model_switch_callback
+                &crate::config::PacingConfig::default(),
+                0,     // max_tool_result_chars
+                0,     // context_token_budget
+                None,  // shared_budget
+            ),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(response)) => {
+                if response.trim().is_empty() {
+                    Ok("[Empty response]".to_string())
+                } else {
+                    Ok(response)
+                }
+            }
+            Ok(Err(e)) => Err(e),
+            Err(_) => anyhow::bail!(
+                "Spawned agent '{name}' timed out after {agentic_timeout_secs}s"
+            ),
+        }
+    }
+
+    /// Persist agent configuration to `workspace/agents/<name>/` for reuse.
+    async fn save_agent_to_workspace(
+        &self,
+        name: &str,
+        config: &DelegateAgentConfig,
+    ) -> anyhow::Result<()> {
+        let agent_dir = self.workspace_dir.join("agents").join(name);
+        tokio::fs::create_dir_all(&agent_dir).await?;
+
+        // Write config.toml (without system_prompt - that goes to IDENTITY.md)
+        let toml_content = format!(
+            "provider = {:?}\n\
+             model = {:?}\n\
+             agentic = {}\n\
+             max_iterations = {}\n\
+             max_depth = {}\n\
+             allowed_tools = {:?}\n",
+            config.provider,
+            config.model,
+            config.agentic,
+            config.max_iterations,
+            config.max_depth,
+            config.allowed_tools,
+        );
+        tokio::fs::write(agent_dir.join("config.toml"), toml_content).await?;
+
+        if let Some(prompt) = &config.system_prompt {
+            tokio::fs::write(agent_dir.join("IDENTITY.md"), prompt).await?;
+        }
+
+        info!(agent = name, dir = %agent_dir.display(), "Saved spawned agent to workspace");
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Tool for SpawnAgentTool {
+    fn name(&self) -> &str {
+        "spawn_agent"
+    }
+
+    fn description(&self) -> &str {
+        "Create and run an ad-hoc sub-agent with a custom persona and tool set. \
+         The agent runs with its own isolated context. Use for specialized tasks \
+         that need a dedicated agent without pre-configuration."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "required": ["name", "system_prompt", "prompt"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Unique identifier for this agent"
+                },
+                "system_prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The agent's persona, role, and instructions"
+                },
+                "prompt": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The task to execute"
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Model override (e.g. 'claude-sonnet-4-20250514'). Falls back to default_model."
+                },
+                "allowed_tools": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Tool allowlist for the agent. If empty, uses a safe default set \
+                                    (file_read, memory_recall, web_search, web_fetch, calculator)."
+                },
+                "context": {
+                    "type": "string",
+                    "description": "Optional context to prepend to the prompt"
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["sync", "background"],
+                    "default": "sync",
+                    "description": "Execution mode. 'background' returns a task_id immediately."
+                },
+                "save": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, persist this agent to workspace/agents/<name>/ for reuse across restarts."
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        // Security check
+        if let Err(error) = self
+            .security
+            .enforce_tool_operation(ToolOperation::Act, "spawn_agent")
+        {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(error),
+            });
+        }
+
+        // Parse required parameters
+        let name = match args.get("name").and_then(|v| v.as_str()).map(str::trim) {
+            Some(n) if !n.is_empty() => n.to_string(),
+            _ => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("Missing or empty 'name' parameter".into()),
+                });
+            }
+        };
+
+        let system_prompt = match args
+            .get("system_prompt")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+        {
+            Some(s) if !s.is_empty() => s.to_string(),
+            _ => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("Missing or empty 'system_prompt' parameter".into()),
+                });
+            }
+        };
+
+        let prompt = match args.get("prompt").and_then(|v| v.as_str()).map(str::trim) {
+            Some(p) if !p.is_empty() => p.to_string(),
+            _ => {
+                return Ok(ToolResult {
+                    success: false,
+                    output: String::new(),
+                    error: Some("Missing or empty 'prompt' parameter".into()),
+                });
+            }
+        };
+
+        // Parse optional parameters
+        let model = args
+            .get("model")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        let allowed_tools = args
+            .get("allowed_tools")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.trim().to_string()))
+                    .filter(|s| !s.is_empty())
+                    .collect::<Vec<String>>()
+            })
+            .filter(|v| !v.is_empty());
+
+        let context = args
+            .get("context")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .unwrap_or("");
+
+        let mode = args
+            .get("mode")
+            .and_then(|v| v.as_str())
+            .unwrap_or("sync");
+
+        let save = args.get("save").and_then(|v| v.as_bool()).unwrap_or(false);
+
+        // Build the DelegateAgentConfig
+        let agent_config = DelegateAgentConfig {
+            provider: self.default_provider.clone(),
+            model: model.unwrap_or_else(|| self.default_model.clone()),
+            system_prompt: Some(system_prompt),
+            api_key: None,
+            temperature: None,
+            max_depth: 3,
+            agentic: true,
+            allowed_tools: allowed_tools.unwrap_or_else(|| {
+                vec![
+                    "file_read".into(),
+                    "memory_recall".into(),
+                    "web_search".into(),
+                    "web_fetch".into(),
+                    "calculator".into(),
+                ]
+            }),
+            max_iterations: 10,
+            timeout_secs: None,
+            agentic_timeout_secs: None,
+            skills_directory: None,
+            memory_namespace: Some(name.clone()),
+        };
+
+        // Register in shared agents map
+        {
+            let mut agents = self.agents.write();
+            agents.insert(name.clone(), agent_config.clone());
+        }
+
+        info!(
+            agent = %name,
+            model = %agent_config.model,
+            tools = ?agent_config.allowed_tools,
+            mode = mode,
+            "Spawning ad-hoc agent"
+        );
+
+        // Build full prompt with optional context
+        let full_prompt = if context.is_empty() {
+            prompt.clone()
+        } else {
+            format!("[Context]\n{context}\n\n[Task]\n{prompt}")
+        };
+
+        if mode == "background" {
+            return self
+                .execute_background(&name, &agent_config, &full_prompt, save)
+                .await;
+        }
+
+        // Synchronous execution
+        let result = self
+            .execute_agent_task(&name, &agent_config, &full_prompt)
+            .await;
+
+        // Save if requested (best-effort, don't fail the tool call)
+        if save {
+            if let Err(e) = self.save_agent_to_workspace(&name, &agent_config).await {
+                warn!(agent = %name, error = %e, "Failed to save spawned agent to workspace");
+            }
+        }
+
+        match result {
+            Ok(response) => Ok(ToolResult {
+                success: true,
+                output: format!(
+                    "[Spawned agent '{name}' ({provider}/{model}, agentic)]\n{response}",
+                    provider = agent_config.provider,
+                    model = agent_config.model,
+                ),
+                error: None,
+            }),
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Spawned agent '{name}' failed: {e}")),
+            }),
+        }
+    }
+}
+
+impl SpawnAgentTool {
+    /// Spawn the agent in a background tokio task. Returns a task_id immediately.
+    async fn execute_background(
+        &self,
+        name: &str,
+        agent_config: &DelegateAgentConfig,
+        full_prompt: &str,
+        save: bool,
+    ) -> anyhow::Result<ToolResult> {
+        let task_id = uuid::Uuid::new_v4().to_string();
+        let results_dir = self.results_dir();
+        tokio::fs::create_dir_all(&results_dir).await?;
+
+        let started_at = chrono::Utc::now().to_rfc3339();
+        let name_owned = name.to_string();
+
+        // Write initial "running" status
+        let initial_result = BackgroundDelegateResult {
+            task_id: task_id.clone(),
+            agent: name_owned.clone(),
+            status: BackgroundTaskStatus::Running,
+            output: None,
+            error: None,
+            started_at: started_at.clone(),
+            finished_at: None,
+        };
+        let result_path = results_dir.join(format!("{task_id}.json"));
+        let json_bytes = serde_json::to_vec_pretty(&initial_result)?;
+        tokio::fs::write(&result_path, &json_bytes).await?;
+
+        // Clone everything needed for the spawned task
+        let agents = Arc::clone(&self.agents);
+        let security = Arc::clone(&self.security);
+        let fallback_credential = self.fallback_credential.clone();
+        let provider_runtime_options = self.provider_runtime_options.clone();
+        let parent_tools = Arc::clone(&self.parent_tools);
+        let multimodal_config = self.multimodal_config.clone();
+        let delegate_config = self.delegate_config.clone();
+        let workspace_dir = self.workspace_dir.clone();
+        let skills_prompt_mode = self.skills_prompt_mode;
+        let memory = self.memory.clone();
+        let default_provider = self.default_provider.clone();
+        let default_model = self.default_model.clone();
+        let agent_config_clone = agent_config.clone();
+        let full_prompt_owned = full_prompt.to_string();
+        let task_id_clone = task_id.clone();
+
+        tokio::spawn(async move {
+            // Build an inner SpawnAgentTool for the spawned context
+            let inner = SpawnAgentTool {
+                agents,
+                security,
+                fallback_credential,
+                provider_runtime_options,
+                parent_tools,
+                multimodal_config,
+                delegate_config,
+                workspace_dir: workspace_dir.clone(),
+                skills_prompt_mode,
+                memory,
+                default_provider,
+                default_model,
+            };
+
+            let outcome = inner
+                .execute_agent_task(&name_owned, &agent_config_clone, &full_prompt_owned)
+                .await;
+
+            // Save if requested (best-effort)
+            if save {
+                if let Err(e) = inner
+                    .save_agent_to_workspace(&name_owned, &agent_config_clone)
+                    .await
+                {
+                    warn!(
+                        agent = %name_owned,
+                        error = %e,
+                        "Failed to save spawned agent to workspace (background)"
+                    );
+                }
+            }
+
+            let finished_at = chrono::Utc::now().to_rfc3339();
+            let final_result = match outcome {
+                Ok(output) => BackgroundDelegateResult {
+                    task_id: task_id_clone.clone(),
+                    agent: name_owned,
+                    status: BackgroundTaskStatus::Completed,
+                    output: Some(output),
+                    error: None,
+                    started_at,
+                    finished_at: Some(finished_at),
+                },
+                Err(err) => BackgroundDelegateResult {
+                    task_id: task_id_clone.clone(),
+                    agent: name_owned,
+                    status: BackgroundTaskStatus::Failed,
+                    output: None,
+                    error: Some(err.to_string()),
+                    started_at,
+                    finished_at: Some(finished_at),
+                },
+            };
+
+            let result_path = results_dir.join(format!("{}.json", task_id_clone));
+            if let Ok(bytes) = serde_json::to_vec_pretty(&final_result) {
+                let _ = tokio::fs::write(&result_path, &bytes).await;
+            }
+        });
+
+        Ok(ToolResult {
+            success: true,
+            output: format!(
+                "Background task started for spawned agent '{name}'.\n\
+                 task_id: {task_id}\n\
+                 Use delegate tool with action='check_result' and task_id='{task_id}' to retrieve the result."
+            ),
+            error: None,
+        })
+    }
+}
+
+// ── Helper types ──────────────────────────────────────────────────
+
+struct ToolArcRef {
+    inner: Arc<dyn Tool>,
+}
+
+impl ToolArcRef {
+    fn new(inner: Arc<dyn Tool>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl Tool for ToolArcRef {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn description(&self) -> &str {
+        self.inner.description()
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        self.inner.parameters_schema()
+    }
+
+    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        self.inner.execute(args).await
+    }
+}
+
+struct NoopObserver;
+
+impl Observer for NoopObserver {
+    fn record_event(&self, _event: &ObserverEvent) {}
+
+    fn record_metric(&self, _metric: &ObserverMetric) {}
+
+    fn name(&self) -> &str {
+        "noop"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}

--- a/src/tools/spawn_agent.rs
+++ b/src/tools/spawn_agent.rs
@@ -268,23 +268,23 @@ impl SpawnAgentTool {
                 &agent_config.provider,
                 &agent_config.model,
                 temperature,
-                true,  // silent
-                None,  // approval
+                true, // silent
+                None, // approval
                 "spawn_agent",
-                None,  // channel_reply_target
+                None, // channel_reply_target
                 &self.multimodal_config,
                 agent_config.max_iterations,
-                None,  // cancellation_token
-                None,  // on_delta
-                None,  // hooks
-                &[],   // excluded_tools
-                &[],   // dedup_exempt_tools
-                None,  // activated_tools
-                None,  // model_switch_callback
+                None, // cancellation_token
+                None, // on_delta
+                None, // hooks
+                &[],  // excluded_tools
+                &[],  // dedup_exempt_tools
+                None, // activated_tools
+                None, // model_switch_callback
                 &crate::config::PacingConfig::default(),
-                0,     // max_tool_result_chars
-                0,     // context_token_budget
-                None,  // shared_budget
+                0,    // max_tool_result_chars
+                0,    // context_token_budget
+                None, // shared_budget
             ),
         )
         .await;
@@ -298,9 +298,9 @@ impl SpawnAgentTool {
                 }
             }
             Ok(Err(e)) => Err(e),
-            Err(_) => anyhow::bail!(
-                "Spawned agent '{name}' timed out after {agentic_timeout_secs}s"
-            ),
+            Err(_) => {
+                anyhow::bail!("Spawned agent '{name}' timed out after {agentic_timeout_secs}s")
+            }
         }
     }
 
@@ -486,10 +486,7 @@ impl Tool for SpawnAgentTool {
             .map(str::trim)
             .unwrap_or("");
 
-        let mode = args
-            .get("mode")
-            .and_then(|v| v.as_str())
-            .unwrap_or("sync");
+        let mode = args.get("mode").and_then(|v| v.as_str()).unwrap_or("sync");
 
         let save = args.get("save").and_then(|v| v.as_bool()).unwrap_or(false);
 

--- a/src/tools/spawn_agent.rs
+++ b/src/tools/spawn_agent.rs
@@ -768,7 +768,7 @@ impl Observer for SubagentObserver {
                 tracing::info!(
                     agent = %self.agent_name,
                     tool = %tool,
-                    duration_ms = duration.as_millis() as u64,
+                    duration_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
                     success = success,
                     "◀ [subagent] tool done"
                 );
@@ -795,13 +795,13 @@ impl Observer for SubagentObserver {
                 if *success {
                     tracing::info!(
                         agent = %self.agent_name,
-                        duration_ms = duration.as_millis() as u64,
+                        duration_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
                         "✓ [subagent] LLM response"
                     );
                 } else {
                     tracing::warn!(
                         agent = %self.agent_name,
-                        duration_ms = duration.as_millis() as u64,
+                        duration_ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
                         error = ?error_message,
                         "✗ [subagent] LLM error"
                     );

--- a/src/tools/spawn_agent.rs
+++ b/src/tools/spawn_agent.rs
@@ -372,6 +372,10 @@ impl Tool for SpawnAgentTool {
                     "minLength": 1,
                     "description": "The task to execute"
                 },
+                "provider": {
+                    "type": "string",
+                    "description": "Provider override (e.g. 'openai', 'anthropic', 'ollama'). Falls back to default_provider."
+                },
                 "model": {
                     "type": "string",
                     "description": "Model override (e.g. 'claude-sonnet-4-20250514'). Falls back to default_model."
@@ -453,6 +457,12 @@ impl Tool for SpawnAgentTool {
         };
 
         // Parse optional parameters
+        let provider = args
+            .get("provider")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
         let model = args
             .get("model")
             .and_then(|v| v.as_str())
@@ -485,7 +495,7 @@ impl Tool for SpawnAgentTool {
 
         // Build the DelegateAgentConfig
         let agent_config = DelegateAgentConfig {
-            provider: self.default_provider.clone(),
+            provider: provider.unwrap_or_else(|| self.default_provider.clone()),
             model: model.unwrap_or_else(|| self.default_model.clone()),
             system_prompt: Some(system_prompt),
             api_key: self.fallback_credential.clone(),

--- a/src/tools/spawn_agent.rs
+++ b/src/tools/spawn_agent.rs
@@ -259,7 +259,7 @@ impl SpawnAgentTool {
         }
         history.push(ChatMessage::user(full_prompt.to_string()));
 
-        let noop_observer = NoopObserver;
+        let noop_observer = SubagentObserver { agent_name: name.to_string() };
         let temperature = agent_config.temperature.unwrap_or(0.7);
 
         let agentic_timeout_secs = agent_config
@@ -747,15 +747,63 @@ impl Tool for ToolArcRef {
     }
 }
 
-struct NoopObserver;
+/// Observer that logs sub-agent events via tracing so they appear in journalctl.
+struct SubagentObserver {
+    agent_name: String,
+}
 
-impl Observer for NoopObserver {
-    fn record_event(&self, _event: &ObserverEvent) {}
+impl Observer for SubagentObserver {
+    fn record_event(&self, event: &ObserverEvent) {
+        match event {
+            ObserverEvent::ToolCallStart { tool, .. } => {
+                tracing::info!(agent = %self.agent_name, tool = %tool, "▶ [subagent] tool start");
+            }
+            ObserverEvent::ToolCall {
+                tool,
+                duration,
+                success,
+            } => {
+                tracing::info!(
+                    agent = %self.agent_name,
+                    tool = %tool,
+                    duration_ms = duration.as_millis() as u64,
+                    success = success,
+                    "◀ [subagent] tool done"
+                );
+            }
+            ObserverEvent::LlmRequest { provider, model, messages_count } => {
+                tracing::info!(
+                    agent = %self.agent_name,
+                    provider = %provider,
+                    model = %model,
+                    messages = messages_count,
+                    "🔄 [subagent] LLM request"
+                );
+            }
+            ObserverEvent::LlmResponse { duration, success, error_message, .. } => {
+                if *success {
+                    tracing::info!(
+                        agent = %self.agent_name,
+                        duration_ms = duration.as_millis() as u64,
+                        "✓ [subagent] LLM response"
+                    );
+                } else {
+                    tracing::warn!(
+                        agent = %self.agent_name,
+                        duration_ms = duration.as_millis() as u64,
+                        error = ?error_message,
+                        "✗ [subagent] LLM error"
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
 
     fn record_metric(&self, _metric: &ObserverMetric) {}
 
     fn name(&self) -> &str {
-        "noop"
+        "subagent-tracing"
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/src/tools/spawn_agent.rs
+++ b/src/tools/spawn_agent.rs
@@ -282,8 +282,8 @@ impl SpawnAgentTool {
                 None, // activated_tools
                 None, // model_switch_callback
                 &crate::config::PacingConfig::default(),
-                0,    // max_tool_result_chars
-                0,    // context_token_budget
+                agent_config.max_tool_result_chars.unwrap_or(0),
+                agent_config.max_context_tokens.unwrap_or(0),
                 None, // shared_budget
             ),
         )
@@ -513,6 +513,8 @@ impl Tool for SpawnAgentTool {
             agentic_timeout_secs: None,
             skills_directory: None,
             memory_namespace: Some(name.clone()),
+            max_context_tokens: None,
+            max_tool_result_chars: None,
         };
 
         // Register in shared agents map

--- a/src/tools/spawn_agent.rs
+++ b/src/tools/spawn_agent.rs
@@ -259,7 +259,9 @@ impl SpawnAgentTool {
         }
         history.push(ChatMessage::user(full_prompt.to_string()));
 
-        let noop_observer = SubagentObserver { agent_name: name.to_string() };
+        let noop_observer = SubagentObserver {
+            agent_name: name.to_string(),
+        };
         let temperature = agent_config.temperature.unwrap_or(0.7);
 
         let agentic_timeout_secs = agent_config
@@ -771,7 +773,11 @@ impl Observer for SubagentObserver {
                     "◀ [subagent] tool done"
                 );
             }
-            ObserverEvent::LlmRequest { provider, model, messages_count } => {
+            ObserverEvent::LlmRequest {
+                provider,
+                model,
+                messages_count,
+            } => {
                 tracing::info!(
                     agent = %self.agent_name,
                     provider = %provider,
@@ -780,7 +786,12 @@ impl Observer for SubagentObserver {
                     "🔄 [subagent] LLM request"
                 );
             }
-            ObserverEvent::LlmResponse { duration, success, error_message, .. } => {
+            ObserverEvent::LlmResponse {
+                duration,
+                success,
+                error_message,
+                ..
+            } => {
                 if *success {
                     tracing::info!(
                         agent = %self.agent_name,

--- a/src/tools/spawn_agent.rs
+++ b/src/tools/spawn_agent.rs
@@ -488,7 +488,7 @@ impl Tool for SpawnAgentTool {
             provider: self.default_provider.clone(),
             model: model.unwrap_or_else(|| self.default_model.clone()),
             system_prompt: Some(system_prompt),
-            api_key: None,
+            api_key: self.fallback_credential.clone(),
             temperature: None,
             max_depth: 3,
             agentic: true,

--- a/src/tools/spawn_agent.rs
+++ b/src/tools/spawn_agent.rs
@@ -49,6 +49,8 @@ pub struct SpawnAgentTool {
     default_provider: String,
     /// Default model name.
     default_model: String,
+    /// Optional concurrency semaphore shared with DelegateTool.
+    subagent_semaphore: Option<Arc<tokio::sync::Semaphore>>,
 }
 
 impl SpawnAgentTool {
@@ -71,6 +73,7 @@ impl SpawnAgentTool {
             memory: None,
             default_provider: "anthropic".into(),
             default_model: "claude-sonnet-4-20250514".into(),
+            subagent_semaphore: None,
         }
     }
 
@@ -101,6 +104,11 @@ impl SpawnAgentTool {
 
     pub fn with_memory(mut self, memory: Arc<dyn Memory>) -> Self {
         self.memory = Some(memory);
+        self
+    }
+
+    pub fn with_subagent_semaphore(mut self, sem: Arc<tokio::sync::Semaphore>) -> Self {
+        self.subagent_semaphore = Some(sem);
         self
     }
 
@@ -531,6 +539,16 @@ impl Tool for SpawnAgentTool {
             "Spawning ad-hoc agent"
         );
 
+        // Acquire concurrency permit if semaphore is configured.
+        let _permit = match &self.subagent_semaphore {
+            Some(sem) => Some(
+                sem.acquire()
+                    .await
+                    .map_err(|_| anyhow::anyhow!("subagent semaphore closed"))?,
+            ),
+            None => None,
+        };
+
         // Build full prompt with optional context
         let full_prompt = if context.is_empty() {
             prompt.clone()
@@ -637,6 +655,7 @@ impl SpawnAgentTool {
                 memory,
                 default_provider,
                 default_model,
+                subagent_semaphore: None,
             };
 
             let outcome = inner

--- a/src/tools/swarm.rs
+++ b/src/tools/swarm.rs
@@ -570,8 +570,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         agents.insert(
@@ -590,8 +590,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
-            max_context_tokens: None,
-            max_tool_result_chars: None,
+                max_context_tokens: None,
+                max_tool_result_chars: None,
             },
         );
         agents

--- a/src/tools/swarm.rs
+++ b/src/tools/swarm.rs
@@ -570,6 +570,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         agents.insert(
@@ -588,6 +590,8 @@ mod tests {
                 agentic_timeout_secs: None,
                 skills_directory: None,
                 memory_namespace: None,
+            max_context_tokens: None,
+            max_tool_result_chars: None,
             },
         );
         agents


### PR DESCRIPTION
## Summary
- Real multi-agent system with workspace agent definitions (`workspace/agents/`) and hot-reload via file watcher
- `spawn_agent` tool for ad-hoc agent creation with optional persist-to-disk
- Per-agent `provider` and `model` configuration for sub-agent model routing
- Per-agent `max_context_tokens` and `max_tool_result_chars` for context window control
- `max_concurrent_subagents` semaphore for delegate/spawn slot saturation control
- `SubagentObserver` for sub-agent tool call and LLM request tracing
- Researcher and assistant workspace agent examples

## Dependencies
- Optional: after #5420 merges, a rustfmt pass on `improver.rs` should be applied

## Test plan
- [ ] `cargo check` passes
- [ ] `cargo test` passes
- [ ] Workspace agents load from `workspace/agents/` directory
- [ ] `spawn_agent` tool creates ad-hoc agents with correct config
- [ ] Sub-agent concurrency respects `max_concurrent_subagents` limit
- [ ] SubagentObserver logs tool calls and LLM requests