### PR TITLE
fix(agent): register skill tools and apply excluded filter in gateway path

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5198,9 +5198,14 @@ pub async fn start_channels(config: Config) -> Result<()> {
         }
     }
 
-    let tools_registry = Arc::new(built_tools);
-
     let skills = zeroclaw_runtime::skills::load_skills_with_config(&workspace, &config);
+
+    // Register skill-defined tools so the gateway can execute them (not just
+    // describe them in the prompt). Without this, skill tools like email.send
+    // appear in the system prompt but return "Unknown tool" when called.
+    zeroclaw_runtime::tools::register_skill_tools(&mut built_tools, &skills, security.clone());
+
+    let tools_registry = Arc::new(built_tools);
 
     // ── Load locale-aware tool descriptions ────────────────────────
     let i18n_locale = config

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -2238,7 +2238,7 @@ mod tests {
         ];
 
         // Step 1: filter excluded tools (mirrors from_config logic)
-        let excluded = vec!["shell".to_string()];
+        let excluded = ["shell".to_string()];
         tools.retain(|t| !excluded.iter().any(|ex| ex == t.name()));
 
         // Step 2: register skill tools (mirrors from_config logic)

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -2190,7 +2190,7 @@ mod tests {
             Box::new(NamedMockTool::new("web_search")),
         ];
 
-        let excluded = vec!["shell".to_string(), "file_write".to_string()];
+        let excluded = ["shell".to_string(), "file_write".to_string()];
         tools.retain(|t| !excluded.iter().any(|ex| ex == t.name()));
 
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
@@ -2206,7 +2206,7 @@ mod tests {
         ];
 
         // Exclude only "shell" — the other two should survive.
-        let excluded = vec!["shell".to_string()];
+        let excluded = ["shell".to_string()];
         tools.retain(|t| !excluded.iter().any(|ex| ex == t.name()));
 
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -536,6 +536,22 @@ impl Agent {
             None
         };
 
+        // Filter out excluded tools (non_cli_excluded_tools). The channel
+        // orchestrator applies this, but Agent::from_config (used by ws.rs)
+        // doesn't go through that path.
+        let excluded = &config.autonomy.non_cli_excluded_tools;
+        if !excluded.is_empty() {
+            tools.retain(|t| !excluded.iter().any(|ex| ex == t.name()));
+        }
+
+        // Load skills and register them as callable tools so WebSocket/daemon
+        // sessions can execute them (not just describe them in the prompt).
+        let skills = crate::skills::load_skills_with_config(
+            &config.workspace_dir,
+            config,
+        );
+        tools::register_skill_tools(&mut tools, &skills, security.clone());
+
         Agent::builder()
             .provider(provider)
             .tools(tools)
@@ -560,10 +576,7 @@ impl Agent {
             .available_hints(available_hints)
             .route_model_by_hint(route_model_by_hint)
             .identity_config(config.identity.clone())
-            .skills(crate::skills::load_skills_with_config(
-                &config.workspace_dir,
-                config,
-            ))
+            .skills(skills)
             .skills_prompt_mode(config.skills.prompt_injection_mode)
             .auto_save(config.memory.auto_save)
             .security_summary(Some(security.prompt_summary()))

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -546,10 +546,7 @@ impl Agent {
 
         // Load skills and register them as callable tools so WebSocket/daemon
         // sessions can execute them (not just describe them in the prompt).
-        let skills = crate::skills::load_skills_with_config(
-            &config.workspace_dir,
-            config,
-        );
+        let skills = crate::skills::load_skills_with_config(&config.workspace_dir, config);
         tools::register_skill_tools(&mut tools, &skills, security.clone());
 
         Agent::builder()
@@ -2096,5 +2093,162 @@ mod tests {
                 );
             }
         }
+    }
+
+    // ── Skill tool registration & excluded_tools filtering ──────────
+
+    /// A mock tool whose name is configurable (unlike `MockTool` which is
+    /// always "echo").
+    struct NamedMockTool {
+        tool_name: String,
+    }
+
+    impl NamedMockTool {
+        fn new(name: &str) -> Self {
+            Self {
+                tool_name: name.to_string(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Tool for NamedMockTool {
+        fn name(&self) -> &str {
+            &self.tool_name
+        }
+
+        fn description(&self) -> &str {
+            "mock"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        async fn execute(&self, _args: serde_json::Value) -> Result<crate::tools::ToolResult> {
+            Ok(crate::tools::ToolResult {
+                success: true,
+                output: "ok".into(),
+                error: None,
+            })
+        }
+    }
+
+    fn make_skill(name: &str, tool_names: &[&str]) -> crate::skills::Skill {
+        crate::skills::Skill {
+            name: name.to_string(),
+            description: format!("{name} skill"),
+            version: "0.1.0".to_string(),
+            author: None,
+            tags: vec![],
+            tools: tool_names
+                .iter()
+                .map(|t| crate::skills::SkillTool {
+                    name: t.to_string(),
+                    description: format!("{t} tool"),
+                    kind: "shell".to_string(),
+                    command: format!("echo {t}"),
+                    args: std::collections::HashMap::new(),
+                })
+                .collect(),
+            prompts: vec![],
+            location: None,
+        }
+    }
+
+    #[test]
+    fn register_skill_tools_adds_skill_tools_to_registry() {
+        let security = Arc::new(crate::security::SecurityPolicy::default());
+        let mut tools: Vec<Box<dyn Tool>> = vec![Box::new(NamedMockTool::new("builtin_a"))];
+
+        let skills = vec![make_skill("deploy", &["run", "status"])];
+        tools::register_skill_tools(&mut tools, &skills, security);
+
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert_eq!(names, &["builtin_a", "deploy.run", "deploy.status"]);
+    }
+
+    #[test]
+    fn register_skill_tools_skips_shadowed_builtins() {
+        let security = Arc::new(crate::security::SecurityPolicy::default());
+        // Pre-populate with a tool whose name matches what the skill would produce.
+        let mut tools: Vec<Box<dyn Tool>> = vec![Box::new(NamedMockTool::new("my_skill.run"))];
+
+        let skills = vec![make_skill("my_skill", &["run"])];
+        tools::register_skill_tools(&mut tools, &skills, security);
+
+        // Should still be just 1 tool — the duplicate was skipped.
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name(), "my_skill.run");
+    }
+
+    #[test]
+    fn excluded_tools_filters_matching_tools() {
+        let mut tools: Vec<Box<dyn Tool>> = vec![
+            Box::new(NamedMockTool::new("shell")),
+            Box::new(NamedMockTool::new("file_write")),
+            Box::new(NamedMockTool::new("web_search")),
+        ];
+
+        let excluded = vec!["shell".to_string(), "file_write".to_string()];
+        tools.retain(|t| !excluded.iter().any(|ex| ex == t.name()));
+
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert_eq!(names, &["web_search"]);
+    }
+
+    #[test]
+    fn excluded_tools_preserves_non_excluded() {
+        let mut tools: Vec<Box<dyn Tool>> = vec![
+            Box::new(NamedMockTool::new("shell")),
+            Box::new(NamedMockTool::new("file_read")),
+            Box::new(NamedMockTool::new("web_fetch")),
+        ];
+
+        // Exclude only "shell" — the other two should survive.
+        let excluded = vec!["shell".to_string()];
+        tools.retain(|t| !excluded.iter().any(|ex| ex == t.name()));
+
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert_eq!(names, &["file_read", "web_fetch"]);
+    }
+
+    #[test]
+    fn empty_excluded_tools_preserves_all() {
+        let mut tools: Vec<Box<dyn Tool>> = vec![
+            Box::new(NamedMockTool::new("shell")),
+            Box::new(NamedMockTool::new("file_read")),
+        ];
+
+        let excluded: Vec<String> = vec![];
+        if !excluded.is_empty() {
+            tools.retain(|t| !excluded.iter().any(|ex| ex == t.name()));
+        }
+
+        assert_eq!(tools.len(), 2);
+    }
+
+    #[test]
+    fn excluded_tools_then_skill_registration_end_to_end() {
+        let security = Arc::new(crate::security::SecurityPolicy::default());
+        let mut tools: Vec<Box<dyn Tool>> = vec![
+            Box::new(NamedMockTool::new("shell")),
+            Box::new(NamedMockTool::new("file_read")),
+            Box::new(NamedMockTool::new("web_fetch")),
+        ];
+
+        // Step 1: filter excluded tools (mirrors from_config logic)
+        let excluded = vec!["shell".to_string()];
+        tools.retain(|t| !excluded.iter().any(|ex| ex == t.name()));
+
+        // Step 2: register skill tools (mirrors from_config logic)
+        let skills = vec![make_skill("ops", &["deploy", "rollback"])];
+        tools::register_skill_tools(&mut tools, &skills, security);
+
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert_eq!(
+            names,
+            &["file_read", "web_fetch", "ops.deploy", "ops.rollback"]
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `Agent::from_config` (used by the WebSocket/gateway path) never calls `tools::register_skill_tools` or filters `non_cli_excluded_tools`. Skills defined in SKILL.toml files are loaded but their tools are not registered, so the agent reports "Unknown tool" when trying to use them. Excluded tools remain in the registry despite being configured for exclusion.
- Why it matters: The gateway/WebSocket path is the primary interface for web UI users. Skill tools are completely non-functional and unwanted tools clutter the tool list, confusing the model and wasting tokens.
- What changed: Added skill tool registration and excluded tool filtering to `Agent::from_config`, matching the CLI orchestrator path.
- What did **not** change: The CLI orchestrator path (`loop_.rs`) is untouched. Skill loading and tool registration implementations are unchanged — only the call sites are added.

### Key change in `crates/zeroclaw-runtime/src/agent/agent.rs`

`Agent::from_config` previously loaded skills but only passed them to the builder for prompt injection — it never registered their tools or applied exclusions. The CLI path in `loop_.rs` did both.

Added before the `Agent::builder()` call (~line 538):

```rust
// Filter out excluded tools (non_cli_excluded_tools)
let excluded = &config.autonomy.non_cli_excluded_tools;
if !excluded.is_empty() {
    tools.retain(|t| !excluded.iter().any(|ex| ex == t.name()));
}

// Register skill tools so WebSocket sessions can execute them
let skills = crate::skills::load_skills_with_config(
    &config.workspace_dir,
    config,
);
tools::register_skill_tools(&mut tools, &skills, security.clone());
```

And moved the `skills` variable into `Agent::builder().skills(skills)` instead of inlining the load call:

```diff
-            .skills(crate::skills::load_skills_with_config(
-                &config.workspace_dir,
-                config,
-            ))
+            .skills(skills)
```

## Label Snapshot (required)

- Risk label: `risk: high`
- Size label: `size: S`
- Scope labels: `agent`, `gateway`, `skills`, `tool`
- Module labels: `agent: from_config`, `gateway: ws`
- Contributor tier label: N/A (first contribution)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `bug`
- Primary scope: `runtime`

## Linked Issue

- Closes # 5850

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

6 new tests added in `crates/zeroclaw-runtime/src/agent/agent.rs`:

| Test | Verifies |
|------|----------|
| `register_skill_tools_adds_skill_tools_to_registry` | Skill tools (`deploy.run`, `deploy.status`) are appended to existing built-in tools |
| `register_skill_tools_skips_shadowed_builtins` | If a built-in already has the same name as a skill tool, the skill is skipped |
| `excluded_tools_filters_matching_tools` | `retain` logic removes tools in the excluded list |
| `excluded_tools_preserves_non_excluded` | Tools not in the excluded list survive filtering |
| `empty_excluded_tools_preserves_all` | Empty excluded list = no filtering |
| `excluded_tools_then_skill_registration_end_to_end` | Both operations in sequence (matching `from_config` order) produce the correct final tool set |

Test infrastructure added: `NamedMockTool` (configurable-name mock) and `make_skill()` helper for constructing `Skill` structs with shell-type tools.

- Evidence provided: Unit tests covering registration, filtering, shadowing, and end-to-end
- If any command is intentionally skipped, explain why: N/A

## Security Impact (required)

- New permissions/capabilities? No — skill tools were already loaded, just not registered in this path
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes

## Compatibility / Migration

- Backward compatible? Yes — adds functionality that was missing. Existing configurations without skills or excluded_tools are unaffected.
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No

## Human Verification (required)

- Verified scenarios: WebSocket gateway session with SKILL.toml-defined tools (`email.send`, `pubmed.search`, `statcan.search`). Before fix: "Unknown tool: email.send". After fix: tools execute correctly. Also verified `non_cli_excluded_tools` removes configured tools from the gateway session's tool list.
- Edge cases checked: Skills with no tools (empty SKILL.toml) — no crash. Excluded tool not in registry — no crash. All tools excluded — agent works with zero tools.
- What was not verified: CLI orchestrator path (already had this functionality).

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: `Agent::from_config` — used by the gateway WebSocket handler for all web UI sessions.
- Potential unintended effects: Tools that were previously invisible to gateway users will now appear and be callable.
- Guardrails/monitoring for early detection: Skill tools run through the same security policy as built-in tools. `non_cli_excluded_tools` provides an escape hatch.

## Agent Collaboration Notes (recommended)

- Agent tools used: Claude Code for test authoring and code review
- Workflow/plan summary: Identified the discrepancy between CLI (`loop_.rs` has both operations) and gateway (`agent.rs` had neither). Applied the same two operations in the same order.
- Verification focus: Ensuring parity between CLI and gateway paths
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`)

## Rollback Plan (required)

- Fast rollback command/path: `git revert <commit>`
- Feature flags or config toggles: `non_cli_excluded_tools` provides per-tool disable capability
- Observable failure symptoms: Gateway users would see "Unknown tool" errors for skill tools again

## Risks and Mitigations

- Risk: Skill tools that were silently unreachable in the gateway may have bugs now exposed.
  - Mitigation: `non_cli_excluded_tools` provides immediate per-tool disable. Skill tools run through the same security policy as all other tools.
