### PR TITLE
fix(config): include optional None fields in known key validator

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -9015,11 +9015,19 @@ impl Config {
                 // serialization round-trip.  This is computed once and cached.
                 static KNOWN_KEYS: OnceLock<Vec<String>> = OnceLock::new();
                 let known = KNOWN_KEYS.get_or_init(|| {
-                    toml::to_string(&Config::default())
+                    let mut keys: Vec<String> = toml::to_string(&Config::default())
                         .ok()
                         .and_then(|s| s.parse::<toml::Table>().ok())
                         .map(|t| t.keys().cloned().collect())
-                        .unwrap_or_default()
+                        .unwrap_or_default();
+                    // Fields that are None in Config::default() and therefore omitted
+                    // by the TOML serializer, but are still valid top-level keys.
+                    for extra in &["api_key", "api_url", "api_path", "provider_max_tokens"] {
+                        if !keys.contains(&extra.to_string()) {
+                            keys.push(extra.to_string());
+                        }
+                    }
+                    keys
                 });
                 for key in raw.keys() {
                     if !known.contains(key) {


### PR DESCRIPTION
Hey there 👋

First off, thanks for the amazing work on ZeroClaw — the runtime is incredibly lean and the new workspace split in v0.6.9 looks great.

I noticed issue #5629 where `api_key` gets falsely flagged as an unknown config key. I ran into the same thing after upgrading. Turns out the validator builds its known-key list from a `Config::default()` serialization round-trip, but any `Option<T>` field that's `None` in the default gets silently dropped by the TOML serializer. So `api_key`, `api_url`, `api_path`, and `provider_max_tokens` all get incorrectly warned as typos when users set them explicitly.

This PR just adds those missing fields to the cached known-key list. It's a small change but should clean up the noise for folks using top-level `api_key` or `api_url`.

I wasn't able to run `cargo check` on my current machine (toolchain issue on my end, sorry!) but the change is contained to the warning logic and doesn't touch any deserialization paths.

Let me know if you'd prefer a different approach — happy to adjust. 🙏

Fixes #5629
