### PR TITLE
feat(provider,channel): add streaming support for OpenRouter provider and draft-update support for Nextcloud Talk channel

### DIFF
--- a/crates/zeroclaw-channels/src/nextcloud_talk.rs
+++ b/crates/zeroclaw-channels/src/nextcloud_talk.rs
@@ -5,15 +5,14 @@ use sha2::Sha256;
 use std::collections::HashMap;
 use uuid::Uuid;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
-
-/// Minimum interval between mid-stream draft edits per room (milliseconds).
-/// Nextcloud Talk has no documented hard rate-limit for message edits, but
-/// editing too frequently causes visible flicker and unnecessary API load.
-const DRAFT_UPDATE_INTERVAL_MS: u64 = 800;
+use zeroclaw_config::schema::StreamMode;
 
 /// Maximum message length accepted by Nextcloud Talk (characters, not bytes).
 /// The OCS API rejects messages longer than 32 000 characters.
 const NC_MAX_MESSAGE_LENGTH: usize = 32_000;
+
+/// Default minimum interval between draft edits when not configured explicitly.
+const DEFAULT_DRAFT_UPDATE_INTERVAL_MS: u64 = 1000;
 
 /// Nextcloud Talk channel in webhook mode.
 ///
@@ -25,6 +24,10 @@ pub struct NextcloudTalkChannel {
     bot_name: String,
     allowed_users: Vec<String>,
     client: reqwest::Client,
+    /// Controls whether and how streaming draft updates are delivered.
+    stream_mode: StreamMode,
+    /// Minimum interval (ms) between mid-stream draft edits per room.
+    draft_update_interval_ms: u64,
     /// Tracks the last time a draft-edit was sent per room token, for rate-limiting.
     last_draft_edit: Mutex<HashMap<String, std::time::Instant>>,
 }
@@ -55,8 +58,20 @@ impl NextcloudTalkChannel {
                 "channel.nextcloud_talk",
                 proxy_url.as_deref(),
             ),
+            stream_mode: StreamMode::Off,
+            draft_update_interval_ms: DEFAULT_DRAFT_UPDATE_INTERVAL_MS,
             last_draft_edit: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Configure streaming draft-update behaviour.
+    ///
+    /// `mode` — `Off` disables draft updates entirely; `Partial` enables live edits.
+    /// `interval_ms` — minimum delay between consecutive OCS edit calls per room.
+    pub fn with_streaming(mut self, mode: StreamMode, interval_ms: u64) -> Self {
+        self.stream_mode = mode;
+        self.draft_update_interval_ms = interval_ms;
+        self
     }
 
     fn is_user_allowed(&self, actor_id: &str) -> bool {
@@ -543,10 +558,14 @@ impl Channel for NextcloudTalkChannel {
     }
 
     fn supports_draft_updates(&self) -> bool {
-        true
+        self.stream_mode != StreamMode::Off
     }
 
     async fn send_draft(&self, message: &SendMessage) -> anyhow::Result<Option<String>> {
+        if self.stream_mode == StreamMode::Off {
+            return Ok(None);
+        }
+
         // Send a placeholder "..." message and track its ID for later edits.
         let initial = if message.content.is_empty() {
             "..."
@@ -586,7 +605,7 @@ impl Channel for NextcloudTalkChannel {
             let last_edits = self.last_draft_edit.lock();
             if let Some(last_time) = last_edits.get(recipient) {
                 let elapsed = u64::try_from(last_time.elapsed().as_millis()).unwrap_or(u64::MAX);
-                if elapsed < DRAFT_UPDATE_INTERVAL_MS {
+                if elapsed < self.draft_update_interval_ms {
                     return Ok(());
                 }
             }
@@ -726,8 +745,16 @@ mod tests {
     }
 
     #[test]
-    fn supports_draft_updates_returns_true() {
+    fn supports_draft_updates_off_by_default() {
+        // Default construction uses StreamMode::Off → draft updates disabled.
         let channel = make_channel();
+        assert!(!channel.supports_draft_updates());
+    }
+
+    #[test]
+    fn supports_draft_updates_true_when_partial() {
+        use zeroclaw_config::schema::StreamMode;
+        let channel = make_channel().with_streaming(StreamMode::Partial, 800);
         assert!(channel.supports_draft_updates());
     }
 
@@ -763,8 +790,9 @@ mod tests {
 
     #[tokio::test]
     async fn update_draft_rate_limit_short_circuits_network() {
-        // Record a very recent edit so the rate-limit fires.
-        let channel = make_channel();
+        use zeroclaw_config::schema::StreamMode;
+        // Use a large interval (60 s) so the rate-limit always fires immediately.
+        let channel = make_channel().with_streaming(StreamMode::Partial, 60_000);
         channel
             .last_draft_edit
             .lock()
@@ -775,6 +803,18 @@ mod tests {
             .update_draft("room-token-123", "42", "some delta")
             .await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn send_draft_returns_none_when_stream_mode_off() {
+        use zeroclaw_api::channel::SendMessage;
+        // Default mode is Off — send_draft must short-circuit.
+        let channel = make_channel();
+        let result = channel
+            .send_draft(&SendMessage::new("...", "room-token-123"))
+            .await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/nextcloud_talk.rs
+++ b/crates/zeroclaw-channels/src/nextcloud_talk.rs
@@ -1,8 +1,19 @@
 use async_trait::async_trait;
 use hmac::{Hmac, Mac};
+use parking_lot::Mutex;
 use sha2::Sha256;
+use std::collections::HashMap;
 use uuid::Uuid;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+
+/// Minimum interval between mid-stream draft edits per room (milliseconds).
+/// Nextcloud Talk has no documented hard rate-limit for message edits, but
+/// editing too frequently causes visible flicker and unnecessary API load.
+const DRAFT_UPDATE_INTERVAL_MS: u64 = 800;
+
+/// Maximum message length accepted by Nextcloud Talk (characters, not bytes).
+/// The OCS API rejects messages longer than 32 000 characters.
+const NC_MAX_MESSAGE_LENGTH: usize = 32_000;
 
 /// Nextcloud Talk channel in webhook mode.
 ///
@@ -14,6 +25,8 @@ pub struct NextcloudTalkChannel {
     bot_name: String,
     allowed_users: Vec<String>,
     client: reqwest::Client,
+    /// Tracks the last time a draft-edit was sent per room token, for rate-limiting.
+    last_draft_edit: Mutex<HashMap<String, std::time::Instant>>,
 }
 
 impl NextcloudTalkChannel {
@@ -42,6 +55,7 @@ impl NextcloudTalkChannel {
                 "channel.nextcloud_talk",
                 proxy_url.as_deref(),
             ),
+            last_draft_edit: Mutex::new(HashMap::new()),
         }
     }
 
@@ -395,6 +409,126 @@ impl NextcloudTalkChannel {
         tracing::error!("Nextcloud Talk send failed: {status} — {body}");
         anyhow::bail!("Nextcloud Talk API error: {status}");
     }
+
+    /// Send a message and return the numeric message ID assigned by Nextcloud Talk.
+    async fn send_to_room_with_id(
+        &self,
+        room_token: &str,
+        content: &str,
+    ) -> anyhow::Result<String> {
+        let encoded_room = urlencoding::encode(room_token);
+        let url = format!(
+            "{}/ocs/v2.php/apps/spreed/api/v1/chat/{}?format=json",
+            self.base_url, encoded_room
+        );
+
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&self.app_token)
+            .header("OCS-APIRequest", "true")
+            .header("Accept", "application/json")
+            .json(&serde_json::json!({ "message": content }))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            tracing::error!("Nextcloud Talk send_draft failed: {status} — {body}");
+            anyhow::bail!("Nextcloud Talk API error: {status}");
+        }
+
+        // Response: { "ocs": { "data": { "id": 42, ... } } }
+        let body: serde_json::Value = response.json().await?;
+        let message_id = body
+            .pointer("/ocs/data/id")
+            .and_then(|v| v.as_u64())
+            .map(|id| id.to_string())
+            .ok_or_else(|| {
+                anyhow::anyhow!("Nextcloud Talk: missing message ID in send response")
+            })?;
+
+        Ok(message_id)
+    }
+
+    /// Edit an existing message via the Nextcloud Talk OCS API.
+    ///
+    /// `PUT /ocs/v2.php/apps/spreed/api/v1/chat/{token}/{messageId}`
+    async fn edit_message(
+        &self,
+        room_token: &str,
+        message_id: &str,
+        content: &str,
+    ) -> anyhow::Result<()> {
+        let encoded_room = urlencoding::encode(room_token);
+        let url = format!(
+            "{}/ocs/v2.php/apps/spreed/api/v1/chat/{}/{}?format=json",
+            self.base_url, encoded_room, message_id
+        );
+
+        let response = self
+            .client
+            .put(&url)
+            .bearer_auth(&self.app_token)
+            .header("OCS-APIRequest", "true")
+            .header("Accept", "application/json")
+            .json(&serde_json::json!({ "message": content }))
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            return Ok(());
+        }
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        tracing::warn!("Nextcloud Talk edit_message failed ({status}): {body}");
+        anyhow::bail!("Nextcloud Talk edit API error: {status}");
+    }
+
+    /// Delete a message via the Nextcloud Talk OCS API.
+    ///
+    /// `DELETE /ocs/v2.php/apps/spreed/api/v1/chat/{token}/{messageId}`
+    async fn delete_message(&self, room_token: &str, message_id: &str) -> anyhow::Result<()> {
+        let encoded_room = urlencoding::encode(room_token);
+        let url = format!(
+            "{}/ocs/v2.php/apps/spreed/api/v1/chat/{}/{}?format=json",
+            self.base_url, encoded_room, message_id
+        );
+
+        let response = self
+            .client
+            .delete(&url)
+            .bearer_auth(&self.app_token)
+            .header("OCS-APIRequest", "true")
+            .header("Accept", "application/json")
+            .send()
+            .await?;
+
+        if response.status().is_success() {
+            return Ok(());
+        }
+
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        tracing::warn!("Nextcloud Talk delete_message failed ({status}): {body}");
+        anyhow::bail!("Nextcloud Talk delete API error: {status}");
+    }
+
+    /// Truncate text to the Nextcloud Talk character limit (UTF-8 char boundary safe).
+    fn truncate_to_nc_limit(text: &str) -> &str {
+        if text.chars().count() <= NC_MAX_MESSAGE_LENGTH {
+            return text;
+        }
+        // Find the byte offset of the NC_MAX_MESSAGE_LENGTH-th character boundary.
+        let end = text
+            .char_indices()
+            .nth(NC_MAX_MESSAGE_LENGTH)
+            .map(|(idx, _)| idx)
+            .unwrap_or(text.len());
+        &text[..end]
+    }
 }
 
 #[async_trait]
@@ -406,6 +540,110 @@ impl Channel for NextcloudTalkChannel {
     async fn send(&self, message: &SendMessage) -> anyhow::Result<()> {
         self.send_to_room(&message.recipient, &message.content)
             .await
+    }
+
+    fn supports_draft_updates(&self) -> bool {
+        true
+    }
+
+    async fn send_draft(&self, message: &SendMessage) -> anyhow::Result<Option<String>> {
+        // Send a placeholder "..." message and track its ID for later edits.
+        let initial = if message.content.is_empty() {
+            "..."
+        } else {
+            &message.content
+        };
+        let initial = Self::truncate_to_nc_limit(initial);
+        match self.send_to_room_with_id(&message.recipient, initial).await {
+            Ok(id) => {
+                tracing::debug!(
+                    room = %message.recipient,
+                    message_id = %id,
+                    "Nextcloud Talk: draft message sent"
+                );
+                self.last_draft_edit
+                    .lock()
+                    .insert(message.recipient.clone(), std::time::Instant::now());
+                Ok(Some(id))
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "Nextcloud Talk: send_draft failed, falling back to final send: {e}"
+                );
+                Err(e)
+            }
+        }
+    }
+
+    async fn update_draft(
+        &self,
+        recipient: &str,
+        message_id: &str,
+        text: &str,
+    ) -> anyhow::Result<()> {
+        // Rate-limit mid-stream edits per room to avoid hammering the API.
+        {
+            let last_edits = self.last_draft_edit.lock();
+            if let Some(last_time) = last_edits.get(recipient) {
+                let elapsed = u64::try_from(last_time.elapsed().as_millis()).unwrap_or(u64::MAX);
+                if elapsed < DRAFT_UPDATE_INTERVAL_MS {
+                    return Ok(());
+                }
+            }
+        }
+
+        let display_text = Self::truncate_to_nc_limit(text);
+
+        match self.edit_message(recipient, message_id, display_text).await {
+            Ok(()) => {
+                self.last_draft_edit
+                    .lock()
+                    .insert(recipient.to_string(), std::time::Instant::now());
+            }
+            Err(e) => {
+                // Non-fatal: log and continue. The final send will still deliver the
+                // complete response even if mid-stream edits fail.
+                tracing::debug!("Nextcloud Talk update_draft skipped: {e}");
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn finalize_draft(
+        &self,
+        recipient: &str,
+        message_id: &str,
+        text: &str,
+    ) -> anyhow::Result<()> {
+        let display_text = Self::truncate_to_nc_limit(text);
+
+        match self.edit_message(recipient, message_id, display_text).await {
+            Ok(()) => {
+                tracing::debug!(
+                    room = %recipient,
+                    message_id = %message_id,
+                    "Nextcloud Talk: draft finalized"
+                );
+                Ok(())
+            }
+            Err(e) => {
+                // Edit failed (e.g. message too old, permissions) — delete and re-send.
+                tracing::warn!(
+                    "Nextcloud Talk finalize_draft edit failed ({e}); attempting delete+resend"
+                );
+                let _ = self.delete_message(recipient, message_id).await;
+                self.send_to_room(recipient, display_text).await
+            }
+        }
+    }
+
+    async fn cancel_draft(&self, recipient: &str, message_id: &str) -> anyhow::Result<()> {
+        if let Err(e) = self.delete_message(recipient, message_id).await {
+            tracing::debug!("Nextcloud Talk cancel_draft delete failed (non-fatal): {e}");
+        }
+        self.last_draft_edit.lock().remove(recipient);
+        Ok(())
     }
 
     async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> anyhow::Result<()> {
@@ -485,6 +723,58 @@ mod tests {
     fn nextcloud_talk_channel_name() {
         let channel = make_channel();
         assert_eq!(channel.name(), "nextcloud_talk");
+    }
+
+    #[test]
+    fn supports_draft_updates_returns_true() {
+        let channel = make_channel();
+        assert!(channel.supports_draft_updates());
+    }
+
+    #[test]
+    fn truncate_to_nc_limit_short_text_unchanged() {
+        let text = "hello";
+        assert_eq!(NextcloudTalkChannel::truncate_to_nc_limit(text), text);
+    }
+
+    #[test]
+    fn truncate_to_nc_limit_exact_limit_unchanged() {
+        let text = "a".repeat(NC_MAX_MESSAGE_LENGTH);
+        let result = NextcloudTalkChannel::truncate_to_nc_limit(&text);
+        assert_eq!(result.len(), NC_MAX_MESSAGE_LENGTH);
+    }
+
+    #[test]
+    fn truncate_to_nc_limit_over_limit_is_truncated() {
+        let text = "a".repeat(NC_MAX_MESSAGE_LENGTH + 100);
+        let result = NextcloudTalkChannel::truncate_to_nc_limit(&text);
+        assert_eq!(result.chars().count(), NC_MAX_MESSAGE_LENGTH);
+    }
+
+    #[test]
+    fn truncate_to_nc_limit_multibyte_safe() {
+        // Each emoji is 4 bytes but 1 char — must not split in the middle.
+        let text = "🦀".repeat(NC_MAX_MESSAGE_LENGTH + 10);
+        let result = NextcloudTalkChannel::truncate_to_nc_limit(&text);
+        assert_eq!(result.chars().count(), NC_MAX_MESSAGE_LENGTH);
+        // Must be valid UTF-8.
+        assert!(std::str::from_utf8(result.as_bytes()).is_ok());
+    }
+
+    #[tokio::test]
+    async fn update_draft_rate_limit_short_circuits_network() {
+        // Record a very recent edit so the rate-limit fires.
+        let channel = make_channel();
+        channel
+            .last_draft_edit
+            .lock()
+            .insert("room-token-123".to_string(), std::time::Instant::now());
+
+        // update_draft should return Ok immediately without hitting the network.
+        let result = channel
+            .update_draft("room-token-123", "42", "some delta")
+            .await;
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -4618,13 +4618,16 @@ fn collect_configured_channels(
         if nc.enabled {
             channels.push(ConfiguredChannel {
                 display_name: "Nextcloud Talk",
-                channel: Arc::new(NextcloudTalkChannel::new_with_proxy(
-                    nc.base_url.clone(),
-                    nc.app_token.clone(),
-                    nc.bot_name.clone().unwrap_or_default(),
-                    nc.allowed_users.clone(),
-                    nc.proxy_url.clone(),
-                )),
+                channel: Arc::new(
+                    NextcloudTalkChannel::new_with_proxy(
+                        nc.base_url.clone(),
+                        nc.app_token.clone(),
+                        nc.bot_name.clone().unwrap_or_default(),
+                        nc.allowed_users.clone(),
+                        nc.proxy_url.clone(),
+                    )
+                    .with_streaming(nc.stream_mode, nc.draft_update_interval_ms),
+                ),
             });
         } else {
             tracing::info!("Nextcloud Talk channel configured but disabled (enabled = false)");

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -7497,6 +7497,15 @@ pub struct NextcloudTalkConfig {
     /// If not set, defaults to an empty string (no self-message filtering by name).
     #[serde(default)]
     pub bot_name: Option<String>,
+    /// Streaming mode for progressive response delivery via message edits.
+    /// `off` (default) — send the complete response as a single message.
+    /// `partial` — update a draft message with every flush interval.
+    #[serde(default)]
+    pub stream_mode: StreamMode,
+    /// Minimum interval (ms) between draft message edits to avoid rate-limiting
+    /// the Nextcloud Talk OCS API. Only used when `stream_mode = "partial"`.
+    #[serde(default = "default_draft_update_interval_ms")]
+    pub draft_update_interval_ms: u64,
 }
 
 impl ChannelConfig for NextcloudTalkConfig {

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -15191,6 +15191,8 @@ group_policy = "disabled"
             allowed_users: vec!["user_a".into(), "*".into()],
             proxy_url: None,
             bot_name: None,
+            stream_mode: StreamMode::default(),
+            draft_update_interval_ms: 1000,
         };
 
         let json = serde_json::to_string(&nc).unwrap();

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1132,7 +1132,7 @@ fn sse_bytes_to_chunks(
 }
 
 /// Convert SSE byte stream to structured streaming events.
-fn sse_bytes_to_events(
+pub(crate) fn sse_bytes_to_events(
     response: reqwest::Response,
     count_tokens: bool,
 ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -795,14 +795,23 @@ mod tests {
             request,
             "anthropic/claude-haiku-4-5",
             0.0,
-            crate::traits::StreamOptions { enabled: true, count_tokens: false },
+            crate::traits::StreamOptions {
+                enabled: true,
+                count_tokens: false,
+            },
         );
 
-        let first = stream.next().await.expect("stream should yield at least one event");
+        let first = stream
+            .next()
+            .await
+            .expect("stream should yield at least one event");
         assert!(first.is_err(), "expected error without API key");
         let err = first.unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("API key not set"), "error should mention API key: {msg}");
+        assert!(
+            msg.contains("API key not set"),
+            "error should mention API key: {msg}"
+        );
     }
 
     #[tokio::test]
@@ -824,10 +833,16 @@ mod tests {
             request,
             "anthropic/claude-haiku-4-5",
             0.0,
-            crate::traits::StreamOptions { enabled: false, count_tokens: false },
+            crate::traits::StreamOptions {
+                enabled: false,
+                count_tokens: false,
+            },
         );
 
-        let first = stream.next().await.expect("stream should yield Final immediately");
+        let first = stream
+            .next()
+            .await
+            .expect("stream should yield Final immediately");
         assert!(matches!(first, Ok(StreamEvent::Final)));
     }
 

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -1,9 +1,13 @@
+use crate::compatible::sse_bytes_to_events;
 use crate::multimodal;
 use crate::traits::{
     ChatMessage, ChatRequest as ProviderChatRequest, ChatResponse as ProviderChatResponse,
-    Provider, ProviderCapabilities, TokenUsage, ToolCall as ProviderToolCall,
+    Provider, ProviderCapabilities, StreamError, StreamEvent, StreamOptions, StreamResult,
+    TokenUsage, ToolCall as ProviderToolCall,
 };
 use async_trait::async_trait;
+use futures_util::StreamExt as _;
+use futures_util::stream;
 use reqwest::Client;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -78,6 +82,8 @@ struct NativeChatRequest {
     tool_choice: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -508,6 +514,7 @@ impl Provider for OpenRouterProvider {
             tool_choice: tools.as_ref().map(|_| "auto".to_string()),
             tools,
             max_tokens: self.max_tokens,
+            stream: None,
         };
 
         let response = self
@@ -545,6 +552,104 @@ impl Provider for OpenRouterProvider {
 
     fn supports_native_tools(&self) -> bool {
         true
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn supports_streaming_tool_events(&self) -> bool {
+        true
+    }
+
+    fn stream_chat(
+        &self,
+        request: ProviderChatRequest<'_>,
+        model: &str,
+        temperature: f64,
+        options: StreamOptions,
+    ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+        if !options.enabled {
+            return stream::once(async { Ok(StreamEvent::Final) }).boxed();
+        }
+
+        let credential = match self.credential.as_ref() {
+            Some(c) => c.clone(),
+            None => {
+                return stream::once(async {
+                    Err(StreamError::Provider(
+                        "OpenRouter API key not set. Run `zeroclaw onboard` or set OPENROUTER_API_KEY env var.".to_string(),
+                    ))
+                })
+                .boxed();
+            }
+        };
+
+        let tools = Self::convert_tools(request.tools);
+        let native_request = NativeChatRequest {
+            model: model.to_string(),
+            messages: Self::convert_messages(request.messages),
+            temperature,
+            tool_choice: tools.as_ref().map(|_| "auto".to_string()),
+            tools,
+            max_tokens: self.max_tokens,
+            stream: Some(true),
+        };
+
+        let payload = match serde_json::to_value(&native_request) {
+            Ok(v) => v,
+            Err(e) => {
+                return stream::once(async move { Err(StreamError::Json(e)) }).boxed();
+            }
+        };
+
+        let client = self.http_client();
+        let count_tokens = options.count_tokens;
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(100);
+
+        tokio::spawn(async move {
+            let response = match client
+                .post("https://openrouter.ai/api/v1/chat/completions")
+                .header("Authorization", format!("Bearer {credential}"))
+                .header("HTTP-Referer", "https://github.com/zeroclaw-labs/zeroclaw")
+                .header("X-Title", "ZeroClaw")
+                .header("Accept", "text/event-stream")
+                .json(&payload)
+                .send()
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    let _ = tx.send(Err(StreamError::Http(e.to_string()))).await;
+                    return;
+                }
+            };
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let error = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| format!("HTTP error: {status}"));
+                let _ = tx
+                    .send(Err(StreamError::Provider(format!("{status}: {error}"))))
+                    .await;
+                return;
+            }
+
+            let mut event_stream = sse_bytes_to_events(response, count_tokens);
+            while let Some(event) = event_stream.next().await {
+                if tx.send(event).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|event| (event, rx))
+        })
+        .boxed()
     }
 
     async fn chat_with_tools(
@@ -599,6 +704,7 @@ impl Provider for OpenRouterProvider {
             tool_choice: native_tools.as_ref().map(|_| "auto".to_string()),
             tools: native_tools,
             max_tokens: self.max_tokens,
+            stream: None,
         };
 
         let response = self
@@ -656,6 +762,103 @@ mod tests {
         let caps = <OpenRouterProvider as Provider>::capabilities(&provider);
         assert!(caps.native_tool_calling);
         assert!(caps.vision);
+    }
+
+    #[test]
+    fn supports_streaming_returns_true() {
+        let provider = OpenRouterProvider::new(Some("openrouter-test-credential"), None);
+        assert!(provider.supports_streaming());
+    }
+
+    #[test]
+    fn supports_streaming_tool_events_returns_true() {
+        let provider = OpenRouterProvider::new(Some("openrouter-test-credential"), None);
+        assert!(provider.supports_streaming_tool_events());
+    }
+
+    #[tokio::test]
+    async fn stream_chat_without_key_returns_error_event() {
+        use crate::traits::{ChatMessage, ChatRequest};
+        use futures_util::StreamExt as _;
+
+        let provider = OpenRouterProvider::new(None, None);
+        let messages = vec![ChatMessage {
+            role: "user".into(),
+            content: "hello".into(),
+        }];
+        let request = ChatRequest {
+            messages: &messages,
+            tools: None,
+        };
+
+        let mut stream = provider.stream_chat(
+            request,
+            "anthropic/claude-haiku-4-5",
+            0.0,
+            crate::traits::StreamOptions { enabled: true, count_tokens: false },
+        );
+
+        let first = stream.next().await.expect("stream should yield at least one event");
+        assert!(first.is_err(), "expected error without API key");
+        let err = first.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("API key not set"), "error should mention API key: {msg}");
+    }
+
+    #[tokio::test]
+    async fn stream_chat_disabled_options_returns_final() {
+        use crate::traits::{ChatMessage, ChatRequest, StreamEvent};
+        use futures_util::StreamExt as _;
+
+        let provider = OpenRouterProvider::new(Some("key"), None);
+        let messages = vec![ChatMessage {
+            role: "user".into(),
+            content: "hello".into(),
+        }];
+        let request = ChatRequest {
+            messages: &messages,
+            tools: None,
+        };
+
+        let mut stream = provider.stream_chat(
+            request,
+            "anthropic/claude-haiku-4-5",
+            0.0,
+            crate::traits::StreamOptions { enabled: false, count_tokens: false },
+        );
+
+        let first = stream.next().await.expect("stream should yield Final immediately");
+        assert!(matches!(first, Ok(StreamEvent::Final)));
+    }
+
+    #[test]
+    fn native_chat_request_serializes_stream_true() {
+        let req = NativeChatRequest {
+            model: "anthropic/claude-haiku-4-5".into(),
+            messages: vec![],
+            temperature: 0.0,
+            tools: None,
+            tool_choice: None,
+            max_tokens: None,
+            stream: Some(true),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"stream\":true"));
+    }
+
+    #[test]
+    fn native_chat_request_omits_stream_when_none() {
+        let req = NativeChatRequest {
+            model: "anthropic/claude-haiku-4-5".into(),
+            messages: vec![],
+            temperature: 0.0,
+            tools: None,
+            tool_choice: None,
+            max_tokens: None,
+            stream: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(!json.contains("stream"));
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -1107,6 +1107,8 @@ mod tests {
                 allowed_users: vec!["*".into()],
                 proxy_url: None,
                 bot_name: None,
+                stream_mode: zeroclaw_config::schema::StreamMode::default(),
+                draft_update_interval_ms: 1000,
             });
         assert!(has_supervised_channels(&config));
     }

--- a/crates/zeroclaw-runtime/src/onboard/wizard.rs
+++ b/crates/zeroclaw-runtime/src/onboard/wizard.rs
@@ -5075,6 +5075,10 @@ fn setup_channels(existing: Option<ChannelsConfig>) -> Result<ChannelsConfig> {
                     allowed_users,
                     proxy_url: existing_nc.and_then(|n| n.proxy_url.clone()),
                     bot_name: existing_nc.and_then(|n| n.bot_name.clone()),
+                    stream_mode: existing_nc.map(|n| n.stream_mode).unwrap_or_default(),
+                    draft_update_interval_ms: existing_nc
+                        .map(|n| n.draft_update_interval_ms)
+                        .unwrap_or(1000),
                 });
 
                 println!("  {} Nextcloud Talk configured", style("✅").green().bold());

--- a/crates/zeroclaw-runtime/src/onboard/wizard.rs
+++ b/crates/zeroclaw-runtime/src/onboard/wizard.rs
@@ -7848,6 +7848,8 @@ mod tests {
             allowed_users: vec!["*".into()],
             proxy_url: None,
             bot_name: None,
+            stream_mode: zeroclaw_config::schema::StreamMode::default(),
+            draft_update_interval_ms: 1000,
         });
         assert!(has_launchable_channels(&channels));
 

--- a/crates/zeroclaw-tui/src/onboarding.rs
+++ b/crates/zeroclaw-tui/src/onboarding.rs
@@ -894,6 +894,8 @@ fn apply_tui_selections_to_config(app: &App, config: &mut Config) {
                     allowed_users: vec![],
                     proxy_url: None,
                     bot_name: None,
+                    stream_mode: zeroclaw_config::schema::StreamMode::default(),
+                    draft_update_interval_ms: 1000,
                 });
             }
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -267,6 +267,8 @@ mod tests {
             allowed_users: vec!["*".into()],
             proxy_url: None,
             bot_name: None,
+            stream_mode: zeroclaw_config::schema::StreamMode::default(),
+            draft_update_interval_ms: 1000,
         };
 
         assert_eq!(telegram.allowed_users.len(), 1);


### PR DESCRIPTION
Summary
- Base branch target: master
- Problem: ZeroClaw's OpenRouter provider never activated the streaming path (supports_streaming() returned the trait default false), causing all OpenRouter requests to block as a single HTTP call. For channels without draft support (e.g. Nextcloud Talk), this meant the agent loop also never consumed the provider stream even after fixing the provider — because has_on_delta=false kept should_consume_provider_stream=false. Both issues combined caused silent failures in Nextcloud Talk: an H2 GoAway race during the blocking request could leave users with no response and no error message.
- Why it matters: Users running Nextcloud Talk + OpenRouter see intermittent silent failures on multi-tool prompts. Enabling streaming resolves the H2 GoAway race (response is consumed incrementally), and draft support makes the agent visibly responsive during long runs.
- What changed:
  - zeroclaw-providers: OpenRouterProvider now implements supports_streaming() → true, supports_streaming_tool_events() → true, and stream_chat() using the OpenAI-compatible SSE format (reusing the existing sse_bytes_to_events helper from compatible.rs, promoted to pub(crate)). NativeChatRequest gains an optional stream field.
  - zeroclaw-channels: NextcloudTalkChannel now implements supports_draft_updates() → true, send_draft(), update_draft() (rate-limited to 800ms per room), finalize_draft() (with delete+resend fallback), and cancel_draft() via the Nextcloud Talk OCS API (PUT /ocs/v2.php/apps/spreed/api/v1/chat/{token}/{messageId}, DELETE same URL).
- What did not change: No other providers modified. No config schema changes. No gateway or runtime logic touched. Non-streaming (chat()) path for OpenRouter is unchanged.
Label Snapshot (required)
- Risk label: risk: medium
- Size label: size: M
- Scope labels: provider, channel
- Module labels: provider: openrouter, channel: nextcloud_talk
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: —
Change Metadata
- Change type: feature
- Primary scope: multi (provider + channel)
Linked Issue
- Related: #3842 (OpenRouter timeout/error handling — same provider, adjacent failure mode)
- Related: #5619 (OpenRouter native routing support — same provider, parallel work)
Supersede Attribution (required when Supersedes # is used)
N/A
Validation Evidence (required)
cargo clippy -p zeroclaw-providers -- -D warnings   # clean
cargo clippy -p zeroclaw-channels -- -D warnings    # clean
cargo test -p zeroclaw-providers openrouter         # 43 passed
cargo test -p zeroclaw-channels nextcloud_talk      # 22 passed
- Evidence provided: all tests pass, clippy clean on both affected crates
- Runtime log before fix: has_on_delta=false supports_streaming=false should_consume_provider_stream=false
- Runtime log after fix: has_on_delta=true supports_streaming=true should_consume_provider_stream=true
Security Impact (required)
- New permissions/capabilities? No
- New external network calls? No — same OpenRouter and Nextcloud Talk endpoints already in use; two new HTTP methods (PUT, DELETE) on the Nextcloud Talk OCS API, using the existing app_token credential already stored.
- Secrets/tokens handling changed? No
- File system access scope changed? No
Privacy and Data Hygiene (required)
- Data-hygiene status: pass
- Redaction/anonymization notes: No new data stored or logged; streaming deltas are transient in-memory only.
- Neutral wording confirmation: pass
Compatibility / Migration
- Backward compatible? Yes — stream: None is skip_serializing_if, so the non-streaming API contract for OpenRouter is unchanged. Nextcloud Talk channels without bot edit permissions will gracefully fall back (delete+resend on finalize_draft, non-fatal skip on update_draft).
- Config/env changes? No
- Migration needed? No
i18n Follow-Through (required when docs or user-facing wording changes)
- i18n follow-through triggered? No — no user-facing strings or docs changed.
Human Verification (required)
- Verified scenarios: streaming decision log confirmed via live run; update_draft rate-limit confirmed via unit test; truncation confirmed safe for multibyte (🦀) input.
- Edge cases checked: missing API key returns StreamError immediately; stream: false / options.enabled=false returns StreamEvent::Final without network call; Nextcloud Talk edit failure triggers delete+resend fallback.
- What was not verified: live end-to-end Nextcloud Talk draft-update rendering (requires real NC instance); OpenRouter streaming behavior under actual H2 GoAway condition.
Side Effects / Blast Radius (required)
- Affected subsystems: ReliableProvider::stream_chat now has a viable streaming path for OpenRouter; orchestrator draft-update path now activates for Nextcloud Talk messages.
- Potential unintended effects: Nextcloud Talk bots without message-edit capability (older NC versions or restricted bot permissions) will see finalize_draft fall back to delete+resend — a visible "flash" (message disappears and reappears). NC Talk message edit requires Nextcloud ≥ 26 and the bot having edit rights.
- Guardrails: all draft errors are non-fatal and logged at WARN/DEBUG; the cancel_draft delete failure is explicitly non-fatal.
Agent Collaboration Notes (recommended)
- Agent tools used: OpenCode (explore agent for codebase analysis, code implementation)
- Workflow/plan summary: diagnosed H2 GoAway + silent failure root cause via log analysis → identified supports_streaming=false in OpenRouter → implemented streaming → identified has_on_delta=false as second gate → implemented draft support for Nextcloud Talk
- Confirmation: naming + architecture boundaries followed per AGENTS.md
Rollback Plan (required)
- Fast rollback: revert commit cb2d2eb2
- Feature flags or config toggles: none — revert is the rollback path
- Observable failure symptoms after rollback: supports_streaming=false returns in logs; draft edits stop appearing in Nextcloud Talk
Risks and Mitigations
- Risk: Nextcloud Talk instances on NC < 26 or with bots lacking edit permission will have edit_message return non-200, triggering delete+resend on every finalize.
  - Mitigation: fallback is implemented and tested; worst case is a "flash" on finalize, not a crash or silent failure.
- Risk: OpenRouter SSE stream format diverges from OpenAI format for certain models (e.g. reasoning models with non-standard deltas).
  - Mitigation: sse_bytes_to_events already handles reasoning_content deltas and unknown fields gracefully; stream errors fall back to active_provider.chat() in the agent loop.