### PR TITLE
fix(cron): disable auto_save for cron agent jobs to prevent recursive memory bloat

### DIFF
--- a/crates/zeroclaw-memory/src/lib.rs
+++ b/crates/zeroclaw-memory/src/lib.rs
@@ -111,6 +111,7 @@ pub fn should_skip_autosave_content(content: &str) -> bool {
     lowered.starts_with("[cron:")
         || lowered.starts_with("[heartbeat task")
         || lowered.starts_with("[distilled_")
+        || lowered.starts_with("[memory context]")
         || lowered.contains("distilled_index_sig:")
 }
 
@@ -441,6 +442,9 @@ mod tests {
         ));
         assert!(should_skip_autosave_content(
             "[Heartbeat Task | high] Execute scheduled patrol"
+        ));
+        assert!(should_skip_autosave_content(
+            "[Memory context]\n- user_msg_abc: some recalled memory\n[/Memory context]\n\n[cron:uuid job] prompt"
         ));
         assert!(!should_skip_autosave_content(
             "User prefers concise answers."

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -306,10 +306,13 @@ async fn run_agent_job(
     let prefixed_prompt = format!("{memory_context}[cron:{} {name}] {prompt}", job.id);
     let model_override = job.model.clone();
 
+    let mut cron_config = config.clone();
+    cron_config.memory.auto_save = false;
+
     let run_result = match job.session_target {
         SessionTarget::Main | SessionTarget::Isolated => {
             Box::pin(crate::agent::run(
-                config.clone(),
+                cron_config,
                 Some(prefixed_prompt),
                 None,
                 model_override,


### PR DESCRIPTION
## Summary

Cron agent jobs inherit the global `auto_save = true` memory config. When the cron scheduler prepends `[Memory context]` to the prompt (from recalled memories), the agent loop's auto-save persists the **entire enriched prompt** — including the `[Memory context]` wrapper — back into `brain.db` as a `Conversation` memory.

On the next cron run, the agent loop's `build_context()` recalls that saved entry (it has **no** `Conversation` category filter, unlike the cron scheduler's own recall at L286), wraps it in **another** `[Memory context]`, and auto-saves an even larger entry. This creates exponential growth.

### Root cause

The existing `should_skip_autosave_content()` guard catches messages starting with `[cron:`, but the cron scheduler prepends memory context **before** the cron prefix:

```rust
// scheduler.rs L306
let prefixed_prompt = format!("{memory_context}[cron:{} {name}] {prompt}", job.id);
//                             ^^^^^^^^^^^^^^^ starts with [Memory context], not [cron:
```

So the skip check fails and auto-save proceeds.

### Evidence from production

`brain.db` after ~2 weeks of daily cron jobs:

| Entry | Size |
|-------|------|
| `user_msg_558a38ed…` | **2,061,705 bytes** |
| `user_msg_76f44c38…` | **1,048,326 bytes** |
| `user_msg_3257a4b4…` | **533,103 bytes** |
| `user_msg_cf57c25f…` | **271,209 bytes** |
| … (15 entries total) | **4.4 MB total** |

Each entry is roughly 2x the previous — classic exponential doubling from the recursive save-recall-save cycle.

This caused the agent loop to log on every cron run:
```
Preemptive context trim: estimated tokens exceed budget estimated=1028403 budget=32000
```

After aggressive trimming, the actual cron prompt was destroyed and the provider call failed:
```
Claude Code exited with non-zero status 1
```

### Fix

1. **`scheduler.rs`**: Set `auto_save = false` on the cloned config before calling `agent::run()` for cron jobs. Cron prompts are synthetic — they should never be persisted as user conversation memories.

2. **`lib.rs` (defense-in-depth)**: Add `[Memory context]` to `should_skip_autosave_content()` so that even if another code path passes an enriched prompt to auto-save, the synthetic wrapper is caught.

### Test plan

- [x] Existing `autosave_content_filter_drops_cron_and_distilled_noise` test updated with `[Memory context]` case
- [x] All 141 cron tests pass
- [x] Full workspace test suite passes (6,353 tests, 0 failures)
- [x] `cargo clippy --workspace --features ci-all -- -D warnings` clean
- [x] Verified fix in production: purged bloated entries, restarted daemon, triggered cron catch-up — job completed successfully and delivered to Telegram with no context trim warnings