### PR TITLE
fix(web): auto-fill pairing code in Docker environments

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -96,17 +96,18 @@ function PairingDialog({ onPair }: { onPair: (code: string) => Promise<void> }) 
   const [displayCode, setDisplayCode] = useState<string | null>(null);
   const [codeLoading, setCodeLoading] = useState(true);
 
-  // Fetch the current pairing code from the admin endpoint (localhost only)
+  // Fetch the current pairing code (public endpoint works in Docker too)
   useEffect(() => {
     let cancelled = false;
     getAdminPairCode()
       .then((data) => {
         if (!cancelled && data.pairing_code) {
           setDisplayCode(data.pairing_code);
+          setCode(data.pairing_code); // auto-fill so user just clicks "Pair"
         }
       })
       .catch(() => {
-        // Admin endpoint not reachable (non-localhost) — user must check terminal
+        // Endpoint not reachable — user must check terminal / docker logs
       })
       .finally(() => {
         if (!cancelled) setCodeLoading(false);
@@ -141,7 +142,7 @@ function PairingDialog({ onPair }: { onPair: (code: string) => Promise<void> }) 
           />
           <h1 className="text-2xl font-bold mb-2 text-gradient-blue">ZeroClaw</h1>
           <p className="text-sm" style={{ color: 'var(--pc-text-muted)' }}>
-            {displayCode ? 'Your pairing code' : 'Enter the pairing code from your terminal'}
+            {displayCode ? 'Your pairing code — click Pair to connect' : 'Enter the pairing code from your terminal'}
           </p>
         </div>
 


### PR DESCRIPTION
## Summary

- Auto-fills the pairing code into the input field when the `/pair/code` endpoint returns it (initial setup, before first pairing)
- In Docker environments, users can now just click "Pair" instead of manually copying from `docker logs`
- Updates subtitle copy to guide the user: "click Pair to connect"

Follows up on #4786 which added the public `/pair/code` endpoint but required manual entry.

## Change

**`web/src/App.tsx`** — calls `setCode(data.pairing_code)` alongside `setDisplayCode` so the input is pre-populated when the code is fetched successfully. Falls back to manual entry if the endpoint is unreachable.

## Test plan

- [ ] Run ZeroClaw in Docker: `docker run -p 42617:42617 ghcr.io/zeroclaw-labs/zeroclaw:latest`
- [ ] Open web dashboard — pairing code should be displayed AND auto-filled in the input
- [ ] Click "Pair" without typing anything — should pair successfully
- [ ] Verify non-Docker (localhost) still works as before
- [ ] Verify that when endpoint is unreachable, manual entry still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)