### PR TITLE
Harden memory recall and session resume

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -331,7 +331,7 @@ async fn build_context(
                 if memory::is_assistant_autosave_key(&entry.key) {
                     continue;
                 }
-                if memory::should_skip_autosave_content(&entry.content) {
+                if memory::should_skip_recalled_memory_content(&entry.content) {
                     continue;
                 }
                 if memory::is_exact_query_echo(&entry.content, user_msg) {

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -334,6 +334,9 @@ async fn build_context(
                 if memory::should_skip_autosave_content(&entry.content) {
                     continue;
                 }
+                if memory::is_exact_query_echo(&entry.content, user_msg) {
+                    continue;
+                }
                 // Skip entries containing tool_result blocks — they can leak
                 // stale tool output from previous heartbeat ticks into new
                 // sessions, presenting the LLM with orphan tool_result data.
@@ -8116,6 +8119,32 @@ Tail"#;
         assert!(context.contains("user_msg_real"));
         assert!(!context.contains("assistant_resp_poisoned"));
         assert!(!context.contains("fabricated event"));
+    }
+
+    #[tokio::test]
+    async fn build_context_excludes_exact_query_echoes() {
+        let tmp = TempDir::new().unwrap();
+        let mem = SqliteMemory::new(tmp.path()).unwrap();
+        mem.store(
+            "user_msg_echo",
+            "hello there",
+            MemoryCategory::Conversation,
+            None,
+        )
+        .await
+        .unwrap();
+        mem.store(
+            "user_msg_preference",
+            "hello there with concise follow-up guidance",
+            MemoryCategory::Conversation,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let context = build_context(&mem, "hello there", 0.0, None).await;
+        assert!(!context.contains("user_msg_echo"));
+        assert!(context.contains("user_msg_preference"));
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/agent/memory_loader.rs
+++ b/src/agent/memory_loader.rs
@@ -116,7 +116,7 @@ mod tests {
             Ok(vec![MemoryEntry {
                 id: "1".into(),
                 key: "k".into(),
-                content: "v".into(),
+                content: "User prefers concise answers.".into(),
                 category: MemoryCategory::Conversation,
                 timestamp: "now".into(),
                 session_id: None,
@@ -216,7 +216,7 @@ mod tests {
             .await
             .unwrap();
         assert!(context.contains("[Memory context]"));
-        assert!(context.contains("- k: v"));
+        assert!(context.contains("- k: User prefers concise answers."));
     }
 
     #[tokio::test]

--- a/src/agent/memory_loader.rs
+++ b/src/agent/memory_loader.rs
@@ -58,7 +58,7 @@ impl MemoryLoader for DefaultMemoryLoader {
             if memory::is_assistant_autosave_key(&entry.key) {
                 continue;
             }
-            if memory::should_skip_autosave_content(&entry.content) {
+            if memory::should_skip_recalled_memory_content(&entry.content) {
                 continue;
             }
             if let Some(score) = entry.score {

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1360,7 +1360,7 @@ fn should_skip_memory_context_entry(key: &str, content: &str, user_msg: &str) ->
         return true;
     }
 
-    if memory::should_skip_autosave_content(content) {
+    if memory::should_skip_recalled_memory_content(content) {
         return true;
     }
 

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -1355,12 +1355,16 @@ fn should_rollback_failed_user_turn(error: &anyhow::Error) -> bool {
     crate::providers::reliable::is_non_retryable(error)
 }
 
-fn should_skip_memory_context_entry(key: &str, content: &str) -> bool {
+fn should_skip_memory_context_entry(key: &str, content: &str, user_msg: &str) -> bool {
     if memory::is_assistant_autosave_key(key) {
         return true;
     }
 
     if memory::should_skip_autosave_content(content) {
+        return true;
+    }
+
+    if memory::is_exact_query_echo(content, user_msg) {
         return true;
     }
 
@@ -1885,7 +1889,7 @@ async fn build_memory_context(
                 break;
             }
 
-            if should_skip_memory_context_entry(&entry.key, &entry.content) {
+            if should_skip_memory_context_entry(&entry.key, &entry.content, user_msg) {
                 continue;
             }
 
@@ -6109,39 +6113,55 @@ mod tests {
     fn memory_context_skip_rules_exclude_history_blobs() {
         assert!(should_skip_memory_context_entry(
             "telegram_123_history",
-            r#"[{"role":"user"}]"#
+            r#"[{"role":"user"}]"#,
+            ""
         ));
         assert!(should_skip_memory_context_entry(
             "assistant_resp_legacy",
-            "fabricated memory"
+            "fabricated memory",
+            ""
         ));
-        assert!(!should_skip_memory_context_entry("telegram_123_45", "hi"));
+        assert!(should_skip_memory_context_entry(
+            "telegram_123_45",
+            "hi",
+            ""
+        ));
+        assert!(!should_skip_memory_context_entry(
+            "telegram_123_46",
+            "Please summarize today's status",
+            ""
+        ));
 
         // Entries containing image markers must be skipped to prevent
         // auto-saved photo messages from duplicating image blocks (#2403).
         assert!(should_skip_memory_context_entry(
             "telegram_user_msg_99",
-            "[IMAGE:/tmp/workspace/photo_1_2.jpg]"
+            "[IMAGE:/tmp/workspace/photo_1_2.jpg]",
+            ""
         ));
         assert!(should_skip_memory_context_entry(
             "telegram_user_msg_100",
-            "[IMAGE:/tmp/workspace/photo_1_2.jpg]\n\nCheck this screenshot"
+            "[IMAGE:/tmp/workspace/photo_1_2.jpg]\n\nCheck this screenshot",
+            ""
         ));
         // Plain text without image markers should not be skipped.
         assert!(!should_skip_memory_context_entry(
             "telegram_user_msg_101",
-            "Please describe the image"
+            "Please describe the image",
+            ""
         ));
 
         // Entries containing tool_result blocks must be skipped (#3402).
         assert!(should_skip_memory_context_entry(
             "telegram_user_msg_200",
             r#"[Tool results]
-<tool_result name="shell">Mon Feb 20</tool_result>"#
+<tool_result name="shell">Mon Feb 20</tool_result>"#,
+            ""
         ));
         assert!(!should_skip_memory_context_entry(
             "telegram_user_msg_201",
-            "plain text without tool results"
+            "plain text without tool results",
+            ""
         ));
     }
 
@@ -9759,6 +9779,34 @@ BTC is currently around $65,000 based on latest tool output."#
             context.contains("screenshot descriptions"),
             "plain text entry should remain in context, got: {context}"
         );
+    }
+
+    #[tokio::test]
+    async fn build_memory_context_excludes_exact_query_echo_entries() {
+        let tmp = TempDir::new().unwrap();
+        let mem = SqliteMemory::new(tmp.path()).unwrap();
+
+        mem.store(
+            "webhook_msg_echo",
+            "hello there",
+            MemoryCategory::Conversation,
+            None,
+        )
+        .await
+        .unwrap();
+        mem.store(
+            "greeting_preference",
+            "hello there with a friendly but concise greeting preference",
+            MemoryCategory::Conversation,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let context = build_memory_context(&mem, "hello there", 0.0, None).await;
+
+        assert!(!context.contains("webhook_msg_echo"));
+        assert!(context.contains("greeting_preference"));
     }
 
     #[tokio::test]

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -152,6 +152,10 @@ pub async fn handle_ws_chat(
 /// Gateway session key prefix to avoid collisions with channel sessions.
 const GW_SESSION_PREFIX: &str = "gw_";
 
+fn should_skip_resumed_session_message(message: &crate::providers::ChatMessage) -> bool {
+    message.role == "assistant" && crate::memory::is_internal_context_leak_content(&message.content)
+}
+
 async fn handle_socket(
     socket: WebSocket,
     state: AppState,
@@ -195,9 +199,21 @@ async fn handle_socket(
     let mut effective_name: Option<String> = None;
     if let Some(ref backend) = state.session_backend {
         let messages = backend.load(&session_key);
-        if !messages.is_empty() {
-            message_count = messages.len();
-            agent.seed_history(&messages);
+        let original_count = messages.len();
+        let filtered_messages: Vec<_> = messages
+            .into_iter()
+            .filter(|message| !should_skip_resumed_session_message(message))
+            .collect();
+
+        if filtered_messages.len() < original_count {
+            let _ = backend.delete_session(&session_key);
+            for message in &filtered_messages {
+                let _ = backend.append(&session_key, message);
+            }
+        }
+        if !filtered_messages.is_empty() {
+            message_count = filtered_messages.len();
+            agent.seed_history(&filtered_messages);
             resumed = true;
         }
         // Set session name if provided (non-empty) on connect
@@ -626,5 +642,19 @@ mod tests {
             "zeroclaw.v1, bearer.zc_tok, other".parse().unwrap(),
         );
         assert_eq!(extract_ws_token(&headers, None), Some("zc_tok"));
+    }
+
+    #[test]
+    fn resumed_session_filter_skips_memory_context_prompt_leaks() {
+        let poisoned = crate::providers::ChatMessage::assistant(
+            "[Memory context]\n- user_msg: hi\n\n[2026-04-09 07:57:11 +02:00] hi",
+        );
+        let healthy =
+            crate::providers::ChatMessage::assistant("Hello! How can I assist you today?");
+        let user = crate::providers::ChatMessage::user("hi");
+
+        assert!(should_skip_resumed_session_message(&poisoned));
+        assert!(!should_skip_resumed_session_message(&healthy));
+        assert!(!should_skip_resumed_session_message(&user));
     }
 }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -122,6 +122,45 @@ pub fn should_skip_autosave_content(content: &str) -> bool {
         || lowered.contains("distilled_index_sig:")
 }
 
+/// Filter persisted memory entries that should not be re-injected into a prompt.
+///
+/// This is intentionally narrower than `should_skip_autosave_content`: autosave
+/// ingress should reject very short chatter, but recall should still allow short
+/// factual memories like "Age is 45" while excluding synthetic noise.
+pub fn should_skip_recalled_memory_content(content: &str) -> bool {
+    let normalized = content.trim();
+    if normalized.is_empty() {
+        return true;
+    }
+
+    if is_internal_context_leak_content(normalized) {
+        return true;
+    }
+
+    let lowered = normalized.to_ascii_lowercase();
+    if lowered.starts_with("[cron:")
+        || lowered.starts_with("[heartbeat task")
+        || lowered.starts_with("[distilled_")
+        || lowered.contains("distilled_index_sig:")
+    {
+        return true;
+    }
+
+    let compact = lowered.split_whitespace().collect::<Vec<_>>().join(" ");
+    matches!(
+        compact.as_str(),
+        "hi" | "hello"
+            | "hey"
+            | "ok"
+            | "okay"
+            | "thanks"
+            | "thank you"
+            | "cool"
+            | "nice"
+            | "got it"
+    )
+}
+
 pub fn is_exact_query_echo(content: &str, query: &str) -> bool {
     fn normalize(value: &str) -> String {
         value
@@ -476,6 +515,22 @@ mod tests {
             "[Heartbeat Task | high] Execute scheduled patrol"
         ));
         assert!(!should_skip_autosave_content(
+            "User prefers concise answers."
+        ));
+    }
+
+    #[test]
+    fn recalled_memory_filter_keeps_short_facts_but_drops_trivial_chat() {
+        assert!(should_skip_recalled_memory_content("hi"));
+        assert!(should_skip_recalled_memory_content("  thank   you "));
+        assert!(should_skip_recalled_memory_content(
+            "[Heartbeat Task | high] Execute scheduled patrol"
+        ));
+        assert!(should_skip_recalled_memory_content(
+            "[Memory context]\n- user_msg: hi"
+        ));
+        assert!(!should_skip_recalled_memory_content("Age is 45"));
+        assert!(!should_skip_recalled_memory_content(
             "User prefers concise answers."
         ));
     }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -52,6 +52,8 @@ use anyhow::Context;
 use std::path::Path;
 use std::sync::Arc;
 
+const MIN_AUTOSAVE_CONTENT_CHARS: usize = 20;
+
 fn create_memory_with_builders<F>(
     backend_name: &str,
     workspace_dir: &Path,
@@ -109,11 +111,38 @@ pub fn should_skip_autosave_content(content: &str) -> bool {
         return true;
     }
 
+    if normalized.chars().count() < MIN_AUTOSAVE_CONTENT_CHARS {
+        return true;
+    }
+
     let lowered = normalized.to_ascii_lowercase();
     lowered.starts_with("[cron:")
         || lowered.starts_with("[heartbeat task")
         || lowered.starts_with("[distilled_")
         || lowered.contains("distilled_index_sig:")
+}
+
+pub fn is_exact_query_echo(content: &str, query: &str) -> bool {
+    fn normalize(value: &str) -> String {
+        value
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .trim()
+            .to_ascii_lowercase()
+    }
+
+    let normalized_content = normalize(content);
+    let normalized_query = normalize(query);
+
+    !normalized_content.is_empty() && normalized_content == normalized_query
+}
+
+/// Detect assistant responses that accidentally leaked internal prompt context
+/// back to the user instead of producing a real answer.
+pub fn is_internal_context_leak_content(content: &str) -> bool {
+    let normalized = content.trim_start();
+    normalized.starts_with("[Memory context]")
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -436,6 +465,7 @@ mod tests {
     #[test]
     fn autosave_content_filter_drops_cron_and_distilled_noise() {
         assert!(should_skip_autosave_content("[cron:auto] patrol check"));
+        assert!(should_skip_autosave_content("hi"));
         assert!(should_skip_autosave_content(
             "[DISTILLED_MEMORY_CHUNK 1/2] DISTILLED_INDEX_SIG:abc123"
         ));
@@ -447,6 +477,25 @@ mod tests {
         ));
         assert!(!should_skip_autosave_content(
             "User prefers concise answers."
+        ));
+    }
+
+    #[test]
+    fn exact_query_echo_detection_normalizes_whitespace_and_case() {
+        assert!(is_exact_query_echo("Hello   there", " hello there "));
+        assert!(!is_exact_query_echo(
+            "User prefers concise greetings",
+            "hello there"
+        ));
+    }
+
+    #[test]
+    fn internal_context_leak_detection_matches_prompt_preamble() {
+        assert!(is_internal_context_leak_content(
+            "[Memory context]\n- user_msg: hi\n\n[2026-04-09 07:57:11 +02:00] hi"
+        ));
+        assert!(!is_internal_context_leak_content(
+            "Hello! How can I assist you today?"
         ));
     }
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions):
- Problem:
- Why it matters:
- What changed:
- What did **not** change (scope boundary):

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`):
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`):
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`):
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- File system access scope changed? (`Yes/No`)
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`)
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any):
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
  - Mitigation:
