### PR TITLE
fix(install): prevent CARGO_FEATURE_ARGS unbound variable on bash 3.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1299,7 +1299,7 @@ if [[ "$SKIP_BUILD" == false ]]; then
   fi
 
   step_dot "Building release binary"
-  cargo build --release --locked "${CARGO_FEATURE_ARGS[@]}"
+  cargo build --release --locked "${CARGO_FEATURE_ARGS[@]+"${CARGO_FEATURE_ARGS[@]}"}"
   step_ok "Release binary built"
 else
   step_dot "Skipping build"
@@ -1318,7 +1318,7 @@ if [[ "$SKIP_INSTALL" == false ]]; then
     fi
   fi
 
-  cargo install --path "$WORK_DIR" --force --locked "${CARGO_FEATURE_ARGS[@]}"
+  cargo install --path "$WORK_DIR" --force --locked "${CARGO_FEATURE_ARGS[@]+"${CARGO_FEATURE_ARGS[@]}"}"
   step_ok "ZeroClaw installed"
 
   # Sync binary to ~/.local/bin so PATH lookups find the fresh version


### PR DESCRIPTION
## Summary
- Fix `install.sh` failure on macOS/bash 3.2 with `set -u` when `CARGO_FEATURE_ARGS` is empty.
- Use nounset-safe array expansion for both cargo build and cargo install command arguments.
- Prevents runtime error: `CARGO_FEATURE_ARGS[@]: unbound variable` at install step.

## Root cause
- In bash 3.2, expanding an empty array with `"${arr[@]}"` under `set -u` can trigger an unbound variable error.

## Test plan
- [x] `bash -n install.sh`
- [ ] Run `sh install.sh` on macOS with no `--cargo-features` and confirm no crash.
- [ ] Run with `--cargo-features` and confirm flags are still passed correctly.