### PR TITLE
fix(security): allow safe redirect targets in forbidden_path_argument

### DIFF
--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -2722,19 +2722,10 @@ mod tests {
         // stdout redirect to /dev/null
         assert_eq!(p.forbidden_path_argument("echo hello >/dev/null"), None);
         // space-separated redirect
-        assert_eq!(
-            p.forbidden_path_argument("some_cmd > /dev/null 2>&1"),
-            None
-        );
+        assert_eq!(p.forbidden_path_argument("some_cmd > /dev/null 2>&1"), None);
         // /dev/stdout and /dev/stderr
-        assert_eq!(
-            p.forbidden_path_argument("echo msg >/dev/stdout"),
-            None
-        );
-        assert_eq!(
-            p.forbidden_path_argument("echo err >/dev/stderr"),
-            None
-        );
+        assert_eq!(p.forbidden_path_argument("echo msg >/dev/stdout"), None);
+        assert_eq!(p.forbidden_path_argument("echo err >/dev/stderr"), None);
         // /dev/zero as input
         assert_eq!(
             p.forbidden_path_argument("dd if=/dev/zero of=./out bs=1 count=1"),

--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -1283,11 +1283,19 @@ impl SecurityPolicy {
             };
 
             // Cover inline forms like `cat</etc/passwd`.
+            // Safe redirect targets (/dev/null, /dev/stdout, etc.) are
+            // always allowed — see `safe_redirect_target()`.
             if let Some(target) = redirection_target(strip_wrapping_quotes(executable)) {
-                if let Some(blocked) = forbidden_candidate(target) {
-                    return Some(blocked);
+                if !safe_redirect_target(target) {
+                    if let Some(blocked) = forbidden_candidate(target) {
+                        return Some(blocked);
+                    }
                 }
             }
+
+            // Track whether the previous token was a bare redirect operator
+            // (e.g. `>`, `>>`, `<`) so the next token is treated as its target.
+            let mut next_is_redirect_target = false;
 
             for token in words {
                 let candidate = strip_wrapping_quotes(token).trim();
@@ -1295,10 +1303,33 @@ impl SecurityPolicy {
                     continue;
                 }
 
-                if let Some(target) = redirection_target(candidate) {
-                    if let Some(blocked) = forbidden_candidate(target) {
-                        return Some(blocked);
+                // If the previous token was a bare redirect operator, this
+                // token is the redirect target path.
+                if next_is_redirect_target {
+                    next_is_redirect_target = false;
+                    if !safe_redirect_target(candidate) {
+                        if let Some(blocked) = forbidden_candidate(candidate) {
+                            return Some(blocked);
+                        }
                     }
+                    continue;
+                }
+
+                match parse_redirection(candidate) {
+                    RedirectionParse::Target(target) => {
+                        if !safe_redirect_target(target) {
+                            if let Some(blocked) = forbidden_candidate(target) {
+                                return Some(blocked);
+                            }
+                        }
+                        continue;
+                    }
+                    RedirectionParse::NeedsNextToken => {
+                        next_is_redirect_target = true;
+                        continue;
+                    }
+                    RedirectionParse::FdOnly => continue,
+                    RedirectionParse::None => {}
                 }
 
                 // Handle option assignment forms like `--file=/etc/passwd`.
@@ -2679,6 +2710,44 @@ mod tests {
         );
         assert_eq!(
             p.forbidden_path_argument("cat</etc/passwd"),
+            Some("/etc/passwd".into())
+        );
+    }
+
+    #[test]
+    fn forbidden_path_argument_allows_safe_redirect_targets() {
+        let p = default_policy();
+        // stderr suppression — the most common pattern reported in #5518
+        assert_eq!(p.forbidden_path_argument("ls ./dir 2>/dev/null"), None);
+        // stdout redirect to /dev/null
+        assert_eq!(p.forbidden_path_argument("echo hello >/dev/null"), None);
+        // space-separated redirect
+        assert_eq!(
+            p.forbidden_path_argument("some_cmd > /dev/null 2>&1"),
+            None
+        );
+        // /dev/stdout and /dev/stderr
+        assert_eq!(
+            p.forbidden_path_argument("echo msg >/dev/stdout"),
+            None
+        );
+        assert_eq!(
+            p.forbidden_path_argument("echo err >/dev/stderr"),
+            None
+        );
+        // /dev/zero as input
+        assert_eq!(
+            p.forbidden_path_argument("dd if=/dev/zero of=./out bs=1 count=1"),
+            None
+        );
+        // Unsafe /dev paths should still be blocked
+        assert_eq!(
+            p.forbidden_path_argument("cat </dev/sda"),
+            Some("/dev/sda".into())
+        );
+        // Unsafe redirect targets should still be blocked
+        assert_eq!(
+            p.forbidden_path_argument("echo pwned >/etc/passwd"),
             Some("/etc/passwd".into())
         );
     }


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `forbidden_path_argument()` rejects standard shell redirect targets like `/dev/null`, `/dev/stdout`, `/dev/stderr` because it never consults the existing `safe_redirect_target()` helper before blocking.
- Why it matters: Skill tool commands using idiomatic stderr suppression (`2>/dev/null`) fail with "Path blocked by security policy", breaking common shell patterns.
- What changed: Wired `safe_redirect_target()` into `forbidden_path_argument()` for all three redirect forms (inline `2>/dev/null`, space-separated `> /dev/null`, executable-attached `cat</dev/null`). Replaced `redirection_target()` with `parse_redirection()` to also handle `NeedsNextToken` (bare operator) and `FdOnly` (`2>&1`) cases correctly.
- What did **not** change: No changes to `safe_redirect_target()` itself, no changes to `is_path_allowed()`, no changes to other security policy checks.

## Label Snapshot (required)

- Risk label: `risk: high`
- Size label: `size: S`
- Scope labels: `security`
- Module labels: N/A (security module, no sub-component label)
- Contributor tier label: auto-managed
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `security`

## Linked Issue

- Closes #5518

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --lib -- -D warnings   # pass (0 warnings)
cargo test --lib   # 6040 passed, 0 failed
cargo test --lib security::policy   # 140 passed, 0 failed
```

- Evidence provided: All 10 `forbidden_path_argument_*` tests pass including the new `forbidden_path_argument_allows_safe_redirect_targets` test which covers stderr suppression, stdout redirect, space-separated redirect, /dev/stdout, /dev/stderr, /dev/zero, and ensures unsafe paths like `/dev/sda` and `/etc/passwd` are still blocked.
- If any command is intentionally skipped: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No — only `/dev/null`, `/dev/stdout`, `/dev/stderr`, `/dev/zero` are whitelisted, matching the pre-existing `safe_redirect_target()` helper. All other paths remain blocked.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No user data involved.
- Neutral wording confirmation: Confirmed.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Tested all redirect forms (inline, space-separated, bare operator + next token) with both safe and unsafe targets.
- Edge cases checked: `2>&1` fd-only redirects (should pass through), bare `>` operator followed by `/dev/null`, unsafe redirects like `>/etc/passwd` still blocked, `/dev/sda` still blocked.
- What was not verified: End-to-end skill tool execution in a running daemon.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `security::policy::forbidden_path_argument` — used by skill tool command validation.
- Potential unintended effects: None expected; the change is strictly additive (allowing previously blocked safe paths).
- Guardrails/monitoring: Comprehensive test coverage for all redirect forms ensures no regression.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Identified root cause (missing `safe_redirect_target()` call), implemented fix with proper `parse_redirection()` integration to handle all redirect token forms.
- Verification focus: Ensure unsafe redirects remain blocked while safe /dev/* targets are allowed.
- Confirmation: naming + architecture boundaries followed.

## Rollback Plan (required)

- Fast rollback command/path: Revert this single commit.
- Feature flags or config toggles: None.
- Observable failure symptoms: Skill tool commands with `/dev/null` redirects would fail again.

## Risks and Mitigations

- Risk: Allowing redirect targets that should be blocked.
  - Mitigation: Only the 4 paths already in `safe_redirect_target()` are allowed (`/dev/null`, `/dev/stdout`, `/dev/stderr`, `/dev/zero`). Test confirms `/dev/sda` and `/etc/passwd` remain blocked.