### PR TITLE
feat(channel): add InboxAPI channel for agent-native email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,21 @@ PROVIDER=openrouter
 # Common models: glm-5, glm-4.7, glm-4-plus, glm-4-flash
 # See docs/zai-glm-setup.md for detailed configuration.
 
+# ── InboxAPI (Agent-Native Email) ───────────────────────────────
+# Agent-native email channel via InboxAPI MCP. Auto-provisions a
+# dedicated email address for your agent — no SMTP/IMAP config needed.
+#
+# Minimal config.toml:
+#   [channels_config.inboxapi]
+#   account_name = "my-agent"
+#   allowed_senders = ["*"]
+#
+# Optional overrides:
+#   endpoint = "https://mcp.inboxapi.ai/mcp"
+#   credentials_path = "~/.local/inboxapi/credentials.json"
+#   poll_interval_secs = 30
+#   content_format = "text"          # "text", "html", or "all"
+
 # ── Web Search ────────────────────────────────────────────────
 # Web search tool for finding information on the internet.
 # Enabled by default with DuckDuckGo (free, no API key required).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13047,6 +13047,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "serde_json",
+ "sha1",
  "sha2",
  "shellexpand",
  "tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ chacha20poly1305 = "0.10"
 
 # HMAC for webhook signature verification
 hmac = "0.12"
+sha1 = "0.10"
 sha2 = "0.10"
 hex = "0.4"
 

--- a/src/channels/inboxapi.rs
+++ b/src/channels/inboxapi.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::doc_link_with_quotes)]
 #![allow(clippy::cast_sign_loss)]
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,7 @@ use sha1::{Digest, Sha1};
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, mpsc};
 use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 
@@ -759,6 +759,8 @@ impl InboxApiChannel {
                 channel: "inboxapi".to_string(),
                 timestamp,
                 thread_ts,
+                interruption_scope_id: None,
+                attachments: vec![],
             };
 
             if tx.send(msg).await.is_err() {
@@ -1063,6 +1065,8 @@ mod tests {
             recipient: "user@example.com".into(),
             subject: Some("Test Subject".into()),
             thread_ts: Some("msg-123".into()),
+            cancellation_token: None,
+            attachments: vec![],
         };
 
         let mut args = serde_json::json!({
@@ -1108,6 +1112,8 @@ mod tests {
             channel: "inboxapi".to_string(),
             timestamp: 0,
             thread_ts: thread_ts.clone(),
+            interruption_scope_id: None,
+            attachments: vec![],
         };
 
         assert_eq!(msg.id, "msg-abc");

--- a/src/channels/inboxapi.rs
+++ b/src/channels/inboxapi.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
+use futures_util::StreamExt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
@@ -105,6 +106,9 @@ struct Credentials {
     /// The provisioned email address (informational).
     #[serde(default)]
     email_address: String,
+    /// RFC3339 cursor for incremental polling. Stored so restarts are idempotent.
+    #[serde(default)]
+    last_poll_cursor: Option<String>,
 }
 
 /// Runtime token state shared across send/listen/health operations.
@@ -190,9 +194,8 @@ impl InboxApiChannel {
         let mut req = self
             .client
             .post(&self.config.endpoint)
-            // Prefer a single JSON response; streaming SSE responses can hang if the server
-            // keeps the connection open.
-            .header("Accept", "application/json")
+            // InboxAPI MCP requires clients to accept both JSON and SSE.
+            .header("Accept", "application/json, text/event-stream")
             .json(&payload);
         if let Some(token) = auth_token {
             req = req.bearer_auth(token);
@@ -205,8 +208,7 @@ impl InboxApiChannel {
             return Err(anyhow!("MCP request failed ({}): {}", status, body));
         }
 
-        let body_text = resp.text().await?;
-        let body: serde_json::Value = Self::parse_sse_response(&body_text)?;
+        let body: serde_json::Value = Self::parse_mcp_response(resp).await?;
 
         // Check for JSON-RPC error
         if let Some(err) = body.get("error") {
@@ -218,6 +220,37 @@ impl InboxApiChannel {
             .get("result")
             .cloned()
             .unwrap_or(serde_json::Value::Null))
+    }
+
+    async fn parse_mcp_response(resp: reqwest::Response) -> Result<serde_json::Value> {
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        if content_type.starts_with("text/event-stream") {
+            return Self::parse_sse_stream(resp).await;
+        }
+
+        let body_text = resp.text().await?;
+        Self::parse_sse_response(&body_text)
+    }
+
+    async fn parse_sse_stream(resp: reqwest::Response) -> Result<serde_json::Value> {
+        let mut stream = resp.bytes_stream();
+        let mut buffer = String::new();
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+            if let Ok(value) = Self::parse_sse_response(&buffer) {
+                return Ok(value);
+            }
+        }
+
+        Self::parse_sse_response(&buffer)
     }
 
     /// Parse a response body that may be SSE-formatted or plain JSON.
@@ -499,12 +532,14 @@ impl InboxApiChannel {
         };
 
         // Persist updated credentials
+        let last_poll_cursor = self.last_poll_time.lock().await.clone();
         if let Err(e) = self.save_credentials(&Credentials {
             account_name: persisted_account_name,
             access_token: access_token.clone(),
             refresh_token: new_refresh,
             expires_at,
             email_address,
+            last_poll_cursor,
         }) {
             warn!("Failed to persist refreshed InboxAPI credentials: {e}");
         }
@@ -524,6 +559,7 @@ impl InboxApiChannel {
 
         // 1. Try loading existing credentials
         if let Some(creds) = self.load_credentials() {
+            *self.last_poll_time.lock().await = creds.last_poll_cursor.clone();
             let ts = self.apply_credentials(&creds);
             let now = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
@@ -681,6 +717,7 @@ impl InboxApiChannel {
             refresh_token: refresh_token.clone(),
             expires_at,
             email_address: email_address.clone(),
+            last_poll_cursor: None,
         };
 
         self.save_credentials(&creds)?;
@@ -719,13 +756,16 @@ impl InboxApiChannel {
 
         // Use timestamp cursor for incremental polling
         let since = self.last_poll_time.lock().await.clone();
+        let tool_name = if since.is_some() {
+            "search_emails"
+        } else {
+            "get_emails"
+        };
         if let Some(ref ts) = since {
             args["since"] = serde_json::json!(ts);
         }
 
-        let result = self
-            .call_mcp_tool("search_emails", args, Some(&token))
-            .await?;
+        let result = self.call_mcp_tool(tool_name, args, Some(&token)).await?;
 
         let content_text = match Self::extract_text_content(&result) {
             Some(text) => text,
@@ -745,7 +785,8 @@ impl InboxApiChannel {
             arr
         } else {
             warn!(
-                "InboxAPI search_emails returned unrecognized format: {}",
+                "InboxAPI {} returned unrecognized format: {}",
+                tool_name,
                 emails
                     .as_object()
                     .map(|o| o.keys().cloned().collect::<Vec<_>>().join(", "))
@@ -842,7 +883,16 @@ impl InboxApiChannel {
 
         // Advance the since cursor for next poll
         if let Some(ts) = latest_received_at {
-            *self.last_poll_time.lock().await = Some(Self::format_cursor(ts));
+            let cursor = Self::format_cursor(ts);
+            *self.last_poll_time.lock().await = Some(cursor.clone());
+
+            // Persist cursor so restarts don't re-ingest the same batch.
+            if let Some(mut creds) = self.load_credentials() {
+                creds.last_poll_cursor = Some(cursor);
+                if let Err(e) = self.save_credentials(&creds) {
+                    warn!("Failed to persist InboxAPI poll cursor: {e}");
+                }
+            }
         }
 
         Ok(())
@@ -1205,6 +1255,7 @@ mod tests {
             refresh_token: "ref-tok-456".into(),
             expires_at: 1_700_000_000,
             email_address: "test-bot@abc.inboxapi.ai".into(),
+            last_poll_cursor: None,
         };
         let json = serde_json::to_string(&creds).unwrap();
         let parsed: Credentials = serde_json::from_str(&json).unwrap();

--- a/src/channels/inboxapi.rs
+++ b/src/channels/inboxapi.rs
@@ -123,6 +123,8 @@ pub struct InboxApiChannel {
     client: reqwest::Client,
     seen_messages: Arc<Mutex<HashSet<String>>>,
     tokens: Arc<RwLock<Option<TokenState>>>,
+    /// ISO 8601 timestamp cursor for incremental polling via `search_emails`.
+    last_poll_time: Arc<Mutex<Option<String>>>,
 }
 
 impl InboxApiChannel {
@@ -132,6 +134,7 @@ impl InboxApiChannel {
             client: reqwest::Client::new(),
             seen_messages: Arc::new(Mutex::new(HashSet::new())),
             tokens: Arc::new(RwLock::new(None)),
+            last_poll_time: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -624,12 +627,19 @@ impl InboxApiChannel {
         debug!("InboxAPI polling for emails...");
 
         let mut args = serde_json::json!({
-            "content_format": self.config.content_format
+            "content_format": self.config.content_format,
+            "limit": EMAIL_POLL_LIMIT,
         });
-        // Request only recent emails (limit)
-        args["limit"] = serde_json::json!(EMAIL_POLL_LIMIT);
 
-        let result = self.call_mcp_tool("get_emails", args, Some(&token)).await?;
+        // Use timestamp cursor for incremental polling
+        let since = self.last_poll_time.lock().await.clone();
+        if let Some(ref ts) = since {
+            args["since"] = serde_json::json!(ts);
+        }
+
+        let result = self
+            .call_mcp_tool("search_emails", args, Some(&token))
+            .await?;
 
         let content_text = match Self::extract_text_content(&result) {
             Some(text) => text,
@@ -665,6 +675,8 @@ impl InboxApiChannel {
                 .map(|r| format!(" (server reported: {})", r))
                 .unwrap_or_default()
         );
+
+        let mut latest_received_at: Option<String> = None;
 
         for email in email_array {
             let msg_id = email["id"]
@@ -705,10 +717,8 @@ impl InboxApiChannel {
                 .unwrap_or("");
             let content = format!("Subject: {}\n\n{}", subject, body);
 
-            let thread_ts = email["in_reply_to"]
-                .as_str()
-                .or_else(|| email["thread_id"].as_str())
-                .map(|s| s.to_string());
+            // Always set thread_ts to the email's own ID so replies use send_reply
+            let thread_ts = Some(msg_id.clone());
 
             let timestamp = email["received_at"]
                 .as_str()
@@ -720,6 +730,21 @@ impl InboxApiChannel {
                         .map(|d| d.as_secs())
                         .unwrap_or(0)
                 });
+
+            // Track latest timestamp for the since cursor
+            let received_at_str = email["date"]
+                .as_str()
+                .or_else(|| email["received_at"].as_str())
+                .map(|s| s.to_string());
+            if let Some(ref ts) = received_at_str {
+                match (&latest_received_at, ts.as_str()) {
+                    (None, _) => latest_received_at = Some(ts.clone()),
+                    (Some(prev), cur) if cur > prev.as_str() => {
+                        latest_received_at = Some(ts.clone());
+                    }
+                    _ => {}
+                }
+            }
 
             let msg = ChannelMessage {
                 id: msg_id,
@@ -734,6 +759,11 @@ impl InboxApiChannel {
             if tx.send(msg).await.is_err() {
                 return Ok(()); // Channel closed
             }
+        }
+
+        // Advance the since cursor for next poll
+        if let Some(ts) = latest_received_at {
+            *self.last_poll_time.lock().await = Some(ts);
         }
 
         Ok(())
@@ -1051,7 +1081,8 @@ mod tests {
         let subject = email["subject"].as_str().unwrap_or("(no subject)");
         let body = email["body"].as_str().unwrap_or("");
         let content = format!("Subject: {}\n\n{}", subject, body);
-        let thread_ts = email["in_reply_to"].as_str().map(|s| s.to_string());
+        // thread_ts is always the email's own ID so replies use send_reply
+        let thread_ts = Some(msg_id.clone());
 
         let msg = ChannelMessage {
             id: msg_id.clone(),
@@ -1067,7 +1098,7 @@ mod tests {
         assert_eq!(msg.sender, "sender@example.com");
         assert_eq!(msg.content, "Subject: Test\n\nHello");
         assert_eq!(msg.channel, "inboxapi");
-        assert_eq!(msg.thread_ts.as_deref(), Some("msg-parent"));
+        assert_eq!(msg.thread_ts.as_deref(), Some("msg-abc"));
     }
 
     // ── Credential serialization ────────────────────────────────────────
@@ -1243,5 +1274,97 @@ mod tests {
             .or_else(|| response.as_array());
         assert!(arr.is_some());
         assert_eq!(arr.unwrap().len(), 0);
+    }
+
+    // ── Timestamp cursor ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn last_poll_time_starts_none() {
+        let channel = InboxApiChannel::new(InboxApiConfig::default());
+        let cursor = channel.last_poll_time.lock().await;
+        assert!(cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn last_poll_time_advances_after_set() {
+        let channel = InboxApiChannel::new(InboxApiConfig::default());
+        *channel.last_poll_time.lock().await = Some("2026-03-14T00:00:00Z".to_string());
+        let cursor = channel.last_poll_time.lock().await.clone();
+        assert_eq!(cursor.as_deref(), Some("2026-03-14T00:00:00Z"));
+    }
+
+    // ── thread_ts always set to msg_id ─────────────────────────────────
+
+    #[test]
+    fn thread_ts_set_to_email_message_id() {
+        // When an email has no in_reply_to, thread_ts should still be Some(msg_id)
+        let email = serde_json::json!({
+            "id": "msg-new",
+            "from": "sender@example.com",
+            "subject": "Fresh email",
+            "body": "No parent thread"
+        });
+
+        let msg_id = email["id"].as_str().unwrap().to_string();
+        let thread_ts = Some(msg_id.clone());
+
+        assert_eq!(thread_ts.as_deref(), Some("msg-new"));
+    }
+
+    #[test]
+    fn thread_ts_ignores_in_reply_to_uses_own_id() {
+        // Even when in_reply_to exists, thread_ts is the email's own ID
+        let email = serde_json::json!({
+            "id": "msg-reply",
+            "from": "sender@example.com",
+            "subject": "Re: Original",
+            "body": "Reply body",
+            "in_reply_to": "msg-original"
+        });
+
+        let msg_id = email["id"].as_str().unwrap().to_string();
+        let thread_ts = Some(msg_id.clone());
+
+        assert_eq!(thread_ts.as_deref(), Some("msg-reply"));
+    }
+
+    // ── Timestamp cursor tracking logic ────────────────────────────────
+
+    #[test]
+    fn latest_received_at_tracks_max_timestamp() {
+        let emails = vec![
+            serde_json::json!({"date": "2026-03-14T10:00:00Z"}),
+            serde_json::json!({"date": "2026-03-14T12:00:00Z"}),
+            serde_json::json!({"date": "2026-03-14T11:00:00Z"}),
+        ];
+
+        let mut latest_received_at: Option<String> = None;
+        for email in &emails {
+            let received_at_str = email["date"]
+                .as_str()
+                .or_else(|| email["received_at"].as_str())
+                .map(|s| s.to_string());
+            if let Some(ref ts) = received_at_str {
+                match (&latest_received_at, ts.as_str()) {
+                    (None, _) => latest_received_at = Some(ts.clone()),
+                    (Some(prev), cur) if cur > prev.as_str() => {
+                        latest_received_at = Some(ts.clone());
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        assert_eq!(latest_received_at.as_deref(), Some("2026-03-14T12:00:00Z"));
+    }
+
+    #[test]
+    fn latest_received_at_falls_back_to_received_at() {
+        let email = serde_json::json!({"received_at": "2026-03-14T09:00:00Z"});
+        let ts = email["date"]
+            .as_str()
+            .or_else(|| email["received_at"].as_str())
+            .map(|s| s.to_string());
+        assert_eq!(ts.as_deref(), Some("2026-03-14T09:00:00Z"));
     }
 }

--- a/src/channels/inboxapi.rs
+++ b/src/channels/inboxapi.rs
@@ -43,7 +43,7 @@ pub struct InboxApiConfig {
     /// Path to credentials JSON file (default: ~/.local/inboxapi/credentials.json).
     #[serde(default = "default_credentials_path")]
     pub credentials_path: String,
-    /// Allowed sender addresses/domains (empty or ["*"] = allow all).
+    /// Allowed sender addresses/domains (empty = deny all, ["*"] = allow all).
     #[serde(default)]
     pub allowed_senders: Vec<String>,
     /// Inbox polling interval in seconds (default: 30).
@@ -141,7 +141,7 @@ impl InboxApiChannel {
     /// Check if a sender email is in the allowlist.
     pub fn is_sender_allowed(&self, email: &str) -> bool {
         if self.config.allowed_senders.is_empty() {
-            return true; // Empty = allow all (use explicit list to restrict)
+            return false; // Empty = deny all (use ["*"] to allow all)
         }
         if self.config.allowed_senders.iter().any(|a| a == "*") {
             return true; // Wildcard = allow all
@@ -288,7 +288,7 @@ impl InboxApiChannel {
 
     // ── Credential management ───────────────────────────────────────────
 
-    /// Resolve the credentials file path (expand ~ and env vars).
+    /// Resolve the credentials file path (expand ~).
     fn credentials_path(&self) -> std::path::PathBuf {
         let expanded = shellexpand::tilde(&self.config.credentials_path).into_owned();
         std::path::PathBuf::from(expanded)
@@ -408,7 +408,7 @@ impl InboxApiChannel {
         };
 
         // Update runtime state
-        let email_address = {
+        let (email_address, persisted_account_name) = {
             let mut state = self.tokens.write().await;
             let email = state
                 .as_ref()
@@ -420,12 +420,17 @@ impl InboxApiChannel {
                 expires_at,
                 email_address: email.clone(),
             });
-            email
+            // Use account name from existing credentials file (may be suffixed)
+            let acct = self
+                .load_credentials()
+                .map(|c| c.account_name)
+                .unwrap_or_else(|| self.config.account_name.clone());
+            (email, acct)
         };
 
         // Persist updated credentials
         if let Err(e) = self.save_credentials(&Credentials {
-            account_name: self.config.account_name.clone(),
+            account_name: persisted_account_name,
             access_token: access_token.clone(),
             refresh_token: new_refresh,
             expires_at,
@@ -659,7 +664,7 @@ impl InboxApiChannel {
             arr
         } else {
             warn!(
-                "InboxAPI get_emails returned unrecognized format: {}",
+                "InboxAPI search_emails returned unrecognized format: {}",
                 emails
                     .as_object()
                     .map(|o| o.keys().cloned().collect::<Vec<_>>().join(", "))
@@ -779,6 +784,17 @@ impl Channel for InboxApiChannel {
     }
 
     async fn send(&self, message: &SendMessage) -> Result<()> {
+        // Ensure in-memory tokens are populated from disk if not already set
+        {
+            let has_tokens = self.tokens.read().await.is_some();
+            if !has_tokens {
+                if let Some(creds) = self.load_credentials() {
+                    let ts = self.apply_credentials(&creds);
+                    *self.tokens.write().await = Some(ts);
+                }
+            }
+        }
+
         let token = self.get_access_token().await?;
 
         if let Some(ref reply_to) = message.thread_ts {
@@ -949,10 +965,10 @@ mod tests {
     // ── Sender allowlist ────────────────────────────────────────────────
 
     #[test]
-    fn is_sender_allowed_empty_list_allows_all() {
+    fn is_sender_allowed_empty_list_denies_all() {
         let channel = InboxApiChannel::new(InboxApiConfig::default());
-        assert!(channel.is_sender_allowed("anyone@example.com"));
-        assert!(channel.is_sender_allowed("other@test.org"));
+        assert!(!channel.is_sender_allowed("anyone@example.com"));
+        assert!(!channel.is_sender_allowed("other@test.org"));
     }
 
     #[test]

--- a/src/channels/inboxapi.rs
+++ b/src/channels/inboxapi.rs
@@ -123,15 +123,22 @@ pub struct InboxApiChannel {
     client: reqwest::Client,
     seen_messages: Arc<Mutex<HashSet<String>>>,
     tokens: Arc<RwLock<Option<TokenState>>>,
-    /// ISO 8601 timestamp cursor for incremental polling via `search_emails`.
+    /// RFC3339/ISO-8601 timestamp cursor for incremental polling via `search_emails`.
     last_poll_time: Arc<Mutex<Option<String>>>,
 }
 
 impl InboxApiChannel {
     pub fn new(config: InboxApiConfig) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .unwrap_or_else(|e| {
+                warn!("Failed to build reqwest client with timeout: {e}; using default client");
+                reqwest::Client::new()
+            });
         Self {
             config,
-            client: reqwest::Client::new(),
+            client,
             seen_messages: Arc::new(Mutex::new(HashSet::new())),
             tokens: Arc::new(RwLock::new(None)),
             last_poll_time: Arc::new(Mutex::new(None)),
@@ -183,7 +190,9 @@ impl InboxApiChannel {
         let mut req = self
             .client
             .post(&self.config.endpoint)
-            .header("Accept", "application/json, text/event-stream")
+            // Prefer a single JSON response; streaming SSE responses can hang if the server
+            // keeps the connection open.
+            .header("Accept", "application/json")
             .json(&payload);
         if let Some(token) = auth_token {
             req = req.bearer_auth(token);
@@ -228,6 +237,32 @@ impl InboxApiChannel {
         }
         // Fallback: treat as plain JSON
         Ok(serde_json::from_str(body)?)
+    }
+
+    /// Parse an email timestamp from InboxAPI fields into a canonical UTC time.
+    fn parse_email_received_at(email: &serde_json::Value) -> Option<chrono::DateTime<chrono::Utc>> {
+        fn parse_any(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+            chrono::DateTime::parse_from_rfc3339(s)
+                .or_else(|_| chrono::DateTime::parse_from_rfc2822(s))
+                .ok()
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+        }
+
+        email
+            .get("received_at")
+            .and_then(|v| v.as_str())
+            .and_then(parse_any)
+            .or_else(|| {
+                email
+                    .get("date")
+                    .and_then(|v| v.as_str())
+                    .and_then(parse_any)
+            })
+    }
+
+    /// Format a UTC timestamp for use as an incremental polling cursor.
+    fn format_cursor(ts: chrono::DateTime<chrono::Utc>) -> String {
+        ts.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
     }
 
     /// Extract text content from an MCP tool result envelope.
@@ -312,19 +347,54 @@ impl InboxApiChannel {
 
     /// Persist credentials to disk with 0600 permissions.
     fn save_credentials(&self, creds: &Credentials) -> Result<()> {
+        use std::io::Write;
+
         let path = self.credentials_path();
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
         let json = serde_json::to_string_pretty(creds)?;
-        std::fs::write(&path, &json)?;
+        let parent = path
+            .parent()
+            .ok_or_else(|| anyhow!("credentials path has no parent: {}", path.display()))?;
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| anyhow!("credentials path has no file name: {}", path.display()))?;
+        let temp_path = parent.join(format!(
+            ".{}.tmp.{}.{}",
+            file_name.to_string_lossy(),
+            std::process::id(),
+            SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos()
+        ));
 
-        // Set file permissions to 0600 (owner read/write only)
         #[cfg(unix)]
+        let mut temp_file = {
+            use std::os::unix::fs::OpenOptionsExt;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&temp_path)?
+        };
+
+        #[cfg(not(unix))]
+        let mut temp_file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp_path)?;
+
+        temp_file.write_all(json.as_bytes())?;
+        temp_file.sync_all()?;
+        drop(temp_file);
+
+        #[cfg(windows)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+            let _ = std::fs::remove_file(&path);
         }
+
+        std::fs::rename(&temp_path, &path).inspect_err(|_| {
+            let _ = std::fs::remove_file(&temp_path);
+        })?;
 
         debug!("Credentials saved to {}", path.display());
         Ok(())
@@ -446,6 +516,12 @@ impl InboxApiChannel {
 
     /// Ensure we have valid tokens, creating an account if needed.
     async fn ensure_authenticated(&self) -> Result<()> {
+        if self.config.account_name.trim().is_empty() {
+            return Err(anyhow!(
+                "InboxAPI account_name must be set to a non-empty, non-whitespace value"
+            ));
+        }
+
         // 1. Try loading existing credentials
         if let Some(creds) = self.load_credentials() {
             let ts = self.apply_credentials(&creds);
@@ -520,6 +596,11 @@ impl InboxApiChannel {
     /// Retries with a random suffix if the configured name is already taken.
     async fn create_account(&self) -> Result<()> {
         let base_name = &self.config.account_name;
+        if base_name.trim().is_empty() {
+            return Err(anyhow!(
+                "InboxAPI account_name must be set to a non-empty, non-whitespace value before creating an account"
+            ));
+        }
         info!("Creating InboxAPI account for '{}'...", base_name);
 
         // Try with configured name first; on collision, retry with suffix
@@ -681,7 +762,7 @@ impl InboxApiChannel {
                 .unwrap_or_default()
         );
 
-        let mut latest_received_at: Option<String> = None;
+        let mut latest_received_at: Option<chrono::DateTime<chrono::Utc>> = None;
 
         for email in email_array {
             let msg_id = email["id"]
@@ -725,9 +806,8 @@ impl InboxApiChannel {
             // Always set thread_ts to the email's own ID so replies use send_reply
             let thread_ts = Some(msg_id.clone());
 
-            let timestamp = email["received_at"]
-                .as_str()
-                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            let received_at = Self::parse_email_received_at(email);
+            let timestamp = received_at
                 .map(|dt| dt.timestamp() as u64)
                 .unwrap_or_else(|| {
                     SystemTime::now()
@@ -736,18 +816,10 @@ impl InboxApiChannel {
                         .unwrap_or(0)
                 });
 
-            // Track latest timestamp for the since cursor
-            let received_at_str = email["date"]
-                .as_str()
-                .or_else(|| email["received_at"].as_str())
-                .map(|s| s.to_string());
-            if let Some(ref ts) = received_at_str {
-                match (&latest_received_at, ts.as_str()) {
-                    (None, _) => latest_received_at = Some(ts.clone()),
-                    (Some(prev), cur) if cur > prev.as_str() => {
-                        latest_received_at = Some(ts.clone());
-                    }
-                    _ => {}
+            // Track latest timestamp for the since cursor (compare by actual time, store canonical RFC3339)
+            if let Some(dt) = received_at {
+                if latest_received_at.map_or(true, |prev| dt > prev) {
+                    latest_received_at = Some(dt);
                 }
             }
 
@@ -770,7 +842,7 @@ impl InboxApiChannel {
 
         // Advance the since cursor for next poll
         if let Some(ts) = latest_received_at {
-            *self.last_poll_time.lock().await = Some(ts);
+            *self.last_poll_time.lock().await = Some(Self::format_cursor(ts));
         }
 
         Ok(())
@@ -1355,38 +1427,33 @@ mod tests {
     #[test]
     fn latest_received_at_tracks_max_timestamp() {
         let emails = vec![
-            serde_json::json!({"date": "2026-03-14T10:00:00Z"}),
-            serde_json::json!({"date": "2026-03-14T12:00:00Z"}),
-            serde_json::json!({"date": "2026-03-14T11:00:00Z"}),
+            serde_json::json!({"received_at": "2026-03-14T10:00:00Z"}),
+            serde_json::json!({"received_at": "2026-03-14T12:00:00Z"}),
+            serde_json::json!({"received_at": "2026-03-14T11:00:00Z"}),
         ];
 
-        let mut latest_received_at: Option<String> = None;
+        let mut latest_received_at: Option<chrono::DateTime<chrono::Utc>> = None;
         for email in &emails {
-            let received_at_str = email["date"]
-                .as_str()
-                .or_else(|| email["received_at"].as_str())
-                .map(|s| s.to_string());
-            if let Some(ref ts) = received_at_str {
-                match (&latest_received_at, ts.as_str()) {
-                    (None, _) => latest_received_at = Some(ts.clone()),
-                    (Some(prev), cur) if cur > prev.as_str() => {
-                        latest_received_at = Some(ts.clone());
-                    }
-                    _ => {}
+            if let Some(dt) = InboxApiChannel::parse_email_received_at(email) {
+                if latest_received_at.map_or(true, |prev| dt > prev) {
+                    latest_received_at = Some(dt);
                 }
             }
         }
 
-        assert_eq!(latest_received_at.as_deref(), Some("2026-03-14T12:00:00Z"));
+        assert_eq!(
+            latest_received_at
+                .map(InboxApiChannel::format_cursor)
+                .as_deref(),
+            Some("2026-03-14T12:00:00Z")
+        );
     }
 
     #[test]
     fn latest_received_at_falls_back_to_received_at() {
-        let email = serde_json::json!({"received_at": "2026-03-14T09:00:00Z"});
-        let ts = email["date"]
-            .as_str()
-            .or_else(|| email["received_at"].as_str())
-            .map(|s| s.to_string());
+        let email = serde_json::json!({"date": "Sat, 14 Mar 2026 09:00:00 +0000"});
+        let ts =
+            InboxApiChannel::parse_email_received_at(&email).map(InboxApiChannel::format_cursor);
         assert_eq!(ts.as_deref(), Some("2026-03-14T09:00:00Z"));
     }
 }

--- a/src/channels/inboxapi.rs
+++ b/src/channels/inboxapi.rs
@@ -1,0 +1,1247 @@
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::doc_link_with_quotes)]
+#![allow(clippy::cast_sign_loss)]
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sha1::{Digest, Sha1};
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio::time::sleep;
+use tracing::{debug, error, info, warn};
+
+use super::traits::{Channel, ChannelMessage, SendMessage};
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+/// Refresh access token when within this many seconds of expiration (1 day).
+const TOKEN_REFRESH_BUFFER_SECS: u64 = 86_400;
+
+/// Default token lifetime when the server doesn't specify `expires_in` (30 days).
+const DEFAULT_TOKEN_EXPIRES_IN_SECS: u64 = 30 * 24 * 60 * 60;
+
+/// SHA-1 hashcash difficulty for account creation (20 leading zero bits).
+const HASHCASH_DIFFICULTY: u32 = 20;
+
+/// Maximum number of emails to fetch per poll cycle.
+const EMAIL_POLL_LIMIT: u64 = 20;
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+/// InboxAPI channel configuration — agent-native email via InboxAPI MCP.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct InboxApiConfig {
+    /// MCP endpoint URL.
+    #[serde(default = "default_endpoint")]
+    pub endpoint: String,
+    /// Agent account name (used for hashcash resource and display name).
+    pub account_name: String,
+    /// Path to credentials JSON file (default: ~/.local/inboxapi/credentials.json).
+    #[serde(default = "default_credentials_path")]
+    pub credentials_path: String,
+    /// Allowed sender addresses/domains (empty or ["*"] = allow all).
+    #[serde(default)]
+    pub allowed_senders: Vec<String>,
+    /// Inbox polling interval in seconds (default: 30).
+    #[serde(default = "default_poll_interval_secs")]
+    pub poll_interval_secs: u64,
+    /// Content format for retrieved emails: "text" (default), "html", or "all".
+    #[serde(default = "default_content_format")]
+    pub content_format: String,
+}
+
+impl crate::config::traits::ChannelConfig for InboxApiConfig {
+    fn name() -> &'static str {
+        "InboxAPI"
+    }
+    fn desc() -> &'static str {
+        "Agent-native email via InboxAPI MCP"
+    }
+}
+
+fn default_endpoint() -> String {
+    "https://mcp.inboxapi.ai/mcp".into()
+}
+
+fn default_credentials_path() -> String {
+    "~/.local/inboxapi/credentials.json".into()
+}
+
+fn default_poll_interval_secs() -> u64 {
+    30
+}
+
+fn default_content_format() -> String {
+    "text".into()
+}
+
+impl Default for InboxApiConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: default_endpoint(),
+            account_name: String::new(),
+            credentials_path: default_credentials_path(),
+            allowed_senders: Vec::new(),
+            poll_interval_secs: default_poll_interval_secs(),
+            content_format: default_content_format(),
+        }
+    }
+}
+
+// ── Credentials ─────────────────────────────────────────────────────────────
+
+/// Persisted InboxAPI credentials.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Credentials {
+    account_name: String,
+    access_token: String,
+    refresh_token: String,
+    /// Seconds since UNIX epoch when the access token expires.
+    expires_at: u64,
+    /// The provisioned email address (informational).
+    #[serde(default)]
+    email_address: String,
+}
+
+/// Runtime token state shared across send/listen/health operations.
+struct TokenState {
+    access_token: String,
+    refresh_token: String,
+    expires_at: u64,
+    email_address: String,
+}
+
+// ── Channel ─────────────────────────────────────────────────────────────────
+
+/// InboxAPI channel — agent-native email over HTTP/MCP.
+pub struct InboxApiChannel {
+    config: InboxApiConfig,
+    client: reqwest::Client,
+    seen_messages: Arc<Mutex<HashSet<String>>>,
+    tokens: Arc<RwLock<Option<TokenState>>>,
+}
+
+impl InboxApiChannel {
+    pub fn new(config: InboxApiConfig) -> Self {
+        Self {
+            config,
+            client: reqwest::Client::new(),
+            seen_messages: Arc::new(Mutex::new(HashSet::new())),
+            tokens: Arc::new(RwLock::new(None)),
+        }
+    }
+
+    /// Check if a sender email is in the allowlist.
+    pub fn is_sender_allowed(&self, email: &str) -> bool {
+        if self.config.allowed_senders.is_empty() {
+            return true; // Empty = allow all (use explicit list to restrict)
+        }
+        if self.config.allowed_senders.iter().any(|a| a == "*") {
+            return true; // Wildcard = allow all
+        }
+        let email_lower = email.to_lowercase();
+        self.config.allowed_senders.iter().any(|allowed| {
+            if allowed.starts_with('@') {
+                // Domain match with @ prefix: "@example.com"
+                email_lower.ends_with(&allowed.to_lowercase())
+            } else if allowed.contains('@') {
+                // Full email address match
+                allowed.eq_ignore_ascii_case(email)
+            } else {
+                // Domain match without @ prefix: "example.com"
+                email_lower.ends_with(&format!("@{}", allowed.to_lowercase()))
+            }
+        })
+    }
+
+    // ── MCP transport ───────────────────────────────────────────────────
+
+    /// Send a JSON-RPC 2.0 tool call to the MCP endpoint.
+    async fn call_mcp_tool(
+        &self,
+        tool_name: &str,
+        args: serde_json::Value,
+        auth_token: Option<&str>,
+    ) -> Result<serde_json::Value> {
+        let payload = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": tool_name,
+                "arguments": args
+            }
+        });
+
+        let mut req = self
+            .client
+            .post(&self.config.endpoint)
+            .header("Accept", "application/json, text/event-stream")
+            .json(&payload);
+        if let Some(token) = auth_token {
+            req = req.bearer_auth(token);
+        }
+
+        let resp = req.send().await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("MCP request failed ({}): {}", status, body));
+        }
+
+        let body_text = resp.text().await?;
+        let body: serde_json::Value = Self::parse_sse_response(&body_text)?;
+
+        // Check for JSON-RPC error
+        if let Some(err) = body.get("error") {
+            return Err(anyhow!("MCP tool error: {}", err));
+        }
+
+        // Extract result — tool responses nest content inside result.content[]
+        Ok(body
+            .get("result")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null))
+    }
+
+    /// Parse a response body that may be SSE-formatted or plain JSON.
+    ///
+    /// rmcp's `StreamableHttpService` (stateless mode) responds with
+    /// `text/event-stream` containing `data: {json}\n\n` events.
+    /// This extracts the JSON-RPC payload from either format.
+    fn parse_sse_response(body: &str) -> Result<serde_json::Value> {
+        // Try SSE: scan for `data:` lines
+        for line in body.lines() {
+            if let Some(data) = line.strip_prefix("data:") {
+                let data = data.trim();
+                if !data.is_empty() {
+                    return Ok(serde_json::from_str(data)?);
+                }
+            }
+        }
+        // Fallback: treat as plain JSON
+        Ok(serde_json::from_str(body)?)
+    }
+
+    /// Extract text content from an MCP tool result envelope.
+    fn extract_text_content(result: &serde_json::Value) -> Option<String> {
+        result
+            .get("content")
+            .and_then(|c| c.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|item| item.get("text"))
+            .and_then(|t| t.as_str())
+            .map(|s| s.to_string())
+    }
+
+    // ── Hashcash ────────────────────────────────────────────────────────
+
+    /// Generate a hashcash stamp with the given resource and difficulty bits.
+    fn generate_hashcash(resource: &str, bits: u32) -> String {
+        let now = chrono::Utc::now().format("%y%m%d").to_string();
+        let rand_bytes: [u8; 8] = rand::random();
+        let rand_b64 =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, rand_bytes);
+
+        let mut counter: u64 = 0;
+        loop {
+            let stamp = format!("1:{}:{}:{}::{}:{}", bits, now, resource, rand_b64, counter);
+            if Self::check_hashcash_bits(&stamp, bits) {
+                return stamp;
+            }
+            counter += 1;
+        }
+    }
+
+    /// Check whether a hashcash stamp has the required leading zero bits in its SHA-1 hash.
+    fn check_hashcash_bits(stamp: &str, bits: u32) -> bool {
+        let hash = Sha1::digest(stamp.as_bytes());
+        let hash_bytes = hash.as_slice();
+
+        let full_bytes = (bits / 8) as usize;
+        let remaining_bits = bits % 8;
+
+        // Check full zero bytes
+        for byte in &hash_bytes[..full_bytes] {
+            if *byte != 0 {
+                return false;
+            }
+        }
+
+        // Check remaining bits in the next byte
+        if remaining_bits > 0 && full_bytes < hash_bytes.len() {
+            let mask = 0xFF_u8 << (8 - remaining_bits);
+            if hash_bytes[full_bytes] & mask != 0 {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    // ── Credential management ───────────────────────────────────────────
+
+    /// Resolve the credentials file path (expand ~ and env vars).
+    fn credentials_path(&self) -> std::path::PathBuf {
+        let expanded = shellexpand::tilde(&self.config.credentials_path).into_owned();
+        std::path::PathBuf::from(expanded)
+    }
+
+    /// Load credentials from disk.
+    fn load_credentials(&self) -> Option<Credentials> {
+        let path = self.credentials_path();
+        let data = std::fs::read_to_string(&path).ok()?;
+        let creds: Credentials = serde_json::from_str(&data).ok()?;
+        if creds.account_name == self.config.account_name
+            || creds
+                .account_name
+                .starts_with(&format!("{}-", self.config.account_name))
+        {
+            Some(creds)
+        } else {
+            None
+        }
+    }
+
+    /// Persist credentials to disk with 0600 permissions.
+    fn save_credentials(&self, creds: &Credentials) -> Result<()> {
+        let path = self.credentials_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let json = serde_json::to_string_pretty(creds)?;
+        std::fs::write(&path, &json)?;
+
+        // Set file permissions to 0600 (owner read/write only)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+        }
+
+        debug!("Credentials saved to {}", path.display());
+        Ok(())
+    }
+
+    /// Populate runtime token state from loaded credentials.
+    fn apply_credentials(&self, creds: &Credentials) -> TokenState {
+        TokenState {
+            access_token: creds.access_token.clone(),
+            refresh_token: creds.refresh_token.clone(),
+            expires_at: creds.expires_at,
+            email_address: creds.email_address.clone(),
+        }
+    }
+
+    // ── Token lifecycle ─────────────────────────────────────────────────
+
+    /// Get a valid access token, refreshing if needed.
+    async fn get_access_token(&self) -> Result<String> {
+        // Check if we have a token and it's not about to expire
+        {
+            let state = self.tokens.read().await;
+            if let Some(ref ts) = *state {
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                // Refresh if within 1 day of expiration
+                if ts.expires_at > now + TOKEN_REFRESH_BUFFER_SECS {
+                    return Ok(ts.access_token.clone());
+                }
+            }
+        }
+
+        // Need to refresh
+        self.refresh_tokens().await
+    }
+
+    /// Refresh the access token using the refresh token.
+    async fn refresh_tokens(&self) -> Result<String> {
+        let refresh_token = {
+            let state = self.tokens.read().await;
+            match *state {
+                Some(ref ts) => ts.refresh_token.clone(),
+                None => return Err(anyhow!("No refresh token available")),
+            }
+        };
+
+        info!("Refreshing InboxAPI access token");
+        let result = self
+            .call_mcp_tool(
+                "auth_refresh",
+                serde_json::json!({ "refresh_token": refresh_token }),
+                None,
+            )
+            .await?;
+
+        let content_text = Self::extract_text_content(&result)
+            .ok_or_else(|| anyhow!("Empty auth_refresh response"))?;
+        let parsed: serde_json::Value = serde_json::from_str(&content_text)?;
+
+        let access_token = parsed["access_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing access_token in refresh response"))?
+            .to_string();
+        let new_refresh = parsed["refresh_token"]
+            .as_str()
+            .unwrap_or(&refresh_token)
+            .to_string();
+        let expires_at = if let Some(ts) = parsed["access_token_expires_at"].as_u64() {
+            ts
+        } else {
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let expires_in = parsed["expires_in"]
+                .as_u64()
+                .unwrap_or(DEFAULT_TOKEN_EXPIRES_IN_SECS);
+            now + expires_in
+        };
+
+        // Update runtime state
+        let email_address = {
+            let mut state = self.tokens.write().await;
+            let email = state
+                .as_ref()
+                .map(|s| s.email_address.clone())
+                .unwrap_or_default();
+            *state = Some(TokenState {
+                access_token: access_token.clone(),
+                refresh_token: new_refresh.clone(),
+                expires_at,
+                email_address: email.clone(),
+            });
+            email
+        };
+
+        // Persist updated credentials
+        if let Err(e) = self.save_credentials(&Credentials {
+            account_name: self.config.account_name.clone(),
+            access_token: access_token.clone(),
+            refresh_token: new_refresh,
+            expires_at,
+            email_address,
+        }) {
+            warn!("Failed to persist refreshed InboxAPI credentials: {e}");
+        }
+
+        Ok(access_token)
+    }
+
+    // ── Auto-onboarding ─────────────────────────────────────────────────
+
+    /// Ensure we have valid tokens, creating an account if needed.
+    async fn ensure_authenticated(&self) -> Result<()> {
+        // 1. Try loading existing credentials
+        if let Some(creds) = self.load_credentials() {
+            let ts = self.apply_credentials(&creds);
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+
+            if ts.expires_at > now + TOKEN_REFRESH_BUFFER_SECS {
+                // Token still valid — verify with introspect
+                let result = self
+                    .call_mcp_tool(
+                        "auth_introspect",
+                        serde_json::json!({ "token": ts.access_token }),
+                        None,
+                    )
+                    .await;
+
+                if result.is_ok() {
+                    info!(
+                        "InboxAPI authenticated as {} ({})",
+                        self.config.account_name, ts.email_address
+                    );
+                    *self.tokens.write().await = Some(ts);
+                    return Ok(());
+                }
+                debug!("Stored token failed introspect, will try refresh");
+            }
+
+            // Try refresh
+            *self.tokens.write().await = Some(ts);
+            if let Ok(token) = self.refresh_tokens().await {
+                info!("InboxAPI token refreshed for {}", self.config.account_name);
+                // Verify the refreshed token
+                let _ = self
+                    .call_mcp_tool(
+                        "auth_introspect",
+                        serde_json::json!({ "token": token }),
+                        None,
+                    )
+                    .await?;
+                return Ok(());
+            }
+            warn!("Token refresh failed, will create new account");
+        }
+
+        // 2. Create new account
+        self.create_account().await
+    }
+
+    /// Attempt to create an account with a specific name, returning the
+    /// account_create result on success.
+    async fn try_account_create(&self, name: &str) -> Result<serde_json::Value> {
+        let resource = name.to_string();
+        let stamp = tokio::task::spawn_blocking(move || {
+            Self::generate_hashcash(&resource, HASHCASH_DIFFICULTY)
+        })
+        .await
+        .map_err(|e| anyhow!("Hashcash generation failed: {}", e))?;
+
+        debug!("Hashcash generated for '{}': {}", name, stamp);
+
+        self.call_mcp_tool(
+            "account_create",
+            serde_json::json!({ "name": name, "hashcash": stamp }),
+            None,
+        )
+        .await
+    }
+
+    /// Create a new InboxAPI account via hashcash proof-of-work.
+    /// Retries with a random suffix if the configured name is already taken.
+    async fn create_account(&self) -> Result<()> {
+        let base_name = &self.config.account_name;
+        info!("Creating InboxAPI account for '{}'...", base_name);
+
+        // Try with configured name first; on collision, retry with suffix
+        let (result, effective_name) = match self.try_account_create(base_name).await {
+            Ok(r) => (r, base_name.clone()),
+            Err(e) if e.to_string().contains("already exists") => {
+                let mut last_err = e;
+                let mut created = None;
+                for _ in 0..3 {
+                    let suffix: u16 = rand::random();
+                    let suffixed = format!("{}-{:04x}", base_name, suffix);
+                    warn!("Account '{}' taken, trying '{}'", base_name, suffixed);
+                    match self.try_account_create(&suffixed).await {
+                        Ok(r) => {
+                            created = Some((r, suffixed));
+                            break;
+                        }
+                        Err(e) => last_err = e,
+                    }
+                }
+                created.ok_or(last_err)?
+            }
+            Err(e) => return Err(e),
+        };
+
+        let content_text = Self::extract_text_content(&result)
+            .ok_or_else(|| anyhow!("Empty account_create response"))?;
+        let parsed: serde_json::Value = serde_json::from_str(&content_text)?;
+
+        let bootstrap_token = parsed["bootstrap_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing bootstrap_token in account_create response"))?;
+
+        // Exchange bootstrap for access + refresh tokens
+        let exchange_result = self
+            .call_mcp_tool(
+                "auth_exchange",
+                serde_json::json!({ "bootstrap_token": bootstrap_token }),
+                None,
+            )
+            .await?;
+
+        let exchange_text = Self::extract_text_content(&exchange_result)
+            .ok_or_else(|| anyhow!("Empty auth_exchange response"))?;
+        let exchange_parsed: serde_json::Value = serde_json::from_str(&exchange_text)?;
+
+        let access_token = exchange_parsed["access_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing access_token in auth_exchange response"))?
+            .to_string();
+        let refresh_token = exchange_parsed["refresh_token"]
+            .as_str()
+            .ok_or_else(|| anyhow!("Missing refresh_token in auth_exchange response"))?
+            .to_string();
+        let expires_at = if let Some(ts) = exchange_parsed["access_token_expires_at"].as_u64() {
+            ts
+        } else {
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let expires_in = exchange_parsed["expires_in"]
+                .as_u64()
+                .unwrap_or(DEFAULT_TOKEN_EXPIRES_IN_SECS);
+            now + expires_in
+        };
+
+        // Try to get the provisioned email address
+        let email_address = exchange_parsed["email"]
+            .as_str()
+            .or_else(|| parsed["email"].as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let creds = Credentials {
+            account_name: effective_name.clone(),
+            access_token: access_token.clone(),
+            refresh_token: refresh_token.clone(),
+            expires_at,
+            email_address: email_address.clone(),
+        };
+
+        self.save_credentials(&creds)?;
+
+        *self.tokens.write().await = Some(TokenState {
+            access_token,
+            refresh_token,
+            expires_at,
+            email_address: email_address.clone(),
+        });
+
+        info!(
+            "InboxAPI account created: {} (email: {})",
+            effective_name,
+            if email_address.is_empty() {
+                "pending"
+            } else {
+                &email_address
+            }
+        );
+
+        Ok(())
+    }
+
+    // ── Polling ─────────────────────────────────────────────────────────
+
+    /// Poll for new emails and dispatch to the channel sender.
+    async fn poll_emails(&self, tx: &mpsc::Sender<ChannelMessage>) -> Result<()> {
+        let token = self.get_access_token().await?;
+        debug!("InboxAPI polling for emails...");
+
+        let mut args = serde_json::json!({
+            "content_format": self.config.content_format
+        });
+        // Request only recent emails (limit)
+        args["limit"] = serde_json::json!(EMAIL_POLL_LIMIT);
+
+        let result = self.call_mcp_tool("get_emails", args, Some(&token)).await?;
+
+        let content_text = match Self::extract_text_content(&result) {
+            Some(text) => text,
+            None => return Ok(()), // No content = no emails
+        };
+
+        let emails: serde_json::Value = match serde_json::from_str(&content_text) {
+            Ok(json) => json,
+            Err(e) => {
+                error!("Failed to parse emails from InboxAPI: {e}");
+                return Ok(());
+            }
+        };
+        let email_array = if let Some(arr) = emails.get("emails").and_then(|e| e.as_array()) {
+            arr
+        } else if let Some(arr) = emails.as_array() {
+            arr
+        } else {
+            warn!(
+                "InboxAPI get_emails returned unrecognized format: {}",
+                emails
+                    .as_object()
+                    .map(|o| o.keys().cloned().collect::<Vec<_>>().join(", "))
+                    .unwrap_or_else(|| "non-object".into())
+            );
+            return Ok(());
+        };
+        let returned_meta = emails.get("returned").and_then(|v| v.as_u64());
+        debug!(
+            "InboxAPI poll: {} email(s) returned{}",
+            email_array.len(),
+            returned_meta
+                .map(|r| format!(" (server reported: {})", r))
+                .unwrap_or_default()
+        );
+
+        for email in email_array {
+            let msg_id = email["id"]
+                .as_str()
+                .or_else(|| email["message_id"].as_str())
+                .unwrap_or("")
+                .to_string();
+
+            if msg_id.is_empty() {
+                continue;
+            }
+
+            // Check if already seen
+            {
+                let mut seen = self.seen_messages.lock().await;
+                if !seen.insert(msg_id.clone()) {
+                    continue;
+                }
+            }
+
+            let sender = email["from"]
+                .as_str()
+                .or_else(|| email["sender"].as_str())
+                .unwrap_or("unknown")
+                .to_string();
+
+            // Check allowlist
+            if !self.is_sender_allowed(&sender) {
+                warn!("Blocked email from {}", sender);
+                continue;
+            }
+
+            let subject = email["subject"].as_str().unwrap_or("(no subject)");
+            let body = email["body"]
+                .as_str()
+                .or_else(|| email["text_body"].as_str())
+                .or_else(|| email["content"].as_str())
+                .unwrap_or("");
+            let content = format!("Subject: {}\n\n{}", subject, body);
+
+            let thread_ts = email["in_reply_to"]
+                .as_str()
+                .or_else(|| email["thread_id"].as_str())
+                .map(|s| s.to_string());
+
+            let timestamp = email["received_at"]
+                .as_str()
+                .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+                .map(|dt| dt.timestamp() as u64)
+                .unwrap_or_else(|| {
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0)
+                });
+
+            let msg = ChannelMessage {
+                id: msg_id,
+                reply_target: sender.clone(),
+                sender,
+                content,
+                channel: "inboxapi".to_string(),
+                timestamp,
+                thread_ts,
+            };
+
+            if tx.send(msg).await.is_err() {
+                return Ok(()); // Channel closed
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// ── Channel trait ───────────────────────────────────────────────────────────
+
+#[async_trait]
+impl Channel for InboxApiChannel {
+    fn name(&self) -> &str {
+        "inboxapi"
+    }
+
+    async fn send(&self, message: &SendMessage) -> Result<()> {
+        let token = self.get_access_token().await?;
+
+        if let Some(ref reply_to) = message.thread_ts {
+            // Reply: use send_reply (subject/to auto-resolved by server)
+            let args = serde_json::json!({
+                "in_reply_to": reply_to,
+                "body": message.content,
+            });
+            self.call_mcp_tool("send_reply", args, Some(&token)).await?;
+        } else {
+            // New email: use send_email (subject required)
+            let args = serde_json::json!({
+                "to": message.recipient,
+                "subject": message.subject.as_deref().unwrap_or("(no subject)"),
+                "body": message.content,
+            });
+            self.call_mcp_tool("send_email", args, Some(&token)).await?;
+        }
+
+        info!("InboxAPI email sent to {}", message.recipient);
+        Ok(())
+    }
+
+    async fn listen(&self, tx: mpsc::Sender<ChannelMessage>) -> Result<()> {
+        // Auto-onboarding: ensure we have valid credentials
+        self.ensure_authenticated().await?;
+
+        let poll_interval = Duration::from_secs(self.config.poll_interval_secs);
+        info!(
+            "InboxAPI channel listening (poll every {}s)",
+            self.config.poll_interval_secs
+        );
+
+        loop {
+            if let Err(e) = self.poll_emails(&tx).await {
+                error!("InboxAPI poll error: {}", e);
+            }
+            sleep(poll_interval).await;
+        }
+    }
+
+    async fn health_check(&self) -> bool {
+        // Ensure in-memory tokens are populated from disk if not already set
+        {
+            let has_tokens = self.tokens.read().await.is_some();
+            if !has_tokens {
+                if let Some(creds) = self.load_credentials() {
+                    let ts = self.apply_credentials(&creds);
+                    *self.tokens.write().await = Some(ts);
+                }
+            }
+        }
+
+        let token = match self.get_access_token().await {
+            Ok(t) => t,
+            Err(_) => return false,
+        };
+
+        self.call_mcp_tool(
+            "auth_introspect",
+            serde_json::json!({ "token": token }),
+            None,
+        )
+        .await
+        .is_ok()
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── Config defaults ─────────────────────────────────────────────────
+
+    #[test]
+    fn config_defaults() {
+        let config = InboxApiConfig::default();
+        assert_eq!(config.endpoint, "https://mcp.inboxapi.ai/mcp");
+        assert_eq!(config.account_name, "");
+        assert_eq!(
+            config.credentials_path,
+            "~/.local/inboxapi/credentials.json"
+        );
+        assert_eq!(config.poll_interval_secs, 30);
+        assert_eq!(config.content_format, "text");
+        assert!(config.allowed_senders.is_empty());
+    }
+
+    #[test]
+    fn config_custom() {
+        let config = InboxApiConfig {
+            endpoint: "https://custom.example.com/mcp".into(),
+            account_name: "test-agent".into(),
+            credentials_path: "/tmp/creds.json".into(),
+            allowed_senders: vec!["user@example.com".into()],
+            poll_interval_secs: 60,
+            content_format: "html".into(),
+        };
+        assert_eq!(config.endpoint, "https://custom.example.com/mcp");
+        assert_eq!(config.account_name, "test-agent");
+        assert_eq!(config.poll_interval_secs, 60);
+        assert_eq!(config.content_format, "html");
+    }
+
+    #[test]
+    fn config_clone() {
+        let config = InboxApiConfig {
+            account_name: "my-agent".into(),
+            allowed_senders: vec!["*".into()],
+            ..Default::default()
+        };
+        let cloned = config.clone();
+        assert_eq!(cloned.account_name, config.account_name);
+        assert_eq!(cloned.allowed_senders, config.allowed_senders);
+        assert_eq!(cloned.endpoint, config.endpoint);
+    }
+
+    #[test]
+    fn config_serde_roundtrip() {
+        let config = InboxApiConfig {
+            account_name: "test-bot".into(),
+            poll_interval_secs: 45,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: InboxApiConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.account_name, "test-bot");
+        assert_eq!(parsed.poll_interval_secs, 45);
+    }
+
+    #[test]
+    fn config_deserialize_with_defaults() {
+        let json = r#"{"account_name": "minimal"}"#;
+        let config: InboxApiConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.account_name, "minimal");
+        assert_eq!(config.endpoint, default_endpoint());
+        assert_eq!(config.credentials_path, default_credentials_path());
+        assert_eq!(config.poll_interval_secs, 30);
+    }
+
+    // ── Channel basics ──────────────────────────────────────────────────
+
+    #[test]
+    fn channel_name() {
+        let channel = InboxApiChannel::new(InboxApiConfig::default());
+        assert_eq!(channel.name(), "inboxapi");
+    }
+
+    #[tokio::test]
+    async fn seen_messages_starts_empty() {
+        let channel = InboxApiChannel::new(InboxApiConfig::default());
+        let seen = channel.seen_messages.lock().await;
+        assert!(seen.is_empty());
+    }
+
+    #[tokio::test]
+    async fn seen_messages_tracks_unique_ids() {
+        let channel = InboxApiChannel::new(InboxApiConfig::default());
+        let mut seen = channel.seen_messages.lock().await;
+        assert!(seen.insert("msg-1".into()));
+        assert!(!seen.insert("msg-1".into()));
+        assert!(seen.insert("msg-2".into()));
+        assert_eq!(seen.len(), 2);
+    }
+
+    // ── Sender allowlist ────────────────────────────────────────────────
+
+    #[test]
+    fn is_sender_allowed_empty_list_allows_all() {
+        let channel = InboxApiChannel::new(InboxApiConfig::default());
+        assert!(channel.is_sender_allowed("anyone@example.com"));
+        assert!(channel.is_sender_allowed("other@test.org"));
+    }
+
+    #[test]
+    fn is_sender_allowed_wildcard_allows_all() {
+        let channel = InboxApiChannel::new(InboxApiConfig {
+            allowed_senders: vec!["*".into()],
+            ..Default::default()
+        });
+        assert!(channel.is_sender_allowed("anyone@example.com"));
+        assert!(channel.is_sender_allowed("other@test.org"));
+    }
+
+    #[test]
+    fn is_sender_allowed_exact_match() {
+        let channel = InboxApiChannel::new(InboxApiConfig {
+            allowed_senders: vec!["alice@example.com".into()],
+            ..Default::default()
+        });
+        assert!(channel.is_sender_allowed("alice@example.com"));
+        assert!(channel.is_sender_allowed("Alice@Example.COM"));
+        assert!(!channel.is_sender_allowed("bob@example.com"));
+    }
+
+    #[test]
+    fn is_sender_allowed_domain_with_at() {
+        let channel = InboxApiChannel::new(InboxApiConfig {
+            allowed_senders: vec!["@example.com".into()],
+            ..Default::default()
+        });
+        assert!(channel.is_sender_allowed("alice@example.com"));
+        assert!(channel.is_sender_allowed("bob@example.com"));
+        assert!(!channel.is_sender_allowed("alice@other.com"));
+    }
+
+    #[test]
+    fn is_sender_allowed_domain_without_at() {
+        let channel = InboxApiChannel::new(InboxApiConfig {
+            allowed_senders: vec!["example.com".into()],
+            ..Default::default()
+        });
+        assert!(channel.is_sender_allowed("alice@example.com"));
+        assert!(!channel.is_sender_allowed("alice@notexample.com"));
+    }
+
+    // ── Hashcash ────────────────────────────────────────────────────────
+
+    #[test]
+    fn hashcash_stamp_format() {
+        let stamp = InboxApiChannel::generate_hashcash("test-resource", 1);
+        let parts: Vec<&str> = stamp.split(':').collect();
+        assert_eq!(parts[0], "1", "version must be 1");
+        assert_eq!(parts[1], "1", "bits must match requested");
+        assert_eq!(parts[3], "test-resource", "resource must match");
+    }
+
+    #[test]
+    fn hashcash_has_required_leading_zero_bits() {
+        // Use low difficulty for fast test
+        let stamp = InboxApiChannel::generate_hashcash("test", 8);
+        assert!(
+            InboxApiChannel::check_hashcash_bits(&stamp, 8),
+            "Generated stamp must pass its own verification"
+        );
+    }
+
+    #[test]
+    fn check_hashcash_bits_rejects_insufficient() {
+        // A stamp with 1-bit difficulty should not reliably pass 20-bit check
+        let stamp = InboxApiChannel::generate_hashcash("test", 1);
+        // Very unlikely to accidentally have 20 leading zero bits
+        // (probability 2^-19 ≈ 0.0002%), but check the mechanism works
+        let hash = Sha1::digest(stamp.as_bytes());
+        let has_20_bits = hash[0] == 0 && hash[1] == 0 && (hash[2] & 0xF0) == 0;
+        assert_eq!(
+            InboxApiChannel::check_hashcash_bits(&stamp, 20),
+            has_20_bits
+        );
+    }
+
+    #[test]
+    fn check_hashcash_bits_zero() {
+        // 0 bits = everything passes
+        assert!(InboxApiChannel::check_hashcash_bits("anything", 0));
+    }
+
+    // ── Message mapping ─────────────────────────────────────────────────
+
+    #[test]
+    fn send_message_to_mcp_args() {
+        let msg = SendMessage {
+            content: "Hello world".into(),
+            recipient: "user@example.com".into(),
+            subject: Some("Test Subject".into()),
+            thread_ts: Some("msg-123".into()),
+        };
+
+        let mut args = serde_json::json!({
+            "to": msg.recipient,
+            "body": msg.content,
+        });
+        if let Some(ref subject) = msg.subject {
+            args["subject"] = serde_json::json!(subject);
+        }
+        if let Some(ref thread) = msg.thread_ts {
+            args["in_reply_to"] = serde_json::json!(thread);
+        }
+
+        assert_eq!(args["to"], "user@example.com");
+        assert_eq!(args["body"], "Hello world");
+        assert_eq!(args["subject"], "Test Subject");
+        assert_eq!(args["in_reply_to"], "msg-123");
+    }
+
+    #[test]
+    fn email_json_to_channel_message() {
+        let email = serde_json::json!({
+            "id": "msg-abc",
+            "from": "sender@example.com",
+            "subject": "Test",
+            "body": "Hello",
+            "in_reply_to": "msg-parent"
+        });
+
+        let msg_id = email["id"].as_str().unwrap().to_string();
+        let sender = email["from"].as_str().unwrap().to_string();
+        let subject = email["subject"].as_str().unwrap_or("(no subject)");
+        let body = email["body"].as_str().unwrap_or("");
+        let content = format!("Subject: {}\n\n{}", subject, body);
+        let thread_ts = email["in_reply_to"].as_str().map(|s| s.to_string());
+
+        let msg = ChannelMessage {
+            id: msg_id.clone(),
+            reply_target: sender.clone(),
+            sender: sender.clone(),
+            content: content.clone(),
+            channel: "inboxapi".to_string(),
+            timestamp: 0,
+            thread_ts: thread_ts.clone(),
+        };
+
+        assert_eq!(msg.id, "msg-abc");
+        assert_eq!(msg.sender, "sender@example.com");
+        assert_eq!(msg.content, "Subject: Test\n\nHello");
+        assert_eq!(msg.channel, "inboxapi");
+        assert_eq!(msg.thread_ts.as_deref(), Some("msg-parent"));
+    }
+
+    // ── Credential serialization ────────────────────────────────────────
+
+    #[test]
+    fn credentials_serde_roundtrip() {
+        let creds = Credentials {
+            account_name: "test-bot".into(),
+            access_token: "acc-tok-123".into(),
+            refresh_token: "ref-tok-456".into(),
+            expires_at: 1_700_000_000,
+            email_address: "test-bot@abc.inboxapi.ai".into(),
+        };
+        let json = serde_json::to_string(&creds).unwrap();
+        let parsed: Credentials = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.account_name, "test-bot");
+        assert_eq!(parsed.access_token, "acc-tok-123");
+        assert_eq!(parsed.refresh_token, "ref-tok-456");
+        assert_eq!(parsed.expires_at, 1_700_000_000);
+        assert_eq!(parsed.email_address, "test-bot@abc.inboxapi.ai");
+    }
+
+    #[test]
+    fn credentials_email_address_defaults_empty() {
+        let json = r#"{
+            "account_name": "test",
+            "access_token": "a",
+            "refresh_token": "r",
+            "expires_at": 0
+        }"#;
+        let creds: Credentials = serde_json::from_str(json).unwrap();
+        assert_eq!(creds.email_address, "");
+    }
+
+    // ── JSON-RPC request format ─────────────────────────────────────────
+
+    #[test]
+    fn jsonrpc_request_format() {
+        let payload = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "send_email",
+                "arguments": {
+                    "to": "user@example.com",
+                    "body": "test"
+                }
+            }
+        });
+
+        assert_eq!(payload["jsonrpc"], "2.0");
+        assert_eq!(payload["method"], "tools/call");
+        assert_eq!(payload["params"]["name"], "send_email");
+        assert_eq!(payload["params"]["arguments"]["to"], "user@example.com");
+    }
+
+    #[test]
+    fn extract_text_content_from_mcp_response() {
+        let result = serde_json::json!({
+            "content": [
+                {
+                    "type": "text",
+                    "text": "{\"access_token\": \"tok-123\"}"
+                }
+            ]
+        });
+        let text = InboxApiChannel::extract_text_content(&result);
+        assert_eq!(text, Some("{\"access_token\": \"tok-123\"}".to_string()));
+    }
+
+    #[test]
+    fn extract_text_content_empty_result() {
+        let result = serde_json::json!({});
+        assert_eq!(InboxApiChannel::extract_text_content(&result), None);
+    }
+
+    #[test]
+    fn extract_text_content_no_text_field() {
+        let result = serde_json::json!({
+            "content": [{"type": "image", "data": "..."}]
+        });
+        assert_eq!(InboxApiChannel::extract_text_content(&result), None);
+    }
+
+    // ── SSE response parsing ───────────────────────────────────────────
+
+    #[test]
+    fn parse_sse_response_single_data_line() {
+        let body = "data: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"content\":[]}}\n\n";
+        let parsed = InboxApiChannel::parse_sse_response(body).unwrap();
+        assert_eq!(parsed["jsonrpc"], "2.0");
+        assert_eq!(parsed["id"], 1);
+        assert!(parsed["result"]["content"].is_array());
+    }
+
+    #[test]
+    fn parse_sse_response_plain_json() {
+        let body = r#"{"jsonrpc":"2.0","id":1,"result":{"content":[]}}"#;
+        let parsed = InboxApiChannel::parse_sse_response(body).unwrap();
+        assert_eq!(parsed["jsonrpc"], "2.0");
+        assert_eq!(parsed["id"], 1);
+    }
+
+    #[test]
+    fn parse_sse_response_with_event_fields() {
+        let body =
+            "event: message\nid: 42\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":null}\n\n";
+        let parsed = InboxApiChannel::parse_sse_response(body).unwrap();
+        assert_eq!(parsed["jsonrpc"], "2.0");
+        assert!(parsed["result"].is_null());
+    }
+
+    #[test]
+    fn parse_sse_response_empty_data_line() {
+        // Empty data: line followed by a real one
+        let body = "data: \ndata: {\"ok\":true}\n\n";
+        let parsed = InboxApiChannel::parse_sse_response(body).unwrap();
+        assert_eq!(parsed["ok"], true);
+    }
+
+    #[test]
+    fn parse_sse_response_invalid_json() {
+        let body = "data: not-json\n\n";
+        assert!(InboxApiChannel::parse_sse_response(body).is_err());
+    }
+
+    // ── Email response parsing ──────────────────────────────────────────
+
+    #[test]
+    fn poll_parses_wrapped_email_response() {
+        let response = serde_json::json!({
+            "emails": [
+                {"id": "msg-1", "from": "alice@example.com", "subject": "Hi", "body": "Hello"}
+            ],
+            "returned": 1,
+            "offset": 0,
+            "limit": 20
+        });
+        let arr = response
+            .get("emails")
+            .and_then(|e| e.as_array())
+            .or_else(|| response.as_array());
+        assert!(arr.is_some());
+        assert_eq!(arr.unwrap().len(), 1);
+        assert_eq!(arr.unwrap()[0]["id"], "msg-1");
+    }
+
+    #[test]
+    fn poll_parses_raw_array_response() {
+        let response = serde_json::json!([
+            {"id": "msg-1", "from": "alice@example.com", "subject": "Hi", "body": "Hello"}
+        ]);
+        let arr = response
+            .get("emails")
+            .and_then(|e| e.as_array())
+            .or_else(|| response.as_array());
+        assert!(arr.is_some());
+        assert_eq!(arr.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn poll_handles_empty_wrapped_response() {
+        let response = serde_json::json!({
+            "emails": [],
+            "returned": 0,
+            "offset": 0,
+            "limit": 20
+        });
+        let arr = response
+            .get("emails")
+            .and_then(|e| e.as_array())
+            .or_else(|| response.as_array());
+        assert!(arr.is_some());
+        assert_eq!(arr.unwrap().len(), 0);
+    }
+}

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -25,6 +25,7 @@ pub mod discord_history;
 pub mod email_channel;
 pub mod gmail_push;
 pub mod imessage;
+pub mod inboxapi;
 pub mod irc;
 #[cfg(feature = "channel-lark")]
 pub mod lark;
@@ -74,6 +75,7 @@ pub use discord_history::DiscordHistoryChannel;
 pub use email_channel::EmailChannel;
 pub use gmail_push::GmailPushChannel;
 pub use imessage::IMessageChannel;
+pub use inboxapi::InboxApiChannel;
 pub use irc::IrcChannel;
 #[cfg(feature = "channel-lark")]
 pub use lark::LarkChannel;
@@ -4634,6 +4636,13 @@ fn collect_configured_channels(
         channels.push(ConfiguredChannel {
             display_name: "iMessage",
             channel: Arc::new(IMessageChannel::new(im.allowed_contacts.clone())),
+        });
+    }
+
+    if let Some(ref inbox) = config.channels_config.inboxapi {
+        channels.push(ConfiguredChannel {
+            display_name: "InboxAPI",
+            channel: Arc::new(InboxApiChannel::new(inbox.clone())),
         });
     }
 

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -6118,6 +6118,8 @@ pub struct ChannelsConfig {
     pub webhook: Option<WebhookConfig>,
     /// iMessage channel configuration (macOS only).
     pub imessage: Option<IMessageConfig>,
+    /// InboxAPI channel configuration (agent-native email).
+    pub inboxapi: Option<crate::channels::inboxapi::InboxApiConfig>,
     /// Matrix channel configuration.
     pub matrix: Option<MatrixConfig>,
     /// Signal channel configuration.
@@ -6223,6 +6225,10 @@ impl ChannelsConfig {
             (
                 Box::new(ConfigWrapper::new(self.imessage.as_ref())),
                 self.imessage.is_some(),
+            ),
+            (
+                Box::new(ConfigWrapper::new(self.inboxapi.as_ref())),
+                self.inboxapi.is_some(),
             ),
             (
                 Box::new(ConfigWrapper::new(self.matrix.as_ref())),
@@ -6338,6 +6344,7 @@ impl Default for ChannelsConfig {
             mattermost: None,
             webhook: None,
             imessage: None,
+            inboxapi: None,
             matrix: None,
             signal: None,
             whatsapp: None,
@@ -11542,6 +11549,7 @@ auto_save = true
                 mattermost: None,
                 webhook: None,
                 imessage: None,
+                inboxapi: None,
                 matrix: None,
                 signal: None,
                 whatsapp: None,
@@ -12569,6 +12577,7 @@ allowed_users = ["@ops:matrix.org"]
             imessage: Some(IMessageConfig {
                 allowed_contacts: vec!["+1".into()],
             }),
+            inboxapi: None,
             matrix: Some(MatrixConfig {
                 homeserver: "https://m.org".into(),
                 access_token: "tok".into(),
@@ -12939,6 +12948,7 @@ channel_ids = ["C123", "D456"]
             mattermost: None,
             webhook: None,
             imessage: None,
+            inboxapi: None,
             matrix: None,
             signal: None,
             whatsapp: Some(WhatsAppConfig {

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -3554,6 +3554,7 @@ enum ChannelMenuChoice {
     Discord,
     Slack,
     IMessage,
+    InboxApi,
     Matrix,
     Signal,
     WhatsApp,
@@ -3575,6 +3576,7 @@ const CHANNEL_MENU_CHOICES: &[ChannelMenuChoice] = &[
     ChannelMenuChoice::Discord,
     ChannelMenuChoice::Slack,
     ChannelMenuChoice::IMessage,
+    ChannelMenuChoice::InboxApi,
     ChannelMenuChoice::Matrix,
     ChannelMenuChoice::Signal,
     ChannelMenuChoice::WhatsApp,
@@ -3638,6 +3640,14 @@ fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
                         "✅ configured"
                     } else {
                         "— macOS only"
+                    }
+                ),
+                ChannelMenuChoice::InboxApi => format!(
+                    "InboxAPI   {}",
+                    if config.inboxapi.is_some() {
+                        "✅ connected"
+                    } else {
+                        "— agent-native email (no SMTP needed)"
                     }
                 ),
                 ChannelMenuChoice::Matrix => format!(
@@ -5499,6 +5509,62 @@ fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
                     style("✅").green().bold(),
                     style(relays.len()).cyan()
                 );
+            }
+            ChannelMenuChoice::InboxApi => {
+                // ── InboxAPI ──
+                println!();
+                println!(
+                    "  {} {}",
+                    style("InboxAPI Setup").white().bold(),
+                    style("— agent-native email, no SMTP/IMAP needed").dim()
+                );
+                print_bullet("InboxAPI gives your agent a dedicated email address");
+                print_bullet("Account is auto-created on first run (no signup needed)");
+                println!();
+
+                let account_name: String = Input::new()
+                    .with_prompt("  Account name (e.g., my-agent)")
+                    .interact_text()?;
+
+                if account_name.trim().is_empty() {
+                    println!("  {} Skipped", style("→").dim());
+                    continue;
+                }
+
+                print_bullet("Allowlist email addresses/domains that can message your agent.");
+                print_bullet("Use '*' to allow anyone, '@domain.com' for domains.");
+
+                let senders_str: String = Input::new()
+                    .with_prompt("  Allowed senders (comma-separated, or * for all)")
+                    .allow_empty(true)
+                    .interact_text()?;
+
+                let allowed_senders = if senders_str.trim() == "*" {
+                    vec!["*".into()]
+                } else {
+                    senders_str
+                        .split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                };
+
+                if allowed_senders.is_empty() {
+                    print_bullet("⚠️  Empty allowlist — inbound emails will be denied.");
+                }
+
+                config.inboxapi = Some(crate::channels::inboxapi::InboxApiConfig {
+                    account_name: account_name.trim().to_string(),
+                    allowed_senders,
+                    ..Default::default()
+                });
+
+                println!(
+                    "  {} InboxAPI configured as '{}'",
+                    style("✅").green().bold(),
+                    style(account_name.trim()).cyan()
+                );
+                print_bullet("Email address will be provisioned on first run");
             }
             ChannelMenuChoice::Done => break,
         }

--- a/src/onboard/wizard.rs
+++ b/src/onboard/wizard.rs
@@ -3645,7 +3645,7 @@ fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
                 ChannelMenuChoice::InboxApi => format!(
                     "InboxAPI   {}",
                     if config.inboxapi.is_some() {
-                        "✅ connected"
+                        "✅ configured"
                     } else {
                         "— agent-native email (no SMTP needed)"
                     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2467,6 +2467,7 @@ mod tests {
 
     #[test]
     fn resolve_provider_credential_bedrock_uses_internal_credential_path() {
+        let _env_lock = env_lock();
         let _generic_guard = EnvGuard::set("API_KEY", Some("generic-key"));
         let _override_guard = EnvGuard::set("OPENROUTER_API_KEY", Some("openrouter-key"));
         let _bedrock_guard = EnvGuard::set("BEDROCK_API_KEY", None);
@@ -2481,6 +2482,7 @@ mod tests {
 
     #[test]
     fn resolve_provider_credential_bedrock_returns_bearer_token_from_env() {
+        let _env_lock = env_lock();
         let _bedrock_guard = EnvGuard::set("BEDROCK_API_KEY", Some("bedrock-bearer-token"));
 
         assert_eq!(


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Zero-config, agent-native email is currently not available as an inbound channel.
- Why it matters: InboxAPI lets agents receive/send email without IMAP/SMTP setup, making “email as a channel” as easy as setting `account_name`.
- What changed: Adds a new `inboxapi` channel, config schema wiring, and onboarding wizard support.
- What did **not** change (scope boundary): No changes to other existing channels’ behavior.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): (auto)
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `channel,config,onboard,dependencies,tests`
- Module labels (`<module>: <component>`): `channel: inboxapi`
- Contributor tier label (auto-managed/read-only): (auto)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `feature`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `channel`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #3385, #5449

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors:
  - #3385 by @shaond
  - #5449 by @shaond
- Integrated scope by source PR: channel implementation + config + onboarding wiring.
- `Co-authored-by` trailers added for materially incorporated contributors? `Yes`
- If `No`, explain why: N/A
- Trailer format check (separate lines, no escaped `\n`): `Pass`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): local run (Apr 8, 2026 UTC)
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? `Yes` (new channel)
- New external network calls? `Yes` (InboxAPI MCP HTTP endpoint)
- Secrets/tokens handling changed? `Yes` (InboxAPI access/refresh tokens persisted to local credentials file)
- File system access scope changed? `Yes` (reads/writes InboxAPI credentials file)
- If any `Yes`, describe risk and mitigation:
  - Credentials file is stored with 0600 permissions; allowlist filtering is supported to constrain senders.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: tests use synthetic addresses/tokens.
- Neutral wording confirmation: confirmed.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` (new optional `[channels_config.inboxapi]` section)
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No`

## Human Verification (required)

- Verified scenarios:
  - Compile + unit/integration tests pass.
  - Clippy clean with `-D warnings`.
  - Live InboxAPI E2E smoke test pass (Apr 8, 2026 UTC) using dedicated account name `musketeer-zeroclaw-e2e-20260408` (inbound poll ingested messages; outbound `send_email` path exercised).
- Edge cases checked:
  - Allowlist behavior covered by tests.

### Live E2E Smoke Test (repeatable, manual)

Goal: prove InboxAPI inbound email → ZeroClaw channel ingestion works end-to-end with a real InboxAPI account, and that cursors survive restarts.

**Pre-reqs**
- Use a dedicated InboxAPI account name (example): `zeroclaw-e2e-inboxapi` (any unique, clearly-identifiable name is fine).
- Ensure you have a clean scratch workspace so the test is repeatable:

```bash
export ZEROCLAW_WORKSPACE=/tmp/zeroclaw-inboxapi-e2e
rm -rf "$ZEROCLAW_WORKSPACE"
mkdir -p "$ZEROCLAW_WORKSPACE"
```

**Configure**
1) Run onboarding and select the `InboxAPI` channel:

```bash
zeroclaw onboard
```

Dev fallback:

```bash
cargo run --release -- onboard
```

2) In the generated `config.toml`, ensure at minimum:
- `[channels_config.inboxapi] account_name = "zeroclaw-e2e-inboxapi"`
- `allowed_senders = ["*"]` for initial smoke testing (tighten later).

**Run**
Start the full runtime (this is what actually runs channels):

```bash
zeroclaw daemon
```

Dev fallback:

```bash
cargo run --release -- daemon
```

**Exercise**
Send emails to the provisioned InboxAPI address:
- Plain text email
- HTML email
- Email with a small attachment (e.g. PDF)
- Two emails back-to-back (idempotency + cursor progression)

**Assertions**
- Each email is ingested exactly once.
- Attachments are present/handled as expected.
- Restart resilience: stop `zeroclaw daemon`, restart it, confirm no reprocessing and cursor continues.

**Cleanup**
Delete the scratch workspace:

```bash
rm -rf "$ZEROCLAW_WORKSPACE"
```

### AI Disclosure

This change was authored and iterated with assistance from an automated AI coding agent (Musketeer). Please review accordingly.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: channel registry, config schema, onboarding wizard.
- Potential unintended effects: none expected unless InboxAPI channel is configured.
- Guardrails/monitoring for early detection: existing channel health checks + logs.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): `gh`, `cargo`.
- Workflow/plan summary (if any): rebase PR branch onto latest `master`, fix compile break from new message struct fields, run full validation.
- Verification focus: clippy large-futures gate + test suite.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: revert this PR.
- Feature flags or config toggles (if any): remove `[channels_config.inboxapi]` from config.
- Observable failure symptoms: InboxAPI channel failing to authenticate/poll; other channels unaffected.

## Risks and Mitigations

- Risk: token persistence and external endpoint reliance.
  - Mitigation: strict file perms, allowlist filtering, clear logging/errors.
