### PR TITLE
docs: rename Smooth Crab to Icy Crab in all READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ Use these when you're past the onboarding flow and want the deeper reference.
 
 ## Icy Crab 🦀
 
-ZeroClaw was built for the smooth crab 🦀, a fast and efficient AI assistant. Built by Argenis De La Rosa and the community.
+ZeroClaw was built for the icy crab 🦀, a fast and efficient AI assistant. Built by Argenis De La Rosa and the community.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/ar/README.md
+++ b/docs/i18n/ar/README.md
@@ -653,7 +653,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 ## Icy Crab 🦀
 
-تم بناء ZeroClaw للسلطعون الناعم 🦀، مساعد ذكاء اصطناعي سريع وفعال. بناه Argenis De La Rosa والمجتمع.
+تم بناء ZeroClaw Icy Crab 🦀، مساعد ذكاء اصطناعي سريع وفعال. بناه Argenis De La Rosa والمجتمع.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/bn/README.md
+++ b/docs/i18n/bn/README.md
@@ -653,7 +653,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 ## Icy Crab 🦀
 
-ZeroClaw smooth crab 🦀 এর জন্য তৈরি হয়েছিল, একটি দ্রুত এবং দক্ষ AI সহকারী। Argenis De La Rosa এবং সম্প্রদায় দ্বারা নির্মিত।
+ZeroClaw icy crab 🦀 এর জন্য তৈরি হয়েছিল, একটি দ্রুত এবং দক্ষ AI সহকারী। Argenis De La Rosa এবং সম্প্রদায় দ্বারা নির্মিত।
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/cs/README.md
+++ b/docs/i18n/cs/README.md
@@ -653,7 +653,7 @@ Používejte tyto, když jste prošli onboardingem a chcete hlubší referenci.
 
 ## Icy Crab 🦀
 
-ZeroClaw byl vytvořen pro smooth crab 🦀, rychlého a efektivního AI asistenta. Vytvořil Argenis De La Rosa a komunita.
+ZeroClaw byl vytvořen pro icy crab 🦀, rychlého a efektivního AI asistenta. Vytvořil Argenis De La Rosa a komunita.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/da/README.md
+++ b/docs/i18n/da/README.md
@@ -653,7 +653,7 @@ Brug disse, naar du er forbi onboarding-flowet og vil have den dybere reference.
 
 ## Icy Crab 🦀
 
-ZeroClaw blev bygget til smooth crab 🦀, en hurtig og effektiv AI-assistent. Bygget af Argenis De La Rosa og faellesskabet.
+ZeroClaw blev bygget til icy crab 🦀, en hurtig og effektiv AI-assistent. Bygget af Argenis De La Rosa og faellesskabet.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/de/README.md
+++ b/docs/i18n/de/README.md
@@ -653,7 +653,7 @@ Verwende diese Ressourcen, wenn du den Onboarding-Prozess abgeschlossen hast und
 
 ## Icy Crab 🦀
 
-ZeroClaw wurde für the icy crab 🦀 gebaut, einen schnellen und effizienten KI-Assistenten. Entwickelt von Argenis De La Rosa und der Community.
+ZeroClaw wurde für Icy Crab 🦀 gebaut, einen schnellen und effizienten KI-Assistenten. Entwickelt von Argenis De La Rosa und der Community.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/de/README.md
+++ b/docs/i18n/de/README.md
@@ -653,7 +653,7 @@ Verwende diese Ressourcen, wenn du den Onboarding-Prozess abgeschlossen hast und
 
 ## Icy Crab 🦀
 
-ZeroClaw wurde für den glatten Krebs 🦀 gebaut, einen schnellen und effizienten KI-Assistenten. Entwickelt von Argenis De La Rosa und der Community.
+ZeroClaw wurde für the icy crab 🦀 gebaut, einen schnellen und effizienten KI-Assistenten. Entwickelt von Argenis De La Rosa und der Community.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/el/README.md
+++ b/docs/i18n/el/README.md
@@ -653,7 +653,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 ## Icy Crab 🦀
 
-Το ZeroClaw δημιουργήθηκε για τον smooth crab 🦀, έναν γρήγορο και αποδοτικό βοηθό AI. Δημιουργήθηκε από τον Argenis De La Rosa και την κοινότητα.
+Το ZeroClaw δημιουργήθηκε για τον icy crab 🦀, έναν γρήγορο και αποδοτικό βοηθό AI. Δημιουργήθηκε από τον Argenis De La Rosa και την κοινότητα.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -653,7 +653,7 @@ Usa estos recursos cuando hayas pasado el flujo de onboarding y quieras la refer
 
 ## Icy Crab 🦀
 
-ZeroClaw fue construido para the icy crab 🦀, un asistente de IA rápido y eficiente. Construido por Argenis De La Rosa y la comunidad.
+ZeroClaw fue construido para Icy Crab 🦀, un asistente de IA rápido y eficiente. Construido por Argenis De La Rosa y la comunidad.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -653,7 +653,7 @@ Usa estos recursos cuando hayas pasado el flujo de onboarding y quieras la refer
 
 ## Icy Crab 🦀
 
-ZeroClaw fue construido para el cangrejo suave 🦀, un asistente de IA rápido y eficiente. Construido por Argenis De La Rosa y la comunidad.
+ZeroClaw fue construido para the icy crab 🦀, un asistente de IA rápido y eficiente. Construido por Argenis De La Rosa y la comunidad.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/fi/README.md
+++ b/docs/i18n/fi/README.md
@@ -653,7 +653,7 @@ Kayta naita, kun olet ohittanut onboarding-kulun ja haluat syvemman viitteen.
 
 ## Icy Crab 🦀
 
-ZeroClaw rakennettiin smooth crab 🦀 -kaveria varten, nopea ja tehokas tekoalyavustaja. Rakennettu Argenis De La Rosan ja yhteison toimesta.
+ZeroClaw rakennettiin icy crab 🦀 -kaveria varten, nopea ja tehokas tekoalyavustaja. Rakennettu Argenis De La Rosan ja yhteison toimesta.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/fr/README.md
+++ b/docs/i18n/fr/README.md
@@ -653,7 +653,7 @@ Utilisez ces ressources lorsque vous avez dépassé le flux d'onboarding et voul
 
 ## Icy Crab 🦀
 
-ZeroClaw a été construit pour the icy crab 🦀, un assistant IA rapide et efficace. Construit par Argenis De La Rosa et la communauté.
+ZeroClaw a été construit pour Icy Crab 🦀, un assistant IA rapide et efficace. Construit par Argenis De La Rosa et la communauté.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/fr/README.md
+++ b/docs/i18n/fr/README.md
@@ -653,7 +653,7 @@ Utilisez ces ressources lorsque vous avez dépassé le flux d'onboarding et voul
 
 ## Icy Crab 🦀
 
-ZeroClaw a été construit pour le crabe lisse 🦀, un assistant IA rapide et efficace. Construit par Argenis De La Rosa et la communauté.
+ZeroClaw a été construit pour the icy crab 🦀, un assistant IA rapide et efficace. Construit par Argenis De La Rosa et la communauté.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/he/README.md
+++ b/docs/i18n/he/README.md
@@ -653,7 +653,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 ## Icy Crab 🦀
 
-ZeroClaw נבנה עבור ה-smooth crab 🦀, עוזר AI מהיר ויעיל. נבנה על ידי Argenis De La Rosa והקהילה.
+ZeroClaw נבנה עבור ה-icy crab 🦀, עוזר AI מהיר ויעיל. נבנה על ידי Argenis De La Rosa והקהילה.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/hi/README.md
+++ b/docs/i18n/hi/README.md
@@ -653,7 +653,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 ## Icy Crab 🦀
 
-ZeroClaw को smooth crab 🦀 के लिए बनाया गया था, एक तेज़ और कुशल AI सहायक। Argenis De La Rosa और समुदाय द्वारा निर्मित।
+ZeroClaw को icy crab 🦀 के लिए बनाया गया था, एक तेज़ और कुशल AI सहायक। Argenis De La Rosa और समुदाय द्वारा निर्मित।
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/hu/README.md
+++ b/docs/i18n/hu/README.md
@@ -653,7 +653,7 @@ Hasznald ezeket, ha tuljutottal az onboarding folyamaton es melyebb referenciara
 
 ## Icy Crab 🦀
 
-A ZeroClaw a smooth crab 🦀 szamara keszult, egy gyors es hatekony MI asszisztens. Epitette Argenis De La Rosa es a kozosseg.
+A ZeroClaw a icy crab 🦀 szamara keszult, egy gyors es hatekony MI asszisztens. Epitette Argenis De La Rosa es a kozosseg.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/id/README.md
+++ b/docs/i18n/id/README.md
@@ -653,7 +653,7 @@ Gunakan ini ketika Anda sudah melewati alur onboarding dan menginginkan referens
 
 ## Icy Crab 🦀
 
-ZeroClaw dibangun untuk smooth crab 🦀, asisten AI yang cepat dan efisien. Dibangun oleh Argenis De La Rosa dan komunitas.
+ZeroClaw dibangun untuk icy crab 🦀, asisten AI yang cepat dan efisien. Dibangun oleh Argenis De La Rosa dan komunitas.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/it/README.md
+++ b/docs/i18n/it/README.md
@@ -653,7 +653,7 @@ Usa queste risorse quando hai superato il flusso di onboarding e vuoi il riferim
 
 ## Icy Crab 🦀
 
-ZeroClaw è stato costruito per the icy crab 🦀, un assistente IA veloce ed efficiente. Costruito da Argenis De La Rosa e la comunità.
+ZeroClaw è stato costruito per Icy Crab 🦀, un assistente IA veloce ed efficiente. Costruito da Argenis De La Rosa e la comunità.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/it/README.md
+++ b/docs/i18n/it/README.md
@@ -653,7 +653,7 @@ Usa queste risorse quando hai superato il flusso di onboarding e vuoi il riferim
 
 ## Icy Crab 🦀
 
-ZeroClaw è stato costruito per il granchio liscio 🦀, un assistente IA veloce ed efficiente. Costruito da Argenis De La Rosa e la comunità.
+ZeroClaw è stato costruito per the icy crab 🦀, un assistente IA veloce ed efficiente. Costruito da Argenis De La Rosa e la comunità.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/ja/README.md
+++ b/docs/i18n/ja/README.md
@@ -653,7 +653,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 ## Icy Crab 🦀
 
-ZeroClawはsmooth crab 🦀のために構築されました。高速で効率的なAIアシスタント。Argenis De La Rosaとコミュニティによって構築されました。
+ZeroClawはicy crab 🦀のために構築されました。高速で効率的なAIアシスタント。Argenis De La Rosaとコミュニティによって構築されました。
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/ko/README.md
+++ b/docs/i18n/ko/README.md
@@ -653,7 +653,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 ## Icy Crab 🦀
 
-ZeroClaw는 빠르고 효율적인 AI 어시스턴트인 smooth crab 🦀을 위해 만들어졌습니다. Argenis De La Rosa와 커뮤니티가 만들었습니다.
+ZeroClaw는 빠르고 효율적인 AI 어시스턴트인 icy crab 🦀을 위해 만들어졌습니다. Argenis De La Rosa와 커뮤니티가 만들었습니다.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/nb/README.md
+++ b/docs/i18n/nb/README.md
@@ -653,7 +653,7 @@ Bruk disse nar du er forbi onboarding-flyten og onsker dypere referanse.
 
 ## Icy Crab 🦀
 
-ZeroClaw ble bygget for den smidige krabben 🦀, en rask og effektiv AI-assistent. Bygget av Argenis De La Rosa og fellesskapet.
+ZeroClaw ble bygget for Icy Crab 🦀, en rask og effektiv AI-assistent. Bygget av Argenis De La Rosa og fellesskapet.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/nl/README.md
+++ b/docs/i18n/nl/README.md
@@ -653,7 +653,7 @@ Gebruik deze wanneer je voorbij de onboarding bent en diepere referentie wilt.
 
 ## Icy Crab 🦀
 
-ZeroClaw is gebouwd voor de smooth crab 🦀, een snelle en efficiënte AI-assistent. Gebouwd door Argenis De La Rosa en de gemeenschap.
+ZeroClaw is gebouwd voor de icy crab 🦀, een snelle en efficiënte AI-assistent. Gebouwd door Argenis De La Rosa en de gemeenschap.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/pl/README.md
+++ b/docs/i18n/pl/README.md
@@ -653,7 +653,7 @@ Używaj tych, gdy przeszedłeś już przez onboarding i chcesz głębszej dokume
 
 ## Icy Crab 🦀
 
-ZeroClaw został zbudowany dla smooth crab 🦀, szybkiego i wydajnego asystenta AI. Stworzony przez Argenisa De La Rosę i społeczność.
+ZeroClaw został zbudowany dla icy crab 🦀, szybkiego i wydajnego asystenta AI. Stworzony przez Argenisa De La Rosę i społeczność.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/pt/README.md
+++ b/docs/i18n/pt/README.md
@@ -653,7 +653,7 @@ Use estes recursos quando tiver passado pelo fluxo de onboarding e quiser a refe
 
 ## Icy Crab 🦀
 
-O ZeroClaw foi construído para the icy crab 🦀, um assistente de IA rápido e eficiente. Construído por Argenis De La Rosa e a comunidade.
+O ZeroClaw foi construído para Icy Crab 🦀, um assistente de IA rápido e eficiente. Construído por Argenis De La Rosa e a comunidade.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/pt/README.md
+++ b/docs/i18n/pt/README.md
@@ -653,7 +653,7 @@ Use estes recursos quando tiver passado pelo fluxo de onboarding e quiser a refe
 
 ## Icy Crab 🦀
 
-O ZeroClaw foi construído para o caranguejo suave 🦀, um assistente de IA rápido e eficiente. Construído por Argenis De La Rosa e a comunidade.
+O ZeroClaw foi construído para the icy crab 🦀, um assistente de IA rápido e eficiente. Construído por Argenis De La Rosa e a comunidade.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/ro/README.md
+++ b/docs/i18n/ro/README.md
@@ -653,7 +653,7 @@ Folosește-le când ai trecut de fluxul de onboarding și vrei referința mai de
 
 ## Icy Crab 🦀
 
-ZeroClaw a fost construit pentru smooth crab 🦀, un asistent AI rapid și eficient. Construit de Argenis De La Rosa și comunitate.
+ZeroClaw a fost construit pentru icy crab 🦀, un asistent AI rapid și eficient. Construit de Argenis De La Rosa și comunitate.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/ru/README.md
+++ b/docs/i18n/ru/README.md
@@ -653,7 +653,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 ## Icy Crab 🦀
 
-ZeroClaw был создан для smooth crab 🦀 — быстрого и эффективного ИИ-ассистента. Создан Argenis De La Rosa и сообществом.
+ZeroClaw был создан для icy crab 🦀 — быстрого и эффективного ИИ-ассистента. Создан Argenis De La Rosa и сообществом.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/sv/README.md
+++ b/docs/i18n/sv/README.md
@@ -653,7 +653,7 @@ Använd dessa när du är förbi onboarding-flödet och vill ha den djupare refe
 
 ## Icy Crab 🦀
 
-ZeroClaw byggdes för smooth crab 🦀, en snabb och effektiv AI-assistent. Byggd av Argenis De La Rosa och gemenskapen.
+ZeroClaw byggdes för icy crab 🦀, en snabb och effektiv AI-assistent. Byggd av Argenis De La Rosa och gemenskapen.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/th/README.md
+++ b/docs/i18n/th/README.md
@@ -653,7 +653,7 @@ Release assets เผยแพร่สำหรับ:
 
 ## Icy Crab 🦀
 
-ZeroClaw ถูกสร้างสำหรับ smooth crab 🦀 ผู้ช่วย AI ที่เร็วและมีประสิทธิภาพ สร้างโดย Argenis De La Rosa และชุมชน
+ZeroClaw ถูกสร้างสำหรับ icy crab 🦀 ผู้ช่วย AI ที่เร็วและมีประสิทธิภาพ สร้างโดย Argenis De La Rosa และชุมชน
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/tl/README.md
+++ b/docs/i18n/tl/README.md
@@ -653,7 +653,7 @@ Gamitin ang mga ito kapag tapos ka na sa onboarding flow at gusto mo ng mas mala
 
 ## Icy Crab 🦀
 
-Ang ZeroClaw ay binuo para sa smooth crab 🦀, isang mabilis at mahusay na AI assistant. Binuo ni Argenis De La Rosa at ng komunidad.
+Ang ZeroClaw ay binuo para sa icy crab 🦀, isang mabilis at mahusay na AI assistant. Binuo ni Argenis De La Rosa at ng komunidad.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/tr/README.md
+++ b/docs/i18n/tr/README.md
@@ -653,7 +653,7 @@ Onboarding akışını geçtikten sonra daha derin referans istediğinizde bunla
 
 ## Icy Crab 🦀
 
-ZeroClaw, smooth crab 🦀 için inşa edildi — hızlı ve verimli bir AI asistanı. Argenis De La Rosa ve topluluk tarafından geliştirildi.
+ZeroClaw, icy crab 🦀 için inşa edildi — hızlı ve verimli bir AI asistanı. Argenis De La Rosa ve topluluk tarafından geliştirildi.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/uk/README.md
+++ b/docs/i18n/uk/README.md
@@ -653,7 +653,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 ## Icy Crab 🦀
 
-ZeroClaw створений для smooth crab 🦀, швидкого та ефективного AI-асистента. Створений Argenis De La Rosa та спільнотою.
+ZeroClaw створений для icy crab 🦀, швидкого та ефективного AI-асистента. Створений Argenis De La Rosa та спільнотою.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/ur/README.md
+++ b/docs/i18n/ur/README.md
@@ -653,7 +653,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 ## Icy Crab 🦀
 
-ZeroClaw smooth crab 🦀 کے لیے بنایا گیا تھا، ایک تیز اور مؤثر AI اسسٹنٹ۔ Argenis De La Rosa اور کمیونٹی نے بنایا۔
+ZeroClaw icy crab 🦀 کے لیے بنایا گیا تھا، ایک تیز اور مؤثر AI اسسٹنٹ۔ Argenis De La Rosa اور کمیونٹی نے بنایا۔
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/vi/README.md
+++ b/docs/i18n/vi/README.md
@@ -653,7 +653,7 @@ Dùng khi bạn đã hoàn thành onboarding và muốn tham khảo sâu hơn.
 
 ## Icy Crab 🦀
 
-ZeroClaw được xây dựng cho smooth crab 🦀, một trợ lý AI nhanh và hiệu quả. Được xây dựng bởi Argenis De La Rosa và cộng đồng.
+ZeroClaw được xây dựng cho icy crab 🦀, một trợ lý AI nhanh và hiệu quả. Được xây dựng bởi Argenis De La Rosa và cộng đồng.
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -653,7 +653,7 @@ curl -LsSf https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/insta
 
 ## Icy Crab 🦀
 
-ZeroClaw 为 smooth crab 🦀 而构建，一个快速高效的 AI 助手。由 Argenis De La Rosa 和社区共同构建。
+ZeroClaw 为 icy crab 🦀 而构建，一个快速高效的 AI 助手。由 Argenis De La Rosa 和社区共同构建。
 
 - [zeroclawlabs.ai](https://zeroclawlabs.ai)
 - [@zeroclawlabs](https://x.com/zeroclawlabs)


### PR DESCRIPTION
## Summary
- Renames the codename from **Smooth Crab** to **Icy Crab** across the root `README.md` and all 30 i18n translations under `docs/i18n/*/README.md`

## Test plan
- [ ] Verify no remaining occurrences of "Smooth Crab" in the repo
- [ ] Confirm all 31 README files render correctly with "Icy Crab 🦀"