### PR TITLE
fix(security): block dangerous interpreter arguments in command policy

### DIFF
--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -1271,9 +1271,9 @@ impl SecurityPolicy {
                 // Ref: https://nodejs.org/api/cli.html
                 !args.iter().any(|arg| {
                     arg.starts_with("-e")
-                        || arg == "--eval"
+                        || arg.starts_with("--eval")
                         || arg.starts_with("-p")
-                        || arg == "--print"
+                        || arg.starts_with("--print")
                 })
             }
             "pip" | "pip3" => {
@@ -1285,7 +1285,13 @@ impl SecurityPolicy {
                 // exec can fetch+run remote packages (npx behavior)
                 // install fetches external packages; lifecycle scripts run arbitrary code
                 // Ref: https://cheatsheetseries.owasp.org/cheatsheets/NPM_Security_Cheat_Sheet.html
-                !args.iter().any(|arg| arg == "exec" || arg == "install")
+                !args.iter().any(|arg| {
+                    arg == "exec"
+                        || arg == "install"
+                        || arg == "i"
+                        || arg == "add"
+                        || arg == "ci"
+                })
             }
             "cargo" => {
                 // install fetches+builds external crate; build.rs executes arbitrary code
@@ -2527,8 +2533,10 @@ mod tests {
         // node: -e/--eval evaluates JS, -p/--print evaluates and prints
         assert!(!p.is_command_allowed("node -e 'require(\"child_process\").execSync(\"id\")'"));
         assert!(!p.is_command_allowed("node --eval 'process.exit(1)'"));
+        assert!(!p.is_command_allowed("node --eval=process.exit(1)"));
         assert!(!p.is_command_allowed("node -p '1+1'"));
         assert!(!p.is_command_allowed("node --print 'process.env'"));
+        assert!(!p.is_command_allowed("node --print=process.env"));
         // Glued form bypass: -c'code' is one whitespace token
         assert!(!p.is_command_allowed("python3 -c'import os'"));
         assert!(!p.is_command_allowed("node -e'process.exit()'"));
@@ -2546,6 +2554,9 @@ mod tests {
         // npm: exec fetches remote, install runs lifecycle scripts
         assert!(!p.is_command_allowed("npm exec -- malicious-pkg"));
         assert!(!p.is_command_allowed("npm install malicious-pkg"));
+        assert!(!p.is_command_allowed("npm i malicious-pkg"));
+        assert!(!p.is_command_allowed("npm add malicious-pkg"));
+        assert!(!p.is_command_allowed("npm ci"));
         // cargo: install fetches+builds external crate (build.rs runs arbitrary code)
         assert!(!p.is_command_allowed("cargo install malicious-crate"));
     }

--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -1257,7 +1257,11 @@ impl SecurityPolicy {
             }
             "python" | "python3" => {
                 // -c executes arbitrary code from argument string
-                // -m runs any installed module as a script
+                // -m runs any installed module as a script — broad block is intentional:
+                //   -m http.server opens a local exfil vector
+                //   -m pip install double-covers the pip arm
+                //   -m pytest, -m mypy, -m venv are blocked as collateral;
+                //   narrowing to a curated module list is a future option
                 // starts_with covers glued form: python3 -c'code' (one whitespace token)
                 // Ref: https://docs.python.org/3/using/cmdline.html
                 !args
@@ -1286,11 +1290,7 @@ impl SecurityPolicy {
                 // install fetches external packages; lifecycle scripts run arbitrary code
                 // Ref: https://cheatsheetseries.owasp.org/cheatsheets/NPM_Security_Cheat_Sheet.html
                 !args.iter().any(|arg| {
-                    arg == "exec"
-                        || arg == "install"
-                        || arg == "i"
-                        || arg == "add"
-                        || arg == "ci"
+                    arg == "exec" || arg == "install" || arg == "i" || arg == "add" || arg == "ci"
                 })
             }
             "cargo" => {
@@ -2530,6 +2530,13 @@ mod tests {
         assert!(!p.is_command_allowed("python3 -c 'import os; os.system(\"id\")'"));
         assert!(!p.is_command_allowed("python -c '__import__(\"os\").system(\"id\")'"));
         assert!(!p.is_command_allowed("python3 -m http.server"));
+        assert!(!p.is_command_allowed("python3 -m pip install evil"));
+        // Broad -m block: these are intentional collateral
+        assert!(!p.is_command_allowed("python3 -m pytest"));
+        assert!(!p.is_command_allowed("python3 -m mypy src/"));
+        assert!(!p.is_command_allowed("python3 -m venv .venv"));
+        // Glued form: -mhttp.server is one token
+        assert!(!p.is_command_allowed("python3 -mhttp.server"));
         // node: -e/--eval evaluates JS, -p/--print evaluates and prints
         assert!(!p.is_command_allowed("node -e 'require(\"child_process\").execSync(\"id\")'"));
         assert!(!p.is_command_allowed("node --eval 'process.exit(1)'"));

--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -1227,7 +1227,16 @@ impl SecurityPolicy {
         })
     }
 
-    /// Check for dangerous arguments that allow sub-command execution.
+    /// Check for dangerous arguments that allow sub-command execution or
+    /// fetch+execute untrusted external code.
+    ///
+    /// Local workspace operations (cargo build, npm test, python script.py)
+    /// are NOT blocked — the user trusts their own project.
+    ///
+    /// References:
+    /// - ZeptoClaw GHSA-5wp8-q9mx-8jx8 (CVSS 9.8): same vulnerability class
+    /// - OpenClaw strictInlineEval: blocks python -c, node -e, etc.
+    /// - OWASP OS Command Injection Defense Cheat Sheet
     fn is_args_safe(&self, base: &str, args: &[String]) -> bool {
         let base = base.to_ascii_lowercase();
         match base.as_str() {
@@ -1245,6 +1254,43 @@ impl SecurityPolicy {
                         || arg.starts_with("alias.")
                         || arg == "-c"
                 })
+            }
+            "python" | "python3" => {
+                // -c executes arbitrary code from argument string
+                // -m runs any installed module as a script
+                // starts_with covers glued form: python3 -c'code' (one whitespace token)
+                // Ref: https://docs.python.org/3/using/cmdline.html
+                !args
+                    .iter()
+                    .any(|arg| arg.starts_with("-c") || arg.starts_with("-m"))
+            }
+            "node" => {
+                // -e/--eval evaluates argument as JavaScript
+                // -p/--print same as --eval but prints the result
+                // starts_with covers glued form: node -e'code' (one whitespace token)
+                // Ref: https://nodejs.org/api/cli.html
+                !args.iter().any(|arg| {
+                    arg.starts_with("-e")
+                        || arg == "--eval"
+                        || arg.starts_with("-p")
+                        || arg == "--print"
+                })
+            }
+            "pip" | "pip3" => {
+                // install/download fetch external packages; setup.py runs arbitrary code
+                // Ref: https://blog.phylum.io/python-package-installation-attacks/
+                !args.iter().any(|arg| arg == "install" || arg == "download")
+            }
+            "npm" => {
+                // exec can fetch+run remote packages (npx behavior)
+                // install fetches external packages; lifecycle scripts run arbitrary code
+                // Ref: https://cheatsheetseries.owasp.org/cheatsheets/NPM_Security_Cheat_Sheet.html
+                !args.iter().any(|arg| arg == "exec" || arg == "install")
+            }
+            "cargo" => {
+                // install fetches+builds external crate; build.rs executes arbitrary code
+                // Ref: https://shnatsel.medium.com/do-not-run-any-cargo-commands-on-untrusted-projects
+                !args.iter().any(|arg| arg == "install")
             }
             _ => true,
         }
@@ -2467,6 +2513,58 @@ mod tests {
         assert!(!p.is_command_allowed("ls >> /tmp/exfil.txt"));
         assert!(!p.is_command_allowed("cat </etc/passwd"));
         assert!(!p.is_command_allowed("cat</etc/passwd"));
+    }
+
+    // ── Interpreter argument injection (#5698) ────────────────────
+
+    #[test]
+    fn interpreter_inline_eval_blocked() {
+        let p = default_policy();
+        // python: -c executes code string, -m runs arbitrary module
+        assert!(!p.is_command_allowed("python3 -c 'import os; os.system(\"id\")'"));
+        assert!(!p.is_command_allowed("python -c '__import__(\"os\").system(\"id\")'"));
+        assert!(!p.is_command_allowed("python3 -m http.server"));
+        // node: -e/--eval evaluates JS, -p/--print evaluates and prints
+        assert!(!p.is_command_allowed("node -e 'require(\"child_process\").execSync(\"id\")'"));
+        assert!(!p.is_command_allowed("node --eval 'process.exit(1)'"));
+        assert!(!p.is_command_allowed("node -p '1+1'"));
+        assert!(!p.is_command_allowed("node --print 'process.env'"));
+        // Glued form bypass: -c'code' is one whitespace token
+        assert!(!p.is_command_allowed("python3 -c'import os'"));
+        assert!(!p.is_command_allowed("node -e'process.exit()'"));
+        // Flag with other args before it
+        assert!(!p.is_command_allowed("python3 -W ignore -c 'import os'"));
+    }
+
+    #[test]
+    fn package_manager_install_blocked() {
+        let p = default_policy();
+        // pip: install/download fetch external packages and run setup.py
+        assert!(!p.is_command_allowed("pip install evil-package"));
+        assert!(!p.is_command_allowed("pip3 install evil-package"));
+        assert!(!p.is_command_allowed("pip download evil-package"));
+        // npm: exec fetches remote, install runs lifecycle scripts
+        assert!(!p.is_command_allowed("npm exec -- malicious-pkg"));
+        assert!(!p.is_command_allowed("npm install malicious-pkg"));
+        // cargo: install fetches+builds external crate (build.rs runs arbitrary code)
+        assert!(!p.is_command_allowed("cargo install malicious-crate"));
+    }
+
+    #[test]
+    fn safe_interpreter_usage_allowed() {
+        let p = default_policy();
+        // Running local files is safe — user trusts their workspace
+        assert!(p.is_command_allowed("python3 script.py"));
+        assert!(p.is_command_allowed("node app.js"));
+        // Read-only / local workspace operations
+        assert!(p.is_command_allowed("pip list"));
+        assert!(p.is_command_allowed("pip freeze"));
+        assert!(p.is_command_allowed("pip show requests"));
+        assert!(p.is_command_allowed("npm test"));
+        assert!(p.is_command_allowed("npm list"));
+        assert!(p.is_command_allowed("cargo build"));
+        assert!(p.is_command_allowed("cargo test"));
+        assert!(p.is_command_allowed("cargo run"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `is_args_safe()` only checks `find` and `git` for dangerous arguments. Six other default-allowlisted commands (`python`, `python3`, `node`, `pip`, `npm`, `cargo`) have arbitrary code execution arguments that pass the policy unchecked.
- Why it matters: An LLM agent operating under the default security policy can execute arbitrary system commands via `python3 -c`, `node -e`, `pip install`, etc. The command allowlist provides a false sense of security.
- What changed: 5 new match arms in `is_args_safe()` blocking dangerous arguments for interpreters and package managers. Uses `starts_with` for single-char flags to catch the glued form (`python3 -c'code'`) and assignment form (`node --eval=code`).
- What did **not** change: Config schema, default allowlist, local workspace operations (`cargo build`, `npm test`, `python3 script.py` all still work).

### Before / After

**Before (current master):**
```
python3 -c 'import os; os.system("id")'           → allowed  ← VULNERABILITY
node -e 'require("child_process").execSync("id")'  → allowed  ← VULNERABILITY
pip install evil-package                            → allowed  ← VULNERABILITY
npm exec -- malicious-pkg                           → allowed  ← VULNERABILITY
cargo install malicious-crate                       → allowed  ← VULNERABILITY
```

**After:**
```
python3 -c 'import os; os.system("id")'           → BLOCKED
node -e 'require("child_process").execSync("id")'  → BLOCKED
pip install evil-package                            → BLOCKED
npm exec -- malicious-pkg                           → BLOCKED
cargo install malicious-crate                       → BLOCKED

python3 script.py                                   → allowed (local file)
node app.js                                         → allowed (local file)
pip list                                            → allowed (read-only)
npm test                                            → allowed (local scripts)
cargo build                                         → allowed (local workspace)
```

### Approaches considered

1. **Argument blocklist per command** (chosen) — Same approach as ZeptoClaw v0.6.2 fix for [GHSA-5wp8-q9mx-8jx8](https://advisories.gitlab.com/pkg/cargo/zeptoclaw/GHSA-5wp8-q9mx-8jx8/) (CVSS 9.8). Extends existing `is_args_safe` pattern. Minimal code surface change.

2. **`strictInlineEval` config flag** ([OpenClaw docs](https://github.com/openclaw/openclaw/blob/main/docs/tools/exec-approvals.md)) — Forces explicit approval for inline eval forms (`python -c`, `node -e`, etc.). More sophisticated but requires an approval system ZeroClaw doesn't have.

3. **Remove interpreters from default allowlist** (OpenClaw docs recommendation: "Do not add interpreter or runtime binaries to safeBins") — Breaking change for ZeroClaw users who expect `python3` and `node` to work out of the box.

4. **Environment sanitization** (Cursor v2.3 fix for [GHSA-82wg-qcm4-fp2w](https://github.com/cursor/cursor/security/advisories/GHSA-82wg-qcm4-fp2w)) — Addresses env var poisoning, a different bypass vector.

### Why approach 1

- Matches existing `is_args_safe` pattern (`find -exec` and `git config` already covered)
- Same fix that resolved CVSS 9.8 in ZeptoClaw
- No breaking changes to default allowlist
- No new config flags or approval infrastructure
- Principle: block args that execute attacker-controlled strings, fetch external code, or run arbitrary installed modules

### Blocked arguments (with evidence)

| Command | Blocked args | Evidence |
|---|---|---|
| `python` / `python3` | `-c`, `-m` | [Python docs](https://docs.python.org/3/using/cmdline.html): `-c` executes code string; `-m` runs arbitrary module. Broad `-m` block is intentional: `-m http.server` opens exfil, `-m pip` double-covers pip arm. Collateral on `-m pytest`/`-m mypy`/`-m venv` accepted — narrowing to a curated module list is a future option. |
| `node` | `-e`/`--eval`, `-p`/`--print` | [Node.js CLI docs](https://nodejs.org/api/cli.html): evaluates/prints argument as JavaScript. `starts_with` covers glued (`-e'code'`) and assignment (`--eval=code`) forms. |
| `pip` / `pip3` | `install`, `download` | [Phylum research](https://blog.phylum.io/python-package-installation-attacks/): `setup.py` runs arbitrary code during install |
| `npm` | `exec`, `install`, `i`, `add`, `ci` | [OWASP NPM Security](https://cheatsheetseries.owasp.org/cheatsheets/NPM_Security_Cheat_Sheet.html): lifecycle scripts run arbitrary code. `i` and `add` are documented aliases for `install`; `ci` is clean-install with identical lifecycle execution. |
| `cargo` | `install` | [Shnatsel](https://shnatsel.medium.com/do-not-run-any-cargo-commands-on-untrusted-projects-4c31c89a78d6): `build.rs` executes arbitrary code |

### Policy decision: broad `-m` block

`python3 -m <module>` is blocked for **all** modules. This is a deliberate conservative stance:
- `-m http.server` opens a local exfiltration vector
- `-m pip install` bypasses the dedicated `pip` arm
- `-m site`, `-m ensurepip` have install/fetch side effects
- Collateral: `-m pytest`, `-m mypy`, `-m venv` are blocked. Agents can use `pytest` directly (if allowlisted) or write a script file.
- Narrowing to a curated dangerous-module list is a viable future refinement if operator friction warrants it.

## Label Snapshot (required)

- Risk label: `risk: high`
- Size label: `size: XS`
- Scope labels: `security`
- Module labels: `config: policy`
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `bug`
- Primary scope: `security`

## Linked Issue

- Closes #5698

## Validation Evidence (required)

```bash
cargo fmt --all -- --check  # pass
cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings  # pass
cargo test --workspace --exclude zeroclaw-desktop --features ci-all  # 6,887 passed, 0 failed
```

- 3 new test functions: `interpreter_inline_eval_blocked` (12 assertions including glued-form, assignment-form, and mid-arg bypasses), `package_manager_install_blocked` (9 assertions including npm aliases), `safe_interpreter_usage_allowed` (10 assertions proving no regression)

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- This PR **reduces** the attack surface by blocking 9 previously-allowed dangerous argument patterns across 5 allowlisted commands.

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes for intended use. Agents that were using `python3 -c` or `node -e` will now be blocked — this is intentional (those were security violations that happened to work).
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: All 5 blocked command families, both exact and glued-form arguments, assignment-form (`--eval=code`), npm aliases (`i`, `add`, `ci`), safe local operations preserved
- Edge cases checked: glued form (`python3 -c'code'`), assignment form (`node --eval=code`), flags after other args (`python3 -W ignore -c 'code'`), case insensitivity, path-prefixed executables (`/usr/bin/python3 -c`)
- What was not verified: Commands not in the default allowlist (already blocked by allowlist gate)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Shell tool execution policy only
- Potential unintended effects: Agents that legitimately need `python3 -c` or `python3 -m pytest` will need the operator to add a custom allowlist entry or use a script file instead
- Guardrails/monitoring: Blocked commands are logged by the existing policy rejection path

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: None — but operators can override by adding specific commands to `allowed_commands` with `block_high_risk_commands = false`
- Observable failure symptoms: Agent reports "command not allowed" for interpreter eval/install patterns that previously worked

## Risks and Mitigations

- Risk: Legitimate `python3 -c` one-liners blocked
  - Mitigation: Agent can write a `.py` file and run it instead. Operators can customize `allowed_commands`.
- Risk: `python3 -m pytest` blocked as collateral of broad `-m` policy
  - Mitigation: Agents can invoke `pytest` directly (if allowlisted) or run via script. Narrowing to a curated module list is a future option.
- Risk: `starts_with("-c")` could false-positive on a future Python flag starting with `-c`
  - Mitigation: Verified against Python 3.14 docs — no other flag starts with `-c`. Same verification done for Node `-e` and `-p`.

## References

- [GHSA-5wp8-q9mx-8jx8](https://advisories.gitlab.com/pkg/cargo/zeptoclaw/GHSA-5wp8-q9mx-8jx8/) — ZeptoClaw allowlist bypass (CVSS 9.8)
- [GHSA-82wg-qcm4-fp2w](https://github.com/cursor/cursor/security/advisories/GHSA-82wg-qcm4-fp2w) — Cursor allowlist bypass via env vars
- [GHSA-w7qc-6grj-w7r8](https://github.com/filebrowser/filebrowser/security/advisories/GHSA-w7qc-6grj-w7r8) — FileBrowser allowlist bypass
- [OpenClaw exec-approvals](https://github.com/openclaw/openclaw/blob/main/docs/tools/exec-approvals.md) — `strictInlineEval` documentation
- [OWASP OS Command Injection Defense](https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html)
