### PR TITLE
fix(ci): fix crates.io publish and add pre-release validation

### DIFF
--- a/.github/workflows/pre-release-validate.yml
+++ b/.github/workflows/pre-release-validate.yml
@@ -1,0 +1,193 @@
+name: Pre-Release Validation
+
+# Run this BEFORE tagging a release to catch config/secret issues early.
+# Trigger manually or from a PR that bumps the version in Cargo.toml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to validate (e.g. 0.6.9)"
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - "Cargo.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-release-readiness:
+    name: Validate Release Readiness
+    runs-on: ubuntu-latest
+    env:
+      PAT: ${{ secrets.PAT }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ -n "$INPUT_VERSION" ]]; then
+            echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+          else
+            version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check crates.io publishability
+        shell: bash
+        run: |
+          echo "::group::Checking cargo publish --dry-run"
+          cargo publish --dry-run --allow-dirty --no-verify 2>&1 || {
+            echo "::error::cargo publish --dry-run failed. Fix dependency version issues before releasing."
+            exit 1
+          }
+          echo "::endgroup::"
+          echo "crates.io publish dry-run passed"
+
+      - name: Check required secrets exist
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CHECK_PAT: ${{ secrets.PAT }}
+          HOMEBREW_CORE_BOT_TOKEN: ${{ secrets.HOMEBREW_CORE_BOT_TOKEN }}
+          HOMEBREW_UPSTREAM_PR_TOKEN: ${{ secrets.HOMEBREW_UPSTREAM_PR_TOKEN }}
+          AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
+          HOMEBREW_CORE_BOT_FORK_REPO: ${{ vars.HOMEBREW_CORE_BOT_FORK_REPO }}
+        run: |
+          failed=0
+
+          check_secret() {
+            local name="$1" value="$2" required="${3:-true}"
+            if [[ -z "$value" ]]; then
+              if [[ "$required" == "true" ]]; then
+                echo "::error::Secret $name is missing or empty"
+                failed=1
+              else
+                echo "::warning::Optional secret $name is not set"
+              fi
+            else
+              echo "OK: $name is configured"
+            fi
+          }
+
+          echo "=== Required Secrets ==="
+          check_secret "CARGO_REGISTRY_TOKEN" "$CARGO_REGISTRY_TOKEN"
+          check_secret "PAT" "$CHECK_PAT"
+          check_secret "AUR_SSH_KEY" "$AUR_SSH_KEY"
+
+          echo ""
+          echo "=== Homebrew Secrets (at least one required) ==="
+          if [[ -n "$HOMEBREW_UPSTREAM_PR_TOKEN" ]]; then
+            echo "OK: HOMEBREW_UPSTREAM_PR_TOKEN is configured"
+          elif [[ -n "$HOMEBREW_CORE_BOT_TOKEN" ]]; then
+            echo "OK: HOMEBREW_CORE_BOT_TOKEN is configured"
+          else
+            echo "::error::Neither HOMEBREW_UPSTREAM_PR_TOKEN nor HOMEBREW_CORE_BOT_TOKEN is set"
+            failed=1
+          fi
+
+          echo ""
+          echo "=== Repository Variables ==="
+          check_secret "HOMEBREW_CORE_BOT_FORK_REPO (var)" "$HOMEBREW_CORE_BOT_FORK_REPO"
+
+          if [[ $failed -ne 0 ]]; then
+            echo ""
+            echo "::error::One or more required secrets are missing. Configure them in repo Settings > Secrets."
+            exit 1
+          fi
+
+      - name: Check PAT access to downstream repos
+        if: env.PAT != ''
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          failed=0
+
+          check_repo_access() {
+            local repo="$1"
+            if gh api "repos/$repo" --jq '.permissions.push' 2>/dev/null | grep -q true; then
+              echo "OK: PAT has write access to $repo"
+            else
+              echo "::error::PAT cannot write to $repo"
+              failed=1
+            fi
+          }
+
+          echo "=== Downstream Repository Access ==="
+          check_repo_access "zeroclaw-labs/zeroclaw-website"
+          check_repo_access "zeroclaw-labs/dokploy"
+          check_repo_access "zeroclaw-labs/easypanel"
+          check_repo_access "zeroclaw-labs/coolify"
+
+          echo ""
+          echo "=== Homebrew Fork Access ==="
+          FORK_REPO="${{ vars.HOMEBREW_CORE_BOT_FORK_REPO }}"
+          if [[ -n "$FORK_REPO" ]]; then
+            check_repo_access "$FORK_REPO"
+          else
+            echo "::warning::HOMEBREW_CORE_BOT_FORK_REPO not set, skipping fork access check"
+          fi
+
+          if [[ $failed -ne 0 ]]; then
+            echo ""
+            echo "::error::PAT lacks write access to one or more downstream repos. Update the PAT scopes."
+            exit 1
+          fi
+
+      - name: Check version sync consistency
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          failed=0
+
+          check_version() {
+            local file="$1" pattern="$2" label="$3"
+            if [[ ! -f "$file" ]]; then
+              echo "::warning::$file not found, skipping"
+              return
+            fi
+            if grep -q "$pattern" "$file"; then
+              echo "OK: $label matches v$VERSION"
+            else
+              echo "::error::$label does not match v$VERSION in $file"
+              failed=1
+            fi
+          }
+
+          echo "=== Version Consistency (v$VERSION) ==="
+          check_version "Cargo.toml" "version = \"$VERSION\"" "Cargo.toml"
+          check_version "Cargo.lock" "version = \"$VERSION\"" "Cargo.lock"
+          check_version "apps/tauri/tauri.conf.json" "\"version\": \"$VERSION\"" "Tauri config"
+          check_version "marketplace/dokploy/meta-entry.json" "\"version\": \"$VERSION\"" "Dokploy meta"
+
+          if [[ $failed -ne 0 ]]; then
+            echo ""
+            echo "::error::Version mismatch detected. Run: scripts/release/bump-version.sh $VERSION"
+            exit 1
+          fi
+
+      - name: Summary
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "## Pre-Release Validation: v$VERSION"
+            echo ""
+            echo "| Check | Status |"
+            echo "|---|---|"
+            echo "| crates.io dry-run | Passed |"
+            echo "| Required secrets | Passed |"
+            echo "| Downstream repo access | Passed |"
+            echo "| Version consistency | Passed |"
+            echo ""
+            echo "**Ready to tag v$VERSION and release.**"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "src/lib.rs"
 
 [dependencies]
 # Internal proc macros
-zeroclaw-macros = { path = "crates/zeroclaw-macros" }
+zeroclaw-macros = { path = "crates/zeroclaw-macros", version = "0.1.0" }
 # CLI - minimal and fast
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"


### PR DESCRIPTION
## Summary
- **Fixes crates.io publish failure**: adds `version = "0.1.0"` to `zeroclaw-macros` dependency (was missing, causing `cargo publish` to reject the package)
- **Adds pre-release validation workflow** (`pre-release-validate.yml`) that catches issues _before_ tagging

## Pre-Release Validation Checks
The new workflow runs automatically on PRs that touch `Cargo.toml` and can be triggered manually:

| Check | What it catches |
|---|---|
| `cargo publish --dry-run` | Missing dep versions, manifest errors |
| Secret existence | Missing `CARGO_REGISTRY_TOKEN`, `PAT`, `AUR_SSH_KEY`, Homebrew tokens |
| Downstream repo access | PAT can't write to website/dokploy/easypanel/coolify repos |
| Version sync | Cargo.toml/Cargo.lock/Tauri/marketplace out of sync |

## Outstanding secrets/permissions to configure
These caused failures in the v0.6.9 release and need manual configuration in repo Settings:

- [ ] **PAT** — needs write access to `zeroclaw-labs/zeroclaw-website` (currently 404)
- [ ] **PAT** — needs write access to `zeroclaw-labs/dokploy`, `easypanel`, `coolify`
- [ ] **HOMEBREW_CORE_BOT_TOKEN** or **HOMEBREW_UPSTREAM_PR_TOKEN** — needs `Contents: write` + PR creation scope on Homebrew fork
- [ ] **AUR_SSH_KEY** — needs valid SSH key for AUR git push

## Test plan
- [ ] CI passes on this PR (the pre-release-validate workflow should also trigger)
- [ ] After merge, re-run failed v0.6.9 release jobs
- [ ] Configure missing secrets per checklist above