### PR TITLE
fix(agent): skip system-prompt tool injection when provider supports native tools

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -8848,10 +8848,12 @@ Let me check the result."#;
             "Native prompt must not contain XML protocol header"
         );
 
-        // Positive: native prompt should still list tools and contain task instructions
+        // When native tools are supported, tool definitions are sent via the
+        // API "tools" field — they must NOT also appear in the system prompt
+        // (see issue #5728).
         assert!(
-            system_prompt.contains("shell"),
-            "Native prompt must list tool names"
+            !system_prompt.contains("## Tools"),
+            "Native prompt must not contain ## Tools section (tools sent via API field)"
         );
         assert!(
             system_prompt.contains("## Your Task"),

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3858,7 +3858,10 @@ pub fn build_system_prompt_with_mode_and_autonomy(
     );
 
     // ── 1. Tooling ──────────────────────────────────────────────
-    if !tools.is_empty() {
+    // When the provider supports native tools, tool definitions are sent via
+    // the API "tools" field.  Skip system-prompt injection to avoid
+    // duplicating them (see issue #5728).
+    if !native_tools && !tools.is_empty() {
         prompt.push_str("## Tools\n\n");
         if compact_context {
             // Compact mode: tool names only, no descriptions/schemas


### PR DESCRIPTION
## What this fixes

**Without this fix**: when a provider supports native tools (`supports_native_tools() = true`), tool definitions are sent BOTH in the system prompt (`## Tools` markdown section) AND in the API request's `tools` field. This wastes tokens and can confuse models that see duplicate tool listings.

**With this fix**: the `## Tools` section is only injected into the system prompt when `native_tools = false`. The XML `<tool_call>` protocol instructions were already correctly guarded; this fixes the remaining unguarded path.

Closes #5728

## Root Cause

In `src/channels/mod.rs`, `build_system_prompt_with_mode_and_autonomy` had `if !tools.is_empty()` which unconditionally injected the `## Tools` section. The `native_tools` parameter was available but only used for task instruction wording, not the tool listing guard.

## Changes

- `src/channels/mod.rs`: Changed `if !tools.is_empty()` to `if !native_tools && !tools.is_empty()`
- `src/agent/loop_.rs`: Updated test to assert `## Tools` is NOT present when `native_tools = true`

`cargo check` passes cleanly.