### PR TITLE
feat(provider): add native extended thinking for Anthropic provider

### DIFF
--- a/src/agent/agent.rs
+++ b/src/agent/agent.rs
@@ -916,6 +916,7 @@ impl Agent {
                         } else {
                             None
                         },
+                        thinking: None,
                     },
                     &effective_model,
                     self.temperature,
@@ -1095,6 +1096,7 @@ impl Agent {
                     } else {
                         None
                     },
+                    thinking: None,
                 },
                 &effective_model,
                 self.temperature,
@@ -1181,6 +1183,7 @@ impl Agent {
                             } else {
                                 None
                             },
+                            thinking: None,
                         },
                         &effective_model,
                         self.temperature,

--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -277,6 +277,9 @@ pub enum DraftEvent {
 
 tokio::task_local! {
     pub(crate) static TOOL_CHOICE_OVERRIDE: Option<String>;
+    /// Native extended thinking parameters, set by the outer orchestration
+    /// functions and read by `run_tool_call_loop` when building `ChatRequest`.
+    pub(crate) static NATIVE_THINKING_OVERRIDE: Option<crate::agent::thinking::NativeThinkingParams>;
 }
 
 /// Convert a tool registry to OpenAI function-calling format for native tool support.
@@ -2013,10 +2016,15 @@ async fn consume_provider_streaming_response(
     cancellation_token: Option<&CancellationToken>,
     on_delta: Option<&tokio::sync::mpsc::Sender<DraftEvent>>,
 ) -> Result<StreamedChatOutcome> {
+    let native_thinking = NATIVE_THINKING_OVERRIDE
+        .try_with(Clone::clone)
+        .ok()
+        .flatten();
     let mut provider_stream = provider.stream_chat(
         ChatRequest {
             messages,
             tools: request_tools,
+            thinking: native_thinking,
         },
         model,
         temperature,
@@ -2583,10 +2591,15 @@ pub(crate) async fn run_tool_call_loop(
                         let _ = tx.send(DraftEvent::Clear).await;
                     }
                     {
+                        let native_thinking = NATIVE_THINKING_OVERRIDE
+                            .try_with(Clone::clone)
+                            .ok()
+                            .flatten();
                         let chat_future = active_provider.chat(
                             ChatRequest {
                                 messages: &prepared_messages.messages,
                                 tools: request_tools,
+                                thinking: native_thinking,
                             },
                             active_model,
                             temperature,
@@ -2605,10 +2618,15 @@ pub(crate) async fn run_tool_call_loop(
         } else {
             // Non-streaming path: wrap with optional per-step timeout from
             // pacing config to catch hung model responses.
+            let native_thinking = NATIVE_THINKING_OVERRIDE
+                .try_with(Clone::clone)
+                .ok()
+                .flatten();
             let chat_future = active_provider.chat(
                 ChatRequest {
                     messages: &prepared_messages.messages,
                     tools: request_tools,
+                    thinking: native_thinking,
                 },
                 active_model,
                 temperature,
@@ -3402,6 +3420,7 @@ pub(crate) async fn run_tool_call_loop(
     let summary_request = crate::providers::ChatRequest {
         messages: history,
         tools: None, // No tools — force a text response
+        thinking: None,
     };
     match provider.chat(summary_request, model, temperature).await {
         Ok(resp) => {
@@ -3878,24 +3897,15 @@ pub async fn run(
     let base_system_prompt = system_prompt.clone();
 
     if let Some(msg) = message {
-        // ── Parse thinking directive from user message ─────────
-        let (thinking_directive, effective_msg) =
-            match crate::agent::thinking::parse_thinking_directive(&msg) {
-                Some((level, remaining)) => {
-                    tracing::info!(thinking_level = ?level, "Thinking directive parsed from message");
-                    (Some(level), remaining)
-                }
-                None => (None, msg.clone()),
-            };
-        let thinking_level = crate::agent::thinking::resolve_thinking_level(
-            thinking_directive,
-            None,
+        // ── Resolve thinking directive from user message ────────
+        let resolved = crate::agent::thinking::resolve_thinking_from_message(
+            &msg,
             &config.agent.thinking,
+            temperature,
         );
-        let thinking_params = crate::agent::thinking::apply_thinking_level(thinking_level);
-        let effective_temperature = crate::agent::thinking::clamp_temperature(
-            temperature + thinking_params.temperature_adjustment,
-        );
+        let effective_msg = resolved.effective_message;
+        let thinking_params = resolved.params;
+        let effective_temperature = resolved.effective_temperature;
 
         // Prepend thinking system prompt prefix when present.
         if let Some(ref prefix) = thinking_params.system_prompt_prefix {
@@ -3962,34 +3972,37 @@ pub async fn run(
         #[allow(unused_assignments)]
         let mut response = String::new();
         loop {
-            match TOOL_LOOP_COST_TRACKING_CONTEXT
+            match NATIVE_THINKING_OVERRIDE
                 .scope(
-                    cost_tracking_context.clone(),
-                    run_tool_call_loop(
-                        provider.as_ref(),
-                        &mut history,
-                        &tools_registry,
-                        observer.as_ref(),
-                        &provider_name,
-                        &model_name,
-                        effective_temperature,
-                        false,
-                        approval_manager.as_ref(),
-                        channel_name,
-                        None,
-                        &config.multimodal,
-                        config.agent.max_tool_iterations,
-                        None,
-                        None,
-                        None,
-                        &excluded_tools,
-                        &config.agent.tool_call_dedup_exempt,
-                        activated_handle.as_ref(),
-                        Some(model_switch_callback.clone()),
-                        &config.pacing,
-                        config.agent.max_tool_result_chars,
-                        config.agent.max_context_tokens,
-                        None, // shared_budget
+                    thinking_params.native_thinking,
+                    TOOL_LOOP_COST_TRACKING_CONTEXT.scope(
+                        cost_tracking_context.clone(),
+                        run_tool_call_loop(
+                            provider.as_ref(),
+                            &mut history,
+                            &tools_registry,
+                            observer.as_ref(),
+                            &provider_name,
+                            &model_name,
+                            effective_temperature,
+                            false,
+                            approval_manager.as_ref(),
+                            channel_name,
+                            None,
+                            &config.multimodal,
+                            config.agent.max_tool_iterations,
+                            None,
+                            None,
+                            None,
+                            &excluded_tools,
+                            &config.agent.tool_call_dedup_exempt,
+                            activated_handle.as_ref(),
+                            Some(model_switch_callback.clone()),
+                            &config.pacing,
+                            config.agent.max_tool_result_chars,
+                            config.agent.max_context_tokens,
+                            None, // shared_budget
+                        ),
                     ),
                 )
                 .await
@@ -4153,24 +4166,15 @@ pub async fn run(
                 _ => {}
             }
 
-            // ── Parse thinking directive from interactive input ───
-            let (thinking_directive, effective_input) =
-                match crate::agent::thinking::parse_thinking_directive(&user_input) {
-                    Some((level, remaining)) => {
-                        tracing::info!(thinking_level = ?level, "Thinking directive parsed");
-                        (Some(level), remaining)
-                    }
-                    None => (None, user_input.clone()),
-                };
-            let thinking_level = crate::agent::thinking::resolve_thinking_level(
-                thinking_directive,
-                None,
+            // ── Resolve thinking directive from interactive input ──
+            let resolved = crate::agent::thinking::resolve_thinking_from_message(
+                &user_input,
                 &config.agent.thinking,
+                temperature,
             );
-            let thinking_params = crate::agent::thinking::apply_thinking_level(thinking_level);
-            let turn_temperature = crate::agent::thinking::clamp_temperature(
-                temperature + thinking_params.temperature_adjustment,
-            );
+            let effective_input = resolved.effective_message;
+            let thinking_params = resolved.params;
+            let turn_temperature = resolved.effective_temperature;
 
             // For non-Medium levels, temporarily patch the system prompt with prefix.
             let turn_system_prompt;
@@ -4272,34 +4276,37 @@ pub async fn run(
             });
 
             let response = loop {
-                match TOOL_LOOP_COST_TRACKING_CONTEXT
+                match NATIVE_THINKING_OVERRIDE
                     .scope(
-                        cost_tracking_context.clone(),
-                        run_tool_call_loop(
-                            provider.as_ref(),
-                            &mut history,
-                            &tools_registry,
-                            observer.as_ref(),
-                            &provider_name,
-                            &model_name,
-                            turn_temperature,
-                            true,
-                            approval_manager.as_ref(),
-                            channel_name,
-                            None,
-                            &config.multimodal,
-                            config.agent.max_tool_iterations,
-                            Some(cancel_token.clone()),
-                            Some(delta_tx.clone()),
-                            None,
-                            &excluded_tools,
-                            &config.agent.tool_call_dedup_exempt,
-                            activated_handle.as_ref(),
-                            Some(model_switch_callback.clone()),
-                            &config.pacing,
-                            config.agent.max_tool_result_chars,
-                            config.agent.max_context_tokens,
-                            None, // shared_budget
+                        thinking_params.native_thinking,
+                        TOOL_LOOP_COST_TRACKING_CONTEXT.scope(
+                            cost_tracking_context.clone(),
+                            run_tool_call_loop(
+                                provider.as_ref(),
+                                &mut history,
+                                &tools_registry,
+                                observer.as_ref(),
+                                &provider_name,
+                                &model_name,
+                                turn_temperature,
+                                true,
+                                approval_manager.as_ref(),
+                                channel_name,
+                                None,
+                                &config.multimodal,
+                                config.agent.max_tool_iterations,
+                                Some(cancel_token.clone()),
+                                Some(delta_tx.clone()),
+                                None,
+                                &excluded_tools,
+                                &config.agent.tool_call_dedup_exempt,
+                                activated_handle.as_ref(),
+                                Some(model_switch_callback.clone()),
+                                &config.pacing,
+                                config.agent.max_tool_result_chars,
+                                config.agent.max_context_tokens,
+                                None, // shared_budget
+                            ),
                         ),
                     )
                     .await
@@ -4729,24 +4736,15 @@ pub async fn process_message(
         system_prompt.push_str(&deferred_section);
     }
 
-    // ── Parse thinking directive from user message ─────────────
-    let (thinking_directive, effective_message) =
-        match crate::agent::thinking::parse_thinking_directive(message) {
-            Some((level, remaining)) => {
-                tracing::info!(thinking_level = ?level, "Thinking directive parsed from message");
-                (Some(level), remaining)
-            }
-            None => (None, message.to_string()),
-        };
-    let thinking_level = crate::agent::thinking::resolve_thinking_level(
-        thinking_directive,
-        None,
+    // ── Resolve thinking directive from user message ────────────
+    let resolved = crate::agent::thinking::resolve_thinking_from_message(
+        message,
         &config.agent.thinking,
+        config.default_temperature,
     );
-    let thinking_params = crate::agent::thinking::apply_thinking_level(thinking_level);
-    let effective_temperature = crate::agent::thinking::clamp_temperature(
-        config.default_temperature + thinking_params.temperature_adjustment,
-    );
+    let effective_message = resolved.effective_message;
+    let thinking_params = resolved.params;
+    let effective_temperature = resolved.effective_temperature;
 
     // Prepend thinking system prompt prefix when present.
     if let Some(ref prefix) = thinking_params.system_prompt_prefix {
@@ -4787,26 +4785,30 @@ pub async fn process_message(
         excluded_tools.extend(config.autonomy.non_cli_excluded_tools.iter().cloned());
     }
 
-    agent_turn(
-        provider.as_ref(),
-        &mut history,
-        &tools_registry,
-        observer.as_ref(),
-        provider_name,
-        &model_name,
-        effective_temperature,
-        true,
-        "daemon",
-        None,
-        &config.multimodal,
-        config.agent.max_tool_iterations,
-        Some(&approval_manager),
-        &excluded_tools,
-        &config.agent.tool_call_dedup_exempt,
-        activated_handle_pm.as_ref(),
-        None,
-    )
-    .await
+    NATIVE_THINKING_OVERRIDE
+        .scope(
+            thinking_params.native_thinking,
+            agent_turn(
+                provider.as_ref(),
+                &mut history,
+                &tools_registry,
+                observer.as_ref(),
+                provider_name,
+                &model_name,
+                effective_temperature,
+                true,
+                "daemon",
+                None,
+                &config.multimodal,
+                config.agent.max_tool_iterations,
+                Some(&approval_manager),
+                &excluded_tools,
+                &config.agent.tool_call_dedup_exempt,
+                activated_handle_pm.as_ref(),
+                None,
+            ),
+        )
+        .await
 }
 
 #[cfg(test)]
@@ -5248,6 +5250,7 @@ mod tests {
                 native_tool_calling: false,
                 vision: true,
                 prompt_caching: false,
+                extended_thinking: false,
             }
         }
 
@@ -5452,6 +5455,7 @@ mod tests {
                 native_tool_calling: true,
                 vision: false,
                 prompt_caching: false,
+                extended_thinking: false,
             }
         }
 

--- a/src/agent/thinking.rs
+++ b/src/agent/thinking.rs
@@ -14,6 +14,8 @@
 //! 3. Agent config (`agent.thinking.default_level`)
 //! 4. Global default (`Medium`)
 
+use std::collections::HashMap;
+
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use zeroclaw_macros::Configurable;
@@ -42,6 +44,31 @@ impl crate::config::HasPropKind for ThinkingLevel {
 }
 
 impl ThinkingLevel {
+    /// Returns the canonical lowercase name of this level.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Minimal => "minimal",
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Max => "max",
+        }
+    }
+
+    /// Returns the default `budget_tokens` for native extended thinking at this level.
+    ///
+    /// Levels below `High` return `None` — they use prompt-based reasoning only.
+    /// `High` and `Max` return token budgets suitable for Anthropic's extended
+    /// thinking API.
+    pub fn default_budget_tokens(&self) -> Option<u32> {
+        match self {
+            Self::Off | Self::Minimal | Self::Low | Self::Medium => None,
+            Self::High => Some(10_000),
+            Self::Max => Some(50_000),
+        }
+    }
+
     /// Parse a thinking level from a string (case-insensitive).
     pub fn from_str_insensitive(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
@@ -63,14 +90,69 @@ pub struct ThinkingConfig {
     /// Default thinking level when no directive is present.
     #[serde(default)]
     pub default_level: ThinkingLevel,
+    /// Enable native extended thinking for providers that support it.
+    /// When `false` or when the provider lacks support, falls back to
+    /// prompt-based reasoning. Default: `true`.
+    #[serde(default = "default_true")]
+    pub native_thinking: bool,
+    /// Override the default `budget_tokens` per level. Keys are level names
+    /// (e.g. `"high"`, `"max"`). Values are token counts. Unspecified levels
+    /// use built-in defaults from `ThinkingLevel::default_budget_tokens()`.
+    #[serde(default)]
+    pub budget_tokens: HashMap<String, u32>,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 impl Default for ThinkingConfig {
     fn default() -> Self {
         Self {
             default_level: ThinkingLevel::Medium,
+            native_thinking: true,
+            budget_tokens: HashMap::new(),
         }
     }
+}
+
+impl ThinkingConfig {
+    /// Resolve the effective `budget_tokens` for a given level, checking
+    /// user overrides first, then falling back to the level's built-in default.
+    /// Log warnings for any unrecognized keys in the `budget_tokens` map.
+    /// Call once during config load to catch typos early.
+    pub fn warn_unknown_budget_keys(&self) {
+        const VALID_LEVELS: &[&str] = &["off", "minimal", "low", "medium", "high", "max"];
+        for key in self.budget_tokens.keys() {
+            if !VALID_LEVELS.contains(&key.as_str()) {
+                tracing::warn!(
+                    key = %key,
+                    "Unknown thinking level in budget_tokens config; \
+                     valid levels are: off, minimal, low, medium, high, max"
+                );
+            }
+        }
+    }
+
+    pub fn budget_tokens_for(&self, level: ThinkingLevel) -> Option<u32> {
+        if let Some(&override_val) = self.budget_tokens.get(level.as_str()) {
+            return Some(override_val);
+        }
+        level.default_budget_tokens()
+    }
+}
+
+/// Maximum allowed `budget_tokens` value. Prevents runaway token costs from
+/// misconfigured overrides. Anthropic's current ceiling is 128K for most
+/// models; we cap below that as a safety margin.
+pub const MAX_BUDGET_TOKENS: u32 = 128_000;
+
+/// Parameters for native extended thinking (Anthropic API).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NativeThinkingParams {
+    /// Token budget allocated for the model's internal reasoning chain.
+    /// Clamped to [`MAX_BUDGET_TOKENS`] during resolution.
+    pub budget_tokens: u32,
 }
 
 /// Parameters derived from a thinking level, applied to the LLM request.
@@ -82,6 +164,9 @@ pub struct ThinkingParams {
     pub max_tokens_adjustment: i64,
     /// Optional system prompt prefix injected before the existing system prompt.
     pub system_prompt_prefix: Option<String>,
+    /// Native extended thinking parameters, populated when the config enables
+    /// native thinking and the level has a `budget_tokens` value.
+    pub native_thinking: Option<NativeThinkingParams>,
 }
 
 /// Parse a `/think:<level>` directive from the start of a message.
@@ -109,6 +194,10 @@ pub fn parse_thinking_directive(message: &str) -> Option<(ThinkingLevel, String)
 }
 
 /// Convert a `ThinkingLevel` into concrete parameters for the LLM request.
+///
+/// This returns prompt-based parameters only. Call
+/// [`apply_thinking_level_with_config`] to also resolve native extended
+/// thinking parameters from the agent config.
 pub fn apply_thinking_level(level: ThinkingLevel) -> ThinkingParams {
     match level {
         ThinkingLevel::Off => ThinkingParams {
@@ -119,6 +208,7 @@ pub fn apply_thinking_level(level: ThinkingLevel) -> ThinkingParams {
                  unless explicitly asked. No preamble."
                     .into(),
             ),
+            native_thinking: None,
         },
         ThinkingLevel::Minimal => ThinkingParams {
             temperature_adjustment: -0.1,
@@ -128,16 +218,19 @@ pub fn apply_thinking_level(level: ThinkingLevel) -> ThinkingParams {
                  Prioritize speed over thoroughness."
                     .into(),
             ),
+            native_thinking: None,
         },
         ThinkingLevel::Low => ThinkingParams {
             temperature_adjustment: -0.05,
             max_tokens_adjustment: 0,
             system_prompt_prefix: Some("Keep reasoning light. Explain only when helpful.".into()),
+            native_thinking: None,
         },
         ThinkingLevel::Medium => ThinkingParams {
             temperature_adjustment: 0.0,
             max_tokens_adjustment: 0,
             system_prompt_prefix: None,
+            native_thinking: None,
         },
         ThinkingLevel::High => ThinkingParams {
             temperature_adjustment: 0.05,
@@ -147,6 +240,7 @@ pub fn apply_thinking_level(level: ThinkingLevel) -> ThinkingParams {
                  consider edge cases before answering."
                     .into(),
             ),
+            native_thinking: None,
         },
         ThinkingLevel::Max => ThinkingParams {
             temperature_adjustment: 0.1,
@@ -157,8 +251,40 @@ pub fn apply_thinking_level(level: ThinkingLevel) -> ThinkingParams {
                  and provide the most thorough analysis possible."
                     .into(),
             ),
+            native_thinking: None,
         },
     }
+}
+
+/// Convert a `ThinkingLevel` into parameters, resolving native extended
+/// thinking from the provided config.
+///
+/// When `config.native_thinking` is `true` and the level has a budget
+/// (either from a user override or the built-in default), the returned
+/// `ThinkingParams` will include `native_thinking` with the resolved
+/// `budget_tokens`. The caller should then check provider capabilities
+/// before forwarding native params to the API.
+pub fn apply_thinking_level_with_config(
+    level: ThinkingLevel,
+    config: &ThinkingConfig,
+) -> ThinkingParams {
+    let mut params = apply_thinking_level(level);
+    if config.native_thinking {
+        if let Some(budget) = config.budget_tokens_for(level) {
+            let clamped = budget.min(MAX_BUDGET_TOKENS);
+            if clamped < budget {
+                tracing::warn!(
+                    requested = budget,
+                    clamped = clamped,
+                    "budget_tokens exceeds maximum; clamping to {MAX_BUDGET_TOKENS}"
+                );
+            }
+            params.native_thinking = Some(NativeThinkingParams {
+                budget_tokens: clamped,
+            });
+        }
+    }
+    params
 }
 
 /// Resolve the effective thinking level using the priority hierarchy:
@@ -179,6 +305,46 @@ pub fn resolve_thinking_level(
 /// Clamp a temperature value to the valid range `[0.0, 2.0]`.
 pub fn clamp_temperature(temp: f64) -> f64 {
     temp.clamp(0.0, 2.0)
+}
+
+/// Result of resolving a thinking directive from a user message.
+pub struct ResolvedThinking {
+    /// The effective message with any `/think:` prefix stripped.
+    pub effective_message: String,
+    /// Resolved thinking parameters (prompt prefix, native thinking, etc.).
+    pub params: ThinkingParams,
+    /// Temperature after applying the thinking level adjustment and clamping.
+    pub effective_temperature: f64,
+}
+
+/// Parse a thinking directive from a message and resolve all thinking
+/// parameters in one step. Combines `parse_thinking_directive`,
+/// `resolve_thinking_level`, `apply_thinking_level_with_config`, and
+/// `clamp_temperature` into a single call.
+pub fn resolve_thinking_from_message(
+    message: &str,
+    config: &ThinkingConfig,
+    base_temperature: f64,
+) -> ResolvedThinking {
+    use std::sync::Once;
+    static VALIDATE_ONCE: Once = Once::new();
+    VALIDATE_ONCE.call_once(|| config.warn_unknown_budget_keys());
+
+    let (directive, effective_message) = match parse_thinking_directive(message) {
+        Some((level, remaining)) => {
+            tracing::info!(thinking_level = ?level, "Thinking directive parsed from message");
+            (Some(level), remaining)
+        }
+        None => (None, message.to_string()),
+    };
+    let level = resolve_thinking_level(directive, None, config);
+    let params = apply_thinking_level_with_config(level, config);
+    let effective_temperature = clamp_temperature(base_temperature + params.temperature_adjustment);
+    ResolvedThinking {
+        effective_message,
+        params,
+        effective_temperature,
+    }
 }
 
 #[cfg(test)]
@@ -357,6 +523,7 @@ mod tests {
     fn resolve_inline_directive_takes_priority() {
         let config = ThinkingConfig {
             default_level: ThinkingLevel::Low,
+            ..ThinkingConfig::default()
         };
         let result =
             resolve_thinking_level(Some(ThinkingLevel::Max), Some(ThinkingLevel::High), &config);
@@ -367,6 +534,7 @@ mod tests {
     fn resolve_session_override_takes_priority_over_config() {
         let config = ThinkingConfig {
             default_level: ThinkingLevel::Low,
+            ..ThinkingConfig::default()
         };
         let result = resolve_thinking_level(None, Some(ThinkingLevel::High), &config);
         assert_eq!(result, ThinkingLevel::High);
@@ -376,6 +544,7 @@ mod tests {
     fn resolve_falls_back_to_config_default() {
         let config = ThinkingConfig {
             default_level: ThinkingLevel::Minimal,
+            ..ThinkingConfig::default()
         };
         let result = resolve_thinking_level(None, None, &config);
         assert_eq!(result, ThinkingLevel::Minimal);
@@ -428,5 +597,145 @@ mod tests {
         let level = ThinkingLevel::High;
         let json = serde_json::to_string(&level).unwrap();
         assert_eq!(json, "\"high\"");
+    }
+
+    // ── Native thinking: budget defaults ────────────────────────
+
+    #[test]
+    fn default_budget_tokens_none_below_high() {
+        assert!(ThinkingLevel::Off.default_budget_tokens().is_none());
+        assert!(ThinkingLevel::Minimal.default_budget_tokens().is_none());
+        assert!(ThinkingLevel::Low.default_budget_tokens().is_none());
+        assert!(ThinkingLevel::Medium.default_budget_tokens().is_none());
+    }
+
+    #[test]
+    fn default_budget_tokens_high_and_max() {
+        assert_eq!(ThinkingLevel::High.default_budget_tokens(), Some(10_000));
+        assert_eq!(ThinkingLevel::Max.default_budget_tokens(), Some(50_000));
+    }
+
+    // ── Native thinking: config resolution ──────────────────────
+
+    #[test]
+    fn budget_tokens_for_uses_override() {
+        let mut overrides = HashMap::new();
+        overrides.insert("high".to_string(), 20_000);
+        let config = ThinkingConfig {
+            default_level: ThinkingLevel::Medium,
+            native_thinking: true,
+            budget_tokens: overrides,
+        };
+        assert_eq!(config.budget_tokens_for(ThinkingLevel::High), Some(20_000));
+        // Max falls back to built-in default (no override).
+        assert_eq!(config.budget_tokens_for(ThinkingLevel::Max), Some(50_000));
+    }
+
+    #[test]
+    fn budget_tokens_for_returns_none_for_low_levels() {
+        let config = ThinkingConfig::default();
+        assert!(config.budget_tokens_for(ThinkingLevel::Off).is_none());
+        assert!(config.budget_tokens_for(ThinkingLevel::Medium).is_none());
+    }
+
+    // ── Native thinking: apply_thinking_level_with_config ───────
+
+    #[test]
+    fn apply_with_config_populates_native_when_enabled() {
+        let config = ThinkingConfig {
+            native_thinking: true,
+            ..ThinkingConfig::default()
+        };
+        let params = apply_thinking_level_with_config(ThinkingLevel::High, &config);
+        let native = params.native_thinking.expect("should have native thinking");
+        assert_eq!(native.budget_tokens, 10_000);
+    }
+
+    #[test]
+    fn apply_with_config_none_when_disabled() {
+        let config = ThinkingConfig {
+            native_thinking: false,
+            ..ThinkingConfig::default()
+        };
+        let params = apply_thinking_level_with_config(ThinkingLevel::High, &config);
+        assert!(params.native_thinking.is_none());
+    }
+
+    #[test]
+    fn apply_with_config_none_for_medium_even_when_enabled() {
+        let config = ThinkingConfig {
+            native_thinking: true,
+            ..ThinkingConfig::default()
+        };
+        let params = apply_thinking_level_with_config(ThinkingLevel::Medium, &config);
+        assert!(params.native_thinking.is_none());
+    }
+
+    #[test]
+    fn apply_with_config_uses_budget_override() {
+        let mut overrides = HashMap::new();
+        overrides.insert("max".to_string(), 100_000);
+        let config = ThinkingConfig {
+            native_thinking: true,
+            budget_tokens: overrides,
+            ..ThinkingConfig::default()
+        };
+        let params = apply_thinking_level_with_config(ThinkingLevel::Max, &config);
+        let native = params.native_thinking.expect("should have native thinking");
+        assert_eq!(native.budget_tokens, 100_000);
+    }
+
+    // ── Native thinking: config serde ───────────────────────────
+
+    #[test]
+    fn thinking_config_native_thinking_defaults_to_true() {
+        let toml_str = "";
+        let config: ThinkingConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.native_thinking);
+        assert!(config.budget_tokens.is_empty());
+    }
+
+    #[test]
+    fn thinking_config_deserializes_native_thinking_false() {
+        let toml_str = r#"native_thinking = false"#;
+        let config: ThinkingConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.native_thinking);
+    }
+
+    #[test]
+    fn thinking_config_deserializes_budget_overrides() {
+        let toml_str = r#"
+default_level = "high"
+native_thinking = true
+
+[budget_tokens]
+high = 25000
+max = 80000
+"#;
+        let config: ThinkingConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.default_level, ThinkingLevel::High);
+        assert!(config.native_thinking);
+        assert_eq!(config.budget_tokens.get("high"), Some(&25000));
+        assert_eq!(config.budget_tokens.get("max"), Some(&80000));
+    }
+
+    // ── Backward compat: apply_thinking_level has no native ─────
+
+    #[test]
+    fn apply_thinking_level_never_sets_native() {
+        for level in [
+            ThinkingLevel::Off,
+            ThinkingLevel::Minimal,
+            ThinkingLevel::Low,
+            ThinkingLevel::Medium,
+            ThinkingLevel::High,
+            ThinkingLevel::Max,
+        ] {
+            let params = apply_thinking_level(level);
+            assert!(
+                params.native_thinking.is_none(),
+                "apply_thinking_level should not populate native_thinking for {level:?}"
+            );
+        }
     }
 }

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -61,6 +61,18 @@ struct NativeChatRequest<'a> {
     tool_choice: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     stream: Option<bool>,
+    /// Native extended thinking configuration. When present, the model
+    /// allocates a dedicated token budget for internal reasoning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<NativeThinkingConfig>,
+}
+
+/// Anthropic API `thinking` parameter format.
+#[derive(Debug, Serialize)]
+struct NativeThinkingConfig {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    budget_tokens: u32,
 }
 
 #[derive(Debug, Serialize)]
@@ -170,6 +182,9 @@ struct NativeContentIn {
     kind: String,
     #[serde(default)]
     text: Option<String>,
+    /// Thinking text from native extended thinking content blocks.
+    #[serde(default)]
+    thinking: Option<String>,
     #[serde(default)]
     id: Option<String>,
     #[serde(default)]
@@ -516,6 +531,7 @@ impl AnthropicProvider {
     fn parse_native_response(response: NativeChatResponse) -> ProviderChatResponse {
         let mut text_parts = Vec::new();
         let mut tool_calls = Vec::new();
+        let mut thinking_parts = Vec::new();
 
         let usage = response.usage.map(|u| TokenUsage {
             input_tokens: u.input_tokens,
@@ -525,6 +541,14 @@ impl AnthropicProvider {
 
         for block in response.content {
             match block.kind.as_str() {
+                "thinking" => {
+                    if let Some(thinking) = block.thinking.as_deref().or(block.text.as_deref()) {
+                        let trimmed = thinking.trim();
+                        if !trimmed.is_empty() {
+                            thinking_parts.push(trimmed.to_string());
+                        }
+                    }
+                }
                 "text" => {
                     if let Some(text) = block.text.map(|t| t.trim().to_string()) {
                         if !text.is_empty() {
@@ -550,6 +574,12 @@ impl AnthropicProvider {
             }
         }
 
+        let reasoning_content = if thinking_parts.is_empty() {
+            None
+        } else {
+            Some(thinking_parts.join("\n"))
+        };
+
         ProviderChatResponse {
             text: if text_parts.is_empty() {
                 None
@@ -558,7 +588,7 @@ impl AnthropicProvider {
             },
             tool_calls,
             usage,
-            reasoning_content: None,
+            reasoning_content,
         }
     }
 
@@ -787,6 +817,7 @@ impl Provider for AnthropicProvider {
             tools: None,
             tool_choice: None,
             stream: None,
+            thinking: None,
         };
 
         let mut request = self
@@ -849,16 +880,49 @@ impl Provider for AnthropicProvider {
         } else {
             system_prompt
         };
-        tracing::debug!(max_tokens = self.max_tokens, model = %model, "Anthropic streaming API request");
+        // When native thinking is requested, force temperature to 1.0
+        // (Anthropic API hard constraint) and build the thinking config.
+        let (effective_temperature, thinking_config) = match request.thinking {
+            Some(params) => {
+                tracing::info!(
+                    budget_tokens = params.budget_tokens,
+                    "Native extended thinking enabled; forcing temperature=1.0"
+                );
+                (
+                    1.0,
+                    Some(NativeThinkingConfig {
+                        kind: "enabled",
+                        budget_tokens: params.budget_tokens,
+                    }),
+                )
+            }
+            None => (temperature, None),
+        };
+
+        // When thinking is enabled, max_tokens must be >= budget_tokens.
+        let effective_max_tokens = match &thinking_config {
+            Some(tc) if self.max_tokens < tc.budget_tokens => {
+                tracing::info!(
+                    original = self.max_tokens,
+                    adjusted = tc.budget_tokens,
+                    "Raising max_tokens to meet budget_tokens minimum"
+                );
+                tc.budget_tokens
+            }
+            _ => self.max_tokens,
+        };
+
+        tracing::debug!(max_tokens = effective_max_tokens, model = %model, "Anthropic streaming API request");
         let native_request = NativeChatRequest {
             model: model.to_string(),
-            max_tokens: self.max_tokens,
+            max_tokens: effective_max_tokens,
             system: system_prompt,
             messages,
-            temperature,
+            temperature: effective_temperature,
             tools: native_tools,
             tool_choice,
             stream: None,
+            thinking: thinking_config,
         };
 
         let req = self
@@ -882,6 +946,7 @@ impl Provider for AnthropicProvider {
             native_tool_calling: true,
             vision: true,
             prompt_caching: true,
+            extended_thinking: true,
         }
     }
 
@@ -932,6 +997,7 @@ impl Provider for AnthropicProvider {
             } else {
                 Some(&tool_specs)
             },
+            thinking: None,
         };
         self.chat(request, model, temperature).await
     }
@@ -1003,16 +1069,41 @@ impl Provider for AnthropicProvider {
             system_prompt
         };
 
-        tracing::debug!(max_tokens = self.max_tokens, model = %model, "Anthropic stream_chat request");
+        // When native thinking is requested, force temperature to 1.0
+        // and build the thinking config (same logic as non-streaming chat).
+        let (effective_temperature, thinking_config) = match request.thinking {
+            Some(params) => {
+                tracing::info!(
+                    budget_tokens = params.budget_tokens,
+                    "Native extended thinking enabled (streaming); forcing temperature=1.0"
+                );
+                (
+                    1.0,
+                    Some(NativeThinkingConfig {
+                        kind: "enabled",
+                        budget_tokens: params.budget_tokens,
+                    }),
+                )
+            }
+            None => (temperature, None),
+        };
+
+        let effective_max_tokens = match &thinking_config {
+            Some(tc) if self.max_tokens < tc.budget_tokens => tc.budget_tokens,
+            _ => self.max_tokens,
+        };
+
+        tracing::debug!(max_tokens = effective_max_tokens, model = %model, "Anthropic stream_chat request");
         let native_request = NativeChatRequest {
             model: model.to_string(),
-            max_tokens: self.max_tokens,
+            max_tokens: effective_max_tokens,
             system: system_prompt,
             messages,
-            temperature,
+            temperature: effective_temperature,
             tools: native_tools,
             tool_choice,
             stream: Some(true),
+            thinking: thinking_config,
         };
 
         let body = Self::build_streaming_request(&native_request);
@@ -1670,6 +1761,7 @@ mod tests {
             tools: None,
             tool_choice: None,
             stream: None,
+            thinking: None,
         };
 
         let json = serde_json::to_string(&req).unwrap();

--- a/src/providers/azure_openai.rs
+++ b/src/providers/azure_openai.rs
@@ -313,6 +313,7 @@ impl Provider for AzureOpenAiProvider {
             native_tool_calling: true,
             vision: true,
             prompt_caching: false,
+            extended_thinking: false,
         }
     }
 

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -1084,6 +1084,7 @@ impl Provider for BedrockProvider {
             native_tool_calling: true,
             vision: true,
             prompt_caching: false,
+            extended_thinking: false,
         }
     }
 

--- a/src/providers/compatible.rs
+++ b/src/providers/compatible.rs
@@ -1660,6 +1660,7 @@ impl Provider for OpenAiCompatibleProvider {
             native_tool_calling: self.native_tool_calling,
             vision: self.supports_vision,
             prompt_caching: false,
+            extended_thinking: false,
         }
     }
 

--- a/src/providers/gemini.rs
+++ b/src/providers/gemini.rs
@@ -1195,6 +1195,7 @@ impl Provider for GeminiProvider {
             vision: true,
             native_tool_calling: false,
             prompt_caching: false,
+            extended_thinking: false,
         }
     }
 

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -634,6 +634,7 @@ impl Provider for OllamaProvider {
             native_tool_calling: false,
             vision: true,
             prompt_caching: false,
+            extended_thinking: false,
         }
     }
 

--- a/src/providers/openai_codex.rs
+++ b/src/providers/openai_codex.rs
@@ -722,6 +722,7 @@ impl Provider for OpenAiCodexProvider {
             native_tool_calling: false,
             vision: true,
             prompt_caching: false,
+            extended_thinking: false,
         }
     }
 

--- a/src/providers/openrouter.rs
+++ b/src/providers/openrouter.rs
@@ -369,6 +369,7 @@ impl Provider for OpenRouterProvider {
             native_tool_calling: true,
             vision: true,
             prompt_caching: false,
+            extended_thinking: false,
         }
     }
 

--- a/src/providers/reliable.rs
+++ b/src/providers/reliable.rs
@@ -940,6 +940,7 @@ impl Provider for ReliableProvider {
                     let req = ChatRequest {
                         messages: &effective_messages,
                         tools: request.tools,
+                        thinking: None,
                     };
                     match provider.chat(req, current_model, temperature).await {
                         Ok(resp) => {
@@ -1126,6 +1127,7 @@ impl Provider for ReliableProvider {
             let req = ChatRequest {
                 messages: request.messages,
                 tools: request.tools,
+                thinking: None,
             };
             let stream = provider.stream_chat(req, &current_model, temperature, options);
             let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(100);
@@ -2152,6 +2154,7 @@ mod tests {
         let request = ChatRequest {
             messages: &messages,
             tools: None,
+            thinking: None,
         };
         let result = provider.chat(request, "test-model", 0.0).await.unwrap();
 
@@ -2188,6 +2191,7 @@ mod tests {
         let request = ChatRequest {
             messages: &messages,
             tools: None,
+            thinking: None,
         };
         let result = provider.chat(request, "test-model", 0.0).await.unwrap();
 
@@ -2259,6 +2263,7 @@ mod tests {
         let request = ChatRequest {
             messages: &messages,
             tools: None,
+            thinking: None,
         };
         let err = provider
             .chat(request, "test", 0.0)
@@ -2375,6 +2380,7 @@ mod tests {
         let request = ChatRequest {
             messages: &messages,
             tools: None,
+            thinking: None,
         };
         let result = provider.chat(request, "claude-opus", 0.0).await.unwrap();
         assert_eq!(result.text.as_deref(), Some("ok from sonnet"));
@@ -2423,6 +2429,7 @@ mod tests {
         let request = ChatRequest {
             messages: &messages,
             tools: None,
+            thinking: None,
         };
         let result = provider.chat(request, "test", 0.0).await.unwrap();
         assert_eq!(result.text.as_deref(), Some("from fallback"));
@@ -2774,6 +2781,7 @@ mod tests {
             ChatRequest {
                 messages: &messages,
                 tools: Some(&tools),
+                thinking: None,
             },
             "model",
             0.0,
@@ -2815,6 +2823,7 @@ mod tests {
             ChatRequest {
                 messages: &messages,
                 tools: Some(&tools),
+                thinking: None,
             },
             "model",
             0.0,

--- a/src/providers/router.rs
+++ b/src/providers/router.rs
@@ -805,6 +805,7 @@ mod tests {
                 native_tool_calling: self.tools,
                 vision: self.vision,
                 prompt_caching: false,
+                extended_thinking: false,
             }
         }
 
@@ -1154,6 +1155,7 @@ mod tests {
             ChatRequest {
                 messages: &messages,
                 tools: Some(&tools),
+                thinking: None,
             },
             "hint:reasoning",
             0.0,

--- a/src/providers/traits.rs
+++ b/src/providers/traits.rs
@@ -92,6 +92,10 @@ impl ChatResponse {
 pub struct ChatRequest<'a> {
     pub messages: &'a [ChatMessage],
     pub tools: Option<&'a [ToolSpec]>,
+    /// Native extended thinking parameters. When `Some`, providers that
+    /// support extended thinking should send a dedicated thinking budget
+    /// in the API request and force `temperature = 1.0`.
+    pub thinking: Option<crate::agent::thinking::NativeThinkingParams>,
 }
 
 /// A tool result to feed back to the LLM.
@@ -269,6 +273,7 @@ pub struct ProviderCapabilityError {
 ///
 /// Describes what features a provider supports, enabling intelligent
 /// adaptation of tool calling modes and request formatting.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ProviderCapabilities {
     /// Whether the provider supports native tool calling via API primitives.
@@ -283,6 +288,9 @@ pub struct ProviderCapabilities {
     /// Whether the provider supports prompt caching (Anthropic cache_control,
     /// OpenAI automatic prompt caching).
     pub prompt_caching: bool,
+    /// Whether the provider supports native extended thinking (Anthropic
+    /// `thinking` parameter with `budget_tokens`).
+    pub extended_thinking: bool,
 }
 
 /// Provider-specific tool payload formats.
@@ -578,6 +586,7 @@ mod tests {
                 native_tool_calling: true,
                 vision: true,
                 prompt_caching: false,
+                extended_thinking: false,
             }
         }
 
@@ -695,16 +704,19 @@ mod tests {
             native_tool_calling: true,
             vision: false,
             prompt_caching: false,
+            extended_thinking: false,
         };
         let caps2 = ProviderCapabilities {
             native_tool_calling: true,
             vision: false,
             prompt_caching: false,
+            extended_thinking: false,
         };
         let caps3 = ProviderCapabilities {
             native_tool_calling: false,
             vision: false,
             prompt_caching: false,
+            extended_thinking: false,
         };
 
         assert_eq!(caps1, caps2);
@@ -864,6 +876,7 @@ mod tests {
         let request = ChatRequest {
             messages: &[ChatMessage::user("Hello")],
             tools: Some(&tools),
+            thinking: None,
         };
 
         let response = provider.chat(request, "model", 0.7).await.unwrap();
@@ -881,6 +894,7 @@ mod tests {
         let request = ChatRequest {
             messages: &[ChatMessage::user("Hello")],
             tools: None,
+            thinking: None,
         };
 
         let response = provider.chat(request, "model", 0.7).await.unwrap();
@@ -981,6 +995,7 @@ mod tests {
                 ChatMessage::system("BASE_SYSTEM_PROMPT"),
             ],
             tools: Some(&tools),
+            thinking: None,
         };
 
         let response = provider.chat(request, "model", 0.7).await.unwrap();
@@ -1003,6 +1018,7 @@ mod tests {
         let request = ChatRequest {
             messages: &[ChatMessage::system("BASE"), ChatMessage::user("Hello")],
             tools: Some(&tools),
+            thinking: None,
         };
 
         let response = provider.chat(request, "model", 0.7).await.unwrap();
@@ -1025,6 +1041,7 @@ mod tests {
         let request = ChatRequest {
             messages: &[ChatMessage::user("Hello")],
             tools: Some(&tools),
+            thinking: None,
         };
 
         let err = provider.chat(request, "model", 0.7).await.unwrap_err();
@@ -1073,6 +1090,7 @@ mod tests {
             ChatRequest {
                 messages: &[ChatMessage::user("hi")],
                 tools: None,
+                thinking: None,
             },
             "model",
             0.0,

--- a/tests/live/openai_codex_vision_e2e.rs
+++ b/tests/live/openai_codex_vision_e2e.rs
@@ -86,6 +86,7 @@ async fn provider_vision_support() -> Result<()> {
     let request = ChatRequest {
         messages: &messages,
         tools: None,
+        thinking: None,
     };
 
     // Send request to provider
@@ -214,6 +215,7 @@ async fn openai_codex_second_vision_support() -> Result<()> {
     let request = ChatRequest {
         messages: &messages,
         tools: None,
+        thinking: None,
     };
 
     // Send request to provider


### PR DESCRIPTION
Add support for Anthropic's native extended thinking API, enabling dedicated reasoning chains via `budget_tokens` for thinking levels High and Max.

Changes:
- Extend ThinkingConfig with `native_thinking` (bool) and `budget_tokens` (per-level overrides) fields
- Add NativeThinkingParams and budget resolution with MAX_BUDGET_TOKENS safety cap (128K)
- Add `extended_thinking` to ProviderCapabilities and `thinking` field to ChatRequest for provider-level capability detection
- Anthropic provider sends `thinking` parameter with budget_tokens, forces temperature=1.0, and parses `type: "thinking"` response blocks into reasoning_content (both streaming and non-streaming)
- Wire native thinking through agent loop via NATIVE_THINKING_OVERRIDE task-local, matching existing TOOL_CHOICE_OVERRIDE pattern
- Extract resolve_thinking_from_message() helper to deduplicate triplicated directive parsing in loop_.rs
- Add ThinkingLevel::as_str() for zero-allocation config key lookups
- Add budget_tokens key validation with warnings for typos
- Fallback: native_thinking=false or unsupported providers use existing prompt-based behavior with zero change

Closes #5630

## Summary

Describe this PR in 2-5 bullets:

- Base branch target (`master` for all contributions):
- Problem:
- Why it matters:
- What changed:
- What did **not** change (scope boundary):

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`):
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only):
- Scope labels (`core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev`, comma-separated):
- Module labels (`<module>: <component>`, for example `channel: telegram`, `provider: kimi`, `tool: shell`):
- Contributor tier label (`trusted contributor|experienced contributor|principal contributor|distinguished contributor`, auto-managed/read-only; author merged PRs >=5/10/20/50):
- If any auto-label is incorrect, note requested correction:

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`):
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`):

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Integrated scope by source PR (what was materially carried forward):
- `Co-authored-by` trailers added for materially incorporated contributors? (`Yes/No`)
- If `No`, explain why (for example: inspiration-only, no direct code/design carry-over):
- Trailer format check (separate lines, no escaped `\n`): (`Pass/Fail`)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf):
- If any command is intentionally skipped, explain why:

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- New external network calls? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- File system access scope changed? (`Yes/No`)
- If any `Yes`, describe risk and mitigation:

## Privacy and Data Hygiene (required)

- Data-hygiene status (`pass|needs-follow-up`):
- Redaction/anonymization notes:
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed):

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (`Yes/No`)
- If `Yes`, locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No`)
- If `Yes`, localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- If `Yes`, Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `No`/`N.A.`, link follow-up issue/PR and explain scope decision:

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows:
- Potential unintended effects:
- Guardrails/monitoring for early detection:

## Agent Collaboration Notes (recommended)

- Agent tools used (if any):
- Workflow/plan summary (if any):
- Verification focus:
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`):

## Rollback Plan (required)

- Fast rollback command/path:
- Feature flags or config toggles (if any):
- Observable failure symptoms:

## Risks and Mitigations

List real risks in this PR (or write `None`).

- Risk:
  - Mitigation:
