### PR TITLE
fix(delegate): use namespaced memory tools for agentic sub-agents

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -15,6 +15,11 @@ use zeroclaw_api::tool::{Tool, ToolResult};
 use zeroclaw_config::schema::{DelegateAgentConfig, DelegateToolConfig};
 use zeroclaw_memory::{Memory, NamespacedMemory};
 use zeroclaw_providers::{self, ChatMessage, Provider};
+use zeroclaw_tools::memory_export::MemoryExportTool;
+use zeroclaw_tools::memory_forget::MemoryForgetTool;
+use zeroclaw_tools::memory_purge::MemoryPurgeTool;
+use zeroclaw_tools::memory_recall::MemoryRecallTool;
+use zeroclaw_tools::memory_store::MemoryStoreTool;
 
 /// Fallback temperature for sub-agent tool loops when the delegate config
 /// leaves it unset; matches the longstanding agentic default that balances
@@ -209,7 +214,6 @@ impl DelegateTool {
     /// Wrap memory with namespace isolation if configured for the given agent.
     /// Returns the namespaced memory if memory_namespace is set, otherwise returns
     /// the original memory.
-    #[allow(dead_code)] // WIP: will be used when delegate agents support memory
     fn get_agent_memory(&self, agent_config: &DelegateAgentConfig) -> Option<Arc<dyn Memory>> {
         self.memory.as_ref().map(|mem| {
             if let Some(namespace) = &agent_config.memory_namespace {
@@ -218,6 +222,53 @@ impl DelegateTool {
                 mem.clone()
             }
         })
+    }
+
+    /// Build the effective tool registry for an agentic sub-agent.
+    ///
+    /// Most tools can safely reuse the parent/root tool instances. Memory tools
+    /// are special because delegate agents may have a `memory_namespace`; those
+    /// tools must be rebuilt against the namespaced memory wrapper so stores and
+    /// recalls are isolated per agent.
+    fn build_agentic_sub_tools(
+        &self,
+        agent_config: &DelegateAgentConfig,
+        allowed: &std::collections::HashSet<&str>,
+    ) -> Vec<Box<dyn Tool>> {
+        let agent_memory = self.get_agent_memory(agent_config);
+        let parent_tools = self.parent_tools.read();
+        parent_tools
+            .iter()
+            .filter(|tool| allowed.contains(tool.name()))
+            .filter(|tool| tool.name() != "delegate")
+            .map(|tool| {
+                if let Some(memory) = agent_memory.as_ref() {
+                    match tool.name() {
+                        "memory_store" => {
+                            Box::new(MemoryStoreTool::new(memory.clone(), self.security.clone()))
+                                as Box<dyn Tool>
+                        }
+                        "memory_recall" => {
+                            Box::new(MemoryRecallTool::new(memory.clone())) as Box<dyn Tool>
+                        }
+                        "memory_forget" => {
+                            Box::new(MemoryForgetTool::new(memory.clone(), self.security.clone()))
+                                as Box<dyn Tool>
+                        }
+                        "memory_export" => {
+                            Box::new(MemoryExportTool::new(memory.clone())) as Box<dyn Tool>
+                        }
+                        "memory_purge" => {
+                            Box::new(MemoryPurgeTool::new(memory.clone(), self.security.clone()))
+                                as Box<dyn Tool>
+                        }
+                        _ => Box::new(ToolArcRef::new(tool.clone())) as Box<dyn Tool>,
+                    }
+                } else {
+                    Box::new(ToolArcRef::new(tool.clone())) as Box<dyn Tool>
+                }
+            })
+            .collect()
     }
 
     /// Directory where background delegate results are stored.
@@ -1117,15 +1168,7 @@ impl DelegateTool {
             .filter(|name| !name.is_empty())
             .collect::<std::collections::HashSet<_>>();
 
-        let sub_tools: Vec<Box<dyn Tool>> = {
-            let parent_tools = self.parent_tools.read();
-            parent_tools
-                .iter()
-                .filter(|tool| allowed.contains(tool.name()))
-                .filter(|tool| tool.name() != "delegate")
-                .map(|tool| Box::new(ToolArcRef::new(tool.clone())) as Box<dyn Tool>)
-                .collect()
-        };
+        let sub_tools = self.build_agentic_sub_tools(agent_config, &allowed);
 
         if sub_tools.is_empty() {
             return Ok(ToolResult {
@@ -1918,6 +1961,118 @@ mod tests {
                 .as_deref()
                 .unwrap_or("")
                 .contains("provider boom")
+        );
+    }
+
+    struct MemoryStoreRecallThenFinalProvider;
+
+    #[async_trait]
+    impl Provider for MemoryStoreRecallThenFinalProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            Ok("unused".to_string())
+        }
+
+        async fn chat(
+            &self,
+            request: ChatRequest<'_>,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<ChatResponse> {
+            let tool_messages = request.messages.iter().filter(|m| m.role == "tool").count();
+            match tool_messages {
+                0 => Ok(ChatResponse {
+                    text: None,
+                    tool_calls: vec![ToolCall {
+                        id: "call_store".to_string(),
+                        name: "memory_store".to_string(),
+                        arguments: "{\"key\":\"delegate-memory-test\",\"content\":\"stored by namespaced delegate\",\"category\":\"core\"}".to_string(),
+                    }],
+                    usage: None,
+                    reasoning_content: None,
+                }),
+                1 => Ok(ChatResponse {
+                    text: None,
+                    tool_calls: vec![ToolCall {
+                        id: "call_recall".to_string(),
+                        name: "memory_recall".to_string(),
+                        arguments: "{\"query\":\"delegate-memory-test\",\"limit\":5}".to_string(),
+                    }],
+                    usage: None,
+                    reasoning_content: None,
+                }),
+                _ => Ok(ChatResponse {
+                    text: Some("memory complete".to_string()),
+                    tool_calls: Vec::new(),
+                    usage: None,
+                    reasoning_content: None,
+                }),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_agentic_memory_tools_use_delegate_namespace() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let memory: Arc<dyn Memory> =
+            Arc::new(zeroclaw_memory::SqliteMemory::new(temp_dir.path()).unwrap());
+        let security = test_security();
+
+        let config = DelegateAgentConfig {
+            provider: "openrouter".to_string(),
+            model: "model-test".to_string(),
+            system_prompt: Some("You are agentic.".to_string()),
+            api_key: Some("delegate-test-credential".to_string()),
+            temperature: Some(0.2),
+            max_depth: 3,
+            agentic: true,
+            allowed_tools: vec!["memory_store".to_string(), "memory_recall".to_string()],
+            max_iterations: 10,
+            timeout_secs: None,
+            agentic_timeout_secs: None,
+            skills_directory: None,
+            memory_namespace: Some("test-agent-ns".to_string()),
+        };
+
+        let tool = DelegateTool::new(HashMap::new(), None, security.clone())
+            .with_parent_tools(Arc::new(RwLock::new(vec![
+                Arc::new(MemoryStoreTool::new(memory.clone(), security.clone())),
+                Arc::new(MemoryRecallTool::new(memory.clone())),
+            ])))
+            .with_memory(memory.clone());
+
+        let provider = MemoryStoreRecallThenFinalProvider;
+        let result = tool
+            .execute_agentic("agentic", &config, &provider, "run", 0.2)
+            .await
+            .unwrap();
+
+        assert!(result.success, "Expected success, got: {:?}", result.error);
+        assert!(result.output.contains("memory complete"));
+
+        let namespaced_results = memory
+            .recall_namespaced("test-agent-ns", "delegate-memory-test", 5, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(namespaced_results.len(), 1);
+        assert_eq!(
+            namespaced_results[0].content,
+            "stored by namespaced delegate"
+        );
+
+        let default_results = memory
+            .recall_namespaced("default", "delegate-memory-test", 5, None, None, None)
+            .await
+            .unwrap();
+        assert!(
+            default_results.is_empty(),
+            "expected no default-namespace memories, got {}",
+            default_results.len()
         );
     }
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: agentic delegate sub-agents reused the parent memory tool instances, so `memory_namespace` was ignored for `memory_store`/`memory_recall` and writes landed in the root namespace.
- Why it matters: delegate workers cannot safely isolate memory per agent if memory tools bypass the namespaced wrapper.
- What changed: rebuild memory-related sub-agent tools against `get_agent_memory(agent_config)` in the agentic delegate path and add a regression test covering namespaced store+recall.
- What did **not** change (scope boundary): no config-schema changes, no non-memory delegate tool behavior changes, no gateway/API changes.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: high`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): expected `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `memory,tool,tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `tool: delegate`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `memory`

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all --check
./scripts/ci/rust_quality_gate.sh
cargo test execute_agentic_memory_tools_use_delegate_namespace --lib
cargo test execute_agentic_runs_tool_call_loop_with_filtered_tools --lib
cargo test mcp_tools_included_in_subagent_tool_list --lib
```

- Evidence provided (test/log/trace/screenshot/perf): new unit test verifies the stored row is present in `test-agent-ns` and absent from `default`; additionally validated in a live Azaris-managed ZeroClaw runtime by comparing unpatched vs patched images.
- If any command is intentionally skipped, explain why: full `cargo test --locked` was not rerun because the change is localized to delegate memory tool wiring; targeted delegate tests plus the repo quality gate and live runtime repro were used instead.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: test data uses project-scoped synthetic keys and content.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: agentic delegate with `memory_namespace` can call `memory_store` and `memory_recall`; namespaced memory is persisted in the delegate namespace instead of `default`; existing filtered-tool and MCP sub-agent tests still pass.
- Edge cases checked: delegate path still excludes recursive `delegate`; non-memory tools still reuse parent tool registry; no default-namespace leak for the regression test key.
- What was not verified: non-agentic delegates (not relevant because they do not run a tool loop), full repository test matrix.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: agentic delegate tool registry construction for memory-related tools.
- Potential unintended effects: memory tool construction now differs from the rest of the sub-tool registry when `memory_namespace` is configured.
- Guardrails/monitoring for early detection: regression test covers namespaced store+recall and existing delegate/MCP tool-list tests still pass.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): local git/cargo tooling, live Kubernetes/Azaris runtime validation.
- Workflow/plan summary (if any): reproduced the namespace issue in a live managed runtime, traced delegate tool wiring, patched only memory tool construction, then validated both locally and in-cluster.
- Verification focus: persisted namespace correctness, not just model-reported tool output.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed.

## Rollback Plan (required)

- Fast rollback command/path: revert this commit or restore the previous `execute_agentic()` sub-tool construction that wraps parent tool arcs directly.
- Feature flags or config toggles (if any): none.
- Observable failure symptoms: delegate sub-agent memories stop appearing under the configured namespace or memory tools fail inside agentic delegates.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: rebuilding memory tools for agentic delegates could drift from parent tool initialization if those constructors gain new required behavior.
  - Mitigation: the change is limited to the five memory tools, uses the same constructors as the root tool registry, and has regression coverage for namespaced store+recall plus existing delegate tool-loop tests.
