### PR TITLE
chore: show only Rust in GitHub language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,14 +21,10 @@
 *.bash text eol=lf linguist-language=Shell
 *.ps1 text eol=crlf linguist-language=PowerShell
 
-# Vendored / non-primary language directories (excluded from GitHub language stats)
-web/** linguist-vendored
-marketplace/** linguist-vendored
-.claude/** linguist-vendored
-dev/** linguist-vendored
-firmware/** linguist-vendored
-scripts/** linguist-vendored
-tests/** linguist-vendored
+# GitHub language stats: show only Rust
+# Mark everything as vendored, then un-vendor Rust source files
+* linguist-vendored
+*.rs linguist-vendored=false
 
 # Documentation
 *.txt text eol=lf


### PR DESCRIPTION
## Summary
- Replace per-directory `linguist-vendored` rules with a catch-all: mark everything vendored, then un-vendor `*.rs`
- Language bar will show 100% Rust
- All files remain fully tracked, searchable, and diffable

## Test plan
- [ ] After merge, verify language bar shows 100% Rust