### PR TITLE
fix: git -C (chdir) blocked by -c (config injection) security check

### DIFF
--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -1260,7 +1260,7 @@ impl SecurityPolicy {
                         || lower.starts_with("config.")
                         || lower == "alias"
                         || lower.starts_with("alias.")
-                        || arg == "-c"  // case-sensitive: -C is safe, -c is not
+                        || arg == "-c" // case-sensitive: -C is safe, -c is not
                 })
             }
             _ => true,

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -1221,8 +1221,11 @@ impl SecurityPolicy {
                 return false;
             }
 
-            // Validate arguments for the command
-            let args: Vec<String> = words.map(|w| w.to_ascii_lowercase()).collect();
+            // Validate arguments for the command.
+            // Pass args without lowercasing — is_args_safe must do its own
+            // case-folding where needed. Lowercasing here caused git -C
+            // (change directory) to collide with -c (config injection).
+            let args: Vec<String> = words.map(|w| w.to_string()).collect();
             if !self.is_args_safe(base_cmd, &args) {
                 return false;
             }
@@ -1241,17 +1244,23 @@ impl SecurityPolicy {
         match base.as_str() {
             "find" => {
                 // find -exec and find -ok allow arbitrary command execution
-                !args.iter().any(|arg| arg == "-exec" || arg == "-ok")
+                !args.iter().any(|arg| {
+                    let lower = arg.to_ascii_lowercase();
+                    lower == "-exec" || lower == "-ok"
+                })
             }
             "git" => {
-                // git config, alias, and -c can be used to set dangerous options
-                // (e.g. git config core.editor "rm -rf /")
+                // git config, alias, and -c (lowercase only) can be used to set
+                // dangerous options (e.g. git config core.editor "rm -rf /").
+                // Use case-sensitive comparison: -C (uppercase) is the safe
+                // "change directory" flag and must not be conflated with -c.
                 !args.iter().any(|arg| {
-                    arg == "config"
-                        || arg.starts_with("config.")
-                        || arg == "alias"
-                        || arg.starts_with("alias.")
-                        || arg == "-c"
+                    let lower = arg.to_ascii_lowercase();
+                    lower == "config"
+                        || lower.starts_with("config.")
+                        || lower == "alias"
+                        || lower.starts_with("alias.")
+                        || arg == "-c"  // case-sensitive: -C is safe, -c is not
                 })
             }
             _ => true,


### PR DESCRIPTION
## Summary

- `is_command_allowed()` was lowercasing all args before passing them to `is_args_safe()`, causing `git -C` (change directory — safe) to collide with `git -c` (config injection — dangerous) and be incorrectly blocked.
- Fix: pass args to `is_args_safe()` without lowercasing; let the function do its own case folding only where needed.
- `git -c` check remains case-sensitive (only lowercase `-c` is dangerous); subcommand name checks (`config`, `alias`) are case-insensitive as before.
- Bonus: made `find -exec`/`-ok` check case-insensitive for correctness.

## Test plan

- [ ] All existing `security` unit tests pass (`cargo test security` — 22 tests)
- [ ] `git -C /some/path push origin master` is now allowed by the policy
- [ ] `git -c core.editor="rm -rf /" commit` is still blocked
- [ ] Full test suite passes (`cargo test --lib` — 5899 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)