### PR TITLE
fix(provider): prefer Codex account id from JWT claims

### DIFF
--- a/src/auth/openai_oauth.rs
+++ b/src/auth/openai_oauth.rs
@@ -321,11 +321,27 @@ pub fn extract_account_id_from_jwt(token: &str) -> Option<String> {
         .ok()?;
     let claims: serde_json::Value = serde_json::from_slice(&decoded).ok()?;
 
+    if let Some(value) = claims
+        .get("chatgpt_account_id")
+        .and_then(|v| v.as_str())
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Some(value.to_string());
+    }
+
+    if let Some(value) = claims
+        .get("https://api.openai.com/auth")
+        .and_then(|v| v.get("chatgpt_account_id"))
+        .and_then(|v| v.as_str())
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Some(value.to_string());
+    }
+
     for key in [
         "account_id",
         "accountId",
         "acct",
-        "sub",
         "https://api.openai.com/account_id",
     ] {
         if let Some(value) = claims.get(key).and_then(|v| v.as_str()) {
@@ -434,5 +450,31 @@ mod tests {
 
         let account = extract_account_id_from_jwt(&token);
         assert_eq!(account.as_deref(), Some("acct_123"));
+    }
+
+    #[test]
+    fn extract_account_id_from_nested_chatgpt_claims() {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode("{}");
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+            "{\"https://api.openai.com/auth\":{\"chatgpt_account_id\":\"55405405-c028-4b57-9563-93119bf910b7\"}}",
+        );
+        let token = format!("{header}.{payload}.sig");
+
+        let account = extract_account_id_from_jwt(&token);
+        assert_eq!(
+            account.as_deref(),
+            Some("55405405-c028-4b57-9563-93119bf910b7")
+        );
+    }
+
+    #[test]
+    fn extract_account_id_ignores_subject_only_tokens() {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode("{}");
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode("{\"sub\":\"windowslive|3fd7089075182c1b\"}");
+        let token = format!("{header}.{payload}.sig");
+
+        let account = extract_account_id_from_jwt(&token);
+        assert_eq!(account, None);
     }
 }

--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -326,6 +326,15 @@ fn nonempty_preserve(text: Option<&str>) -> Option<String> {
     })
 }
 
+fn resolve_account_id_for_request(
+    profile_account_id: Option<&str>,
+    access_token: Option<&str>,
+) -> Option<String> {
+    access_token
+        .and_then(extract_account_id_from_jwt)
+        .or_else(|| first_nonempty(profile_account_id))
+}
+
 fn extract_responses_text(response: &ResponsesResponse) -> Option<String> {
     if let Some(text) = first_nonempty(response.output_text.as_deref()) {
         return Some(text);
@@ -631,11 +640,12 @@ impl OpenAiCodexProvider {
             Err(err) => return Err(err),
         };
 
-        let account_id = profile.and_then(|profile| profile.account_id).or_else(|| {
-            oauth_access_token
-                .as_deref()
-                .and_then(extract_account_id_from_jwt)
-        });
+        let account_id = resolve_account_id_for_request(
+            profile
+                .as_ref()
+                .and_then(|profile| profile.account_id.as_deref()),
+            oauth_access_token.as_deref(),
+        );
         let access_token = if use_gateway_api_key_auth {
             oauth_access_token
         } else {
@@ -768,6 +778,7 @@ impl Provider for OpenAiCodexProvider {
 mod tests {
     use super::*;
     use crate::providers::test_util::{EnvGuard, env_lock};
+    use base64::Engine;
 
     #[test]
     fn extracts_output_text_first() {
@@ -952,6 +963,27 @@ mod tests {
             resolve_reasoning_effort("gpt-5-codex", None),
             "low".to_string()
         );
+    }
+
+    #[test]
+    fn request_account_id_prefers_token_over_stale_profile_value() {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode("{}");
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+            "{\"https://api.openai.com/auth\":{\"chatgpt_account_id\":\"55405405-c028-4b57-9563-93119bf910b7\"}}",
+        );
+        let token = format!("{header}.{payload}.sig");
+
+        let resolved = resolve_account_id_for_request(Some("windowslive|stale"), Some(&token));
+        assert_eq!(
+            resolved.as_deref(),
+            Some("55405405-c028-4b57-9563-93119bf910b7")
+        );
+    }
+
+    #[test]
+    fn request_account_id_falls_back_to_profile_when_token_missing() {
+        let resolved = resolve_account_id_for_request(Some("acct_123"), None);
+        assert_eq!(resolved.as_deref(), Some("acct_123"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- resolve OpenAI Codex account IDs from `chatgpt_account_id` claims before falling back to stored profile data
- support both top-level and nested `https://api.openai.com/auth.chatgpt_account_id` JWT layouts
- stop treating `sub` as an account-id fallback so stale `windowslive|...` subjects do not leak into Codex requests
- keep scope limited to provider auth/account resolution; no onboarding or TUI flow changes

## Validation
- `/Users/caleb/.cargo/bin/cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/tmp/zc-pr-target /Users/caleb/.cargo/bin/cargo clippy --all-targets -- -D warnings`
- `env -u ARK_API_KEY -u DOUBAO_API_KEY -u VOLCENGINE_API_KEY CARGO_TARGET_DIR=/tmp/zc-pr-target /Users/caleb/.cargo/bin/cargo test`