### PR TITLE
docs: add pr-review-prompt to contributing

### DIFF
--- a/docs/contributing/pr-review-prompt.md
+++ b/docs/contributing/pr-review-prompt.md
@@ -1,0 +1,53 @@
+You are reviewing a pull request in the `zeroclaw-labs/zeroclaw` repository.
+The GitHub CLI (`gh`) is available and authenticated.
+
+**Fetch this in order:**
+
+1. `gh pr view <number> --repo zeroclaw-labs/zeroclaw`
+   Description, labels, linked issues, validation evidence.
+
+2a. `gh pr view <number> --comments --repo zeroclaw-labs/zeroclaw`
+    Top-level conversation.
+
+2b. `gh api repos/zeroclaw-labs/zeroclaw/pulls/<number>/comments --paginate`
+    Every inline thread. Read full reply chains before drawing any conclusion
+    about whether something is open or settled. Note author commitments made
+    in replies.
+
+2c. `gh api repos/zeroclaw-labs/zeroclaw/pulls/<number>/reviews --paginate`
+    All formal review verdicts. Note which CHANGES_REQUESTED are still active
+    (not superseded by a later APPROVED or DISMISSED). Check whether you have
+    already reviewed this PR.
+
+3. `gh issue view <RFC-number> --repo zeroclaw-labs/zeroclaw`
+   Fetch relevant RFCs before reading the diff — always fetch #5615. Read
+   them; do not assume their content. The RFC table for reference:
+
+   | RFC | Issue |
+   |-----|-------|
+   | Microkernel Architecture    | #5574 |
+   | Documentation Standards     | #5576 |
+   | Team Governance             | #5577 |
+   | CI/CD Pipeline              | #5579 |
+   | Contribution Culture        | #5615 |
+   | Zero Compromise in Practice | #5653 |
+
+4. `gh pr diff <number> --repo zeroclaw-labs/zeroclaw`
+   Read the full diff. Cross-check against any author commitments from step
+   2b and against the local repository where needed.
+
+Before writing, take stock: what has already been raised, what is settled,
+what is still live, who holds active blocks and whether the diff addresses
+them.
+
+Write as a thoughtful senior contributor who has read everything and cares
+about the outcome. Don't re-raise settled points. If you have your own
+findings to block on, say so clearly. If others hold active blocks and the
+diff hasn't addressed them, name it — but don't approve over another
+reviewer's CHANGES_REQUESTED. If you have nothing new to block on but others
+do, use `--comment`.
+
+Post using:
+`gh pr review <number> --repo zeroclaw-labs/zeroclaw <verdict-flag> --body-file <tmp>`
+
+The PR to review is: #


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: No canonical, agent-ready PR review prompt exists in the contributing docs
- Why it matters: Reviewers (human or AI) have no structured process for fetching comment threads, respecting prior review blocks, and grounding findings in the RFC framework
- What changed: Added `docs/contributing/pr-review-prompt.md` — revised prompt with natural tone, covering data fetching, thread-state inventory, RFC grounding, and verdict discipline
- What did **not** change: No code, config, or existing docs modified

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: auto
- Scope labels: `docs`
- Module labels: N/A
- Contributor tier label: auto
- If any auto-label is incorrect: N/A

## Change Metadata

- Change type: `docs`
- Primary scope: `docs`

## Linked Issue

- Closes #
- Related: #5615
- Supersedes #5682

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors: #5682 by @WareWolf-MoonWall
- Integrated scope by source PR: Full file — revised for tone; same structural intent carried forward
- `Co-authored-by` trailers added for materially incorporated contributors? No
- If `No`, explain why: Self-supersede; same author rewrote their own closed PR
- Trailer format check: N/A

## Validation Evidence (required)

- `cargo fmt / clippy / test`: intentionally skipped — docs-only, no Rust changes
- Evidence provided: Prompt validated end-to-end against approximately six real PR reviews; verdict logic, RFC grounding, and comment-thread handling confirmed to produce useful, natural-sounding output across all cases

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: pass

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No — this is a process/tooling document for contributors and reviewers, not user-facing content

## Human Verification (required)

- Verified scenarios: prompt exercised end-to-end across ~6 real PR reviews covering docs-only, code, and mixed-scope PRs
- Edge cases checked: re-review flow, prior blocks with no new findings, author commitments not reflected in diff
- What was not verified: automated or CI-driven execution

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: none
- Potential unintended effects: none
- Guardrails/monitoring: N/A

## Agent Collaboration Notes (recommended)

- Agent tools used: Zed AI
- Workflow/plan summary: prompt drafted and iteratively refined through conversation, validated against live reviews, then committed as a single clean file
- Verification focus: tone naturalness, verdict logic consistency, RFC grounding, comment-exchange coverage
- Confirmation: naming + architecture boundaries followed per `AGENTS.md` and `CONTRIBUTING.md`

## Rollback Plan (required)

- Fast rollback: revert commit or delete file
- Feature flags: N/A
- Observable failure symptoms: N/A

## Risks and Mitigations

- Risk: prompt may drift as RFCs evolve
  - Mitigation: prompt defers to RFC content fetched at review time rather than summarising it inline — staleness is self-limiting