### PR TITLE
chore: exclude web/ and marketplace/ from GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,10 @@
 *.bash text eol=lf linguist-language=Shell
 *.ps1 text eol=crlf linguist-language=PowerShell
 
+# Vendored / non-primary language directories (excluded from GitHub language stats)
+web/* linguist-vendored
+marketplace/* linguist-vendored
+
 # Documentation
 *.txt text eol=lf
 LICENSE* text eol=lf


### PR DESCRIPTION
## Summary
- Mark `web/*` and `marketplace/*` as `linguist-vendored` in `.gitattributes`
- This excludes the React frontend (~20K lines TypeScript) from GitHub's language statistics bar
- Files remain fully searchable, diffable, and unchanged — only the stats display is affected
- Reduces TypeScript from 6.9% to near-zero, accurately reflecting this as a Rust project

## Test plan
- [ ] After merge, verify the language bar on the repo main page shows ~97%+ Rust
- [ ] Verify TypeScript files in `web/src/` are still searchable on GitHub