### PR TITLE
fix(daemon,onboard): include webhook in supervised and launchable channel checks

### DIFF
--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -143,7 +143,7 @@ pub async fn run(
             ));
         } else {
             crate::health::mark_component_ok("channels");
-            tracing::info!("No real-time channels configured; channel supervisor disabled");
+            tracing::info!("No channels configured; channel supervisor disabled");
         }
     } else {
         crate::health::mark_component_ok("channels");
@@ -960,11 +960,7 @@ fn validate_heartbeat_channel_config(config: &Config, channel: &str) -> Result<(
 }
 
 fn has_supervised_channels(config: &Config) -> bool {
-    config
-        .channels
-        .channels_except_webhook()
-        .iter()
-        .any(|(_, ok)| *ok)
+    config.channels.channels().iter().any(|(_, ok)| *ok)
 }
 
 // run_mqtt_sop_listener has been moved to zeroclaw-channels::orchestrator::mqtt.
@@ -1113,6 +1109,21 @@ mod tests {
             allowed_users: vec!["*".into()],
             proxy_url: None,
             bot_name: None,
+        });
+        assert!(has_supervised_channels(&config));
+    }
+
+    #[test]
+    fn webhook_only_config_is_supervised() {
+        let mut config = Config::default();
+        config.channels.webhook = Some(zeroclaw_config::schema::WebhookConfig {
+            enabled: true,
+            port: 8080,
+            listen_path: None,
+            send_url: None,
+            send_method: None,
+            auth_header: None,
+            secret: None,
         });
         assert!(has_supervised_channels(&config));
     }

--- a/crates/zeroclaw-runtime/src/onboard/wizard.rs
+++ b/crates/zeroclaw-runtime/src/onboard/wizard.rs
@@ -94,7 +94,7 @@ const MODEL_CACHE_TTL_SECS: u64 = 12 * 60 * 60;
 const CUSTOM_MODEL_SENTINEL: &str = "__custom_model__";
 
 fn has_launchable_channels(channels: &ChannelsConfig) -> bool {
-    channels.channels_except_webhook().iter().any(|(_, ok)| *ok)
+    channels.channels().iter().any(|(_, ok)| *ok)
 }
 
 // ── Main wizard entry point ──────────────────────────────────────
@@ -7850,6 +7850,23 @@ mod tests {
             port: None,
             proxy_url: None,
         });
+        assert!(has_launchable_channels(&channels));
+    }
+
+    #[test]
+    fn webhook_only_config_is_launchable() {
+        let channels = ChannelsConfig {
+            webhook: Some(zeroclaw_config::schema::WebhookConfig {
+                enabled: true,
+                port: 8080,
+                listen_path: None,
+                send_url: None,
+                send_method: None,
+                auth_header: None,
+                secret: None,
+            }),
+            ..Default::default()
+        };
         assert!(has_launchable_channels(&channels));
     }
 


### PR DESCRIPTION
## Summary

- `has_supervised_channels()` in `crates/zeroclaw-runtime/src/daemon/mod.rs` called `channels_except_webhook()`, so a webhook-only config never started the channel supervisor — the HTTP listener never bound to its port.
- `has_launchable_channels()` in `crates/zeroclaw-runtime/src/onboard/wizard.rs` had the same bug: webhook-only configs never showed the "Launch channels now?" prompt after onboarding.
- Both callsites changed from `channels_except_webhook()` to `channels()`, which includes webhook using the same `is_some()` check every other channel uses.
- The wizard bug was found incidentally during investigation of the daemon bug. Same root cause, same fix, bundled here.

## Label Snapshot

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `runtime`, `onboard`
- Module labels: `daemon:core`, `onboard:wizard`, `channel:webhook`

## Change Metadata

- Change type: `bug`
- Primary scope: `runtime`

## Linked Issue

- Fixes #5798

## Validation Evidence

TDD approach: tests were written first and confirmed failing before the fix was applied, then confirmed passing after.

```bash
# Red — both fail before fix
cargo test -p zeroclaw-runtime webhook_only
# test daemon::tests::webhook_only_config_is_supervised ... FAILED
# test onboard::wizard::tests::webhook_only_config_is_launchable ... FAILED

# Green — both pass after fix
cargo test -p zeroclaw-runtime webhook_only
# test daemon::tests::webhook_only_config_is_supervised ... ok
# test onboard::wizard::tests::webhook_only_config_is_launchable ... ok
```

## Attribution

@mn13's root cause analysis in #5798 was accurate and independently arrived at the same fix. The diagnosis (`channels_except_webhook()` as the culprit, `channels()` as the fix) matches exactly.

## Note to @mn13

We do not run the webhook channel in our own setup, so end-to-end verification on a live webhook config falls to you. Please test this branch against your reproduction case from #5798 and confirm the `Connection refused` behavior is resolved before this merges.

## Security Impact

- New permissions or capabilities: No
- New external network calls: No
- Secrets or token handling changed: No
- Attack surface changed: No — webhook startup behavior was already gated on explicit config; this only fixes the supervisor not starting when it should

## Compatibility

- Backward compatible: Yes
- Config or env changes: No
- Migration needed: No

## Rollback Plan

`git revert 6db79f98` — reverts both callsite changes and both tests in one commit.