### PR TITLE
perf(deps): tier channels into core (default) and extended (opt-in)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12213,7 +12213,6 @@ version = "0.6.9"
 dependencies = [
  "aardvark-sys",
  "anyhow",
- "async-imap",
  "async-trait",
  "axum",
  "base64 0.22.1",
@@ -12239,10 +12238,8 @@ dependencies = [
  "hyper-util",
  "image",
  "indicatif",
- "lettre",
  "libc",
  "lru",
- "mail-parser",
  "mime_guess",
  "nanohtml2text",
  "nostr-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,11 +197,6 @@ rustls-pki-types = { version = "1.14.0", optional = true }
 tokio-rustls = { version = "0.26.4", optional = true }
 webpki-roots = { version = "1.0.6", optional = true }
 
-# email
-lettre = { version = "0.11.19", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"], optional = true }
-mail-parser = { version = "0.11.2", optional = true }
-async-imap = { version = "0.11", features = ["runtime-tokio"], default-features = false, optional = true }
-
 # HTTP server (gateway) — replaces raw TCP for proper HTTP/1.1 compliance
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio", "query", "ws", "macros"], optional = true }
 hyper = { version = "1", features = ["http1", "server"], optional = true }
@@ -233,6 +228,7 @@ default = [
 
 # The full agent runtime — agent loop, channels, tools, gateway, TUI, all subsystems.
 # Without this, you get the kernel: config + providers + memory + CLI chat.
+# Heavy-dep channels (email, telegram, lark) are in channels-extended, not here.
 agent-runtime = [
     "dep:zeroclaw-runtime", "dep:zeroclaw-channels", "dep:zeroclaw-tools",
     "dep:rusqlite",
@@ -240,11 +236,9 @@ agent-runtime = [
     "dep:ratatui", "dep:crossterm",
     "dep:tokio-tungstenite", "dep:tokio-socks", "dep:hostname",
     "dep:rustls", "dep:rustls-pemfile", "dep:rustls-pki-types", "dep:tokio-rustls", "dep:webpki-roots",
-    "dep:lettre", "dep:mail-parser", "dep:async-imap",
     "dep:axum", "dep:hyper", "dep:hyper-util", "dep:tower", "dep:tower-http", "dep:http-body-util",
     "dep:mime_guess",
     "gateway", "tui-onboarding",
-    "channel-email", "channel-telegram", "channel-lark",
     "channel-discord", "channel-slack", "channel-signal",
     "channel-mattermost", "channel-irc", "channel-imessage",
     "channel-dingtalk", "channel-qq", "channel-bluesky",
@@ -253,6 +247,12 @@ agent-runtime = [
     "channel-mochat", "channel-wecom", "channel-clawdtalk",
     "channel-webhook", "channel-acp-server", "channel-whatsapp-cloud",
     "channel-voice-call",
+]
+
+# Channels that pull in heavy optional dependencies (image codecs, protobuf,
+# email stack). Enable individually or use this meta-feature.
+channels-extended = [
+    "channel-email", "channel-telegram", "channel-lark",
 ]
 
 # Major subsystems — each forwards to exactly ONE crate
@@ -312,7 +312,7 @@ metrics = ["observability-prometheus"]
 
 # CI meta-feature
 ci-all = [
-    "agent-runtime",
+    "agent-runtime", "channels-extended",
     "channel-nostr", "channel-matrix", "whatsapp-web",
     "observability-prometheus", "observability-otel",
     "hardware", "peripheral-rpi",

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -3,11 +3,14 @@ mod agent_robustness;
 mod backup_cron_scheduling;
 mod channel_matrix;
 mod channel_routing;
+#[cfg(feature = "channel-email")]
 mod email_attachments;
 mod hooks;
 mod memory_comparison;
 mod memory_loop_continuity;
 mod memory_restart;
 mod report_template_tool_test;
+#[cfg(feature = "channel-telegram")]
 mod telegram_attachment_fallback;
+#[cfg(feature = "channel-telegram")]
 mod telegram_finalize_draft;


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- **Problem:** The `agent-runtime` default feature compiled all 28 channels including three with heavy optional dependencies (email → lettre/imap, telegram → image codecs, lark → protobuf), slowing default builds.
- **What changed:**
  - Moved `channel-email`, `channel-telegram`, `channel-lark` out of `agent-runtime` default
  - Created new `channels-extended` meta-feature for all heavy-dep channels
  - Added `channels-extended` to `ci-all` for full CI coverage
  - Removed phantom `lettre`, `mail-parser`, `async-imap` deps from root `Cargo.toml`
  - Feature-gated telegram and email integration tests
- **What did NOT change:** All 21 lightweight channels remain in default. Config format, CLI unchanged. Channels still available via `--features channel-telegram` or `--features channels-extended`.

### Feature structure after this PR

```
default = ["agent-runtime", ...]

agent-runtime = [
    ... 21 lightweight channels (no extra deps) ...
    gateway, tui-onboarding
]

channels-extended = [
    "channel-email",     # lettre, mail-parser, async-imap
    "channel-telegram",  # image (jpeg/png codecs)
    "channel-lark",      # prost (protobuf)
]

ci-all = ["agent-runtime", "channels-extended", ...]
```

## Label Snapshot (required)

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `channel`, `dependencies`
- Change type: `refactor`
- Primary scope: `channel`

## Validation Evidence (required)

```bash
cargo check                           # clean
cargo check --no-default-features     # clean
cargo check --features channels-extended  # clean
cargo clippy --all-targets -- -D warnings # clean
cargo test --workspace                # all passing
```

Binary size (default features): 13,323,664 → 13,239,904 bytes (~82KB reduction).
Main benefit: faster default compiles — no image codecs, protobuf, or email stack.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Partially — default build no longer includes email/telegram/lark channels
- Config/env changes? No
- Migration needed? Users relying on email, telegram, or lark channels need to add `--features channels-extended` or the individual channel feature

## Human Verification (required)

- Verified: default build compiles and runs without extended channels
- Verified: `channels-extended` feature enables all three heavy channels
- Verified: `ci-all` includes `channels-extended`
- Verified: integration tests gated correctly

## Rollback Plan (required)

- Fast rollback: `git revert <merge-commit>`
- Observable failure: email/telegram/lark channels unavailable in default builds

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)