### PR TITLE
fix(ci): downgrade Homebrew fork push check from error to warning

### DIFF
--- a/.github/workflows/pub-homebrew-core.yml
+++ b/.github/workflows/pub-homebrew-core.yml
@@ -206,9 +206,9 @@ jobs:
           bot_email="${BOT_EMAIL:-${fork_owner}@users.noreply.github.com}"
 
           # Pre-flight: verify token has push access to the fork
+          # Note: classic PATs may not return .permissions on forked repos; treat as warning, not hard fail.
           if ! gh api "repos/${BOT_FORK_REPO}" --jq '.permissions.push' 2>/dev/null | grep -q true; then
-            echo "::error::Token lacks push access to ${BOT_FORK_REPO}. Ensure HOMEBREW_CORE_BOT_TOKEN (or HOMEBREW_UPSTREAM_PR_TOKEN) is a PAT with 'Contents: write' scope for ${BOT_FORK_REPO}."
-            exit 1
+            echo "::warning::Could not confirm push access to ${BOT_FORK_REPO} via API (classic PATs may not report fork permissions). Attempting push anyway."
           fi
 
           git -C "$repo_dir" config user.name "$fork_owner"


### PR DESCRIPTION
## Summary
- Changes the Homebrew workflow pre-flight push check from a hard error to a warning
- Classic PATs don't always return `.permissions` on forked repos via the GitHub API, causing false negatives
- The actual `git push` will still fail with a clear error if the token truly lacks access

This was causing the v0.6.9 Homebrew publish to fail despite the token having correct permissions.

## Test plan
- [ ] CI passes
- [ ] Re-run Homebrew publish job after merge