### PR TITLE
fix(skills): pass allow_scripts through ReadSkillTool to skill loader

### DIFF
--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -142,12 +142,13 @@ pub fn load_skills_with_open_skills_settings(
     workspace_dir: &Path,
     open_skills_enabled: bool,
     open_skills_dir: Option<&str>,
+    allow_scripts: bool,
 ) -> Vec<Skill> {
     load_skills_with_open_skills_config(
         workspace_dir,
         Some(open_skills_enabled),
         open_skills_dir,
-        None,
+        Some(allow_scripts),
     )
 }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -496,6 +496,7 @@ pub fn all_tools_with_runtime(
             workspace_dir.to_path_buf(),
             root_config.skills.open_skills_enabled,
             root_config.skills.open_skills_dir.clone(),
+            root_config.skills.allow_scripts,
         )));
     }
 

--- a/src/tools/read_skill.rs
+++ b/src/tools/read_skill.rs
@@ -8,6 +8,7 @@ pub struct ReadSkillTool {
     workspace_dir: PathBuf,
     open_skills_enabled: bool,
     open_skills_dir: Option<String>,
+    allow_scripts: bool,
 }
 
 impl ReadSkillTool {
@@ -15,11 +16,13 @@ impl ReadSkillTool {
         workspace_dir: PathBuf,
         open_skills_enabled: bool,
         open_skills_dir: Option<String>,
+        allow_scripts: bool,
     ) -> Self {
         Self {
             workspace_dir,
             open_skills_enabled,
             open_skills_dir,
+            allow_scripts,
         }
     }
 }
@@ -59,6 +62,7 @@ impl Tool for ReadSkillTool {
             &self.workspace_dir,
             self.open_skills_enabled,
             self.open_skills_dir.as_deref(),
+            self.allow_scripts,
         );
 
         let Some(skill) = skills
@@ -118,7 +122,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn make_tool(tmp: &TempDir) -> ReadSkillTool {
-        ReadSkillTool::new(tmp.path().join("workspace"), false, None)
+        ReadSkillTool::new(tmp.path().join("workspace"), false, None, false)
     }
 
     #[tokio::test]


### PR DESCRIPTION
> **Python Skills Enablement — PR 1 of 5**
> This is part of a series fixing bugs that prevent **any** Python-based skill from working on ZeroClaw. PRs 1–4 are independent bug fixes; PR 5 adds a new tool. Together they bring ZeroClaw to parity with OpenClaw for Python skill execution.
> 
> | # | PR | What it unblocks |
> |---|-----|-----------------|
> | **1** | **#5747 (this)** | **`allow_scripts = true` config is actually honoured** |
> | 2 | #5748 | `python3` allowed on Pi; Docker sandbox gets workspace mount |
> | 3 | #5749 | `[skill].prompts` are injected into model context |
> | 4 | #5750 | `runtime.kind = "native"` skips Docker auto-selection |
> | 5 | #5751 | `model_spawn` tool (live switch + parallel ephemeral spawns) |

## Summary

Fixes #5697.

**Impact**: `skills.allow_scripts = true` in config has no effect on ZeroClaw today. Any skill that includes script files is silently blocked, even when the user has explicitly opted in. This affects every user who sets `allow_scripts = true` — not just InvestorClaw.

`ReadSkillTool` was constructed without an `allow_scripts` field, and its `execute()` called `load_skills_with_open_skills_settings` with a hardcoded `None` for `allow_scripts`. That `None` silently became `false` via `unwrap_or(false)` in `load_skills_with_open_skills_config`.

## Why this works on OpenClaw but not ZeroClaw

OpenClaw's Node/TypeScript runtime spawns Python skill scripts via subprocess with no command-allowlist or sandbox layer — `allow_scripts` is handled at a higher level. ZeroClaw's Rust runtime adds security gates (`allow_scripts`, command policy, sandbox detection) that are individually correct but weren't fully wired through `ReadSkillTool`, creating a silent no-op.

## Root cause

Three-step propagation failure:

1. `tools/mod.rs:418` — `ReadSkillTool::new(workspace_dir, open_skills_enabled, open_skills_dir)` — `allow_scripts` from `root_config.skills` never passed
2. `read_skill.rs:58` — `execute()` calls `load_skills_with_open_skills_settings(…)` — no `allow_scripts` param existed
3. `skills/mod.rs:153` — `load_skills_with_open_skills_settings` passed `None` to `load_skills_with_open_skills_config` → `unwrap_or(false)`

## Changes

- `ReadSkillTool`: add `allow_scripts: bool` field; add param to `new()`; thread through to `execute()`
- `load_skills_with_open_skills_settings`: add `allow_scripts: bool` param; forward as `Some(allow_scripts)` instead of `None`
- `tools/mod.rs`: pass `root_config.skills.allow_scripts` at construction site
- Test helper `make_tool`: updated to match new signature (passes `false`, preserving existing test behaviour)

## Testing

All 5 existing `read_skill` and `tools` unit tests pass:
```
test tools::read_skill::tests::reads_toml_skill_manifest_by_name ... ok
test tools::tests::all_tools_excludes_read_skill_in_full_mode ... ok
test tools::tests::all_tools_includes_read_skill_in_compact_mode ... ok
test tools::read_skill::tests::unknown_skill_lists_available_names ... ok
test tools::read_skill::tests::reads_markdown_skill_by_name ... ok
```

Happy to run any additional test scenarios on the target hardware (Raspberry Pi 4, zeroclaw v0.6.9) if that helps the review.

## Context

Found while developing [InvestorClaw](https://github.com/perlowja/InvestorClaw), a FINOS CDM 5.x-inspired portfolio analysis skill originally built for OpenClaw, which works there without issue. These bugs surfaced when porting InvestorClaw to ZeroClaw as a cross-platform exemplar skill. Contributing in a personal capacity, independent of employer.