### PR TITLE
test(channels): add enabled=false guard tests for collect_configured_channels

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -10352,6 +10352,41 @@ This is an example JSON object for profile settings."#;
         );
     }
 
+    #[cfg(feature = "channel-email")]
+    #[test]
+    fn collect_configured_channels_skips_disabled_email() {
+        let mut config = Config::default();
+        config.channels_config.email = Some(zeroclaw_config::scattered_types::EmailConfig {
+            enabled: false,
+            ..Default::default()
+        });
+
+        let channels = collect_configured_channels(&config, "test");
+        assert!(
+            !channels.iter().any(|entry| entry.display_name == "Email"),
+            "disabled email should not be collected"
+        );
+    }
+
+    #[cfg(feature = "channel-voice-call")]
+    #[test]
+    fn collect_configured_channels_skips_disabled_voice_call() {
+        let mut config = Config::default();
+        config.channels_config.voice_call =
+            Some(zeroclaw_config::scattered_types::VoiceCallConfig {
+                enabled: false,
+                ..Default::default()
+            });
+
+        let channels = collect_configured_channels(&config, "test");
+        assert!(
+            !channels
+                .iter()
+                .any(|entry| entry.display_name == "Voice Call"),
+            "disabled voice-call should not be collected"
+        );
+    }
+
     struct AlwaysFailChannel {
         name: &'static str,
         calls: Arc<AtomicUsize>,


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: #5659 was merged while a blocking review item was still open — the `collect_configured_channels` enabled guard for Email and VoiceCall had no test coverage.
- Why it matters: The `enabled` field on `EmailConfig` and `VoiceCallConfig` is the mechanism that makes these channels disableable. Without tests, a regression could silently re-enable a channel the operator turned off.
- What changed: Two tests added to `crates/zeroclaw-channels/src/orchestrator/mod.rs` proving that `collect_configured_channels` skips channels with `enabled: false`.
- What did **not** change (scope boundary): No runtime behavior, no config changes, no new dependencies. Tests only.

cc @theonlyhennygod — follow-up to the premature merge of #5659 per @WareWolf-MoonWall's review.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `channel`, `tests`
- Module labels: `channel: email`, `channel: voice-call`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `tests`
- Primary scope: `channel`

## Linked Issue

- Related #5659
- Related #5655

## Validation Evidence (required)

```bash
cargo fmt --all -- --check  # pass
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings  # pass
cargo test -p zeroclaw-channels --features channel-email,channel-voice-call  # pass
```

- Evidence provided: Tests assert that `collect_configured_channels` excludes Email and VoiceCall when `enabled: false`, matching the four cases @WareWolf-MoonWall identified in the #5659 review.
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: N/A

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: `enabled: false` for both Email and VoiceCall excluded from collected channels
- Edge cases checked: Only `enabled: false` path — `enabled: true` collection is already covered by existing integration tests
- What was not verified: Full orchestrator startup (covered by existing tests)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: None (test-only)
- Potential unintended effects: None
- Guardrails/monitoring for early detection: CI

## Rollback Plan (required)

- Fast rollback command/path: `git revert <sha>`
- Feature flags or config toggles: None
- Observable failure symptoms: N/A (test-only)

## Risks and Mitigations

None.