### PR TITLE
fix(onboard): wire nostr, whatsapp-web, and hardware wizard sections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12268,6 +12268,7 @@ dependencies = [
  "mail-parser",
  "mime_guess",
  "nanohtml2text",
+ "nostr-sdk",
  "parking_lot",
  "portable-atomic",
  "rand 0.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,6 +179,9 @@ crossterm = { version = "0.29", features = ["event-stream"], optional = true }
 # Hardware discovery (device path globbing)
 glob = { version = "0.3", optional = true }
 
+# Nostr key validation for wizard (behind channel-nostr feature)
+nostr-sdk = { version = "0.44", default-features = false, optional = true }
+
 # Binary discovery (init system detection)
 which = { version = "8.0", optional = true }
 
@@ -262,7 +265,7 @@ schema-export = ["zeroclaw-config/schema-export"]
 channel-email = ["zeroclaw-channels/channel-email"]
 channel-telegram = ["zeroclaw-channels/channel-telegram"]
 channel-lark = ["zeroclaw-channels/channel-lark"]
-channel-nostr = ["zeroclaw-channels/channel-nostr"]
+channel-nostr = ["zeroclaw-channels/channel-nostr", "zeroclaw-runtime/channel-nostr", "dep:nostr-sdk"]
 channel-matrix = ["zeroclaw-channels/channel-matrix"]
 channel-discord = ["zeroclaw-channels/channel-discord"]
 channel-slack = ["zeroclaw-channels/channel-slack"]

--- a/crates/zeroclaw-runtime/Cargo.toml
+++ b/crates/zeroclaw-runtime/Cargo.toml
@@ -94,6 +94,7 @@ sandbox-landlock = ["dep:landlock"]
 schema-export = ["dep:schemars", "zeroclaw-config/schema-export"]
 
 
+channel-nostr = ["zeroclaw-config/channel-nostr"]
 browser-native = []
 rag-pdf = ["dep:pdf-extract"]
 plugins-wasm = ["dep:zeroclaw-plugins"]

--- a/crates/zeroclaw-runtime/src/onboard/mod.rs
+++ b/crates/zeroclaw-runtime/src/onboard/mod.rs
@@ -3,8 +3,8 @@ pub mod wizard;
 // Re-exported for CLI and external use
 #[allow(unused_imports)]
 pub use wizard::{
-    run_channels_repair_wizard, run_models_list, run_models_refresh, run_models_refresh_all,
-    run_models_set, run_models_status, run_quick_setup, run_wizard,
+    WizardCallbacks, run_channels_repair_wizard, run_models_list, run_models_refresh,
+    run_models_refresh_all, run_models_set, run_models_status, run_quick_setup, run_wizard,
 };
 
 #[cfg(test)]

--- a/crates/zeroclaw-runtime/src/onboard/wizard.rs
+++ b/crates/zeroclaw-runtime/src/onboard/wizard.rs
@@ -38,6 +38,9 @@ pub type NostrKeyValidator = Box<dyn Fn(&str) -> Result<String>>;
 
 /// Callbacks injected by the binary crate to wire wizard sections whose
 /// implementations live in downstream crates (zeroclaw-hardware, zeroclaw-channels).
+///
+/// NOTE: Transitional bridge — see RFC #5574 Phase 2 D4. This struct will be
+/// replaced when `zeroclaw onboard` integrates with `PluginRegistry::install`.
 #[derive(Default)]
 pub struct WizardCallbacks {
     /// Full interactive hardware setup flow. When `Some`, the wizard runs
@@ -5307,6 +5310,12 @@ fn setup_channels(
                             continue;
                         }
                     }
+                } else {
+                    println!(
+                        "  {} Key validation unavailable in this build — skipping",
+                        style("⚠").yellow().bold()
+                    );
+                    continue;
                 }
 
                 let default_relays = default_nostr_relays().join(",");

--- a/crates/zeroclaw-runtime/src/onboard/wizard.rs
+++ b/crates/zeroclaw-runtime/src/onboard/wizard.rs
@@ -1,5 +1,4 @@
 use crate::cli_input::Input;
-// TODO: hardware wizard code moved to zeroclaw-hardware; wire via callback
 use anyhow::{Context, Result, bail};
 use console::style;
 use dialoguer::{Confirm, Select};
@@ -20,8 +19,7 @@ use zeroclaw_config::schema::{
     SignalConfig, StreamMode, WhatsAppConfig,
 };
 use zeroclaw_config::schema::{HardwareConfig, HardwareTransport};
-// TODO: nostr onboarding disabled until zeroclaw-channels provides it
-#[cfg(any())]
+#[cfg(feature = "channel-nostr")]
 use zeroclaw_config::schema::{NostrConfig, default_nostr_relays};
 use zeroclaw_memory::{
     default_memory_backend_key, memory_backend_profile, selectable_memory_backends,
@@ -31,6 +29,32 @@ use zeroclaw_providers::{
     is_moonshot_alias, is_qianfan_alias, is_qwen_alias, is_qwen_oauth_alias, is_zai_alias,
     is_zai_cn_alias,
 };
+
+// ── Wizard callbacks for cross-crate functionality ─────────────
+
+/// Callback type for Nostr key validation: accepts a key string, returns public key hex.
+#[cfg(feature = "channel-nostr")]
+pub type NostrKeyValidator = Box<dyn Fn(&str) -> Result<String>>;
+
+/// Callbacks injected by the binary crate to wire wizard sections whose
+/// implementations live in downstream crates (zeroclaw-hardware, zeroclaw-channels).
+#[derive(Default)]
+pub struct WizardCallbacks {
+    /// Full interactive hardware setup flow. When `Some`, the wizard runs
+    /// hardware discovery and configuration; when `None`, hardware is skipped
+    /// and `HardwareConfig::default()` is used.
+    pub hardware_setup: Option<Box<dyn Fn() -> Result<HardwareConfig>>>,
+
+    /// Validate a Nostr private key string (hex or nsec) and return the
+    /// public key hex on success. Requires `nostr-sdk` which lives in
+    /// `zeroclaw-channels`.
+    #[cfg(feature = "channel-nostr")]
+    pub nostr_validate_key: Option<NostrKeyValidator>,
+
+    /// Whether the `whatsapp-web` feature is compiled in. When `true`, the
+    /// wizard shows the WhatsApp Web option without a missing-feature warning.
+    pub whatsapp_web_available: bool,
+}
 
 // ── Project context collected during wizard ──────────────────────
 
@@ -78,7 +102,7 @@ enum InteractiveOnboardingMode {
     UpdateProviderOnly,
 }
 
-pub async fn run_wizard(force: bool) -> Result<Config> {
+pub async fn run_wizard(force: bool, callbacks: WizardCallbacks) -> Result<Config> {
     println!("{}", style(BANNER).cyan().bold());
 
     println!(
@@ -106,7 +130,7 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
     let (provider, api_key, model, provider_api_url) = setup_provider(&workspace_dir).await?;
 
     print_step(3, 9, "Channels (How You Talk to ZeroClaw)");
-    let channels_config = setup_channels(None)?;
+    let channels_config = setup_channels(None, &callbacks)?;
 
     print_step(4, 9, "Tunnel (Expose to Internet)");
     let tunnel_config = setup_tunnel()?;
@@ -115,7 +139,11 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
     let (composio_config, secrets_config) = setup_tool_mode()?;
 
     print_step(6, 9, "Hardware (Physical World)");
-    let hardware_config = setup_hardware()?;
+    let hardware_config = if let Some(ref hw_setup) = callbacks.hardware_setup {
+        hw_setup()?
+    } else {
+        HardwareConfig::default()
+    };
 
     print_step(7, 9, "Memory Configuration");
     let memory_config = setup_memory()?;
@@ -265,7 +293,7 @@ pub async fn run_wizard(force: bool) -> Result<Config> {
 }
 
 /// Interactive repair flow: rerun channel setup only without redoing full onboarding.
-pub async fn run_channels_repair_wizard() -> Result<Config> {
+pub async fn run_channels_repair_wizard(callbacks: WizardCallbacks) -> Result<Config> {
     println!("{}", style(BANNER).cyan().bold());
     println!(
         "  {}",
@@ -278,7 +306,7 @@ pub async fn run_channels_repair_wizard() -> Result<Config> {
     let mut config = Box::pin(Config::load_or_init()).await?;
 
     print_step(1, 1, "Channels (How You Talk to ZeroClaw)");
-    config.channels_config = setup_channels(Some(config.channels_config.clone()))?;
+    config.channels_config = setup_channels(Some(config.channels_config.clone()), &callbacks)?;
     config.save().await?;
     persist_workspace_selection(&config.config_path).await?;
 
@@ -3202,198 +3230,6 @@ fn setup_tool_mode() -> Result<(ComposioConfig, SecretsConfig)> {
     Ok((composio_config, secrets_config))
 }
 
-// ── Step 6: Hardware (Physical World) ───────────────────────────
-
-// TODO: hardware wizard moved to zeroclaw-hardware; wire via callback in follow-up PR
-#[cfg(any())]
-fn setup_hardware() -> Result<HardwareConfig> {
-    print_bullet("ZeroClaw can talk to physical hardware (LEDs, sensors, motors).");
-    print_bullet("Scanning for connected devices...");
-    println!();
-
-    // ── Auto-discovery ──
-    let devices = hardware::discover_hardware();
-
-    if devices.is_empty() {
-        println!(
-            "  {} {}",
-            style("ℹ").dim(),
-            style("No hardware devices detected on this system.").dim()
-        );
-        println!(
-            "  {} {}",
-            style("ℹ").dim(),
-            style("You can enable hardware later in config.toml under [hardware].").dim()
-        );
-    } else {
-        println!(
-            "  {} {} device(s) found:",
-            style("✓").green().bold(),
-            devices.len()
-        );
-        for device in &devices {
-            let detail = device
-                .detail
-                .as_deref()
-                .map(|d| format!(" ({d})"))
-                .unwrap_or_default();
-            let path = device
-                .device_path
-                .as_deref()
-                .map(|p| format!(" → {p}"))
-                .unwrap_or_default();
-            println!(
-                "    {} {}{}{} [{}]",
-                style("›").cyan(),
-                style(&device.name).green(),
-                style(&detail).dim(),
-                style(&path).dim(),
-                style(device.transport.to_string()).cyan()
-            );
-        }
-    }
-    println!();
-
-    let options = vec![
-        "🚀 Native — direct GPIO on this Linux board (Raspberry Pi, Orange Pi, etc.)",
-        "🔌 Tethered — control an Arduino/ESP32/Nucleo plugged into USB",
-        "🔬 Debug Probe — flash/read MCUs via SWD/JTAG (probe-rs)",
-        "☁️  Software Only — no hardware access (default)",
-    ];
-
-    let recommended = hardware::recommended_wizard_default(&devices);
-
-    let choice = Select::new()
-        .with_prompt("  How should ZeroClaw interact with the physical world?")
-        .items(&options)
-        .default(recommended)
-        .interact()?;
-
-    let mut hw_config = hardware::config_from_wizard_choice(choice, &devices);
-
-    // ── Serial: pick a port if multiple found ──
-    if hw_config.transport_mode() == HardwareTransport::Serial {
-        let serial_devices: Vec<&hardware::DiscoveredDevice> = devices
-            .iter()
-            .filter(|d| d.transport == HardwareTransport::Serial)
-            .collect();
-
-        if serial_devices.len() > 1 {
-            let port_labels: Vec<String> = serial_devices
-                .iter()
-                .map(|d| {
-                    format!(
-                        "{} ({})",
-                        d.device_path.as_deref().unwrap_or("unknown"),
-                        d.name
-                    )
-                })
-                .collect();
-
-            let port_idx = Select::new()
-                .with_prompt("  Multiple serial devices found — select one")
-                .items(&port_labels)
-                .default(0)
-                .interact()?;
-
-            hw_config.serial_port = serial_devices[port_idx].device_path.clone();
-        } else if serial_devices.is_empty() {
-            // User chose serial but no device discovered — ask for manual path
-            let manual_port: String = Input::new()
-                .with_prompt("  Serial port path (e.g. /dev/ttyUSB0)")
-                .default("/dev/ttyUSB0")
-                .interact_text()?;
-            hw_config.serial_port = Some(manual_port);
-        }
-
-        // Baud rate
-        let baud_options = vec![
-            "115200 (default, recommended)",
-            "9600 (legacy Arduino)",
-            "57600",
-            "230400",
-            "Custom",
-        ];
-        let baud_idx = Select::new()
-            .with_prompt("  Serial baud rate")
-            .items(&baud_options)
-            .default(0)
-            .interact()?;
-
-        hw_config.baud_rate = match baud_idx {
-            1 => 9600,
-            2 => 57600,
-            3 => 230_400,
-            4 => {
-                let custom: String = Input::new()
-                    .with_prompt("  Custom baud rate")
-                    .default("115200")
-                    .interact_text()?;
-                custom.parse::<u32>().unwrap_or(115_200)
-            }
-            _ => 115_200,
-        };
-    }
-
-    // ── Probe: ask for target chip ──
-    if hw_config.transport_mode() == HardwareTransport::Probe && hw_config.probe_target.is_none() {
-        let target: String = Input::new()
-            .with_prompt("  Target MCU chip (e.g. STM32F411CEUx, nRF52840_xxAA)")
-            .default("STM32F411CEUx")
-            .interact_text()?;
-        hw_config.probe_target = Some(target);
-    }
-
-    // ── Datasheet RAG ──
-    if hw_config.enabled {
-        let datasheets = Confirm::new()
-            .with_prompt("  Enable datasheet RAG? (index PDF schematics for AI pin lookups)")
-            .default(true)
-            .interact()?;
-        hw_config.workspace_datasheets = datasheets;
-    }
-
-    // ── Summary ──
-    if hw_config.enabled {
-        let transport_label = match hw_config.transport_mode() {
-            HardwareTransport::Native => "Native GPIO".to_string(),
-            HardwareTransport::Serial => format!(
-                "Serial → {} @ {} baud",
-                hw_config.serial_port.as_deref().unwrap_or("?"),
-                hw_config.baud_rate
-            ),
-            HardwareTransport::Probe => format!(
-                "Probe (SWD/JTAG) → {}",
-                hw_config.probe_target.as_deref().unwrap_or("?")
-            ),
-            HardwareTransport::None => "Software Only".to_string(),
-        };
-
-        println!(
-            "  {} Hardware: {} | datasheets: {}",
-            style("✓").green().bold(),
-            style(&transport_label).green(),
-            if hw_config.workspace_datasheets {
-                style("on").green().to_string()
-            } else {
-                style("off").dim().to_string()
-            }
-        );
-    } else {
-        println!(
-            "  {} Hardware: {}",
-            style("✓").green().bold(),
-            style("disabled (software only)").dim()
-        );
-    }
-
-    Ok(hw_config)
-}
-
-fn setup_hardware() -> Result<HardwareConfig> {
-    Ok(HardwareConfig::default())
-}
-
 // ── Step 6: Project Context ─────────────────────────────────────
 
 fn setup_project_context() -> Result<ProjectContext> {
@@ -3550,8 +3386,7 @@ enum ChannelMenuChoice {
     QqOfficial,
     Lark,
     Feishu,
-    // TODO: nostr onboarding disabled until zeroclaw-channels provides it
-    #[cfg(any())]
+    #[cfg(feature = "channel-nostr")]
     Nostr,
     Done,
 }
@@ -3572,8 +3407,7 @@ const CHANNEL_MENU_CHOICES: &[ChannelMenuChoice] = &[
     ChannelMenuChoice::QqOfficial,
     ChannelMenuChoice::Lark,
     ChannelMenuChoice::Feishu,
-    // TODO: nostr onboarding disabled until zeroclaw-channels provides it
-    #[cfg(any())]
+    #[cfg(feature = "channel-nostr")]
     ChannelMenuChoice::Nostr,
     ChannelMenuChoice::Done,
 ];
@@ -3583,7 +3417,10 @@ fn channel_menu_choices() -> &'static [ChannelMenuChoice] {
 }
 
 #[allow(clippy::too_many_lines)]
-fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
+fn setup_channels(
+    existing: Option<ChannelsConfig>,
+    callbacks: &WizardCallbacks,
+) -> Result<ChannelsConfig> {
     print_bullet("Channels let you talk to ZeroClaw from anywhere.");
     print_bullet("CLI is always available. Connect more channels now.");
     println!();
@@ -3717,8 +3554,7 @@ fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
                         "— Feishu Bot"
                     }
                 ),
-                // TODO: nostr onboarding disabled until zeroclaw-channels provides it
-                #[cfg(any())]
+                #[cfg(feature = "channel-nostr")]
                 ChannelMenuChoice::Nostr => format!(
                     "Nostr {}",
                     if config.nostr.is_some() {
@@ -4523,10 +4359,7 @@ fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
                     .interact()?;
 
                 if mode_idx == 0 {
-                    // Compile-time check: warn early if the feature is not enabled.
-                    // TODO: whatsapp-web feature moved to zeroclaw-channels
-                    #[cfg(any())]
-                    {
+                    if !callbacks.whatsapp_web_available {
                         println!();
                         println!(
                             "  {} {}",
@@ -5434,8 +5267,7 @@ fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
                     proxy_url: existing_lk.and_then(|l| l.proxy_url.clone()),
                 });
             }
-            // TODO: nostr onboarding disabled until zeroclaw-channels provides it
-            #[cfg(any())]
+            #[cfg(feature = "channel-nostr")]
             ChannelMenuChoice::Nostr => {
                 // ── Nostr ──
                 println!();
@@ -5457,21 +5289,23 @@ fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
                     continue;
                 }
 
-                // Validate the key immediately
-                match nostr_sdk::Keys::parse(private_key.trim()) {
-                    Ok(keys) => {
-                        println!(
-                            "  {} Key valid — public key: {}",
-                            style("✅").green().bold(),
-                            style(keys.public_key().to_hex()).cyan()
-                        );
-                    }
-                    Err(_) => {
-                        println!(
-                            "  {} Invalid private key — check format and try again",
-                            style("❌").red().bold()
-                        );
-                        continue;
+                // Validate the key via callback (requires nostr-sdk in zeroclaw-channels)
+                if let Some(ref validate) = callbacks.nostr_validate_key {
+                    match validate(private_key.trim()) {
+                        Ok(pubkey_hex) => {
+                            println!(
+                                "  {} Key valid — public key: {}",
+                                style("✅").green().bold(),
+                                style(&pubkey_hex).cyan()
+                            );
+                        }
+                        Err(_) => {
+                            println!(
+                                "  {} Invalid private key — check format and try again",
+                                style("❌").red().bold()
+                            );
+                            continue;
+                        }
                     }
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2044,6 +2044,7 @@ async fn main() -> Result<()> {
 /// Build wizard callbacks that wire downstream crate functionality into the onboarding wizard.
 fn build_wizard_callbacks() -> onboard::WizardCallbacks {
     onboard::WizardCallbacks {
+        #[cfg(feature = "hardware")]
         hardware_setup: Some(Box::new(|| {
             use console::style;
             use dialoguer::{Confirm, Select};
@@ -2242,6 +2243,8 @@ fn build_wizard_callbacks() -> onboard::WizardCallbacks {
 
             Ok(hw_config)
         })),
+        #[cfg(not(feature = "hardware"))]
+        hardware_setup: None,
 
         #[cfg(feature = "channel-nostr")]
         nostr_validate_key: Some(Box::new(|key: &str| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1062,8 +1062,10 @@ async fn main() -> Result<()> {
             return Ok(());
         }
 
+        let wizard_callbacks = build_wizard_callbacks();
+
         let config = if channels_only {
-            Box::pin(onboard::run_channels_repair_wizard()).await
+            Box::pin(onboard::run_channels_repair_wizard(wizard_callbacks)).await
         } else if quick || has_provider_flags {
             Box::pin(onboard::run_quick_setup(
                 api_key.as_deref(),
@@ -1074,7 +1076,7 @@ async fn main() -> Result<()> {
             ))
             .await
         } else if is_tty || env_interactive {
-            Box::pin(onboard::run_wizard(force)).await
+            Box::pin(onboard::run_wizard(force, wizard_callbacks)).await
         } else {
             Box::pin(onboard::run_quick_setup(
                 api_key.as_deref(),
@@ -2036,6 +2038,219 @@ async fn main() -> Result<()> {
                 Ok(())
             }
         },
+    }
+}
+
+/// Build wizard callbacks that wire downstream crate functionality into the onboarding wizard.
+fn build_wizard_callbacks() -> onboard::WizardCallbacks {
+    onboard::WizardCallbacks {
+        hardware_setup: Some(Box::new(|| {
+            use console::style;
+            use dialoguer::{Confirm, Select};
+
+            println!(
+                "  {} {}",
+                style("ℹ").dim(),
+                style("ZeroClaw can talk to physical hardware (LEDs, sensors, motors).").dim()
+            );
+            println!(
+                "  {} {}",
+                style("ℹ").dim(),
+                style("Scanning for connected devices...").dim()
+            );
+            println!();
+
+            let devices = zeroclaw_hardware::discover_hardware();
+
+            if devices.is_empty() {
+                println!(
+                    "  {} {}",
+                    style("ℹ").dim(),
+                    style("No hardware devices detected on this system.").dim()
+                );
+                println!(
+                    "  {} {}",
+                    style("ℹ").dim(),
+                    style("You can enable hardware later in config.toml under [hardware].").dim()
+                );
+            } else {
+                println!(
+                    "  {} {} device(s) found:",
+                    style("✓").green().bold(),
+                    devices.len()
+                );
+                for device in &devices {
+                    let detail = device
+                        .detail
+                        .as_deref()
+                        .map(|d| format!(" ({d})"))
+                        .unwrap_or_default();
+                    let path = device
+                        .device_path
+                        .as_deref()
+                        .map(|p| format!(" → {p}"))
+                        .unwrap_or_default();
+                    println!(
+                        "    {} {}{}{} [{}]",
+                        style("›").cyan(),
+                        style(&device.name).green(),
+                        style(&detail).dim(),
+                        style(&path).dim(),
+                        style(device.transport.to_string()).cyan()
+                    );
+                }
+            }
+            println!();
+
+            let options = vec![
+                "🚀 Native — direct GPIO on this Linux board (Raspberry Pi, Orange Pi, etc.)",
+                "🔌 Tethered — control an Arduino/ESP32/Nucleo plugged into USB",
+                "🔬 Debug Probe — flash/read MCUs via SWD/JTAG (probe-rs)",
+                "☁️  Software Only — no hardware access (default)",
+            ];
+
+            let recommended = zeroclaw_hardware::recommended_wizard_default(&devices);
+
+            let choice = Select::new()
+                .with_prompt("  How should ZeroClaw interact with the physical world?")
+                .items(&options)
+                .default(recommended)
+                .interact()?;
+
+            let mut hw_config = zeroclaw_hardware::config_from_wizard_choice(choice, &devices);
+
+            use zeroclaw_config::schema::HardwareTransport;
+
+            // Serial: pick a port if multiple found
+            if hw_config.transport_mode() == HardwareTransport::Serial {
+                let serial_devices: Vec<&zeroclaw_hardware::DiscoveredDevice> = devices
+                    .iter()
+                    .filter(|d| d.transport == HardwareTransport::Serial)
+                    .collect();
+
+                if serial_devices.len() > 1 {
+                    let port_labels: Vec<String> = serial_devices
+                        .iter()
+                        .map(|d| {
+                            format!(
+                                "{} ({})",
+                                d.device_path.as_deref().unwrap_or("unknown"),
+                                d.name
+                            )
+                        })
+                        .collect();
+
+                    let port_idx = Select::new()
+                        .with_prompt("  Multiple serial devices found — select one")
+                        .items(&port_labels)
+                        .default(0)
+                        .interact()?;
+
+                    hw_config.serial_port = serial_devices[port_idx].device_path.clone();
+                } else if serial_devices.is_empty() {
+                    let manual_port: String = dialoguer::Input::new()
+                        .with_prompt("  Serial port path (e.g. /dev/ttyUSB0)")
+                        .default("/dev/ttyUSB0".into())
+                        .interact_text()?;
+                    hw_config.serial_port = Some(manual_port);
+                }
+
+                // Baud rate
+                let baud_options = vec![
+                    "115200 (default, recommended)",
+                    "9600 (legacy Arduino)",
+                    "57600",
+                    "230400",
+                    "Custom",
+                ];
+                let baud_idx = Select::new()
+                    .with_prompt("  Serial baud rate")
+                    .items(&baud_options)
+                    .default(0)
+                    .interact()?;
+
+                hw_config.baud_rate = match baud_idx {
+                    1 => 9600,
+                    2 => 57600,
+                    3 => 230_400,
+                    4 => {
+                        let custom: String = dialoguer::Input::new()
+                            .with_prompt("  Custom baud rate")
+                            .default("115200".into())
+                            .interact_text()?;
+                        custom.parse::<u32>().unwrap_or(115_200)
+                    }
+                    _ => 115_200,
+                };
+            }
+
+            // Probe: ask for target chip
+            if hw_config.transport_mode() == HardwareTransport::Probe
+                && hw_config.probe_target.is_none()
+            {
+                let target: String = dialoguer::Input::new()
+                    .with_prompt("  Target MCU chip (e.g. STM32F411CEUx, nRF52840_xxAA)")
+                    .default("STM32F411CEUx".into())
+                    .interact_text()?;
+                hw_config.probe_target = Some(target);
+            }
+
+            // Datasheet RAG
+            if hw_config.enabled {
+                let datasheets = Confirm::new()
+                    .with_prompt(
+                        "  Enable datasheet RAG? (index PDF schematics for AI pin lookups)",
+                    )
+                    .default(true)
+                    .interact()?;
+                hw_config.workspace_datasheets = datasheets;
+            }
+
+            // Summary
+            if hw_config.enabled {
+                let transport_label = match hw_config.transport_mode() {
+                    HardwareTransport::Native => "Native GPIO".to_string(),
+                    HardwareTransport::Serial => format!(
+                        "Serial → {} @ {} baud",
+                        hw_config.serial_port.as_deref().unwrap_or("?"),
+                        hw_config.baud_rate
+                    ),
+                    HardwareTransport::Probe => format!(
+                        "Probe (SWD/JTAG) → {}",
+                        hw_config.probe_target.as_deref().unwrap_or("?")
+                    ),
+                    HardwareTransport::None => "Software Only".to_string(),
+                };
+
+                println!(
+                    "  {} Hardware: {} | datasheets: {}",
+                    style("✓").green().bold(),
+                    style(&transport_label).green(),
+                    if hw_config.workspace_datasheets {
+                        style("on").green().to_string()
+                    } else {
+                        style("off").dim().to_string()
+                    }
+                );
+            } else {
+                println!(
+                    "  {} Hardware: {}",
+                    style("✓").green().bold(),
+                    style("disabled (software only)").dim()
+                );
+            }
+
+            Ok(hw_config)
+        })),
+
+        #[cfg(feature = "channel-nostr")]
+        nostr_validate_key: Some(Box::new(|key: &str| {
+            let keys = nostr_sdk::Keys::parse(key)
+                .map_err(|e| anyhow::anyhow!("invalid nostr key: {e}"))?;
+            Ok(keys.public_key().to_hex())
+        })),
+
+        whatsapp_web_available: cfg!(feature = "whatsapp-web"),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2042,6 +2042,7 @@ async fn main() -> Result<()> {
 }
 
 /// Build wizard callbacks that wire downstream crate functionality into the onboarding wizard.
+#[cfg(feature = "agent-runtime")]
 fn build_wizard_callbacks() -> onboard::WizardCallbacks {
     onboard::WizardCallbacks {
         #[cfg(feature = "hardware")]


### PR DESCRIPTION
## Summary

- Add `WizardCallbacks` struct with callback injection for cross-crate wizard functionality
- Wire hardware setup: binary crate provides full interactive discovery/configuration flow via `zeroclaw_hardware` functions
- Wire nostr key validation: `nostr_sdk::Keys::parse()` injected via `NostrKeyValidator` callback
- Wire whatsapp-web feature check: runtime `bool` replaces compile-time `#[cfg(any())]` gate
- Forward `channel-nostr` feature from root → `zeroclaw-runtime` → `zeroclaw-config` so `NostrConfig` is available
- Add `nostr-sdk` as optional dep in root crate behind `channel-nostr` feature
- Replace all `#[cfg(any())]` gates with proper `#[cfg(feature = "channel-nostr")]` or runtime callbacks
- Update `run_wizard` and `run_channels_repair_wizard` signatures to accept callbacks

Follow-up to #5559.
Closes #5603

## Test plan

- [ ] `zeroclaw onboard` — full wizard completes
- [ ] Nostr section appears when built with `--features channel-nostr`
- [ ] Nostr key validation accepts valid hex/nsec keys, rejects invalid
- [ ] WhatsApp Web warning appears when feature is not compiled in
- [ ] Hardware section runs discovery and presents interactive setup when callback is wired
- [ ] Hardware defaults to `HardwareConfig::default()` when callback is absent