### PR TITLE
chore: remove empty CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,0 @@
-# Changelog


### PR DESCRIPTION
## Summary
- Remove `CHANGELOG.md` which contained only `# Changelog` with no actual content
- Not referenced by any CI workflows or scripts

## Test plan
- [x] Verified no CI/script references to CHANGELOG.md