### PR TITLE
fix: use SqliteSessionBackend for session tools (matches gateway)

### DIFF
--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -738,7 +738,9 @@ pub fn all_tools_with_runtime(
     tool_arcs.push(Arc::new(ImageInfoTool::new(security.clone())));
 
     // Session-to-session messaging tools (always available when sessions dir exists)
-    if let Ok(session_store) = crate::channels::session_store::SessionStore::new(workspace_dir) {
+    // Use SqliteSessionBackend (same as gateway) so tools see gateway WS sessions.
+    // SessionStore (JSONL) only sees .jsonl files which the gateway doesn't create.
+    if let Ok(session_store) = crate::channels::session_sqlite::SqliteSessionBackend::new(workspace_dir) {
         let backend: Arc<dyn crate::channels::session_backend::SessionBackend> =
             Arc::new(session_store);
         tool_arcs.push(Arc::new(SessionsListTool::new(backend.clone())));


### PR DESCRIPTION
Fixes #5769

## Summary

Session tools (`sessions_list`, `sessions_history`, `sessions_send`) were initialized with the JSONL-based `SessionStore` backend, while the gateway WebSocket handler stores sessions in `SqliteSessionBackend`. This caused the tools to return empty results for all gateway sessions because they looked for `.jsonl` files that the gateway never creates.

## Change

**`src/tools/mod.rs`** — one-line change:

```diff
-    if let Ok(session_store) = crate::channels::session_store::SessionStore::new(workspace_dir) {
+    if let Ok(session_store) = crate::channels::session_sqlite::SqliteSessionBackend::new(workspace_dir) {
```

Both types implement `SessionBackend` with the same `new(&Path)` signature. The gateway already imports and uses `SqliteSessionBackend` (`src/gateway/mod.rs:27`).

## Testing

- Deployed with this fix in production — `sessions_list` now correctly returns gateway WS sessions
- `sessions_history` correctly loads messages by session ID
- No impact on channel sessions (Discord/Telegram) which go through their own persistence path