### PR TITLE
fix(runtime): hide windows shell console window

### DIFF
--- a/crates/zeroclaw-config/src/platform/native.rs
+++ b/crates/zeroclaw-config/src/platform/native.rs
@@ -54,15 +54,11 @@ impl RuntimeAdapter for NativeRuntime {
 
         #[cfg(target_os = "windows")]
         {
-            use std::os::windows::process::CommandExt;
             const CREATE_NO_WINDOW: u32 = 0x08000000;
 
             let mut process = tokio::process::Command::new("cmd.exe");
-            process
-                .arg("/C")
-                .arg(command)
-                .current_dir(workspace_dir)
-                .creation_flags(CREATE_NO_WINDOW);
+            process.arg("/C").arg(command).current_dir(workspace_dir);
+            std::os::windows::process::CommandExt::creation_flags(&mut process, CREATE_NO_WINDOW);
             Ok(process)
         }
     }

--- a/crates/zeroclaw-config/src/platform/native.rs
+++ b/crates/zeroclaw-config/src/platform/native.rs
@@ -54,8 +54,15 @@ impl RuntimeAdapter for NativeRuntime {
 
         #[cfg(target_os = "windows")]
         {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+
             let mut process = tokio::process::Command::new("cmd.exe");
-            process.arg("/C").arg(command).current_dir(workspace_dir);
+            process
+                .arg("/C")
+                .arg(command)
+                .current_dir(workspace_dir)
+                .creation_flags(CREATE_NO_WINDOW);
             Ok(process)
         }
     }

--- a/crates/zeroclaw-config/src/platform/native.rs
+++ b/crates/zeroclaw-config/src/platform/native.rs
@@ -57,8 +57,11 @@ impl RuntimeAdapter for NativeRuntime {
             const CREATE_NO_WINDOW: u32 = 0x08000000;
 
             let mut process = tokio::process::Command::new("cmd.exe");
-            process.arg("/C").arg(command).current_dir(workspace_dir);
-            std::os::windows::process::CommandExt::creation_flags(&mut process, CREATE_NO_WINDOW);
+            process
+                .arg("/C")
+                .arg(command)
+                .current_dir(workspace_dir)
+                .creation_flags(CREATE_NO_WINDOW);
             Ok(process)
         }
     }


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: Windows shell execution via the native runtime briefly flashes a `cmd.exe` console window.
- Why it matters: The console flash is distracting and makes local shell-backed workflows feel rough on Windows.
- What changed: The Windows branch in `NativeRuntime::build_shell_command` now applies `CREATE_NO_WINDOW` when spawning `cmd.exe`.
- What did **not** change (scope boundary): No non-Windows shell behavior, command routing, or runtime abstractions were changed.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: XS`
- Scope labels: `runtime`
- Module labels: `runtime: native`
- Contributor tier label: auto-managed
- If any auto-label is incorrect, note requested correction: None.

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `runtime`

## Linked Issue

- Closes #5562
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N/A
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N/A
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): `cargo fmt --all -- --check` passed locally.
- If any command is intentionally skipped, explain why: `cargo clippy --all-targets -- -D warnings` and `cargo test` were not rerun to completion for this small Windows-only fix in this session.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): `No`
- New external network calls? (`Yes/No`): `No`
- Secrets/tokens handling changed? (`Yes/No`): `No`
- File system access scope changed? (`Yes/No`): `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: No user data, secrets, or personal identifiers were added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Confirmed.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): `Yes`
- Config/env changes? (`Yes/No`): `No`
- Migration needed? (`Yes/No`): `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N/A
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N/A
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N/A
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N/A

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Reviewed the Windows shell spawn path and confirmed the change only affects `cmd.exe` creation flags under `#[cfg(target_os = "windows")]`.
- Edge cases checked: Non-Windows command construction remains unchanged; Windows-only symbols are scoped inside the Windows cfg branch.
- What was not verified: Live execution on a Windows host and a full local `cargo test` / `cargo clippy` run.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Native runtime shell command execution on Windows.
- Potential unintended effects: Some Windows environments may rely on a visible shell window for debugging, though the runtime path is intended for headless command execution.
- Guardrails/monitoring for early detection: Existing runtime command execution behavior on Windows can be validated by manually invoking shell-backed tools after merge.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex terminal tools, `git`, and `gh` CLI.
- Workflow/plan summary (if any): Inspected the runtime implementation, applied a minimal Windows-only fix, formatted the change, created the issue, pushed the branch, and prepared this PR.
- Verification focus: Scope containment and avoiding behavior changes outside the Windows shell path.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `7627a7b8` from this branch or back out the merged commit from `master`.
- Feature flags or config toggles (if any): None.
- Observable failure symptoms: Windows shell commands fail to launch or behave differently than prior releases.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: `CREATE_NO_WINDOW` could hide a console some users expected to see while debugging.
- Mitigation: The flag is only applied in the existing non-interactive Windows shell execution branch and does not affect non-Windows runtimes.
