### PR TITLE
feat(ci): add musl/Alpine Linux builds to release and cross-platform workflows

### DIFF
--- a/.github/workflows/cross-platform-build-manual.yml
+++ b/.github/workflows/cross-platform-build-manual.yml
@@ -49,6 +49,12 @@ jobs:
             cross_compiler: gcc-arm-linux-gnueabihf
             linker_env: CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER
             linker: arm-linux-gnueabihf-gcc
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            musl: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            cross: true
           - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: windows-latest
@@ -73,10 +79,24 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y ${{ matrix.cross_compiler }}
 
+      - name: Install musl tools
+        if: matrix.musl
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y musl-tools
+
+      - name: Install cross
+        if: matrix.cross
+        uses: taiki-e/install-action@64e57c80700f98e60aa5ef0848d1d9cce31d5ea2 # cross
+
       - name: Build release
         shell: bash
         run: |
           if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
             export "${{ matrix.linker_env }}=${{ matrix.linker }}"
           fi
-          cargo build --release --locked --features channel-matrix,channel-lark --target ${{ matrix.target }}
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --locked --features channel-matrix,channel-lark --target ${{ matrix.target }}
+          else
+            cargo build --release --locked --features channel-matrix,channel-lark --target ${{ matrix.target }}
+          fi

--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -214,6 +214,16 @@ jobs:
             target: x86_64-pc-windows-msvc
             artifact: zeroclaw.exe
             ext: zip
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            artifact: zeroclaw
+            ext: tar.gz
+            musl: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            artifact: zeroclaw
+            ext: tar.gz
+            cross: true
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
@@ -236,6 +246,16 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y ${{ matrix.cross_compiler }}
 
+      - name: Install musl tools
+        if: matrix.musl
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y musl-tools
+
+      - name: Install cross
+        if: matrix.cross
+        uses: taiki-e/install-action@64e57c80700f98e60aa5ef0848d1d9cce31d5ea2 # cross
+
       - name: Setup Android NDK
         if: matrix.ndk
         run: echo "$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin" >> "$GITHUB_PATH"
@@ -246,7 +266,11 @@ jobs:
           if [ -n "${{ matrix.linker_env || '' }}" ] && [ -n "${{ matrix.linker || '' }}" ]; then
             export "${{ matrix.linker_env }}=${{ matrix.linker }}"
           fi
-          cargo build --release --locked --features "${{ env.RELEASE_CARGO_FEATURES }}" --target ${{ matrix.target }}
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            cross build --release --locked --features "${{ env.RELEASE_CARGO_FEATURES }}" --target ${{ matrix.target }}
+          else
+            cargo build --release --locked --features "${{ env.RELEASE_CARGO_FEATURES }}" --target ${{ matrix.target }}
+          fi
 
       - name: Check binary size
         shell: bash

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -227,6 +227,16 @@ jobs:
             target: x86_64-pc-windows-msvc
             artifact: zeroclaw.exe
             ext: zip
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            artifact: zeroclaw
+            ext: tar.gz
+            musl: true
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            artifact: zeroclaw
+            ext: tar.gz
+            cross: true
     continue-on-error: ${{ matrix.experimental || false }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -250,6 +260,16 @@ jobs:
           sudo apt-get update -qq
           sudo apt-get install -y ${{ matrix.cross_compiler }}
 
+      - name: Install musl tools
+        if: matrix.musl
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y musl-tools
+
+      - name: Install cross
+        if: matrix.cross
+        uses: taiki-e/install-action@64e57c80700f98e60aa5ef0848d1d9cce31d5ea2 # cross
+
       - name: Setup Android NDK
         if: matrix.ndk
         run: echo "$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin" >> "$GITHUB_PATH"
@@ -269,10 +289,14 @@ jobs:
           fi
           # Use matrix-level feature override if set, otherwise use global RELEASE_CARGO_FEATURES
           FEATURES="${{ matrix.cargo_features || env.RELEASE_CARGO_FEATURES }}"
+          BUILD_CMD="cargo"
+          if [ "${{ matrix.cross }}" = "true" ]; then
+            BUILD_CMD="cross"
+          fi
           if [ "${{ matrix.skip_prometheus || 'false' }}" = "true" ]; then
-            cargo build --release --locked --no-default-features --features "agent-runtime,schema-export,${FEATURES}" --target ${{ matrix.target }}
+            $BUILD_CMD build --release --locked --no-default-features --features "agent-runtime,schema-export,${FEATURES}" --target ${{ matrix.target }}
           else
-            cargo build --release --locked --features "${FEATURES}" --target ${{ matrix.target }}
+            $BUILD_CMD build --release --locked --features "${FEATURES}" --target ${{ matrix.target }}
           fi
 
       - name: Check binary size

--- a/README.md
+++ b/README.md
@@ -593,12 +593,21 @@ For pre-built binaries, see [GitHub Releases](https://github.com/zeroclaw-labs/z
 
 Release assets are published for:
 
-- Linux: `x86_64`, `aarch64`, `armv7`
+- Linux (glibc): `x86_64`, `aarch64`, `armv7`
+- Linux (musl/Alpine): `x86_64`, `aarch64`
 - macOS: `x86_64`, `aarch64`
 - Windows: `x86_64`
 
 Download the latest assets from:
 <https://github.com/zeroclaw-labs/zeroclaw/releases/latest>
+
+Example (Alpine/musl):
+
+```bash
+curl -fsSLO https://github.com/zeroclaw-labs/zeroclaw/releases/latest/download/zeroclaw-x86_64-unknown-linux-musl.tar.gz
+tar xzf zeroclaw-x86_64-unknown-linux-musl.tar.gz
+install -m 0755 zeroclaw "$HOME/.cargo/bin/zeroclaw"
+```
 
 ## Docs
 


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): master
- Problem:
  - No prebuilt binaries for musl, though usually for small machines you want prebuilt binaries, because they don't necessarily have as much CPU & memory to compile Rust.
- Why it matters:
  - Zeroclaw is lightweight, so it should be able to also run on lightweight musl builds (so I can run it in Alpine)
- What changed:
  - Add x86_64-unknown-linux-musl and aarch64-unknown-linux-musl build targets to beta, stable, and cross-platform release workflows
  - Pin `taiki-e/install-action` to the `cross` tag commit SHA (matches the repo's pinned-action policy)
  - Update README with musl/Alpine platform listing and manual download/install example
- What did **not** change (scope boundary):
  - `install.sh` (this PR does not modify it; Alpine/musl users use the README curl/tar example or build from source until a follow-up wires the installer to musl release assets)
  - No other existing release targets were removed or altered beyond adding musl.

## Label Snapshot (required)

- Risk label (`risk: low|medium|high`): low
- Size label (`size: XS|S|M|L|XL`, auto-managed/read-only): S
- Scope labels: ci, docs
- Module labels: N/A
- Contributor tier label (auto-managed/read-only): N/A (first contribution)
- If any auto-label is incorrect, note requested correction: risk auto-assigned as high (workflow files); accepted.

## Change Metadata

- Change type (`bug|feature|refactor|docs|security|chore`): feature
- Primary scope (`runtime|provider|channel|memory|security|ci|docs|multi`): ci

## Linked Issue

- Closes # N/A
- Related # N/A
- Depends on # N/A
- Supersedes #5660

## Supersede Attribution (required when `Supersedes #` is used)

- Superseded PRs + authors: #5660 by @gregnazario
- Integrated scope by source PR: full scope carried forward; this PR is a direct continuation after rebase
- `Co-authored-by` trailers added for materially incorporated contributors? No
- If `No`, explain why: same author; no external scope incorporated
- Trailer format check: N/A

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided: CI green on all Quality Gate and CI jobs (Apr 17). Workflow YAML syntax validated by the CI lint pass. The musl and cross build jobs themselves are not exercised by the PR CI (they are release-only); correctness is inferred from the pattern matching existing cross-compilation targets already in the matrix.
- If any command is intentionally skipped, explain why: N/A — CI-only change; Rust source is unchanged.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: no personal data in diff; workflow and README changes only
- Neutral wording confirmation: pass

## Compatibility / Migration

- Backward compatible? Yes — existing targets and release artifacts are unchanged
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? Yes — README.md updated with new platform listing and install example
- Locale navigation parity updated? No — deferred to next release per maintainer decision
- Localized runtime-contract docs updated? N/A
- Vietnamese canonical docs synced? N/A
- If any No/N/A: locale README parity for musl platform listing is intentionally deferred; scope-limited to en for this PR

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: YAML structure reviewed against existing matrix entries; `taiki-e/install-action` SHA confirmed against the `cross` tag at time of authoring
- Edge cases checked: `matrix.cross` and `matrix.musl` are falsy when unset — conditional steps do not fire for non-musl targets
- What was not verified: actual musl binary execution on Alpine (release-only job; cannot be triggered in PR CI)

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `release-beta-on-push.yml`, `release-stable-manual.yml`, `cross-platform-build-manual.yml`
- Potential unintended effects: two additional build jobs per release run (~5–8 min each, parallel); release artifact count increases by 2 tarballs per release
- Guardrails/monitoring for early detection: if either musl job fails, the release workflow surfaces it as a failed job; existing `CI Required Gate` is unaffected

## Agent Collaboration Notes (recommended)

- Agent tools used: N/A
- Workflow/plan summary: N/A
- Verification focus: SHA pinning, conditional step correctness, matrix isolation
- Confirmation: naming + architecture boundaries followed: Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-sha>` — changes are confined to three workflow files and README; no data-layer side effects
- Feature flags or config toggles: none; musl targets are unconditionally added to the matrix
- Observable failure symptoms: musl release jobs fail in the next beta/stable run; no impact on existing targets or the main CI gate

## Risks and Mitigations

- Risk: `cross` Docker image used by `cross build` could drift or become unavailable
  - Mitigation: `taiki-e/install-action` is SHA-pinned; `--locked` ensures Cargo.lock is respected inside the cross container
- Risk: musl build produces a binary with unexpected missing symbols if a transitive dep has non-musl-compatible FFI
  - Mitigation: build failure surfaces immediately in the release job; no existing targets are affected

Originally was https://github.com/zeroclaw-labs/zeroclaw/pull/5660