### PR TITLE
fix(channels): add enabled field and orchestrator wiring for Email and VoiceCall

### DIFF
--- a/crates/zeroclaw-channels/src/email_channel.rs
+++ b/crates/zeroclaw-channels/src/email_channel.rs
@@ -688,6 +688,7 @@ mod tests {
     #[test]
     fn email_config_custom() {
         let config = EmailConfig {
+            enabled: true,
             imap_host: "imap.example.com".to_string(),
             imap_port: 993,
             imap_folder: "Archive".to_string(),
@@ -711,6 +712,7 @@ mod tests {
     #[test]
     fn email_config_clone() {
         let config = EmailConfig {
+            enabled: true,
             imap_host: "imap.test.com".to_string(),
             imap_port: 993,
             imap_folder: "INBOX".to_string(),
@@ -959,6 +961,7 @@ mod tests {
     #[test]
     fn email_config_serialize_deserialize() {
         let config = EmailConfig {
+            enabled: true,
             imap_host: "imap.example.com".to_string(),
             imap_port: 993,
             imap_folder: "INBOX".to_string(),
@@ -1042,6 +1045,7 @@ mod tests {
     #[test]
     fn email_config_debug_output() {
         let config = EmailConfig {
+            enabled: true,
             imap_host: "imap.debug.com".to_string(),
             ..Default::default()
         };

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -50,6 +50,7 @@ pub use crate::slack::SlackChannel;
 pub use crate::transcription;
 pub use crate::tts::{TtsManager, TtsProvider};
 pub use crate::twitter::TwitterChannel;
+#[cfg(feature = "channel-voice-call")]
 pub use crate::voice_call::VoiceCallChannel;
 #[cfg(feature = "voice-wake")]
 pub use crate::voice_wake::VoiceWakeChannel;
@@ -4242,10 +4243,25 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 anyhow::bail!("LINE channel requires the `channel-line` feature");
             }
         }
+        "voice-call" => {
+            #[cfg(feature = "channel-voice-call")]
+            {
+                let vc = config
+                    .channels_config
+                    .voice_call
+                    .as_ref()
+                    .context("Voice Call channel is not configured")?;
+                Ok(Arc::new(VoiceCallChannel::new(vc.clone())))
+            }
+            #[cfg(not(feature = "channel-voice-call"))]
+            {
+                anyhow::bail!("Voice Call channel requires the `channel-voice-call` feature");
+            }
+        }
         other => anyhow::bail!(
             "Unknown channel '{other}'. Supported: telegram, discord, slack, mattermost, signal, \
             matrix, whatsapp, qq, lark, feishu, dingtalk, wecom, nextcloud_talk, wati, linq, \
-            email, gmail_push, irc, twitter, mochat, discord_history, imessage, line"
+            email, gmail_push, irc, twitter, mochat, discord_history, imessage, line, voice-call"
         ),
     }
 }
@@ -4633,10 +4649,14 @@ fn collect_configured_channels(
 
     #[cfg(feature = "channel-email")]
     if let Some(ref email_cfg) = config.channels_config.email {
-        channels.push(ConfiguredChannel {
-            display_name: "Email",
-            channel: Arc::new(EmailChannel::new(email_cfg.clone())),
-        });
+        if email_cfg.enabled {
+            channels.push(ConfiguredChannel {
+                display_name: "Email",
+                channel: Arc::new(EmailChannel::new(email_cfg.clone())),
+            });
+        } else {
+            tracing::info!("Email channel configured but disabled (enabled = false)");
+        }
     }
 
     #[cfg(feature = "channel-email")]
@@ -4892,6 +4912,18 @@ fn collect_configured_channels(
                 config.transcription.clone(),
             )),
         });
+    }
+
+    #[cfg(feature = "channel-voice-call")]
+    if let Some(ref vc) = config.channels_config.voice_call {
+        if vc.enabled {
+            channels.push(ConfiguredChannel {
+                display_name: "Voice Call",
+                channel: Arc::new(VoiceCallChannel::new(vc.clone())),
+            });
+        } else {
+            tracing::info!("Voice Call channel configured but disabled (enabled = false)");
+        }
     }
 
     if let Some(ref wh) = config.channels_config.webhook {

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -11450,6 +11450,46 @@ This is an example JSON object for profile settings."#;
         }
     }
 
+    #[cfg(feature = "channel-voice-call")]
+    #[test]
+    fn build_channel_by_id_unconfigured_voice_call_returns_error() {
+        let config = Config::default();
+        match build_channel_by_id(&config, "voice-call") {
+            Err(e) => {
+                let err_msg = e.to_string();
+                assert!(
+                    err_msg.contains("not configured"),
+                    "expected 'not configured' in error, got: {err_msg}"
+                );
+            }
+            Ok(_) => panic!("should fail when voice-call is not configured"),
+        }
+    }
+
+    #[cfg(feature = "channel-voice-call")]
+    #[test]
+    fn build_channel_by_id_configured_voice_call_succeeds() {
+        let mut config = Config::default();
+        config.channels_config.voice_call =
+            Some(zeroclaw_config::scattered_types::VoiceCallConfig {
+                enabled: true,
+                provider: zeroclaw_config::scattered_types::VoiceProvider::Twilio,
+                account_id: "AC_TEST".to_string(),
+                auth_token: "test_token".to_string(),
+                from_number: "+15551234567".to_string(),
+                webhook_port: 8090,
+                require_outbound_approval: true,
+                transcription_logging: true,
+                tts_voice: None,
+                max_call_duration_secs: 3600,
+                webhook_base_url: None,
+            });
+        match build_channel_by_id(&config, "voice-call") {
+            Ok(channel) => assert_eq!(channel.name(), "voice_call"),
+            Err(e) => panic!("should succeed when voice-call is configured: {e}"),
+        }
+    }
+
     // ── is_stop_command tests ─────────────────────────────────────────────
 
     #[test]

--- a/crates/zeroclaw-channels/src/voice_call.rs
+++ b/crates/zeroclaw-channels/src/voice_call.rs
@@ -517,6 +517,7 @@ mod tests {
 
     fn test_config() -> VoiceCallConfig {
         VoiceCallConfig {
+            enabled: true,
             provider: VoiceProvider::Twilio,
             account_id: "AC_TEST_ACCOUNT".into(),
             auth_token: "test_token".into(),

--- a/crates/zeroclaw-config/src/scattered_types.rs
+++ b/crates/zeroclaw-config/src/scattered_types.rs
@@ -345,6 +345,8 @@ fn default_max_attachment_bytes() -> usize {
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
 #[prefix = "channels.email"]
 pub struct EmailConfig {
+    #[serde(default)]
+    pub enabled: bool,
     pub imap_host: String,
     #[serde(default = "default_imap_port")]
     pub imap_port: u16,
@@ -381,6 +383,7 @@ impl ChannelConfig for EmailConfig {
 impl Default for EmailConfig {
     fn default() -> Self {
         Self {
+            enabled: false,
             imap_host: String::new(),
             imap_port: default_imap_port(),
             imap_folder: default_imap_folder(),
@@ -508,6 +511,8 @@ fn default_max_call_duration() -> u64 {
 #[prefix = "channels.voice-call"]
 pub struct VoiceCallConfig {
     #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
     pub provider: VoiceProvider,
     pub account_id: String,
     pub auth_token: String,
@@ -529,6 +534,7 @@ pub struct VoiceCallConfig {
 impl Default for VoiceCallConfig {
     fn default() -> Self {
         Self {
+            enabled: false,
             provider: VoiceProvider::default(),
             account_id: String::new(),
             auth_token: String::new(),

--- a/crates/zeroclaw-gateway/src/api.rs
+++ b/crates/zeroclaw-gateway/src/api.rs
@@ -1706,6 +1706,7 @@ mod tests {
             proxy_url: None,
         });
         cfg.channels_config.email = Some(zeroclaw_config::scattered_types::EmailConfig {
+            enabled: true,
             imap_host: "imap.example.com".to_string(),
             imap_port: 993,
             imap_folder: "INBOX".to_string(),
@@ -1847,6 +1848,7 @@ mod tests {
             proxy_url: None,
         });
         current.channels_config.email = Some(zeroclaw_config::scattered_types::EmailConfig {
+            enabled: true,
             imap_host: "imap.example.com".to_string(),
             imap_port: 993,
             imap_folder: "INBOX".to_string(),


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `EmailConfig` and `VoiceCallConfig` are the only two channel configs missing `enabled: bool`, causing `backfill_enabled()` warnings on every `zeroclaw config list`. Additionally, Email had no `enabled` guard in `collect_configured_channels`, and `VoiceCallChannel` was imported but never wired into the orchestrator at all.
- Why it matters: Users see spurious warnings; Email can't be disabled without removing the config section; VoiceCall has no runtime activation path
- What changed: Added `enabled` field to both structs, added `enabled` guard for Email, wired VoiceCall into `collect_configured_channels` and `build_channel_by_id` behind `channel-voice-call` feature gate, added orchestrator routing tests for voice-call
- What did **not** change: No behavioral changes to other channels; VoiceCall implementation unchanged; `channels_except_webhook()` display listing unchanged (uses `.is_some()` for all channels, consistent with existing pattern)

### Reviewer notes

**`..Default::default()` in email_channel.rs tests:** 10 tests use `EmailConfig { allowed_senders: ..., ..Default::default() }` which gives `enabled: false`. This is correct — those tests exercise `EmailChannel::new()` behavior (sender allowlisting, serialization, debug output) and never go through `collect_configured_channels`. Only tests that construct configs for orchestrator collection need `enabled: true`.

**`VoiceCallChannel` re-export visibility change:** The orchestrator re-export at `mod.rs:53` was previously unconditional (`pub use crate::voice_call::VoiceCallChannel`). It's now behind `#[cfg(feature = "channel-voice-call")]`. This is a correction — `voice_call` in `lib.rs` is already feature-gated, so the unconditional re-export could only resolve when the feature was active anyway. No downstream breakage possible.

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `channel`, `config`
- Module labels: `channel: email`, `channel: voice-call`
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `bug`
- Primary scope: `channel`

## Linked Issue

- Closes #5655
- Related #5637

## Validation Evidence (required)

```bash
cargo fmt --all -- --check                                                          # clean
cargo clippy --all-targets -- -D warnings                                           # 0 errors
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings  # 0 errors
cargo clippy --bin zeroclaw --no-default-features -- -D warnings                    # 0 errors
cargo test --workspace --features ci-all                                            # 6,900 passed, 0 failed
```

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Neutral wording confirmation: N/A

## Compatibility / Migration

- Backward compatible? Yes — `enabled` defaults to `false` via `#[serde(default)]`. `backfill_enabled()` sets it to `true` for existing configs that lack an explicit `enabled` key, so existing channel behavior is preserved.
- Config/env changes? Yes — new optional `enabled` field in `[channels_config.email]` and `[channels_config.voice_call]`
- Migration needed? No — `backfill_enabled()` handles existing configs automatically

## Human Verification (required)

- Verified scenarios: `zeroclaw config list` produces no `backfill_enabled` warnings; Email with `enabled = false` not collected; VoiceCall wiring compiles behind feature gate; `build_channel_by_id` routes `"voice-call"` correctly
- Edge cases checked: Existing configs without explicit `enabled` key — `backfill_enabled()` sets to `true` so channels remain active; `..Default::default()` tests correctly get `enabled: false` without breaking
- What was not verified: Live Email/VoiceCall channel runtime behavior with the new guard

## Side Effects / Blast Radius (required)

- Affected subsystems: `zeroclaw-config` (schema), `zeroclaw-channels` (orchestrator, email, voice_call)
- Potential unintended effects: Existing Email configs that relied on section-existence-implies-active will continue working via `backfill_enabled()`. New configs must set `enabled = true` explicitly.
- Guardrails: `#[serde(default)]` ensures backward compatibility; `backfill_enabled()` tested in schema.rs; new `build_channel_by_id` tests for voice-call routing

## Rollback Plan (required)

- Fast rollback: Revert this PR
- Feature flags: `channel-voice-call` gates VoiceCall wiring
- Observable failure: Email/VoiceCall channels not starting — check `enabled` field in config

## Risks and Mitigations

- Risk: Existing Email users could lose channel if `backfill_enabled()` doesn't fire (e.g., config loaded without raw TOML pass)
  - Mitigation: `backfill_enabled()` runs on every config load from file; only programmatic `Config::default()` would have `enabled: false`, which is correct for new configs