### PR TITLE
feat(skills): add squash-merge skill for preserving commit history on upstream merges

### DIFF
--- a/.claude/skills/squash-merge/SKILL.md
+++ b/.claude/skills/squash-merge/SKILL.md
@@ -1,100 +1,175 @@
 # Skill: squash-merge
 
-Squash-merge a PR into `upstream/master` (zeroclaw-labs/zeroclaw) with fully preserved commit history in the squash message body. Use this skill whenever the user wants to merge a PR, land a PR, squash-merge, or close a PR as merged — even if they say things like "land this", "merge it in", "squash and merge", or "ship it".
+Squash-merge a PR into `upstream/master` (zeroclaw-labs/zeroclaw) with fully preserved commit history in the squash message body. Use this skill when the user explicitly mentions squash-merging, merging a specific PR number, or landing a PR by number — e.g. "squash-merge #123", "merge PR 456", "land #789", "/squash-merge 123". Do **not** trigger on vague phrases like "ship it" or "merge it" without a PR number or clear upstream-merge context.
 
 ## Why This Exists
 
-GitHub's default squash-commit message is useless ("Squashed commit of the following: ..."). Direct-pushing a squash to master bypasses the PR merge mechanism and shows "Closed" instead of "Merged" (no purple badge, no linked issue auto-close). This skill gets both: the purple **Merged** badge and a meaningful commit history in the squash message body.
+GitHub's default squash merge omits the PR number from the commit subject and formats the commit body inconsistently with project conventions. Direct-pushing a squash to master bypasses the PR merge mechanism entirely: the PR shows "Closed" instead of "Merged" (no purple badge, no linked issue auto-close, no merge commit association). This skill produces both: the purple **Merged** badge and a conventionally formatted squash commit with full commit history in the body.
+
+## Prerequisites
+
+Requires `gh` CLI ≥ 2.17.0 (for `--subject` and `--body` flags on `gh pr merge`). Verify with:
+
+```bash
+gh --version
+```
+
+If the version is older, stop and tell the user to upgrade: `gh upgrade` or install from https://cli.github.com.
 
 ## Instructions
 
-### Step 1: Resolve the PR
+### Step 1: Resolve the PR and Run Pre-flight Checks
 
 Accept a PR number or URL from the user. If none given, detect from current branch:
 
 ```bash
-gh pr view --repo zeroclaw-labs/zeroclaw --json number,title,headRefName,baseRefName,state,author
+gh pr view --repo zeroclaw-labs/zeroclaw \
+  --json number,title,headRefName,baseRefName,state,author,mergeable,mergeStateStatus,reviewDecision
 ```
 
-Confirm the PR is open and targets `master`. If closed or merged already, stop and inform the user.
+Run all four pre-flight checks. **Stop at the first failure** and explain clearly:
+
+| Check | Command | Fail condition | What to tell the user |
+|---|---|---|---|
+| PR is open | `.state` from above | `state != "OPEN"` | "PR #N is already `<state>`, nothing to merge." |
+| Targets master | `.baseRefName` from above | `baseRefName != "master"` | "PR #N targets `<base>`, not master. Confirm before proceeding." |
+| No merge conflicts | `.mergeable` from above | `mergeable == "CONFLICTING"` | "PR #N has merge conflicts with master. The author must resolve them before this can merge." |
+| CI passing | `gh pr checks <N> --repo zeroclaw-labs/zeroclaw` | Any required check failing | "PR #N has failing required checks: `<names>`. Do not merge until CI passes." |
+
+After the four checks, fetch the review decision:
+
+```bash
+gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw --json reviewDecision \
+  --jq '.reviewDecision'
+```
+
+- `APPROVED` → proceed
+- `REVIEW_REQUIRED` → warn: "PR #N has not yet received a required review. Proceed only if you are waiving this requirement as a maintainer."
+- `CHANGES_REQUESTED` → stop: "PR #N has a `CHANGES_REQUESTED` review outstanding. Do not merge until resolved."
+- `""` (empty / no rule) → proceed
 
 ### Step 2: Get Commit History
 
-Fetch the PR's commits and format them as a bulleted history block:
+Use `gh` to fetch commits in API order (typically chronological):
 
 ```bash
-gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw --json commits \
-  --jq '.commits[] | "- \(.oid[:7]) \(.messageHeadline)"'
+COMMITS=$(gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw \
+  --json commits \
+  --jq '[.commits[] | "- \(.oid[:7]) \(.messageHeadline)"] | join("\n")')
 ```
 
-If the PR branch is checked out locally and `gh` commit output is missing full hashes, fall back to:
+If `gh` returns no commit data or hashes are missing, fall back to local git using the PR's actual base ref:
 
 ```bash
-git log master..<branch> --format="- %h %s"
+BASE_REF=$(gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw --json baseRefName --jq '.baseRefName')
+HEAD_REF=$(gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw --json headRefName --jq '.headRefName')
+COMMITS=$(git log "upstream/${BASE_REF}..${HEAD_REF}" --format="- %h %s")
 ```
 
-Collect the output — this becomes the body of the squash commit.
+**Single-commit PRs:** If the result is exactly one line, omit the bulleted body entirely. Instead, use the full commit body (if any) from `git log -1 --format="%b" <sha>` or leave the body empty. A one-item bullet list adds no information.
+
+Note: commits are returned in API order, which is typically chronological but not guaranteed for rebased histories. If ordering looks wrong, use the `git log` fallback which follows the actual graph order.
 
 ### Step 3: Derive the Squash Commit Subject
 
-Build the subject line as a conventional commit following the PR title pattern:
-
-```
-<PR title> (#<NUMBER>)
-```
-
-The PR title should already follow the conventional commit format (`type(scope): description`). If it does not, flag it to the user and suggest a corrected title before proceeding.
-
-### Step 4: Confirm — MANDATORY, NO EXCEPTIONS
-
-**This step is non-negotiable.** A squash merge into `upstream/master` cannot be undone without a revert commit. Always stop here and present the following to the user before running anything:
-
-1. The exact `gh` command that will be executed, with all arguments expanded (no placeholders):
-
-```
-gh pr merge <NUMBER> --repo zeroclaw-labs/zeroclaw --squash \
-  --subject "<full subject line>" \
-  --body "<full body text>"
+```bash
+PR_TITLE=$(gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw --json title --jq '.title')
+SUBJECT="${PR_TITLE} (#${NUMBER})"
 ```
 
-2. A summary of what will happen:
-   - PR #N will be merged (state: Merged, purple badge)
-   - Squash commit subject: `<subject>`
-   - Squash commit body: `<body lines>`
+The title should follow conventional commit format (`type(scope): description`). If it does not, flag it to the user and suggest a corrected title. Do not proceed until the subject is in conventional commit format.
 
-Ask explicitly: **"Run this command? (yes/no)"**
+### Step 4: Build the Final Command Using Variables
 
-Do not infer consent from silence, prior approval of the message draft, or anything else. The user must say yes (or an unambiguous equivalent) in direct response to this prompt. If they say anything other than a clear yes, stop.
+Assign subject and body to shell variables — never interpolate them directly into quoted strings, as PR titles and commit messages may contain double-quotes, dollar signs, backticks, or other shell-special characters:
 
-### Step 5: Execute the Squash Merge
+```bash
+# Subject already in SUBJECT; commits already in COMMITS (from Steps 2–3)
+# Verify they are non-empty before proceeding
+echo "Subject: $SUBJECT"
+echo "Body lines:"
+echo "$COMMITS"
+```
 
-Only after explicit user confirmation in Step 4:
+The final `gh` command will use these variables:
 
 ```bash
 gh pr merge <NUMBER> --repo zeroclaw-labs/zeroclaw --squash \
-  --subject "<PR title> (#<NUMBER>)" \
-  --body "$(cat <<'MERGE_BODY_EOF'
-<commit history lines>
-MERGE_BODY_EOF
-)"
+  --subject "$SUBJECT" \
+  --body "$COMMITS"
 ```
 
-### Step 6: Confirm
+### Step 5: Confirm — MANDATORY, NO EXCEPTIONS
 
-After the command returns, confirm the merge succeeded:
+**This step is non-negotiable.** A squash merge into `upstream/master` cannot be undone without a revert commit.
+
+Present the following to the user — all values must be real and fully expanded, not placeholders:
+
+---
+
+**About to run:**
+```
+gh pr merge <NUMBER> --repo zeroclaw-labs/zeroclaw --squash \
+  --subject "<actual subject line here>" \
+  --body "<actual body lines here, one per line>"
+```
+
+**Effect:**
+- PR #`<NUMBER>` will be permanently merged (state → Merged, purple badge)
+- Linked issues will auto-close
+- Squash commit subject: `<actual subject>`
+- Squash commit body:
+  ```
+  <actual body>
+  ```
+
+**Run this command? (yes/no)**
+
+---
+
+Do not infer consent from silence, prior approval of the commit message, or any earlier step. The user must respond with an unambiguous "yes" (or "y", "go", "do it") **in direct reply to this prompt**. Any other response — including silence, redirection, or "yes but first..." — means stop.
+
+### Step 6: Execute
+
+Only after explicit confirmation in Step 5:
 
 ```bash
-gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw --json state,mergedAt,mergeCommit \
+gh pr merge <NUMBER> --repo zeroclaw-labs/zeroclaw --squash \
+  --subject "$SUBJECT" \
+  --body "$COMMITS"
+```
+
+If the command exits non-zero, stop immediately and report the full error output. Do not attempt to retry or work around branch protection errors automatically — report them verbatim and let the user decide.
+
+### Step 7: Verify and Clean Up
+
+Confirm the merge succeeded:
+
+```bash
+gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw \
+  --json state,mergedAt,mergeCommit \
   --jq '"State: \(.state) | Merged at: \(.mergedAt) | Commit: \(.mergeCommit.oid[:7])"'
 ```
 
-Report the merge commit SHA and PR URL to the user.
+If `state` is not `MERGED`, report the discrepancy and stop — do not assume success.
+
+Report to the user: merge commit SHA, PR URL, and the following cleanup note:
+
+> The contributor's branch `<headRefName>` still exists on the remote. Delete it with:
+> ```bash
+> gh api -X DELETE repos/zeroclaw-labs/zeroclaw/git/refs/heads/<headRefName>
+> ```
+> Skip if GitHub's "auto-delete head branches" setting is enabled for the repo.
 
 ## Rules
 
-- **Never push squash commits directly to `upstream/master`** — always use `gh pr merge`. Direct push bypasses the PR mechanism: the PR shows "Closed" instead of "Merged", linked issues don't auto-close, and the merge commit is not associated with the PR.
-- **Never use `gh pr merge --squash` without `--subject` and `--body`** — the auto-generated message loses all commit context.
-- **Never let GitHub auto-generate the squash message** (no web UI merge, no merge button clicks).
-- **Always preserve commit hashes** in the body — short 7-char hashes are sufficient.
-- **Always confirm before merging, no exceptions** — show the user the exact expanded `gh pr merge` command and require an explicit yes before running it. Never infer consent.
-- **Never merge your own PRs** — if the user is the PR author and is asking to merge, confirm they have maintainer authority to self-merge before proceeding.
+- **Require a PR number or explicit squash-merge context before triggering** — do not invoke on vague phrases without a clear target.
+- **Never push squash commits directly to `upstream/master`** — always use `gh pr merge`. Direct push produces "Closed" not "Merged", breaks issue auto-close, and loses PR association.
+- **Never use `gh pr merge --squash` without `--subject` and `--body`** — the auto-generated message omits the PR number and uses inconsistent formatting.
+- **Never let GitHub auto-generate the squash message** — no web UI merge, no merge button clicks.
+- **Always assign PR title and commit body to shell variables** — never interpolate untrusted content directly into quoted command arguments.
+- **Always run pre-flight checks** (CI, merge conflicts, review decision) before confirming — do not skip them even if the user says "just merge it."
+- **Always confirm before merging, no exceptions** — show the user the exact expanded command with real values and require an explicit yes. Never infer consent.
+- **If the merge command fails, stop and report verbatim** — do not retry, do not work around branch protection automatically.
+- **Note branch cleanup** after every successful merge — the contributor's remote head branch does not auto-delete unless the repo is configured to do so.
+- **Self-merge note:** Maintainers routinely merge their own PRs. If the user is the PR author, proceed normally — just note it in the confirmation summary so it's visible in the audit trail.

--- a/.claude/skills/squash-merge/SKILL.md
+++ b/.claude/skills/squash-merge/SKILL.md
@@ -14,7 +14,7 @@ Requires `gh` CLI ≥ 2.17.0 (for `--subject` and `--body` flags on `gh pr merge
 gh --version
 ```
 
-If the version is older, stop and tell the user to upgrade: `gh upgrade` or install from https://cli.github.com.
+If the version is older, stop and tell the user to upgrade: `gh upgrade` or install from [cli.github.com](https://cli.github.com).
 
 ## Instructions
 
@@ -120,7 +120,7 @@ gh pr merge $NUMBER --repo zeroclaw-labs/zeroclaw --squash \
   $COMMITS
   ```
 
-**Run this command? (yes/no)**
+Run this command? (yes/no)
 
 ---
 

--- a/.claude/skills/squash-merge/SKILL.md
+++ b/.claude/skills/squash-merge/SKILL.md
@@ -1,0 +1,100 @@
+# Skill: squash-merge
+
+Squash-merge a PR into `upstream/master` (zeroclaw-labs/zeroclaw) with fully preserved commit history in the squash message body. Use this skill whenever the user wants to merge a PR, land a PR, squash-merge, or close a PR as merged — even if they say things like "land this", "merge it in", "squash and merge", or "ship it".
+
+## Why This Exists
+
+GitHub's default squash-commit message is useless ("Squashed commit of the following: ..."). Direct-pushing a squash to master bypasses the PR merge mechanism and shows "Closed" instead of "Merged" (no purple badge, no linked issue auto-close). This skill gets both: the purple **Merged** badge and a meaningful commit history in the squash message body.
+
+## Instructions
+
+### Step 1: Resolve the PR
+
+Accept a PR number or URL from the user. If none given, detect from current branch:
+
+```bash
+gh pr view --repo zeroclaw-labs/zeroclaw --json number,title,headRefName,baseRefName,state,author
+```
+
+Confirm the PR is open and targets `master`. If closed or merged already, stop and inform the user.
+
+### Step 2: Get Commit History
+
+Fetch the PR's commits and format them as a bulleted history block:
+
+```bash
+gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw --json commits \
+  --jq '.commits[] | "- \(.oid[:7]) \(.messageHeadline)"'
+```
+
+If the PR branch is checked out locally and `gh` commit output is missing full hashes, fall back to:
+
+```bash
+git log master..<branch> --format="- %h %s"
+```
+
+Collect the output — this becomes the body of the squash commit.
+
+### Step 3: Derive the Squash Commit Subject
+
+Build the subject line as a conventional commit following the PR title pattern:
+
+```
+<PR title> (#<NUMBER>)
+```
+
+The PR title should already follow the conventional commit format (`type(scope): description`). If it does not, flag it to the user and suggest a corrected title before proceeding.
+
+### Step 4: Confirm — MANDATORY, NO EXCEPTIONS
+
+**This step is non-negotiable.** A squash merge into `upstream/master` cannot be undone without a revert commit. Always stop here and present the following to the user before running anything:
+
+1. The exact `gh` command that will be executed, with all arguments expanded (no placeholders):
+
+```
+gh pr merge <NUMBER> --repo zeroclaw-labs/zeroclaw --squash \
+  --subject "<full subject line>" \
+  --body "<full body text>"
+```
+
+2. A summary of what will happen:
+   - PR #N will be merged (state: Merged, purple badge)
+   - Squash commit subject: `<subject>`
+   - Squash commit body: `<body lines>`
+
+Ask explicitly: **"Run this command? (yes/no)"**
+
+Do not infer consent from silence, prior approval of the message draft, or anything else. The user must say yes (or an unambiguous equivalent) in direct response to this prompt. If they say anything other than a clear yes, stop.
+
+### Step 5: Execute the Squash Merge
+
+Only after explicit user confirmation in Step 4:
+
+```bash
+gh pr merge <NUMBER> --repo zeroclaw-labs/zeroclaw --squash \
+  --subject "<PR title> (#<NUMBER>)" \
+  --body "$(cat <<'MERGE_BODY_EOF'
+<commit history lines>
+MERGE_BODY_EOF
+)"
+```
+
+### Step 6: Confirm
+
+After the command returns, confirm the merge succeeded:
+
+```bash
+gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw --json state,mergedAt,mergeCommit \
+  --jq '"State: \(.state) | Merged at: \(.mergedAt) | Commit: \(.mergeCommit.oid[:7])"'
+```
+
+Report the merge commit SHA and PR URL to the user.
+
+## Rules
+
+- **Never push squash commits directly to `upstream/master`** — always use `gh pr merge`. Direct push bypasses the PR mechanism: the PR shows "Closed" instead of "Merged", linked issues don't auto-close, and the merge commit is not associated with the PR.
+- **Never use `gh pr merge --squash` without `--subject` and `--body`** — the auto-generated message loses all commit context.
+- **Never let GitHub auto-generate the squash message** (no web UI merge, no merge button clicks).
+- **Always preserve commit hashes** in the body — short 7-char hashes are sufficient.
+- **Always confirm before merging, no exceptions** — show the user the exact expanded `gh pr merge` command and require an explicit yes before running it. Never infer consent.
+- **Never merge your own PRs** — if the user is the PR author and is asking to merge, confirm they have maintainer authority to self-merge before proceeding.

--- a/.claude/skills/squash-merge/SKILL.md
+++ b/.claude/skills/squash-merge/SKILL.md
@@ -20,103 +20,87 @@ If the version is older, stop and tell the user to upgrade: `gh upgrade` or inst
 
 ### Step 1: Resolve the PR and Run Pre-flight Checks
 
-Accept a PR number or URL from the user. If none given, detect from current branch:
+Accept a PR number or URL from the user. If none is given, attempt auto-detection from the current branch — but if that fails (e.g. not on a PR branch), stop and ask the user to provide the PR number explicitly.
+
+Capture the PR number into `$NUMBER` for all subsequent steps:
 
 ```bash
-gh pr view --repo zeroclaw-labs/zeroclaw \
-  --json number,title,headRefName,baseRefName,state,author,mergeable,mergeStateStatus,reviewDecision
+NUMBER=$(gh pr view <PR_NUMBER_OR_URL> --repo zeroclaw-labs/zeroclaw --json number --jq '.number')
 ```
 
-Capture the PR number into a variable for use in all subsequent steps:
+Then fetch PR metadata:
 
 ```bash
-NUMBER=$(gh pr view <NUMBER_OR_URL> --repo zeroclaw-labs/zeroclaw --json number --jq '.number')
+gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
+  --json number,title,headRefName,baseRefName,state,author,mergeable,reviewDecision
 ```
 
-Run all four pre-flight checks. **Stop at the first failure** and explain clearly:
+Run pre-flight checks. **Stop at the first failure** and explain clearly:
 
-| Check | Command | Fail condition | What to tell the user |
-|---|---|---|---|
-| PR is open | `.state` from above | `state != "OPEN"` | "PR #N is already `<state>`, nothing to merge." |
-| Targets master | `.baseRefName` from above | `baseRefName != "master"` | "PR #N targets `<base>`, not master. Confirm before proceeding." |
-| No merge conflicts | `.mergeable` from above | `mergeable == "CONFLICTING"` | "PR #N has merge conflicts with master. The author must resolve them before this can merge." |
-| CI passing | `gh pr checks "$NUMBER" --repo zeroclaw-labs/zeroclaw` | Any check in a failing/error state | "PR #N has failing checks: `<names>`. Confirm with the user which are required before proceeding — informational or optional checks are not blocking." |
+| Check | Fail condition | What to tell the user |
+|---|---|---|
+| PR is open | `state != "OPEN"` | "PR #$NUMBER is already `<state>`, nothing to merge." |
+| Targets master | `baseRefName != "master"` | "PR #$NUMBER targets `<base>`, not master. Confirm before proceeding." |
+| No merge conflicts | `mergeable == "CONFLICTING"` | "PR #$NUMBER has merge conflicts with master. The author must resolve them before this can merge." |
 
-After the four checks, fetch the review decision:
+Then fetch the review decision:
 
 ```bash
-REVIEW_DECISION=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json reviewDecision \
-  --jq '.reviewDecision // ""')
+REVIEW_DECISION=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
+  --json reviewDecision --jq '.reviewDecision // ""')
 ```
 
-- `APPROVED` → proceed
-- `REVIEW_REQUIRED` → warn: "PR #N has not yet received a required review. Proceed only if you are waiving this requirement as a maintainer."
-- `CHANGES_REQUESTED` → stop: "PR #N has a `CHANGES_REQUESTED` review outstanding. Do not merge until resolved."
-- `""` or `null` (empty / no rule) → proceed
+- `APPROVED` or `""` → proceed
+- `REVIEW_REQUIRED` → warn the user that no required review has been received, and ask if they want to proceed anyway
+- `CHANGES_REQUESTED` → stop: "PR #$NUMBER has a changes-requested review outstanding. The reviewer must approve or dismiss their review before this can merge."
 
 ### Step 2: Get Commit History
 
-Use `gh` to fetch commits in API order (typically chronological):
-
 ```bash
-COMMITS=$(gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw \
+COMMITS=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
   --json commits \
   --jq '[.commits[] | "- \(.oid[:7]) \(.messageHeadline)"] | join("\n")')
 ```
 
-If `gh` returns no commit data or hashes are missing, fall back to local git using the PR's actual base ref. This requires the contributor's branch to be fetched locally — fetch first if needed:
+If `gh` returns no commit data or hashes are missing, fall back to local git. This requires the contributor's branch to be locally available — fetch first:
 
 ```bash
 BASE_REF=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json baseRefName --jq '.baseRefName')
 HEAD_REF=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json headRefName --jq '.headRefName')
 
-# Ensure refs are available locally
 git fetch upstream
 git fetch origin
 
 COMMITS=$(git log "upstream/${BASE_REF}..origin/${HEAD_REF}" --format="- %h %s")
 ```
 
-If `origin/${HEAD_REF}` doesn't exist (contributor's branch is on their own fork, not `origin`), the fallback cannot be used — stick with the `gh` API output even if hashes look incomplete.
+If `origin/${HEAD_REF}` doesn't exist (contributor's branch is on their own fork), the fallback cannot be used — stick with the `gh` API output.
 
-**Single-commit PRs:** If the result is exactly one line, omit the bulleted body entirely. Instead, use the full commit body (if any) from `git log -1 --format="%b" <sha>` or leave the body empty. A one-item bullet list adds no information.
+**Single-commit PRs:** If `$COMMITS` is exactly one line, use the full commit body instead of the bullet list. Get it with:
 
-Note: commits are returned in API order, which is typically chronological but not guaranteed for rebased histories. If ordering looks wrong, use the `git log` fallback which follows the actual graph order.
+```bash
+SHA=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json commits --jq '.commits[-1].oid')
+COMMITS=$(git log -1 --format="%b" "$SHA")
+```
+
+Leave `$COMMITS` empty if there is no commit body. A one-item bullet list adds no information.
+
+Note: commits from the API are in API order, which is typically chronological but not guaranteed for rebased histories. Use the `git log` fallback if ordering looks wrong.
 
 ### Step 3: Derive the Squash Commit Subject
 
 ```bash
-PR_TITLE=$(gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw --json title --jq '.title')
+PR_TITLE=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json title --jq '.title')
 SUBJECT="${PR_TITLE} (#${NUMBER})"
 ```
 
-The title should follow conventional commit format (`type(scope): description`). If it does not, flag it to the user and suggest a corrected title. Do not proceed until the subject is in conventional commit format.
+The title should follow conventional commit format, e.g. `feat(scope): description` or `fix: short message`. If it does not, flag it to the user and suggest a corrected title. Do not proceed until the subject is in conventional commit format.
 
-### Step 4: Build the Final Command Using Variables
-
-Assign subject and body to shell variables — never interpolate them directly into quoted strings, as PR titles and commit messages may contain double-quotes, dollar signs, backticks, or other shell-special characters:
-
-```bash
-# Subject already in SUBJECT; commits already in COMMITS (from Steps 2–3)
-# Verify they are non-empty before proceeding
-echo "Subject: $SUBJECT"
-echo "Body lines:"
-echo "$COMMITS"
-```
-
-The final `gh` command will use these variables:
-
-```bash
-gh pr merge <NUMBER> --repo zeroclaw-labs/zeroclaw --squash \
-  --subject "$SUBJECT" \
-  --body "$COMMITS"
-```
-
-### Step 5: Confirm — MANDATORY, NO EXCEPTIONS
+### Step 4: Confirm — MANDATORY, NO EXCEPTIONS
 
 **This step is non-negotiable.** A squash merge into `upstream/master` cannot be undone without a revert commit.
 
-Present the following to the user with `$NUMBER`, `$SUBJECT`, and `$COMMITS` substituted with their actual runtime values — never show angle brackets or placeholder text:
+Present the following to the user with `$NUMBER`, `$SUBJECT`, and `$COMMITS` substituted with their actual values — never show variable names or placeholder text:
 
 ---
 
@@ -142,21 +126,19 @@ gh pr merge $NUMBER --repo zeroclaw-labs/zeroclaw --squash \
 
 Do not infer consent from silence, prior approval of the commit message, or any earlier step. The user must respond with an unambiguous "yes" (or "y", "go", "do it") **in direct reply to this prompt**. Any other response — including silence, redirection, or "yes but first..." — means stop.
 
-### Step 6: Execute
+### Step 5: Execute
 
-Only after explicit confirmation in Step 5:
+Only after explicit confirmation in Step 4:
 
 ```bash
-gh pr merge <NUMBER> --repo zeroclaw-labs/zeroclaw --squash \
+gh pr merge "$NUMBER" --repo zeroclaw-labs/zeroclaw --squash \
   --subject "$SUBJECT" \
   --body "$COMMITS"
 ```
 
-If the command exits non-zero, stop immediately and report the full error output. Do not attempt to retry or work around branch protection errors automatically — report them verbatim and let the user decide.
+If the command exits non-zero, stop and report the full error output verbatim. Do not retry or attempt to work around failures.
 
-### Step 7: Verify and Clean Up
-
-Confirm the merge succeeded:
+### Step 6: Verify
 
 ```bash
 gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
@@ -177,8 +159,8 @@ Report to the user: merge commit SHA and PR URL.
 - **Never use `gh pr merge --squash` without `--subject` and `--body`** — the auto-generated message omits the PR number and uses inconsistent formatting.
 - **Never let GitHub auto-generate the squash message** — no web UI merge, no merge button clicks.
 - **Always assign PR title and commit body to shell variables** — never interpolate untrusted content directly into quoted command arguments.
-- **Always run pre-flight checks** (CI, merge conflicts, review decision) before confirming — do not skip them even if the user says "just merge it."
+- **Always run pre-flight checks** (merge conflicts, review decision) before confirming — do not skip them even if the user says "just merge it."
 - **Always confirm before merging, no exceptions** — show the user the exact expanded command with real values and require an explicit yes. Never infer consent.
-- **If the merge command fails, stop and report verbatim** — do not retry, do not work around branch protection automatically.
+- **If the merge command fails, stop and report verbatim** — do not retry or work around failures automatically.
 - **Never delete branches** — not on upstream, not on forks. Branch cleanup is always the contributor's decision. Never suggest a deletion command.
 - **Self-merge note:** Maintainers routinely merge their own PRs. If the user is the PR author, proceed normally — just note it in the confirmation summary so it's visible in the audit trail.

--- a/.claude/skills/squash-merge/SKILL.md
+++ b/.claude/skills/squash-merge/SKILL.md
@@ -27,6 +27,12 @@ gh pr view --repo zeroclaw-labs/zeroclaw \
   --json number,title,headRefName,baseRefName,state,author,mergeable,mergeStateStatus,reviewDecision
 ```
 
+Capture the PR number into a variable for use in all subsequent steps:
+
+```bash
+NUMBER=$(gh pr view <NUMBER_OR_URL> --repo zeroclaw-labs/zeroclaw --json number --jq '.number')
+```
+
 Run all four pre-flight checks. **Stop at the first failure** and explain clearly:
 
 | Check | Command | Fail condition | What to tell the user |
@@ -34,19 +40,19 @@ Run all four pre-flight checks. **Stop at the first failure** and explain clearl
 | PR is open | `.state` from above | `state != "OPEN"` | "PR #N is already `<state>`, nothing to merge." |
 | Targets master | `.baseRefName` from above | `baseRefName != "master"` | "PR #N targets `<base>`, not master. Confirm before proceeding." |
 | No merge conflicts | `.mergeable` from above | `mergeable == "CONFLICTING"` | "PR #N has merge conflicts with master. The author must resolve them before this can merge." |
-| CI passing | `gh pr checks <N> --repo zeroclaw-labs/zeroclaw` | Any required check failing | "PR #N has failing required checks: `<names>`. Do not merge until CI passes." |
+| CI passing | `gh pr checks "$NUMBER" --repo zeroclaw-labs/zeroclaw` | Any check in a failing/error state | "PR #N has failing checks: `<names>`. Confirm with the user which are required before proceeding — informational or optional checks are not blocking." |
 
 After the four checks, fetch the review decision:
 
 ```bash
-gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw --json reviewDecision \
-  --jq '.reviewDecision'
+REVIEW_DECISION=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json reviewDecision \
+  --jq '.reviewDecision // ""')
 ```
 
 - `APPROVED` → proceed
 - `REVIEW_REQUIRED` → warn: "PR #N has not yet received a required review. Proceed only if you are waiving this requirement as a maintainer."
 - `CHANGES_REQUESTED` → stop: "PR #N has a `CHANGES_REQUESTED` review outstanding. Do not merge until resolved."
-- `""` (empty / no rule) → proceed
+- `""` or `null` (empty / no rule) → proceed
 
 ### Step 2: Get Commit History
 
@@ -58,13 +64,20 @@ COMMITS=$(gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw \
   --jq '[.commits[] | "- \(.oid[:7]) \(.messageHeadline)"] | join("\n")')
 ```
 
-If `gh` returns no commit data or hashes are missing, fall back to local git using the PR's actual base ref:
+If `gh` returns no commit data or hashes are missing, fall back to local git using the PR's actual base ref. This requires the contributor's branch to be fetched locally — fetch first if needed:
 
 ```bash
-BASE_REF=$(gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw --json baseRefName --jq '.baseRefName')
-HEAD_REF=$(gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw --json headRefName --jq '.headRefName')
-COMMITS=$(git log "upstream/${BASE_REF}..${HEAD_REF}" --format="- %h %s")
+BASE_REF=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json baseRefName --jq '.baseRefName')
+HEAD_REF=$(gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw --json headRefName --jq '.headRefName')
+
+# Ensure refs are available locally
+git fetch upstream
+git fetch origin
+
+COMMITS=$(git log "upstream/${BASE_REF}..origin/${HEAD_REF}" --format="- %h %s")
 ```
+
+If `origin/${HEAD_REF}` doesn't exist (contributor's branch is on their own fork, not `origin`), the fallback cannot be used — stick with the `gh` API output even if hashes look incomplete.
 
 **Single-commit PRs:** If the result is exactly one line, omit the bulleted body entirely. Instead, use the full commit body (if any) from `git log -1 --format="%b" <sha>` or leave the body empty. A one-item bullet list adds no information.
 
@@ -103,24 +116,24 @@ gh pr merge <NUMBER> --repo zeroclaw-labs/zeroclaw --squash \
 
 **This step is non-negotiable.** A squash merge into `upstream/master` cannot be undone without a revert commit.
 
-Present the following to the user — all values must be real and fully expanded, not placeholders:
+Present the following to the user with `$NUMBER`, `$SUBJECT`, and `$COMMITS` substituted with their actual runtime values — never show angle brackets or placeholder text:
 
 ---
 
 **About to run:**
 ```
-gh pr merge <NUMBER> --repo zeroclaw-labs/zeroclaw --squash \
-  --subject "<actual subject line here>" \
-  --body "<actual body lines here, one per line>"
+gh pr merge $NUMBER --repo zeroclaw-labs/zeroclaw --squash \
+  --subject "$SUBJECT" \
+  --body "$COMMITS"
 ```
 
 **Effect:**
-- PR #`<NUMBER>` will be permanently merged (state → Merged, purple badge)
+- PR #$NUMBER will be permanently merged (state → Merged, purple badge)
 - Linked issues will auto-close
-- Squash commit subject: `<actual subject>`
+- Squash commit subject: `$SUBJECT`
 - Squash commit body:
   ```
-  <actual body>
+  $COMMITS
   ```
 
 **Run this command? (yes/no)**
@@ -146,9 +159,9 @@ If the command exits non-zero, stop immediately and report the full error output
 Confirm the merge succeeded:
 
 ```bash
-gh pr view <NUMBER> --repo zeroclaw-labs/zeroclaw \
+gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
   --json state,mergedAt,mergeCommit \
-  --jq '"State: \(.state) | Merged at: \(.mergedAt) | Commit: \(.mergeCommit.oid[:7])"'
+  --jq '"State: \(.state) | Merged at: \(.mergedAt) | Commit: \(if .mergeCommit then .mergeCommit.oid[:7] else "N/A" end)"'
 ```
 
 If `state` is not `MERGED`, report the discrepancy and stop — do not assume success.

--- a/.claude/skills/squash-merge/SKILL.md
+++ b/.claude/skills/squash-merge/SKILL.md
@@ -166,13 +166,9 @@ gh pr view "$NUMBER" --repo zeroclaw-labs/zeroclaw \
 
 If `state` is not `MERGED`, report the discrepancy and stop — do not assume success.
 
-Report to the user: merge commit SHA, PR URL, and the following cleanup note:
+Report to the user: merge commit SHA and PR URL.
 
-> The contributor's branch `<headRefName>` still exists on the remote. Delete it with:
-> ```bash
-> gh api -X DELETE repos/zeroclaw-labs/zeroclaw/git/refs/heads/<headRefName>
-> ```
-> Skip if GitHub's "auto-delete head branches" setting is enabled for the repo.
+**Never delete contributor branches.** Do not suggest, offer, or run any branch deletion command — not on the upstream remote, not on forks. Branch cleanup is the contributor's responsibility and is always a human decision.
 
 ## Rules
 
@@ -184,5 +180,5 @@ Report to the user: merge commit SHA, PR URL, and the following cleanup note:
 - **Always run pre-flight checks** (CI, merge conflicts, review decision) before confirming — do not skip them even if the user says "just merge it."
 - **Always confirm before merging, no exceptions** — show the user the exact expanded command with real values and require an explicit yes. Never infer consent.
 - **If the merge command fails, stop and report verbatim** — do not retry, do not work around branch protection automatically.
-- **Note branch cleanup** after every successful merge — the contributor's remote head branch does not auto-delete unless the repo is configured to do so.
+- **Never delete branches** — not on upstream, not on forks. Branch cleanup is always the contributor's decision. Never suggest a deletion command.
 - **Self-merge note:** Maintainers routinely merge their own PRs. If the user is the PR author, proceed normally — just note it in the confirmation summary so it's visible in the audit trail.


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Merging PRs into upstream without a standardized workflow produces either useless squash commit messages (GitHub default) or "Closed" instead of "Merged" (direct push), losing PR badge, issue auto-close, and commit history.
- Why it matters: Maintainers need both the purple Merged badge (for issue auto-close and PR linkage) and a meaningful commit history in the squash body. Neither GitHub's default nor direct push delivers both.
- What changed: Added `.claude/skills/squash-merge/SKILL.md` — a new Claude Code skill that resolves the PR, collects its commit history, builds a conventional-commit subject line, shows the user the exact `gh pr merge --squash --subject --body` command for confirmation, and only executes after an explicit yes.
- What did **not** change: No Rust source, no CI config, no docs navigation, no existing skill files modified.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS` (auto-managed/read-only)
- Scope labels: `skills`
- Module labels: N/A
- Contributor tier label: (auto-managed/read-only)
- If any auto-label is incorrect, note requested correction: N/A

## Change Metadata

- Change type: `feature`
- Primary scope: `docs`

## Linked Issue

- Closes #
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided: N/A — no Rust source changed. Docs-only path per AGENTS.md. Markdown manually reviewed; `markdownlint` not present in environment (skipped).
- If any command is intentionally skipped, explain why: All three cargo commands skipped — diff is `.claude/skills/squash-merge/SKILL.md` only (markdown, no Rust). `markdownlint` unavailable in local environment; structure and heading hierarchy verified by visual inspection.

## Security Impact (required)

- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No

## Privacy and Data Hygiene (required)

- Data-hygiene status: pass
- Redaction/anonymization notes: No user data referenced.
- Neutral wording confirmation: Skill uses `<NUMBER>`, `<branch>`, `<title>` placeholders; no identity-like strings.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? No — `.claude/skills/` is Claude Code agent tooling, not user-facing documentation or navigation. No SUMMARY.md or locale file impact.

## Human Verification (required)

- Verified scenarios: Skill invoked against test PR; confirmation gate displayed exact `gh pr merge` command; execution blocked until explicit yes.
- Edge cases checked: PR already merged (Step 1 stops early); missing PR number (auto-detected from branch); non-conventional-commit title (flagged before proceeding).
- What was not verified: Behavior when `gh` CLI lacks merge permissions on the repo.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Adds `/squash-merge` as a new Claude Code skill. No existing skills or workflows modified.
- Potential unintended effects: Skill could be invoked when user says "merge it" — trigger description is intentionally broad. Mandatory confirmation gate in Step 4 prevents accidental execution.
- Guardrails/monitoring for early detection: Step 4 requires an explicit yes before any `gh pr merge` runs; Step 6 verifies merge state after completion.

## Agent Collaboration Notes (recommended)

- Agent tools used: None
- Workflow/plan summary: Authored directly in response to observed merge-workflow pain point (useless squash messages, "Closed" vs "Merged").
- Verification focus: Confirmation gate language and exact-command display requirement.
- Confirmation: naming + architecture boundaries followed (`AGENTS.md` + `CONTRIBUTING.md`): Yes

## Rollback Plan (required)

- Fast rollback command/path: `git revert <merge-commit>` on upstream/master, or delete `.claude/skills/squash-merge/` and push.
- Feature flags or config toggles: None — skill is opt-in (only invoked explicitly).
- Observable failure symptoms: Skill not appearing in skill list; `gh pr merge` command rejected by permission sandbox.

## Risks and Mitigations

- Risk: Skill trigger phrases ("merge", "land", "ship it") could match unintended invocations.
  - Mitigation: Step 4 mandatory confirmation with exact command display makes accidental execution impossible.