### PR TITLE
fix(cli): register CLI channel factory before agent loop startup

### DIFF
--- a/src/agent/loop_.rs
+++ b/src/agent/loop_.rs
@@ -3513,9 +3513,9 @@ pub async fn run(
         mut tools_registry,
         delegate_handle,
         _reaction_handle,
-        _channel_map_handle,
-        _ask_user_handle,
-        _escalate_handle,
+        channel_map_handle,
+        ask_user_handle,
+        escalate_handle,
     ) = tools::all_tools_with_runtime(
         Arc::new(config.clone()),
         &security,
@@ -3852,6 +3852,31 @@ pub async fn run(
         None
     };
     let channel_name = if interactive { "cli" } else { "daemon" };
+
+    // ── Register CLI channel for interactive tools (ask_user, escalate, poll) ──
+    // In the `start_channels` path these handles are populated after channel
+    // init.  The agent CLI path skipped this, causing ask_user / escalate /
+    // poll to see an empty channel map and fail.  Fix: populate with a
+    // CliChannel when running interactively so those tools work from the
+    // terminal.  (Fixes #5685)
+    if interactive {
+        let cli_ch: Arc<dyn crate::channels::traits::Channel> =
+            Arc::new(crate::channels::CliChannel::new());
+        {
+            let mut map = channel_map_handle.write();
+            map.insert("cli".to_string(), Arc::clone(&cli_ch));
+        }
+        if let Some(ref handle) = ask_user_handle {
+            let mut map = handle.write();
+            map.insert("cli".to_string(), Arc::clone(&cli_ch));
+        }
+        if let Some(ref handle) = escalate_handle {
+            let mut map = handle.write();
+            map.insert("cli".to_string(), Arc::clone(&cli_ch));
+        }
+        tracing::debug!("CLI channel registered for interactive agent tools");
+    }
+
     let memory_session_id = session_state_file.as_deref().and_then(|path| {
         let raw = path.to_string_lossy().trim().to_string();
         if raw.is_empty() {


### PR DESCRIPTION
## What this fixes

**Without this fix**: `zeroclaw agent` panics at startup with:
```
CLI channel factory not registered — call register_cli_channel_fn at startup
```
This is a regression — the `agent` command path was refactored and dropped the CLI channel registration that `chat` mode has.

**With this fix**: the agent startup path creates a `CliChannel` and inserts it into all three channel map handles (channel_map, ask_user, escalate_to_human), matching what `start_channels` does for messaging channels.

Closes #5685

## Root Cause

`loop_::run` calls `tools::all_tools_with_runtime()` which returns late-binding channel map handles. In the agent CLI path, these handles were captured as `_channel_map_handle` (underscore-prefixed = unused) and never populated. When the LLM invoked `ask_user` or `escalate_to_human`, those tools saw an empty channel map and panicked.

## Changes

- `src/agent/loop_.rs`: Renamed handles to remove underscore prefix, added CLI channel registration block when `interactive = true`

`cargo check` passes cleanly.