### PR TITLE
fix(security): runtime.kind=native no longer auto-selects Docker sandbox

### DIFF
--- a/src/security/detect.rs
+++ b/src/security/detect.rs
@@ -4,8 +4,13 @@ use crate::config::{SandboxBackend, SecurityConfig};
 use crate::security::traits::Sandbox;
 use std::sync::Arc;
 
-/// Create a sandbox based on auto-detection or explicit config
-pub fn create_sandbox(config: &SecurityConfig) -> Arc<dyn Sandbox> {
+/// Create a sandbox based on auto-detection or explicit config.
+///
+/// `runtime_kind` is the `runtime.kind` string from the top-level config
+/// (e.g. `"native"`, `"docker"`).  When the caller has set `runtime.kind =
+/// "native"`, Docker must never be selected as the sandbox backend during
+/// auto-detection — the user explicitly opted out of container wrapping.
+pub fn create_sandbox(config: &SecurityConfig, runtime_kind: &str) -> Arc<dyn Sandbox> {
     let backend = &config.sandbox.backend;
 
     // If explicitly disabled, return noop
@@ -77,14 +82,19 @@ pub fn create_sandbox(config: &SecurityConfig) -> Arc<dyn Sandbox> {
             Arc::new(super::traits::NoopSandbox)
         }
         SandboxBackend::Auto | SandboxBackend::None => {
-            // Auto-detect best available
-            detect_best_sandbox()
+            // Auto-detect best available, skipping Docker when native runtime is in use
+            detect_best_sandbox(runtime_kind)
         }
     }
 }
 
-/// Auto-detect the best available sandbox
-fn detect_best_sandbox() -> Arc<dyn Sandbox> {
+/// Auto-detect the best available sandbox.
+///
+/// When `runtime_kind` is `"native"` the caller has explicitly opted out of
+/// container wrapping, so Docker is excluded from consideration even if it is
+/// installed on the host.
+fn detect_best_sandbox(runtime_kind: &str) -> Arc<dyn Sandbox> {
+    let skip_docker = runtime_kind == "native";
     #[cfg(target_os = "linux")]
     {
         // Try Landlock first (native, no dependencies)
@@ -121,10 +131,19 @@ fn detect_best_sandbox() -> Arc<dyn Sandbox> {
         }
     }
 
-    // Docker is heavy but works everywhere if docker is installed
-    if let Ok(sandbox) = super::docker::DockerSandbox::probe() {
-        tracing::info!("Docker sandbox enabled");
-        return Arc::new(sandbox);
+    // Docker is heavy but works everywhere if docker is installed.
+    // Skip it when runtime.kind = "native" — the user explicitly opted out of
+    // container wrapping, and forcing Docker would break Python skills (Alpine
+    // has no python3) and workspace access on resource-constrained hosts.
+    if !skip_docker {
+        if let Ok(sandbox) = super::docker::DockerSandbox::probe() {
+            tracing::info!("Docker sandbox enabled");
+            return Arc::new(sandbox);
+        }
+    } else {
+        tracing::debug!(
+            "Docker sandbox skipped: runtime.kind = \"native\" overrides auto-detection"
+        );
     }
 
     // Fallback: application-layer security only
@@ -139,7 +158,7 @@ mod tests {
 
     #[test]
     fn detect_best_sandbox_returns_something() {
-        let sandbox = detect_best_sandbox();
+        let sandbox = detect_best_sandbox("");
         // Should always return at least NoopSandbox
         assert!(sandbox.is_available());
     }
@@ -154,7 +173,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let sandbox = create_sandbox(&config);
+        let sandbox = create_sandbox(&config, "");
         assert_eq!(sandbox.name(), "none");
     }
 
@@ -168,8 +187,49 @@ mod tests {
             },
             ..Default::default()
         };
-        let sandbox = create_sandbox(&config);
+        let sandbox = create_sandbox(&config, "");
         // Should return some sandbox (at least NoopSandbox)
         assert!(sandbox.is_available());
+    }
+
+    #[test]
+    fn native_runtime_with_auto_sandbox_never_selects_docker() {
+        // When runtime.kind = "native", Docker must be skipped in auto-detection
+        // even when Docker is installed on the host.  The sandbox must be
+        // either a native OS sandbox (Landlock/Firejail/Seatbelt) or NoopSandbox.
+        let config = SecurityConfig {
+            sandbox: SandboxConfig {
+                enabled: None,
+                backend: SandboxBackend::Auto,
+                firejail_args: Vec::new(),
+            },
+            ..Default::default()
+        };
+        let sandbox = create_sandbox(&config, "native");
+        assert_ne!(
+            sandbox.name(),
+            "docker",
+            "runtime.kind='native' must not select Docker sandbox during auto-detection"
+        );
+        // Whatever was selected, it must be functional (or noop)
+        assert!(sandbox.is_available());
+    }
+
+    #[test]
+    fn explicit_docker_backend_is_not_blocked_by_native_runtime() {
+        // If the user *explicitly* sets security.sandbox.backend = "docker",
+        // respect that even when runtime.kind = "native".  The native-runtime
+        // exclusion only applies to auto-detection.
+        let config = SecurityConfig {
+            sandbox: SandboxConfig {
+                enabled: None,
+                backend: SandboxBackend::Docker,
+                firejail_args: Vec::new(),
+            },
+            ..Default::default()
+        };
+        // This must not panic.  If Docker is unavailable it falls back to noop,
+        // but the important thing is that the explicit request is honoured.
+        let _sandbox = create_sandbox(&config, "native");
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -408,7 +408,7 @@ pub fn all_tools_with_runtime(
     Option<ChannelMapHandle>,
 ) {
     let has_shell_access = runtime.has_shell_access();
-    let sandbox = create_sandbox(&root_config.security);
+    let sandbox = create_sandbox(&root_config.security, runtime.name());
     let mut tool_arcs: Vec<Arc<dyn Tool>> = vec![
         Arc::new(RateLimitedTool::new(
             PathGuardedTool::new(


### PR DESCRIPTION
## Problem

When `security.sandbox.backend = "auto"` (the default), the auto-detection path selected Docker as the sandbox backend if Docker was installed — regardless of `runtime.kind`.

Users who set `runtime.kind = "native"` to avoid container overhead still had all shell commands wrapped in `docker run alpine:latest`, causing:

- **Broken Python skills**: Alpine has no `python3`
- **No workspace access**: no volume mount in the container
- **High latency**: Docker startup overhead on every shell command; severe on Raspberry Pi-class hosts

The user expectation is clear: `runtime.kind = "native"` means *run natively — no containers*.

## Fix

**`src/security/detect.rs`**
- `create_sandbox` now accepts `runtime_kind: &str` alongside `SecurityConfig`
- `detect_best_sandbox` skips Docker in auto-detection when `runtime_kind == "native"`
- Explicit `security.sandbox.backend = "docker"` is still honoured even when `runtime.kind = "native"` — the guard only affects auto-detection
- Added debug log when Docker is intentionally skipped

**`src/tools/mod.rs`**
- Updated `create_sandbox` call to pass `runtime.name()` (already available at the call site)

## New tests

| Test | What it verifies |
|------|-----------------|
| `native_runtime_with_auto_sandbox_never_selects_docker` | Docker is not chosen when `runtime.kind = "native"` and backend is `auto` |
| `explicit_docker_backend_is_not_blocked_by_native_runtime` | Explicit `backend = "docker"` still works; the guard is auto-detection only |

```
cargo test --lib -- security::detect::tests
# 5 passed; 0 failed
```

Closes #5719

🤖 Generated with [Claude Code](https://claude.com/claude-code)