### PR TITLE
fix(config): add allowed_path/allowed_paths aliases for allowed_roots

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -5513,7 +5513,7 @@ pub struct AutonomyConfig {
     /// Extra directory roots the agent may read/write outside the workspace.
     /// Supports absolute, `~/...`, and workspace-relative entries.
     /// Resolved paths under any of these roots pass `is_resolved_path_allowed`.
-    #[serde(default)]
+    #[serde(default, alias = "allowed_path", alias = "allowed_paths")]
     pub allowed_roots: Vec<String>,
 
     /// Tools to exclude from non-CLI channels (e.g. Telegram, Discord).

--- a/tests/component/config_schema.rs
+++ b/tests/component/config_schema.rs
@@ -342,6 +342,26 @@ fn autonomy_config_toml_roundtrip() {
     assert!(!parsed.autonomy.workspace_only);
 }
 
+#[test]
+fn autonomy_config_allowed_path_alias_maps_to_allowed_roots() {
+    let toml_str = r#"
+[autonomy]
+allowed_path = ["~/work", "~/"]
+"#;
+    let parsed: Config = toml::from_str(toml_str).expect("allowed_path alias should parse");
+    assert_eq!(parsed.autonomy.allowed_roots, vec!["~/work", "~/"]);
+}
+
+#[test]
+fn autonomy_config_allowed_paths_alias_maps_to_allowed_roots() {
+    let toml_str = r#"
+[autonomy]
+allowed_paths = ["/tmp/data"]
+"#;
+    let parsed: Config = toml::from_str(toml_str).expect("allowed_paths alias should parse");
+    assert_eq!(parsed.autonomy.allowed_roots, vec!["/tmp/data"]);
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Backward compatibility
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Users set `allowed_path = ["~/work", "~/"]` in `[autonomy]` config expecting directory access, but the actual config key is `allowed_roots`. The wrong key is silently ignored, leaving the agent unable to access paths outside the workspace.
- Why it matters: Every user who guesses the wrong key name gets no error and no access — a silent misconfiguration that's hard to diagnose.
- What changed: Added `#[serde(alias = "allowed_path", alias = "allowed_paths")]` to the `allowed_roots` field in `AutonomyConfig`, so both intuitive names work.
- What did **not** change (scope boundary): No changes to path validation logic, security policy, or `allowed_roots` behavior. Only deserialization aliases added.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `config`
- Module labels: N/A
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): runtime

## Linked Issue

- Closes #5533

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo test --test component -- autonomy_config_allowed_path  # 2 passed
```

- Evidence provided: Two new tests verify `allowed_path` and `allowed_paths` aliases both deserialize into `allowed_roots`.
- If any command is intentionally skipped, explain why: `cargo fmt/clippy` deferred to CI.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No (aliases map to existing `allowed_roots` — same security semantics)

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No (additive alias only)
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: `allowed_path` and `allowed_paths` both deserialize correctly. Existing `allowed_roots` config continues to work (serde aliases are additive).
- Edge cases checked: Empty arrays, single-element arrays, tilde paths.
- What was not verified: End-to-end agent path access with the alias config.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Config deserialization only.
- Potential unintended effects: None — aliases are purely additive.
- Guardrails/monitoring for early detection: New unit tests.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Traced config key mismatch from issue report, confirmed `allowed_roots` is the canonical key, added serde aliases.
- Verification focus: Deserialization parity between alias and canonical key.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <sha>`
- Feature flags or config toggles: None
- Observable failure symptoms: `allowed_path` config key stops working (returns to silent ignore)

## Risks and Mitigations

None.