### PR TITLE
fix(agent): deduplicate ToolCall event in turn_streamed

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -1126,12 +1126,8 @@ impl Agent {
                         }
                         zeroclaw_providers::traits::StreamEvent::ToolCall(tc) => {
                             got_stream = true;
-                            let _ = event_tx
-                                .send(TurnEvent::ToolCall {
-                                    name: tc.name.clone(),
-                                    args: serde_json::from_str(&tc.arguments).unwrap_or_default(),
-                                })
-                                .await;
+                            // ToolCall event is sent later (after parse_response) to
+                            // avoid duplicates; just collect here.
                             streamed_tool_calls.push(tc);
                         }
                         zeroclaw_providers::traits::StreamEvent::PreExecutedToolCall {


### PR DESCRIPTION
## Summary

In `turn_streamed`, `TurnEvent::ToolCall` was being emitted **twice** for every tool call:

1. Inside the `StreamEvent::ToolCall` match arm during stream processing
2. Again in the post-`parse_response` loop before tool execution

This caused every `tool_call` SSE event to be sent to clients twice, as shown below:

<img width="1812" height="1842" alt="tool_call_dup" src="https://github.com/user-attachments/assets/70e56557-72dd-4000-b8f4-e98d4eabe36c" />

## Fix

Remove the `event_tx.send(TurnEvent::ToolCall {...})` call from the `StreamEvent::ToolCall` match arm. The post-parse loop already covers both streaming and non-streaming paths, so it is the single, correct place to emit `ToolCall` events.

A brief comment is left at the match arm to explain why the send is intentionally absent there.

## Risk

Low — runtime/agent only; no API boundary changes. Existing test `turn_streamed_passes_tool_specs_to_provider` passes.

## Checklist
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test` passes