### PR TITLE
test(fuzz): wire fuzz stub targets to real ZeroClaw code paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ rust_out
 
 # Auto-generated Tauri schemas
 apps/tauri/gen/schemas/linux-schema.json
+fuzz/target/
+fuzz/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [".", "crates/robot-kit", "crates/aardvark-sys", "crates/zeroclaw-macros", "apps/tauri"]
+exclude = ["fuzz"]
 resolver = "2"
 
 [package]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -7,10 +7,13 @@ edition = "2024"
 [package.metadata]
 cargo-fuzz = true
 
+[workspace]
+
 [dependencies]
 libfuzzer-sys = "0.4"
 
 [dependencies.zeroclaw]
+package = "zeroclawlabs"
 path = ".."
 
 [[bin]]

--- a/fuzz/fuzz_targets/fuzz_config_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_config_parse.rs
@@ -3,7 +3,7 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
-        // Fuzz TOML config parsing — silently discard invalid input
-        let _ = toml::from_str::<toml::Value>(s);
+        // Fuzz TOML config parsing into real ZeroClaw Config struct
+        let _ = toml::from_str::<zeroclaw::Config>(s);
     }
 });

--- a/fuzz/fuzz_targets/fuzz_provider_response.rs
+++ b/fuzz/fuzz_targets/fuzz_provider_response.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
+use zeroclaw::providers::traits::ConversationMessage;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
-        // Fuzz provider API response deserialization
-        let _ = serde_json::from_str::<serde_json::Value>(s);
+        let _ = serde_json::from_str::<ConversationMessage>(s);
     }
 });

--- a/fuzz/fuzz_targets/fuzz_tool_params.rs
+++ b/fuzz/fuzz_targets/fuzz_tool_params.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
+use zeroclaw::tools::traits::ToolSpec;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
-        // Fuzz JSON tool parameter parsing — silently discard invalid input
-        let _ = serde_json::from_str::<serde_json::Value>(s);
+        let _ = serde_json::from_str::<ToolSpec>(s);
     }
 });

--- a/fuzz/fuzz_targets/fuzz_webhook_payload.rs
+++ b/fuzz/fuzz_targets/fuzz_webhook_payload.rs
@@ -1,9 +1,9 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
+use zeroclaw::gateway::WebhookBody;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
-        // Fuzz webhook body deserialization
-        let _ = serde_json::from_str::<serde_json::Value>(s);
+        let _ = serde_json::from_str::<WebhookBody>(s);
     }
 });


### PR DESCRIPTION
# PR: test(fuzz): wire fuzz stub targets to real ZeroClaw code paths

## Summary

- **Base branch target**: `master`
- **Problem**: 4 of 5 fuzz targets (`fuzz_config_parse`, `fuzz_provider_response`, `fuzz_tool_params`, `fuzz_webhook_payload`) only deserialize into generic `serde_json::Value` or `toml::Value` — they test the serde crate, not ZeroClaw logic.
- **Why it matters**: Fuzzing is a critical security layer. Testing generic deserialization misses real vulnerabilities in ZeroClaw's actual type parsing and validation.
- **What changed**:
  - `fuzz_config_parse`: `toml::Value` → `zeroclaw::Config`
  - `fuzz_provider_response`: `serde_json::Value` → `ConversationMessage`
  - `fuzz_tool_params`: `serde_json::Value` → `ToolSpec`
  - `fuzz_webhook_payload`: `serde_json::Value` → `WebhookBody`
  - Added `exclude = ["fuzz"]` to workspace `Cargo.toml`
  - Added `[workspace]` section to `fuzz/Cargo.toml`
  - Fixed dependency: `package = "zeroclawlabs"`
  - Added `fuzz/target/` and `fuzz/Cargo.lock` to `.gitignore`
- **What did not change**: `fuzz_command_validation.rs` (already correct). No source code changes outside `fuzz/`.

## Label Snapshot (required)

- **Risk label**: `risk: low` — Track A. Test-only changes, no production code affected.
- **Size label**: `size: XS` — 14 insertions, 8 deletions across 7 files.
- **Scope labels**: `tests`
- **Module labels**: `tests: fuzz`
- **Contributor tier label**: _(auto-managed)_
- **If any auto-label is incorrect, note requested correction**: N/A

## Change Metadata

- **Change type**: `test`
- **Primary scope**: `runtime`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

- N/A — does not supersede any existing PR. No overlapping PRs found.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check                  # PASS
cargo clippy --lib -p zeroclawlabs -- -D warnings  # PASS
```

- **Evidence provided**: Local quality gates passed.
- **If any command is intentionally skipped, explain why**: None skipped.

## Security Impact (required)

- **New permissions/capabilities?**: No
- **New external network calls?**: No
- **Secrets/tokens handling changed?**: No
- **File system access scope changed?**: No
- **If any Yes, describe risk and mitigation**: N/A

## Privacy and Data Hygiene (required)

- **Data-hygiene status**: `pass`
- **Redaction/anonymization notes**: N/A — fuzz targets use arbitrary byte data.
- **Neutral wording confirmation**: Yes.

## Compatibility / Migration

- **Backward compatible?**: Yes
- **Config/env changes?**: No
- **Migration needed?**: No
- **If yes, exact upgrade steps**: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- **i18n follow-through triggered?**: No

## Human Verification (required)

**What was personally validated beyond CI**:

- **Verified scenarios**: All 4 fuzz targets now use real ZeroClaw types. `fuzz_command_validation.rs` unchanged.
- **Edge cases checked**: No new clippy warnings. No new dependencies added.
- **What was not verified**: Full `cargo fuzz build` (requires cargo-fuzz installation; CI will execute).

## Side Effects / Blast Radius (required)

- **Affected subsystems/workflows**: Fuzz testing infrastructure only.
- **Potential unintended effects**: None — fuzz targets exercise existing deserialization code paths.
- **Guardrails/monitoring for early detection**: Each target now exercises a distinct ZeroClaw type.

## Agent Collaboration Notes (recommended)

- **Agent tools used**: Autonomous agent (OpenCode/Sisyphus workflow)
- **Workflow/plan summary**: Track A Sprint 3 quality pass — Task 3 of 3
- **Verification focus**: Confirm fuzz targets use real ZeroClaw types, not generic `Value`
- **Confirmation**: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes — conventional commits, minimal changes, no new dependencies.

## Rollback Plan (required)

- **Fast rollback command/path**: `git revert <commit>` on `master`
- **Feature flags or config toggles (if any)**: None
- **Observable failure symptoms**: None — fuzz targets are test-only.

## Risks and Mitigations

- **Risk**: None
