### PR TITLE
fix(channels): strip <think> tags from streaming draft updates

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -11673,17 +11673,26 @@ This is an example JSON object for profile settings."#;
 
     #[test]
     fn strip_think_tags_inline_removes_single_block() {
-        assert_eq!(strip_think_tags_inline("<think>reasoning</think>Hello"), "Hello");
+        assert_eq!(
+            strip_think_tags_inline("<think>reasoning</think>Hello"),
+            "Hello"
+        );
     }
 
     #[test]
     fn strip_think_tags_inline_removes_multiple_blocks() {
-        assert_eq!(strip_think_tags_inline("<think>a</think>X<think>b</think>Y"), "XY");
+        assert_eq!(
+            strip_think_tags_inline("<think>a</think>X<think>b</think>Y"),
+            "XY"
+        );
     }
 
     #[test]
     fn strip_think_tags_inline_handles_unclosed_block() {
-        assert_eq!(strip_think_tags_inline("visible<think>hidden tail"), "visible");
+        assert_eq!(
+            strip_think_tags_inline("visible<think>hidden tail"),
+            "visible"
+        );
     }
 
     #[test]
@@ -11698,7 +11707,10 @@ This is an example JSON object for profile settings."#;
 
     #[test]
     fn strip_think_tags_inline_strips_surrounding_whitespace() {
-        assert_eq!(strip_think_tags_inline("<think>hidden</think>  Answer  "), "Answer");
+        assert_eq!(
+            strip_think_tags_inline("<think>hidden</think>  Answer  "),
+            "Answer"
+        );
     }
 
     // ── Tests for #4827: tool context preservation ──────────────


### PR DESCRIPTION
## Summary
- Models like Qwen emit `<think>...</think>` reasoning blocks that were stripped from the final response via `strip_think_tags()` but leaked to users during partial streaming
- `DraftEvent::Content` and `DraftEvent::Progress` sent raw accumulated text to `update_draft()` without sanitization
- Add `strip_think_tags_inline()` to `channels/mod.rs` that strips think blocks from streaming draft text before sending to the channel
- Handles single blocks, multiple blocks, unclosed blocks (drops tail), and trims whitespace

## Root cause
The existing `strip_think_tags` functions in `compatible.rs`, `loop_.rs`, and `ollama.rs` only operate on the final complete response. The streaming draft handler accumulates text chunks and sends them directly to the channel without any think-tag sanitization.

## Test plan
- [x] 6 unit tests for `strip_think_tags_inline`: single block, multiple blocks, unclosed block, no tags, empty string, whitespace trimming
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt -- --check` passes
- [ ] Manual test: Qwen model with `stream_mode = "partial"` no longer shows `<think>` content during streaming