### PR TITLE
fix(gateway): read active model from live config instead of startup snapshot

### DIFF
--- a/src/gateway/api.rs
+++ b/src/gateway/api.rs
@@ -119,7 +119,7 @@ pub async fn handle_api_status(
 
     let body = serde_json::json!({
         "provider": config.default_provider,
-        "model": state.model,
+        "model": state.active_model(),
         "temperature": state.temperature,
         "uptime_seconds": health.uptime_seconds,
         "gateway_port": config.gateway.port,

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -377,6 +377,22 @@ pub struct AppState {
     pub webauthn: Option<Arc<api_webauthn::WebAuthnState>>,
 }
 
+impl AppState {
+    /// Return the currently configured model from live config, falling back to
+    /// the startup snapshot stored in `self.model`.
+    ///
+    /// This ensures that `PUT /api/config` changes to `default_model` are
+    /// reflected immediately by gateway handlers instead of being silently
+    /// ignored until the next restart.  See issue #5363.
+    pub fn active_model(&self) -> String {
+        self.config
+            .lock()
+            .default_model
+            .clone()
+            .unwrap_or_else(|| self.model.clone())
+    }
+}
+
 /// Run the HTTP gateway using axum with proper HTTP/1.1 compliance.
 #[allow(clippy::too_many_lines)]
 pub async fn run_gateway(
@@ -1289,7 +1305,7 @@ async fn run_gateway_chat_simple(state: &AppState, message: &str) -> anyhow::Res
         let config_guard = state.config.lock();
         crate::channels::build_system_prompt(
             &config_guard.workspace_dir,
-            &state.model,
+            &state.active_model(),
             &[], // tools - empty for simple chat
             &[], // skills
             Some(&config_guard.identity),
@@ -1307,7 +1323,7 @@ async fn run_gateway_chat_simple(state: &AppState, message: &str) -> anyhow::Res
 
     state
         .provider
-        .chat_with_history(&prepared.messages, &state.model, state.temperature)
+        .chat_with_history(&prepared.messages, &state.active_model(), state.temperature)
         .await
 }
 
@@ -1440,7 +1456,7 @@ async fn handle_webhook(
         .default_provider
         .clone()
         .unwrap_or_else(|| "unknown".to_string());
-    let model_label = state.model.clone();
+    let model_label = state.active_model();
     let started_at = Instant::now();
 
     state
@@ -1484,7 +1500,7 @@ async fn handle_webhook(
                     cost_usd: None,
                 });
 
-            let body = serde_json::json!({"response": response, "model": state.model});
+            let body = serde_json::json!({"response": response, "model": state.active_model()});
             (StatusCode::OK, Json(body))
         }
         Err(e) => {

--- a/src/gateway/ws.rs
+++ b/src/gateway/ws.rs
@@ -412,7 +412,7 @@ async fn process_chat_message(
     let _ = state.event_tx.send(serde_json::json!({
         "type": "agent_start",
         "provider": provider_label,
-        "model": state.model,
+        "model": state.active_model(),
     }));
 
     // Set session state to running
@@ -469,7 +469,7 @@ async fn process_chat_message(
             if state.auto_save {
                 let mem = state.mem.clone();
                 let provider = state.provider.clone();
-                let model = state.model.clone();
+                let model = state.active_model();
                 let user_msg = content.to_string();
                 let assistant_resp = response.clone();
                 tokio::spawn(async move {
@@ -507,7 +507,7 @@ async fn process_chat_message(
             let _ = state.event_tx.send(serde_json::json!({
                 "type": "agent_end",
                 "provider": provider_label,
-                "model": state.model,
+                "model": state.active_model(),
             }));
         }
         Err(e) => {


### PR DESCRIPTION
## What this fixes

**Without this fix**: `AppState.model` is set once at startup and never updated when config changes via `PUT /api/config`. Model switching in the UI has no effect on the backend. This particularly impacts custom providers (like NVIDIA API) with multiple models.

**With this fix**: `AppState::active_model()` reads `default_model` from the live `Arc<Mutex<Config>>`, so config changes take effect immediately.

Closes #5363, Closes #5229

## Changes

- `src/gateway/mod.rs`: Added `active_model()` method, replaced 4 `state.model` usages
- `src/gateway/ws.rs`: Replaced 3 `state.model` usages in WebSocket chat handling
- `src/gateway/api.rs`: Replaced 1 `state.model` usage in `/api/status` response

`cargo check` passes cleanly.