### PR TITLE
fix(cargo): cascade observability-prometheus to gateway crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,10 @@ whatsapp-web = ["zeroclaw-channels/whatsapp-web"]
 voice-wake = ["zeroclaw-channels/voice-wake"]
 
 # Backends and platform flags — each forwards to ONE crate
-observability-prometheus = ["zeroclaw-runtime/observability-prometheus"]
+observability-prometheus = [
+    "zeroclaw-runtime/observability-prometheus",
+    "zeroclaw-gateway/observability-prometheus",
+]
 observability-otel = ["zeroclaw-runtime/observability-otel"]
 hardware = ["dep:zeroclaw-hardware", "zeroclaw-hardware/hardware"]
 peripheral-rpi = ["dep:zeroclaw-hardware", "zeroclaw-hardware/peripheral-rpi"]


### PR DESCRIPTION
## Summary

- Base branch target (`master` for all contributions): `master`
- Problem: Workspace `observability-prometheus` feature only forwarded to `zeroclaw-runtime`, leaving the gateway binary compiled without its Prometheus code path. `/metrics` served the `prometheus_disabled_hint()` fallback even when `[observability] backend = "prometheus"` was set in `config.toml`.
- Why it matters: Administrators/SRE cannot scrape metrics from the gateway — observability is silently broken for any user who follows the documented install path.
- What changed: `Cargo.toml` workspace feature now also forwards to `zeroclaw-gateway/observability-prometheus` so the gateway crate is built with its Prometheus exposition handler enabled.
- What did **not** change (scope boundary): No code, no runtime behavior, no config schema, no docs. Same latent issue exists for `observability-otel` and a misconfiguration hint could be improved at `crates/zeroclaw-gateway/src/lib.rs:1188`, but both are left for follow-up PRs to keep this change minimal and focused.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS` (auto-managed)
- Scope labels: `observability, gateway, runtime, dependencies`
- Module labels: `gateway: observability`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `ci` (build/feature wiring; closest match — this is a workspace `Cargo.toml` feature cascade)

## Linked Issue

- Closes #5755
- Related #
- Depends on # (if stacked): N/A
- Supersedes # (if replacing older PR): N/A

## Supersede Attribution (required when `Supersedes #` is used)

N/A — no superseded PR.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo check --features agent-runtime,observability-prometheus,gateway
cargo clippy -p zeroclaw-gateway --features observability-prometheus --all-targets -- -D warnings
```

- Evidence provided: all three commands above pass locally; feature now propagates so `zeroclaw-gateway` compiles its Prometheus handler.
- Issue author confirmed end-to-end reproduction on `9f0de18b` with the same one-line cascade — `/metrics` serves `# HELP zeroclaw_deployment_failure_rate ...` after the fix (see #5755 confirmation).
- If any command is intentionally skipped, explain why: full `cargo test` suite skipped because this is a `Cargo.toml` feature wiring edit with no behavioral or code change; CI will run the full workspace matrix.

## Security Impact (required)

- New permissions/capabilities? `No`
- New external network calls? `No`
- Secrets/tokens handling changed? `No`
- File system access scope changed? `No`
- If any `Yes`, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: None — build-config change only.
- Neutral wording confirmation: ZeroClaw-native wording used throughout.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? `No` — no docs or user-facing wording touched.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: `cargo check` + `cargo clippy` pass with `observability-prometheus` enabled through the workspace feature.
- Edge cases checked: Feature still activates the runtime path (existing wiring preserved); gateway path is now additionally activated.
- What was not verified: End-to-end `/metrics` HTTP scrape not re-run locally in this PR — already reproduced and confirmed by the issue reporter on the same commit.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Only builds that enable `observability-prometheus` (opt-in feature). Default builds unaffected.
- Potential unintended effects: Build time for users enabling this feature will include the gateway's Prometheus code path — negligible.
- Guardrails/monitoring for early detection: `/metrics` endpoint response is the canonical signal; 200 + `# HELP` lines confirms activation.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Claude Code for patch application and PR authoring.
- Workflow/plan summary (if any): Read AGENTS.md → fetched issue #5755 + comments → confirmed gateway crate already exposes the `observability-prometheus` feature gate → applied one-line cascade → `fmt` / `check` / `clippy` locally.
- Verification focus: Workspace feature resolver correctness.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): `Yes`

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-sha>` — single-file revert to the previous 1-line `observability-prometheus = ["zeroclaw-runtime/observability-prometheus"]`.
- Feature flags or config toggles: Feature itself is the toggle; users not opting into `observability-prometheus` are unaffected.
- Observable failure symptoms: If somehow regressed, `/metrics` would again return the `prometheus_disabled_hint()` text.

## Risks and Mitigations

- Risk: None beyond trivially longer compile time for users opting into `observability-prometheus`.
  - Mitigation: Feature is opt-in; default builds untouched.
