### PR TITLE
fix(approval): recognize yes/a reliably in tmux prompts

### DIFF
--- a/src/approval/mod.rs
+++ b/src/approval/mod.rs
@@ -9,7 +9,7 @@ use chrono::Utc;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, ErrorKind, Write};
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -207,16 +207,50 @@ fn prompt_cli_interactive(request: &ApprovalRequest) -> ApprovalResponse {
     eprint!("   [Y]es / [N]o / [A]lways for {}: ", request.tool_name);
     let _ = io::stderr().flush();
 
-    let stdin = io::stdin();
-    let mut line = String::new();
-    if stdin.lock().read_line(&mut line).is_err() {
-        return ApprovalResponse::No;
+    #[cfg(unix)]
+    {
+        // Prefer the controlling terminal so approval prompts do not compete
+        // with any higher-level stdin reader that may already own the pipe/PTY.
+        if let Ok(tty) = std::fs::OpenOptions::new().read(true).open("/dev/tty") {
+            let mut reader = io::BufReader::new(tty);
+            if let Ok(response) = read_approval_response(&mut reader) {
+                return response;
+            }
+        }
     }
 
-    match line.trim().to_ascii_lowercase().as_str() {
+    let stdin = io::stdin();
+    let mut reader = stdin.lock();
+    read_approval_response(&mut reader).unwrap_or(ApprovalResponse::No)
+}
+
+fn read_approval_response<R: BufRead>(reader: &mut R) -> io::Result<ApprovalResponse> {
+    let mut line = String::new();
+    let bytes = reader.read_line(&mut line)?;
+    if bytes == 0 {
+        return Err(io::Error::new(
+            ErrorKind::UnexpectedEof,
+            "no approval input received",
+        ));
+    }
+    Ok(parse_approval_response(&line))
+}
+
+fn parse_approval_response(input: &str) -> ApprovalResponse {
+    let normalized = input.trim().to_ascii_lowercase();
+    match normalized.as_str() {
         "y" | "yes" => ApprovalResponse::Yes,
+        "n" | "no" => ApprovalResponse::No,
         "a" | "always" => ApprovalResponse::Always,
-        _ => ApprovalResponse::No,
+        _ => match input
+            .chars()
+            .find(|c| c.is_ascii_alphabetic())
+            .map(|c| c.to_ascii_lowercase())
+        {
+            Some('y') => ApprovalResponse::Yes,
+            Some('a') => ApprovalResponse::Always,
+            _ => ApprovalResponse::No,
+        },
     }
 }
 
@@ -262,6 +296,7 @@ fn truncate_for_summary(input: &str, max_chars: usize) -> String {
 mod tests {
     use super::*;
     use crate::config::AutonomyConfig;
+    use std::io::Cursor;
 
     fn supervised_config() -> AutonomyConfig {
         AutonomyConfig {
@@ -548,6 +583,31 @@ mod tests {
         assert_eq!(json, "\"always\"");
         let parsed: ApprovalResponse = serde_json::from_str("\"no\"").unwrap();
         assert_eq!(parsed, ApprovalResponse::No);
+    }
+
+    #[test]
+    fn parse_approval_response_accepts_explicit_choices() {
+        assert_eq!(parse_approval_response("Y"), ApprovalResponse::Yes);
+        assert_eq!(parse_approval_response("yes"), ApprovalResponse::Yes);
+        assert_eq!(parse_approval_response("N"), ApprovalResponse::No);
+        assert_eq!(parse_approval_response("always"), ApprovalResponse::Always);
+    }
+
+    #[test]
+    fn parse_approval_response_accepts_wrapped_choice_tokens() {
+        assert_eq!(parse_approval_response("[Y]"), ApprovalResponse::Yes);
+        assert_eq!(parse_approval_response("(a)"), ApprovalResponse::Always);
+        assert_eq!(
+            parse_approval_response("\u{1b}[200~A\u{1b}[201~"),
+            ApprovalResponse::Always
+        );
+    }
+
+    #[test]
+    fn read_approval_response_parses_single_letter_lines() {
+        let mut input = Cursor::new(b"A\n");
+        let parsed = read_approval_response(&mut input).unwrap();
+        assert_eq!(parsed, ApprovalResponse::Always);
     }
 
     // ── ApprovalRequest ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): `master`
- Problem: In an interactive terminal such as `tmux`, the CLI approval prompt can fail to recognize typed responses like `yes` or `a`.
- Why it matters: If `yes` or `a` is not recognized, the tool call is denied even though the user tried to approve it.
- What changed: The approval prompt now reads from the controlling terminal (`/dev/tty`) when available, falls back to `stdin`, and accepts wrapped/pasted single-letter responses such as `[Y]`, `(a)`, and bracketed-paste `A`.
- What did **not** change (scope boundary): No approval policy, auto-approval rules, tool permissions, config keys, or non-interactive approval behavior changed.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: medium`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): `size: S`
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `core`, `security`, `tests`
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): `security: approval`
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: None

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): `bug`
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): `security`

## Linked Issue

- Closes # N.A.
- Related # N.A.
- Depends on # N.A.
- Supersedes # N.A.

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): N.A.
- Integrated scope by source PR (what was materially carried forward): N.A.
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`): N.A.
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over): N.A.
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`): N.A.

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
  - `cargo fmt --all -- --check`: passed
  - `cargo clippy --all-targets -- -D warnings`: passed
  - `env -u ARK_API_KEY -u DOUBAO_API_KEY -u VOLCENGINE_API_KEY CARGO_TARGET_DIR=/tmp/zc-approval-ci /Users/caleb/.cargo/bin/cargo nextest run --locked`: passed, `12435` tests passed, `13` skipped
  - `CARGO_TARGET_DIR=/tmp/zc-approval-ci /Users/caleb/.cargo/bin/cargo check --features ci-all --locked`: passed
  - `CARGO_TARGET_DIR=/tmp/zc-approval-ci /Users/caleb/.cargo/bin/cargo build --profile ci --locked`: passed
  - `CARGO_TARGET_DIR=/tmp/zc-approval-ci /Users/caleb/.cargo/bin/cargo bench --no-run --locked`: passed
  - `PATH=/Users/caleb/.cargo/bin:$PATH BASE_SHA=$(git merge-base origin/master HEAD) bash scripts/ci/rust_strict_delta_gate.sh`: passed
  - `BASE_SHA=$(git merge-base origin/master HEAD) bash scripts/ci/docs_quality_gate.sh`: passed, no docs files detected
  - `/Users/caleb/.cargo/bin/cargo deny check licenses sources`: passed
  - `/Users/caleb/.cargo/bin/cargo audit`: failed on pre-existing repository dependency advisories, including `wasmtime 41.0.4` advisories and existing desktop `tauri/gtk` dependency-chain warnings; this PR does not change `Cargo.lock` or dependency selection
- If any command is intentionally skipped, explain why: None intentionally skipped. `cargo audit` was run and is blocked by current upstream dependency advisories unrelated to this approval-only patch.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): Yes
- If any `Yes`, describe risk and mitigation: Interactive Unix CLI approval prompts now try to read `/dev/tty` in read-only mode before falling back to `stdin`. This is limited to the controlling terminal, avoids broad file access, and preserves the existing safe fallback.

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): `pass`
- Redaction/anonymization notes: No personal data, credentials, or real identifiers added.
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): Pass

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N.A.

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`): N.A.
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`): N.A.
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`): N.A.
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: N.A.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Inspected `origin/master` approval prompt behavior; verified the fix only changes `src/approval/mod.rs`; verified parsing for explicit `yes` / `always`, wrapped `[Y]` / `(a)`, and bracketed-paste `A` through regression tests.
- Edge cases checked: EOF-safe fallback, non-Unix/stdin fallback path by construction, and unrecognized input still resolves to `No`.
- What was not verified: A live manual `tmux` reproduction was not rerun in this pass.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Interactive CLI approval prompts.
- Potential unintended effects: On unusual Unix sessions where `/dev/tty` is unavailable or unreadable, the prompt should fall back to the existing `stdin` path.
- Guardrails/monitoring for early detection: Focused unit tests cover response parsing and EOF-safe reads; existing approval tests still pass.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex CLI/worktree commands, `gh`, Cargo validation commands.
- Workflow/plan summary (if any): Isolated the approval-only change, compared it with `origin/master`, ran repository validation, and reopened the PR with a clearer user-symptom-first description.
- Verification focus: `tmux`/TTY-style approval input reliability and no change to approval policy semantics.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: Revert commit `6262d3e0` or close this PR before merge.
- Feature flags or config toggles (if any): None
- Observable failure symptoms: Interactive approval prompts stop recognizing typed responses, default to `No`, or block unexpectedly.

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk: Reading `/dev/tty` could fail in sessions without a controlling terminal.
  - Mitigation: The code falls back to the existing `stdin` reader and defaults to `No` on unreadable/EOF input.

