### PR TITLE
chore: exclude Python tooling dirs from GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,11 @@
 # Vendored / non-primary language directories (excluded from GitHub language stats)
 web/** linguist-vendored
 marketplace/** linguist-vendored
+.claude/** linguist-vendored
+dev/** linguist-vendored
+firmware/** linguist-vendored
+scripts/** linguist-vendored
+tests/** linguist-vendored
 
 # Documentation
 *.txt text eol=lf

--- a/README.md
+++ b/README.md
@@ -648,7 +648,7 @@ Use these when you're past the onboarding flow and want the deeper reference.
 - Proxy agent playbook: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Hardware guides: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw was built for the smooth crab 🦀, a fast and efficient AI assistant. Built by Argenis De La Rosa and the community.
 

--- a/docs/i18n/ar/README.md
+++ b/docs/i18n/ar/README.md
@@ -651,7 +651,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 - دليل وكيل البروكسي: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - أدلة الأجهزة: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 تم بناء ZeroClaw للسلطعون الناعم 🦀، مساعد ذكاء اصطناعي سريع وفعال. بناه Argenis De La Rosa والمجتمع.
 

--- a/docs/i18n/bn/README.md
+++ b/docs/i18n/bn/README.md
@@ -651,7 +651,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 - প্রক্সি এজেন্ট প্লেবুক: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - হার্ডওয়্যার গাইড: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw smooth crab 🦀 এর জন্য তৈরি হয়েছিল, একটি দ্রুত এবং দক্ষ AI সহকারী। Argenis De La Rosa এবং সম্প্রদায় দ্বারা নির্মিত।
 

--- a/docs/i18n/cs/README.md
+++ b/docs/i18n/cs/README.md
@@ -651,7 +651,7 @@ Používejte tyto, když jste prošli onboardingem a chcete hlubší referenci.
 - Příručka proxy agenta: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Hardwarové průvodce: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw byl vytvořen pro smooth crab 🦀, rychlého a efektivního AI asistenta. Vytvořil Argenis De La Rosa a komunita.
 

--- a/docs/i18n/da/README.md
+++ b/docs/i18n/da/README.md
@@ -651,7 +651,7 @@ Brug disse, naar du er forbi onboarding-flowet og vil have den dybere reference.
 - Proxy-agent-haandbog: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Hardwareguider: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw blev bygget til smooth crab 🦀, en hurtig og effektiv AI-assistent. Bygget af Argenis De La Rosa og faellesskabet.
 

--- a/docs/i18n/de/README.md
+++ b/docs/i18n/de/README.md
@@ -651,7 +651,7 @@ Verwende diese Ressourcen, wenn du den Onboarding-Prozess abgeschlossen hast und
 - Proxy-Agent-Handbuch: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Hardware-Leitfäden: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw wurde für den glatten Krebs 🦀 gebaut, einen schnellen und effizienten KI-Assistenten. Entwickelt von Argenis De La Rosa und der Community.
 

--- a/docs/i18n/el/README.md
+++ b/docs/i18n/el/README.md
@@ -651,7 +651,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 - Εγχειρίδιο proxy agent: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Οδηγοί υλικού: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 Το ZeroClaw δημιουργήθηκε για τον smooth crab 🦀, έναν γρήγορο και αποδοτικό βοηθό AI. Δημιουργήθηκε από τον Argenis De La Rosa και την κοινότητα.
 

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -651,7 +651,7 @@ Usa estos recursos cuando hayas pasado el flujo de onboarding y quieras la refer
 - Manual de agente proxy: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Guías de hardware: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw fue construido para el cangrejo suave 🦀, un asistente de IA rápido y eficiente. Construido por Argenis De La Rosa y la comunidad.
 

--- a/docs/i18n/fi/README.md
+++ b/docs/i18n/fi/README.md
@@ -651,7 +651,7 @@ Kayta naita, kun olet ohittanut onboarding-kulun ja haluat syvemman viitteen.
 - Proxy-agentin kasikirja: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Laitteisto-oppaat: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw rakennettiin smooth crab 🦀 -kaveria varten, nopea ja tehokas tekoalyavustaja. Rakennettu Argenis De La Rosan ja yhteison toimesta.
 

--- a/docs/i18n/fr/README.md
+++ b/docs/i18n/fr/README.md
@@ -651,7 +651,7 @@ Utilisez ces ressources lorsque vous avez dépassé le flux d'onboarding et voul
 - Manuel de l'agent proxy : [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Guides matériels : [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw a été construit pour le crabe lisse 🦀, un assistant IA rapide et efficace. Construit par Argenis De La Rosa et la communauté.
 

--- a/docs/i18n/he/README.md
+++ b/docs/i18n/he/README.md
@@ -651,7 +651,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 - מדריך סוכן פרוקסי: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - מדריכי חומרה: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw נבנה עבור ה-smooth crab 🦀, עוזר AI מהיר ויעיל. נבנה על ידי Argenis De La Rosa והקהילה.
 

--- a/docs/i18n/hi/README.md
+++ b/docs/i18n/hi/README.md
@@ -651,7 +651,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 - प्रॉक्सी एजेंट प्लेबुक: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - हार्डवेयर गाइड: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw को smooth crab 🦀 के लिए बनाया गया था, एक तेज़ और कुशल AI सहायक। Argenis De La Rosa और समुदाय द्वारा निर्मित।
 

--- a/docs/i18n/hu/README.md
+++ b/docs/i18n/hu/README.md
@@ -651,7 +651,7 @@ Hasznald ezeket, ha tuljutottal az onboarding folyamaton es melyebb referenciara
 - Proxy agens kezikonyv: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Hardver utmutatok: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 A ZeroClaw a smooth crab 🦀 szamara keszult, egy gyors es hatekony MI asszisztens. Epitette Argenis De La Rosa es a kozosseg.
 

--- a/docs/i18n/id/README.md
+++ b/docs/i18n/id/README.md
@@ -651,7 +651,7 @@ Gunakan ini ketika Anda sudah melewati alur onboarding dan menginginkan referens
 - Playbook proxy agent: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Panduan perangkat keras: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw dibangun untuk smooth crab 🦀, asisten AI yang cepat dan efisien. Dibangun oleh Argenis De La Rosa dan komunitas.
 

--- a/docs/i18n/it/README.md
+++ b/docs/i18n/it/README.md
@@ -651,7 +651,7 @@ Usa queste risorse quando hai superato il flusso di onboarding e vuoi il riferim
 - Manuale dell'agente proxy: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Guide hardware: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw è stato costruito per il granchio liscio 🦀, un assistente IA veloce ed efficiente. Costruito da Argenis De La Rosa e la comunità.
 

--- a/docs/i18n/ja/README.md
+++ b/docs/i18n/ja/README.md
@@ -651,7 +651,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 - プロキシエージェントプレイブック：[docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - ハードウェアガイド：[docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClawはsmooth crab 🦀のために構築されました。高速で効率的なAIアシスタント。Argenis De La Rosaとコミュニティによって構築されました。
 

--- a/docs/i18n/ko/README.md
+++ b/docs/i18n/ko/README.md
@@ -651,7 +651,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 - 프록시 에이전트 플레이북: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - 하드웨어 가이드: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw는 빠르고 효율적인 AI 어시스턴트인 smooth crab 🦀을 위해 만들어졌습니다. Argenis De La Rosa와 커뮤니티가 만들었습니다.
 

--- a/docs/i18n/nb/README.md
+++ b/docs/i18n/nb/README.md
@@ -651,7 +651,7 @@ Bruk disse nar du er forbi onboarding-flyten og onsker dypere referanse.
 - Proxy-agenthandbok: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Maskinvareguider: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw ble bygget for den smidige krabben 🦀, en rask og effektiv AI-assistent. Bygget av Argenis De La Rosa og fellesskapet.
 

--- a/docs/i18n/nl/README.md
+++ b/docs/i18n/nl/README.md
@@ -651,7 +651,7 @@ Gebruik deze wanneer je voorbij de onboarding bent en diepere referentie wilt.
 - Proxy-agent-draaiboek: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Hardwaregidsen: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw is gebouwd voor de smooth crab 🦀, een snelle en efficiënte AI-assistent. Gebouwd door Argenis De La Rosa en de gemeenschap.
 

--- a/docs/i18n/pl/README.md
+++ b/docs/i18n/pl/README.md
@@ -651,7 +651,7 @@ Używaj tych, gdy przeszedłeś już przez onboarding i chcesz głębszej dokume
 - Podręcznik agenta proxy: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Przewodniki sprzętowe: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw został zbudowany dla smooth crab 🦀, szybkiego i wydajnego asystenta AI. Stworzony przez Argenisa De La Rosę i społeczność.
 

--- a/docs/i18n/pt/README.md
+++ b/docs/i18n/pt/README.md
@@ -651,7 +651,7 @@ Use estes recursos quando tiver passado pelo fluxo de onboarding e quiser a refe
 - Manual de agente proxy: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Guias de hardware: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 O ZeroClaw foi construído para o caranguejo suave 🦀, um assistente de IA rápido e eficiente. Construído por Argenis De La Rosa e a comunidade.
 

--- a/docs/i18n/ro/README.md
+++ b/docs/i18n/ro/README.md
@@ -651,7 +651,7 @@ Folosește-le când ai trecut de fluxul de onboarding și vrei referința mai de
 - Playbook proxy agent: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Ghiduri hardware: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw a fost construit pentru smooth crab 🦀, un asistent AI rapid și eficient. Construit de Argenis De La Rosa și comunitate.
 

--- a/docs/i18n/ru/README.md
+++ b/docs/i18n/ru/README.md
@@ -651,7 +651,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 - Руководство по прокси-агенту: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Руководства по оборудованию: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw был создан для smooth crab 🦀 — быстрого и эффективного ИИ-ассистента. Создан Argenis De La Rosa и сообществом.
 

--- a/docs/i18n/sv/README.md
+++ b/docs/i18n/sv/README.md
@@ -651,7 +651,7 @@ Använd dessa när du är förbi onboarding-flödet och vill ha den djupare refe
 - Proxy-agentplaybook: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Hårdvaruguider: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw byggdes för smooth crab 🦀, en snabb och effektiv AI-assistent. Byggd av Argenis De La Rosa och gemenskapen.
 

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -651,7 +651,7 @@ Release assets เผยแพร่สำหรับ:
 - Playbook proxy agent: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - คู่มือฮาร์ดแวร์: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw ถูกสร้างสำหรับ smooth crab 🦀 ผู้ช่วย AI ที่เร็วและมีประสิทธิภาพ สร้างโดย Argenis De La Rosa และชุมชน
 

--- a/docs/i18n/tl/README.md
+++ b/docs/i18n/tl/README.md
@@ -651,7 +651,7 @@ Gamitin ang mga ito kapag tapos ka na sa onboarding flow at gusto mo ng mas mala
 - Proxy agent playbook: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Hardware guides: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 Ang ZeroClaw ay binuo para sa smooth crab 🦀, isang mabilis at mahusay na AI assistant. Binuo ni Argenis De La Rosa at ng komunidad.
 

--- a/docs/i18n/tr/README.md
+++ b/docs/i18n/tr/README.md
@@ -651,7 +651,7 @@ Onboarding akışını geçtikten sonra daha derin referans istediğinizde bunla
 - Proxy ajan el kitabı: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Donanım rehberleri: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw, smooth crab 🦀 için inşa edildi — hızlı ve verimli bir AI asistanı. Argenis De La Rosa ve topluluk tarafından geliştirildi.
 

--- a/docs/i18n/uk/README.md
+++ b/docs/i18n/uk/README.md
@@ -651,7 +651,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 - Посібник проксі-агента: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Посібники з апаратного забезпечення: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw створений для smooth crab 🦀, швидкого та ефективного AI-асистента. Створений Argenis De La Rosa та спільнотою.
 

--- a/docs/i18n/ur/README.md
+++ b/docs/i18n/ur/README.md
@@ -651,7 +651,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 - پراکسی ایجنٹ پلے بک: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - ہارڈویئر گائیڈز: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw smooth crab 🦀 کے لیے بنایا گیا تھا، ایک تیز اور مؤثر AI اسسٹنٹ۔ Argenis De La Rosa اور کمیونٹی نے بنایا۔
 

--- a/docs/i18n/vi/README.md
+++ b/docs/i18n/vi/README.md
@@ -651,7 +651,7 @@ Dùng khi bạn đã hoàn thành onboarding và muốn tham khảo sâu hơn.
 - Sổ tay proxy agent: [docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - Hướng dẫn phần cứng: [docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw được xây dựng cho smooth crab 🦀, một trợ lý AI nhanh và hiệu quả. Được xây dựng bởi Argenis De La Rosa và cộng đồng.
 

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -651,7 +651,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 - 代理代理手册：[docs/ops/proxy-agent-playbook.md](docs/ops/proxy-agent-playbook.md)
 - 硬件指南：[docs/hardware/README.md](docs/hardware/README.md)
 
-## Smooth Crab 🦀
+## Icy Crab 🦀
 
 ZeroClaw 为 smooth crab 🦀 而构建，一个快速高效的 AI 助手。由 Argenis De La Rosa 和社区共同构建。
 


### PR DESCRIPTION
## Summary
- Mark `.claude/**`, `dev/**`, `firmware/**`, `scripts/**`, `tests/**` as `linguist-vendored` in `.gitattributes`
- Removes Python (0.9%) from GitHub language bar — these are all tooling/scripts, not core application code
- Files remain fully searchable and diffable

## Test plan
- [ ] After merge, verify Python is removed from the language bar on the repo main page