### PR TITLE
fix(dist): include web dashboard in binary releases, AUR, and cargo install

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -257,14 +257,21 @@ jobs:
       - name: Package (Unix)
         if: runner.os != 'Windows'
         run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ../../../zeroclaw-${{ matrix.target }}.${{ matrix.ext }} ${{ matrix.artifact }}
+          mkdir -p staging/web
+          cp target/${{ matrix.target }}/release/${{ matrix.artifact }} staging/
+          cp -r web/dist staging/web/dist
+          cd staging
+          tar czf ../zeroclaw-${{ matrix.target }}.${{ matrix.ext }} ${{ matrix.artifact }} web/dist
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
+        shell: bash
         run: |
-          cd target/${{ matrix.target }}/release
-          7z a ../../../zeroclaw-${{ matrix.target }}.${{ matrix.ext }} ${{ matrix.artifact }}
+          mkdir -p staging/web
+          cp target/${{ matrix.target }}/release/${{ matrix.artifact }} staging/
+          cp -r web/dist staging/web/dist
+          cd staging
+          7z a ../zeroclaw-${{ matrix.target }}.${{ matrix.ext }} ${{ matrix.artifact }} web/dist
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -284,14 +284,21 @@ jobs:
       - name: Package (Unix)
         if: runner.os != 'Windows'
         run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ../../../zeroclaw-${{ matrix.target }}.${{ matrix.ext }} ${{ matrix.artifact }}
+          mkdir -p staging/web
+          cp target/${{ matrix.target }}/release/${{ matrix.artifact }} staging/
+          cp -r web/dist staging/web/dist
+          cd staging
+          tar czf ../zeroclaw-${{ matrix.target }}.${{ matrix.ext }} ${{ matrix.artifact }} web/dist
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
+        shell: bash
         run: |
-          cd target/${{ matrix.target }}/release
-          7z a ../../../zeroclaw-${{ matrix.target }}.${{ matrix.ext }} ${{ matrix.artifact }}
+          mkdir -p staging/web
+          cp target/${{ matrix.target }}/release/${{ matrix.artifact }} staging/
+          cp -r web/dist staging/web/dist
+          cd staging
+          7z a ../zeroclaw-${{ matrix.target }}.${{ matrix.ext }} ${{ matrix.artifact }} web/dist
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/crates/zeroclaw-gateway/build.rs
+++ b/crates/zeroclaw-gateway/build.rs
@@ -1,6 +1,58 @@
+use std::process::Command;
+
 fn main() {
     // Web dashboard is served from the filesystem at runtime via
     // `gateway.web_dist_dir` — no compile-time embedding needed.
     //
-    // To build the dashboard:  cd web && npm ci && npm run build
+    // For `cargo install` users: attempt a best-effort npm build so the
+    // dashboard is available out of the box. If node/npm is missing or
+    // the build fails, we skip silently — the binary works fine without it.
+    build_web_dashboard();
+}
+
+fn build_web_dashboard() {
+    let web_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|root| root.join("web"));
+
+    let Some(web_dir) = web_dir else { return };
+    if !web_dir.join("package.json").exists() {
+        return;
+    }
+
+    // Already built — skip
+    if web_dir.join("dist/index.html").exists() {
+        return;
+    }
+
+    // Rerun if the web source changes
+    println!(
+        "cargo:rerun-if-changed={}",
+        web_dir.join("package.json").display()
+    );
+    println!("cargo:rerun-if-changed={}", web_dir.join("src").display());
+
+    let npm = if cfg!(target_os = "windows") {
+        "npm.cmd"
+    } else {
+        "npm"
+    };
+
+    let ok = Command::new(npm)
+        .args(["ci", "--ignore-scripts"])
+        .current_dir(&web_dir)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if !ok {
+        // npm not available or install failed — skip silently
+        return;
+    }
+
+    let _ = Command::new(npm)
+        .args(["run", "build"])
+        .current_dir(&web_dir)
+        .status();
 }

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -284,6 +284,10 @@ fn parse_client_ip(value: &str) -> Option<IpAddr> {
     value.parse::<IpAddr>().ok()
 }
 
+fn dirs_data_local() -> Option<std::path::PathBuf> {
+    directories::BaseDirs::new().map(|d| d.data_local_dir().to_path_buf())
+}
+
 fn forwarded_client_ip(headers: &HeaderMap) -> Option<IpAddr> {
     if let Some(xff) = headers.get("X-Forwarded-For").and_then(|v| v.to_str().ok()) {
         for candidate in xff.split(',') {
@@ -756,7 +760,7 @@ pub async fn run_gateway(
         .map(std::path::PathBuf::from)
         .or_else(|| {
             // Auto-detect: check common locations relative to the binary and CWD
-            let candidates = [
+            let mut candidates = vec![
                 // Relative to CWD (development: running from repo root)
                 std::path::PathBuf::from("web/dist"),
                 // Relative to binary (installed alongside binary)
@@ -766,7 +770,13 @@ pub async fn run_gateway(
                     .unwrap_or_default(),
                 // Docker / packaged layout
                 std::path::PathBuf::from("/zeroclaw-data/web/dist"),
+                // AUR / system package
+                std::path::PathBuf::from("/usr/share/zeroclawlabs/web/dist"),
             ];
+            // XDG data home (prebuilt binary installer)
+            if let Some(data_dir) = dirs_data_local() {
+                candidates.push(data_dir.join("zeroclaw/web/dist"));
+            }
             candidates
                 .into_iter()
                 .find(|p| !p.as_os_str().is_empty() && p.join("index.html").is_file())

--- a/dist/aur/PKGBUILD
+++ b/dist/aur/PKGBUILD
@@ -22,6 +22,10 @@ prepare() {
 
 build() {
   cd "${_reponame}-${pkgver}"
+
+  # Build web dashboard (served from filesystem at runtime)
+  cd web && npm ci && npm run build && cd ..
+
   export RUSTUP_TOOLCHAIN=stable
   export CARGO_TARGET_DIR=target
   cargo build --frozen --release --profile dist --features channel-matrix,channel-lark
@@ -30,6 +34,11 @@ build() {
 package() {
   cd "${_reponame}-${pkgver}"
   install -Dm0755 -t "${pkgdir}/usr/bin/" "target/dist/zeroclaw"
+
+  # Install web dashboard assets (served from filesystem at runtime)
+  install -dm0755 "${pkgdir}/usr/share/${pkgname}/web/dist"
+  cp -r web/dist/* "${pkgdir}/usr/share/${pkgname}/web/dist/"
+
   install -Dm0644 LICENSE-MIT "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE-MIT"
   install -Dm0644 LICENSE-APACHE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE-APACHE"
 }

--- a/install.sh
+++ b/install.sh
@@ -428,6 +428,17 @@ install_prebuilt_binary() {
   install_dir="$HOME/.cargo/bin"
   mkdir -p "$install_dir"
   install -m 0755 "$extracted_bin" "$install_dir/zeroclaw"
+
+  # Install web dashboard assets if included in the archive
+  local web_dist_src
+  web_dist_src="$(find "$temp_dir" -type d -name dist -path '*/web/dist' | head -n 1 || true)"
+  if [[ -n "$web_dist_src" && -d "$web_dist_src" ]]; then
+    local data_dir="$HOME/.local/share/zeroclaw/web/dist"
+    mkdir -p "$data_dir"
+    cp -r "$web_dist_src"/* "$data_dir/"
+    step_ok "Web dashboard installed to $data_dir"
+  fi
+
   rm -rf "$temp_dir"
 
   step_ok "Installed pre-built binary to $install_dir/zeroclaw"


### PR DESCRIPTION
## Summary

- **Binary releases** (stable + beta): Package steps now bundle `web/dist/` alongside the binary in tar.gz/zip archives via a staging directory
- **AUR**: PKGBUILD `build()` runs `npm ci && npm run build`, `package()` installs dashboard to `/usr/share/zeroclawlabs/web/dist/`
- **`cargo install`**: `build.rs` restored with best-effort npm build (skips silently if node/npm unavailable)
- **`install.sh`**: Prebuilt binary installer extracts and installs `web/dist/` to `~/.local/share/zeroclaw/web/dist/`
- **Auto-detection**: Gateway now also checks AUR (`/usr/share/zeroclawlabs/web/dist`) and XDG data home paths

## Test plan

- [ ] `cargo check` — compiles cleanly
- [ ] `cargo clippy` — zero warnings
- [ ] `cargo test` — all tests pass
- [ ] `bash -n install.sh` — syntax valid
- [ ] Verify release archive structure includes `web/dist/` alongside binary
- [ ] Verify AUR package installs dashboard to `/usr/share/zeroclawlabs/web/dist/`
- [ ] Verify `cargo install` triggers npm build when node is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)