### PR TITLE
fix(provider): make Ollama native tool calling configurable

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -591,6 +591,13 @@ pub struct ModelProviderConfig {
     /// whose chat template rejects system messages at non-first positions.
     #[serde(default)]
     pub merge_system_into_user: bool,
+    /// When true, tools are sent via the provider's native API parameter
+    /// instead of being injected as XML instructions in the system prompt.
+    /// Useful for Ollama models that support native tool calling (e.g.
+    /// qwen3.5, llama3.3, mistral). Can also be set via env var
+    /// `OLLAMA_NATIVE_TOOLS=true`. Default: false.
+    #[serde(default)]
+    pub native_tools: bool,
 }
 
 // ── Delegate Tool Configuration ─────────────────────────────────

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -712,6 +712,9 @@ pub struct ProviderRuntimeOptions {
     /// When true, system messages are merged into the first user message before
     /// sending. Propagated from `ModelProviderConfig::merge_system_into_user`.
     pub merge_system_into_user: bool,
+    /// When true, tools are sent via the provider's native API parameter
+    /// (e.g. Ollama's `/api/chat` `tools` field) instead of prompt-guided XML.
+    pub native_tools: bool,
 }
 
 impl Default for ProviderRuntimeOptions {
@@ -728,6 +731,7 @@ impl Default for ProviderRuntimeOptions {
             api_path: None,
             provider_max_tokens: None,
             merge_system_into_user: false,
+            native_tools: false,
         }
     }
 }
@@ -756,6 +760,26 @@ pub fn provider_runtime_options_from_config(
         .map(|p| p.merge_system_into_user)
         .unwrap_or(false);
 
+    // Resolve native_tools from the active model provider profile, same lookup
+    // strategy as merge_system_into_user above.
+    let native_tools = config
+        .api_url
+        .as_deref()
+        .map(str::trim)
+        .filter(|u| !u.is_empty())
+        .and_then(|active_url| {
+            config.model_providers.values().find(|p| {
+                p.base_url
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|u| !u.is_empty())
+                    .map(|u| u.trim_end_matches('/'))
+                    == Some(active_url.trim_end_matches('/'))
+            })
+        })
+        .map(|p| p.native_tools)
+        .unwrap_or(false);
+
     ProviderRuntimeOptions {
         auth_profile_override: None,
         provider_api_url: config.api_url.clone(),
@@ -768,6 +792,7 @@ pub fn provider_runtime_options_from_config(
         api_path: config.api_path.clone(),
         provider_max_tokens: config.provider_max_tokens,
         merge_system_into_user,
+        native_tools,
     }
 }
 
@@ -1202,11 +1227,17 @@ fn create_provider_with_url_and_options(
 
             let api_url = env_url.as_deref().or(api_url);
 
-            Ok(Box::new(ollama::OllamaProvider::new_with_reasoning(
-                api_url,
-                key,
-                options.reasoning_enabled,
-            )))
+            // Allow enabling native tool calling via config or env var.
+            let native_tools = options.native_tools
+                || std::env::var("OLLAMA_NATIVE_TOOLS")
+                    .ok()
+                    .map(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"))
+                    .unwrap_or(false);
+
+            Ok(Box::new(
+                ollama::OllamaProvider::new_with_reasoning(api_url, key, options.reasoning_enabled)
+                    .with_native_tools(native_tools),
+            ))
         }
         "gemini" | "google" | "google-gemini" => {
             let state_dir = options.zeroclaw_dir.clone().unwrap_or_else(|| {

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -11,6 +11,11 @@ pub struct OllamaProvider {
     base_url: String,
     api_key: Option<String>,
     reasoning_enabled: Option<bool>,
+    /// When `true`, the provider sends tool definitions via the native
+    /// `/api/chat` `tools` parameter instead of injecting XML instructions
+    /// into the system prompt. Many modern Ollama models (qwen3.5, llama3.3,
+    /// mistral, etc.) support this. Defaults to `false` for backward compat.
+    native_tools: bool,
 }
 
 // ─── Request Structures ───────────────────────────────────────────────────────
@@ -144,7 +149,16 @@ impl OllamaProvider {
             base_url: Self::normalize_base_url(base_url.unwrap_or("http://localhost:11434")),
             api_key,
             reasoning_enabled,
+            native_tools: false,
         }
+    }
+
+    /// Enable or disable native tool calling via the `/api/chat` `tools`
+    /// parameter. When enabled, tool definitions are sent natively instead of
+    /// being injected as XML instructions in the system prompt.
+    pub fn with_native_tools(mut self, enabled: bool) -> Self {
+        self.native_tools = enabled;
+        self
     }
 
     fn is_local_endpoint(&self) -> bool {
@@ -631,7 +645,7 @@ impl OllamaProvider {
 impl Provider for OllamaProvider {
     fn capabilities(&self) -> ProviderCapabilities {
         ProviderCapabilities {
-            native_tool_calling: false,
+            native_tool_calling: self.native_tools,
             vision: true,
             prompt_caching: false,
         }
@@ -825,13 +839,7 @@ impl Provider for OllamaProvider {
     }
 
     fn supports_native_tools(&self) -> bool {
-        // Default to prompt-guided tool calling (XML instructions in system prompt)
-        // because many Ollama-served models do not support Ollama's native
-        // /api/chat tool-calling parameter. Models that lack support silently
-        // ignore the tools array and emit tool-call JSON as plain text, which the
-        // agent loop cannot parse without the XML protocol instructions.
-        // See: https://github.com/zeroclaw-labs/zeroclaw/issues/3999
-        false
+        self.native_tools
     }
 
     async fn chat(
@@ -1230,7 +1238,7 @@ mod tests {
     }
 
     #[test]
-    fn capabilities_disable_native_tools_and_enable_vision() {
+    fn capabilities_default_disables_native_tools_and_enables_vision() {
         let provider = OllamaProvider::new(None, None);
         let caps = <OllamaProvider as Provider>::capabilities(&provider);
         assert!(
@@ -1238,6 +1246,17 @@ mod tests {
             "Ollama should default to prompt-guided tool calling"
         );
         assert!(caps.vision);
+    }
+
+    #[test]
+    fn capabilities_with_native_tools_enabled() {
+        let provider = OllamaProvider::new(None, None).with_native_tools(true);
+        let caps = <OllamaProvider as Provider>::capabilities(&provider);
+        assert!(
+            caps.native_tool_calling,
+            "Ollama with native_tools=true should report native tool calling"
+        );
+        assert!(provider.supports_native_tools());
     }
 
     #[test]

--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -1133,6 +1133,7 @@ data: [DONE]
             api_path: None,
             provider_max_tokens: None,
             merge_system_into_user: false,
+            native_tools: false,
         };
         let provider =
             OpenAiCodexProvider::new(&options, None).expect("provider should initialize");

--- a/tests/live/openai_codex_vision_e2e.rs
+++ b/tests/live/openai_codex_vision_e2e.rs
@@ -157,6 +157,7 @@ async fn openai_codex_second_vision_support() -> Result<()> {
         extra_headers: std::collections::HashMap::new(),
         api_path: None,
         merge_system_into_user: false,
+        native_tools: false,
     };
 
     let provider = zeroclaw::providers::create_provider_with_options("openai-codex", None, &opts)?;


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The Ollama provider hardcodes `supports_native_tools() = false`, forcing all models to use prompt-guided XML-based tool calling. Modern models like qwen3.5:4b-q8_0, llama3.3, and mistral fully support Ollama's native `/api/chat` tool-calling parameter, but ZeroClaw cannot use it.
- Why it matters: Tool calling fails completely for models that do not follow the XML `<tool_call>` format but do support native tool calling via the Ollama API.
- What changed: Added a configurable `native_tools` field to `OllamaProvider` (default: `false` for backward compatibility). Users can enable it via config (`native_tools = true` in a `[model_providers.<name>]` section) or env var (`OLLAMA_NATIVE_TOOLS=true`). Updated `capabilities()` and `supports_native_tools()` to reflect the setting.
- What did **not** change (scope boundary): Default behavior unchanged (still prompt-guided). No changes to other providers. No auto-detection of model capabilities (that would require querying Ollama's model info API, which is a larger feature).

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels: `provider`, `config`
- Module labels: `provider: ollama`
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): provider

## Linked Issue

- Closes #5500

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check    # Pass
cargo clippy --all-targets -- -D warnings    # Pending CI
cargo test    # Pending CI
```

- Evidence provided (test/log/trace/screenshot/perf): Added unit test `capabilities_with_native_tools_enabled` that verifies `with_native_tools(true)` correctly reports native tool calling support. Existing default test updated to confirm backward-compatible behavior.
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — new optional `native_tools` field in `[model_providers.<name>]` config section and `OLLAMA_NATIVE_TOOLS` env var. Both default to false.
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Default behavior unchanged (native_tools=false), builder method toggles capability correctly.
- Edge cases checked: Env var parsing (1/true/yes/on accepted, all others default to false).
- What was not verified: End-to-end native tool calling with a live Ollama model (requires local Ollama instance with compatible model).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Ollama provider tool-calling path only when explicitly enabled by user.
- Potential unintended effects: None when native_tools is false (default). When enabled, models that silently ignore the tools array may produce unparseable responses, but this is opt-in.
- Guardrails/monitoring for early detection: Feature is opt-in only.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Added configurable native_tools field to OllamaProvider, wired through config and env var, updated tests.
- Verification focus: Backward compatibility, opt-in gating.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: `native_tools = false` (default) or unset `OLLAMA_NATIVE_TOOLS`
- Observable failure symptoms: Tool calls fail if enabled for incompatible models

## Risks and Mitigations

- Risk: Users enable native_tools for models that silently ignore the tools array, causing tool calls to fail.
  - Mitigation: Default is false; only activated by explicit opt-in. Documentation in config field describes which models support it.