### PR TITLE
fix(agents): delegate agents respect skills.prompt_injection_mode config

### DIFF
--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -73,6 +73,8 @@ pub struct DelegateTool {
     cancellation_token: CancellationToken,
     /// Optional memory instance for namespace isolation on delegate agents.
     memory: Option<Arc<dyn Memory>>,
+    /// Skills prompt injection mode inherited from global config.
+    skills_prompt_mode: crate::config::SkillsPromptInjectionMode,
 }
 
 impl DelegateTool {
@@ -107,6 +109,7 @@ impl DelegateTool {
             workspace_dir: PathBuf::new(),
             cancellation_token: CancellationToken::new(),
             memory: None,
+            skills_prompt_mode: crate::config::SkillsPromptInjectionMode::default(),
         }
     }
 
@@ -147,6 +150,7 @@ impl DelegateTool {
             workspace_dir: PathBuf::new(),
             cancellation_token: CancellationToken::new(),
             memory: None,
+            skills_prompt_mode: crate::config::SkillsPromptInjectionMode::default(),
         }
     }
 
@@ -195,6 +199,16 @@ impl DelegateTool {
     /// Attach memory for namespace isolation on delegate agents.
     pub fn with_memory(mut self, memory: Arc<dyn Memory>) -> Self {
         self.memory = Some(memory);
+        self
+    }
+
+    /// Set the skills prompt injection mode (Full or Compact) inherited from
+    /// the global `[skills].prompt_injection_mode` config value.
+    pub fn with_skills_prompt_mode(
+        mut self,
+        mode: crate::config::SkillsPromptInjectionMode,
+    ) -> Self {
+        self.skills_prompt_mode = mode;
         self
     }
 
@@ -636,6 +650,7 @@ impl DelegateTool {
         let workspace_dir = self.workspace_dir.clone();
         let child_token = self.cancellation_token.child_token();
         let task_id_clone = task_id.clone();
+        let skills_prompt_mode = self.skills_prompt_mode;
 
         tokio::spawn(async move {
             // Build an inner DelegateTool for the spawned context
@@ -651,6 +666,7 @@ impl DelegateTool {
                 workspace_dir: workspace_dir.clone(),
                 cancellation_token: child_token.clone(),
                 memory: None,
+                skills_prompt_mode,
             };
 
             let args_inner = json!({
@@ -792,6 +808,7 @@ impl DelegateTool {
             let delegate_config = self.delegate_config.clone();
             let workspace_dir = self.workspace_dir.clone();
             let cancellation_token = self.cancellation_token.child_token();
+            let skills_prompt_mode = self.skills_prompt_mode;
             let agent_name = agent_name.clone();
             let prompt = prompt.to_string();
             let args_clone = args.clone();
@@ -809,6 +826,7 @@ impl DelegateTool {
                     workspace_dir,
                     cancellation_token,
                     memory: None,
+                    skills_prompt_mode,
                 };
                 let result = Box::pin(inner.execute_sync(&agent_name, &prompt, &args_clone)).await;
                 (agent_name, result)
@@ -1048,7 +1066,7 @@ impl DelegateTool {
             model_name: &agent_config.model,
             tools: sub_tools,
             skills: &skills,
-            skills_prompt_mode: crate::config::SkillsPromptInjectionMode::Full,
+            skills_prompt_mode: self.skills_prompt_mode,
             identity_config: None,
             dispatcher_instructions: "",
             tool_descriptions: None,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -924,7 +924,8 @@ pub fn all_tools_with_runtime(
         .with_multimodal_config(root_config.multimodal.clone())
         .with_delegate_config(root_config.delegate.clone())
         .with_workspace_dir(workspace_dir.to_path_buf())
-        .with_memory(memory.clone());
+        .with_memory(memory.clone())
+        .with_skills_prompt_mode(root_config.skills.prompt_injection_mode);
         tool_arcs.push(Arc::new(delegate_tool));
         Some(parent_tools)
     };


### PR DESCRIPTION
## What this fixes

**Without this fix**: delegate agents hardcode `SkillsPromptInjectionMode::Full` when building enriched prompts, ignoring `[skills].prompt_injection_mode` in config. Users with many skills on smaller-context models get context overflow errors even when they've configured `compact` mode.

**With this fix**: delegate agents read `prompt_injection_mode` from the global skills config, matching the behavior of the main agent loop.

Closes #5155

## Changes

- `src/tools/delegate.rs`: Added `skills_prompt_mode` field to `DelegateTool`, builder method, and replaced hardcoded `Full` with `self.skills_prompt_mode`
- `src/tools/mod.rs`: Thread `root_config.skills.prompt_injection_mode` at construction site

`cargo check` passes cleanly.