### PR TITLE
fix(providers): add tool name to native messages for Groq compatibility

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -2934,7 +2934,7 @@ pub(crate) async fn run_tool_call_loop(
         // When multiple tool calls are present and interactive CLI approval is not needed, run
         // tool executions concurrently for lower wall-clock latency.
         let mut tool_results = String::new();
-        let mut individual_results: Vec<(Option<String>, String)> = Vec::new();
+        let mut individual_results: Vec<(String, Option<String>, String)> = Vec::new();
         let mut ordered_results: Vec<Option<(String, Option<String>, ToolExecutionOutcome)>> =
             (0..tool_calls.len()).map(|_| None).collect();
         let allow_parallel_execution = should_execute_tools_in_parallel(&tool_calls, approval);
@@ -3284,7 +3284,7 @@ pub(crate) async fn run_tool_call_loop(
                 }
             }
             let result_output = truncate_tool_result(&outcome.output, max_tool_result_chars);
-            individual_results.push((tool_call_id, result_output.clone()));
+            individual_results.push((tool_name.clone(), tool_call_id, result_output.clone()));
             let _ = writeln!(
                 tool_results,
                 "<tool_result name=\"{}\">\n{}\n</tool_result>",
@@ -3349,11 +3349,12 @@ pub(crate) async fn run_tool_call_loop(
                 && !individual_results.is_empty()
                 && individual_results
                     .iter()
-                    .all(|(tool_call_id, _)| tool_call_id.is_some());
+                    .all(|(_, tool_call_id, _)| tool_call_id.is_some());
             if all_results_have_ids {
-                for (tool_call_id, result) in &individual_results {
+                for (name, tool_call_id, result) in &individual_results {
                     let tool_msg = serde_json::json!({
                         "tool_call_id": tool_call_id,
+                        "name": name,
                         "content": result,
                     });
                     history.push(ChatMessage::tool(tool_msg.to_string()));
@@ -3362,11 +3363,12 @@ pub(crate) async fn run_tool_call_loop(
                 history.push(ChatMessage::user(format!("[Tool results]\n{tool_results}")));
             }
         } else {
-            for (native_call, (_, result)) in
+            for (native_call, (name, _, result)) in
                 native_tool_calls.iter().zip(individual_results.iter())
             {
                 let tool_msg = serde_json::json!({
                     "tool_call_id": native_call.id,
+                    "name": name,
                     "content": result,
                 });
                 history.push(ChatMessage::tool(tool_msg.to_string()));

--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -727,6 +727,8 @@ struct NativeMessage {
     #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<MessageContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     tool_call_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_calls: Option<Vec<ToolCall>>,
@@ -1519,6 +1521,7 @@ impl OpenAiCompatibleProvider {
                                 return NativeMessage {
                                     role: "assistant".to_string(),
                                     content,
+                                    name: None,
                                     tool_call_id: None,
                                     tool_calls: Some(tool_calls),
                                     reasoning_content,
@@ -1534,15 +1537,43 @@ impl OpenAiCompatibleProvider {
                             .get("tool_call_id")
                             .and_then(serde_json::Value::as_str)
                             .map(ToString::to_string);
+                        let name = value
+                            .get("name")
+                            .and_then(serde_json::Value::as_str)
+                            .map(ToString::to_string);
                         let content = value
                             .get("content")
                             .and_then(serde_json::Value::as_str)
                             .map(|value| MessageContent::Text(value.to_string()))
                             .or_else(|| Some(MessageContent::Text(message.content.clone())));
 
+                        // If tool_call_id is missing (e.g., truncation corrupted
+                        // the JSON), fall back to a user message to avoid API
+                        // errors from providers that require tool_call_id.
+                        if tool_call_id.is_none() {
+                            let text = content
+                                .as_ref()
+                                .map(|c| match c {
+                                    MessageContent::Text(t) => t.clone(),
+                                    MessageContent::Parts(_) => message.content.clone(),
+                                })
+                                .unwrap_or_else(|| message.content.clone());
+                            return NativeMessage {
+                                role: "user".to_string(),
+                                content: Some(MessageContent::Text(
+                                    format!("[Tool result] {text}")
+                                )),
+                                name: None,
+                                tool_call_id: None,
+                                tool_calls: None,
+                                reasoning_content: None,
+                            };
+                        }
+
                         return NativeMessage {
                             role: "tool".to_string(),
                             content,
+                            name,
                             tool_call_id,
                             tool_calls: None,
                             reasoning_content: None,
@@ -1550,13 +1581,22 @@ impl OpenAiCompatibleProvider {
                     }
                 }
 
+                // If a role:tool message fell through (JSON parse failed,
+                // e.g., truncation broke the JSON), convert to role:user to
+                // avoid sending tool messages without tool_call_id.
+                let role = if message.role == "tool" { "user" } else { &message.role };
                 NativeMessage {
-                    role: message.role.clone(),
+                    role: role.to_string(),
                     content: Some(Self::to_message_content(
-                        &message.role,
-                        &message.content,
+                        role,
+                        &if message.role == "tool" {
+                            format!("[Tool result] {}", message.content)
+                        } else {
+                            message.content.clone()
+                        },
                         allow_user_image_parts,
                     )),
+                    name: None,
                     tool_call_id: None,
                     tool_calls: None,
                     reasoning_content: None,
@@ -3062,9 +3102,80 @@ mod tests {
         assert_eq!(converted.len(), 1);
         assert_eq!(converted[0].role, "tool");
         assert_eq!(converted[0].tool_call_id.as_deref(), Some("call_abc"));
+        assert!(converted[0].name.is_none());
         assert!(matches!(
             converted[0].content.as_ref(),
             Some(MessageContent::Text(value)) if value == "done"
+        ));
+    }
+
+    #[test]
+    fn convert_messages_for_native_extracts_tool_name() {
+        let input = vec![ChatMessage::tool(
+            r#"{"tool_call_id":"call_abc","name":"shell","content":"ok"}"#,
+        )];
+
+        let converted = OpenAiCompatibleProvider::convert_messages_for_native(&input, true);
+        assert_eq!(converted.len(), 1);
+        assert_eq!(converted[0].role, "tool");
+        assert_eq!(converted[0].name.as_deref(), Some("shell"));
+        assert_eq!(converted[0].tool_call_id.as_deref(), Some("call_abc"));
+    }
+
+    #[test]
+    fn convert_messages_for_native_tool_name_serialized_when_present() {
+        let msg = NativeMessage {
+            role: "tool".to_string(),
+            content: Some(MessageContent::Text("ok".to_string())),
+            name: Some("shell".to_string()),
+            tool_call_id: Some("call_1".to_string()),
+            tool_calls: None,
+            reasoning_content: None,
+        };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(
+            json.contains(r#""name":"shell""#),
+            "name should be serialized"
+        );
+
+        let msg_no_name = NativeMessage {
+            role: "tool".to_string(),
+            content: Some(MessageContent::Text("ok".to_string())),
+            name: None,
+            tool_call_id: Some("call_1".to_string()),
+            tool_calls: None,
+            reasoning_content: None,
+        };
+        let json = serde_json::to_string(&msg_no_name).unwrap();
+        assert!(!json.contains("name"), "name should be omitted when None");
+    }
+
+    #[test]
+    fn convert_messages_for_native_missing_tool_call_id_falls_back_to_user() {
+        // Tool message with content but no tool_call_id
+        let input = vec![ChatMessage::tool(r#"{"content":"some result"}"#)];
+
+        let converted = OpenAiCompatibleProvider::convert_messages_for_native(&input, true);
+        assert_eq!(converted.len(), 1);
+        assert_eq!(converted[0].role, "user");
+        assert!(converted[0].tool_call_id.is_none());
+        assert!(matches!(
+            converted[0].content.as_ref(),
+            Some(MessageContent::Text(value)) if value.contains("[Tool result]")
+        ));
+    }
+
+    #[test]
+    fn convert_messages_for_native_unparseable_tool_falls_back_to_user() {
+        // Tool message with non-JSON content (e.g., truncation broke the JSON)
+        let input = vec![ChatMessage::tool("this is not json")];
+
+        let converted = OpenAiCompatibleProvider::convert_messages_for_native(&input, true);
+        assert_eq!(converted.len(), 1);
+        assert_eq!(converted[0].role, "user");
+        assert!(matches!(
+            converted[0].content.as_ref(),
+            Some(MessageContent::Text(value)) if value.contains("[Tool result]")
         ));
     }
 
@@ -3896,6 +4007,7 @@ mod tests {
         let msg_without = NativeMessage {
             role: "assistant".to_string(),
             content: Some(MessageContent::Text("hi".to_string())),
+            name: None,
             tool_call_id: None,
             tool_calls: None,
             reasoning_content: None,
@@ -3909,6 +4021,7 @@ mod tests {
         let msg_with = NativeMessage {
             role: "assistant".to_string(),
             content: Some(MessageContent::Text("hi".to_string())),
+            name: None,
             tool_call_id: None,
             tool_calls: None,
             reasoning_content: Some("thinking...".to_string()),


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Groq's Harmony tokenizer requires every `role:tool` message to have a `name` field, returning 400 "Tools should have a name!" without it. Additionally, tool messages with missing `tool_call_id` (from context truncation) cause 400 errors on Groq and other OpenAI-compatible providers.
- Why it matters: ZeroClaw is unusable with Groq's native tool calling without this fix.
- What changed: Added `name` field to `NativeMessage`, stored tool name in history JSON, added safety nets for malformed tool messages.
- What did **not** change (scope boundary): No changes to tool_choice handling, tool spec conversion, streaming paths, or non-OpenAI-compatible providers.

## Label Snapshot

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `provider`, `agent`
- Module labels: `provider: compatible`, `agent: loop`
- Contributor tier label: N/A (first contribution)

## Change Metadata

- Change type: `bug`
- Primary scope: `provider`

## Validation Evidence

```bash
cargo fmt --all -- --check   # Pass (rustfmt formatting verified via CI)
cargo clippy --all-targets -- -D warnings  # Pass (clippy clean after fixing wildcard match)
cargo test  # Pass (all existing + 4 new tests)
```

- Evidence provided: CI checks all green (Lint, Strict Delta Lint, Test, Build x86_64/aarch64/Windows, Security Audit, 32-bit Check, Benchmarks Compile)
- If any command is intentionally skipped, explain why: N/A

## Security Impact

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene

- Data-hygiene status: `pass`
- Redaction/anonymization notes: Tool name is already present in assistant tool_calls and is not sensitive.
- Neutral wording confirmation: All wording uses ZeroClaw/project-native labels.

## Compatibility / Migration

- Backward compatible? Yes — `name` field uses `skip_serializing_if = "Option::is_none"`, so providers that don't need it won't see it. Old history messages without `name` continue to work (field will be `None`).
- Config/env changes? No
- Migration needed? No

## Human Verification

- Verified scenarios: Live testing against Groq `openai/gpt-oss-120b` with `tool_dispatcher = "native"` — multi-turn tool calling conversations work without 400 errors.
- Edge cases checked: Tool messages with missing `tool_call_id` (truncation), unparseable JSON content (corruption), tool messages without `name` field (backward compat).
- What was not verified: Other OpenAI-compatible providers (DeepSeek, Mistral, etc.) — but the `name` field is spec-compliant and gated with `skip_serializing_if`.

## Side Effects / Blast Radius

- Affected subsystems/workflows: All providers using `OpenAiCompatibleProvider::convert_messages_for_native()` and `run_tool_call_loop()` history construction.
- Potential unintended effects: The fallback-to-user for malformed tool messages changes error behavior from an API 400 to a `[Tool result]` user message the model sees. This is intentionally more graceful.
- Guardrails/monitoring for early detection: Existing tracing/logging for tool message conversion. The `[Tool result]` prefix makes fallback messages identifiable in logs.

## Agent Collaboration Notes

- Agent tools used: Claude Code (Anthropic CLI)
- Workflow/plan summary: Identified root cause via Groq error logs, traced through `convert_messages_for_native` and `run_tool_call_loop`, added `name` field and safety nets, verified with live Groq testing.
- Verification focus: Groq compatibility, backward compatibility with existing providers, handling of corrupted/truncated history messages.
- Confirmation: naming + architecture boundaries followed.

## Rollback Plan

- Fast rollback command/path: Revert commit — single commit, no migrations.
- Feature flags or config toggles: None needed — `name` field is optional (`Option<String>`) with `skip_serializing_if`.
- Observable failure symptoms: Groq 400 errors return if reverted. No degradation for non-Groq providers.

## Risks and Mitigations

- Risk: The `[Tool result]` fallback for malformed tool messages could confuse models that expect structured tool results.
  - Mitigation: This only triggers for already-broken messages that would otherwise cause a 400 error. A user-role message is strictly better than an API failure.