### PR TITLE
fix(memory): skip user autosave keys in all memory context paths

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -1355,6 +1355,13 @@ fn should_skip_memory_context_entry(key: &str, content: &str) -> bool {
         return true;
     }
 
+    // Skip raw per-turn user messages: re-injecting them causes each
+    // recalled entry to embed all prior generations, growing exponentially.
+    // Consolidated knowledge is already promoted to Core/Daily entries.
+    if zeroclaw_memory::is_user_autosave_key(key) {
+        return true;
+    }
+
     if zeroclaw_memory::should_skip_autosave_content(content) {
         return true;
     }
@@ -5877,6 +5884,22 @@ mod tests {
         assert!(!should_skip_memory_context_entry(
             "telegram_user_msg_201",
             "plain text without tool results"
+        ));
+
+        // Per-turn user auto-save keys must be skipped to prevent exponential
+        // context bloat from re-injected conversation history.
+        assert!(should_skip_memory_context_entry(
+            "user_msg",
+            "original user message text"
+        ));
+        assert!(should_skip_memory_context_entry(
+            "user_msg_a1b2c3d4e5f6",
+            "follow-up message embedding prior context"
+        ));
+        // Channel-scoped keys (e.g. telegram_*) must NOT be affected.
+        assert!(!should_skip_memory_context_entry(
+            "telegram_user_msg_101",
+            "Please describe the image"
         ));
     }
 

--- a/crates/zeroclaw-memory/src/lib.rs
+++ b/crates/zeroclaw-memory/src/lib.rs
@@ -1,4 +1,20 @@
 //! Memory subsystem: backends, embeddings, consolidation, retrieval.
+//!
+//! ## Reserved Key Prefixes
+//!
+//! The following key prefixes are reserved for the auto-save system. Any memory
+//! stored under these keys will be **excluded from context assembly** by all
+//! three context-building paths (`build_context`, `DefaultMemoryLoader`, and
+//! `should_skip_memory_context_entry`). Do not use these prefixes for semantic
+//! memories that should surface in agent context.
+//!
+//! | Prefix | Purpose | Detection function |
+//! |---|---|---|
+//! | `assistant_resp` / `assistant_resp_*` | Model-authored assistant summaries (untrusted context) | [`is_assistant_autosave_key`] |
+//! | `user_msg` / `user_msg_*` | Raw per-turn user messages (consolidation queue) | [`is_user_autosave_key`] |
+//!
+//! Channel-scoped variants (e.g. `telegram_user_msg_*`, `discord_*`) are
+//! **not** filtered — they use different prefixes and are handled separately.
 
 pub mod audit;
 pub mod backend;

--- a/crates/zeroclaw-memory/src/lib.rs
+++ b/crates/zeroclaw-memory/src/lib.rs
@@ -99,6 +99,15 @@ pub fn is_assistant_autosave_key(key: &str) -> bool {
     normalized == "assistant_resp" || normalized.starts_with("assistant_resp_")
 }
 
+/// Auto-save key used for raw user messages captured per-turn.
+/// Re-injecting these into build_context causes exponential bloat: each recalled
+/// entry contains prior generations' context verbatim, growing unboundedly.
+/// Consolidated knowledge is already promoted to Core/Daily entries.
+pub fn is_user_autosave_key(key: &str) -> bool {
+    let normalized = key.trim().to_ascii_lowercase();
+    normalized == "user_msg" || normalized.starts_with("user_msg_")
+}
+
 /// Filter known synthetic autosave noise patterns that should not be
 /// persisted as user conversation memories.
 pub fn should_skip_autosave_content(content: &str) -> bool {
@@ -429,6 +438,15 @@ mod tests {
         assert!(is_assistant_autosave_key("ASSISTANT_RESP_abcd"));
         assert!(!is_assistant_autosave_key("assistant_response"));
         assert!(!is_assistant_autosave_key("user_msg_1234"));
+    }
+
+    #[test]
+    fn user_autosave_key_detection_matches_per_turn_patterns() {
+        assert!(is_user_autosave_key("user_msg"));
+        assert!(is_user_autosave_key("user_msg_1234"));
+        assert!(is_user_autosave_key("USER_MSG_abcd"));
+        assert!(!is_user_autosave_key("user_message"));
+        assert!(!is_user_autosave_key("assistant_resp_1234"));
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -351,6 +351,12 @@ async fn build_context(
                 if zeroclaw_memory::is_assistant_autosave_key(&entry.key) {
                     continue;
                 }
+                // Skip raw per-turn user messages: re-injecting them causes each
+                // recalled entry to embed all prior generations, growing exponentially.
+                // Consolidated knowledge is already promoted to Core/Daily entries.
+                if zeroclaw_memory::is_user_autosave_key(&entry.key) {
+                    continue;
+                }
                 if zeroclaw_memory::should_skip_autosave_content(&entry.content) {
                     continue;
                 }
@@ -6180,7 +6186,7 @@ mod tests {
         .await
         .unwrap();
         mem.store(
-            "user_msg_real",
+            "user_preference",
             "User asked for concise status updates",
             MemoryCategory::Conversation,
             None,
@@ -6189,9 +6195,44 @@ mod tests {
         .unwrap();
 
         let context = build_context(&mem, "status updates", 0.0, None).await;
-        assert!(context.contains("user_msg_real"));
+        assert!(context.contains("user_preference"));
         assert!(!context.contains("assistant_resp_poisoned"));
         assert!(!context.contains("fabricated event"));
+    }
+
+    #[tokio::test]
+    async fn build_context_ignores_user_autosave_entries() {
+        let tmp = TempDir::new().unwrap();
+        let mem = SqliteMemory::new(tmp.path()).unwrap();
+        mem.store(
+            "user_msg",
+            "Original user message with full conversation history",
+            MemoryCategory::Conversation,
+            None,
+        )
+        .await
+        .unwrap();
+        mem.store(
+            "user_msg_a1b2c3d4",
+            "Follow-up user message embedding prior context verbatim",
+            MemoryCategory::Conversation,
+            None,
+        )
+        .await
+        .unwrap();
+        mem.store(
+            "user_preference",
+            "User prefers concise answers",
+            MemoryCategory::Conversation,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let context = build_context(&mem, "answers", 0.0, None).await;
+        assert!(context.contains("user_preference"));
+        assert!(!context.contains("user_msg"));
+        assert!(!context.contains("embedding prior context"));
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/crates/zeroclaw-runtime/src/agent/memory_loader.rs
+++ b/crates/zeroclaw-runtime/src/agent/memory_loader.rs
@@ -58,6 +58,9 @@ impl MemoryLoader for DefaultMemoryLoader {
             if zeroclaw_memory::is_assistant_autosave_key(&entry.key) {
                 continue;
             }
+            if zeroclaw_memory::is_user_autosave_key(&entry.key) {
+                continue;
+            }
             if zeroclaw_memory::should_skip_autosave_content(&entry.content) {
                 continue;
             }
@@ -258,5 +261,46 @@ mod tests {
         assert!(context.contains("user_fact"));
         assert!(!context.contains("assistant_resp_legacy"));
         assert!(!context.contains("fabricated detail"));
+    }
+
+    #[tokio::test]
+    async fn default_loader_skips_user_autosave_entries() {
+        let loader = DefaultMemoryLoader::new(5, 0.0);
+        let memory = MockMemoryWithEntries {
+            entries: Arc::new(vec![
+                MemoryEntry {
+                    id: "1".into(),
+                    key: "user_msg_e5f6g7h8".into(),
+                    content: "User message embedding prior context verbatim".into(),
+                    category: MemoryCategory::Conversation,
+                    timestamp: "now".into(),
+                    session_id: None,
+                    score: Some(0.95),
+                    namespace: "default".into(),
+                    importance: None,
+                    superseded_by: None,
+                },
+                MemoryEntry {
+                    id: "2".into(),
+                    key: "user_fact".into(),
+                    content: "User prefers concise answers".into(),
+                    category: MemoryCategory::Conversation,
+                    timestamp: "now".into(),
+                    session_id: None,
+                    score: Some(0.9),
+                    namespace: "default".into(),
+                    importance: None,
+                    superseded_by: None,
+                },
+            ]),
+        };
+
+        let context = loader
+            .load_context(&memory, "answer style", None)
+            .await
+            .unwrap();
+        assert!(context.contains("user_fact"));
+        assert!(!context.contains("user_msg_e5f6g7h8"));
+        assert!(!context.contains("embedding prior context"));
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Per-turn user messages (`user_msg`, `user_msg_<uuid>`) are auto-saved for consolidation but get re-injected into memory recall context. Each recalled entry embeds prior context verbatim, causing exponential bloat across turns.
- Why it matters: Over multiple turns the context window fills with recursively-nested history, degrading response quality and wasting tokens.
- What changed: Wired `is_user_autosave_key()` (from #5631) into all three memory context-building paths: `build_context()` in `crates/zeroclaw-runtime/src/agent/loop_.rs`, `DefaultMemoryLoader` in `crates/zeroclaw-runtime/src/agent/memory_loader.rs`, and `should_skip_memory_context_entry()` in `crates/zeroclaw-channels/src/orchestrator/mod.rs`. Fixed pre-existing test using a `user_msg_real` key as the pass-through case. Added dedicated tests for each path.
- What did **not** change (scope boundary): No changes to memory storage, consolidation, key generation, or channel key patterns. No new dependencies.
- Related upstream fix: #5664 (`fix(cron): disable auto_save for cron agent jobs`) addresses the same bloat symptom via a different and complementary mechanism — it disables `auto_save` on the cron write path and adds a content-level skip filter. This PR addresses the read path across all three context-building callers, including non-cron paths where `auto_save` remains active.

## Label Snapshot (required)

- Risk label (`risk: high`): `risk: high` — modifies `crates/zeroclaw-runtime/src/agent/`, which is an explicitly listed high-risk path in `AGENTS.md`; also modifies `crates/zeroclaw-channels/src/orchestrator/mod.rs`
- Size label (`size: S`): `size: S` — ~107 lines changed across 3 files
- Scope labels: `memory`, `agent`, `channel`, `tests`
- Module labels: `memory: context-filtering`, `agent: build_context`, `channel: memory-context`
- Contributor tier label: auto-managed

## Change Metadata

- Change type: `bug`
- Primary scope: `memory`

## Dependencies

- Stacked on #5631 (feat: add is_user_autosave_key detector) — must merge first; this branch is rebased on top of it
- #5633 (CI: suppress wasmtime RUSTSEC-2026-04-09 audit batch) — already merged

## Linked Issue

- Stacked on #5631

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check   # pass
cargo clippy --all-targets -- -D warnings  # pass
cargo test  # 821 passed; 0 failed; 7 ignored
```

- Evidence provided: 3 new tests added covering each context path. Pre-existing test fixed. Full suite green.
- Note: `cargo test -p zeroclaw-channels --lib` has 2 pre-existing failures (`build_channel_by_id_*telegram*`) introduced by upstream #5639 (Telegram moved out of orchestrator); these are unrelated to this PR and do not appear in the root `cargo test` run.
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: test data uses impersonal placeholders (`user_preference`, `user_fact`, `fabricated event`)
- Neutral wording confirmation: all test language is system-focused, no identity-specific wording

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No` — no docs or user-facing wording changed

## Human Verification (required)

- Verified scenarios:
  - `build_context()` correctly filters `user_msg` and `user_msg_<uuid>` while preserving `user_preference`
  - `DefaultMemoryLoader` correctly filters `user_msg_<uuid>` while preserving `user_fact`
  - `should_skip_memory_context_entry()` correctly filters `user_msg` patterns while preserving `telegram_user_msg_*` (different prefix)
- Edge cases checked:
  - Channel-scoped keys (`telegram_user_msg_101`) are NOT filtered (different prefix)
  - `user_message` is NOT matched (distinct word boundary)
  - Case-insensitive matching works
- What was not verified: live multi-turn agent loop (would require running daemon with provider credentials)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
  - Agent memory context enrichment (all channels + direct agent)
  - Channel memory context injection
  - `DefaultMemoryLoader` users
- Potential unintended effects:
  - If a user manually stores a memory with key `user_msg` or `user_msg_*`, it will be filtered from context. This is unlikely since these keys are reserved for auto-save. The reserved-prefix contract is documented in `crates/zeroclaw-memory/src/lib.rs` (added in #5631).
  - Channel conversation keys (`telegram_*`, `discord_*`) are unaffected — they use different prefixes.
- Guardrails/monitoring for early detection: existing integration tests (`tests/integration/agent.rs`) cover memory enrichment end-to-end

## Agent Collaboration Notes (recommended)

- Agent tools used: codebase exploration, test execution, git operations
- Workflow/plan summary: identified asymmetry across 3 context paths, fixed broken test, added coverage for each path
- Verification focus: ensuring no regression in non-user_msg key filtering, channel key isolation
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <sha>` — single commit, all filtering removed atomically
- Feature flags or config toggles (if any): none — if rollback needed, revert restores original behavior
- Observable failure symptoms: user memories stop appearing in context (extremely unlikely — only `user_msg*`-prefixed keys are affected)

## Risks and Mitigations

- Risk: Manually-created memories with `user_msg` prefix would be filtered from context
  - Mitigation: `user_msg` prefix is reserved for auto-save system; documented in the module-level reserved key prefix table in `crates/zeroclaw-memory/src/lib.rs` (added in #5631). Consolidated memories use semantic keys (e.g., `user_preference`, `user_fact`).

