### PR TITLE
fix(ci): skip crates.io publishability check on PR triggers

### DIFF
--- a/.github/workflows/pre-release-validate.yml
+++ b/.github/workflows/pre-release-validate.yml
@@ -185,7 +185,11 @@ jobs:
             echo ""
             echo "| Check | Status |"
             echo "|---|---|"
-            echo "| crates.io dry-run | Passed |"
+            if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+              echo "| crates.io dry-run | Passed |"
+            else
+              echo "| crates.io dry-run | Skipped (PR) |"
+            fi
             echo "| Required secrets | Passed |"
             echo "| Downstream repo access | Passed |"
             echo "| Version consistency | Passed |"

--- a/.github/workflows/pre-release-validate.yml
+++ b/.github/workflows/pre-release-validate.yml
@@ -40,6 +40,7 @@ jobs:
           fi
 
       - name: Check crates.io publishability
+        if: github.event_name == 'workflow_dispatch'
         shell: bash
         run: |
           echo "::group::Checking cargo publish --dry-run"


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `Pre-Release Validation` workflow runs `cargo publish --dry-run` on every PR touching root `Cargo.toml`, but workspace crates aren't published to crates.io, so it always fails with `no matching package named zeroclaw-api found`
- Why it matters: Contributors forced to ignore failing CI or revert legitimate `Cargo.toml` changes (happened in #5642)
- What changed: Gated the crates.io publishability check behind `workflow_dispatch` so it only runs during manual pre-release validation
- What did **not** change: Other validation steps (secrets, PAT access, version consistency) still run on PRs

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `ci`
- Module labels: N/A
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `bug`
- Primary scope: `ci`

## Linked Issue

- Closes #5657
- Related #5559, #5642

## Validation Evidence (required)

```bash
# CI-only change — no Rust code modified
# Validated by confirming workflow syntax is valid YAML
```

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Neutral wording confirmation: N/A

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Human Verification (required)

- Verified scenarios: Confirmed `cargo publish --dry-run` fails on current master for any PR touching `Cargo.toml`; confirmed the `workflow_dispatch` condition correctly gates the step
- Edge cases checked: `workflow_dispatch` manual trigger still runs the publishability check
- What was not verified: Actual `workflow_dispatch` trigger (requires repo admin)

## Side Effects / Blast Radius (required)

- Affected subsystems: Pre-Release Validation CI workflow only
- Potential unintended effects: None — other validation steps unchanged
- Guardrails: Manual `workflow_dispatch` still validates publishability before actual releases

## Rollback Plan (required)

- Fast rollback: Revert this PR
- Feature flags: None
- Observable failure: `Pre-Release Validation` would start failing on Cargo.toml PRs again

## Risks and Mitigations

- Risk: Publishability issues could slip through to release time
  - Mitigation: `workflow_dispatch` check still runs before tagging; actual publish workflows (`publish-crates.yml`) have their own dry-run step