### PR TITLE
docs(skills): add verification discipline rules for PR review

### DIFF
--- a/.claude/skills/github-issue/SKILL.md
+++ b/.claude/skills/github-issue/SKILL.md
@@ -130,4 +130,5 @@ Return the resulting issue URL to the user.
 - **Use neutral project-scoped placeholders** per ZeroClaw's privacy contract.
 - **One concept per issue** — enforce the scope guard.
 - **Auto-detect, don't guess** — use real command output for environment fields.
+- **Quote observed output verbatim** — error messages, stack traces, warnings, and command output must be copy-pasted into the relevant fields (`Steps to reproduce`, `Observed behavior`, `Logs`) exactly as they appeared. Do not paraphrase. Do not summarize. The maintainer searching for this bug later will grep for the exact string; paraphrase breaks that search. If the output is long, include the head and tail with a `...` marker in the middle rather than rewriting it.
 - **Match GitHub's rendering** — use `### Field Label` sections so issues look consistent whether filed via web UI or this skill.

--- a/.claude/skills/github-pr-review/SKILL.md
+++ b/.claude/skills/github-pr-review/SKILL.md
@@ -42,7 +42,7 @@ This skill accepts a PR number, URL, or no argument (process the queue).
 |---|---|---|
 | 1. Triage | Read PR, comprehension summary, draft/assignee/path/CI checks | Draft → stop. High-risk path → skip. CI failing → block. |
 | 2. Gate Checks | Malicious scan, template, size, privacy, duplicates, quality, architecture, attribution, language | Any gate fail → block or close with comment. |
-| 3. Review | Risk-routed depth, code review with severity-tagged comments, regression analysis, security/perf assessment, docs, i18n, tests | Comment format: `[blocking]`/`[suggestion]`/`[question]` + what/why/action. |
+| 3. Review | Risk-routed depth, code review with severity-tagged comments, regression analysis, security/perf assessment, docs, i18n, tests | Comment format: `[blocking]`/`[suggestion]`/`[question]` + what/why/action. **Apply verification discipline rules R1–R5 (see `references/review-protocol.md` §3.8) before issuing any verdict.** |
 | 4. Final Review | Re-read for changes, handle new commits, issue verdict | Three outcomes: ready-to-merge, needs-author-action, needs-maintainer-review. |
 | 5. Report & Cleanup | Session report on PR, delete worktree | Every field filled. "Looks good" is not valid. |
 
@@ -51,9 +51,10 @@ This skill accepts a PR number, URL, or no argument (process the queue).
 1. **Create an isolated worktree** for each PR. Do not reuse worktrees. Clean up when finished.
 2. **Check draft status** at every phase boundary. If draft, stop and clean up.
 3. **Use `gh` CLI** for all GitHub operations (PR metadata, comments, labels, reviews, checks).
-4. **Use `cargo test`** (or `./dev/ci.sh test`) for validation.
-5. **Never merge.** Never push code to contributor branches. You are a reviewer.
-6. **Always thank contributors.** Always explain closures. Never close without a clear reason.
+4. **Run the full validation battery locally** — `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build`, `cargo test` — not `cargo check` or `cargo test --lib`. See `references/review-protocol.md` §3.7.
+5. **Execute the contributor's test plan** — every checkbox in the PR body's "## Test plan" section must be run or explicitly labeled `needs-manual` / `needs-credentials` / `platform-blocked`. See §3.8 R1.
+6. **Never merge.** Never push code to contributor branches. You are a reviewer.
+7. **Always thank contributors.** Always explain closures. Never close without a clear reason.
 
 ## Core Engineering Constraints
 

--- a/.claude/skills/github-pr-review/references/review-protocol.md
+++ b/.claude/skills/github-pr-review/references/review-protocol.md
@@ -149,6 +149,8 @@ Review the diff for:
 - Consistency with existing codebase patterns and conventions.
 - Correctness, edge cases, and potential regressions.
 - AI model name accuracy — if the PR references model names, verify them against the provider's current documentation.
+- **Generated artifact integrity — per R2 (§3.8).** If the diff touches code that produces user-facing artifacts (shell completions, JSON schemas, derive macros, build templates, any code-gen), source inspection alone is insufficient. Build the artifact and inspect its output.
+- **Deprecation and rename stubs — per R4 (§3.8).** If the PR renames or deprecates a user-facing CLI command, subcommand, flag, or API surface, stress-test every renamed/deprecated entry point with the five-probe template.
 
 **Comment on issues. Do not push code fixes.** The agent is a reviewer, not a contributor.
 
@@ -187,14 +189,84 @@ Include this assessment in your final verdict comment (§4.2). This makes your r
 ### 3.6 — i18n Follow-Through
 
 - **IF** the PR modifies docs or navigation → Verify updates across all supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`) per `docs/contributing/docs-contract.md`.
+- **Before issuing a parity finding**, apply **R5 (§3.8):** grep the relevant locale files to confirm the identifier or section being changed actually exists in that locale. Pre-existing locale drift is not this PR's responsibility.
 - **IF** locale parity is missing → Comment with specific locales that need updates.
 
 ### 3.7 — Testing & Validation
 
-- Run `cargo test` (or `./dev/ci.sh test` for full validation).
-- Confirm all existing tests pass.
-- Assess whether new functionality has appropriate test coverage — comment if not.
-- Confirm no regressions.
+Run the full local validation battery — not just a subset:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo build
+cargo test --quiet 2>&1 | tee /tmp/pr-<number>-test.log
+```
+
+Do not substitute `cargo check` for `cargo build`. Do not substitute `cargo test --lib` for full `cargo test` — the integration, component, and system test binaries catch regressions that `--lib` alone misses. CI runs the full battery on merge; running it locally gives you direct access to log lines and warnings that CI UI hides, and it is cheap.
+
+For every WARN / ERROR / `warning:` line captured during this phase, apply **R3 (§3.8):** investigate or explicitly root-cause as pre-existing. "Noise in the test output" is not an acceptable dismissal.
+
+After the validation battery passes, execute the contributor's stated test plan per **R1 (§3.8).** Every checkbox in the PR body's "## Test plan" section must be executed, or explicitly labeled:
+- `needs-manual` — interactive command (e.g. wizard UI)
+- `needs-credentials` — requires live credentials the agent does not hold
+- `platform-blocked` — cannot run on the current OS/arch (e.g. Linux-only crate on macOS)
+
+"Not run" is never a valid final state for a test plan checkbox.
+
+Assess whether new functionality has appropriate test coverage — comment if not. Confirm no regressions.
+
+---
+
+### 3.8 — Verification Discipline Rules
+
+These rules codify reviewer failure modes observed in prior sessions. They are non-negotiable checks that must be satisfied before issuing a verdict. Each rule names the phase where it fires and the failure it prevents.
+
+**R1 — Execute the contributor's test plan.** If the PR body contains a "## Test plan" section (or equivalent checkbox list), every checkbox must be executed or explicitly labeled `needs-manual`, `needs-credentials`, or `platform-blocked`.
+- **Fires during:** §3.7.
+- **Prevents:** Verdicts that skip the contributor's stated acceptance criteria. The contributor wrote those checkboxes as the definition of done; running fewer is both rude and unreliable.
+- **Failure mode it addresses:** Reviewer runs 3 of 6 test plan commands and assumes the rest are fine.
+
+**R2 — Inspect generated artifacts, not just the code that generates them.** If the diff touches code that produces user-facing artifacts (shell completions, JSON schemas, derive macros, build templates, code-gen), build the artifact and inspect its output. Grep the generated output for removed, renamed, or deprecated symbols.
+- **Fires during:** §3.2, §3.7.
+- **Prevents:** Stale references leaking into artifacts that users consume.
+- **Failure mode it addresses:** Reviewer reads the completion-wrapper source code, sees it was retargeted to the new command name, and never runs the binary to produce the actual completion script — missing a clap auto-describe line that still references the old name.
+
+**R3 — Investigate every WARN / ERROR line emitted during validation.** Every `WARN`, `ERROR`, or `warning:` line captured during build/test/test-plan execution must be either:
+- (a) confirmed as pre-existing on master with a documented root cause (file:line + one-sentence explanation), or
+- (b) flagged as a review finding.
+
+"Pre-existing" without evidence is not a valid dismissal. "Not related to this PR" without verification is not a valid dismissal.
+- **Fires during:** §3.7.
+- **Prevents:** Latent bugs hidden in noise. If a warning appears during manual verification, it is a signal, not noise.
+- **Failure mode it addresses:** Reviewer sees two `backfill_enabled: failed to set channels.email.enabled` warnings in their own test output, dismisses them as unrelated, and misses that the PR makes those warnings user-visible for the first time.
+
+**R4 — Stress-test deprecation and rename stubs.** For any PR that renames or deprecates a user-facing CLI command, subcommand, flag, or API surface, run the five-probe template against every renamed or deprecated entry point:
+
+1. `--help` — verify help text reflects the deprecation.
+2. Bare invocation with no subcommand args — verify the deprecation handler fires *before* clap errors on missing required args.
+3. Invocation with a missing required positional — verify the deprecation handler still fires, not a raw framework error.
+4. Invocation with an unknown flag — verify the deprecation message still surfaces.
+5. Invocation with valid syntax — verify the friendly error message.
+
+- **Fires during:** §3.2, §3.7.
+- **Prevents:** Rename stubs that only fire on the happy path, leaving muscle-memory users with raw framework errors instead of a friendly "this command moved" message.
+- **Failure mode it addresses:** Reviewer verifies `zeroclaw props list` produces the deprecation error, concludes the stub works, and never tries `zeroclaw props get` (no positional) — missing that clap rejects with a raw arg-missing error before the handler can fire.
+
+**R5 — Grep locale files before flagging i18n parity gaps.** Before issuing a finding that a PR breaks locale parity, grep the relevant locale files in `docs/i18n/**` for the identifier or section being changed. If the identifier does not exist in that locale, the gap is pre-existing drift and is not this PR's responsibility.
+- **Fires during:** §3.6.
+- **Prevents:** Over-reach findings that ask contributors to fix unrelated locale drift.
+- **Failure mode it addresses:** Reviewer flags `docs/i18n/zh-CN/reference/cli/commands-reference.zh-CN.md` for missing the new `config` section, when that locale never had the old `props` section either.
+
+**Discipline principles underlying these rules:**
+
+1. **Execute, don't infer.** If you can run the command, run it. Inference from source is strictly inferior to direct observation.
+2. **Quote verbatim, don't paraphrase.** When a finding cites an error message, warning, or generated line, use the exact string. "Looks like a warning about channels" is not actionable; `WARN backfill_enabled: failed to set channels.email.enabled: Unknown property` is.
+3. **Investigate signals, don't dismiss them.** Every log line you see during manual verification is evidence. The cost of investigating is one grep; the cost of missing is a latent bug in master.
+4. **Verify before flagging.** Before issuing any finding that claims "X does not exist" or "Y breaks Z", grep for X and read Y. Inference from filenames or naming conventions produces false positives.
+5. **Stub stress is cheap.** Deprecation and rename surfaces have small surface areas and well-defined expected behavior. Five probes take thirty seconds and catch the kinds of bugs that ship to users otherwise.
+
+When a reviewer discovers a new failure mode that belongs in this list, add it here rather than keeping it as tribal knowledge. Rules earn their place by preventing a specific, observed failure.
 
 ---
 
@@ -287,16 +359,17 @@ Be specific. "Looks good" is not a valid entry.
 2. **Draft check is continuous.** Check at every phase boundary.
 3. **Comprehend before you critique.** Summarize what the PR does and why before issuing any judgments.
 4. **Review, don't rewrite.** Comment on issues. Do not push code to contributor branches.
-5. **The only hard stop is malicious content.** Everything else is within your judgment.
-6. **Repository docs are authoritative.** Follow `reviewer-playbook.md`, `pr-workflow.md`, and `pr-discipline.md`. This prompt adds agent-specific behavior on top of those processes.
-7. **Thin is sacred.** We are above our <5MB target and fighting to get back. Every PR either helps or hurts — there is no neutral.
-8. **Edge is the floor, cloud is welcome.** If it doesn't work on a $10 board, it doesn't ship in core.
-9. **Traits are the architecture.** Hardcoded implementations bypass the design. Don't allow it.
-10. **Security is the baseline, not a feature.** Never weaken it.
-11. **Privacy is a merge gate.** No PII, no real identities, no credentials in diffs.
-12. **CI must pass first.** Don't invest review effort in code that doesn't compile.
-13. **Route by risk, not intuition.** Use labels and changed paths to determine review depth.
-14. **Respect contributors.** Always thank. Always explain. Never close without a clear reason.
-15. **Your report is your accountability.** If it's not in the report, it didn't happen.
-16. **English only** unless it's i18n/translation content.
-17. **Clean workspace always.** Isolated worktree, cleaned up after.
+5. **Execute, don't infer.** Follow the verification discipline rules in §3.8 (R1–R5). Run the contributor's test plan. Inspect generated artifacts. Investigate every warning. Stress-test stubs. Grep before flagging.
+6. **The only hard stop is malicious content.** Everything else is within your judgment.
+7. **Repository docs are authoritative.** Follow `reviewer-playbook.md`, `pr-workflow.md`, and `pr-discipline.md`. This prompt adds agent-specific behavior on top of those processes.
+8. **Thin is sacred.** We are above our <5MB target and fighting to get back. Every PR either helps or hurts — there is no neutral.
+9. **Edge is the floor, cloud is welcome.** If it doesn't work on a $10 board, it doesn't ship in core.
+10. **Traits are the architecture.** Hardcoded implementations bypass the design. Don't allow it.
+11. **Security is the baseline, not a feature.** Never weaken it.
+12. **Privacy is a merge gate.** No PII, no real identities, no credentials in diffs.
+13. **CI must pass first.** Don't invest review effort in code that doesn't compile.
+14. **Route by risk, not intuition.** Use labels and changed paths to determine review depth.
+15. **Respect contributors.** Always thank. Always explain. Never close without a clear reason.
+16. **Your report is your accountability.** If it's not in the report, it didn't happen.
+17. **English only** unless it's i18n/translation content.
+18. **Clean workspace always.** Isolated worktree, cleaned up after.

--- a/.claude/skills/github-pr/SKILL.md
+++ b/.claude/skills/github-pr/SKILL.md
@@ -44,7 +44,28 @@ rustc --version 2>/dev/null
 
 Also review the changed files and commit messages to understand the nature of the change (bug fix, feature, refactor, docs, chore, etc.) and which subsystems are affected.
 
+### Step 1a: Run the Validation Battery (required before drafting)
+
+Before drafting the PR body, actually run the commands the PR template's "Validation Evidence" section asks for. Do not paraphrase results, do not write "tests pass" from memory, do not skip on the assumption that CI will catch it. The evidence section needs literal output from a real local run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets -- -D warnings
+cargo build
+cargo test
+```
+
+For docs-only changes, replace the Rust battery with markdown lint and link-integrity checks per `AGENTS.md`, and if touching bootstrap scripts add `bash -n install.sh`.
+
+Capture the tail of each command's output. You will paste the relevant excerpts (last 5–10 lines, any failures, any warnings) into the PR body's Validation Evidence section. If a command fails, stop and fix the underlying issue before drafting the PR — do not draft a PR on a broken tree.
+
+If a command is intentionally skipped (e.g., platform-blocked), note it explicitly in the evidence with a one-line reason. "Skipped" without explanation is not acceptable.
+
+If the validation run emits any `WARN` / `ERROR` / `warning:` lines, investigate them the same way a reviewer would: confirm pre-existing on master with root cause, or flag as something to address before opening. Do not ship a PR whose own local validation surfaces warnings you cannot explain.
+
 ### Step 2: Pre-Fill the Template
+
+When populating the "Validation Evidence" section, paste the actual tail output of the commands from Step 1a — do not paraphrase. The reviewer will be looking for literal strings to diff against their own validation run.
 
 Using the parsed template structure and gathered context, draft a complete PR body:
 
@@ -165,7 +186,9 @@ When the user wants to sync the PR description after pushing new changes:
 
 2. Re-read the PR template. Analyze which sections are now stale based on the new changes — use the template's section names and field descriptions to identify what needs updating rather than relying on hardcoded assumptions.
 
-3. Present proposed updates section-by-section and confirm before applying.
+3. **If any of the new commits touch code (not pure docs)**, re-run the validation battery from Step 1a before updating the Validation Evidence section. Stale validation evidence is worse than no evidence — it misleads the reviewer.
+
+4. Present proposed updates section-by-section and confirm before applying.
 
 ### Step 6: Apply Updates
 


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): master
- Problem: The `github-pr-review` skill's protocol allowed reviewers to skip test plan checkboxes, ignore WARN lines surfaced during their own validation, fail to inspect generated artifacts (only reading the code that generates them), and miss bugs in deprecation/rename stubs by only testing the happy path. A recent self-critique of a PR #5637 review identified four concrete misses that all trace back to missing discipline, not missing judgment.
- Why it matters: Both runs of the reviewer reached the same verdict, but one produced two real bug findings and a root-caused latent warning while the other produced three cosmetic suggestions. Verdict accuracy is a low bar; finding actionability is the real metric. Codifying the discipline as explicit rules closes the gap without adding machinery.
- What changed: New §3.8 — Verification Discipline Rules (R1–R5) in `review-protocol.md`, cross-referenced from §3.2/§3.6/§3.7. Parallel additions to `github-pr` (pre-push validation battery, post-new-commit re-run) and `github-issue` (verbatim output quoting). Quick-reference updates in `github-pr-review/SKILL.md`.
- What did **not** change (scope boundary): No code changes. No changes to `skill-creator` (its eval loop already enforces the same discipline in a different shape). No changes to `zeroclaw` operator skill. No changes to review workflow phases 1, 2, 4, or 5 — only Phase 3 discipline.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): risk: low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): (auto)
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): docs, skills
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`): n/a
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50): (auto)
- If any auto-label is incorrect, note requested correction: n/a

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): docs
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): docs

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

N/A — not a supersede.

## Validation Evidence (required)

Commands and result summary:

```bash
# Markdown-only changes under .claude/skills/**, no Rust code touched
# Structure sanity check:
grep -n "^###\? " .claude/skills/github-pr-review/references/review-protocol.md
#   → §1.1–1.6, §2.1–2.9, §3.1–3.8 (new), §4.1–4.2, §5, §6, Core Principles
#   → all section numbering contiguous, no orphan headers
```

- Evidence provided (test/log/trace/screenshot/perf): section-structure grep above confirms §3.8 inserted cleanly between §3.7 and §4
- If any command is intentionally skipped, explain why: `cargo fmt/clippy/test` not run — no Rust code changed, no `Cargo.toml` / `Cargo.lock` / `src/**` / `crates/**` touched. Markdown lint and link-integrity checks apply for docs-only changes per `AGENTS.md`; the changed files are skill prompts under `.claude/skills/**` which are not part of the project's markdown lint surface.

## Security Impact (required)

- New permissions/capabilities? (Yes/No): No
- New external network calls? (Yes/No): No
- Secrets/tokens handling changed? (Yes/No): No
- File system access scope changed? (Yes/No): No
- If any Yes, describe risk and mitigation: n/a

## Privacy and Data Hygiene (required)

- Data-hygiene status (pass/needs-follow-up): pass
- Redaction/anonymization notes: No identifiers in any of the changed files. The §3.8 rule examples reference PR #5637 generically by number only, not by contributor identity.
- Neutral wording confirmation: confirmed — all references are project-native (reviewer, contributor, agent, main) with no identity-specific language.

## Compatibility / Migration

- Backward compatible? (Yes/No): Yes
- Config/env changes? (Yes/No): No
- Migration needed? (Yes/No): No
- If yes, exact upgrade steps: n/a

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (Yes/No): No
- If Yes, locale navigation parity updated: n/a
- If Yes, localized runtime-contract docs updated: n/a
- If Yes, Vietnamese canonical docs synced: n/a
- If any No/N.A., link follow-up issue/PR and explain scope decision: The changed files are agent skill prompts under `.claude/skills/**` — they are internal tooling, not user-facing documentation, and are not listed in `docs-contract.md`'s supported-locale set. No i18n surface.

## Test plan

- [ ] Read `.claude/skills/github-pr-review/references/review-protocol.md` §3.8 end-to-end and confirm R1–R5 read as non-ambiguous checks.
- [ ] Confirm §3.2, §3.6, §3.7 cross-references land on R2/R4, R5, R1/R3 respectively.
- [ ] Verify `github-pr-review/SKILL.md` Phase 3 row and Execution Rules reference §3.8.
- [ ] Verify `github-pr/SKILL.md` Step 1a demands literal validation output, and Step 5 re-runs on new code commits.
- [ ] Verify `github-issue/SKILL.md` Important Rules contains the verbatim-quoting rule.
- [ ] Spot-check: run `grep -n "^###\? " .claude/skills/github-pr-review/references/review-protocol.md` and confirm section numbering is contiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)