### PR TITLE
fix(shell): guard bypass

### DIFF
--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -3531,6 +3531,118 @@ mod tests {
         assert!(result.unwrap_err().contains("high-risk"));
     }
 
+    // ── Shell guard bypass with wildcard + unblocked ──────────
+
+    #[test]
+    fn wildcard_unblocked_allows_backticks() {
+        let p = SecurityPolicy {
+            allowed_commands: vec!["*".into()],
+            block_high_risk_commands: false,
+            ..SecurityPolicy::default()
+        };
+        assert!(p.is_command_allowed("echo `whoami`"));
+        assert!(p.is_command_allowed("ls `which git`"));
+    }
+
+    #[test]
+    fn wildcard_unblocked_allows_dollar_paren() {
+        let p = SecurityPolicy {
+            allowed_commands: vec!["*".into()],
+            block_high_risk_commands: false,
+            ..SecurityPolicy::default()
+        };
+        assert!(p.is_command_allowed("echo $(cat /etc/hostname)"));
+        assert!(p.is_command_allowed("echo $(rm -rf /)"));
+    }
+
+    #[test]
+    fn wildcard_unblocked_allows_dollar_brace() {
+        let p = SecurityPolicy {
+            allowed_commands: vec!["*".into()],
+            block_high_risk_commands: false,
+            ..SecurityPolicy::default()
+        };
+        assert!(p.is_command_allowed("echo ${HOME}"));
+        assert!(p.is_command_allowed("echo ${PATH}"));
+    }
+
+    #[test]
+    fn wildcard_unblocked_allows_process_substitution() {
+        let p = SecurityPolicy {
+            allowed_commands: vec!["*".into()],
+            block_high_risk_commands: false,
+            ..SecurityPolicy::default()
+        };
+        assert!(p.is_command_allowed("diff <(ls dir1) <(ls dir2)"));
+        assert!(p.is_command_allowed("tee >(grep error > errors.log)"));
+    }
+
+    #[test]
+    fn wildcard_unblocked_allows_pipes_and_chains() {
+        let p = SecurityPolicy {
+            allowed_commands: vec!["*".into()],
+            block_high_risk_commands: false,
+            ..SecurityPolicy::default()
+        };
+        assert!(p.is_command_allowed("ps aux | grep python | wc -l"));
+        assert!(p.is_command_allowed("echo hello && echo world"));
+    }
+
+    #[test]
+    fn wildcard_blocked_still_runs_shell_guard() {
+        // allowed_commands=["*"] but block_high_risk_commands=true (default)
+        // — the shell expansion guard must still fire.
+        let p = SecurityPolicy {
+            allowed_commands: vec!["*".into()],
+            block_high_risk_commands: true,
+            ..SecurityPolicy::default()
+        };
+        assert!(!p.is_command_allowed("echo `whoami`"));
+        assert!(!p.is_command_allowed("echo $(cat /etc/passwd)"));
+        assert!(!p.is_command_allowed("echo ${HOME}"));
+        assert!(!p.is_command_allowed("diff <(ls dir1) <(ls dir2)"));
+    }
+
+    #[test]
+    fn specific_allowlist_still_runs_shell_guard() {
+        // Non-wildcard allowlist — the guard must always run regardless
+        // of block_high_risk_commands.
+        let p = SecurityPolicy {
+            allowed_commands: vec!["echo".into(), "ls".into(), "diff".into()],
+            block_high_risk_commands: false,
+            ..SecurityPolicy::default()
+        };
+        assert!(!p.is_command_allowed("echo `whoami`"));
+        assert!(!p.is_command_allowed("echo $(cat /etc/passwd)"));
+        assert!(!p.is_command_allowed("echo ${HOME}"));
+        assert!(!p.is_command_allowed("diff <(ls dir1) <(ls dir2)"));
+    }
+
+    #[test]
+    fn specific_allowlist_with_block_true_still_runs_shell_guard() {
+        let p = SecurityPolicy {
+            allowed_commands: vec!["echo".into(), "ls".into()],
+            block_high_risk_commands: true,
+            ..SecurityPolicy::default()
+        };
+        assert!(!p.is_command_allowed("echo `whoami`"));
+        assert!(!p.is_command_allowed("echo $(rm -rf /)"));
+        assert!(!p.is_command_allowed("echo ${HOME}"));
+    }
+
+    #[test]
+    fn wildcard_unblocked_readonly_still_blocked() {
+        // Even with wildcard + unblocked, ReadOnly trumps everything.
+        let p = SecurityPolicy {
+            autonomy: AutonomyLevel::ReadOnly,
+            allowed_commands: vec!["*".into()],
+            block_high_risk_commands: false,
+            ..SecurityPolicy::default()
+        };
+        assert!(!p.is_command_allowed("ls"));
+        assert!(!p.is_command_allowed("echo `whoami`"));
+    }
+
     #[test]
     fn per_sender_tracker_isolates_counts() {
         let t = PerSenderTracker::new();

--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -989,15 +989,6 @@ impl SecurityPolicy {
 
         let risk = self.command_risk_level(command);
 
-        // When the operator has set `allowed_commands = ["*"]` AND explicitly
-        // disabled `block_high_risk_commands`, they have opted out of all
-        // command-level restrictions.  Short-circuit: skip the risk and
-        // autonomy gates entirely.  See #4485.
-        let has_wildcard = self.allowed_commands.iter().any(|c| c.trim() == "*");
-        if has_wildcard && !self.block_high_risk_commands {
-            return Ok(risk);
-        }
-
         if risk == CommandRiskLevel::High {
             if self.block_high_risk_commands && !self.is_command_explicitly_allowed(command) {
                 return Err("Command blocked: high-risk command is disallowed by policy".into());
@@ -1087,6 +1078,15 @@ impl SecurityPolicy {
     pub fn is_command_allowed(&self, command: &str) -> bool {
         if self.autonomy == AutonomyLevel::ReadOnly {
             return false;
+        }
+
+        // When the operator has explicitly opted out of all command-level
+        // restrictions (wildcard + no high-risk blocking), skip the
+        // subshell/expansion guard entirely. This allows backticks,
+        // $(), heredocs, etc. in trusted environments.
+        let has_wildcard = self.allowed_commands.iter().any(|c| c.trim() == "*");
+        if has_wildcard && !self.block_high_risk_commands {
+            return true;
         }
 
         // Block subshell/expansion operators — these allow hiding arbitrary


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: When `allowed_commands=["*"]` and `block_high_risk_commands=false`, the shell expansion guard in `is_command_allowed` still blocks backticks, `$()`, `${}`, `<()`, and `>()`. The wildcard+unblocked short-circuit was in `validate_command_execution` but never reached `is_command_allowed`, making the "allow everything" configuration ineffective.
- Why it matters: Self-hosted deployments with full autonomy enabled cannot use standard shell constructs like `psql -c` with heredoc pipes or `curl $(hostname)`. The configuration intent is not honored.
- What changed: Moved the wildcard+unblocked short-circuit from `validate_command_execution` into `is_command_allowed`, so the shell expansion guard is skipped when both conditions are met.
- What did **not** change: The guard still runs in all other configurations. ReadOnly autonomy still blocks everything. Non-wildcard allowlists still enforce the guard.

### Key change in `crates/zeroclaw-config/src/policy.rs`

The short-circuit was in `validate_command_execution` (too late — after `is_command_allowed` already rejected the command):

```diff
-        // validate_command_execution (line ~992)
-        let has_wildcard = self.allowed_commands.iter().any(|c| c.trim() == "*");
-        if has_wildcard && !self.block_high_risk_commands {
-            return Ok(risk);
-        }
```

Moved into `is_command_allowed` (line ~1083), before the subshell/expansion guard:

```diff
+        // is_command_allowed — skip subshell guard for trusted environments
+        let has_wildcard = self.allowed_commands.iter().any(|c| c.trim() == "*");
+        if has_wildcard && !self.block_high_risk_commands {
+            return true;
+        }
+
         // Block subshell/expansion operators — these allow hiding arbitrary
         // commands inside an allowed command ...
```

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `security`, `config`, `runtime`
- Module labels: `tool: shell`
- Contributor tier label: N/A (first contribution)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `security`

## Linked Issue

- Closes #
- Related #4485

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

9 new tests added in `crates/zeroclaw-config/src/policy.rs`:

| Test | Verifies |
|------|----------|
| `wildcard_unblocked_allows_backticks` | `["*"]` + unblocked permits `` `cmd` `` |
| `wildcard_unblocked_allows_dollar_paren` | Same permits `$(cmd)` |
| `wildcard_unblocked_allows_dollar_brace` | Same permits `${var}` |
| `wildcard_unblocked_allows_process_substitution` | Same permits `<()` and `>()` |
| `wildcard_unblocked_allows_pipes_and_chains` | Same permits `\|` and `&&` |
| `wildcard_blocked_still_runs_shell_guard` | `["*"]` + blocked (default) still rejects expansions |
| `specific_allowlist_still_runs_shell_guard` | Non-wildcard list still rejects expansions |
| `specific_allowlist_with_block_true_still_runs_shell_guard` | Non-wildcard + blocked still rejects |
| `wildcard_unblocked_readonly_still_blocked` | ReadOnly autonomy trumps wildcard+unblocked |

- Evidence provided: Unit tests covering all 4 config×autonomy combinations
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes — only affects the `allowed_commands=["*"]` + `block_high_risk_commands=false` combination, which was previously broken.
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: Self-hosted ZeroClaw with full autonomy — `curl`, `psql -c "SELECT ..."`, pipe chains, and `$()` subshells all work after fix. Default config still blocks expansions.
- Edge cases checked: ReadOnly autonomy blocks everything regardless. Specific (non-wildcard) allowlists enforce the guard regardless of `block_high_risk_commands`.
- What was not verified: Interactive shell sessions (not applicable).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `SecurityPolicy::is_command_allowed` — called by the shell tool before every command execution.
- Potential unintended effects: None — the change only affects a configuration that was previously non-functional.
- Guardrails/monitoring for early detection: 9 new tests; existing test suite covers all other autonomy modes.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code for test authoring
- Verification focus: Ensuring the guard is only bypassed for the exact wildcard+unblocked combination
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`)

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: Gated on `allowed_commands=["*"]` AND `block_high_risk_commands=false` — both must be explicitly set
- Observable failure symptoms: Shell commands with backticks/subshells would fail again

## Risks and Mitigations

- Risk: Operator sets both flags without understanding implications.
  - Mitigation: Both require explicit opt-in. Defaults are safe (`block_high_risk_commands=true`).