### PR TITLE
docs(contributing): add "When to Supersede" guidance and fixup-friendly defaults

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,8 @@ All PRs must target **`master`**. PRs targeting `main` will be rejected.
 > 3. Open a PR targeting `master`
 >
 > Do **not** create or push to a `main` branch. There is no `main` branch — it will not work.
+>
+> **Recommended:** keep "Allow edits from maintainers" enabled on your PRs. This is the default for PRs from personal forks and lets maintainers push small fixups directly rather than superseding your PR. See [`docs/contributing/pr-discipline.md`](docs/contributing/pr-discipline.md).
 
 ## First-Time Contributors
 

--- a/docs/contributing/pr-discipline.md
+++ b/docs/contributing/pr-discipline.md
@@ -22,7 +22,7 @@ Treat privacy and neutrality as merge gates, not best-effort guidelines.
 
 Superseding a contributor PR is appropriate in a limited set of situations. Before opening a superseding PR, consider the alternatives in this order:
 
-1. **Push fixups to the contributor's branch.** If the contributor PR has `maintainerCanModify: true` (the default for PRs from personal forks — check with `gh pr view <number> --json maintainerCanModify`), push small fixes directly to their branch and merge the contributor's PR. This preserves full attribution in `git log`, `git blame`, and the contributor's GitHub profile. Coordinate with the contributor if the fix isn't trivial — pushing to their branch while they have unpushed local work creates conflicts they'll need to resolve.
+1. **Push fixups to the contributor's branch.** If the contributor PR has `maintainerCanModify: true` (the default for PRs from personal forks — check with `gh pr view <number> --json maintainerCanModify`), push small fixes directly to their branch and merge the contributor's PR. This preserves full attribution in `git log`, `git blame`, and the contributor's GitHub profile. Coordinate with the contributor if the fix isn't trivial — pushing to their branch while they have unpushed local work creates conflicts they'll need to resolve. If the contributor is actively iterating, prefer option 2 below.
 
 2. **Leave a review with specific requested changes.** If the contributor is active and the fix is within their scope (e.g., a single clippy lint, an edge case, a test addition), request the change and give them an opportunity to push a fixup commit. Single-line fixes are usually better handled by requesting the change or pushing a fixup directly.
 

--- a/docs/contributing/pr-discipline.md
+++ b/docs/contributing/pr-discipline.md
@@ -18,6 +18,25 @@ Treat privacy and neutrality as merge gates, not best-effort guidelines.
 - If reproducing external incidents, redact and anonymize all payloads before committing.
 - Before push, review `git diff --cached` specifically for accidental sensitive strings and identity leakage.
 
+## When to Supersede (Required)
+
+Superseding a contributor PR is appropriate in a limited set of situations. Before opening a superseding PR, consider the alternatives in this order:
+
+1. **Push fixups to the contributor's branch.** If the contributor PR has `maintainerCanModify: true` (the default for PRs from personal forks — check with `gh pr view <number> --json maintainerCanModify`), push small fixes directly to their branch and merge the contributor's PR. This preserves full attribution in `git log`, `git blame`, and the contributor's GitHub profile.
+
+2. **Leave a review with specific requested changes.** If the contributor is active and the fix is within their scope (e.g., a single clippy lint, an edge case, a test addition), request the change and give them an opportunity to push a fixup commit. Single-line fixes are usually better handled by requesting the change or pushing a fixup directly.
+
+3. **Open a follow-up PR after merging.** If the contributor PR is correct as-is and additional hardening is needed, merge the contributor PR first, then open a separate hardening PR. Preserves attribution; the cost is a brief window with known issues on master.
+
+Supersede when one or more of the following apply:
+
+- The contributor is unresponsive (no reply within the project's review SLA).
+- The change requires substantially more work than the contributor's original scope.
+- Multiple related contributor PRs need to be unified into a single coherent change.
+- The contributor has opted out of maintainer edits (`maintainerCanModify: false`) and a follow-up PR is impractical.
+
+When superseding is the right choice, follow the attribution rules in the next section. Always include `Co-authored-by` trailers for materially incorporated contributors, regardless of the circumstances that led to the supersede.
+
 ## Superseded-PR Attribution (Required)
 
 When a PR supersedes another contributor's PR and carries forward substantive code or design decisions, preserve authorship explicitly.

--- a/docs/contributing/pr-discipline.md
+++ b/docs/contributing/pr-discipline.md
@@ -22,7 +22,7 @@ Treat privacy and neutrality as merge gates, not best-effort guidelines.
 
 Superseding a contributor PR is appropriate in a limited set of situations. Before opening a superseding PR, consider the alternatives in this order:
 
-1. **Push fixups to the contributor's branch.** If the contributor PR has `maintainerCanModify: true` (the default for PRs from personal forks — check with `gh pr view <number> --json maintainerCanModify`), push small fixes directly to their branch and merge the contributor's PR. This preserves full attribution in `git log`, `git blame`, and the contributor's GitHub profile.
+1. **Push fixups to the contributor's branch.** If the contributor PR has `maintainerCanModify: true` (the default for PRs from personal forks — check with `gh pr view <number> --json maintainerCanModify`), push small fixes directly to their branch and merge the contributor's PR. This preserves full attribution in `git log`, `git blame`, and the contributor's GitHub profile. Coordinate with the contributor if the fix isn't trivial — pushing to their branch while they have unpushed local work creates conflicts they'll need to resolve.
 
 2. **Leave a review with specific requested changes.** If the contributor is active and the fix is within their scope (e.g., a single clippy lint, an edge case, a test addition), request the change and give them an opportunity to push a fixup commit. Single-line fixes are usually better handled by requesting the change or pushing a fixup directly.
 


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `pr-discipline.md` documents *how* to supersede a PR (Co-authored-by, templates, attribution) but is silent on *when* superseding is appropriate vs alternatives (pushing fixups, review cycles, follow-up PRs).
- Why it matters: Issue #4363 documented a measurable pattern — of the last 200 merged PRs, ~70% are authored by the maintainer, and contributors with repeated submissions show low merge rates. #4495 is a concrete case where a single clippy lint closed a draft PR without a review cycle. Guidance on *when* to supersede vs push a fixup would reduce this pattern without changing the quality bar.
- What changed: Added a "When to Supersede" subsection to `pr-discipline.md` above the existing Supersede mechanics. Added a recommendation to `CONTRIBUTING.md` asking contributors to keep "Allow edits from maintainers" enabled (the default for personal forks).
- What did **not** change: Attribution rules, templates, trailer format requirements, or the quality bar for merging.

## Label Snapshot (required)

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `docs`
- Module labels: —

## Change Metadata

- Change type: `docs`
- Primary scope: `docs`

## Linked Issue

- Closes #4363 (per the closing comment's invitation for a docs PR)
- Related #4495

## Validation Evidence (required)

```
./scripts/ci/docs_quality_gate.sh  # ok — no blocking markdown issues on changed lines
```

Docs-only change; no Rust validation applicable.

## Security Impact (required)

- New permissions/capabilities? No
- No code changes

## Rollback Plan (required)

- `git revert` — changes are additive to both files. Existing superseding workflow continues to work unchanged if the guidance is removed.

## Risks and Mitigations

- Risk: Maintainers interpret "push fixups" as a mandate rather than a preference, slowing down review for ambiguous cases.
  - Mitigation: The new section is explicit that superseding remains appropriate for substantial changes, unresponsive contributors, or when `maintainerCanModify: false`. The CONTRIBUTING.md note is phrased as a recommendation, not a requirement.