### PR TITLE
fix(channels): decrypt all secrets on runtime config reload; guard Telegram against encrypted token

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -865,7 +865,6 @@ async fn config_file_stamp(path: &Path) -> Option<ConfigFileStamp> {
     })
 }
 
-
 async fn load_runtime_defaults_from_config_file(path: &Path) -> Result<ChannelRuntimeDefaults> {
     let contents = tokio::fs::read_to_string(path)
         .await

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -865,22 +865,6 @@ async fn config_file_stamp(path: &Path) -> Option<ConfigFileStamp> {
     })
 }
 
-fn decrypt_optional_secret_for_runtime_reload(
-    store: &zeroclaw_runtime::security::SecretStore,
-    value: &mut Option<String>,
-    field_name: &str,
-) -> Result<()> {
-    if let Some(raw) = value.clone()
-        && zeroclaw_runtime::security::SecretStore::is_encrypted(&raw)
-    {
-        *value = Some(
-            store
-                .decrypt(&raw)
-                .with_context(|| format!("Failed to decrypt {field_name}"))?,
-        );
-    }
-    Ok(())
-}
 
 async fn load_runtime_defaults_from_config_file(path: &Path) -> Result<ChannelRuntimeDefaults> {
     let contents = tokio::fs::read_to_string(path)
@@ -893,29 +877,9 @@ async fn load_runtime_defaults_from_config_file(path: &Path) -> Result<ChannelRu
     if let Some(zeroclaw_dir) = path.parent() {
         let store =
             zeroclaw_runtime::security::SecretStore::new(zeroclaw_dir, parsed.secrets.encrypt);
-        decrypt_optional_secret_for_runtime_reload(&store, &mut parsed.api_key, "config.api_key")?;
-        // Decrypt TTS provider API keys for runtime reload
-        if let Some(ref mut openai) = parsed.tts.openai {
-            decrypt_optional_secret_for_runtime_reload(
-                &store,
-                &mut openai.api_key,
-                "config.tts.openai.api_key",
-            )?;
-        }
-        if let Some(ref mut elevenlabs) = parsed.tts.elevenlabs {
-            decrypt_optional_secret_for_runtime_reload(
-                &store,
-                &mut elevenlabs.api_key,
-                "config.tts.elevenlabs.api_key",
-            )?;
-        }
-        if let Some(ref mut google) = parsed.tts.google {
-            decrypt_optional_secret_for_runtime_reload(
-                &store,
-                &mut google.api_key,
-                "config.tts.google.api_key",
-            )?;
-        }
+        // Decrypt all #[secret]-annotated fields (api keys, tokens, channel credentials, etc.)
+        // via the macro-generated Configurable chain rather than manually listing each field.
+        parsed.decrypt_secrets(&store)?;
     }
 
     parsed.apply_env_overrides();

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -2784,6 +2784,18 @@ impl Channel for TelegramChannel {
             let _ = self.get_bot_username().await;
         }
 
+        // Guard: detect encrypted-but-not-decrypted token early so we fail fast with a
+        // clear message instead of looping forever on 401 errors from the Telegram API.
+        if self.bot_token.starts_with("enc2:") || self.bot_token.starts_with("enc:") {
+            anyhow::bail!(
+                "Telegram bot_token appears to still be encrypted (starts with '{}...'). \
+                 This usually means the secret key file (~/.zeroclaw/.secret_key) is missing \
+                 or the config was not decrypted before starting channels. \
+                 Re-run `zeroclaw onboard` or ensure the secret key file is present.",
+                &self.bot_token[..self.bot_token.find(':').unwrap_or(4) + 1]
+            );
+        }
+
         tracing::info!("Telegram channel listening for messages...");
 
         // Startup probe: claim the getUpdates slot before entering the long-poll loop.

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12378,6 +12378,54 @@ default_temperature = 0.7
     }
 
     #[tokio::test]
+    async fn config_save_encrypts_telegram_bot_token() {
+        let dir = std::env::temp_dir().join(format!(
+            "zeroclaw_test_telegram_encrypt_{}",
+            uuid::Uuid::new_v4()
+        ));
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        let mut config = Config {
+            workspace_dir: dir.join("workspace"),
+            config_path: dir.join("config.toml"),
+            ..Default::default()
+        };
+        config.secrets.encrypt = true;
+        config.channels_config.telegram = Some(TelegramConfig {
+            enabled: true,
+            bot_token: "123456789:ABCdefGHIjklMNOpqrSTUvwxYZ".into(),
+            allowed_users: vec!["testuser".into()],
+            ..Default::default()
+        });
+
+        config.save().await.unwrap();
+
+        // Verify the saved file has the token encrypted
+        let contents = tokio::fs::read_to_string(dir.join("config.toml")).await.unwrap();
+        let on_disk: Config = toml::from_str(&contents).unwrap();
+        let stored_token = &on_disk.channels_config.telegram.as_ref().unwrap().bot_token;
+        assert!(
+            crate::secrets::SecretStore::is_encrypted(stored_token),
+            "bot_token should be encrypted on disk, got: {stored_token}"
+        );
+
+        // Verify decryption restores the plaintext token
+        let store = crate::secrets::SecretStore::new(&dir, true);
+        let decrypted = store.decrypt(stored_token).unwrap();
+        assert_eq!(decrypted, "123456789:ABCdefGHIjklMNOpqrSTUvwxYZ");
+
+        // Verify Config::load_or_init equivalent: decrypt_secrets restores the token
+        let mut reloaded: Config = toml::from_str(&contents).unwrap();
+        reloaded.decrypt_secrets(&store).unwrap();
+        assert_eq!(
+            reloaded.channels_config.telegram.as_ref().unwrap().bot_token,
+            "123456789:ABCdefGHIjklMNOpqrSTUvwxYZ"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&dir).await;
+    }
+
+    #[tokio::test]
     async fn config_save_atomic_cleanup() {
         let dir =
             std::env::temp_dir().join(format!("zeroclaw_test_config_{}", uuid::Uuid::new_v4()));

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -12401,7 +12401,9 @@ default_temperature = 0.7
         config.save().await.unwrap();
 
         // Verify the saved file has the token encrypted
-        let contents = tokio::fs::read_to_string(dir.join("config.toml")).await.unwrap();
+        let contents = tokio::fs::read_to_string(dir.join("config.toml"))
+            .await
+            .unwrap();
         let on_disk: Config = toml::from_str(&contents).unwrap();
         let stored_token = &on_disk.channels_config.telegram.as_ref().unwrap().bot_token;
         assert!(
@@ -12418,7 +12420,12 @@ default_temperature = 0.7
         let mut reloaded: Config = toml::from_str(&contents).unwrap();
         reloaded.decrypt_secrets(&store).unwrap();
         assert_eq!(
-            reloaded.channels_config.telegram.as_ref().unwrap().bot_token,
+            reloaded
+                .channels_config
+                .telegram
+                .as_ref()
+                .unwrap()
+                .bot_token,
             "123456789:ABCdefGHIjklMNOpqrSTUvwxYZ"
         );
 


### PR DESCRIPTION
## Summary

- `load_runtime_defaults_from_config_file` was hand-decrypting only `api_key` and TTS keys, skipping every other `#[secret]` field (channel `bot_token`s, etc.). Replaced with a single `decrypt_secrets()` call that covers all annotated fields recursively via the `Configurable` macro chain.
- Added an early guard in the Telegram polling loop: if `bot_token` still carries an `enc2:` / `enc:` prefix, the channel fails immediately with a clear error message instead of silently looping on 401 errors every 5 seconds ("no response" symptom).
- Added `config_save_encrypts_telegram_bot_token` round-trip test: saves with `secrets.encrypt = true`, verifies on-disk token is encrypted, and confirms `decrypt_secrets` restores the plaintext value.

Closes #5654

## Test plan

- [x] `cargo check -p zeroclaw-channels -p zeroclaw-config` passes
- [x] `cargo test -p zeroclaw-channels` — 915 passed, 2 pre-existing failures unrelated to this change
- [x] New round-trip test `config_save_encrypts_telegram_bot_token` added to `zeroclaw-config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)