### PR TITLE
feat(cli): rename props subcommand to config, deprecate props

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -493,8 +493,8 @@ pub struct ChannelsConfig {
 ```
 
 That's it. The `#[secret]` annotation automatically:
-- Includes the field in `zeroclaw props list --secrets`
-- Makes it settable via `zeroclaw props set channels.your-channel.bot-token`
+- Includes the field in `zeroclaw config list --secrets`
+- Makes it settable via `zeroclaw config set channels.your-channel.bot-token`
 - Encrypts it on config save and decrypts on load
 - Converts the field name from `snake_case` to `kebab-case` in the CLI
 

--- a/crates/zeroclaw-config/src/helpers.rs
+++ b/crates/zeroclaw-config/src/helpers.rs
@@ -1,4 +1,4 @@
-//! Property helpers used by the `Configurable` derive macro and the `zeroclaw props` CLI.
+//! Property helpers used by the `Configurable` derive macro and the `zeroclaw config` CLI.
 
 use crate::traits::{PropFieldInfo, PropKind};
 

--- a/crates/zeroclaw-config/src/traits.rs
+++ b/crates/zeroclaw-config/src/traits.rs
@@ -3,7 +3,7 @@
 pub struct SecretFieldInfo {
     /// Full dotted name (e.g. `channels.matrix.access-token`)
     pub name: &'static str,
-    /// Category for grouping in `zeroclaw props list`
+    /// Category for grouping in `zeroclaw config list`
     pub category: &'static str,
     /// Whether this field currently has a non-empty value
     pub is_set: bool,

--- a/docs/reference/cli/commands-reference.md
+++ b/docs/reference/cli/commands-reference.md
@@ -24,8 +24,7 @@ Last verified: **March 26, 2026**.
 | `integrations` | Inspect integration details |
 | `skills` | List/install/remove skills |
 | `migrate` | Import from external runtimes (currently OpenClaw) |
-| `props` | View, set, or initialize config properties |
-| `config` | Export machine-readable config schema |
+| `config` | Manage configuration (view/set properties, export schema) |
 | `completions` | Generate shell completion scripts to stdout |
 | `hardware` | Discover and introspect USB hardware |
 | `peripheral` | Configure and flash peripherals |
@@ -197,9 +196,25 @@ Skill manifests (`SKILL.toml`) support `prompts` and `[[tools]]`; both are injec
 
 ### `config`
 
-- `zeroclaw config schema`
+- `zeroclaw config list` — list all properties with current values
+- `zeroclaw config list --secrets` — list only secret (encrypted) fields
+- `zeroclaw config list --filter channels.matrix` — filter by path prefix
+- `zeroclaw config get <path>` — get a single property value (secrets show set/unset status)
+- `zeroclaw config set <path> <value>` — set a property value
+- `zeroclaw config set <path>` — secret fields prompt for masked input; enum fields offer interactive selection
+- `zeroclaw config set --no-interactive <path> <value>` — scripted mode, no prompts
+- `zeroclaw config init <section>` — create an unconfigured section with defaults (`enabled=false`)
+- `zeroclaw config init` — initialize all unconfigured sections
+- `zeroclaw config schema` — print JSON Schema (draft 2020-12) to stdout
 
-`config schema` prints a JSON Schema (draft 2020-12) for the full `config.toml` contract to stdout.
+Secret fields (API keys, tokens, passwords) are automatically detected via `#[secret]`
+annotations. When setting a secret, input is masked regardless of whether a value is
+provided on the command line.
+
+Enum fields (e.g. `stream-mode`, `search-mode`) offer interactive selection via arrow
+keys when the value is omitted. Provide the value directly to skip the prompt.
+
+Shell tab-completion for property paths is included in `zeroclaw completions <shell>`.
 
 ### `completions`
 
@@ -225,34 +240,14 @@ Skill manifests (`SKILL.toml`) support `prompts` and `[[tools]]`; both are injec
 - `zeroclaw peripheral setup-uno-q [--host <ip_or_host>]`
 - `zeroclaw peripheral flash-nucleo`
 
-### `props`
+### `props` (deprecated)
 
-Manage individual config properties without editing `config.toml` directly.
-Properties are addressed by dotted path (e.g. `channels.matrix.mention-only`).
-
-- `zeroclaw props list` — list all properties with current values
-- `zeroclaw props list --secrets` — list only secret (encrypted) fields
-- `zeroclaw props list --filter channels.matrix` — filter by path prefix
-- `zeroclaw props get <path>` — get a single property value (secrets show set/unset status)
-- `zeroclaw props set <path> <value>` — set a property value
-- `zeroclaw props set <path>` — secret fields prompt for masked input; enum fields offer interactive selection
-- `zeroclaw props set --no-interactive <path> <value>` — scripted mode, no prompts
-- `zeroclaw props init <section>` — create an unconfigured section with defaults (`enabled=false`)
-- `zeroclaw props init` — initialize all unconfigured sections
-
-Secret fields (API keys, tokens, passwords) are automatically detected via `#[secret]`
-annotations. When setting a secret, input is masked regardless of whether a value is
-provided on the command line.
-
-Enum fields (e.g. `stream-mode`, `search-mode`) offer interactive selection via arrow
-keys when the value is omitted. Provide the value directly to skip the prompt.
-
-Shell tab-completion for property paths is included in `zeroclaw completions <shell>`.
+`zeroclaw props` has been renamed to `zeroclaw config`. Replace `props` with `config` in your commands.
 
 #### Adding new config fields
 
 Config structs derive `Configurable` with `#[prefix]` and `#[nested]` attributes.
-Adding a new field to an existing struct makes it immediately available via `props`.
+Adding a new field to an existing struct makes it immediately available via `config`.
 New enum types require a one-line `HasPropKind` impl. See `CONTRIBUTING.md` for details.
 
 ## Validation Tip

--- a/docs/security/matrix-e2ee-guide.md
+++ b/docs/security/matrix-e2ee-guide.md
@@ -105,7 +105,7 @@ curl -sS -H "Authorization: Bearer $MATRIX_TOKEN" \
 - If `device_id` is missing, set `channels_config.matrix.device_id` manually.
 - To update the access token without re-running onboard:
   ```bash
-  zeroclaw props set channels.matrix.access-token
+  zeroclaw config set channels.matrix.access-token
   ```
 
 ### D. E2EE-specific checks
@@ -250,7 +250,7 @@ Paste the recovery key (input is masked). It will be encrypted and stored in `co
 Option B — via the secret CLI (recommended for existing installs):
 
 ```bash
-zeroclaw props set channels.matrix.recovery-key
+zeroclaw config set channels.matrix.recovery-key
 ```
 
 Input is masked. The value is encrypted at rest immediately.

--- a/src/main.rs
+++ b/src/main.rs
@@ -531,13 +531,26 @@ Examples:
     #[command(long_about = "\
 Manage ZeroClaw configuration.
 
-Inspect and export configuration settings. Use 'schema' to dump \
-the full JSON Schema for the config file, which documents every \
-available key, type, and default value.
+View, set, or initialize config properties by dotted path. \
+Use 'schema' to dump the full JSON Schema for the config file.
+
+Properties are addressed by dotted path (e.g. channels.matrix.mention-only).
+Secret fields (API keys, tokens) automatically use masked input.
+Enum fields offer interactive selection when value is omitted.
 
 Examples:
-  zeroclaw config schema              # print JSON Schema to stdout
-  zeroclaw config schema > schema.json")]
+  zeroclaw config list                                  # list all properties
+  zeroclaw config list --secrets                        # list only secrets
+  zeroclaw config list --filter channels.matrix         # filter by prefix
+  zeroclaw config get channels.matrix.mention-only      # get a value
+  zeroclaw config set channels.matrix.mention-only true # set a value
+  zeroclaw config set channels.matrix.access-token      # secret: masked input
+  zeroclaw config set channels.matrix.stream-mode       # enum: interactive select
+  zeroclaw config init channels.matrix                  # init section with defaults
+  zeroclaw config schema                                # print JSON Schema to stdout
+  zeroclaw config schema > schema.json
+
+Property path tab completion is included automatically in `zeroclaw completions <shell>`.")]
     Config {
         #[command(subcommand)]
         config_command: ConfigCommands,
@@ -624,28 +637,11 @@ Examples:
         install: bool,
     },
 
-    /// View or change config properties by dotted path
-    #[command(long_about = "\
-View, set, or initialize config properties.
-
-Properties are addressed by dotted path (e.g. channels.matrix.mention-only).
-Secret fields (API keys, tokens) automatically use masked input.
-Enum fields offer interactive selection when value is omitted.
-
-Examples:
-  zeroclaw props list                                  # list all properties
-  zeroclaw props list --secrets                        # list only secrets
-  zeroclaw props list --filter channels.matrix         # filter by prefix
-  zeroclaw props get channels.matrix.mention-only      # get a value
-  zeroclaw props set channels.matrix.mention-only true # set a value
-  zeroclaw props set channels.matrix.access-token      # secret: masked input
-  zeroclaw props set channels.matrix.stream-mode       # enum: interactive select
-  zeroclaw props init channels.matrix                  # init section with defaults
-
-Property path tab completion is included automatically in `zeroclaw completions <shell>`.")]
+    /// Deprecated: use `zeroclaw config` instead
+    #[command(hide = true)]
     Props {
         #[command(subcommand)]
-        props_command: PropsCommands,
+        props_command: DeprecatedPropsCommands,
     },
 
     /// Manage WASM plugins
@@ -656,8 +652,58 @@ Property path tab completion is included automatically in `zeroclaw completions 
     },
 }
 
+/// Stub enum that mirrors the old `props` subcommands so clap can still parse
+/// `zeroclaw props <anything>` and print a deprecation message.
 #[derive(Subcommand, Debug)]
-enum PropsCommands {
+enum DeprecatedPropsCommands {
+    #[command(hide = true)]
+    List {
+        #[arg(short, long)]
+        filter: Option<String>,
+        #[arg(long)]
+        secrets: bool,
+    },
+    #[command(hide = true)]
+    Get { path: String },
+    #[command(hide = true)]
+    Set {
+        path: String,
+        value: Option<String>,
+        #[arg(long)]
+        no_interactive: bool,
+    },
+    #[command(hide = true)]
+    Init { section: Option<String> },
+    #[command(hide = true)]
+    Complete { partial: Option<String> },
+}
+
+#[cfg(feature = "plugins-wasm")]
+#[derive(Subcommand, Debug)]
+enum PluginCommands {
+    /// List installed plugins
+    List,
+    /// Install a plugin from a directory or URL
+    Install {
+        /// Path to plugin directory or manifest
+        source: String,
+    },
+    /// Remove an installed plugin
+    Remove {
+        /// Plugin name
+        name: String,
+    },
+    /// Show information about a plugin
+    Info {
+        /// Plugin name
+        name: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum ConfigCommands {
+    /// Dump the full configuration JSON Schema to stdout
+    Schema,
     /// List all config properties with current values
     List {
         /// Filter by path prefix (e.g. "channels.telegram")
@@ -693,34 +739,6 @@ enum PropsCommands {
         /// Partial path to complete
         partial: Option<String>,
     },
-}
-
-#[cfg(feature = "plugins-wasm")]
-#[derive(Subcommand, Debug)]
-enum PluginCommands {
-    /// List installed plugins
-    List,
-    /// Install a plugin from a directory or URL
-    Install {
-        /// Path to plugin directory or manifest
-        source: String,
-    },
-    /// Remove an installed plugin
-    Remove {
-        /// Plugin name
-        name: String,
-    },
-    /// Show information about a plugin
-    Info {
-        /// Plugin name
-        name: String,
-    },
-}
-
-#[derive(Subcommand, Debug)]
-enum ConfigCommands {
-    /// Dump the full configuration JSON Schema to stdout
-    Schema,
 }
 
 #[derive(Subcommand, Debug)]
@@ -1849,10 +1867,7 @@ async fn main() -> Result<()> {
                 );
                 Ok(())
             }
-        },
-
-        Commands::Props { props_command } => match props_command {
-            PropsCommands::List { filter, secrets } => {
+            ConfigCommands::List { filter, secrets } => {
                 let entries = config.prop_fields();
                 let mut current_category = "";
                 for entry in &entries {
@@ -1879,7 +1894,7 @@ async fn main() -> Result<()> {
                 }
                 Ok(())
             }
-            PropsCommands::Get { path } => {
+            ConfigCommands::Get { path } => {
                 if Config::prop_is_secret(&path) {
                     let entries = config.prop_fields();
                     let is_set = entries
@@ -1900,16 +1915,15 @@ async fn main() -> Result<()> {
                 }
                 Ok(())
             }
-            PropsCommands::Set {
+            ConfigCommands::Set {
                 path,
                 value,
                 no_interactive,
             } => {
                 if no_interactive {
-                    // Scripted mode: require value on CLI, no prompts
                     let val = value.ok_or_else(|| {
                         anyhow::anyhow!(
-                            "Value required in --no-interactive mode. Usage: zeroclaw props set --no-interactive {path} <value>"
+                            "Value required in --no-interactive mode. Usage: zeroclaw config set --no-interactive {path} <value>"
                         )
                     })?;
                     config.set_prop(&path, &val)?;
@@ -1930,7 +1944,6 @@ async fn main() -> Result<()> {
                 } else if let Some(val) = value {
                     config.set_prop(&path, &val)?;
                 } else {
-                    // Enum fields get interactive selection; everything else needs a value
                     let variants = config
                         .prop_fields()
                         .into_iter()
@@ -1952,14 +1965,14 @@ async fn main() -> Result<()> {
                             .interact()?;
                         config.set_prop(&path, &variants[selected])?;
                     } else {
-                        anyhow::bail!("Value required. Usage: zeroclaw props set {path} <value>");
+                        anyhow::bail!("Value required. Usage: zeroclaw config set {path} <value>");
                     }
                 }
                 config.save().await?;
                 println!("{path} updated.");
                 Ok(())
             }
-            PropsCommands::Init { section } => {
+            ConfigCommands::Init { section } => {
                 let initialized = config.init_defaults(section.as_deref());
                 if initialized.is_empty() {
                     println!("All sections already configured.");
@@ -1972,11 +1985,11 @@ async fn main() -> Result<()> {
                         println!("  {name}");
                     }
                     config.save().await?;
-                    println!("\nRun `zeroclaw props list` to review, then set required fields.");
+                    println!("\nRun `zeroclaw config list` to review, then set required fields.");
                 }
                 Ok(())
             }
-            PropsCommands::Complete { partial } => {
+            ConfigCommands::Complete { partial } => {
                 let prefix = partial.as_deref().unwrap_or("");
                 for entry in config.prop_fields() {
                     if entry.name.starts_with(prefix) {
@@ -1986,6 +1999,12 @@ async fn main() -> Result<()> {
                 Ok(())
             }
         },
+
+        Commands::Props { .. } => {
+            eprintln!("Error: `zeroclaw props` has been renamed to `zeroclaw config`.");
+            eprintln!("Replace `props` with `config` in your command and try again.");
+            std::process::exit(1);
+        }
 
         #[cfg(feature = "plugins-wasm")]
         Commands::Plugin { plugin_command } => match plugin_command {
@@ -2219,17 +2238,17 @@ fn write_shell_completion<W: Write>(shell: CompletionShell, writer: &mut W) -> R
     match shell {
         CompletionShell::Bash => {
             generate(shells::Bash, &mut cmd, bin_name.clone(), writer);
-            // Wrap clap's _zeroclaw to inject dynamic props path completion
+            // Wrap clap's _zeroclaw to inject dynamic config path completion
             writeln!(
                 writer,
                 r#"
-# Dynamic completion for zeroclaw props get/set paths
+# Dynamic completion for zeroclaw config get/set paths
 if type _zeroclaw &>/dev/null; then
     _zeroclaw_clap_orig() {{ _zeroclaw "$@"; }}
     _zeroclaw() {{
         local cur="${{COMP_WORDS[COMP_CWORD]}}"
-        if [[ "${{COMP_WORDS[*]}}" =~ "props "(get|set)" " ]]; then
-            COMPREPLY=($(compgen -W "$(zeroclaw props complete "$cur" 2>/dev/null)" -- "$cur"))
+        if [[ "${{COMP_WORDS[*]}}" =~ "config "(get|set)" " ]]; then
+            COMPREPLY=($(compgen -W "$(zeroclaw config complete "$cur" 2>/dev/null)" -- "$cur"))
             return
         fi
         _zeroclaw_clap_orig "$@"
@@ -2242,24 +2261,24 @@ fi"#
             writeln!(
                 writer,
                 r#"
-# Dynamic completion for zeroclaw props get/set paths
-complete -c zeroclaw -n '__fish_seen_subcommand_from props; and __fish_seen_subcommand_from get set' \
-    -a '(zeroclaw props complete (commandline -ct) 2>/dev/null)' -f"#
+# Dynamic completion for zeroclaw config get/set paths
+complete -c zeroclaw -n '__fish_seen_subcommand_from config; and __fish_seen_subcommand_from get set' \
+    -a '(zeroclaw config complete (commandline -ct) 2>/dev/null)' -f"#
             )?;
         }
         CompletionShell::Zsh => {
             generate(shells::Zsh, &mut cmd, bin_name.clone(), writer);
-            // Wrap clap's _zeroclaw to inject dynamic props path completion
+            // Wrap clap's _zeroclaw to inject dynamic config path completion
             writeln!(
                 writer,
                 r#"
-# Dynamic completion for zeroclaw props get/set paths
+# Dynamic completion for zeroclaw config get/set paths
 if (( $+functions[_zeroclaw] )); then
     functions[_zeroclaw_clap_orig]=$functions[_zeroclaw]
     _zeroclaw() {{
-        if [[ "${{words[*]}}" == *"props "(get|set)* ]] && (( CURRENT > 3 )); then
+        if [[ "${{words[*]}}" == *"config "(get|set)* ]] && (( CURRENT > 3 )); then
             local -a props
-            props=(${{(f)"$(zeroclaw props complete "$words[CURRENT]" 2>/dev/null)"}})
+            props=(${{(f)"$(zeroclaw config complete "$words[CURRENT]" 2>/dev/null)"}})
             compadd -a props
             return
         fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -656,26 +656,8 @@ Examples:
 /// `zeroclaw props <anything>` and print a deprecation message.
 #[derive(Subcommand, Debug)]
 enum DeprecatedPropsCommands {
-    #[command(hide = true)]
-    List {
-        #[arg(short, long)]
-        filter: Option<String>,
-        #[arg(long)]
-        secrets: bool,
-    },
-    #[command(hide = true)]
-    Get { path: String },
-    #[command(hide = true)]
-    Set {
-        path: String,
-        value: Option<String>,
-        #[arg(long)]
-        no_interactive: bool,
-    },
-    #[command(hide = true)]
-    Init { section: Option<String> },
-    #[command(hide = true)]
-    Complete { partial: Option<String> },
+    #[command(external_subcommand)]
+    Any(Vec<String>),
 }
 
 #[cfg(feature = "plugins-wasm")]
@@ -2001,9 +1983,10 @@ async fn main() -> Result<()> {
         },
 
         Commands::Props { .. } => {
-            eprintln!("Error: `zeroclaw props` has been renamed to `zeroclaw config`.");
-            eprintln!("Replace `props` with `config` in your command and try again.");
-            std::process::exit(1);
+            anyhow::bail!(
+                "`zeroclaw props` has been renamed to `zeroclaw config`. \
+                 Replace `props` with `config` in your command and try again."
+            );
         }
 
         #[cfg(feature = "plugins-wasm")]


### PR DESCRIPTION
## Summary

- Merge all `PropsCommands` variants (`List`, `Get`, `Set`, `Init`, `Complete`) into `ConfigCommands` alongside existing `Schema`
- Replace `Props` command with a hidden deprecation stub that prints an error and exits non-zero
- Update shell completion scripts (bash, fish, zsh) to target `zeroclaw config` instead of `zeroclaw props`
- Update all documentation and references across CLI docs, E2EE guide, and CONTRIBUTING.md

Follow-up to #5559.
Closes #5622

## Test plan

- [ ] `zeroclaw config list` — lists all properties
- [ ] `zeroclaw config get <path>` — gets a property value
- [ ] `zeroclaw config set <path> <value>` — sets a property
- [ ] `zeroclaw config schema` — prints JSON schema
- [ ] `zeroclaw config init` — initializes sections
- [ ] `zeroclaw props list` — prints deprecation error, exits non-zero