### PR TITLE
fix(security): preserve original arg case so git -C is not blocked as git -c

### DIFF
--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -1221,11 +1221,15 @@ impl SecurityPolicy {
                 return false;
             }
 
-            // Validate arguments for the command
-            let args: Vec<String> = words.map(|w| w.to_ascii_lowercase()).collect();
-            if !self.is_args_safe(base_cmd, &args) {
+            // Validate arguments for the command.
+            // Preserve original case for flag matching (e.g. git -C vs -c),
+            // while keeping a lowercased copy for case-insensitive checks elsewhere.
+            let args_orig: Vec<String> = words.map(|w| w.to_string()).collect();
+            let args: Vec<String> = args_orig.iter().map(|w| w.to_ascii_lowercase()).collect();
+            if !self.is_args_safe(base_cmd, &args_orig) {
                 return false;
             }
+            let _ = args; // lowercased args available for future use
         }
 
         // At least one command must be present


### PR DESCRIPTION
## Summary

`git -C /path` was being blocked by the security policy even when the path was allowlisted. This caused the `git_operations` tool (and any shell command using `git -C`) to fail with a policy error.

## Root Cause

In `policy.rs`, all command arguments were lowercased **before** being passed to `is_args_safe()`:

```rust
// Before (buggy)
let args: Vec<String> = words.map(|w| w.to_ascii_lowercase()).collect();
if !self.is_args_safe(base_cmd, &args) { ... }
```

The `git` branch in `is_args_safe` blocks the `-c` flag to prevent config injection attacks (e.g. `git -c core.editor="rm -rf /"`). But because `-C` was lowercased to `-c` before the check, the legitimate "change directory" flag was also blocked.

## Fix

Preserve original-case args for `is_args_safe()`, while keeping a lowercased copy available for future case-insensitive checks:

```rust
// After (fixed)
let args_orig: Vec<String> = words.map(|w| w.to_string()).collect();
let args: Vec<String> = args_orig.iter().map(|w| w.to_ascii_lowercase()).collect();
if !self.is_args_safe(base_cmd, &args_orig) { ... }
let _ = args; // lowercased args available for future use
```

Now `-C` and `-c` are correctly distinguished: `-c` (config injection) remains blocked, `-C` (change directory) is allowed.

## Testing

- `git -C /some/path status` → ✅ allowed
- `git -c core.editor=evil ...` → ✅ still blocked
