### PR TITLE
ci(build): add binary size check to PR CI

### DIFF
--- a/.github/workflows/ci-run.yml
+++ b/.github/workflows/ci-run.yml
@@ -151,6 +151,15 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: clang
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
 
+      - name: Check binary size
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          BIN="target/${{ matrix.target }}/ci/zeroclaw"
+          if [ -f "$BIN" ]; then
+            bash scripts/ci/check_binary_size.sh "$BIN" "${{ matrix.target }}"
+          fi
+
   check-all-features:
     name: Check (all features)
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a binary size check step after every CI build that runs `scripts/ci/check_binary_size.sh`
- Enforces the 20MB hard limit and surfaces advisory (>15MB) and target (>5MB) warnings directly in PR checks
- Skipped on Windows where the binary name differs

Part of the binary size optimization initiative (PRs #5707, #5708, #5711, #5714).

## Test plan
- [ ] CI pipeline runs successfully on this PR
- [ ] Binary size step appears in build job output for Linux and macOS targets
- [ ] Step is correctly skipped on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)