### PR TITLE
fix(integrations): mark Hugging Face and LM Studio as Available

### DIFF
--- a/src/integrations/registry.rs
+++ b/src/integrations/registry.rs
@@ -284,13 +284,25 @@ pub fn all_integrations() -> Vec<IntegrationEntry> {
             name: "Hugging Face",
             description: "Open-source models",
             category: IntegrationCategory::AiModel,
-            status_fn: |_| IntegrationStatus::ComingSoon,
+            status_fn: |c| {
+                if matches!(c.default_provider.as_deref(), Some("huggingface" | "hf")) {
+                    IntegrationStatus::Active
+                } else {
+                    IntegrationStatus::Available
+                }
+            },
         },
         IntegrationEntry {
             name: "LM Studio",
             description: "Local model server",
             category: IntegrationCategory::AiModel,
-            status_fn: |_| IntegrationStatus::ComingSoon,
+            status_fn: |c| {
+                if matches!(c.default_provider.as_deref(), Some("lmstudio" | "lm-studio")) {
+                    IntegrationStatus::Active
+                } else {
+                    IntegrationStatus::Available
+                }
+            },
         },
         IntegrationEntry {
             name: "Venice",


### PR DESCRIPTION
## Summary

- Hugging Face and LM Studio were marked `ComingSoon` in the integrations registry despite being fully implemented in `providers/mod.rs`
- Updates their `status_fn` to match the pattern used by all other providers (Available by default, Active when configured as `default_provider`)
- Includes alias support: `hf` for Hugging Face, `lm-studio` for LM Studio

## Test plan

- [x] `cargo build` — compiles clean
- [x] `cargo test --lib integrations` — all 25 tests pass
- [ ] Open Integrations page — Hugging Face and LM Studio should show "Available" instead of "Coming Soon"
- [ ] Set `default_provider = "huggingface"` in config — should show "Active"
- [ ] Set `default_provider = "lmstudio"` in config — should show "Active"

🤖 Generated with [Claude Code](https://claude.com/claude-code)