### PR TITLE
feat(channel): propagate sender user ID into channel system prompt

### DIFF
--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -639,6 +639,7 @@ fn build_channel_system_prompt(
     base_prompt: &str,
     channel_name: &str,
     reply_target: &str,
+    sender: &str,
 ) -> String {
     let mut prompt = base_prompt.to_string();
 
@@ -672,7 +673,10 @@ fn build_channel_system_prompt(
     if !reply_target.is_empty() {
         let context = format!(
             "\n\nChannel context: You are currently responding on channel={channel_name}, \
-             reply_target={reply_target}. When scheduling delayed messages or reminders \
+             reply_target={reply_target}, sender={sender}. \
+             The sender field is the platform-specific user ID of the person who sent \
+             this message. Use it to distinguish between different users. \
+             When scheduling delayed messages or reminders \
              via cron_add for this conversation, use delivery={{\"mode\":\"announce\",\
              \"channel\":\"{channel_name}\",\"to\":\"{reply_target}\"}} so the message \
              reaches the user."
@@ -2737,8 +2741,12 @@ async fn process_channel_message(
     } else {
         refreshed_new_session_system_prompt(ctx.as_ref())
     };
-    let mut system_prompt =
-        build_channel_system_prompt(&base_system_prompt, &msg.channel, &msg.reply_target);
+    let mut system_prompt = build_channel_system_prompt(
+        &base_system_prompt,
+        &msg.channel,
+        &msg.reply_target,
+        &msg.sender,
+    );
     if !memory_context.is_empty() {
         let _ = write!(system_prompt, "\n\n{memory_context}");
     }
@@ -11818,5 +11826,34 @@ This is an example JSON object for profile settings."#;
     fn default_keep_tool_context_turns_is_two() {
         let config = crate::config::schema::AgentConfig::default();
         assert_eq!(config.keep_tool_context_turns, 2);
+    }
+
+    #[test]
+    fn build_channel_system_prompt_includes_sender_id() {
+        let prompt = build_channel_system_prompt(
+            "You are a helpful assistant.",
+            "mattermost",
+            "channel123:root456",
+            "user_abc123",
+        );
+        assert!(prompt.contains("sender=user_abc123"));
+        assert!(prompt.contains("channel=mattermost"));
+        assert!(prompt.contains("reply_target=channel123:root456"));
+    }
+
+    #[test]
+    fn build_channel_system_prompt_omits_context_when_reply_target_empty() {
+        let prompt = build_channel_system_prompt("Base prompt.", "mattermost", "", "user_abc123");
+        assert!(!prompt.contains("sender="));
+        assert!(!prompt.contains("Channel context:"));
+    }
+
+    #[test]
+    fn build_channel_system_prompt_sender_distinguishes_users() {
+        let prompt_a = build_channel_system_prompt("Base.", "mattermost", "ch:thread", "user_aaa");
+        let prompt_b = build_channel_system_prompt("Base.", "mattermost", "ch:thread", "user_bbb");
+        assert!(prompt_a.contains("sender=user_aaa"));
+        assert!(prompt_b.contains("sender=user_bbb"));
+        assert_ne!(prompt_a, prompt_b);
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): master
- Problem: Mattermost sender IDs are available in runtime, but they are not propagated into the channel system prompt, so the model can distinguish channels/threads but not the user who addressed the bot.
- Why it matters: Future RBAC and user-scoped behavior need the bot to distinguish one Mattermost user from another by internal platform ID.
- What changed: Added `sender` to the channel system prompt context, passed `msg.sender` at prompt build time, and added regression tests plus a live Mattermost verification.
- What did **not** change (scope boundary): No Mattermost discovery/polling/listener scoping changes, no config contract changes for this feature, no reply routing changes, and no unrelated architectural expansion.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): risk: medium
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): auto
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): channel,tests
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): channel: mattermost
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): feature
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): channel

## Linked Issue

- Closes #N/A
- Related #N/A
- Depends #N/A
- Supersedes #N/A

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): No
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): not superseding any PR
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): Pass

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
CARGO_BUILD_JOBS=1 cargo clippy --all-targets -- -D warnings
CARGO_BUILD_JOBS=1 cargo test
cargo build --release
```

- Evidence provided (test/log/trace/screenshot/perf): local command output; targeted unit tests for prompt construction; live Mattermost DM verification against the local debug daemon
- If any command is intentionally skipped, explain why: none

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: platform-specific sender IDs are now intentionally included in model prompt context for channel runs; no tokens or additional profile fields are injected; live-test secrets are not included in repo changes or PR text
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: coding agent sent a live Mattermost DM to the bot from user `nhkmck65yf8tir6p618b1wac1y`; the bot replied with that exact sender ID; human repeated with a second prompt and received the same correct ID
- Edge cases checked: prompt includes `sender=` when `reply_target` is present; prompt omits channel context when `reply_target` is empty; different senders produce different prompts
- What was not verified: provider-specific downstream handling of sender IDs outside the tested Mattermost flow; behavior on every non-Mattermost channel integration

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: channel system prompt construction; channel-driven LLM runs where `reply_target` is present; Mattermost runtime behavior verified live
- Potential unintended effects: models may reference sender IDs more explicitly in replies; prompt context changed for other channel integrations that use the same helper
- Guardrails/monitoring for early detection: focused unit tests on prompt content and live Mattermost verification against the local daemon

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): repository search/read tools, terminal validation, browser inspection, Mattermost API workflow for live verification
- Workflow/plan summary (if any): traced Mattermost message flow, confirmed `msg.sender` already existed in runtime, patched prompt construction at the root cause, added regression tests, ran full local validation, then verified live in Mattermost
- Verification focus: sender ID propagation into prompt and observable bot behavior in Mattermost
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: revert commit `11da7df1`
- Feature flags or config toggles (if any): none
- Observable failure symptoms: channel replies unexpectedly mention sender IDs, or prompt-sensitive behavior changes in channel conversations

## Risks and Mitigations

- Risk: prompt contract changed for channel runs that include `reply_target`, not just Mattermost
- Mitigation: kept the change minimal and localized to the existing context block; added regression tests that pin the new behavior

- Risk: platform user IDs are now forwarded to the model provider as part of prompt context
- Mitigation: only the existing platform sender ID is added, with no secrets or extra profile metadata; this is required for user distinction and future RBAC work