### PR TITLE
fix(tools): multiply embedding score by 100 before percent display

### DIFF
--- a/crates/zeroclaw-tools/src/discord_search.rs
+++ b/crates/zeroclaw-tools/src/discord_search.rs
@@ -127,7 +127,7 @@ impl Tool for DiscordSearchTool {
                 for entry in &entries {
                     let score = entry
                         .score
-                        .map_or_else(String::new, |s| format!(" [{s:.0}%]"));
+                        .map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
                     let _ = writeln!(output, "- {}{score}", entry.content);
                 }
                 Ok(ToolResult {

--- a/crates/zeroclaw-tools/src/memory_recall.rs
+++ b/crates/zeroclaw-tools/src/memory_recall.rs
@@ -124,7 +124,7 @@ impl Tool for MemoryRecallTool {
                 for entry in &entries {
                     let score = entry
                         .score
-                        .map_or_else(String::new, |s| format!(" [{s:.0}%]"));
+                        .map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
                     let _ = writeln!(
                         output,
                         "- [{}] {}: {}{score}",


### PR DESCRIPTION
## Summary

- Cosine similarity scores are floats in `0.0–1.0`, but `memory_recall.rs` and `discord_search.rs` formatted them directly with `{s:.0}%`, causing `0.63` → `[1%]` and `0.42` → `[0%]`.
- Multiply by `100.0` before formatting so scores render correctly: `0.63` → `[63%]`, `0.42` → `[42%]`.

Closes #5536

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy -p zeroclaw-tools -- -D warnings` passes
- [x] `cargo test -p zeroclaw-tools` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)