### PR TITLE
fix(skills): prompts inside [skill] TOML section were silently dropped

### DIFF
--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -66,6 +66,9 @@ struct SkillManifest {
     skill: SkillMeta,
     #[serde(default)]
     tools: Vec<SkillTool>,
+    /// Top-level `prompts` field — supported for backward compatibility.
+    /// Prefer `prompts` inside the `[skill]` section (`SkillMeta.prompts`).
+    /// When both are present they are merged: `[skill].prompts` first, then top-level.
     #[serde(default)]
     prompts: Vec<String>,
 }
@@ -80,6 +83,24 @@ struct SkillMeta {
     author: Option<String>,
     #[serde(default)]
     tags: Vec<String>,
+    /// System-prompt instructions for this skill.
+    ///
+    /// These are injected into the model's system prompt when
+    /// `skills.prompt_injection_mode = "full"` (the default), allowing the
+    /// model to learn which tool to call for each user intent.
+    ///
+    /// **Location in SKILL.toml**: inside the `[skill]` section.
+    ///
+    /// ```toml
+    /// [skill]
+    /// name = "my-skill"
+    /// description = "..."
+    /// prompts = [
+    ///   "When the user asks to run X, call the x_tool tool.",
+    /// ]
+    /// ```
+    #[serde(default)]
+    prompts: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -536,6 +557,13 @@ fn load_skill_toml(path: &Path) -> Result<Skill> {
     let content = std::fs::read_to_string(path)?;
     let manifest: SkillManifest = toml::from_str(&content)?;
 
+    // Merge prompts from both locations: [skill].prompts first (the canonical,
+    // intuitive location), then top-level prompts (legacy/compat).
+    // In practice only one location is used, but merging is harmless and
+    // ensures both forms work.
+    let mut prompts = manifest.skill.prompts;
+    prompts.extend(manifest.prompts);
+
     Ok(Skill {
         name: manifest.skill.name,
         description: manifest.skill.description,
@@ -543,7 +571,7 @@ fn load_skill_toml(path: &Path) -> Result<Skill> {
         author: manifest.skill.author,
         tags: manifest.skill.tags,
         tools: manifest.tools,
-        prompts: manifest.prompts,
+        prompts,
         location: Some(path.to_path_buf()),
     })
 }
@@ -927,7 +955,13 @@ pub fn init_skills_dir(workspace_dir: &Path) -> Result<()> {
              description = \"What this skill does\"\n\
              version = \"0.1.0\"\n\
              author = \"your-name\"\n\
-             tags = [\"productivity\", \"automation\"]\n\n\
+             tags = [\"productivity\", \"automation\"]\n\
+             # prompts are injected into the model system prompt when\n\
+             # prompt_injection_mode = \"full\" (the default).\n\
+             # Use them to teach the agent which tool to call for each command.\n\
+             prompts = [\n\
+               \"When the user asks to run my-skill, call the my_skill.my_tool tool.\",\n\
+             ]\n\n\
              [[tools]]\n\
              name = \"my_tool\"\n\
              description = \"What this tool does\"\n\
@@ -1852,6 +1886,114 @@ description = "Bare minimum"
         assert!(skills[0].author.is_none());
         assert!(skills[0].tags.is_empty());
         assert!(skills[0].tools.is_empty());
+    }
+
+    /// Regression test for #5721: `prompts` inside `[skill]` must be parsed
+    /// and injected into the system prompt in Full mode.
+    ///
+    /// Previously, `prompts` was defined only at the top level of `SkillManifest`,
+    /// so putting it inside `[skill]` (the intuitive location) caused it to be
+    /// silently dropped.
+    #[test]
+    fn toml_skill_prompts_inside_skill_section_are_injected() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("skills/probe");
+        fs::create_dir_all(&skill_dir).unwrap();
+
+        // This is the form users naturally write — prompts inside [skill].
+        fs::write(
+            skill_dir.join("SKILL.toml"),
+            r#"
+[skill]
+name = "probe"
+description = "Test skill"
+prompts = ["If asked about XYZZY_PROBE_STRING, respond YES_FOUND"]
+"#,
+        )
+        .unwrap();
+
+        let skills = load_skills(dir.path());
+        assert_eq!(skills.len(), 1);
+        assert_eq!(
+            skills[0].prompts,
+            vec!["If asked about XYZZY_PROBE_STRING, respond YES_FOUND"],
+            "prompts inside [skill] section must be parsed"
+        );
+
+        // Verify Full-mode system prompt includes the instruction.
+        let prompt = skills_to_prompt(&skills, dir.path());
+        assert!(
+            prompt.contains("XYZZY_PROBE_STRING"),
+            "skill prompt must appear in Full-mode system prompt"
+        );
+        assert!(
+            prompt.contains("<instruction>"),
+            "skill prompt must be wrapped in <instruction> tag"
+        );
+    }
+
+    /// Backward-compat: top-level `prompts` (the old undocumented format)
+    /// must still work and be merged with `[skill].prompts`.
+    #[test]
+    fn toml_skill_top_level_prompts_still_work() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("skills/legacy");
+        fs::create_dir_all(&skill_dir).unwrap();
+
+        // prompts must appear BEFORE [skill] to be parsed as top-level
+        // (in TOML, bare keys after a [table] header belong to that table).
+        fs::write(
+            skill_dir.join("SKILL.toml"),
+            r#"
+prompts = ["top-level instruction"]
+
+[skill]
+name = "legacy"
+description = "Legacy format"
+"#,
+        )
+        .unwrap();
+
+        let skills = load_skills(dir.path());
+        assert_eq!(skills.len(), 1);
+        assert!(
+            skills[0].prompts.contains(&"top-level instruction".to_string()),
+            "top-level prompts must still be parsed for backward compat"
+        );
+    }
+
+    /// Both `[skill].prompts` and top-level `prompts` are independently
+    /// parsed and merged into `Skill.prompts`.  This test uses a TOML file
+    /// where the two fields are at genuinely different levels — no duplicate
+    /// keys — to verify the merge logic.
+    #[test]
+    fn toml_skill_prompts_merge_both_locations() {
+        // Build the skill struct directly (bypassing TOML parsing) to test
+        // the merge logic in load_skill_toml without relying on TOML
+        // duplicate-key behaviour (which is undefined / rejected by the spec).
+        let manifest = SkillManifest {
+            skill: SkillMeta {
+                name: "both".to_string(),
+                description: "Both locations".to_string(),
+                version: "0.1.0".to_string(),
+                author: None,
+                tags: vec![],
+                prompts: vec!["skill-section instruction".to_string()],
+            },
+            tools: vec![],
+            // top-level prompts (legacy location)
+            prompts: vec!["top-level instruction".to_string()],
+        };
+
+        // Replicate the merge logic from load_skill_toml.
+        let mut prompts = manifest.skill.prompts.clone();
+        prompts.extend(manifest.prompts.clone());
+
+        assert_eq!(
+            prompts,
+            vec!["skill-section instruction", "top-level instruction"],
+            "[skill].prompts must come first; top-level prompts appended after"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> **Python Skills Enablement — PR 3 of 5**
> This is part of a series fixing bugs that prevent **any** Python-based skill from working on ZeroClaw. PRs 1–4 are independent bug fixes; PR 5 adds a new tool. Together they bring ZeroClaw to parity with OpenClaw for Python skill execution.
> 
> | # | PR | What it unblocks |
> |---|-----|-----------------|
> | 1 | #5747 | `allow_scripts = true` config is actually honoured |
> | 2 | #5748 | `python3` allowed on Pi; Docker sandbox gets workspace mount |
> | **3** | **#5749 (this)** | **`[skill].prompts` are injected into model context** |
> | 4 | #5750 | `runtime.kind = "native"` skips Docker auto-selection |
> | 5 | #5751 | `model_spawn` tool (live switch + parallel ephemeral spawns) |

## What this unblocks

**Without this fix**: any skill that puts `prompts` inside `[skill]` (the intuitive, documented location) gets zero prompt injection — `prompt_injection_mode = "full"` appears to have no effect. This affects every TOML-based skill on ZeroClaw, not just InvestorClaw.

**With this fix**: both `[skill].prompts` (canonical) and top-level `prompts` (legacy) work. Existing skills are unaffected; new skills can use the intuitive form.

---

## Problem

When a skill manifest placed `prompts` inside the `[skill]` table (the natural location), they were silently discarded. `SkillMeta` had no `prompts` field, so TOML deserialization threw them away before `skills_to_prompt_with_mode` ever saw them.

As a result, `prompt_injection_mode = "full"` never injected skill instructions into the model system prompt, regardless of config. The mode appeared to have no effect.

**Root cause in `src/skills/mod.rs`:**

```toml
# user writes this — intuitive location:
[skill]
name        = "investorclaw"
description = "Portfolio analysis"
prompts     = ["You are a portfolio analyst ..."]  # ← silently dropped

# only this form was actually read:
prompts = ["..."]   # top-level — non-obvious
```

## Fix

- Add `prompts: Vec<String>` to `SkillMeta` (canonical location is now `[skill]`)
- Merge `manifest.skill.prompts` + `manifest.prompts` in `load_skill_toml`; skill-section entries appear first, top-level entries appended for backward compatibility
- Update `init_skills_dir` README template to show the correct form
- Add three regression tests:
  - `toml_skill_prompts_inside_skill_section_are_injected` — main fix
  - `toml_skill_top_level_prompts_still_work` — backward compat
  - `toml_skill_prompts_merge_both_locations` — merge logic

## Testing

```
cargo test --lib -- skills::tests
# 34 passed; 0 failed
```

Closes #5721

---
*Resubmitted from perlowja/zeroclaw#5736 under perlowjanv with review fix:*
- Fixed misleading test: `toml_skill_top_level_prompts_still_work` placed `prompts` after the `[skill]` header, which TOML parses as `[skill].prompts` — not top-level. Moved `prompts` before the header so the test exercises the actual legacy path it claims to test.