### PR TITLE
docs(pr-template): streamline from 15 sections to 7

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,45 +1,14 @@
 ## Summary
 
-Describe this PR in 2-5 bullets:
-
-- Base branch target (`master` for all contributions):
-- Problem:
-- Why it matters:
-- What changed:
-- What did **not** change (scope boundary):
-
-## Label Snapshot (required)
-
-- Risk label (`risk: low|medium|high`):
-- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
-- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):
-- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`):
-- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
-- If any auto-label is incorrect, note requested correction:
-
-## Change Metadata
-
-- Change type (`bug|feature|refactor|docs|security|chore`):
-- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):
-
-## Linked Issue
-
-- Closes #
-- Related #
-- Depends on # (if stacked)
-- Supersedes # (if replacing older PR)
-
-## Supersede Attribution (required when `Supersedes #` is used)
-
-- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
-- Integrated scope by source PR (what was materially carried forward):
-- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
-- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
-- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)
+- **Base branch:** `master` (all contributions)
+- **What changed and why:** (2–5 bullets — the diff shows *what*, you explain *why*)
+- **Scope boundary:** (what this PR explicitly does NOT change)
+- **Blast radius:** (what other subsystems or consumers could be affected)
+- **Linked issue(s):** `Closes #`, `Related #`, `Depends on #` (stacked), `Supersedes #` (replacing older PR)
 
 ## Validation Evidence (required)
 
-Commands and result summary:
+Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").
 
 ```bash
 cargo fmt --all -- --check
@@ -47,68 +16,56 @@ cargo clippy --all-targets -- -D warnings
 cargo test
 ```
 
-- Evidence provided (test/log/trace/screenshot/perf):
-- If any command is intentionally skipped, explain why:
+Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.
 
-## Security Impact (required)
+- **Commands run and tail output:**
+- **Beyond CI — what did you manually verify?** (scenarios, edge cases, what you did NOT verify)
+- **If any command was intentionally skipped, why:**
 
-- New permissions/capabilities? (`Yes/No`)
+## Security & Privacy Impact (required)
+
+Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.
+
+- New permissions, capabilities, or file system access scope? (`Yes/No`)
 - New external network calls? (`Yes/No`)
-- Secrets/tokens handling changed? (`Yes/No`)
-- File system access scope changed? (`Yes/No`)
-- If any `Yes`, describe risk and mitigation:
+- Secrets / tokens / credentials handling changed? (`Yes/No`)
+- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`Yes/No`)
+- If any `Yes`, describe the risk and mitigation:
 
-## Privacy and Data Hygiene (required)
-
-- Data-hygiene status (`pass|needs-follow-up`):
-- Redaction/anonymization notes:
-- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):
-
-## Compatibility / Migration
+## Compatibility (required)
 
 - Backward compatible? (`Yes/No`)
-- Config/env changes? (`Yes/No`)
-- Migration needed? (`Yes/No`)
-- If yes, exact upgrade steps:
+- Config / env / CLI surface changed? (`Yes/No`)
+- If `No` or `Yes` to either: exact upgrade steps for existing users:
 
-## i18n Follow-Through (required when docs or user-facing wording changes)
+## Rollback (required for `risk: medium` and `risk: high`)
 
-- i18n follow-through triggered? (`Yes/No`)
-- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
-- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
-- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
-- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:
+Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.
 
-## Human Verification (required)
+Medium/high-risk PRs must fill:
 
-What was personally validated beyond CI:
+- **Fast rollback command/path:**
+- **Feature flags or config toggles:** (or `None`)
+- **Observable failure symptoms:** (what to grep logs for, which metric moves, which alert fires)
 
-- Verified scenarios:
-- Edge cases checked:
-- What was not verified:
+## Supersede Attribution (required only when `Supersedes #` is used)
 
-## Side Effects / Blast Radius (required)
+- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
+- Scope materially carried forward:
+- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`)
+- If `No`, why (inspiration-only, no direct code/design carry-over):
 
-- Affected subsystems/workflows:
-- Potential unintended effects:
-- Guardrails/monitoring for early detection:
+## i18n Follow-Through (required only when docs or user-facing wording change)
 
-## Agent Collaboration Notes (recommended)
+- Locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No/N.A.`)
+- Localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
+- Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
+- If any `N.A.`, explain scope decision:
 
-- Agent tools used (if any):
-- Workflow/plan summary (if any):
-- Verification focus:
-- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):
+---
 
-## Rollback Plan (required)
+**Labels** live in the GitHub label UI, not in the body. Set `risk:*`, `size:*`, and scope labels via the sidebar. Auto-label corrections: add `risk: manual` and the intended label.
 
-- Fast rollback command/path:
-- Feature flags or config toggles (if any):
-- Observable failure symptoms:
+**Commit trailers** capture AI-assisted collaboration (`Co-Authored-By: Claude ...`) — no separate section needed.
 
-## Risks and Mitigations
-
-List real risks in this PR (or write `None`).
-
-- Risk:
-  - Mitigation:
+**Privacy contract** (`docs/contributing/pr-discipline.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions): master
- Problem: The current PR template is enterprise-compliance territory — 15 sections, 9 required — most asking questions whose answers are already knowable from the diff, labels, commit messages, or CI output. Contributors self-label in the body while the GitHub label UI holds the source of truth; they re-state change type after writing a conventional commit title; `Human Verification` and `Validation Evidence` ask the same question at two levels of depth; `Agent Collaboration Notes` duplicates `Co-Authored-By` commit trailers. The resulting bloat trains contributors to skim, paraphrase, or leave sections blank — the exact failure mode strict reviewer discipline (PR #5647 R1–R5) is supposed to catch but cannot, because the template itself undermines it.
- Why it matters: A shorter template with strict enforcement beats a longer template with loose enforcement. This is the Linux kernel and Rust compiler lesson, and it's observable in this repo: the #5644/#5647 branch-rename recovery produced two drafts of the same PR — the first omitted 5 required sections under time pressure, the second included all 15 only after explicit re-read discipline. 15 sections is too many for a solo maintainer + small-contributor repo; the tail half trains the agent (human or AI) to cut corners on the essential half.
- What changed: Rewrote `.github/pull_request_template.md` from 15 sections to 7 — 5 always-required, 2 conditional. Removed Label Snapshot, Change Metadata, Linked Issue (now a Summary sub-bullet), Agent Collaboration Notes, Human Verification (now a Validation Evidence sub-bullet), Side Effects / Blast Radius (now a Summary sub-bullet), and Risks and Mitigations. Merged Privacy into Security as a single checklist. Made Rollback conditional on `risk: medium|high`. Added a footer noting where labels, AI attribution, and privacy enforcement live. Net: 123 → 40 effective lines (~67% reduction).
- What did **not** change (scope boundary): No changes to `CONTRIBUTING.md`, `AGENTS.md`, `docs/contributing/pr-workflow.md`, or any i18n locale files — they all reference the template by path, not by section name, so "complete every section" continues to hold with fewer sections. No reviewer skill changes (those shipped in #5647). No CI workflow changes. The Privacy contract in `pr-discipline.md` is preserved as a merge gate, just rephrased in the template footer instead of its own body section.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): `risk: low`
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): (auto; +40/-83 single-file → likely `size: S`)
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated): `docs`
- Module labels (`<module>: <component>`): n/a
- Contributor tier label: (auto)
- If any auto-label is incorrect, note requested correction: n/a

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): docs
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): docs

## Linked Issue

- Closes #
- Related # 5647 (the skill discipline PR that motivated the template rethink; this PR is the logical follow-up)
- Depends on # (none — this PR is independent of #5647 and can merge in either order)
- Supersedes #

## Supersede Attribution (required when `Supersedes #` is used)

N/A — not a supersede.

## Validation Evidence (required)

Docs-only change to `.github/pull_request_template.md`. Ran the repo's own docs quality gate:

```
$ BASE_SHA=$(git merge-base origin/master HEAD) bash scripts/ci/docs_quality_gate.sh
Linting docs files: .github/pull_request_template.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: .github/pull_request_template.md !target/**
Linting: 1 file(s)
Summary: 0 error(s)
```

Gate passed clean — zero markdown issues on the new template. No Rust files touched, so `cargo fmt/clippy/build/test` is not applicable.

Downstream reference check (confirming no file hardcodes a removed section name):

```
$ grep -rn "Label Snapshot\|Change Metadata\|Human Verification\|Side Effects\|Agent Collaboration\|Risks and Mitigations" \
    CONTRIBUTING.md AGENTS.md docs/contributing/ docs/i18n/ scripts/ci/ .claude/skills/
# no matches in CONTRIBUTING.md, AGENTS.md, docs/contributing/pr-workflow.md,
# docs/i18n/zh-CN/contributing/pr-workflow.zh-CN.md, docs/i18n/vi/pr-workflow.md,
# scripts/ci/docs_quality_gate.sh, scripts/ci/collect_changed_links.py
# All existing references to pull_request_template.md cite it by PATH only,
# not by section name — so renaming/removing sections is safe.
```

- Evidence provided (test/log/trace/screenshot/perf): literal docs quality gate output + downstream-reference grep
- If any command is intentionally skipped, explain why: Rust battery skipped — no Rust files in diff.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- New external network calls? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- File system access scope changed? (`Yes/No`): No
- If any `Yes`, describe risk and mitigation: n/a

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`): pass
- Redaction/anonymization notes: No identifiers in the new template. Footer explicitly preserves the privacy contract pointer (`docs/contributing/pr-discipline.md`).
- Neutral wording confirmation: confirmed — all language is project-native, no identity-specific wording.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: None. The new template applies to future PRs only; existing open PRs keep their current bodies unchanged. Contributors don't need to do anything — GitHub uses whichever template is on `master` at the time they open a PR.

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`): No
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md`: n/a
- If `Yes`, localized runtime-contract docs updated: n/a
- If `Yes`, Vietnamese canonical docs synced: n/a
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision: `.github/pull_request_template.md` is not a runtime-contract doc and has no locale equivalents. Grepped `docs/i18n/**` for references — both locale files (`docs/i18n/zh-CN/contributing/pr-workflow.zh-CN.md` and `docs/i18n/vi/pr-workflow.md`) mention the template only by path, not by section name. Their prose says "complete the template fully," which remains true with 7 sections. No locale parity surface to update.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
  - Read the new template end-to-end and confirmed it has the 7 sections proposed (Summary / Validation Evidence / Security & Privacy Impact / Compatibility / Rollback / Supersede Attribution / i18n Follow-Through) plus the footer.
  - Ran `scripts/ci/docs_quality_gate.sh` against the diff — 0 errors.
  - Grepped all likely downstream consumers (`CONTRIBUTING.md`, `AGENTS.md`, `docs/contributing/`, `docs/i18n/`, `scripts/ci/`, `.claude/skills/`) for any hard-coded section name from the old template. Zero external references; all are by path only.
  - Confirmed `CONTRIBUTING.md:269,296` ("complete every section in `.github/pull_request_template.md`") remains satisfiable with fewer sections.
  - Confirmed `AGENTS.md:99` ("Follow `.github/pull_request_template.md` fully") remains satisfiable.
- Edge cases checked:
  - Diff is `+40 / -83` — net reduction of 43 lines, 67% shorter than original. Every removed section either duplicates information available elsewhere (labels, commit trailers, title conventions) or is folded into a sub-bullet of a retained section.
  - Footer preserves all non-section discipline: label UI pointer, Co-Authored-By trailer convention, privacy contract path. None of these were lost.
  - `pr-discipline.md` governs privacy; deletion of the `Privacy and Data Hygiene` section as its own block does NOT remove the privacy gate — it's folded into the `Security & Privacy Impact` checklist as the "PII, real identities, or personal data" yes/no line, AND re-stated in the footer.
- What was not verified:
  - I did not open a test PR using the new template to see how GitHub renders it end-to-end in the web UI. This would require merging first and then filing a throwaway PR, which is unnecessary ceremony for a markdown format that has no rendering edge cases.
  - I did not solicit contributor feedback. N=1 (maintainer) decision; the goal is to reduce maintainer fatigue, and the maintainer is the decision-maker.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
  - All future PRs opened against `master` will use the new template by default.
  - Existing open PRs are unaffected — their bodies are frozen.
  - The `github-pr` skill in this repo parses `.github/pull_request_template.md` dynamically (it re-reads the template every time per SKILL.md "Shared: Read the PR Template"), so it will automatically use the new structure on the next invocation. No skill edits required for this PR to take effect.
  - The `github-pr-review` skill's §2.2 "PR Template Completeness" check will continue to work — it validates template-completion generically, not section-by-section.
- Potential unintended effects:
  - **Loss of contributor self-classification:** Removing `Change Metadata` and `Label Snapshot` means contributors won't type labels into the body. Mitigation: the GitHub label UI + `pr-path-labeler.yml` auto-labeling cover 90% of the cases. For the remaining 10%, reviewers can add labels in under 5 seconds.
  - **Risk of "Rollback optional on low-risk" being abused:** A contributor could mis-label a PR as `risk: low` to avoid filling Rollback. Mitigation: the reviewer skill's §3.8 R-future could add "if auto-path-labeler assigned `risk: high` and the contributor downgraded to `risk: low` without explanation, treat as a finding." Out of scope for this PR; flagging for future discipline rule.
  - **Reviewer workflow:** Reviewers who memorized "check section N for X" will need to re-learn. Mitigation: the reviewer skill does NOT hard-code section names (it reads the template dynamically), so agent reviewers adapt automatically. Human reviewers benefit from less noise.
- Guardrails/monitoring for early detection:
  - Watch the next ~5 PRs for whether contributors fill Validation Evidence and Security & Privacy more completely than they did under the old template. If not, the issue is discipline enforcement, not template length — revisit §3.8 of the reviewer protocol.
  - If contributors start asking "where do I put X?" for a field that was removed, that's evidence the field was load-bearing and should come back. Expected questions: "where does change type go?" (answer: commit title), "where do I list rollback for low-risk?" (answer: `git revert <sha>` is the default, omit the section entirely).

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Claude Code (Opus 4.6, 1M context) drafted both the new template and this PR body, using the `github-pr` skill. The Step 1a validation discipline is from PR #5647 (not yet merged), so it was applied manually here.
- Workflow/plan summary (if any): Session started with a request to consider whether the template was too long after multiple drafts in #5644 surfaced that 15 sections created fatigue. Section-by-section review classified each one by the "answers a question the maintainer actually asks" test. Eight sections failed that test (answer knowable elsewhere or redundant with another section). The streamlined 7-section version preserves every load-bearing question — just expressed more densely.
- Verification focus: The concern with template changes is silently breaking downstream references. Verified by grep that no file under `CONTRIBUTING.md`, `AGENTS.md`, `docs/contributing/`, `docs/i18n/`, `scripts/ci/`, or `.claude/skills/` hardcodes a removed section name. All references are by path.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): confirmed. This is a pure template/workflow change; no source code, no architecture boundaries, no trait impacts.

## Rollback Plan (required)

- Fast rollback command/path: `git revert 41fa39ec` — single-commit PR, clean revert. Restores the 15-section template verbatim.
- Feature flags or config toggles (if any): None. Templates are not feature-flagged.
- Observable failure symptoms: If the streamlined template creates problems, the symptom would be one of:
  - Contributors open PRs that omit information reviewers need (e.g., no migration steps on a breaking change). Signal: reviewers start leaving `[blocking]` comments asking for information that used to be a dedicated field.
  - Auto-label workflows break because they parse the template body for fields that no longer exist. Signal: `pr-path-labeler.yml` errors. Pre-checked — that workflow does not parse body content, only file paths.
  - Agent reviewers (the `github-pr-review` skill) mis-apply the template completeness check. Signal: `agent-approved` label getting applied to PRs missing required fields. Unlikely — the skill reads the template dynamically.
  - If any of these fire, the revert is clean. Nothing else depends on the template's section structure.

## Risks and Mitigations

- Risk: The template change is derived from N=1 observation (one self-critique of #5644/#5647). Small sample, strong prior — the prior being "enterprise-compliance templates universally cause fatigue," which is well-documented outside this repo.
  - Mitigation: Make the change cheap to reverse (single-commit PR, clean revert). Monitor the next 5–10 PRs for signs the streamlining went too far. If it did, specific sections can be restored individually without wholesale revert.
- Risk: Removing `Label Snapshot` means the body no longer prompts contributors to think about risk/size/scope labels, potentially leaving PRs unlabeled.
  - Mitigation: `pr-path-labeler.yml` auto-labels based on changed paths. For anything it misses, the reviewer-playbook's §3.1 five-minute intake triage already checks label presence. The prompt to self-label exists in `pr-workflow.md`, not the template — so it's not lost.
- Risk: Removing `Agent Collaboration Notes` may reduce visibility of AI-assisted PRs for maintainer review.
  - Mitigation: `Co-Authored-By: Claude ...` commit trailers already capture this, survive rebase/squash, and are immediately visible in `git log`. The body field was duplicating what trailers already expressed. This commit itself has the trailer.
- Risk: Someone relying on muscle memory of the old template structure will be briefly disoriented.
  - Mitigation: The changed sections are all in a direction of "fewer things to fill," not "new things to learn." The learning curve is negative — existing contributors do less work, not more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)