### PR TITLE
fix(channels): add feishu and lark to channel send CLI

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -4480,8 +4480,38 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 qq.allowed_users.clone(),
             )))
         }
+        "lark" => {
+            #[cfg(feature = "channel-lark")]
+            {
+                let lk = config
+                    .channels_config
+                    .lark
+                    .as_ref()
+                    .context("Lark channel is not configured")?;
+                Ok(Arc::new(LarkChannel::from_lark_config(lk)))
+            }
+            #[cfg(not(feature = "channel-lark"))]
+            {
+                anyhow::bail!("Lark channel requires the `channel-lark` feature");
+            }
+        }
+        "feishu" => {
+            #[cfg(feature = "channel-lark")]
+            {
+                let fs = config
+                    .channels_config
+                    .feishu
+                    .as_ref()
+                    .context("Feishu channel is not configured")?;
+                Ok(Arc::new(LarkChannel::from_feishu_config(fs)))
+            }
+            #[cfg(not(feature = "channel-lark"))]
+            {
+                anyhow::bail!("Feishu channel requires the `channel-lark` feature");
+            }
+        }
         other => anyhow::bail!(
-            "Unknown channel '{other}'. Supported: telegram, discord, slack, mattermost, signal, matrix, whatsapp, qq"
+            "Unknown channel '{other}'. Supported: telegram, discord, slack, mattermost, signal, matrix, whatsapp, qq, lark, feishu"
         ),
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The `zeroclaw channel send --channel-id feishu` command fails with "Unknown channel 'feishu'" because `build_channel_by_id()` is missing match arms for "feishu" and "lark", even though `LarkChannel` implementation and config (`FeishuConfig`, `LarkConfig`) already exist and work correctly in the daemon and cron scheduler.
- Why it matters: Users who configure Feishu/Lark channels in `config.toml` cannot send messages via the CLI `channel send` command.
- What changed: Added "lark" and "feishu" match arms to `build_channel_by_id()` in `src/channels/mod.rs`, gated behind the `channel-lark` feature flag, using the existing `LarkChannel::from_lark_config()` and `LarkChannel::from_feishu_config()` constructors. Updated the error message to list lark and feishu as supported channels.
- What did **not** change (scope boundary): No changes to `LarkChannel` implementation, config schema, gateway, cron scheduler, or any other subsystem. Only the CLI `channel send` path is affected.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `channel`
- Module labels: `channel: lark`
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): channel

## Linked Issue

- Closes #5488

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check    # Pass
cargo clippy --all-targets -- -D warnings    # Pending CI
cargo test    # Pending CI
```

- Evidence provided (test/log/trace/screenshot/perf): Existing `build_channel_by_id_unknown_channel_returns_error` test still passes (checks for "Unknown channel" substring). The new match arms follow the identical pattern used in `cron/scheduler.rs` which already handles lark/feishu.
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Code review of match arm pattern matches cron scheduler implementation exactly.
- Edge cases checked: Feature-gated paths for `channel-lark` enabled/disabled.
- What was not verified: End-to-end Feishu API message delivery (requires live credentials).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Only `zeroclaw channel send` CLI command.
- Potential unintended effects: None — additive match arms only.
- Guardrails/monitoring for early detection: Existing channel send tests.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Identified missing match arms by tracing error message, added feishu/lark support matching existing cron scheduler pattern.
- Verification focus: Pattern consistency with cron scheduler, feature flag gating.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: `channel-lark` feature flag
- Observable failure symptoms: "Unknown channel 'feishu'" error returns

## Risks and Mitigations

None.