### PR TITLE
fix(agent): preserve tool_call_id during tool result truncation

### DIFF
--- a/src/agent/context_compressor.rs
+++ b/src/agent/context_compressor.rs
@@ -276,7 +276,7 @@ impl ContextCompressor {
                 continue;
             }
             let original_len = msg.content.len();
-            msg.content = crate::agent::loop_::truncate_tool_result(&msg.content, max);
+            msg.content = crate::agent::history::truncate_tool_message(&msg.content, max);
             saved += original_len - msg.content.len();
         }
         saved

--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -55,6 +55,28 @@ pub(crate) fn truncate_tool_result(output: &str, max_chars: usize) -> String {
     )
 }
 
+/// Truncate a tool message's content, preserving JSON structure when the
+/// message stores `tool_call_id` alongside `content` (native tool-call
+/// format). Without this, `truncate_tool_result` destroys the JSON envelope
+/// and downstream providers receive a `null` `call_id` (#5425).
+pub(crate) fn truncate_tool_message(msg_content: &str, max_chars: usize) -> String {
+    if max_chars == 0 || msg_content.len() <= max_chars {
+        return msg_content.to_string();
+    }
+    if let Ok(mut obj) =
+        serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(msg_content)
+    {
+        if obj.contains_key("tool_call_id") {
+            if let Some(serde_json::Value::String(inner)) = obj.get("content") {
+                let truncated = truncate_tool_result(inner, max_chars);
+                obj.insert("content".to_string(), serde_json::Value::String(truncated));
+                return serde_json::to_string(&obj).unwrap_or_else(|_| msg_content.to_string());
+            }
+        }
+    }
+    truncate_tool_result(msg_content, max_chars)
+}
+
 /// Aggressively trim old tool result messages in history to recover from
 /// context overflow. Keeps the last `protect_last_n` messages untouched.
 /// Returns total characters saved.
@@ -68,7 +90,7 @@ pub(crate) fn fast_trim_tool_results(
     for msg in &mut history[..cutoff] {
         if msg.role == "tool" && msg.content.len() > trim_to {
             let original_len = msg.content.len();
-            msg.content = truncate_tool_result(&msg.content, trim_to);
+            msg.content = truncate_tool_message(&msg.content, trim_to);
             saved += original_len - msg.content.len();
         }
     }

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -4886,6 +4886,39 @@ mod tests {
         assert!(result.ends_with("yz"));
     }
 
+    // ── truncate_tool_message tests ─────────────────────────────
+
+    #[test]
+    fn truncate_tool_message_preserves_json_structure() {
+        use crate::agent::history::truncate_tool_message;
+        let big_content = "x".repeat(5000);
+        let msg = serde_json::json!({
+            "tool_call_id": "call_abc123",
+            "content": big_content,
+        })
+        .to_string();
+        let result = truncate_tool_message(&msg, 2000);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(parsed["tool_call_id"], "call_abc123");
+        assert!(parsed["content"].as_str().unwrap().contains("[... "));
+    }
+
+    #[test]
+    fn truncate_tool_message_plain_text_fallback() {
+        use crate::agent::history::truncate_tool_message;
+        let plain = "a".repeat(5000);
+        let result = truncate_tool_message(&plain, 2000);
+        assert!(result.contains("[... "));
+        assert!(result.len() < 5000);
+    }
+
+    #[test]
+    fn truncate_tool_message_short_passthrough() {
+        use crate::agent::history::truncate_tool_message;
+        let msg = r#"{"tool_call_id":"call_1","content":"ok"}"#;
+        assert_eq!(truncate_tool_message(msg, 2000), msg);
+    }
+
     // ── fast_trim_tool_results tests ────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `fast_trim_tool_results` and context compressor truncated tool result messages as plain text, destroying the JSON envelope that carries `tool_call_id`. Downstream OpenAI-compatible providers then received a `null` `call_id`, causing `400 Bad Request: Missing required parameter: 'input[25].call_id'` errors and no reply to the user.
- Why it matters: S0 severity — causes complete message processing failure and contributes to OOM crashes when the daemon cannot recover from the API error.
- What changed: Introduced `truncate_tool_message()` in `history.rs` that parses JSON tool messages, truncates only the inner `content` field, and preserves the `tool_call_id` envelope. Updated both truncation call sites (`history::fast_trim_tool_results` and `context_compressor::fast_trim_tool_results`) to use this new function.
- What did **not** change: `truncate_tool_result()` itself is unchanged — it still handles plain text truncation. The tool result construction path in `loop_.rs` is untouched.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `agent`
- Module labels: `agent: context_compressor`, `agent: history`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `runtime`

## Linked Issue

- Closes #5425
- Related: N/A
- Depends on: N/A
- Supersedes: N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # Pass
cargo clippy --all-targets -- -D warnings   # Pass
cargo test --lib truncate_tool   # 10 passed (7 existing + 3 new)
cargo test --lib fast_trim   # 10 passed (all existing)
```

- Evidence provided: Unit tests for `truncate_tool_message` covering JSON preservation, plain-text fallback, and short passthrough. All existing `truncate_tool_result` and `fast_trim` tests continue to pass.
- If any command is intentionally skipped, explain why: Full `cargo test` not run locally (large test suite), but all relevant unit tests pass.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Constructed a JSON tool message with `tool_call_id` + large `content`, verified `truncate_tool_message` preserves the ID while truncating content. Verified plain text messages still truncate correctly.
- Edge cases checked: Short messages (passthrough), non-JSON messages (fallback to plain truncation), JSON without `tool_call_id` (fallback to plain truncation).
- What was not verified: Live daemon end-to-end with an OpenAI-compatible provider returning the error.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Context compression and history trimming for tool messages.
- Potential unintended effects: None — the new path is strictly additive (JSON-aware truncation only activates when `tool_call_id` is present in the JSON).
- Guardrails/monitoring for early detection: The existing `truncate_tool_result` behavior is unchanged for non-JSON content. Any regression in context compression would surface as context-window errors in logs.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Analyzed issue logs → identified JSON corruption in truncation path → added JSON-aware wrapper → updated both call sites → added tests.
- Verification focus: JSON structure preservation, backward compatibility with plain text truncation.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit-sha>`
- Feature flags or config toggles: None needed — change is a pure bug fix.
- Observable failure symptoms: If rolled back, the original `400 Bad Request: Missing required parameter: 'input[N].call_id'` error would reappear in logs when tool results are truncated during context compression.

## Risks and Mitigations

- Risk: `serde_json::to_string` on the reconstructed JSON could theoretically produce a slightly different key order than the original.
  - Mitigation: The downstream parser (`compatible.rs:1515`) uses `serde_json::from_str` + `.get("tool_call_id")`, which is key-order agnostic. No impact.