### PR TITLE
feat(providers): add streaming support to OpenRouterProvider

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1132,7 +1132,7 @@ fn sse_bytes_to_chunks(
 }
 
 /// Convert SSE byte stream to structured streaming events.
-fn sse_bytes_to_events(
+pub(crate) fn sse_bytes_to_events(
     response: reqwest::Response,
     count_tokens: bool,
 ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -1,9 +1,13 @@
+use crate::compatible::sse_bytes_to_events;
 use crate::multimodal;
 use crate::traits::{
     ChatMessage, ChatRequest as ProviderChatRequest, ChatResponse as ProviderChatResponse,
-    Provider, ProviderCapabilities, TokenUsage, ToolCall as ProviderToolCall,
+    Provider, ProviderCapabilities, StreamError, StreamEvent, StreamOptions, StreamResult,
+    TokenUsage, ToolCall as ProviderToolCall,
 };
 use async_trait::async_trait;
+use futures_util::StreamExt as _;
+use futures_util::stream;
 use reqwest::Client;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -78,6 +82,8 @@ struct NativeChatRequest {
     tool_choice: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stream: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -508,6 +514,7 @@ impl Provider for OpenRouterProvider {
             tool_choice: tools.as_ref().map(|_| "auto".to_string()),
             tools,
             max_tokens: self.max_tokens,
+            stream: None,
         };
 
         let response = self
@@ -545,6 +552,104 @@ impl Provider for OpenRouterProvider {
 
     fn supports_native_tools(&self) -> bool {
         true
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn supports_streaming_tool_events(&self) -> bool {
+        true
+    }
+
+    fn stream_chat(
+        &self,
+        request: ProviderChatRequest<'_>,
+        model: &str,
+        temperature: f64,
+        options: StreamOptions,
+    ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+        if !options.enabled {
+            return stream::once(async { Ok(StreamEvent::Final) }).boxed();
+        }
+
+        let credential = match self.credential.as_ref() {
+            Some(c) => c.clone(),
+            None => {
+                return stream::once(async {
+                    Err(StreamError::Provider(
+                        "OpenRouter API key not set. Run `zeroclaw onboard` or set OPENROUTER_API_KEY env var.".to_string(),
+                    ))
+                })
+                .boxed();
+            }
+        };
+
+        let tools = Self::convert_tools(request.tools);
+        let native_request = NativeChatRequest {
+            model: model.to_string(),
+            messages: Self::convert_messages(request.messages),
+            temperature,
+            tool_choice: tools.as_ref().map(|_| "auto".to_string()),
+            tools,
+            max_tokens: self.max_tokens,
+            stream: Some(true),
+        };
+
+        let payload = match serde_json::to_value(&native_request) {
+            Ok(v) => v,
+            Err(e) => {
+                return stream::once(async move { Err(StreamError::Json(e)) }).boxed();
+            }
+        };
+
+        let client = self.http_client();
+        let count_tokens = options.count_tokens;
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(100);
+
+        tokio::spawn(async move {
+            let response = match client
+                .post("https://openrouter.ai/api/v1/chat/completions")
+                .header("Authorization", format!("Bearer {credential}"))
+                .header("HTTP-Referer", "https://github.com/zeroclaw-labs/zeroclaw")
+                .header("X-Title", "ZeroClaw")
+                .header("Accept", "text/event-stream")
+                .json(&payload)
+                .send()
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    let _ = tx.send(Err(StreamError::Http(e.to_string()))).await;
+                    return;
+                }
+            };
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let error = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| format!("HTTP error: {status}"));
+                let _ = tx
+                    .send(Err(StreamError::Provider(format!("{status}: {error}"))))
+                    .await;
+                return;
+            }
+
+            let mut event_stream = sse_bytes_to_events(response, count_tokens);
+            while let Some(event) = event_stream.next().await {
+                if tx.send(event).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|event| (event, rx))
+        })
+        .boxed()
     }
 
     async fn chat_with_tools(
@@ -599,6 +704,7 @@ impl Provider for OpenRouterProvider {
             tool_choice: native_tools.as_ref().map(|_| "auto".to_string()),
             tools: native_tools,
             max_tokens: self.max_tokens,
+            stream: None,
         };
 
         let response = self
@@ -656,6 +762,118 @@ mod tests {
         let caps = <OpenRouterProvider as Provider>::capabilities(&provider);
         assert!(caps.native_tool_calling);
         assert!(caps.vision);
+    }
+
+    #[test]
+    fn supports_streaming_returns_true() {
+        let provider = OpenRouterProvider::new(Some("openrouter-test-credential"), None);
+        assert!(provider.supports_streaming());
+    }
+
+    #[test]
+    fn supports_streaming_tool_events_returns_true() {
+        let provider = OpenRouterProvider::new(Some("openrouter-test-credential"), None);
+        assert!(provider.supports_streaming_tool_events());
+    }
+
+    #[tokio::test]
+    async fn stream_chat_without_key_returns_error_event() {
+        use crate::traits::{ChatMessage, ChatRequest};
+        use futures_util::StreamExt as _;
+
+        let provider = OpenRouterProvider::new(None, None);
+        let messages = vec![ChatMessage {
+            role: "user".into(),
+            content: "hello".into(),
+        }];
+        let request = ChatRequest {
+            messages: &messages,
+            tools: None,
+        };
+
+        let mut stream = provider.stream_chat(
+            request,
+            "anthropic/claude-haiku-4-5",
+            0.0,
+            crate::traits::StreamOptions {
+                enabled: true,
+                count_tokens: false,
+            },
+        );
+
+        let first = stream
+            .next()
+            .await
+            .expect("stream should yield at least one event");
+        assert!(first.is_err(), "expected error without API key");
+        let err = first.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("API key not set"),
+            "error should mention API key: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_chat_disabled_options_returns_final() {
+        use crate::traits::{ChatMessage, ChatRequest, StreamEvent};
+        use futures_util::StreamExt as _;
+
+        let provider = OpenRouterProvider::new(Some("key"), None);
+        let messages = vec![ChatMessage {
+            role: "user".into(),
+            content: "hello".into(),
+        }];
+        let request = ChatRequest {
+            messages: &messages,
+            tools: None,
+        };
+
+        let mut stream = provider.stream_chat(
+            request,
+            "anthropic/claude-haiku-4-5",
+            0.0,
+            crate::traits::StreamOptions {
+                enabled: false,
+                count_tokens: false,
+            },
+        );
+
+        let first = stream
+            .next()
+            .await
+            .expect("stream should yield Final immediately");
+        assert!(matches!(first, Ok(StreamEvent::Final)));
+    }
+
+    #[test]
+    fn native_chat_request_serializes_stream_true() {
+        let req = NativeChatRequest {
+            model: "anthropic/claude-haiku-4-5".into(),
+            messages: vec![],
+            temperature: 0.0,
+            tools: None,
+            tool_choice: None,
+            max_tokens: None,
+            stream: Some(true),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("\"stream\":true"));
+    }
+
+    #[test]
+    fn native_chat_request_omits_stream_when_none() {
+        let req = NativeChatRequest {
+            model: "anthropic/claude-haiku-4-5".into(),
+            messages: vec![],
+            temperature: 0.0,
+            tools: None,
+            tool_choice: None,
+            max_tokens: None,
+            stream: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(!json.contains("stream"));
     }
 
     #[test]


### PR DESCRIPTION
Split https://github.com/zeroclaw-labs/zeroclaw/pull/5667


Implements `stream_chat`, `supports_streaming`, and `supports_streaming_tool_events` on `OpenRouterProvider` using the shared `sse_bytes_to_events` helper (now `pub(crate)`). Adds `stream: Option<bool>` to
  `NativeChatRequest` and covers the new paths with unit tests.

  ## Summary

  - Base branch target: `master`
  - Problem: `OpenRouterProvider` did not implement the streaming interface — `supports_streaming()` returned the trait default (`false`) and `stream_chat()` was a no-op, so OpenRouter could never deliver
  progressive responses.
  - Why it matters: Streaming is the primary UX path for long responses; without it, users on OpenRouter see nothing until the full reply is ready.
  - What changed: `stream_chat` sends `stream: true` to the OpenRouter `/chat/completions` endpoint, pipes the SSE response through the existing `sse_bytes_to_events` parser, and forwards events over a bounded
  `mpsc` channel as a `BoxStream`. `sse_bytes_to_events` in `compatible.rs` is promoted from `fn` to `pub(crate)` to enable this reuse. `NativeChatRequest` gains an optional `stream` field that is omitted from JSON
  when `None`.
  - What did **not** change: The non-streaming `chat` and `chat_with_tools` paths are untouched. No public crate API changed. No other provider was modified.

  ## Label Snapshot (required)

  - Risk label: `risk: low`
  - Size label: `size: M`
  - Scope labels: `provider`
  - Module labels: `provider: openrouter`                                                                                                                                                                              
  - Contributor tier label: *(auto-managed)*
  - If any auto-label is incorrect, note requested correction: N/A                                                                                                                                                     
                                                                                                                                                                                                                       
  ## Change Metadata
                                                                                                                                                                                                                       
  - Change type: `feature`
  - Primary scope: `provider`
                                                                                                                                                                                                                       
  ## Linked Issue
                                                                                                                                                                                                                       
  - Closes #      
  - Related #
  - Depends on #
  - Supersedes #

  ## Supersede Attribution (required when `Supersedes #` is used)

  N/A                                                                                                                                                                                                                  
   
  ## Validation Evidence (required)                                                                                                                                                                                    
                  
  ```bash
  cargo fmt --all -- --check
  cargo clippy --all-targets -- -D warnings
  cargo test -p zeroclaw-providers
```
                                                                                                                                                                                                                       
  - Evidence provided: 6 new unit tests pass without network access — supports_streaming_returns_true, supports_streaming_tool_events_returns_true, stream_chat_without_key_returns_error_event,                       
  stream_chat_disabled_options_returns_final, native_chat_request_serializes_stream_true, native_chat_request_omits_stream_when_none.                                                                                  
  - If any command is intentionally skipped: live SSE integration test skipped (requires a valid OpenRouter API key); covered by the error-path unit test instead.                                                     
                                                                                                                                                                                                                       
  Security Impact (required)
                                                                                                                                                                                                                       
  - New permissions/capabilities? No                                                                                                                                                                                   
  - New external network calls? Yes — stream_chat opens an SSE connection to https://openrouter.ai/api/v1/chat/completions. This is the same endpoint already used by the non-streaming chat path; no new host is
  introduced.                                                                                                                                                                                                          
  - Secrets/tokens handling changed? No — the API key is read from self.credential identically to the existing path.
  - File system access scope changed? No                                                                                                                                                                               
  - If any Yes, describe risk and mitigation: The SSE connection is long-lived for the duration of a streamed reply. The mpsc channel is bounded (capacity 100) so a slow consumer cannot cause unbounded memory
  growth. The tokio::spawn task exits when the channel receiver is dropped.                                                                                                                                            
                  
  Privacy and Data Hygiene (required)                                                                                                                                                                                  
                  
  - Data-hygiene status: pass
  - Redaction/anonymization notes: No user content is logged. The spawned task logs nothing.
  - Neutral wording confirmation: Yes — no identity-like wording introduced.                                                                                                                                           
                                                                                                                                                                                                                       
  Compatibility / Migration                                                                                                                                                                                            
                                                                                                                                                                                                                       
  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  i18n Follow-Through (required when docs or user-facing wording changes)

  - i18n follow-through triggered? No — no user-facing strings or docs changed.                                                                                                                                        
   
  Human Verification (required)                                                                                                                                                                                        
                  
  - Verified scenarios: stream_chat with options.enabled = false returns StreamEvent::Final immediately; stream_chat without a credential returns StreamError::Provider as the first event; NativeChatRequest omits    
  stream from JSON when None and serializes "stream":true when Some(true).
  - Edge cases checked: missing API key, disabled streaming options, JSON serialization of the new field.                                                                                                              
  - What was not verified: live round-trip against the OpenRouter API with a real key and a model that supports SSE tool events.                                                                                       
                                                                                                                                                                                                                       
  Side Effects / Blast Radius (required)                                                                                                                                                                               
                                                                                                                                                                                                                       
  - Affected subsystems/workflows: zeroclaw-providers crate only. Any caller that dispatches to OpenRouterProvider via the Provider trait will now receive streaming events when stream_chat is invoked.               
  - Potential unintended effects: The pub(crate) promotion of sse_bytes_to_events makes it accessible to future providers within the crate — this is intentional but widens internal surface.
  - Guardrails/monitoring for early detection: Existing provider-level error handling surfaces StreamError to the runtime; no new silent failure paths.                                                                
                                                                                                                                                                                                                       
  Agent Collaboration Notes (recommended)                                                                                                                                                                              
                                                                                                                                                                                                                       
  - Agent tools used: None
  - Workflow/plan summary: N/A
  - Verification focus: Correct stream: None on non-streaming paths to avoid accidentally enabling SSE on chat/chat_with_tools.                                                                                        
  - Confirmation: naming + architecture boundaries followed per AGENTS.md + CONTRIBUTING.md: Yes                                                                                                                       
                                                                                                                                                                                                                       
  Rollback Plan (required)                                                                                                                                                                                             
                  
  - Fast rollback command/path: revert this PR; no migration or data change to undo.                                                                                                                                   
  - Feature flags or config toggles: StreamOptions::enabled = false disables the streaming path at call-site without a code change.
  - Observable failure symptoms: provider returns StreamError::Http or StreamError::Provider events; runtime logs will surface these as warnings.                                                                      
                                                                                                                                                                                                                       
  Risks and Mitigations                                                                                                                                                                                                
                                                                                                                                                                                                                       
  - Risk: OpenRouter SSE responses may differ slightly from the OpenAI-compatible format assumed by sse_bytes_to_events (e.g. non-standard data: fields or missing [DONE] sentinel).                                   
    - Mitigation: sse_bytes_to_events already handles malformed chunks gracefully (skips unknown fields, emits StreamEvent::Final on [DONE]). Any parsing failures surface as StreamError events rather than panics.
