### PR TITLE
fix(config): default session_ttl_hours to 168h and cap seed_history

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -374,6 +374,9 @@ impl Agent {
                 self.history.push(ConversationMessage::Chat(msg.clone()));
             }
         }
+        // Trim immediately after seeding to prevent unbounded memory growth
+        // when persisted sessions contain thousands of messages.
+        self.trim_history();
     }
 
     pub async fn from_config(config: &Config) -> Result<Self> {

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -2212,8 +2212,8 @@ pub struct GatewayConfig {
     #[serde(default = "default_true")]
     pub session_persistence: bool,
 
-    /// Auto-archive stale gateway sessions older than N hours. 0 = disabled. Default: 0.
-    #[serde(default)]
+    /// Auto-archive stale gateway sessions older than N hours. 0 = disabled. Default: 168 (7 days).
+    #[serde(default = "default_session_ttl_hours")]
     pub session_ttl_hours: u32,
 
     /// Pairing dashboard configuration
@@ -2245,6 +2245,10 @@ fn default_webhook_rate_limit() -> u32 {
 
 fn default_idempotency_ttl_secs() -> u64 {
     300
+}
+
+fn default_session_ttl_hours() -> u32 {
+    168 // 7 days
 }
 
 fn default_gateway_rate_limit_max_keys() -> usize {
@@ -2279,7 +2283,7 @@ impl Default for GatewayConfig {
             idempotency_ttl_secs: default_idempotency_ttl_secs(),
             idempotency_max_keys: default_gateway_idempotency_max_keys(),
             session_persistence: true,
-            session_ttl_hours: 0,
+            session_ttl_hours: default_session_ttl_hours(),
             pairing_dashboard: PairingDashboardConfig::default(),
             tls: None,
         }
@@ -6491,8 +6495,8 @@ pub struct ChannelsConfig {
     /// SQLite provides FTS5 search, metadata tracking, and TTL cleanup.
     #[serde(default = "default_session_backend")]
     pub session_backend: String,
-    /// Auto-archive stale sessions older than this many hours. `0` disables. Default: `0`.
-    #[serde(default)]
+    /// Auto-archive stale sessions older than this many hours. `0` disables. Default: `168` (7 days).
+    #[serde(default = "default_session_ttl_hours")]
     pub session_ttl_hours: u32,
     /// Inbound message debounce window in milliseconds. When a sender fires
     /// multiple messages within this window, they are accumulated and dispatched
@@ -6698,7 +6702,7 @@ impl Default for ChannelsConfig {
             show_tool_calls: false,
             session_persistence: true,
             session_backend: default_session_backend(),
-            session_ttl_hours: 0,
+            session_ttl_hours: default_session_ttl_hours(),
             debounce_ms: 0,
         }
     }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: ZeroClaw daemon OOM-killed at ~8.5GB RSS on WSL2. The process immediately grows back to ~8.5GB after restart. Root cause: `session_ttl_hours` defaults to `0` (disabled), so persisted sessions grow unboundedly on disk. On daemon restart, all sessions are loaded into memory via `seed_history()`, which has no size cap.
- Why it matters: Makes ZeroClaw unusable on memory-constrained environments (WSL2, small VMs, Raspberry Pi). The OOM kills cascade and affect other processes.
- What changed: (1) Default `session_ttl_hours` to 168 (7 days) for both gateway and channel sessions. (2) Call `trim_history()` after `seed_history()` in the Agent so loading a large persisted session doesn't consume unbounded memory.
- What did **not** change (scope boundary): No changes to session persistence format, cleanup logic, or pruning strategies. Users who explicitly set `session_ttl_hours = 0` keep the old behavior.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels: `config`, `agent`
- Module labels: N/A
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): bug
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): runtime

## Linked Issue

- Closes #5542

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo check  # clean build
```

- Evidence provided: Build compiles successfully. Default value change is backward-compatible (users who set `session_ttl_hours = 0` explicitly keep the old behavior). `trim_history()` is an existing, well-tested function.
- If any command is intentionally skipped, explain why: Full test suite deferred to CI.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass (sessions are archived, not deleted — data retention improved)
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: confirmed

## Compatibility / Migration

- Backward compatible? Yes (users can set `session_ttl_hours = 0` to restore old behavior)
- Config/env changes? Yes — default changes from 0 to 168
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Default value propagation through both GatewayConfig and ChannelsConfig. `seed_history` -> `trim_history` call order.
- Edge cases checked: Empty history (no-op trim). Existing `session_ttl_hours = 0` config (preserved as explicit override). Test assertions that hardcode `session_ttl_hours: 0` in test data (unaffected — they set explicit values, not defaults).
- What was not verified: Long-running daemon memory profile. WSL2 reproduction.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Session persistence defaults, agent history seeding.
- Potential unintended effects: Users who relied on infinite session retention will now see sessions archived after 7 days. This is the intended fix — infinite retention causes OOM.
- Guardrails/monitoring for early detection: Existing `cleanup_stale` logs.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code (investigation agent identified root cause via codebase analysis)
- Workflow/plan summary: Investigation agent traced the ~8.5GB OOM pattern to startup session hydration with unbounded session_ttl_hours. Applied two-pronged fix: TTL default + seed cap.
- Verification focus: Memory growth path analysis, config default propagation.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <sha>`
- Feature flags or config toggles: `session_ttl_hours = 0` restores old behavior
- Observable failure symptoms: OOM kills return at ~8.5GB RSS

## Risks and Mitigations

- Risk: Users with long-running sessions (>7 days) lose older context after this change.
  - Mitigation: Sessions are archived, not deleted. Users can increase `session_ttl_hours` in config. The old default (infinite) was a memory safety hazard.