### PR TITLE
fix(channel): add email to cron delivery dispatch

### DIFF
--- a/src/cron/scheduler.rs
+++ b/src/cron/scheduler.rs
@@ -5,8 +5,8 @@ use crate::channels::MatrixChannel;
 #[cfg(feature = "whatsapp-web")]
 use crate::channels::WhatsAppWebChannel;
 use crate::channels::{
-    Channel, DiscordChannel, MattermostChannel, QQChannel, SendMessage, SignalChannel,
-    SlackChannel, TelegramChannel,
+    Channel, DiscordChannel, EmailChannel, MattermostChannel, QQChannel, SendMessage,
+    SignalChannel, SlackChannel, TelegramChannel,
 };
 use crate::config::Config;
 use crate::config::schema::{CronJobDecl, CronScheduleDecl};
@@ -707,6 +707,17 @@ pub(crate) async fn deliver_announcement(
             {
                 anyhow::bail!("feishu delivery channel requires `channel-lark` feature");
             }
+        }
+        "email" => {
+            let em = config
+                .channels_config
+                .email
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("email channel not configured"))?;
+            let channel = EmailChannel::new(em.clone());
+            channel
+                .send(&SendMessage::new(safe_output.as_str(), target))
+                .await?;
         }
         other => anyhow::bail!("unsupported delivery channel: {other}"),
     }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Cron jobs with `delivery.channel = "email"` fail with "unsupported delivery channel: email" because the `deliver_announcement` function in `src/cron/scheduler.rs` has no `"email"` match arm. The agent tells users email isn't supported for delivery even though the daemon recognizes the channel and `zeroclaw doctor` shows it healthy.
- Why it matters: Users who configure email channels following the documented example cannot send emails through the agent or scheduled jobs.
- What changed: Added `"email"` match arm to `deliver_announcement()` using the existing `EmailChannel::new()` constructor and `Channel::send()` trait method. Added `EmailChannel` to the cron scheduler imports.
- What did **not** change (scope boundary): No changes to EmailConfig, email channel implementation, CLI `channel send`, or daemon channel collection. Only the cron delivery dispatch is affected.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: XS`
- Scope labels: `channel`, `cron`
- Module labels: `channel: email`
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): channel

## Linked Issue

- Closes #5528

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo check  # clean build, no errors
```

- Evidence provided: Build compiles successfully. The new match arm follows the identical pattern used by all other channels in `deliver_announcement`.
- If any command is intentionally skipped, explain why: Full test suite deferred to CI.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No (email sending already exists in EmailChannel)
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Match arm pattern consistency with other channels (telegram, discord, slack, etc.). EmailChannel::new() takes config.clone(), Channel::send() takes SendMessage.
- Edge cases checked: Email config not present (returns "email channel not configured" error).
- What was not verified: End-to-end email delivery via cron job (requires configured SMTP credentials).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Cron delivery dispatch only.
- Potential unintended effects: None — additive match arm.
- Guardrails/monitoring for early detection: Existing cron scheduler tests.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code
- Workflow/plan summary: Traced "email channel isn't supported" error to missing match arm in deliver_announcement. The CLI `channel send` path (build_channel_by_id) already had email support (added in #5506), but the cron delivery path was missed.
- Verification focus: Pattern consistency with existing channel delivery arms.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <sha>`
- Feature flags or config toggles: None
- Observable failure symptoms: "unsupported delivery channel: email" error returns

## Risks and Mitigations

None.