### PR TITLE
fix(daemon,cron): filter Conversation memories from scheduled task recall

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -280,6 +280,8 @@ async fn run_agent_job(
     let prompt = job.prompt.clone().unwrap_or_default();
 
     // Recall relevant memories so cron jobs have context awareness.
+    // Exclude `Conversation` memories to prevent chat context from
+    // leaking into scheduled executions (see #5415).
     let memory_context = match crate::memory::create_memory(
         &config.memory,
         &config.workspace_dir,
@@ -289,10 +291,20 @@ async fn run_agent_job(
             Ok(entries) if !entries.is_empty() => {
                 let ctx: String = entries
                     .iter()
+                    .filter(|e| {
+                        !matches!(
+                            e.category,
+                            crate::memory::traits::MemoryCategory::Conversation
+                        )
+                    })
                     .map(|e| format!("- {}: {}", e.key, e.content))
                     .collect::<Vec<_>>()
                     .join("\n");
-                format!("[Memory context]\n{ctx}\n\n")
+                if ctx.is_empty() {
+                    String::new()
+                } else {
+                    format!("[Memory context]\n{ctx}\n\n")
+                }
             }
             _ => String::new(),
         },

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -434,15 +434,27 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
             let task_prompt = format!("[Heartbeat Task | {}] {}", task.priority, task.text);
 
             // Recall relevant memories so heartbeat tasks have context awareness.
+            // Exclude `Conversation` memories to prevent chat context from
+            // leaking into scheduled executions (see #5415).
             let memory_context = if let Some(ref mem) = heartbeat_memory {
                 match mem.recall(&task.text, 5, None, None, None).await {
                     Ok(entries) if !entries.is_empty() => {
                         let ctx: String = entries
                             .iter()
+                            .filter(|e| {
+                                !matches!(
+                                    e.category,
+                                    crate::memory::traits::MemoryCategory::Conversation
+                                )
+                            })
                             .map(|e| format!("- {}: {}", e.key, e.content))
                             .collect::<Vec<_>>()
                             .join("\n");
-                        Some(format!("[Memory context]\n{ctx}\n"))
+                        if ctx.is_empty() {
+                            None
+                        } else {
+                            Some(format!("[Memory context]\n{ctx}\n"))
+                        }
                     }
                     _ => None,
                 }


### PR DESCRIPTION
## Summary

- Heartbeat and cron workers recalled ALL memory entries — including `MemoryCategory::Conversation` from Discord/Telegram chat — when building prompts for scheduled tasks, causing private chat context to spill into unrelated scheduled executions.
- Added a `.filter()` step in both `src/daemon/mod.rs` (heartbeat worker) and `src/cron/scheduler.rs` (cron job runner) to exclude `Conversation`-category memories from recall results.
- Handles the edge case where filtering leaves zero entries (returns empty context instead of a spurious `[Memory context]` header).

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels: `cron`, `daemon`, `memory`, `heartbeat`, `security`

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `security`, `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `multi` (daemon + cron + memory)

## Linked Issue

- Closes #5415

## Validation Evidence (required)

```bash
cargo check          # ✅ compiles clean
cargo clippy --all-targets -- -D warnings  # ✅ no warnings
cargo test cron      # ✅ 8 passed
```

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- This PR *reduces* data exposure by filtering conversation memories out of scheduled task prompts.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- This fix prevents conversation-origin data from leaking into scheduled task contexts.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Human Verification (required)

- Verified scenarios: After the fix, cron and heartbeat recall results no longer include `Conversation`-category entries; only `Core`, `Daily`, and `Custom` memories appear in scheduled task prompts.
- Edge cases checked: All recalled entries are `Conversation`-category → result is empty context, no spurious `[Memory context]` header emitted.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Heartbeat worker prompt assembly, cron job prompt assembly.
- Potential unintended effects: Scheduled tasks lose access to conversation-sourced context they may have previously (incorrectly) relied on. This is intentional.

## Rollback Plan (required)

- Fast rollback: `git revert <merge-commit>` on `master`

## Risks and Mitigations

- Risk: Scheduled tasks that previously (incorrectly) benefited from conversation memories will lose that context.
  - Mitigation: This is the intended fix. Conversation memories are private to their originating channel and should never appear in autonomous scheduled tasks.