### PR TITLE
fix(ci): migrate AUR package to zeroclawlabs

### DIFF
--- a/.github/workflows/pub-aur.yml
+++ b/.github/workflows/pub-aur.yml
@@ -112,7 +112,7 @@ jobs:
           srcinfo_file="$(mktemp)"
           sed -e "s/pkgver = .*/pkgver = ${VERSION}/" \
               -e "s/sha256sums = .*/sha256sums = ${TARBALL_SHA}/" \
-              -e "s|zeroclaw-[0-9.]*.tar.gz|zeroclaw-${VERSION}.tar.gz|g" \
+              -e "s|zeroclawlabs-[0-9.]*.tar.gz|zeroclawlabs-${VERSION}.tar.gz|g" \
               -e "s|/v[0-9.]*\.tar\.gz|/v${VERSION}.tar.gz|g" \
               dist/aur/.SRCINFO > "$srcinfo_file"
 
@@ -160,7 +160,7 @@ jobs:
           fi
 
           tmp_dir="$(mktemp -d)"
-          git clone ssh://aur@aur.archlinux.org/zeroclaw.git "$tmp_dir/aur"
+          git clone ssh://aur@aur.archlinux.org/zeroclawlabs.git "$tmp_dir/aur"
 
           cp "$PKGBUILD_FILE" "$tmp_dir/aur/PKGBUILD"
           cp "$SRCINFO_FILE" "$tmp_dir/aur/.SRCINFO"
@@ -169,7 +169,8 @@ jobs:
           git config user.name "zeroclaw-bot"
           git config user.email "bot@zeroclaw.dev"
           git add PKGBUILD .SRCINFO
-          git commit -m "zeroclaw ${VERSION}"
+          git diff --cached --quiet && { echo "No changes to push."; exit 0; }
+          git commit -m "zeroclawlabs ${VERSION}"
           git push origin HEAD
 
           echo "AUR package updated to ${VERSION}"

--- a/dist/aur/.SRCINFO
+++ b/dist/aur/.SRCINFO
@@ -1,16 +1,21 @@
-pkgbase = zeroclaw
+pkgbase = zeroclawlabs
 	pkgdesc = Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant.
-	pkgver = 0.5.9
+	pkgver = 0.6.9
 	pkgrel = 1
 	url = https://github.com/zeroclaw-labs/zeroclaw
 	arch = x86_64
+	arch = aarch64
 	license = MIT
 	license = Apache-2.0
 	makedepends = cargo
 	makedepends = git
+	makedepends = nodejs
+	makedepends = npm
 	depends = gcc-libs
 	depends = openssl
-	source = zeroclaw-0.5.9.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.5.9.tar.gz
+	provides = zeroclaw
+	conflicts = zeroclaw
+	source = zeroclawlabs-0.6.9.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v0.6.9.tar.gz
 	sha256sums = SKIP
 
-pkgname = zeroclaw
+pkgname = zeroclawlabs

--- a/dist/aur/PKGBUILD
+++ b/dist/aur/PKGBUILD
@@ -1,31 +1,34 @@
 # Maintainer: zeroclaw-labs <bot@zeroclaw.dev>
-pkgname=zeroclaw
-pkgver=0.5.9
+pkgname=zeroclawlabs
+_reponame=zeroclaw
+pkgver=0.6.9
 pkgrel=1
 pkgdesc="Zero overhead. Zero compromise. 100% Rust. The fastest, smallest AI assistant."
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url="https://github.com/zeroclaw-labs/zeroclaw"
 license=('MIT' 'Apache-2.0')
 depends=('gcc-libs' 'openssl')
-makedepends=('cargo' 'git')
+makedepends=('cargo' 'git' 'nodejs' 'npm')
+provides=('zeroclaw')
+conflicts=('zeroclaw')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/zeroclaw-labs/zeroclaw/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=('SKIP')
 
 prepare() {
-  cd "${pkgname}-${pkgver}"
+  cd "${_reponame}-${pkgver}"
   export RUSTUP_TOOLCHAIN=stable
   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
 }
 
 build() {
-  cd "${pkgname}-${pkgver}"
+  cd "${_reponame}-${pkgver}"
   export RUSTUP_TOOLCHAIN=stable
   export CARGO_TARGET_DIR=target
-  cargo build --frozen --release --profile dist
+  cargo build --frozen --release --profile dist --features channel-matrix,channel-lark
 }
 
 package() {
-  cd "${pkgname}-${pkgver}"
+  cd "${_reponame}-${pkgver}"
   install -Dm0755 -t "${pkgdir}/usr/bin/" "target/dist/zeroclaw"
   install -Dm0644 LICENSE-MIT "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE-MIT"
   install -Dm0644 LICENSE-APACHE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE-APACHE"


### PR DESCRIPTION
## Summary
- Migrates AUR package from `zeroclaw` (not owned by us) to `zeroclawlabs` (owned by `zeroclaw-bot` account)
- Created `zeroclawlabs` package on AUR with v0.6.9
- Created `zeroclaw-labs/aur-zeroclaw` GitHub mirror repo

### PKGBUILD changes
- Package name: `zeroclaw` → `zeroclawlabs`
- Added `aarch64` architecture support
- Added `nodejs`/`npm` makedepends (for web dashboard build)
- Added `channel-matrix,channel-lark` build features
- Added `provides=('zeroclaw')` and `conflicts=('zeroclaw')` for smooth migration

### Workflow changes
- AUR clone URL: `zeroclaw.git` → `zeroclawlabs.git`
- Commit message prefix: `zeroclaw` → `zeroclawlabs`
- Added no-op guard when PKGBUILD hasn't changed
- Updated .SRCINFO sed patterns for new package name

## Test plan
- [ ] CI passes
- [ ] After merge, trigger `pub-aur.yml` manually with `v0.6.9`
- [ ] Verify package at https://aur.archlinux.org/packages/zeroclawlabs