### PR TITLE
fix(channel): include channel-lark in default features and prompt for Feishu encrypt key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,7 +240,7 @@ landlock = { version = "0.4", optional = true }
 libc = "0.2"
 
 [features]
-default = ["observability-prometheus", "skill-creation"]
+default = ["observability-prometheus", "skill-creation", "channel-lark"]
 channel-nostr = ["dep:nostr-sdk"]
 hardware = ["nusb", "tokio-serial"]
 channel-matrix = ["dep:matrix-sdk"]

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -5352,14 +5352,32 @@ fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
                     LarkReceiveMode::Webhook
                 };
 
-                let verification_token = if receive_mode == LarkReceiveMode::Webhook {
-                    let token: String = Input::new()
-                        .with_prompt("  Verification Token (optional, for Webhook mode)")
+                let existing_lk = config.lark.as_ref();
+
+                let encrypt_key = {
+                    let existing_ek = existing_lk.and_then(|l| l.encrypt_key.clone());
+                    let prompt_default = existing_ek.clone().unwrap_or_default();
+                    let ek: String = Input::new()
+                        .with_prompt("  Encrypt Key (optional, from Event Subscriptions page)")
+                        .default(prompt_default)
                         .allow_empty(true)
                         .interact_text()?;
-                    if token.is_empty() { None } else { Some(token) }
-                } else {
-                    None
+                    let ek = ek.trim().to_string();
+                    if ek.is_empty() { existing_ek } else { Some(ek) }
+                };
+
+                let verification_token = {
+                    let existing_vt = existing_lk.and_then(|l| l.verification_token.clone());
+                    let prompt_default = existing_vt.clone().unwrap_or_default();
+                    let vt: String = Input::new()
+                        .with_prompt(
+                            "  Verification Token (optional, from Event Subscriptions page)",
+                        )
+                        .default(prompt_default)
+                        .allow_empty(true)
+                        .interact_text()?;
+                    let vt = vt.trim().to_string();
+                    if vt.is_empty() { existing_vt } else { Some(vt) }
                 };
 
                 if receive_mode == LarkReceiveMode::Webhook && verification_token.is_none() {
@@ -5397,12 +5415,11 @@ fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
                     );
                 }
 
-                let existing_lk = config.lark.as_ref();
                 config.lark = Some(LarkConfig {
                     app_id,
                     app_secret,
                     verification_token,
-                    encrypt_key: existing_lk.and_then(|l| l.encrypt_key.clone()),
+                    encrypt_key,
                     allowed_users,
                     mention_only: existing_lk.map(|l| l.mention_only).unwrap_or(false),
                     use_feishu: is_feishu,


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Two related Feishu/Lark onboarding bugs: (1) a plain `cargo build --release` does not include `channel-lark`, so users who configure Lark/Feishu during onboarding get "compiled without channel-lark" at runtime (#5309); (2) the onboarding wizard never prompts for Encrypt Key and only prompts for Verification Token in Webhook mode, but Feishu requires both for event subscription verification regardless of receive mode (#5312).
- Why it matters: Feishu users cannot receive messages after onboarding — the channel either silently skips (no feature) or lacks the credentials needed for event verification.
- What changed: Added `channel-lark` to default Cargo features; refactored onboard wizard to prompt for Encrypt Key and Verification Token in both WebSocket and Webhook modes, pre-filling from existing config when re-onboarding.
- What did **not** change (scope boundary): No changes to the Lark/Feishu channel runtime, config schema, or webhook/WebSocket transport logic.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels: `channel`, `onboard`, `config`
- Module labels: `channel: lark`, `channel: feishu`
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #5309
- Closes #5312

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check  # PASS (exit 0)
```

- Evidence provided: `cargo fmt` passes on changed files.
- If any command is intentionally skipped, explain why: `cargo clippy` and `cargo test` not run locally due to cross-platform build environment (changes are limited to Cargo feature flags and interactive prompt logic).

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `Yes` — the onboard wizard now prompts for Encrypt Key and Verification Token (both optional) during Feishu/Lark setup and stores them in the existing config fields. No new storage mechanism.
- File system access scope changed? `No`
- If any `Yes`, describe risk and mitigation: These fields were already defined in `LarkConfig` and `FeishuConfig` schemas and already encrypted/decrypted by the config secret store. The change only adds the interactive prompt to populate them during onboarding.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No personal data added.
- Neutral wording confirmation: Yes, uses project-native labels (Lark/Feishu).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` — no new config fields. Existing configs gain default Lark feature.
- Migration needed? `No`
- If yes, exact upgrade steps: N/A. Users who previously built without `--features channel-lark` will now get it by default. Users who explicitly pass `--no-default-features` are unaffected.

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No` — only interactive prompt text changed, not docs.

## Human Verification (required)

- Verified scenarios: Reviewed onboard wizard flow for Lark and Feishu menu choices; confirmed encrypt_key and verification_token are prompted regardless of receive mode; confirmed existing values are pre-filled as defaults during re-onboarding.
- Edge cases checked: Empty input preserves existing config value; fresh onboarding with no existing config sets fields to None when left blank.
- What was not verified: Full end-to-end Feishu WebSocket connection (requires Feishu app credentials).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Default binary size increases slightly due to `prost` dependency (Lark protobuf codec). Onboard wizard Lark/Feishu flow now has two additional prompts.
- Potential unintended effects: Users who relied on a minimal default build without Lark may see a slightly larger binary.
- Guardrails/monitoring for early detection: CI builds already include `channel-lark` via `ci-all`.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Analyzed both issues, identified root causes in `Cargo.toml` (missing default feature) and `src/onboard/wizard.rs` (conditional prompt logic), applied minimal fix.
- Verification focus: Correct prompt ordering, existing-value preservation, formatter compliance.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: Revert this commit; or remove `channel-lark` from default features to restore previous binary behavior.
- Feature flags or config toggles: `channel-lark` Cargo feature can be excluded with `--no-default-features`.
- Observable failure symptoms: If reverted, Feishu users will again see "compiled without channel-lark" warning and be unable to receive messages.

## Risks and Mitigations

- Risk: Default binary size increase from including `prost` dependency.
  - Mitigation: `prost` is already used by `whatsapp-web` and `ci-all` builds; impact is minimal. Users who need minimal binaries can use `--no-default-features`.