### PR TITLE
fix(tool): reject sub_resource for services that don't support it

### DIFF
--- a/src/tools/google_workspace.rs
+++ b/src/tools/google_workspace.rs
@@ -13,6 +13,16 @@ const MAX_OUTPUT_BYTES: usize = 1_048_576;
 
 use crate::config::DEFAULT_GWS_SERVICES;
 
+/// Services whose `gws` CLI shape uses a sub-resource segment:
+/// `gws <service> <resource> <sub_resource> <method>`.
+///
+/// All other services use the 3-segment shape:
+/// `gws <service> <resource> <method>`.
+///
+/// When the caller provides `sub_resource` for a service **not** in this list
+/// we return a helpful error instead of forwarding the malformed command to `gws`.
+const SERVICES_WITH_SUB_RESOURCES: &[&str] = &["gmail"];
+
 /// Google Workspace CLI (`gws`) integration tool.
 ///
 /// Wraps the `gws` CLI binary to give the agent structured access to
@@ -143,19 +153,19 @@ impl Tool for GoogleWorkspaceTool {
             "properties": {
                 "service": {
                     "type": "string",
-                    "description": "Google Workspace service (e.g. drive, gmail, calendar, sheets, docs, slides, tasks, people, chat, classroom, forms, keep, meet, events)"
+                    "description": "Google Workspace service (e.g. drive, gmail, calendar, sheets, docs, slides, tasks, people, chat, classroom, forms, keep, meet)"
                 },
                 "resource": {
                     "type": "string",
-                    "description": "Service resource (e.g. files, messages, events, spreadsheets)"
+                    "description": "Top-level resource for the service. Examples: drive\u{2192}files, gmail\u{2192}users, calendar\u{2192}events, sheets\u{2192}spreadsheets, docs\u{2192}documents, tasks\u{2192}tasklists, people\u{2192}connections"
                 },
                 "method": {
                     "type": "string",
-                    "description": "Method to call on the resource (e.g. list, get, create, update, delete)"
+                    "description": "Method to call on the resource (e.g. list, get, create, update, delete, patch, send)"
                 },
                 "sub_resource": {
                     "type": "string",
-                    "description": "Optional sub-resource for nested operations"
+                    "description": "Sub-resource for nested operations. Only used by Gmail (e.g. messages, drafts, labels, settings under the users resource). Most services like calendar, drive, sheets, docs do NOT use sub_resource \u{2014} omit it for those."
                 },
                 "params": {
                     "type": "object",
@@ -228,6 +238,22 @@ impl Tool for GoogleWorkspaceTool {
         } else {
             None
         };
+
+        // Reject sub_resource for services that only use the 3-segment shape.
+        // The LLM often incorrectly includes sub_resource for services like
+        // calendar or drive, causing gws to error on the extra positional arg.
+        if sub_resource.is_some() && !SERVICES_WITH_SUB_RESOURCES.contains(&service) {
+            return Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!(
+                    "The '{service}' service does not use sub_resource. \
+                     Use the 3-argument form: service={service}, resource=<resource>, method=<method>. \
+                     Only these services support sub_resource: {}",
+                    SERVICES_WITH_SUB_RESOURCES.join(", ")
+                )),
+            });
+        }
 
         // Security checks
         if self.security.is_rate_limited() {
@@ -1019,6 +1045,78 @@ mod tests {
         // After construction, stored values are trimmed and plain equality works.
         assert!(tool.is_operation_allowed("gmail", "users", Some("drafts"), "create"));
         assert!(!tool.is_operation_allowed("gmail", "users", Some(" drafts "), "create"));
+    }
+
+    // ── sub_resource guard for non-Gmail services ────────────
+
+    #[tokio::test]
+    async fn rejects_sub_resource_for_calendar() {
+        let tool =
+            GoogleWorkspaceTool::new(test_security(), vec![], vec![], None, None, 60, 30, false);
+        let result = tool
+            .execute(json!({
+                "service": "calendar",
+                "resource": "events",
+                "sub_resource": "instances",
+                "method": "list"
+            }))
+            .await
+            .expect("calendar + sub_resource should return a result");
+
+        assert!(!result.success);
+        let err = result.error.as_deref().unwrap_or("");
+        assert!(
+            err.contains("does not use sub_resource"),
+            "expected sub_resource rejection, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_sub_resource_for_drive() {
+        let tool =
+            GoogleWorkspaceTool::new(test_security(), vec![], vec![], None, None, 60, 30, false);
+        let result = tool
+            .execute(json!({
+                "service": "drive",
+                "resource": "files",
+                "sub_resource": "permissions",
+                "method": "list"
+            }))
+            .await
+            .expect("drive + sub_resource should return a result");
+
+        assert!(!result.success);
+        let err = result.error.as_deref().unwrap_or("");
+        assert!(
+            err.contains("does not use sub_resource"),
+            "expected sub_resource rejection, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn allows_sub_resource_for_gmail() {
+        // Gmail is the one service that uses sub_resource. If gws is not
+        // installed the call will fail at spawn, but it must NOT fail at
+        // the sub_resource validation gate.
+        let tool =
+            GoogleWorkspaceTool::new(test_security(), vec![], vec![], None, None, 60, 30, false);
+        let result = tool
+            .execute(json!({
+                "service": "gmail",
+                "resource": "users",
+                "sub_resource": "messages",
+                "method": "list"
+            }))
+            .await
+            .expect("gmail + sub_resource should return a result");
+
+        // The error (if any) should NOT be the sub_resource rejection.
+        // It might be a gws-not-found or timeout error — that's fine.
+        let err = result.error.as_deref().unwrap_or("");
+        assert!(
+            !err.contains("does not use sub_resource"),
+            "gmail sub_resource should be allowed, got: {err}"
+        );
     }
 
     // ── page_limit / page_all flag building ─────────────────


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The `google_workspace` tool's parameter schema doesn't clearly indicate which services support `sub_resource`, causing LLMs to incorrectly include it for services like calendar, drive, etc. The `gws` CLI then errors on the extra positional argument (reported as "sub_resource shouldn't be included").
- Why it matters: The google_workspace tool is effectively unusable for most services because the LLM keeps sending malformed requests. Users have to disable the tool entirely and use shell-based `gws` calls as a workaround.
- What changed: Added a `SERVICES_WITH_SUB_RESOURCES` constant (currently `["gmail"]`), validation that rejects `sub_resource` for non-qualifying services with a helpful error, and improved parameter schema descriptions to guide LLMs correctly.
- What did **not** change (scope boundary): The `gws` CLI itself, the allowed operations config, the Gmail sub_resource flow, or any other tool behavior.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels: `tool`
- Module labels: `tool: google_workspace`
- Contributor tier label: N/A
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `runtime`

## Linked Issue

- Closes #5444
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check   # Pass
cargo clippy --all-targets -- -D warnings   # Pass
cargo test --lib google_workspace   # 41 passed, 0 failed (includes 3 new tests)
cargo test --lib -- --skip gateway   # 5793 passed, 0 failed
```

- Evidence provided (test/log/trace/screenshot/perf): Unit test output above. Added 3 new tests: `rejects_sub_resource_for_calendar`, `rejects_sub_resource_for_drive`, `allows_sub_resource_for_gmail`.
- If any command is intentionally skipped, explain why: `--skip gateway` used for full suite because gateway tests have pre-existing timeout issues unrelated to this PR.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Confirmed

## Compatibility / Migration

- Backward compatible? Yes — calls that previously succeeded (no sub_resource for non-Gmail services) continue to work. Calls that previously failed at the gws CLI level now fail earlier with a better error message.
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Calendar query without sub_resource passes validation; Calendar query with sub_resource returns clear error; Gmail query with sub_resource passes validation; Drive query with sub_resource returns clear error.
- Edge cases checked: Empty sub_resource not provided (None), Gmail operations still work correctly with sub_resource.
- What was not verified: End-to-end with live `gws` CLI (requires Google auth setup).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Only the `google_workspace` tool's validation layer.
- Potential unintended effects: If a future `gws` version adds sub_resource support to other services, the `SERVICES_WITH_SUB_RESOURCES` constant will need updating.
- Guardrails/monitoring for early detection: The constant is clearly documented and easy to extend.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Analyzed issue report, traced error path through tool code, identified LLM-side schema confusion as root cause, added server-side validation + improved schema descriptions.
- Verification focus: Correctness of sub_resource rejection for non-Gmail services while preserving Gmail behavior.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None needed — the constant can be quickly expanded.
- Observable failure symptoms: LLM calls with sub_resource for non-Gmail services would show "does not use sub_resource" error instead of `gws` CLI errors.

## Risks and Mitigations

- Risk: A Google Workspace service other than Gmail legitimately uses sub_resources in gws.
  - Mitigation: The `SERVICES_WITH_SUB_RESOURCES` constant is easy to extend. The validation is purely additive — it turns opaque gws CLI errors into actionable tool-level errors.