### PR TITLE
fix: wire SOP subcommand in CLI entrypoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -460,6 +460,12 @@ Examples:
         skill_command: SkillCommands,
     },
 
+    /// Manage standard operating procedures (SOPs)
+    Sop {
+        #[command(subcommand)]
+        sop_command: SopCommands,
+    },
+
     /// Migrate data from other agent runtimes
     Migrate {
         #[command(subcommand)]
@@ -1668,6 +1674,8 @@ async fn main() -> Result<()> {
         } => integrations::handle_command(integration_command, &config),
 
         Commands::Skills { skill_command } => skills::handle_command(skill_command, &config),
+
+        Commands::Sop { sop_command } => sop::handle_command(sop_command, &config),
 
         Commands::Migrate { migrate_command } => {
             migration::handle_command(migrate_command, &config).await

--- a/src/sop/mod.rs
+++ b/src/sop/mod.rs
@@ -6,10 +6,10 @@ use anyhow::Result;
 pub fn handle_command(command: crate::SopCommands, config: &crate::config::Config) -> Result<()> {
     let workspace_dir = &config.workspace_dir;
     let default_mode = parse_execution_mode(&config.sop.default_execution_mode);
+    let sops = load_sops(workspace_dir, config.sop.sops_dir.as_deref(), default_mode);
 
     match command {
         crate::SopCommands::List => {
-            let sops = load_sops(workspace_dir, config.sop.sops_dir.as_deref(), default_mode);
             if sops.is_empty() {
                 println!("No SOPs found.");
                 println!();
@@ -42,7 +42,6 @@ pub fn handle_command(command: crate::SopCommands, config: &crate::config::Confi
             Ok(())
         }
         crate::SopCommands::Validate { name } => {
-            let sops = load_sops(workspace_dir, config.sop.sops_dir.as_deref(), default_mode);
             let targets: Vec<_> = match &name {
                 Some(n) => sops.iter().filter(|s| s.name == *n).collect(),
                 None => sops.iter().collect(),
@@ -76,7 +75,6 @@ pub fn handle_command(command: crate::SopCommands, config: &crate::config::Confi
             Ok(())
         }
         crate::SopCommands::Show { name } => {
-            let sops = load_sops(workspace_dir, config.sop.sops_dir.as_deref(), default_mode);
             let sop = sops
                 .iter()
                 .find(|s| s.name == name)

--- a/src/sop/mod.rs
+++ b/src/sop/mod.rs
@@ -1,6 +1,137 @@
 #[allow(unused_imports)]
 pub use zeroclaw_runtime::sop::*;
 
+use anyhow::Result;
+
+pub fn handle_command(command: crate::SopCommands, config: &crate::config::Config) -> Result<()> {
+    let workspace_dir = &config.workspace_dir;
+    let default_mode = parse_execution_mode(&config.sop.default_execution_mode);
+
+    match command {
+        crate::SopCommands::List => {
+            let sops = load_sops(workspace_dir, config.sop.sops_dir.as_deref(), default_mode);
+            if sops.is_empty() {
+                println!("No SOPs found.");
+                println!();
+                println!("  Create one: mkdir -p <workspace>/sops/my-sop");
+                println!("              then add SOP.toml and SOP.md");
+            } else {
+                println!("Loaded SOPs ({}):", sops.len());
+                println!();
+                for sop in &sops {
+                    println!(
+                        "  {} v{} [{}] — {}",
+                        console::style(&sop.name).white().bold(),
+                        sop.version,
+                        sop.priority,
+                        sop.description,
+                    );
+                    println!(
+                        "    Mode: {}  Steps: {}  Triggers: {}",
+                        sop.execution_mode,
+                        sop.steps.len(),
+                        sop.triggers
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                    );
+                }
+            }
+            println!();
+            Ok(())
+        }
+        crate::SopCommands::Validate { name } => {
+            let sops = load_sops(workspace_dir, config.sop.sops_dir.as_deref(), default_mode);
+            let targets: Vec<_> = match &name {
+                Some(n) => sops.iter().filter(|s| s.name == *n).collect(),
+                None => sops.iter().collect(),
+            };
+
+            if targets.is_empty() {
+                if let Some(n) = &name {
+                    anyhow::bail!("SOP not found: {n}");
+                }
+                println!("No SOPs found to validate.");
+                return Ok(());
+            }
+
+            let mut any_warnings = false;
+            for sop in &targets {
+                let warnings = validate_sop(sop);
+                if warnings.is_empty() {
+                    println!("  ✅ {} — valid", sop.name);
+                } else {
+                    any_warnings = true;
+                    println!("  ⚠️  {} — {} warning(s):", sop.name, warnings.len());
+                    for w in &warnings {
+                        println!("       - {w}");
+                    }
+                }
+            }
+            if !any_warnings {
+                println!();
+                println!("All SOPs passed validation.");
+            }
+            Ok(())
+        }
+        crate::SopCommands::Show { name } => {
+            let sops = load_sops(workspace_dir, config.sop.sops_dir.as_deref(), default_mode);
+            let sop = sops
+                .iter()
+                .find(|s| s.name == name)
+                .ok_or_else(|| anyhow::anyhow!("SOP not found: {name}"))?;
+
+            println!(
+                "{} v{}",
+                console::style(&sop.name).white().bold(),
+                sop.version
+            );
+            println!("  {}", sop.description);
+            println!();
+            println!("  Priority:       {}", sop.priority);
+            println!("  Execution mode: {}", sop.execution_mode);
+            println!("  Deterministic:  {}", sop.deterministic);
+            println!("  Cooldown:       {}s", sop.cooldown_secs);
+            println!("  Max concurrent: {}", sop.max_concurrent);
+            if let Some(loc) = &sop.location {
+                println!("  Location:       {}", loc.display());
+            }
+            println!();
+            println!("  Triggers:");
+            for trigger in &sop.triggers {
+                println!("    - {trigger}");
+            }
+
+            if !sop.steps.is_empty() {
+                println!();
+                println!("  Steps:");
+                for step in &sop.steps {
+                    let confirm = if step.requires_confirmation {
+                        " [confirmation required]"
+                    } else {
+                        ""
+                    };
+                    println!(
+                        "    {}. {}{}",
+                        step.number,
+                        console::style(&step.title).bold(),
+                        confirm,
+                    );
+                    if !step.body.is_empty() {
+                        println!("       {}", step.body);
+                    }
+                    if !step.suggested_tools.is_empty() {
+                        println!("       Tools: {}", step.suggested_tools.join(", "));
+                    }
+                }
+            }
+            println!();
+            Ok(())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: The `Sop` subcommand was defined in `lib.rs` (`SopCommands`) and had a working `handle_command` in the `sop` module, but was never added to the `Commands` enum or match dispatch in `main.rs`, making `zeroclaw sop` unusable.
- Why it matters: Users could not use `zeroclaw sop list`, `zeroclaw sop show`, or `zeroclaw sop validate` despite the feature being fully implemented.
- What changed: Added the `Sop` variant to the `Commands` enum and its match arm in `main()`. Added the `handle_command` implementation for `src/sop/mod.rs`
- What did **not** change (scope boundary): Changes are only specific to the `sop` sub command of the CLI and enables users to use it, anything outside this did not change.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `core`
- Module labels: `core: cli`
- Contributor tier label: _(auto-managed)_
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `runtime`

## Linked Issue

- Closes #5560
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
<img width="923" height="426" alt="image" src="https://github.com/user-attachments/assets/93d349be-82f4-405c-a4e0-96b288bb9237" />
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status : `pass`
- Redaction/anonymization notes: `not applicable`
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): `confirmed`

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No`
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)
Compiled -> installed -> Ran the command on my machine
What was personally validated beyond CI:

- Verified scenarios: Manually executed the sub command after the build
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `sop sub command`
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): VS Code Github Copilot
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: PR revert
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).
`None`
