### PR TITLE
fix(telegram): batch media-group images into a single agent request

### DIFF
--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -395,9 +395,7 @@ impl TelegramChannel {
             tts_config: None,
             voice_chats: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
             pending_voice: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-            pending_media_groups: Arc::new(std::sync::Mutex::new(
-                std::collections::HashMap::new(),
-            )),
+            pending_media_groups: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             proxy_url: None,
         }
     }
@@ -1207,10 +1205,7 @@ Allowlist Telegram username (without '@') or numeric user ID.",
     /// Downloads each attachment, concatenates their `[IMAGE:]`/`[Document:]`
     /// markers into one content string, and uses the first message's caption (if
     /// any) as the shared text. Returns `None` if no attachments could be parsed.
-    async fn merge_media_group(
-        &self,
-        updates: &[serde_json::Value],
-    ) -> Option<ChannelMessage> {
+    async fn merge_media_group(&self, updates: &[serde_json::Value]) -> Option<ChannelMessage> {
         if updates.is_empty() {
             return None;
         }
@@ -1264,8 +1259,12 @@ Allowlist Telegram username (without '@') or numeric user ID.",
         let mut shared_caption: Option<String> = None;
 
         for update in updates {
-            let message = update.get("message")?;
-            let attachment = Self::parse_attachment_metadata(message)?;
+            let Some(message) = update.get("message") else {
+                continue;
+            };
+            let Some(attachment) = Self::parse_attachment_metadata(message) else {
+                continue;
+            };
 
             // Check file size limit
             if let Some(size) = attachment.file_size {

--- a/src/channels/telegram.rs
+++ b/src/channels/telegram.rs
@@ -314,6 +314,13 @@ fn parse_attachment_markers(message: &str) -> (String, Vec<TelegramAttachment>) 
 /// Telegram Bot API maximum file download size (20 MB).
 const TELEGRAM_MAX_FILE_DOWNLOAD_BYTES: u64 = 20 * 1024 * 1024;
 
+/// Buffered media-group updates keyed by `media_group_id`.
+type MediaGroupBuffer = Arc<
+    std::sync::Mutex<
+        std::collections::HashMap<String, (Vec<serde_json::Value>, std::time::Instant)>,
+    >,
+>;
+
 /// Telegram channel — long-polls the Bot API for updates
 pub struct TelegramChannel {
     bot_token: String,
@@ -338,6 +345,11 @@ pub struct TelegramChannel {
     voice_chats: Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
     pending_voice:
         Arc<std::sync::Mutex<std::collections::HashMap<String, (String, std::time::Instant)>>>,
+    /// Buffer for Telegram media-group messages (multiple photos/documents sent
+    /// together). Keyed by `media_group_id`; each value holds the accumulated
+    /// updates and the timestamp of the most recent addition so we can flush
+    /// after a short debounce window.
+    pending_media_groups: MediaGroupBuffer,
     /// Per-channel proxy URL override.
     proxy_url: Option<String>,
 }
@@ -383,6 +395,9 @@ impl TelegramChannel {
             tts_config: None,
             voice_chats: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
             pending_voice: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+            pending_media_groups: Arc::new(std::sync::Mutex::new(
+                std::collections::HashMap::new(),
+            )),
             proxy_url: None,
         }
     }
@@ -1160,6 +1175,189 @@ Allowlist Telegram username (without '@') or numeric user ID.",
 
         Some(ChannelMessage {
             id: format!("telegram_{chat_id}_{message_id}"),
+            sender: sender_identity,
+            reply_target,
+            content,
+            channel: "telegram".to_string(),
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
+            thread_ts: thread_id,
+            interruption_scope_id: None,
+            attachments: vec![],
+        })
+    }
+
+    /// Extract the `media_group_id` from a Telegram update, if present.
+    ///
+    /// Telegram assigns a shared `media_group_id` to all messages that belong to
+    /// the same album (multiple photos/documents sent together). Returns `None`
+    /// for single-attachment or text messages.
+    fn extract_media_group_id(update: &serde_json::Value) -> Option<String> {
+        update
+            .get("message")
+            .and_then(|m| m.get("media_group_id"))
+            .and_then(serde_json::Value::as_str)
+            .map(String::from)
+    }
+
+    /// Merge a set of buffered media-group updates into a single `ChannelMessage`.
+    ///
+    /// Downloads each attachment, concatenates their `[IMAGE:]`/`[Document:]`
+    /// markers into one content string, and uses the first message's caption (if
+    /// any) as the shared text. Returns `None` if no attachments could be parsed.
+    async fn merge_media_group(
+        &self,
+        updates: &[serde_json::Value],
+    ) -> Option<ChannelMessage> {
+        if updates.is_empty() {
+            return None;
+        }
+
+        // Use the first update for chat/sender metadata.
+        let first_message = updates[0].get("message")?;
+        let (username, sender_id, sender_identity) = Self::extract_sender_info(first_message);
+
+        let mut identities = vec![username.as_str()];
+        if let Some(id) = sender_id.as_deref() {
+            identities.push(id);
+        }
+        if !self.is_any_user_allowed(identities.iter().copied()) {
+            return None;
+        }
+
+        let chat_id = first_message
+            .get("chat")
+            .and_then(|chat| chat.get("id"))
+            .and_then(serde_json::Value::as_i64)
+            .map(|id| id.to_string())?;
+
+        let first_message_id = first_message
+            .get("message_id")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0);
+
+        let thread_id = first_message
+            .get("message_thread_id")
+            .and_then(serde_json::Value::as_i64)
+            .map(|id| id.to_string());
+
+        let reply_target = if let Some(ref tid) = thread_id {
+            format!("{}:{}", chat_id, tid)
+        } else {
+            chat_id.clone()
+        };
+
+        let workspace = self.workspace_dir.as_ref().or_else(|| {
+            tracing::warn!("Cannot save attachment: workspace_dir not configured");
+            None
+        })?;
+
+        let save_dir = workspace.join("telegram_files");
+        if let Err(e) = tokio::fs::create_dir_all(&save_dir).await {
+            tracing::warn!("Failed to create telegram_files directory: {e}");
+            return None;
+        }
+
+        let mut content_parts: Vec<String> = Vec::new();
+        let mut shared_caption: Option<String> = None;
+
+        for update in updates {
+            let message = update.get("message")?;
+            let attachment = Self::parse_attachment_metadata(message)?;
+
+            // Check file size limit
+            if let Some(size) = attachment.file_size {
+                if size > TELEGRAM_MAX_FILE_DOWNLOAD_BYTES {
+                    tracing::info!(
+                        "Skipping media-group attachment: file size {size} bytes exceeds limit"
+                    );
+                    continue;
+                }
+            }
+
+            // Capture the first non-empty caption as the shared caption
+            if shared_caption.is_none() {
+                if let Some(ref cap) = attachment.caption {
+                    if !cap.is_empty() {
+                        shared_caption = Some(cap.clone());
+                    }
+                }
+            }
+
+            let message_id = message
+                .get("message_id")
+                .and_then(serde_json::Value::as_i64)
+                .unwrap_or(0);
+
+            let tg_file_path = match self.get_file_path(&attachment.file_id).await {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!("Failed to get media-group file path: {e}");
+                    continue;
+                }
+            };
+
+            let file_data = match self.download_file(&tg_file_path).await {
+                Ok(d) => d,
+                Err(e) => {
+                    tracing::warn!("Failed to download media-group attachment: {e}");
+                    continue;
+                }
+            };
+
+            let local_filename = match &attachment.file_name {
+                Some(name) => name.clone(),
+                None => {
+                    let ext = tg_file_path.rsplit('.').next().unwrap_or("jpg");
+                    format!("photo_{chat_id}_{message_id}.{ext}")
+                }
+            };
+
+            let local_path = save_dir.join(&local_filename);
+            if let Err(e) = tokio::fs::write(&local_path, &file_data).await {
+                tracing::warn!(
+                    "Failed to save media-group attachment to {}: {e}",
+                    local_path.display()
+                );
+                continue;
+            }
+
+            content_parts.push(format_attachment_content(
+                attachment.kind,
+                &local_filename,
+                &local_path,
+            ));
+        }
+
+        if content_parts.is_empty() {
+            return None;
+        }
+
+        let mut content = content_parts.join("\n");
+
+        if let Some(caption) = shared_caption {
+            use std::fmt::Write;
+            let _ = write!(content, "\n\n{caption}");
+        }
+
+        // Prepend reply context from first message
+        if let Some(quote) = self.extract_reply_context(first_message) {
+            content = format!("{quote}\n\n{content}");
+        }
+
+        if let Some(attr) = Self::format_forward_attribution(first_message) {
+            content = format!("{attr}{content}");
+        }
+
+        tracing::info!(
+            "Merged media group with {} attachments for chat {chat_id}",
+            content_parts.len()
+        );
+
+        Some(ChannelMessage {
+            id: format!("telegram_{chat_id}_{first_message_id}"),
             sender: sender_identity,
             reply_target,
             content,
@@ -2910,10 +3108,32 @@ Ensure only one `zeroclaw` process is using this bot token."
             }
 
             if let Some(results) = data.get("result").and_then(serde_json::Value::as_array) {
+                // Track which media_group_ids we saw in this batch so we
+                // can flush them after all updates are processed.
+                let mut batch_media_group_ids: Vec<String> = Vec::new();
+
                 for update in results {
                     // Advance offset past this update
                     if let Some(uid) = update.get("update_id").and_then(serde_json::Value::as_i64) {
                         offset = uid + 1;
+                    }
+
+                    // If this update belongs to a media group (album),
+                    // buffer it instead of dispatching immediately. All
+                    // members of the group will be merged into a single
+                    // ChannelMessage once the batch is complete.
+                    if let Some(mg_id) = Self::extract_media_group_id(update) {
+                        if let Ok(mut groups) = self.pending_media_groups.lock() {
+                            let entry = groups
+                                .entry(mg_id.clone())
+                                .or_insert_with(|| (Vec::new(), std::time::Instant::now()));
+                            entry.0.push(update.clone());
+                            entry.1 = std::time::Instant::now();
+                        }
+                        if !batch_media_group_ids.contains(&mg_id) {
+                            batch_media_group_ids.push(mg_id);
+                        }
+                        continue;
                     }
 
                     let msg = if let Some(m) = self.parse_update_message(update) {
@@ -2953,6 +3173,56 @@ Ensure only one `zeroclaw` process is using this bot token."
                     if tx.send(msg).await.is_err() {
                         return Ok(());
                     }
+                }
+
+                // Flush completed media groups from this batch.
+                // Telegram delivers all album members in a single
+                // getUpdates response, so every group ID we saw in this
+                // batch is complete.
+                for mg_id in &batch_media_group_ids {
+                    let updates_buf = if let Ok(mut groups) = self.pending_media_groups.lock() {
+                        groups.remove(mg_id).map(|(v, _)| v)
+                    } else {
+                        None
+                    };
+
+                    if let Some(buf) = updates_buf {
+                        if let Some(msg) = self.merge_media_group(&buf).await {
+                            if self.ack_reactions {
+                                // Send ack reaction for the first message in the group
+                                if let Some((reaction_chat_id, reaction_message_id)) =
+                                    Self::extract_update_message_target(&buf[0])
+                                {
+                                    self.try_add_ack_reaction_nonblocking(
+                                        reaction_chat_id,
+                                        reaction_message_id,
+                                    );
+                                }
+                            }
+
+                            let typing_body = serde_json::json!({
+                                "chat_id": &msg.reply_target,
+                                "action": "typing"
+                            });
+                            let _ = self
+                                .http_client()
+                                .post(self.api_url("sendChatAction"))
+                                .json(&typing_body)
+                                .send()
+                                .await;
+
+                            if tx.send(msg).await.is_err() {
+                                return Ok(());
+                            }
+                        }
+                    }
+                }
+
+                // Evict stale media groups that were never completed
+                // (e.g. partial delivery edge case). Anything older than
+                // 30 seconds is discarded.
+                if let Ok(mut groups) = self.pending_media_groups.lock() {
+                    groups.retain(|_, (_, ts)| ts.elapsed().as_secs() < 30);
                 }
             }
         }
@@ -4639,6 +4909,51 @@ mod tests {
     #[test]
     fn telegram_max_file_download_bytes_is_20mb() {
         assert_eq!(TELEGRAM_MAX_FILE_DOWNLOAD_BYTES, 20 * 1024 * 1024);
+    }
+
+    // ── Media group batching tests ──────────────────────────────
+
+    #[test]
+    fn extract_media_group_id_present() {
+        let update = serde_json::json!({
+            "update_id": 100,
+            "message": {
+                "message_id": 1,
+                "media_group_id": "12345678901234567",
+                "photo": [{"file_id": "abc", "width": 100, "height": 100}],
+                "chat": {"id": 42}
+            }
+        });
+        assert_eq!(
+            TelegramChannel::extract_media_group_id(&update),
+            Some("12345678901234567".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_media_group_id_absent_for_single_photo() {
+        let update = serde_json::json!({
+            "update_id": 100,
+            "message": {
+                "message_id": 1,
+                "photo": [{"file_id": "abc", "width": 100, "height": 100}],
+                "chat": {"id": 42}
+            }
+        });
+        assert_eq!(TelegramChannel::extract_media_group_id(&update), None);
+    }
+
+    #[test]
+    fn extract_media_group_id_absent_for_text() {
+        let update = serde_json::json!({
+            "update_id": 100,
+            "message": {
+                "message_id": 1,
+                "text": "hello",
+                "chat": {"id": 42}
+            }
+        });
+        assert_eq!(TelegramChannel::extract_media_group_id(&update), None);
     }
 
     // ── Attachment content format tests ──────────────────────────────


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: When multiple images are sent as an album on Telegram, each arrives as a separate update. The bot processes each independently, causing N separate agent requests where each subsequent request accumulates all prior images in conversation history (1 + 2 + ... + N images processed total).
- Why it matters: Compounding API costs (10 images = 55 image processings), duplicate/fragmented agent responses, and poor user experience.
- What changed: Added media-group buffering in the Telegram polling loop. Updates with a shared `media_group_id` are accumulated during each poll batch, then merged into a single `ChannelMessage` with all `[IMAGE:]` markers concatenated. Added `MediaGroupBuffer` type alias, `extract_media_group_id()` and `merge_media_group()` helper methods, and stale-group eviction (30s timeout).
- What did **not** change: Single-image messages are unaffected. The multimodal pipeline's `max_images` limit still applies. No changes to attachment downloading, file storage, or the `[IMAGE:]` marker format.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: M`
- Scope labels: `channel`
- Module labels: `channel: telegram`
- Contributor tier label: auto-managed
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #5514

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --lib -- -D warnings   # pass (0 warnings)
cargo test --lib   # 6042 passed, 0 failed
cargo test --lib channels::telegram   # 152 passed, 0 failed
```

- Evidence provided: 3 new unit tests for `extract_media_group_id` covering media-group present, absent for single photo, and absent for text messages. All 152 existing telegram tests continue to pass.
- If any command is intentionally skipped: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No user data involved in code changes.
- Neutral wording confirmation: Confirmed.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Unit tests for media_group_id extraction. Code review of buffering logic, merge logic, and stale eviction.
- Edge cases checked: Empty media groups, single-photo messages (no media_group_id), stale group eviction after 30s, caption carried from first image in group.
- What was not verified: End-to-end Telegram album sending with a live bot.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Telegram channel polling loop, attachment message processing.
- Potential unintended effects: If Telegram splits a media group across two separate `getUpdates` responses (rare edge case), the group would be flushed when the first batch completes, then the remaining images would form a separate smaller group. The 30s stale eviction handles orphaned groups.
- Guardrails/monitoring: `tracing::info` log when media group is merged with attachment count.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Analyzed the Telegram polling loop, identified that `media_group_id` was never checked, implemented buffering pattern similar to existing `pending_voice` approach.
- Verification focus: Ensure single-image messages are unaffected, media groups are correctly merged, stale groups are evicted.
- Confirmation: naming + architecture boundaries followed.

## Rollback Plan (required)

- Fast rollback command/path: Revert this single commit.
- Feature flags or config toggles: None.
- Observable failure symptoms: Multiple agent responses for album sends (original behavior returns).

## Risks and Mitigations

- Risk: Media group split across two getUpdates responses causes partial flush.
  - Mitigation: Stale group eviction (30s) ensures orphaned buffers are cleaned up. In practice, Telegram delivers all album members in a single response.
- Risk: Memory accumulation from buffered updates.
  - Mitigation: 30s eviction timeout prevents unbounded growth. Each buffer entry holds only the JSON updates (small).