### PR TITLE
fix(config): false "Unknown config key" warning for Option fields and aliases

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -9367,6 +9367,43 @@ async fn ensure_bootstrap_files(workspace_dir: &Path) -> Result<()> {
 }
 
 impl Config {
+    /// Return top-level TOML keys in `raw_toml` that Config does not recognise.
+    ///
+    /// Keys present in `Config::default()` serialization pass immediately.
+    /// Remaining keys are probed: the key is deserialized in isolation and
+    /// the result compared to the default — a changed output means serde
+    /// consumed it (covers `Option<T>` fields and `#[serde(alias)]` names).
+    pub fn unknown_keys(raw_toml: &str) -> Vec<String> {
+        let raw: toml::Table = match raw_toml.parse() {
+            Ok(t) => t,
+            Err(_) => return Vec::new(),
+        };
+        static DEFAULTS: OnceLock<toml::Table> = OnceLock::new();
+        let defaults = DEFAULTS.get_or_init(|| {
+            toml::to_string(&Config::default())
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_default()
+        });
+        raw.keys()
+            .filter(|key| {
+                if defaults.contains_key(key.as_str()) {
+                    return false;
+                }
+                let mut t = toml::Table::new();
+                t.insert((*key).clone(), raw[key.as_str()].clone());
+                let consumed = toml::to_string(&t)
+                    .ok()
+                    .and_then(|s| toml::from_str::<Config>(&s).ok())
+                    .and_then(|c| toml::to_string(&c).ok())
+                    .and_then(|s| s.parse::<toml::Table>().ok())
+                    .is_some_and(|t| t != *defaults);
+                !consumed
+            })
+            .cloned()
+            .collect()
+    }
+
     pub async fn load_or_init() -> Result<Self> {
         let (default_zeroclaw_dir, default_workspace_dir) = default_config_and_workspace_dirs()?;
 
@@ -9443,24 +9480,10 @@ impl Config {
             // TOML table keys against what Config actually deserializes.
             // This replaces the previous serde_ignored-based approach which
             // had false-positive issues with #[serde(default)] nested structs.
-            if let Ok(raw) = contents.parse::<toml::Table>() {
-                // Build the set of known top-level keys from a default Config
-                // serialization round-trip.  This is computed once and cached.
-                static KNOWN_KEYS: OnceLock<Vec<String>> = OnceLock::new();
-                let known = KNOWN_KEYS.get_or_init(|| {
-                    toml::to_string(&Config::default())
-                        .ok()
-                        .and_then(|s| s.parse::<toml::Table>().ok())
-                        .map(|t| t.keys().cloned().collect())
-                        .unwrap_or_default()
-                });
-                for key in raw.keys() {
-                    if !known.contains(key) {
-                        tracing::warn!(
-                            "Unknown config key ignored: \"{key}\". Check config.toml for typos or deprecated options.",
-                        );
-                    }
-                }
+            for key in Self::unknown_keys(&contents) {
+                tracing::warn!(
+                    "Unknown config key ignored: \"{key}\". Check config.toml for typos or deprecated options.",
+                );
             }
             // Set computed paths that are skipped during serialization
             config.config_path = config_path.clone();

--- a/tests/component/config_schema.rs
+++ b/tests/component/config_schema.rs
@@ -9,6 +9,20 @@ use zeroclaw::config::{AutonomyConfig, ChannelsConfig, Config, GatewayConfig, Se
 // Invalid value fail-fast
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// Regression test for #5414, #5320, #5483, #5507: Option<T> fields
+/// (api_key) and serde aliases (model_provider) must not be flagged as
+/// unknown config keys.
+#[test]
+fn config_valid_keys_not_flagged_as_unknown() {
+    // api_key: Option<T> defaulting to None — TOML omits it.
+    // model_provider: serde alias for default_provider.
+    let unknown = Config::unknown_keys("api_key = \"sk-test\"\nmodel_provider = \"ollama\"\n");
+    assert!(
+        unknown.is_empty(),
+        "api_key and model_provider should not be flagged as unknown, got: {unknown:?}",
+    );
+}
+
 #[test]
 fn config_unknown_keys_parse_without_error() {
     let toml_str = r#"


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The unknown-config-key detector serialized `Config::default()` to TOML and compared raw keys against the result. Two classes of valid keys were falsely flagged: (1) `Option<T>` fields defaulting to `None` (`api_key`, `api_url`) — TOML has no null, so `None` is silently omitted from serialization; (2) `#[serde(alias)]` keys (`model_provider`, `model`) — serde always serializes under the canonical field name, so the alias never appears in the known set.
- Why it matters: Every user who sets `api_key` in `config.toml` sees a spurious warning on every subcommand (`doctor`, `daemon`, `gateway`).
- What changed: Extracted the detection logic into `Config::unknown_keys()` and added a probe fallback — for any key not in the default serialization, a single-key table is deserialized and re-serialized; if the output differs from the default, serde consumed it (via `Option<T>` population or alias resolution). The call site in `load_or_init()` now delegates to this function and warns on the result.
- What did **not** change (scope boundary): No changes to the `Config` struct, serde attributes, or deserialization logic. The existing `OnceLock` caching pattern is preserved.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): S
- Scope labels: config, tests
- Module labels: config: schema
- Contributor tier label: auto-managed/read-only
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): runtime

## Linked Issue

- Closes #5414
- Closes #5320
- Closes #5483
- Closes #5507
- Supersedes #5508

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors: #5508 by @singlerider
- Integrated scope by source PR: The `Option<T>` detection fix from #5508 is fully incorporated here alongside the alias fix — same code block, single solution.
- `Co-authored-by` trailers added for materially incorporated contributors? N/A (same author)
- Trailer format check: Pass

## Validation Evidence (required)

```bash
cargo test --test component -- config_schema
```

- Evidence provided: All 40 config schema tests pass. New test `config_valid_keys_not_flagged_as_unknown` calls `Config::unknown_keys()` directly and was verified to **fail on the old logic** (reports `["api_key", "model_provider"]`) and **pass on the new logic** (returns empty).
- If any command is intentionally skipped, explain why: `cargo fmt` and `cargo clippy` not run locally; CI will gate these.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: `api_key`, `api_url` (Option<T>) and `model_provider`, `model` (serde alias) no longer trigger the warning. Truly unknown keys still produce warnings.
- Edge cases checked: Config with no Option fields set (no change in behavior). Alias set to the same value as the default (theoretically a false positive — extremely unlikely in practice since it requires using an alias AND matching the exact default value).
- What was not verified: End-to-end `zeroclaw doctor` run with a live config file.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Config loading path only.
- Potential unintended effects: `Config::unknown_keys()` is now `pub`. This was a deliberate choice — the detection logic cannot be meaningfully tested without exposing it, since it was previously inlined inside an async filesystem-dependent function (`load_or_init`). A fix that cannot be proven by a test is not a fix. Reviewers who prefer a smaller public surface may suggest `#[doc(hidden)]` or moving the test into a `#[cfg(test)]` module inside the crate.
- Guardrails/monitoring for early detection: Existing test suite covers config parsing boundaries.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Test-first approach — wrote failing test against `Config::unknown_keys()`, verified it caught both `api_key` and `model_provider`, applied the probe fix, verified the test passes.
- Verification focus: Test exercises the actual production function, not a copy of the logic.
- Confirmation: naming + architecture boundaries followed

## Rollback Plan (required)

- Fast rollback command/path: `git revert <sha>`
- Feature flags or config toggles: None
- Observable failure symptoms: Spurious "Unknown config key" warnings reappear

## Risks and Mitigations

- Risk: Using an alias key AND setting it to the exact same value as the default (e.g. `model = "anthropic/claude-sonnet-4.6"`) would still produce a false positive, because the probe sees no value change.
  - Mitigation: This is an extremely unlikely edge case. Users who use the alias form almost certainly set a non-default value.