### PR TITLE
fix(skills): respect allow_scripts config in read_skill and delegate tools

### DIFF
--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -73,6 +73,8 @@ pub struct DelegateTool {
     cancellation_token: CancellationToken,
     /// Optional memory instance for namespace isolation on delegate agents.
     memory: Option<Arc<dyn Memory>>,
+    /// Whether script files in skills are allowed (from root config).
+    allow_scripts: bool,
 }
 
 impl DelegateTool {
@@ -107,6 +109,7 @@ impl DelegateTool {
             workspace_dir: PathBuf::new(),
             cancellation_token: CancellationToken::new(),
             memory: None,
+            allow_scripts: false,
         }
     }
 
@@ -147,6 +150,7 @@ impl DelegateTool {
             workspace_dir: PathBuf::new(),
             cancellation_token: CancellationToken::new(),
             memory: None,
+            allow_scripts: false,
         }
     }
 
@@ -195,6 +199,12 @@ impl DelegateTool {
     /// Attach memory for namespace isolation on delegate agents.
     pub fn with_memory(mut self, memory: Arc<dyn Memory>) -> Self {
         self.memory = Some(memory);
+        self
+    }
+
+    /// Set whether script files in skills are allowed.
+    pub fn with_allow_scripts(mut self, allow_scripts: bool) -> Self {
+        self.allow_scripts = allow_scripts;
         self
     }
 
@@ -1026,7 +1036,7 @@ impl DelegateTool {
             .filter(|s| !s.trim().is_empty())
             .map(|dir| workspace_dir.join(dir))
             .unwrap_or_else(|| crate::skills::skills_dir(workspace_dir));
-        let skills = crate::skills::load_skills_from_directory(&skills_dir, false);
+        let skills = crate::skills::load_skills_from_directory(&skills_dir, self.allow_scripts);
 
         // Determine shell policy instructions when the `shell` tool is in the
         // effective tool list.

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -496,6 +496,7 @@ pub fn all_tools_with_runtime(
             workspace_dir.to_path_buf(),
             root_config.skills.open_skills_enabled,
             root_config.skills.open_skills_dir.clone(),
+            root_config.skills.allow_scripts,
         )));
     }
 
@@ -924,7 +925,8 @@ pub fn all_tools_with_runtime(
         .with_multimodal_config(root_config.multimodal.clone())
         .with_delegate_config(root_config.delegate.clone())
         .with_workspace_dir(workspace_dir.to_path_buf())
-        .with_memory(memory.clone());
+        .with_memory(memory.clone())
+        .with_allow_scripts(root_config.skills.allow_scripts);
         tool_arcs.push(Arc::new(delegate_tool));
         Some(parent_tools)
     };

--- a/src/tools/read_skill.rs
+++ b/src/tools/read_skill.rs
@@ -8,6 +8,7 @@ pub struct ReadSkillTool {
     workspace_dir: PathBuf,
     open_skills_enabled: bool,
     open_skills_dir: Option<String>,
+    allow_scripts: bool,
 }
 
 impl ReadSkillTool {
@@ -15,11 +16,13 @@ impl ReadSkillTool {
         workspace_dir: PathBuf,
         open_skills_enabled: bool,
         open_skills_dir: Option<String>,
+        allow_scripts: bool,
     ) -> Self {
         Self {
             workspace_dir,
             open_skills_enabled,
             open_skills_dir,
+            allow_scripts,
         }
     }
 }
@@ -55,10 +58,11 @@ impl Tool for ReadSkillTool {
             .filter(|value| !value.is_empty())
             .ok_or_else(|| anyhow::anyhow!("Missing 'name' parameter"))?;
 
-        let skills = crate::skills::load_skills_with_open_skills_settings(
+        let skills = crate::skills::load_skills_with_open_skills_config(
             &self.workspace_dir,
-            self.open_skills_enabled,
+            Some(self.open_skills_enabled),
             self.open_skills_dir.as_deref(),
+            Some(self.allow_scripts),
         );
 
         let Some(skill) = skills
@@ -118,7 +122,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn make_tool(tmp: &TempDir) -> ReadSkillTool {
-        ReadSkillTool::new(tmp.path().join("workspace"), false, None)
+        ReadSkillTool::new(tmp.path().join("workspace"), false, None, false)
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #5697

Two code paths were ignoring the `skills.allow_scripts = true` config setting, causing skills with script files (.sh) to always be blocked regardless of configuration.

## Changes

- **`ReadSkillTool`**: Was calling `load_skills_with_open_skills_settings()` which passed `None` for `allow_scripts` (defaulting to `false`). Now calls `load_skills_with_open_skills_config()` directly with the config value.
- **`DelegateTool`**: `build_enriched_system_prompt()` hardcoded `allow_scripts = false` when loading skills. Added an `allow_scripts` field and `with_allow_scripts()` builder method to propagate the config value.

## Root cause

Both `ReadSkillTool` (used by the `read_skill` tool in compact skills mode) and `DelegateTool` (used for sub-agent skill loading) had their own skill loading paths that bypassed the central `load_skills_with_config()` function, hardcoding `allow_scripts = false` instead of reading from the user's config.

## Testing

- Existing unit tests for `ReadSkillTool` updated to pass the new parameter
- The existing `audit_allows_shell_script_files_when_enabled` test in `audit.rs` confirms the audit layer correctly respects `allow_scripts = true`