### PR TITLE
fix(channels/telegram): send inline_keyboard for tool approval requests

### DIFF
--- a/crates/zeroclaw-api/src/channel.rs
+++ b/crates/zeroclaw-api/src/channel.rs
@@ -1,7 +1,29 @@
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
 use crate::media::MediaAttachment;
+
+// ── Channel approval types ──────────────────────────────────────
+
+/// Compact description of a tool call presented to the user for approval.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChannelApprovalRequest {
+    pub tool_name: String,
+    pub arguments_summary: String,
+}
+
+/// The operator's response to a channel-presented approval prompt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ChannelApprovalResponse {
+    /// Execute this one call.
+    Approve,
+    /// Deny this call.
+    Deny,
+    /// Execute and add tool to session-scoped allowlist.
+    AlwaysApprove,
+}
 
 /// A message received from or sent to a channel
 #[derive(Debug, Clone)]
@@ -209,5 +231,19 @@ pub trait Channel: Send + Sync {
         _reason: Option<String>,
     ) -> anyhow::Result<()> {
         Ok(())
+    }
+
+    /// Request interactive tool-call approval from the channel operator.
+    ///
+    /// Returns `Ok(Some(response))` when the channel supports interactive
+    /// approval (e.g. Telegram inline keyboards). Returns `Ok(None)` when the
+    /// channel does not support approval prompts — the caller should fall back
+    /// to its default policy (typically auto-deny).
+    async fn request_approval(
+        &self,
+        _recipient: &str,
+        _request: &ChannelApprovalRequest,
+    ) -> anyhow::Result<Option<ChannelApprovalResponse>> {
+        Ok(None)
     }
 }

--- a/crates/zeroclaw-api/src/channel.rs
+++ b/crates/zeroclaw-api/src/channel.rs
@@ -22,6 +22,7 @@ pub enum ChannelApprovalResponse {
     /// Deny this call.
     Deny,
     /// Execute and add tool to session-scoped allowlist.
+    #[serde(rename = "always")]
     AlwaysApprove,
 }
 

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -3918,7 +3918,8 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 .with_streaming(tg.stream_mode, tg.draft_update_interval_ms)
                 .with_transcription(config.transcription.clone())
                 .with_tts(config.tts.clone())
-                .with_workspace_dir(config.workspace_dir.clone()),
+                .with_workspace_dir(config.workspace_dir.clone())
+                .with_approval_timeout_secs(tg.approval_timeout_secs),
             ))
         }
         "discord" => {
@@ -4347,7 +4348,8 @@ fn collect_configured_channels(
                     .with_transcription(config.transcription.clone())
                     .with_tts(config.tts.clone())
                     .with_workspace_dir(config.workspace_dir.clone())
-                    .with_proxy_url(tg.proxy_url.clone()),
+                    .with_proxy_url(tg.proxy_url.clone())
+                    .with_approval_timeout_secs(tg.approval_timeout_secs),
                 ),
             });
         } else {
@@ -11515,6 +11517,7 @@ This is an example JSON object for profile settings."#;
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            approval_timeout_secs: 120,
         });
         match build_channel_by_id(&config, "telegram") {
             Ok(channel) => assert_eq!(channel.name(), "telegram"),

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -3055,6 +3055,7 @@ async fn process_channel_message(
                         ctx.max_tool_result_chars,
                         ctx.context_token_budget,
                         None, // shared_budget
+                        target_channel.as_deref(),
                     ),
                     ),
                     ),

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -350,6 +350,10 @@ pub struct TelegramChannel {
             >,
         >,
     >,
+    /// Seconds to wait for the operator to tap an inline-keyboard button on a
+    /// tool approval prompt before auto-denying. Configurable via
+    /// `channels.telegram.approval_timeout_secs`. Default: 120.
+    approval_timeout_secs: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -395,7 +399,14 @@ impl TelegramChannel {
             pending_voice: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             proxy_url: None,
             pending_approvals: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
+            approval_timeout_secs: 120,
         }
+    }
+
+    /// Override the approval prompt timeout (default 120s).
+    pub fn with_approval_timeout_secs(mut self, secs: u64) -> Self {
+        self.approval_timeout_secs = secs;
+        self
     }
 
     /// Configure whether Telegram-native acknowledgement reactions are sent.
@@ -3164,8 +3175,14 @@ Ensure only one `zeroclaw` process is using this bot token."
             }
         }
 
-        // Wait up to 120 seconds for the user to tap a button.
-        let result = match tokio::time::timeout(Duration::from_secs(120), rx).await {
+        // Wait for the user to tap a button. Timeout is configurable via
+        // `channels.telegram.approval_timeout_secs` (default 120s).
+        let result = match tokio::time::timeout(
+            Duration::from_secs(self.approval_timeout_secs),
+            rx,
+        )
+        .await
+        {
             Ok(Ok(response)) => Some(response),
             _ => {
                 // Timeout or sender dropped — clean up and deny.
@@ -5285,6 +5302,14 @@ mod tests {
             let map = ch.pending_approvals.lock().await;
             assert!(map.is_empty());
         });
+    }
+
+    #[test]
+    fn approval_timeout_defaults_to_120_and_is_overridable() {
+        let ch = TelegramChannel::new("t".into(), vec!["*".into()], false);
+        assert_eq!(ch.approval_timeout_secs, 120);
+        let ch = ch.with_approval_timeout_secs(30);
+        assert_eq!(ch.approval_timeout_secs, 30);
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -3177,19 +3177,15 @@ Ensure only one `zeroclaw` process is using this bot token."
 
         // Wait for the user to tap a button. Timeout is configurable via
         // `channels.telegram.approval_timeout_secs` (default 120s).
-        let result = match tokio::time::timeout(
-            Duration::from_secs(self.approval_timeout_secs),
-            rx,
-        )
-        .await
-        {
-            Ok(Ok(response)) => Some(response),
-            _ => {
-                // Timeout or sender dropped — clean up and deny.
-                self.pending_approvals.lock().await.remove(&approval_id);
-                Some(ChannelApprovalResponse::Deny)
-            }
-        };
+        let result =
+            match tokio::time::timeout(Duration::from_secs(self.approval_timeout_secs), rx).await {
+                Ok(Ok(response)) => Some(response),
+                _ => {
+                    // Timeout or sender dropped — clean up and deny.
+                    self.pending_approvals.lock().await.remove(&approval_id);
+                    Some(ChannelApprovalResponse::Deny)
+                }
+            };
 
         Ok(result)
     }

--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -340,6 +340,16 @@ pub struct TelegramChannel {
         Arc<std::sync::Mutex<std::collections::HashMap<String, (String, std::time::Instant)>>>,
     /// Per-channel proxy URL override.
     proxy_url: Option<String>,
+    /// Pending approval requests: callback_data key → oneshot sender.
+    /// `listen()` resolves these when a matching `callback_query` arrives.
+    pending_approvals: Arc<
+        tokio::sync::Mutex<
+            std::collections::HashMap<
+                String,
+                tokio::sync::oneshot::Sender<zeroclaw_api::channel::ChannelApprovalResponse>,
+            >,
+        >,
+    >,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -384,6 +394,7 @@ impl TelegramChannel {
             voice_chats: Arc::new(std::sync::Mutex::new(std::collections::HashSet::new())),
             pending_voice: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             proxy_url: None,
+            pending_approvals: Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new())),
         }
     }
 
@@ -2796,7 +2807,7 @@ impl Channel for TelegramChannel {
             let probe = serde_json::json!({
                 "offset": offset,
                 "timeout": 0,
-                "allowed_updates": ["message"]
+                "allowed_updates": ["message", "callback_query"]
             });
             match self.http_client().post(&url).json(&probe).send().await {
                 Err(e) => {
@@ -2869,7 +2880,7 @@ impl Channel for TelegramChannel {
             let body = serde_json::json!({
                 "offset": offset,
                 "timeout": 30,
-                "allowed_updates": ["message"]
+                "allowed_updates": ["message", "callback_query"]
             });
 
             let resp = match self.http_client().post(&url).json(&body).send().await {
@@ -2928,6 +2939,68 @@ Ensure only one `zeroclaw` process is using this bot token."
                     // Advance offset past this update
                     if let Some(uid) = update.get("update_id").and_then(serde_json::Value::as_i64) {
                         offset = uid + 1;
+                    }
+
+                    // ── Handle callback_query (inline keyboard taps) ──
+                    if let Some(cb) = update.get("callback_query") {
+                        let cb_id = cb
+                            .get("id")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or_default();
+                        let cb_data = cb
+                            .get("data")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or_default();
+
+                        if let Some(rest) = cb_data.strip_prefix("approval:")
+                            && let Some((approval_id, action)) = rest.rsplit_once(':')
+                        {
+                            let response = match action {
+                                "approve" => {
+                                    Some(zeroclaw_api::channel::ChannelApprovalResponse::Approve)
+                                }
+                                "always" => Some(
+                                    zeroclaw_api::channel::ChannelApprovalResponse::AlwaysApprove,
+                                ),
+                                "deny" => {
+                                    Some(zeroclaw_api::channel::ChannelApprovalResponse::Deny)
+                                }
+                                other => {
+                                    tracing::warn!("Unknown approval callback action: {other}");
+                                    None
+                                }
+                            };
+
+                            if let Some(resp) = response
+                                && let Some(sender) =
+                                    self.pending_approvals.lock().await.remove(approval_id)
+                            {
+                                let _ = sender.send(resp);
+                            }
+
+                            // Answer the callback query to dismiss the spinner.
+                            let answer_text = match action {
+                                "approve" => "✅ Approved",
+                                "always" => "✅✅ Always approved",
+                                "deny" => "❌ Denied",
+                                _ => "⚠️ Unknown action",
+                            };
+                            let answer_body = serde_json::json!({
+                                "callback_query_id": cb_id,
+                                "text": answer_text,
+                            });
+                            if let Err(e) = self
+                                .http_client()
+                                .post(self.api_url("answerCallbackQuery"))
+                                .json(&answer_body)
+                                .send()
+                                .await
+                            {
+                                tracing::warn!("answerCallbackQuery failed: {e}");
+                            }
+                        }
+
+                        continue; // callback_query is not a regular message
                     }
 
                     let msg = if let Some(m) = self.parse_update_message(update) {
@@ -3023,6 +3096,85 @@ Ensure only one `zeroclaw` process is using this bot token."
             handle.abort();
         }
         Ok(())
+    }
+
+    async fn request_approval(
+        &self,
+        recipient: &str,
+        request: &zeroclaw_api::channel::ChannelApprovalRequest,
+    ) -> anyhow::Result<Option<zeroclaw_api::channel::ChannelApprovalResponse>> {
+        use zeroclaw_api::channel::ChannelApprovalResponse;
+
+        // Parse recipient for chat_id (may contain ":thread_id" suffix).
+        let chat_id = recipient.split_once(':').map_or(recipient, |(c, _)| c);
+
+        // Unique key embedded in callback_data so listen() can route the tap.
+        let approval_id = uuid::Uuid::new_v4().to_string();
+
+        let tool = Self::escape_html(&request.tool_name);
+        let args = Self::escape_html(&request.arguments_summary);
+        let text = format!(
+            "\u{1f527} <b>Tool approval required</b>\n\n\
+             Tool: <code>{tool}</code>\n\
+             {args}\n\n\
+             Tap a button below:",
+        );
+
+        let reply_markup = serde_json::json!({
+            "inline_keyboard": [[
+                { "text": "✅ Approve",  "callback_data": format!("approval:{}:approve", approval_id) },
+                { "text": "❌ Deny",     "callback_data": format!("approval:{}:deny", approval_id) },
+                { "text": "✅✅ Always", "callback_data": format!("approval:{}:always", approval_id) },
+            ]]
+        });
+
+        let body = serde_json::json!({
+            "chat_id": chat_id,
+            "text": text,
+            "parse_mode": "HTML",
+            "reply_markup": reply_markup,
+        });
+
+        // Register the oneshot BEFORE sending the message to avoid a race
+        // where the user taps the button before the sender is in the map.
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.pending_approvals
+            .lock()
+            .await
+            .insert(approval_id.clone(), tx);
+
+        let resp = self
+            .http_client()
+            .post(self.api_url("sendMessage"))
+            .json(&body)
+            .send()
+            .await;
+
+        match resp {
+            Ok(r) if r.status().is_success() => {}
+            Ok(r) => {
+                self.pending_approvals.lock().await.remove(&approval_id);
+                let status = r.status();
+                let err = r.text().await.unwrap_or_default();
+                anyhow::bail!("Telegram sendMessage (approval) failed ({status}): {err}");
+            }
+            Err(e) => {
+                self.pending_approvals.lock().await.remove(&approval_id);
+                return Err(e.into());
+            }
+        }
+
+        // Wait up to 120 seconds for the user to tap a button.
+        let result = match tokio::time::timeout(Duration::from_secs(120), rx).await {
+            Ok(Ok(response)) => Some(response),
+            _ => {
+                // Timeout or sender dropped — clean up and deny.
+                self.pending_approvals.lock().await.remove(&approval_id);
+                Some(ChannelApprovalResponse::Deny)
+            }
+        };
+
+        Ok(result)
     }
 }
 
@@ -5118,5 +5270,81 @@ mod tests {
         let photo_content = "[IMAGE:/tmp/photo.jpg]".to_string();
         let content = format!("{attr}{photo_content}");
         assert_eq!(content, "[Forwarded from @bob] [IMAGE:/tmp/photo.jpg]");
+    }
+
+    // ── Approval inline keyboard tests ────────────────────────
+
+    #[test]
+    fn pending_approvals_map_is_initially_empty() {
+        let ch = TelegramChannel::new("token".into(), vec!["*".into()], false);
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let map = ch.pending_approvals.lock().await;
+            assert!(map.is_empty());
+        });
+    }
+
+    #[tokio::test]
+    async fn pending_approval_oneshot_delivers_response() {
+        use zeroclaw_api::channel::ChannelApprovalResponse;
+
+        let ch = TelegramChannel::new("token".into(), vec!["*".into()], false);
+        let approval_id = "test-approval-123".to_string();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+
+        ch.pending_approvals
+            .lock()
+            .await
+            .insert(approval_id.clone(), tx);
+
+        // Simulate what listen() does when a callback_query arrives
+        if let Some(sender) = ch.pending_approvals.lock().await.remove(&approval_id) {
+            sender.send(ChannelApprovalResponse::Approve).unwrap();
+        }
+
+        let result = rx.await.unwrap();
+        assert_eq!(result, ChannelApprovalResponse::Approve);
+    }
+
+    #[test]
+    fn callback_data_format_parses_correctly() {
+        // Verify the callback_data format used by request_approval
+        let cb_data = "approval:abc-123:approve";
+        let rest = cb_data.strip_prefix("approval:").unwrap();
+        let (id, action) = rest.rsplit_once(':').unwrap();
+        assert_eq!(id, "abc-123");
+        assert_eq!(action, "approve");
+
+        let cb_data = "approval:abc-123:deny";
+        let rest = cb_data.strip_prefix("approval:").unwrap();
+        let (id, action) = rest.rsplit_once(':').unwrap();
+        assert_eq!(id, "abc-123");
+        assert_eq!(action, "deny");
+
+        let cb_data = "approval:abc-123:always";
+        let rest = cb_data.strip_prefix("approval:").unwrap();
+        let (id, action) = rest.rsplit_once(':').unwrap();
+        assert_eq!(id, "abc-123");
+        assert_eq!(action, "always");
+    }
+
+    #[test]
+    fn callback_data_with_uuid_parses_correctly() {
+        // UUIDs contain hyphens — rsplit_once(':') must split at the LAST colon
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let cb_data = format!("approval:{uuid}:approve");
+        let rest = cb_data.strip_prefix("approval:").unwrap();
+        let (id, action) = rest.rsplit_once(':').unwrap();
+        assert_eq!(id, uuid);
+        assert_eq!(action, "approve");
+    }
+
+    #[test]
+    fn non_approval_callback_data_is_ignored() {
+        let cb_data = "some_other_action:data";
+        assert!(cb_data.strip_prefix("approval:").is_none());
     }
 }

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6799,6 +6799,10 @@ fn default_multi_message_delay_ms() -> u64 {
     800
 }
 
+fn default_telegram_approval_timeout_secs() -> u64 {
+    120
+}
+
 fn default_matrix_draft_update_interval_ms() -> u64 {
     1500
 }
@@ -6839,6 +6843,10 @@ pub struct TelegramConfig {
     /// Overrides the global `[proxy]` setting for this channel only.
     #[serde(default)]
     pub proxy_url: Option<String>,
+    /// How long (seconds) to wait for the operator to tap an inline-keyboard
+    /// button on a tool approval prompt before auto-denying. Default: 120.
+    #[serde(default = "default_telegram_approval_timeout_secs")]
+    pub approval_timeout_secs: u64,
 }
 
 impl ChannelConfig for TelegramConfig {
@@ -11662,6 +11670,7 @@ auto_save = true
                     mention_only: false,
                     ack_reactions: None,
                     proxy_url: None,
+                    approval_timeout_secs: default_telegram_approval_timeout_secs(),
                 }),
                 discord: None,
                 discord_history: None,
@@ -12551,6 +12560,7 @@ default_temperature = 0.7
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            approval_timeout_secs: 120,
         };
         let json = serde_json::to_string(&tc).unwrap();
         let parsed: TelegramConfig = serde_json::from_str(&json).unwrap();
@@ -15731,6 +15741,7 @@ require_otp_to_resume = true
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            approval_timeout_secs: default_telegram_approval_timeout_secs(),
         });
 
         // Save (triggers encryption)

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -47,6 +47,7 @@ use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
+use zeroclaw_api::channel::Channel;
 use zeroclaw_api::provider::StreamEvent;
 use zeroclaw_config::schema::Config;
 use zeroclaw_memory::{self, Memory, MemoryCategory, decay};
@@ -643,6 +644,7 @@ pub async fn agent_turn(
     dedup_exempt_tools: &[String],
     activated_tools: Option<&std::sync::Arc<std::sync::Mutex<crate::tools::ActivatedToolSet>>>,
     model_switch_callback: Option<ModelSwitchCallback>,
+    channel: Option<&dyn Channel>,
 ) -> Result<String> {
     run_tool_call_loop(
         provider,
@@ -669,6 +671,7 @@ pub async fn agent_turn(
         0,    // max_tool_result_chars: 0 = disabled (legacy callers)
         0,    // context_token_budget: 0 = disabled (legacy callers)
         None, // shared_budget: no shared budget for legacy callers
+        channel,
     )
     .await
 }
@@ -807,6 +810,7 @@ pub async fn run_tool_call_loop(
     max_tool_result_chars: usize,
     context_token_budget: usize,
     shared_budget: Option<Arc<std::sync::atomic::AtomicUsize>>,
+    channel: Option<&dyn Channel>,
 ) -> Result<String> {
     let max_iterations = if max_tool_iterations == 0 {
         DEFAULT_MAX_TOOL_ITERATIONS
@@ -1517,10 +1521,40 @@ pub async fn run_tool_call_loop(
                 };
 
                 // Interactive CLI: prompt the operator.
-                // Non-interactive (channels): auto-deny since no operator
-                // is present to approve.
+                // Non-interactive (channels): try the channel's inline
+                // approval (e.g. Telegram inline keyboard) before falling
+                // back to auto-deny.
                 let decision = if mgr.is_non_interactive() {
-                    ApprovalResponse::No
+                    let channel_decision = if let Some(ch) = channel {
+                        let ch_request = zeroclaw_api::channel::ChannelApprovalRequest {
+                            tool_name: request.tool_name.clone(),
+                            arguments_summary: crate::approval::summarize_args(&request.arguments),
+                        };
+                        let recipient = channel_reply_target.unwrap_or_default();
+                        match ch.request_approval(recipient, &ch_request).await {
+                            Ok(Some(r)) => Some(r),
+                            Ok(None) => None,
+                            Err(e) => {
+                                tracing::warn!("Channel approval request failed: {e}");
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+                    match channel_decision {
+                        Some(zeroclaw_api::channel::ChannelApprovalResponse::Approve) => {
+                            ApprovalResponse::Yes
+                        }
+                        Some(zeroclaw_api::channel::ChannelApprovalResponse::AlwaysApprove) => {
+                            ApprovalResponse::Always
+                        }
+                        Some(zeroclaw_api::channel::ChannelApprovalResponse::Deny) => {
+                            ApprovalResponse::No
+                        }
+                        // Channel doesn't support approval — auto-deny.
+                        None => ApprovalResponse::No,
+                    }
                 } else {
                     mgr.prompt_cli(&request)
                 };
@@ -2501,6 +2535,7 @@ pub async fn run(
                         config.agent.max_tool_result_chars,
                         config.agent.max_context_tokens,
                         None, // shared_budget
+                        None, // channel: CLI mode — uses prompt_cli
                     ),
                 )
                 .await
@@ -2810,6 +2845,7 @@ pub async fn run(
                             config.agent.max_tool_result_chars,
                             config.agent.max_context_tokens,
                             None, // shared_budget
+                            None, // channel: interactive CLI — uses prompt_cli
                         ),
                     )
                     .await
@@ -3322,6 +3358,7 @@ pub async fn process_message(
         &config.agent.tool_call_dedup_exempt,
         activated_handle_pm.as_ref(),
         None,
+        None, // channel: process_message path has no channel ref
     )
     .await
 }
@@ -4367,6 +4404,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect_err("provider without vision support should fail");
@@ -4422,6 +4460,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect_err("oversized payload must fail");
@@ -4471,6 +4510,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("valid multimodal payload should pass");
@@ -4519,6 +4559,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect_err("should fail without vision_provider config");
@@ -4574,6 +4615,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect_err("should fail when vision provider cannot be created");
@@ -4629,6 +4671,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("text-only messages should succeed with default provider");
@@ -4685,6 +4728,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect_err("should fail due to nonexistent vision provider");
@@ -4739,6 +4783,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("empty image markers should not trigger vision routing");
@@ -4793,6 +4838,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect_err("should attempt vision provider creation for multiple images");
@@ -4930,6 +4976,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("parallel execution should complete");
@@ -5007,6 +5054,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("cron_add delivery defaults should be injected");
@@ -5076,6 +5124,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("explicit delivery mode should be preserved");
@@ -5140,6 +5189,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("loop should finish after deduplicating repeated calls");
@@ -5217,6 +5267,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("non-interactive shell should succeed for low-risk command");
@@ -5284,6 +5335,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("loop should finish with exempt tool executing twice");
@@ -5371,6 +5423,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("loop should complete");
@@ -5432,6 +5485,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("native fallback id flow should complete");
@@ -5520,6 +5574,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("native tool-call text should be relayed through on_delta");
@@ -5585,6 +5640,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("streaming provider should complete");
@@ -5653,6 +5709,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("streaming tool loop should execute tool and finish");
@@ -5728,6 +5785,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("native streaming events should preserve tool loop semantics");
@@ -5812,6 +5870,7 @@ mod tests {
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("routed streaming provider should complete");
@@ -5895,6 +5954,7 @@ mod tests {
                 &[],
                 Some(&activated),
                 None,
+                None, // channel
             )
             .await
             .expect("wrapper path should execute activated tools");
@@ -6872,6 +6932,7 @@ Let me check the result."#;
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("tool loop should complete");
@@ -7031,6 +7092,7 @@ Let me check the result."#;
                     0,
                     0,
                     None,
+                    None, // channel
                 ),
             )
             .await
@@ -7116,6 +7178,7 @@ Let me check the result."#;
                     0,
                     0,
                     None,
+                    None, // channel
                 ),
             )
             .await
@@ -7174,6 +7237,7 @@ Let me check the result."#;
             0,
             0,
             None,
+            None, // channel
         )
         .await
         .expect("should succeed without cost scope");

--- a/crates/zeroclaw-runtime/src/approval/mod.rs
+++ b/crates/zeroclaw-runtime/src/approval/mod.rs
@@ -666,8 +666,7 @@ mod tests {
         // ApprovalResponse::Always and keep audit logs consistent.
         let json = serde_json::to_string(&ChannelApprovalResponse::AlwaysApprove).unwrap();
         assert_eq!(json, "\"always\"");
-        let parsed: ChannelApprovalResponse =
-            serde_json::from_str("\"always\"").unwrap();
+        let parsed: ChannelApprovalResponse = serde_json::from_str("\"always\"").unwrap();
         assert_eq!(parsed, ChannelApprovalResponse::AlwaysApprove);
         let parsed: ChannelApprovalResponse = serde_json::from_str("\"deny\"").unwrap();
         assert_eq!(parsed, ChannelApprovalResponse::Deny);

--- a/crates/zeroclaw-runtime/src/approval/mod.rs
+++ b/crates/zeroclaw-runtime/src/approval/mod.rs
@@ -662,8 +662,13 @@ mod tests {
     #[test]
     fn channel_approval_response_serde_roundtrip() {
         use zeroclaw_api::channel::ChannelApprovalResponse;
+        // AlwaysApprove serializes to "always" to match the CLI-side
+        // ApprovalResponse::Always and keep audit logs consistent.
         let json = serde_json::to_string(&ChannelApprovalResponse::AlwaysApprove).unwrap();
-        assert_eq!(json, "\"alwaysapprove\"");
+        assert_eq!(json, "\"always\"");
+        let parsed: ChannelApprovalResponse =
+            serde_json::from_str("\"always\"").unwrap();
+        assert_eq!(parsed, ChannelApprovalResponse::AlwaysApprove);
         let parsed: ChannelApprovalResponse = serde_json::from_str("\"deny\"").unwrap();
         assert_eq!(parsed, ChannelApprovalResponse::Deny);
     }

--- a/crates/zeroclaw-runtime/src/approval/mod.rs
+++ b/crates/zeroclaw-runtime/src/approval/mod.rs
@@ -610,4 +610,61 @@ mod tests {
             "always_ask must override auto_approve"
         );
     }
+
+    // ── ChannelApprovalResponse → ApprovalResponse mapping ──────
+
+    #[test]
+    fn channel_approve_maps_to_yes() {
+        use zeroclaw_api::channel::ChannelApprovalResponse;
+        let mapped = match ChannelApprovalResponse::Approve {
+            ChannelApprovalResponse::Approve => ApprovalResponse::Yes,
+            ChannelApprovalResponse::AlwaysApprove => ApprovalResponse::Always,
+            ChannelApprovalResponse::Deny => ApprovalResponse::No,
+        };
+        assert_eq!(mapped, ApprovalResponse::Yes);
+    }
+
+    #[test]
+    fn channel_always_approve_maps_to_always() {
+        use zeroclaw_api::channel::ChannelApprovalResponse;
+        let mapped = match ChannelApprovalResponse::AlwaysApprove {
+            ChannelApprovalResponse::Approve => ApprovalResponse::Yes,
+            ChannelApprovalResponse::AlwaysApprove => ApprovalResponse::Always,
+            ChannelApprovalResponse::Deny => ApprovalResponse::No,
+        };
+        assert_eq!(mapped, ApprovalResponse::Always);
+    }
+
+    #[test]
+    fn channel_deny_maps_to_no() {
+        use zeroclaw_api::channel::ChannelApprovalResponse;
+        let mapped = match ChannelApprovalResponse::Deny {
+            ChannelApprovalResponse::Approve => ApprovalResponse::Yes,
+            ChannelApprovalResponse::AlwaysApprove => ApprovalResponse::Always,
+            ChannelApprovalResponse::Deny => ApprovalResponse::No,
+        };
+        assert_eq!(mapped, ApprovalResponse::No);
+    }
+
+    #[test]
+    fn channel_approval_request_serde_roundtrip() {
+        use zeroclaw_api::channel::ChannelApprovalRequest;
+        let req = ChannelApprovalRequest {
+            tool_name: "shell".into(),
+            arguments_summary: "command: ls -la".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: ChannelApprovalRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.tool_name, "shell");
+        assert_eq!(parsed.arguments_summary, "command: ls -la");
+    }
+
+    #[test]
+    fn channel_approval_response_serde_roundtrip() {
+        use zeroclaw_api::channel::ChannelApprovalResponse;
+        let json = serde_json::to_string(&ChannelApprovalResponse::AlwaysApprove).unwrap();
+        assert_eq!(json, "\"alwaysapprove\"");
+        let parsed: ChannelApprovalResponse = serde_json::from_str("\"deny\"").unwrap();
+        assert_eq!(parsed, ChannelApprovalResponse::Deny);
+    }
 }

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -1055,6 +1055,7 @@ mod tests {
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            approval_timeout_secs: 120,
         });
         assert!(has_supervised_channels(&config));
     }
@@ -1185,6 +1186,7 @@ mod tests {
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            approval_timeout_secs: 120,
         });
 
         let target = resolve_heartbeat_delivery(&config).unwrap();
@@ -1204,6 +1206,7 @@ mod tests {
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            approval_timeout_secs: 120,
         });
 
         let target = resolve_heartbeat_delivery(&config).unwrap();

--- a/crates/zeroclaw-runtime/src/integrations/registry.rs
+++ b/crates/zeroclaw-runtime/src/integrations/registry.rs
@@ -864,6 +864,7 @@ mod tests {
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            approval_timeout_secs: 120,
         });
         let entries = all_integrations();
         let tg = entries.iter().find(|e| e.name == "Telegram").unwrap();

--- a/crates/zeroclaw-runtime/src/onboard/wizard.rs
+++ b/crates/zeroclaw-runtime/src/onboard/wizard.rs
@@ -3757,6 +3757,9 @@ fn setup_channels(
                     mention_only: existing_tg.map(|t| t.mention_only).unwrap_or(false),
                     ack_reactions: existing_tg.and_then(|t| t.ack_reactions),
                     proxy_url: existing_tg.and_then(|t| t.proxy_url.clone()),
+                    approval_timeout_secs: existing_tg
+                        .map(|t| t.approval_timeout_secs)
+                        .unwrap_or(120),
                 });
             }
             ChannelMenuChoice::Discord => {

--- a/crates/zeroclaw-runtime/src/tools/delegate.rs
+++ b/crates/zeroclaw-runtime/src/tools/delegate.rs
@@ -1175,6 +1175,7 @@ impl DelegateTool {
                 0,    // max_tool_result_chars: inherit from parent config in future
                 0,    // context_token_budget: 0 = disabled for subagents
                 None, // shared_budget: TODO thread from parent in future
+                None, // channel: delegate subagents don't support approval
             ),
         )
         .await;

--- a/crates/zeroclaw-tui/src/onboarding.rs
+++ b/crates/zeroclaw-tui/src/onboarding.rs
@@ -755,6 +755,7 @@ fn apply_tui_selections_to_config(app: &App, config: &mut Config) {
                     mention_only: false,
                     ack_reactions: None,
                     proxy_url: None,
+                    approval_timeout_secs: 120,
                 });
             }
         }
@@ -3500,6 +3501,7 @@ mod tests {
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            approval_timeout_secs: 120,
         });
         apply_tui_selections_to_config(&app, &mut config);
         let tg = config.channels.telegram.as_ref().unwrap();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -219,6 +219,7 @@ mod tests {
             mention_only: false,
             ack_reactions: None,
             proxy_url: None,
+            approval_timeout_secs: 120,
         };
 
         let discord = DiscordConfig {


### PR DESCRIPTION
## Why

In supervised mode, the Telegram channel silently auto-denied every tool approval request because there was no interactive operator to approve them. Users on Telegram had no way to approve tool calls — the agent was effectively locked out of supervised tools when accessed via Telegram.

## What changed

| Crate | Change |
|-------|--------|
| `zeroclaw-api` | Added `ChannelApprovalRequest`, `ChannelApprovalResponse` types and `Channel::request_approval()` default method |
| `zeroclaw-channels` (Telegram) | Implemented `request_approval()` with inline keyboard buttons; updated `listen()` to handle `callback_query` updates |
| `zeroclaw-channels` (orchestrator) | Passes channel reference to `run_tool_call_loop` |
| `zeroclaw-runtime` (agent loop) | Threaded `channel: Option<&dyn Channel>` through `agent_turn`/`run_tool_call_loop`; approval hook tries channel approval before auto-deny |
| `zeroclaw-runtime` (delegate) | Added `None` channel parameter for subagent calls |

## How it works

1. When the agent loop encounters a tool needing approval in non-interactive mode, it calls `channel.request_approval()` on the active channel
2. The default `Channel` trait implementation returns `Ok(None)` (unsupported) — preserving existing auto-deny behavior for all other channels
3. `TelegramChannel::request_approval()` sends a message with `reply_markup` containing an inline keyboard (Approve / Deny / Always)
4. A oneshot channel is registered in a `pending_approvals` map **before** the message is sent (race-safe)
5. `listen()` now accepts `callback_query` updates alongside `message` updates — when a matching callback arrives, it resolves the oneshot and calls `answerCallbackQuery`
6. The approval flow awaits with a 120s timeout; on timeout, auto-denies

## Checklist

- [x] Non-breaking: `Channel::request_approval()` has a default impl — all 30+ channels unaffected
- [x] Race-safe: oneshot registered before `sendMessage` fires
- [x] Explicit action matching: only `approve`/`deny`/`always` are handled; unknown actions are logged and ignored
- [x] `answerCallbackQuery` failures logged at warn level
- [x] Unit tests for callback_data parsing, oneshot delivery, and response mapping
- [x] Follows conventional commit format

Closes #5778