### PR TITLE
fix(channel,onboard): sanitize orphaned tool messages, deduplicate memory, fix workspace pointer order

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1186,6 +1186,8 @@ fn proactive_trim_turns(turns: &mut Vec<ChatMessage>, budget: usize) -> usize {
 
     if drop_count > 0 {
         turns.drain(..drop_count);
+        // Remove orphaned tool messages after trimming (#5475).
+        sanitize_orphaned_tool_messages(turns);
     }
     drop_count
 }
@@ -1280,7 +1282,8 @@ fn strip_old_tool_context(ctx: &ChannelRuntimeContext, sender_key: &str, keep_tu
 
     // Remove tool and intermediate assistant messages before the boundary.
     // An "intermediate assistant" is one whose content looks like a tool
-    // call (contains `<tool_call>` or starts with `{\"tool_call`).
+    // call (contains `<tool_call>` or starts with `{\"tool_call`) or
+    // native JSON tool_calls.
     let mut i = 0;
     while i < protect_from && i < turns.len() {
         let dominated = turns[i].role == "tool"
@@ -1295,6 +1298,12 @@ fn strip_old_tool_context(ctx: &ChannelRuntimeContext, sender_key: &str, keep_tu
     }
 }
 
+    // After stripping, ensure no orphaned tool messages remain.
+    // A tool-role message without a preceding assistant with tool_calls
+    // violates the OpenAI API contract and causes provider errors (#5475).
+    sanitize_orphaned_tool_messages(turns);
+}
+
 /// Heuristic: does this assistant message content represent a tool call
 /// rather than a final text response?
 fn is_tool_call_content(content: &str) -> bool {
@@ -1302,6 +1311,42 @@ fn is_tool_call_content(content: &str) -> bool {
     trimmed.contains("<tool_call>")
         || trimmed.starts_with("{\"tool_call\"")
         || trimmed.starts_with("{\"name\"")
+        || is_native_json_tool_call(trimmed)
+}
+
+/// Check if the content is a native JSON tool-call message (OpenAI format).
+fn is_native_json_tool_call(content: &str) -> bool {
+    if !content.starts_with('{') {
+        return false;
+    }
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(content) {
+        if let Some(arr) = val.get("tool_calls").and_then(|v| v.as_array()) {
+            return !arr.is_empty();
+        }
+    }
+    false
+}
+
+/// Remove orphaned tool-role messages that appear without a preceding
+/// assistant message containing tool_calls (#5475).
+fn sanitize_orphaned_tool_messages(turns: &mut Vec<ChatMessage>) {
+    let mut i = 0;
+    while i < turns.len() {
+        if turns[i].role == "tool" {
+            let has_preceding_tool_call = i > 0
+                && turns[i - 1].role == "assistant"
+                && is_tool_call_content(&turns[i - 1].content);
+            let continues_tool_batch = i > 0 && turns[i - 1].role == "tool";
+
+            if !has_preceding_tool_call && !continues_tool_batch {
+                turns.remove(i);
+            } else {
+                i += 1;
+            }
+        } else {
+            i += 1;
+        }
+    }
 }
 
 fn rollback_orphan_user_turn(
@@ -2580,21 +2625,8 @@ async fn process_channel_message(
             return;
         }
     };
-    if ctx.auto_save_memory
-        && msg.content.chars().count() >= AUTOSAVE_MIN_MESSAGE_CHARS
-        && !memory::should_skip_autosave_content(&msg.content)
-    {
-        let autosave_key = conversation_memory_key(&msg);
-        let _ = ctx
-            .memory
-            .store(
-                &autosave_key,
-                &msg.content,
-                crate::memory::MemoryCategory::Conversation,
-                Some(&history_key),
-            )
-            .await;
-    }
+    // NOTE: Raw user-message auto-save removed (#5470).
+    // Post-LLM consolidation already creates structured memories.
 
     println!("  ⏳ Processing message...");
     let started_at = Instant::now();
@@ -5639,6 +5671,8 @@ pub async fn start_channels(config: Config) -> Result<()> {
             if msgs.len() > MAX_CHANNEL_HISTORY {
                 msgs.drain(..msgs.len() - MAX_CHANNEL_HISTORY);
             }
+            // Remove orphaned tool messages after trimming (#5475).
+            sanitize_orphaned_tool_messages(&mut msgs);
             // Close orphaned user turns from crashed sessions.
             if msgs.last().is_some_and(|m| m.role == "user") {
                 let closure =

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1296,7 +1296,6 @@ fn strip_old_tool_context(ctx: &ChannelRuntimeContext, sender_key: &str, keep_tu
             i += 1;
         }
     }
-}
 
     // After stripping, ensure no orphaned tool messages remain.
     // A tool-role message without a preceding assistant with tool_calls

--- a/src/cron/schedule.rs
+++ b/src/cron/schedule.rs
@@ -165,7 +165,7 @@ fn normalize_weekday_field(field: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{Datelike, TimeZone};
+    use chrono::{Datelike, Offset, TimeZone};
 
     #[test]
     fn next_run_for_schedule_supports_every_and_at() {

--- a/src/cron/schedule.rs
+++ b/src/cron/schedule.rs
@@ -165,7 +165,7 @@ fn normalize_weekday_field(field: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{Datelike, Offset, TimeZone};
+    use chrono::{Datelike, TimeZone};
 
     #[test]
     fn next_run_for_schedule_supports_every_and_at() {

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -227,8 +227,8 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
         if config.memory.auto_save { "on" } else { "off" }
     );
 
-    config.save().await?;
     persist_workspace_selection(&config.config_path).await?;
+    config.save().await?;
 
     // ── Final summary ────────────────────────────────────────────
     print_summary(&config);
@@ -277,8 +277,8 @@ pub async fn run_channels_repair_wizard() -> Result<Config> {
 
     print_step(1, 1, "Channels (How You Talk to ZeroClaw)");
     config.channels_config = setup_channels(Some(config.channels_config.clone()))?;
-    config.save().await?;
     persist_workspace_selection(&config.config_path).await?;
+    config.save().await?;
 
     println!();
     println!(
@@ -342,8 +342,8 @@ async fn run_provider_update_wizard(workspace_dir: &Path, config_path: &Path) ->
     let (provider, api_key, model, provider_api_url) = setup_provider(workspace_dir).await?;
     apply_provider_update(&mut config, provider, api_key, model, provider_api_url);
 
-    config.save().await?;
     persist_workspace_selection(&config.config_path).await?;
+    config.save().await?;
 
     println!(
         "  {} Provider settings updated at {}",
@@ -673,8 +673,8 @@ async fn run_quick_setup_with_home(
         shell_tool: crate::config::ShellToolConfig::default(),
     };
 
-    config.save().await?;
     persist_workspace_selection(&config.config_path).await?;
+    config.save().await?;
 
     // Scaffold minimal workspace files
     let default_ctx = ProjectContext {


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Three bugs: (1) Copilot+Telegram "Invalid parameter: messages with role 'tool' must be a response to a preceding message with 'tool_calls'" (#5475), (2) memory duplicates on every turn (#5470), (3) Windows fsync error causes custom workspace path to be ignored (#5465).
- Why it matters: #5475 blocks tool-using conversations with Copilot; #5470 wastes storage and pollutes recall; #5465 prevents Windows users from using custom paths.
- What changed: Added sanitize_orphaned_tool_messages() for history trimming/hydration; extended is_tool_call_content for native JSON tool_calls; removed redundant raw auto-save (consolidation handles it); reordered persist_workspace_selection before config.save() in all wizard paths.
- What did **not** change: No changes to provider implementations, session persistence format, or consolidation logic.

## Label Snapshot (required)

- Risk label: risk: medium
- Size label: size: S
- Scope labels: channel, onboard, memory
- Module labels: channel: telegram, provider: copilot
- Contributor tier label: auto-managed
- If any auto-label is incorrect: n/a

## Change Metadata

- Change type: bug
- Primary scope: multi

## Linked Issue

- Closes #5475
- Closes #5470
- Closes #5465

## Validation Evidence (required)

\`\`\`bash
cargo fmt --all -- --check   # pass
cargo check                  # pass
\`\`\`

- Evidence provided: compilation passes, formatting clean
- If any command is intentionally skipped: cargo clippy/test have pre-existing failures unrelated to this PR

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: n/a
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Reviewed all code paths where tool messages can become orphaned (session hydration, strip_old_tool_context, proactive_trim_turns). Verified consolidation covers auto-save scope. Verified workspace pointer order across all 4 wizard paths.
- Edge cases checked: Tool messages at history start after trim, consecutive tool messages in batch, empty tool_calls arrays, non-JSON assistant content.
- What was not verified: Live Copilot+Telegram E2E test, Windows fsync behavior.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: channel message processing, session hydration, memory auto-save, onboard wizard
- Potential unintended effects: Messages failing during LLM call (before consolidation) won't be saved to memory. Acceptable because session history preserves them.
- Guardrails/monitoring: Memory consolidation errors logged at debug level.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Verification focus: Compilation, formatting, code path analysis
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: git revert <commit>
- Feature flags or config toggles: none
- Observable failure symptoms: Original errors from #5475, #5470, #5465

## Risks and Mitigations

- Risk: sanitize_orphaned_tool_messages runs O(n) on every history trim
  - Mitigation: History capped at ~50 turns, overhead negligible
- Risk: Removing raw auto-save could lose data if consolidation fails
  - Mitigation: Session history preserves all messages regardless