### PR TITLE
fix(security): block dangerous interpreter arguments in command policy

### DIFF
--- a/src/security/policy.rs
+++ b/src/security/policy.rs
@@ -1254,6 +1254,30 @@ impl SecurityPolicy {
                         || arg == "-c"
                 })
             }
+            "python" | "python3" => {
+                // -c executes arbitrary Python code, -m runs arbitrary modules
+                !args.iter().any(|arg| arg == "-c" || arg == "-m")
+            }
+            "node" => {
+                // -e / --eval evaluate arbitrary JS, --input-type enables code eval
+                !args.iter().any(|arg| {
+                    arg == "-e" || arg == "--eval" || arg == "--input-type"
+                })
+            }
+            "pip" | "pip3" => {
+                // install/download run arbitrary setup.py / pyproject.toml
+                !args.iter().any(|arg| arg == "install" || arg == "download")
+            }
+            "npm" => {
+                // exec/run/start execute arbitrary scripts or packages
+                !args.iter().any(|arg| {
+                    arg == "exec" || arg == "run" || arg == "start"
+                })
+            }
+            "cargo" => {
+                // install runs arbitrary build.rs, run executes project binaries
+                !args.iter().any(|arg| arg == "install" || arg == "run")
+            }
             _ => true,
         }
     }
@@ -2543,6 +2567,36 @@ mod tests {
         assert!(p.is_command_allowed("find . -name '*.txt'"));
         assert!(p.is_command_allowed("git status"));
         assert!(p.is_command_allowed("git add ."));
+    }
+
+    #[test]
+    fn interpreter_argument_injection_blocked() {
+        let p = default_policy();
+        // python/python3 -c executes arbitrary code
+        assert!(!p.is_command_allowed("python3 -c 'import os; os.system(\"id\")'"));
+        assert!(!p.is_command_allowed("python -c 'print(1)'"));
+        // python -m runs arbitrary modules
+        assert!(!p.is_command_allowed("python3 -m http.server"));
+        // node -e/--eval evaluates arbitrary JS
+        assert!(!p.is_command_allowed("node -e 'require(\"child_process\").execSync(\"id\")'"));
+        assert!(!p.is_command_allowed("node --eval 'process.exit(1)'"));
+        // pip install/download runs arbitrary setup.py
+        assert!(!p.is_command_allowed("pip install evil-package"));
+        assert!(!p.is_command_allowed("pip3 download malicious-package"));
+        // npm exec/run/start execute arbitrary scripts
+        assert!(!p.is_command_allowed("npm exec -- malicious-package"));
+        assert!(!p.is_command_allowed("npm run evil-script"));
+        assert!(!p.is_command_allowed("npm start"));
+        // cargo install/run executes arbitrary build.rs / binaries
+        assert!(!p.is_command_allowed("cargo install malicious-crate"));
+        assert!(!p.is_command_allowed("cargo run"));
+        // Legitimate uses should still work
+        assert!(p.is_command_allowed("python3 script.py"));
+        assert!(p.is_command_allowed("node server.js"));
+        assert!(p.is_command_allowed("pip list"));
+        assert!(p.is_command_allowed("npm ls"));
+        assert!(p.is_command_allowed("cargo build"));
+        assert!(p.is_command_allowed("cargo test"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #5698

The `is_args_safe()` function in the security policy only checked `find` and `git` for dangerous arguments. All other default-allowlisted interpreters (python3, node, pip, npm, cargo) passed arguments unchecked, allowing arbitrary code execution via their `-c`, `-e`, `install`, etc. flags.

## Changes

Extended `is_args_safe()` match arms to block dangerous arguments for:

| Command | Blocked args | Risk |
|---------|-------------|------|
| `python`/`python3` | `-c`, `-m` | Arbitrary code/module execution |
| `node` | `-e`, `--eval`, `--input-type` | JavaScript code evaluation |
| `pip`/`pip3` | `install`, `download` | Arbitrary setup.py execution |
| `npm` | `exec`, `run`, `start` | Arbitrary script execution |
| `cargo` | `install`, `run` | Arbitrary build.rs execution |

Legitimate uses (`python3 script.py`, `node server.js`, `pip list`, `npm ls`, `cargo build`, etc.) continue to work.

## Testing

- Added `interpreter_argument_injection_blocked` test covering all new checks and verifying legitimate uses still pass
- Existing `command_argument_injection_blocked` test unchanged

## Security impact

This closes a **S0 security vulnerability** where any LLM agent under the default security policy could execute arbitrary system commands via allowlisted interpreters (e.g., `python3 -c 'import os; os.system("rm -rf /")'`).