### PR TITLE
fix(observability): complete OTEL trace pipeline for all agent session types

### DIFF
--- a/crates/zeroclaw-api/src/observability_traits.rs
+++ b/crates/zeroclaw-api/src/observability_traits.rs
@@ -18,6 +18,8 @@ pub enum ObserverEvent {
         provider: String,
         model: String,
         messages_count: usize,
+        /// Serialised prompt content (opt-in via `ZEROCLAW_OTEL_TRACE_CONTENT`).
+        prompt_content: Option<String>,
     },
     /// Result of a single LLM provider call.
     LlmResponse {
@@ -28,6 +30,8 @@ pub enum ObserverEvent {
         error_message: Option<String>,
         input_tokens: Option<u64>,
         output_tokens: Option<u64>,
+        /// LLM response content (opt-in via `ZEROCLAW_OTEL_TRACE_CONTENT`).
+        response_content: Option<String>,
     },
     /// The agent session has finished.
     ///
@@ -49,6 +53,8 @@ pub enum ObserverEvent {
         tool: String,
         duration: Duration,
         success: bool,
+        /// Tool execution output (opt-in via `ZEROCLAW_OTEL_TRACE_CONTENT`).
+        output: Option<String>,
     },
     /// The agent produced a final answer for the current user message.
     TurnComplete,
@@ -249,6 +255,7 @@ mod tests {
             tool: "shell".into(),
             duration: Duration::from_millis(10),
             success: true,
+            output: None,
         };
         let metric = ObserverMetric::RequestLatency(Duration::from_millis(8));
 

--- a/crates/zeroclaw-api/src/provider.rs
+++ b/crates/zeroclaw-api/src/provider.rs
@@ -196,14 +196,18 @@ pub enum StreamEvent {
     PreExecutedToolCall { name: String, args: String },
     /// The result of a pre-executed tool call.
     PreExecutedToolResult { name: String, output: String },
-    /// Stream has completed.
-    Final,
+    /// Stream has completed, optionally carrying final token usage.
+    Final {
+        /// Token usage reported by the provider at end-of-stream.
+        /// `None` if the provider does not report usage during streaming.
+        usage: Option<TokenUsage>,
+    },
 }
 
 impl StreamEvent {
     pub fn from_chunk(chunk: StreamChunk) -> Self {
         if chunk.is_final {
-            Self::Final
+            Self::Final { usage: None }
         } else {
             Self::TextDelta(chunk)
         }

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1509,6 +1509,7 @@ async fn handle_webhook(
             provider: provider_label.clone(),
             model: model_label.clone(),
             messages_count: 1,
+            prompt_content: None,
         },
     );
 
@@ -1524,6 +1525,7 @@ async fn handle_webhook(
                     error_message: None,
                     input_tokens: None,
                     output_tokens: None,
+                    response_content: None,
                 },
             );
             state.observer.record_metric(
@@ -1555,6 +1557,7 @@ async fn handle_webhook(
                     error_message: Some(sanitized.clone()),
                     input_tokens: None,
                     output_tokens: None,
+                    response_content: None,
                 },
             );
             state.observer.record_metric(

--- a/crates/zeroclaw-gateway/src/sse.rs
+++ b/crates/zeroclaw-gateway/src/sse.rs
@@ -141,6 +141,7 @@ impl zeroclaw_runtime::observability::Observer for BroadcastObserver {
                 tool,
                 duration,
                 success,
+                ..
             } => serde_json::json!({
                 "type": "tool_call",
                 "tool": tool,

--- a/crates/zeroclaw-providers/src/anthropic.rs
+++ b/crates/zeroclaw-providers/src/anthropic.rs
@@ -592,6 +592,9 @@ impl AnthropicProvider {
         let mut tool_id: Option<String> = None;
         let mut tool_name: Option<String> = None;
         let mut tool_input_json = String::new();
+        let mut stream_input_tokens: Option<u64> = None;
+        let mut stream_output_tokens: Option<u64> = None;
+        let mut stream_cached_tokens: Option<u64> = None;
 
         while let Ok(Some(line)) = lines.next_line().await {
             let line = line.trim().to_string();
@@ -617,15 +620,31 @@ impl AnthropicProvider {
                         .and_then(|m| m.get("model"))
                         .and_then(|m| m.as_str())
                         .unwrap_or("unknown");
-                    let input_tokens = event
-                        .get("message")
-                        .and_then(|m| m.get("usage"))
+                    let usage = event.get("message").and_then(|m| m.get("usage"));
+                    let input_tokens = usage
                         .and_then(|u| u.get("input_tokens"))
                         .and_then(|t| t.as_u64())
                         .unwrap_or(0);
+                    let cache_read = usage
+                        .and_then(|u| u.get("cache_read_input_tokens"))
+                        .and_then(|t| t.as_u64());
+                    let cache_creation = usage
+                        .and_then(|u| u.get("cache_creation_input_tokens"))
+                        .and_then(|t| t.as_u64());
+                    let total_input =
+                        input_tokens + cache_read.unwrap_or(0) + cache_creation.unwrap_or(0);
+                    if total_input > 0 {
+                        stream_input_tokens = Some(total_input);
+                    }
+                    if cache_read.is_some() || cache_creation.is_some() {
+                        stream_cached_tokens = cache_read;
+                    }
                     tracing::debug!(
                         model = %model,
-                        input_tokens = input_tokens,
+                        input_tokens,
+                        cache_read = ?cache_read,
+                        cache_creation = ?cache_creation,
+                        total_input,
                         "Anthropic stream: message_start"
                     );
                 }
@@ -714,6 +733,9 @@ impl AnthropicProvider {
                         .and_then(|u| u.get("output_tokens"))
                         .and_then(|t| t.as_u64())
                         .unwrap_or(0);
+                    if output_tokens > 0 {
+                        stream_output_tokens = Some(output_tokens);
+                    }
                     if stop_reason == "max_tokens" {
                         tracing::warn!(
                             output_tokens = output_tokens,
@@ -728,8 +750,21 @@ impl AnthropicProvider {
                     }
                 }
                 "message_stop" => {
-                    tracing::debug!("Anthropic stream: message_stop");
-                    let _ = tx.send(Ok(StreamEvent::Final)).await;
+                    let usage = if stream_input_tokens.is_some() || stream_output_tokens.is_some() {
+                        Some(TokenUsage {
+                            input_tokens: stream_input_tokens,
+                            output_tokens: stream_output_tokens,
+                            cached_input_tokens: stream_cached_tokens,
+                        })
+                    } else {
+                        None
+                    };
+                    tracing::debug!(
+                        input_tokens = ?stream_input_tokens,
+                        output_tokens = ?stream_output_tokens,
+                        "Anthropic stream: message_stop"
+                    );
+                    let _ = tx.send(Ok(StreamEvent::Final { usage })).await;
                     return;
                 }
                 "error" => {
@@ -745,7 +780,7 @@ impl AnthropicProvider {
             }
         }
 
-        let _ = tx.send(Ok(StreamEvent::Final)).await;
+        let _ = tx.send(Ok(StreamEvent::Final { usage: None })).await;
     }
 }
 
@@ -966,7 +1001,7 @@ impl Provider for AnthropicProvider {
         options: StreamOptions,
     ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
         if !options.enabled {
-            return stream::once(async { Ok(StreamEvent::Final) }).boxed();
+            return stream::once(async { Ok(StreamEvent::Final { usage: None }) }).boxed();
         }
 
         let credential = match self.credential.as_ref() {

--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1280,7 +1280,7 @@ pub(crate) fn sse_bytes_to_events(
             }
         }
 
-        let _ = tx.send(Ok(StreamEvent::Final)).await;
+        let _ = tx.send(Ok(StreamEvent::Final { usage: None })).await;
     });
 
     stream::unfold(rx, |mut rx| async move {
@@ -2178,7 +2178,7 @@ impl Provider for OpenAiCompatibleProvider {
         options: StreamOptions,
     ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
         if !options.enabled {
-            return stream::once(async { Ok(StreamEvent::Final) }).boxed();
+            return stream::once(async { Ok(StreamEvent::Final { usage: None }) }).boxed();
         }
 
         let credential = self.credential.clone();

--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -570,7 +570,7 @@ impl Provider for OpenRouterProvider {
         options: StreamOptions,
     ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
         if !options.enabled {
-            return stream::once(async { Ok(StreamEvent::Final) }).boxed();
+            return stream::once(async { Ok(StreamEvent::Final { usage: None }) }).boxed();
         }
 
         let credential = match self.credential.as_ref() {
@@ -843,7 +843,7 @@ mod tests {
             .next()
             .await
             .expect("stream should yield Final immediately");
-        assert!(matches!(first, Ok(StreamEvent::Final)));
+        assert!(matches!(first, Ok(StreamEvent::Final { usage: None })));
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -2664,7 +2664,7 @@ mod tests {
                     name: "shell".to_string(),
                     arguments: r#"{"command":"date"}"#.to_string(),
                 })),
-                Ok(StreamEvent::Final),
+                Ok(StreamEvent::Final { usage: None }),
             ])
             .boxed()
         }
@@ -2720,7 +2720,7 @@ mod tests {
             StreamEvent::ToolCall(call) => assert_eq!(call.name, "shell"),
             other => panic!("expected tool-call event, got {other:?}"),
         }
-        assert!(matches!(second, StreamEvent::Final));
+        assert!(matches!(second, StreamEvent::Final { .. }));
         assert_eq!(primary.stream_calls.load(Ordering::SeqCst), 0);
         assert_eq!(fallback.stream_calls.load(Ordering::SeqCst), 1);
     }

--- a/crates/zeroclaw-providers/src/router.rs
+++ b/crates/zeroclaw-providers/src/router.rs
@@ -507,7 +507,7 @@ mod tests {
                     name: "shell".to_string(),
                     arguments: r#"{"command":"date"}"#.to_string(),
                 })),
-                Ok(StreamEvent::Final),
+                Ok(StreamEvent::Final { usage: None }),
             ])
             .boxed()
         }
@@ -1097,7 +1097,7 @@ mod tests {
             }
             other => panic!("expected tool-call event, got {other:?}"),
         }
-        assert!(matches!(second, StreamEvent::Final));
+        assert!(matches!(second, StreamEvent::Final { .. }));
         assert_eq!(streaming.stream_calls.load(Ordering::SeqCst), 1);
         assert_eq!(streaming.tool_event_calls.load(Ordering::SeqCst), 1);
         assert_eq!(*streaming.last_stream_model.lock(), "claude-opus");

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -22,6 +22,26 @@ use zeroclaw_providers::{self, ChatMessage, ChatRequest, ConversationMessage, Pr
 // Re-export TurnEvent from zeroclaw-types for backwards compatibility.
 pub use zeroclaw_api::agent::TurnEvent;
 
+/// Check whether OTEL content tracing is enabled via environment variable.
+pub fn trace_content_enabled() -> bool {
+    std::env::var("ZEROCLAW_OTEL_TRACE_CONTENT")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false)
+}
+
+/// Safely truncate a UTF-8 string to at most `max_bytes` bytes without
+/// splitting a multi-byte character.
+pub fn truncate_utf8(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &s[..end])
+}
+
 pub struct Agent {
     provider: Box<dyn Provider>,
     tools: Vec<Box<dyn Tool>>,
@@ -33,6 +53,7 @@ pub struct Agent {
     memory_loader: Box<dyn MemoryLoader>,
     config: zeroclaw_config::schema::AgentConfig,
     model_name: String,
+    provider_name: String,
     temperature: f64,
     workspace_dir: std::path::PathBuf,
     identity_config: zeroclaw_config::schema::IdentityConfig,
@@ -72,6 +93,7 @@ pub struct AgentBuilder {
     memory_loader: Option<Box<dyn MemoryLoader>>,
     config: Option<zeroclaw_config::schema::AgentConfig>,
     model_name: Option<String>,
+    provider_name: Option<String>,
     temperature: Option<f64>,
     workspace_dir: Option<std::path::PathBuf>,
     identity_config: Option<zeroclaw_config::schema::IdentityConfig>,
@@ -109,6 +131,7 @@ impl AgentBuilder {
             memory_loader: None,
             config: None,
             model_name: None,
+            provider_name: None,
             temperature: None,
             workspace_dir: None,
             identity_config: None,
@@ -171,6 +194,11 @@ impl AgentBuilder {
 
     pub fn model_name(mut self, model_name: String) -> Self {
         self.model_name = Some(model_name);
+        self
+    }
+
+    pub fn provider_name(mut self, provider_name: String) -> Self {
+        self.provider_name = Some(provider_name);
         self
     }
 
@@ -309,6 +337,7 @@ impl AgentBuilder {
             model_name: self
                 .model_name
                 .unwrap_or_else(|| "anthropic/claude-sonnet-4-20250514".into()),
+            provider_name: self.provider_name.unwrap_or_else(|| "unknown".into()),
             temperature: self.temperature.unwrap_or(0.7),
             workspace_dir: self
                 .workspace_dir
@@ -550,6 +579,7 @@ impl Agent {
             .prompt_builder(SystemPromptBuilder::with_defaults())
             .config(config.agent.clone())
             .model_name(model_name)
+            .provider_name(provider_name.to_string())
             .temperature(
                 fallback_provider_ag
                     .and_then(|e| e.temperature)
@@ -679,6 +709,17 @@ impl Agent {
             }
         }
 
+        // Emit ToolCallStart so the OTEL observer can attach arguments to the span.
+        let tc = trace_content_enabled();
+        self.observer.record_event(&ObserverEvent::ToolCallStart {
+            tool: tool_name.clone(),
+            arguments: if tc {
+                Some(truncate_utf8(&tool_args.to_string(), 1024))
+            } else {
+                None
+            },
+        });
+
         // First try to find tool in static registry, then in activated MCP tools.
         let (result, success) =
             if let Some(tool) = self.tools.iter().find(|t| t.name() == tool_name) {
@@ -688,6 +729,11 @@ impl Agent {
                             tool: tool_name.clone(),
                             duration: start.elapsed(),
                             success: r.success,
+                            output: if tc {
+                                Some(truncate_utf8(&r.output, 4096))
+                            } else {
+                                None
+                            },
                         });
                         if r.success {
                             (r.output, true)
@@ -696,12 +742,18 @@ impl Agent {
                         }
                     }
                     Err(e) => {
+                        let reason = format!("Error executing {}: {e}", tool_name);
                         self.observer.record_event(&ObserverEvent::ToolCall {
                             tool: tool_name.clone(),
                             duration: start.elapsed(),
                             success: false,
+                            output: if tc {
+                                Some(truncate_utf8(&reason, 4096))
+                            } else {
+                                None
+                            },
                         });
-                        (format!("Error executing {}: {e}", tool_name), false)
+                        (reason, false)
                     }
                 }
             } else if let Some(activated_arc) = self.activated_tools.as_ref() {
@@ -713,6 +765,11 @@ impl Agent {
                                 tool: tool_name.clone(),
                                 duration: start.elapsed(),
                                 success: r.success,
+                                output: if tc {
+                                    Some(truncate_utf8(&r.output, 4096))
+                                } else {
+                                    None
+                                },
                             });
                             if r.success {
                                 (r.output, true)
@@ -721,12 +778,18 @@ impl Agent {
                             }
                         }
                         Err(e) => {
+                            let reason = format!("Error executing {}: {e}", tool_name);
                             self.observer.record_event(&ObserverEvent::ToolCall {
                                 tool: tool_name.clone(),
                                 duration: start.elapsed(),
                                 success: false,
+                                output: if tc {
+                                    Some(truncate_utf8(&reason, 4096))
+                                } else {
+                                    None
+                                },
                             });
-                            (format!("Error executing {}: {e}", tool_name), false)
+                            (reason, false)
                         }
                     }
                 } else {
@@ -907,6 +970,20 @@ impl Agent {
                 });
             }
 
+            let tc = trace_content_enabled();
+            self.observer.record_event(&ObserverEvent::LlmRequest {
+                provider: self.provider_name.clone(),
+                model: effective_model.clone(),
+                messages_count: messages.len(),
+                prompt_content: if tc {
+                    serde_json::to_string(&messages)
+                        .ok()
+                        .map(|s| truncate_utf8(&s, 32_768))
+                } else {
+                    None
+                },
+            });
+            let llm_start = std::time::Instant::now();
             let response = match self
                 .provider
                 .chat(
@@ -923,8 +1000,41 @@ impl Agent {
                 )
                 .await
             {
-                Ok(resp) => resp,
-                Err(err) => return Err(err),
+                Ok(resp) => {
+                    let (input_tokens, output_tokens) = resp
+                        .usage
+                        .as_ref()
+                        .map(|u| (u.input_tokens, u.output_tokens))
+                        .unwrap_or((None, None));
+                    self.observer.record_event(&ObserverEvent::LlmResponse {
+                        provider: self.provider_name.clone(),
+                        model: effective_model.clone(),
+                        duration: llm_start.elapsed(),
+                        success: true,
+                        error_message: None,
+                        input_tokens,
+                        output_tokens,
+                        response_content: if tc {
+                            resp.text.as_deref().map(|t| truncate_utf8(t, 32_768))
+                        } else {
+                            None
+                        },
+                    });
+                    resp
+                }
+                Err(err) => {
+                    self.observer.record_event(&ObserverEvent::LlmResponse {
+                        provider: self.provider_name.clone(),
+                        model: effective_model.clone(),
+                        duration: llm_start.elapsed(),
+                        success: false,
+                        error_message: Some(err.to_string()),
+                        input_tokens: None,
+                        output_tokens: None,
+                        response_content: None,
+                    });
+                    return Err(err);
+                }
             };
 
             let (text, calls) = self.tool_dispatcher.parse_response(&response);
@@ -995,6 +1105,12 @@ impl Agent {
         user_message: &str,
         event_tx: tokio::sync::mpsc::Sender<TurnEvent>,
     ) -> Result<String> {
+        let streamed_start = std::time::Instant::now();
+        self.observer.record_event(&ObserverEvent::AgentStart {
+            provider: self.provider_name.clone(),
+            model: self.model_name.clone(),
+        });
+
         // ── Preamble (identical to turn) ───────────────────────────────
         if self.history.is_empty() {
             let system_prompt = self.build_system_prompt()?;
@@ -1075,6 +1191,13 @@ impl Agent {
                             cached.clone(),
                         )));
                     self.trim_history();
+                    self.observer.record_event(&ObserverEvent::AgentEnd {
+                        provider: self.provider_name.clone(),
+                        model: self.model_name.clone(),
+                        duration: streamed_start.elapsed(),
+                        tokens_used: None,
+                        cost_usd: None,
+                    });
                     return Ok(cached);
                 }
                 self.observer.record_event(&ObserverEvent::CacheMiss {
@@ -1086,6 +1209,21 @@ impl Agent {
             // Try streaming first; if the provider returns content we
             // forward deltas.  Otherwise fall back to non-streaming chat.
             use futures_util::StreamExt;
+
+            let tc = trace_content_enabled();
+            self.observer.record_event(&ObserverEvent::LlmRequest {
+                provider: self.provider_name.clone(),
+                model: effective_model.clone(),
+                messages_count: messages.len(),
+                prompt_content: if tc {
+                    serde_json::to_string(&messages)
+                        .ok()
+                        .map(|s| truncate_utf8(&s, 32_768))
+                } else {
+                    None
+                },
+            });
+            let llm_start = std::time::Instant::now();
 
             let stream_opts = zeroclaw_providers::traits::StreamOptions::new(true);
             let mut stream = self.provider.stream_chat(
@@ -1105,6 +1243,7 @@ impl Agent {
             let mut streamed_text = String::new();
             let mut streamed_tool_calls: Vec<zeroclaw_providers::traits::ToolCall> = Vec::new();
             let mut got_stream = false;
+            let mut stream_usage: Option<zeroclaw_providers::traits::TokenUsage> = None;
 
             while let Some(item) = stream.next().await {
                 match item {
@@ -1124,11 +1263,11 @@ impl Agent {
                                     event_tx.send(TurnEvent::Chunk { delta: chunk.delta }).await;
                             }
                         }
-                        zeroclaw_providers::traits::StreamEvent::ToolCall(tc) => {
+                        zeroclaw_providers::traits::StreamEvent::ToolCall(tc_event) => {
                             got_stream = true;
                             // ToolCall event is sent later (after parse_response) to
                             // avoid duplicates; just collect here.
-                            streamed_tool_calls.push(tc);
+                            streamed_tool_calls.push(tc_event);
                         }
                         zeroclaw_providers::traits::StreamEvent::PreExecutedToolCall {
                             name,
@@ -1148,7 +1287,10 @@ impl Agent {
                         } => {
                             let _ = event_tx.send(TurnEvent::ToolResult { name, output }).await;
                         }
-                        zeroclaw_providers::traits::StreamEvent::Final => break,
+                        zeroclaw_providers::traits::StreamEvent::Final { usage } => {
+                            stream_usage = usage;
+                            break;
+                        }
                     },
                     Err(_) => break,
                 }
@@ -1159,6 +1301,24 @@ impl Agent {
             // If streaming produced text, use it as the response and
             // check for tool calls via the dispatcher.
             let response = if got_stream {
+                let (s_input, s_output) = stream_usage
+                    .as_ref()
+                    .map(|u| (u.input_tokens, u.output_tokens))
+                    .unwrap_or((None, None));
+                self.observer.record_event(&ObserverEvent::LlmResponse {
+                    provider: self.provider_name.clone(),
+                    model: effective_model.clone(),
+                    duration: llm_start.elapsed(),
+                    success: true,
+                    error_message: None,
+                    input_tokens: s_input,
+                    output_tokens: s_output,
+                    response_content: if tc {
+                        Some(truncate_utf8(&streamed_text, 32_768))
+                    } else {
+                        None
+                    },
+                });
                 // Build a synthetic ChatResponse from streamed text
                 zeroclaw_providers::ChatResponse {
                     text: Some(streamed_text),
@@ -1184,8 +1344,48 @@ impl Agent {
                     )
                     .await
                 {
-                    Ok(resp) => resp,
-                    Err(err) => return Err(err),
+                    Ok(resp) => {
+                        let (input_tokens, output_tokens) = resp
+                            .usage
+                            .as_ref()
+                            .map(|u| (u.input_tokens, u.output_tokens))
+                            .unwrap_or((None, None));
+                        self.observer.record_event(&ObserverEvent::LlmResponse {
+                            provider: self.provider_name.clone(),
+                            model: effective_model.clone(),
+                            duration: llm_start.elapsed(),
+                            success: true,
+                            error_message: None,
+                            input_tokens,
+                            output_tokens,
+                            response_content: if tc {
+                                resp.text.as_deref().map(|t| truncate_utf8(t, 32_768))
+                            } else {
+                                None
+                            },
+                        });
+                        resp
+                    }
+                    Err(err) => {
+                        self.observer.record_event(&ObserverEvent::LlmResponse {
+                            provider: self.provider_name.clone(),
+                            model: effective_model.clone(),
+                            duration: llm_start.elapsed(),
+                            success: false,
+                            error_message: Some(err.to_string()),
+                            input_tokens: None,
+                            output_tokens: None,
+                            response_content: None,
+                        });
+                        self.observer.record_event(&ObserverEvent::AgentEnd {
+                            provider: self.provider_name.clone(),
+                            model: self.model_name.clone(),
+                            duration: streamed_start.elapsed(),
+                            tokens_used: None,
+                            cost_usd: None,
+                        });
+                        return Err(err);
+                    }
                 }
             };
 
@@ -1223,6 +1423,13 @@ impl Agent {
                     )));
                 self.trim_history();
 
+                self.observer.record_event(&ObserverEvent::AgentEnd {
+                    provider: self.provider_name.clone(),
+                    model: self.model_name.clone(),
+                    duration: streamed_start.elapsed(),
+                    tokens_used: None,
+                    cost_usd: None,
+                });
                 return Ok(final_text);
             }
 
@@ -1267,6 +1474,13 @@ impl Agent {
             self.trim_history();
         }
 
+        self.observer.record_event(&ObserverEvent::AgentEnd {
+            provider: self.provider_name.clone(),
+            model: self.model_name.clone(),
+            duration: streamed_start.elapsed(),
+            tokens_used: None,
+            cost_usd: None,
+        });
         anyhow::bail!(
             "Agent exceeded maximum tool iterations ({})",
             self.config.max_tool_iterations
@@ -1889,7 +2103,7 @@ mod tests {
                 );
                 stream::iter(vec![
                     Ok(tc),
-                    Ok(zeroclaw_providers::traits::StreamEvent::Final),
+                    Ok(zeroclaw_providers::traits::StreamEvent::Final { usage: None }),
                 ])
                 .boxed()
             } else {
@@ -1903,7 +2117,7 @@ mod tests {
                 );
                 stream::iter(vec![
                     Ok(chunk),
-                    Ok(zeroclaw_providers::traits::StreamEvent::Final),
+                    Ok(zeroclaw_providers::traits::StreamEvent::Final { usage: None }),
                 ])
                 .boxed()
             }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -569,7 +569,7 @@ async fn consume_provider_streaming_response(
 
         let event = event_result.map_err(|err| anyhow::anyhow!("provider stream error: {err}"))?;
         match event {
-            StreamEvent::Final => break,
+            StreamEvent::Final { .. } => break,
             StreamEvent::ToolCall(tool_call) => {
                 outcome.tool_calls.push(tool_call);
                 suppress_forwarding = true;
@@ -1003,6 +1003,7 @@ pub async fn run_tool_call_loop(
             provider: active_provider_name.to_string(),
             model: active_model.to_string(),
             messages_count: history.len(),
+            prompt_content: None,
         });
         runtime_trace::record_event(
             "llm_request",
@@ -1193,6 +1194,7 @@ pub async fn run_tool_call_loop(
                     error_message: None,
                     input_tokens: resp_input_tokens,
                     output_tokens: resp_output_tokens,
+                    response_content: None,
                 });
 
                 // Record cost via task-local tracker (no-op when not scoped)
@@ -1308,6 +1310,7 @@ pub async fn run_tool_call_loop(
                     error_message: Some(safe_error.clone()),
                     input_tokens: None,
                     output_tokens: None,
+                    response_content: None,
                 });
                 runtime_trace::record_event(
                     "llm_response",
@@ -4095,12 +4098,12 @@ mod tests {
                 NativeStreamTurn::ToolCall(tool_call) => {
                     Box::pin(futures_util::stream::iter(vec![
                         Ok(StreamEvent::ToolCall(tool_call)),
-                        Ok(StreamEvent::Final),
+                        Ok(StreamEvent::Final { usage: None }),
                     ]))
                 }
                 NativeStreamTurn::Text(text) => Box::pin(futures_util::stream::iter(vec![
                     Ok(StreamEvent::TextDelta(StreamChunk::delta(text))),
-                    Ok(StreamEvent::Final),
+                    Ok(StreamEvent::Final { usage: None }),
                 ])),
             }
         }

--- a/crates/zeroclaw-runtime/src/agent/tool_execution.rs
+++ b/crates/zeroclaw-runtime/src/agent/tool_execution.rs
@@ -42,10 +42,15 @@ pub async fn execute_one_tool(
     observer: &dyn Observer,
     cancellation_token: Option<&CancellationToken>,
 ) -> Result<ToolExecutionOutcome> {
+    let trace_content = crate::agent::agent::trace_content_enabled();
     let args_summary = truncate_with_ellipsis(&call_arguments.to_string(), 300);
     observer.record_event(&ObserverEvent::ToolCallStart {
         tool: call_name.to_string(),
-        arguments: Some(args_summary),
+        arguments: if trace_content {
+            Some(args_summary)
+        } else {
+            None
+        },
     });
     let start = Instant::now();
 
@@ -62,6 +67,11 @@ pub async fn execute_one_tool(
             tool: call_name.to_string(),
             duration,
             success: false,
+            output: if trace_content {
+                Some(reason.clone())
+            } else {
+                None
+            },
         });
         return Ok(ToolExecutionOutcome {
             output: reason.clone(),
@@ -84,10 +94,16 @@ pub async fn execute_one_tool(
     match tool_result {
         Ok(r) => {
             let duration = start.elapsed();
+            let tool_output_for_trace = if trace_content {
+                Some(crate::agent::agent::truncate_utf8(&r.output, 4096))
+            } else {
+                None
+            };
             observer.record_event(&ObserverEvent::ToolCall {
                 tool: call_name.to_string(),
                 duration,
                 success: r.success,
+                output: tool_output_for_trace,
             });
             if r.success {
                 let normalized_output = if r.output.is_empty() {
@@ -113,12 +129,17 @@ pub async fn execute_one_tool(
         }
         Err(e) => {
             let duration = start.elapsed();
+            let reason = format!("Error executing {call_name}: {e}");
             observer.record_event(&ObserverEvent::ToolCall {
                 tool: call_name.to_string(),
                 duration,
                 success: false,
+                output: if trace_content {
+                    Some(crate::agent::agent::truncate_utf8(&reason, 4096))
+                } else {
+                    None
+                },
             });
-            let reason = format!("Error executing {call_name}: {e}");
             Ok(ToolExecutionOutcome {
                 output: reason.clone(),
                 success: false,

--- a/crates/zeroclaw-runtime/src/observability/log.rs
+++ b/crates/zeroclaw-runtime/src/observability/log.rs
@@ -40,6 +40,7 @@ impl Observer for LogObserver {
                 tool,
                 duration,
                 success,
+                ..
             } => {
                 let ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
                 info!(tool = %tool, duration_ms = ms, success = success, "tool.call");
@@ -69,6 +70,7 @@ impl Observer for LogObserver {
                 provider,
                 model,
                 messages_count,
+                ..
             } => {
                 info!(
                     provider = %provider,
@@ -85,6 +87,7 @@ impl Observer for LogObserver {
                 error_message,
                 input_tokens,
                 output_tokens,
+                ..
             } => {
                 let ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
                 info!(
@@ -220,6 +223,7 @@ mod tests {
             error_message: None,
             input_tokens: Some(100),
             output_tokens: Some(50),
+            response_content: None,
         });
         obs.record_event(&ObserverEvent::LlmResponse {
             provider: "openrouter".into(),
@@ -229,11 +233,13 @@ mod tests {
             error_message: Some("rate limited".into()),
             input_tokens: None,
             output_tokens: None,
+            response_content: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
             duration: Duration::from_millis(10),
             success: false,
+            output: None,
         });
         obs.record_event(&ObserverEvent::ChannelMessage {
             channel: "telegram".into(),

--- a/crates/zeroclaw-runtime/src/observability/noop.rs
+++ b/crates/zeroclaw-runtime/src/observability/noop.rs
@@ -56,6 +56,7 @@ mod tests {
             tool: "shell".into(),
             duration: Duration::from_secs(1),
             success: true,
+            output: None,
         });
         obs.record_event(&ObserverEvent::ChannelMessage {
             channel: "cli".into(),

--- a/crates/zeroclaw-runtime/src/observability/otel.rs
+++ b/crates/zeroclaw-runtime/src/observability/otel.rs
@@ -1,18 +1,26 @@
 use super::traits::{Observer, ObserverEvent, ObserverMetric};
 use opentelemetry::metrics::{Counter, Gauge, Histogram};
-use opentelemetry::trace::{Span, SpanKind, Status, Tracer};
-use opentelemetry::{KeyValue, global};
+use opentelemetry::trace::{Span, SpanKind, Status, TraceContextExt, Tracer};
+use opentelemetry::{Context, KeyValue, global};
 use opentelemetry_otlp::{WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
+use parking_lot::Mutex;
 use std::any::Any;
 use std::collections::HashMap;
+use std::sync::OnceLock;
 use std::time::SystemTime;
+
+static TRACER_PROVIDER: OnceLock<SdkTracerProvider> = OnceLock::new();
+static METER_PROVIDER: OnceLock<SdkMeterProvider> = OnceLock::new();
 
 /// OpenTelemetry-backed observer — exports traces and metrics via OTLP.
 pub struct OtelObserver {
-    tracer_provider: SdkTracerProvider,
-    meter_provider: SdkMeterProvider,
+    // Span parenting state
+    agent_context: Mutex<Option<Context>>,
+    pending_messages_count: Mutex<Option<usize>>,
+    pending_tool_args: Mutex<Option<String>>,
+    pending_prompt_content: Mutex<Option<String>>,
 
     // Metrics instruments
     agent_starts: Counter<u64>,
@@ -48,53 +56,58 @@ impl OtelObserver {
         let metrics_endpoint = format!("{}/v1/metrics", base_endpoint.trim_end_matches('/'));
         let service_name = service_name.unwrap_or("zeroclaw");
 
-        // ── Trace exporter ──────────────────────────────────────
-        let mut span_builder = opentelemetry_otlp::SpanExporter::builder()
-            .with_http()
-            .with_endpoint(&traces_endpoint);
-        if let Some(ref h) = headers {
-            span_builder = span_builder.with_headers(h.clone());
-        }
-        let span_exporter = span_builder
-            .build()
-            .map_err(|e| format!("Failed to create OTLP span exporter: {e}"))?;
+        // ── Singleton tracer provider (OnceLock) ────────────────
+        let _tp = TRACER_PROVIDER.get_or_init(|| {
+            let mut span_builder = opentelemetry_otlp::SpanExporter::builder()
+                .with_http()
+                .with_endpoint(&traces_endpoint);
+            if let Some(ref h) = headers {
+                span_builder = span_builder.with_headers(h.clone());
+            }
+            let span_exporter = span_builder
+                .build()
+                .expect("Failed to create OTLP span exporter");
 
-        let tracer_provider = SdkTracerProvider::builder()
-            .with_batch_exporter(span_exporter)
-            .with_resource(
-                opentelemetry_sdk::Resource::builder()
-                    .with_service_name(service_name.to_string())
-                    .build(),
-            )
-            .build();
+            let tp = SdkTracerProvider::builder()
+                .with_batch_exporter(span_exporter)
+                .with_resource(
+                    opentelemetry_sdk::Resource::builder()
+                        .with_service_name(service_name.to_string())
+                        .build(),
+                )
+                .build();
 
-        global::set_tracer_provider(tracer_provider.clone());
+            global::set_tracer_provider(tp.clone());
+            tp
+        });
 
-        // ── Metric exporter ─────────────────────────────────────
-        let mut metric_builder = opentelemetry_otlp::MetricExporter::builder()
-            .with_http()
-            .with_endpoint(&metrics_endpoint);
-        if let Some(ref h) = headers {
-            metric_builder = metric_builder.with_headers(h.clone());
-        }
-        let metric_exporter = metric_builder
-            .build()
-            .map_err(|e| format!("Failed to create OTLP metric exporter: {e}"))?;
+        // ── Singleton meter provider (OnceLock) ─────────────────
+        let _mp = METER_PROVIDER.get_or_init(|| {
+            let mut metric_builder = opentelemetry_otlp::MetricExporter::builder()
+                .with_http()
+                .with_endpoint(&metrics_endpoint);
+            if let Some(ref h) = headers {
+                metric_builder = metric_builder.with_headers(h.clone());
+            }
+            let metric_exporter = metric_builder
+                .build()
+                .expect("Failed to create OTLP metric exporter");
 
-        let metric_reader =
-            opentelemetry_sdk::metrics::PeriodicReader::builder(metric_exporter).build();
+            let metric_reader =
+                opentelemetry_sdk::metrics::PeriodicReader::builder(metric_exporter).build();
 
-        let meter_provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
-            .with_reader(metric_reader)
-            .with_resource(
-                opentelemetry_sdk::Resource::builder()
-                    .with_service_name(service_name.to_string())
-                    .build(),
-            )
-            .build();
+            let mp = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+                .with_reader(metric_reader)
+                .with_resource(
+                    opentelemetry_sdk::Resource::builder()
+                        .with_service_name(service_name.to_string())
+                        .build(),
+                )
+                .build();
 
-        let meter_provider_clone = meter_provider.clone();
-        global::set_meter_provider(meter_provider);
+            global::set_meter_provider(mp.clone());
+            mp
+        });
 
         // ── Create metric instruments ────────────────────────────
         let meter = global::meter("zeroclaw");
@@ -185,8 +198,10 @@ impl OtelObserver {
             .build();
 
         Ok(Self {
-            tracer_provider,
-            meter_provider: meter_provider_clone,
+            agent_context: Mutex::new(None),
+            pending_messages_count: Mutex::new(None),
+            pending_tool_args: Mutex::new(None),
+            pending_prompt_content: Mutex::new(None),
             agent_starts,
             agent_duration,
             llm_calls,
@@ -211,6 +226,17 @@ impl Observer for OtelObserver {
     fn record_event(&self, event: &ObserverEvent) {
         let tracer = global::tracer("zeroclaw");
 
+        // Macro: build a span as child of the agent root context, or standalone.
+        macro_rules! child_span {
+            ($builder:expr, $ctx:expr) => {
+                if let Some(parent_ctx) = $ctx.as_ref() {
+                    tracer.build_with_context($builder, parent_ctx)
+                } else {
+                    tracer.build($builder)
+                }
+            };
+        }
+
         match event {
             ObserverEvent::AgentStart { provider, model } => {
                 self.agent_starts.add(
@@ -220,10 +246,31 @@ impl Observer for OtelObserver {
                         KeyValue::new("model", model.clone()),
                     ],
                 );
+
+                // Create root span for the agent invocation
+                let span = tracer.build(
+                    opentelemetry::trace::SpanBuilder::from_name("agent.invocation")
+                        .with_kind(SpanKind::Internal)
+                        .with_attributes(vec![
+                            KeyValue::new("provider", provider.clone()),
+                            KeyValue::new("model", model.clone()),
+                        ]),
+                );
+                let ctx = Context::current_with_span(span);
+                *self.agent_context.lock() = Some(ctx);
             }
-            ObserverEvent::LlmRequest { .. }
-            | ObserverEvent::ToolCallStart { .. }
-            | ObserverEvent::TurnComplete
+            ObserverEvent::LlmRequest {
+                messages_count,
+                prompt_content,
+                ..
+            } => {
+                *self.pending_messages_count.lock() = Some(*messages_count);
+                *self.pending_prompt_content.lock() = prompt_content.clone();
+            }
+            ObserverEvent::ToolCallStart { arguments, .. } => {
+                *self.pending_tool_args.lock() = arguments.clone();
+            }
+            ObserverEvent::TurnComplete
             | ObserverEvent::CacheHit { .. }
             | ObserverEvent::CacheMiss { .. } => {}
             ObserverEvent::LlmResponse {
@@ -231,9 +278,10 @@ impl Observer for OtelObserver {
                 model,
                 duration,
                 success,
-                error_message: _,
-                input_tokens: _,
-                output_tokens: _,
+                error_message,
+                input_tokens,
+                output_tokens,
+                response_content,
             } => {
                 let secs = duration.as_secs_f64();
                 let attrs = [
@@ -244,25 +292,51 @@ impl Observer for OtelObserver {
                 self.llm_calls.add(1, &attrs);
                 self.llm_duration.record(secs, &attrs);
 
-                // Create a completed span for visibility in trace backends.
                 let start_time = SystemTime::now()
                     .checked_sub(*duration)
                     .unwrap_or(SystemTime::now());
-                let mut span = tracer.build(
-                    opentelemetry::trace::SpanBuilder::from_name("llm.call")
-                        .with_kind(SpanKind::Internal)
-                        .with_start_time(start_time)
-                        .with_attributes(vec![
-                            KeyValue::new("provider", provider.clone()),
-                            KeyValue::new("model", model.clone()),
-                            KeyValue::new("success", *success),
-                            KeyValue::new("duration_s", secs),
-                        ]),
-                );
+
+                let messages_count = self.pending_messages_count.lock().take().unwrap_or(0);
+                let prompt_content = self.pending_prompt_content.lock().take();
+
+                let mut span_attrs = vec![
+                    KeyValue::new("provider", provider.clone()),
+                    KeyValue::new("model", model.clone()),
+                    KeyValue::new("success", *success),
+                    KeyValue::new("duration_s", secs),
+                    KeyValue::new("messages_count", messages_count as i64),
+                ];
+                if let Some(input) = input_tokens {
+                    span_attrs.push(KeyValue::new("gen_ai.usage.input_tokens", *input as i64));
+                }
+                if let Some(output) = output_tokens {
+                    span_attrs.push(KeyValue::new("gen_ai.usage.output_tokens", *output as i64));
+                }
+                let total = input_tokens.unwrap_or(0) + output_tokens.unwrap_or(0);
+                if total > 0 {
+                    span_attrs.push(KeyValue::new("gen_ai.usage.total_tokens", total as i64));
+                }
+                if let Some(err) = error_message {
+                    span_attrs.push(KeyValue::new("error.message", err.clone()));
+                }
+                if let Some(content) = prompt_content {
+                    span_attrs.push(KeyValue::new("gen_ai.content.prompt", content));
+                }
+                if let Some(content) = response_content {
+                    span_attrs.push(KeyValue::new("gen_ai.content.completion", content.clone()));
+                }
+
+                let builder = opentelemetry::trace::SpanBuilder::from_name("llm.call")
+                    .with_kind(SpanKind::Client)
+                    .with_start_time(start_time)
+                    .with_attributes(span_attrs);
+
+                let parent_ctx = self.agent_context.lock().clone();
+                let mut span = child_span!(builder, parent_ctx);
                 if *success {
                     span.set_status(Status::Ok);
                 } else {
-                    span.set_status(Status::error(""));
+                    span.set_status(Status::error(error_message.clone().unwrap_or_default()));
                 }
                 span.end();
             }
@@ -274,28 +348,25 @@ impl Observer for OtelObserver {
                 cost_usd,
             } => {
                 let secs = duration.as_secs_f64();
-                let start_time = SystemTime::now()
-                    .checked_sub(*duration)
-                    .unwrap_or(SystemTime::now());
 
-                // Create a completed span with correct timing
-                let mut span = tracer.build(
-                    opentelemetry::trace::SpanBuilder::from_name("agent.invocation")
-                        .with_kind(SpanKind::Internal)
-                        .with_start_time(start_time)
-                        .with_attributes(vec![
-                            KeyValue::new("provider", provider.clone()),
-                            KeyValue::new("model", model.clone()),
-                            KeyValue::new("duration_s", secs),
-                        ]),
-                );
-                if let Some(t) = tokens_used {
-                    span.set_attribute(KeyValue::new("tokens_used", *t as i64));
+                // End the root agent span that was created in AgentStart
+                if let Some(ctx) = self.agent_context.lock().take() {
+                    let span = ctx.span();
+                    span.set_attribute(KeyValue::new("duration_s", secs));
+                    if let Some(t) = tokens_used {
+                        span.set_attribute(KeyValue::new("gen_ai.usage.total_tokens", *t as i64));
+                    }
+                    if let Some(c) = cost_usd {
+                        span.set_attribute(KeyValue::new("cost_usd", *c));
+                    }
+                    span.set_status(Status::Ok);
+                    span.end();
                 }
-                if let Some(c) = cost_usd {
-                    span.set_attribute(KeyValue::new("cost_usd", *c));
-                }
-                span.end();
+
+                // Clear pending state
+                *self.pending_messages_count.lock() = None;
+                *self.pending_tool_args.lock() = None;
+                *self.pending_prompt_content.lock() = None;
 
                 self.agent_duration.record(
                     secs,
@@ -304,13 +375,12 @@ impl Observer for OtelObserver {
                         KeyValue::new("model", model.clone()),
                     ],
                 );
-                // Note: tokens are recorded via record_metric(TokensUsed) to avoid
-                // double-counting. AgentEnd only records duration.
             }
             ObserverEvent::ToolCall {
                 tool,
                 duration,
                 success,
+                output,
             } => {
                 let secs = duration.as_secs_f64();
                 let start_time = SystemTime::now()
@@ -323,16 +393,30 @@ impl Observer for OtelObserver {
                     Status::error("")
                 };
 
-                let mut span = tracer.build(
-                    opentelemetry::trace::SpanBuilder::from_name("tool.call")
-                        .with_kind(SpanKind::Internal)
-                        .with_start_time(start_time)
-                        .with_attributes(vec![
-                            KeyValue::new("tool.name", tool.clone()),
-                            KeyValue::new("tool.success", *success),
-                            KeyValue::new("duration_s", secs),
-                        ]),
-                );
+                let mut span_attrs = vec![
+                    KeyValue::new("tool.name", tool.clone()),
+                    KeyValue::new("tool.success", *success),
+                    KeyValue::new("duration_s", secs),
+                ];
+                if let Some(args) = self.pending_tool_args.lock().take() {
+                    span_attrs.push(KeyValue::new("tool.arguments", args));
+                }
+                if let Some(out) = output {
+                    let truncated = if out.len() > 4096 {
+                        format!("{}...", &out[..out.floor_char_boundary(4096)])
+                    } else {
+                        out.clone()
+                    };
+                    span_attrs.push(KeyValue::new("tool.output", truncated));
+                }
+
+                let builder = opentelemetry::trace::SpanBuilder::from_name("tool.call")
+                    .with_kind(SpanKind::Internal)
+                    .with_start_time(start_time)
+                    .with_attributes(span_attrs);
+
+                let parent_ctx = self.agent_context.lock().clone();
+                let mut span = child_span!(builder, parent_ctx);
                 span.set_status(status);
                 span.end();
 
@@ -357,15 +441,15 @@ impl Observer for OtelObserver {
                 self.heartbeat_ticks.add(1, &[]);
             }
             ObserverEvent::Error { component, message } => {
-                // Create an error span for visibility in trace backends
-                let mut span = tracer.build(
-                    opentelemetry::trace::SpanBuilder::from_name("error")
-                        .with_kind(SpanKind::Internal)
-                        .with_attributes(vec![
-                            KeyValue::new("component", component.clone()),
-                            KeyValue::new("error.message", message.clone()),
-                        ]),
-                );
+                let builder = opentelemetry::trace::SpanBuilder::from_name("error")
+                    .with_kind(SpanKind::Internal)
+                    .with_attributes(vec![
+                        KeyValue::new("component", component.clone()),
+                        KeyValue::new("error.message", message.clone()),
+                    ]);
+
+                let parent_ctx = self.agent_context.lock().clone();
+                let mut span = child_span!(builder, parent_ctx);
                 span.set_status(Status::error(message.clone()));
                 span.end();
 
@@ -384,17 +468,18 @@ impl Observer for OtelObserver {
                     .checked_sub(duration)
                     .unwrap_or(SystemTime::now());
 
-                let mut span = tracer.build(
-                    opentelemetry::trace::SpanBuilder::from_name("hand.run")
-                        .with_kind(SpanKind::Internal)
-                        .with_start_time(start_time)
-                        .with_attributes(vec![
-                            KeyValue::new("hand.name", hand_name.clone()),
-                            KeyValue::new("hand.success", true),
-                            KeyValue::new("hand.findings", *findings_count as i64),
-                            KeyValue::new("duration_s", secs),
-                        ]),
-                );
+                let builder = opentelemetry::trace::SpanBuilder::from_name("hand.run")
+                    .with_kind(SpanKind::Internal)
+                    .with_start_time(start_time)
+                    .with_attributes(vec![
+                        KeyValue::new("hand.name", hand_name.clone()),
+                        KeyValue::new("hand.success", true),
+                        KeyValue::new("hand.findings", *findings_count as i64),
+                        KeyValue::new("duration_s", secs),
+                    ]);
+
+                let parent_ctx = self.agent_context.lock().clone();
+                let mut span = child_span!(builder, parent_ctx);
                 span.set_status(Status::Ok);
                 span.end();
 
@@ -421,17 +506,18 @@ impl Observer for OtelObserver {
                     .checked_sub(duration)
                     .unwrap_or(SystemTime::now());
 
-                let mut span = tracer.build(
-                    opentelemetry::trace::SpanBuilder::from_name("hand.run")
-                        .with_kind(SpanKind::Internal)
-                        .with_start_time(start_time)
-                        .with_attributes(vec![
-                            KeyValue::new("hand.name", hand_name.clone()),
-                            KeyValue::new("hand.success", false),
-                            KeyValue::new("error.message", error.clone()),
-                            KeyValue::new("duration_s", secs),
-                        ]),
-                );
+                let builder = opentelemetry::trace::SpanBuilder::from_name("hand.run")
+                    .with_kind(SpanKind::Internal)
+                    .with_start_time(start_time)
+                    .with_attributes(vec![
+                        KeyValue::new("hand.name", hand_name.clone()),
+                        KeyValue::new("hand.success", false),
+                        KeyValue::new("error.message", error.clone()),
+                        KeyValue::new("duration_s", secs),
+                    ]);
+
+                let parent_ctx = self.agent_context.lock().clone();
+                let mut span = child_span!(builder, parent_ctx);
                 span.set_status(Status::error(error.clone()));
                 span.end();
 
@@ -496,10 +582,14 @@ impl Observer for OtelObserver {
     }
 
     fn flush(&self) {
-        if let Err(e) = self.tracer_provider.force_flush() {
+        if let Some(tp) = TRACER_PROVIDER.get()
+            && let Err(e) = tp.force_flush()
+        {
             tracing::warn!("OTel trace flush failed: {e}");
         }
-        if let Err(e) = self.meter_provider.force_flush() {
+        if let Some(mp) = METER_PROVIDER.get()
+            && let Err(e) = mp.force_flush()
+        {
             tracing::warn!("OTel metric flush failed: {e}");
         }
     }
@@ -548,6 +638,7 @@ mod tests {
             provider: "openrouter".into(),
             model: "claude-sonnet".into(),
             messages_count: 2,
+            prompt_content: None,
         });
         obs.record_event(&ObserverEvent::LlmResponse {
             provider: "openrouter".into(),
@@ -557,6 +648,7 @@ mod tests {
             error_message: None,
             input_tokens: Some(100),
             output_tokens: Some(50),
+            response_content: None,
         });
         obs.record_event(&ObserverEvent::AgentEnd {
             provider: "openrouter".into(),
@@ -580,11 +672,13 @@ mod tests {
             tool: "shell".into(),
             duration: Duration::from_millis(10),
             success: true,
+            output: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "file_read".into(),
             duration: Duration::from_millis(5),
             success: false,
+            output: None,
         });
         obs.record_event(&ObserverEvent::TurnComplete);
         obs.record_event(&ObserverEvent::ChannelMessage {
@@ -638,6 +732,7 @@ mod tests {
             error_message: Some("404 Not Found".into()),
             input_tokens: None,
             output_tokens: None,
+            response_content: None,
         });
     }
 
@@ -730,11 +825,13 @@ mod tests {
             error_message: None,
             input_tokens: Some(10),
             output_tokens: Some(5),
+            response_content: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
             duration: Duration::from_millis(50),
             success: true,
+            output: None,
         });
     }
 

--- a/crates/zeroclaw-runtime/src/observability/prometheus.rs
+++ b/crates/zeroclaw-runtime/src/observability/prometheus.rs
@@ -339,7 +339,7 @@ impl Observer for PrometheusObserver {
                 success,
                 input_tokens,
                 output_tokens,
-                ..
+                ..  // duration, error_message, response_content
             } => {
                 let success_str = if *success { "true" } else { "false" };
                 self.llm_requests
@@ -365,6 +365,7 @@ impl Observer for PrometheusObserver {
                 tool,
                 duration,
                 success,
+                ..
             } => {
                 let success_str = if *success { "true" } else { "false" };
                 self.tool_calls
@@ -554,11 +555,13 @@ mod tests {
             tool: "shell".into(),
             duration: Duration::from_millis(10),
             success: true,
+            output: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "file_read".into(),
             duration: Duration::from_millis(5),
             success: false,
+            output: None,
         });
         obs.record_event(&ObserverEvent::ChannelMessage {
             channel: "telegram".into(),
@@ -592,6 +595,7 @@ mod tests {
             tool: "shell".into(),
             duration: Duration::from_millis(100),
             success: true,
+            output: None,
         });
         obs.record_event(&ObserverEvent::HeartbeatTick);
         obs.record_metric(&ObserverMetric::RequestLatency(Duration::from_millis(250)));
@@ -623,16 +627,19 @@ mod tests {
             tool: "shell".into(),
             duration: Duration::from_millis(10),
             success: true,
+            output: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
             duration: Duration::from_millis(10),
             success: true,
+            output: None,
         });
         obs.record_event(&ObserverEvent::ToolCall {
             tool: "shell".into(),
             duration: Duration::from_millis(10),
             success: false,
+            output: None,
         });
 
         let output = obs.encode();
@@ -683,6 +690,7 @@ mod tests {
             error_message: None,
             input_tokens: Some(100),
             output_tokens: Some(50),
+            response_content: None,
         });
         obs.record_event(&ObserverEvent::LlmResponse {
             provider: "openrouter".into(),
@@ -692,6 +700,7 @@ mod tests {
             error_message: None,
             input_tokens: Some(200),
             output_tokens: Some(80),
+            response_content: None,
         });
 
         let output = obs.encode();
@@ -773,6 +782,7 @@ mod tests {
             error_message: Some("timeout".into()),
             input_tokens: None,
             output_tokens: None,
+            response_content: None,
         });
 
         let output = obs.encode();

--- a/crates/zeroclaw-runtime/src/observability/traits.rs
+++ b/crates/zeroclaw-runtime/src/observability/traits.rs
@@ -65,6 +65,7 @@ mod tests {
             tool: "shell".into(),
             duration: Duration::from_millis(10),
             success: true,
+            output: None,
         };
         let metric = ObserverMetric::RequestLatency(Duration::from_millis(8));
 

--- a/crates/zeroclaw-runtime/src/observability/verbose.rs
+++ b/crates/zeroclaw-runtime/src/observability/verbose.rs
@@ -26,6 +26,7 @@ impl Observer for VerboseObserver {
                 provider,
                 model,
                 messages_count,
+                ..
             } => {
                 eprintln!("> Thinking");
                 eprintln!(
@@ -46,6 +47,7 @@ impl Observer for VerboseObserver {
                 tool,
                 duration,
                 success,
+                ..
             } => {
                 let ms = u64::try_from(duration.as_millis()).unwrap_or(u64::MAX);
                 eprintln!("< Tool {tool} (success={success}, duration_ms={ms})");
@@ -86,6 +88,7 @@ mod tests {
             provider: "openrouter".into(),
             model: "claude".into(),
             messages_count: 3,
+            prompt_content: None,
         });
         obs.record_event(&ObserverEvent::LlmResponse {
             provider: "openrouter".into(),
@@ -95,6 +98,7 @@ mod tests {
             error_message: None,
             input_tokens: Some(50),
             output_tokens: Some(25),
+            response_content: None,
         });
         obs.record_event(&ObserverEvent::ToolCallStart {
             tool: "shell".into(),
@@ -104,6 +108,7 @@ mod tests {
             tool: "shell".into(),
             duration: Duration::from_millis(2),
             success: true,
+            output: None,
         });
         obs.record_event(&ObserverEvent::TurnComplete);
     }

--- a/src/providers/traits.rs
+++ b/src/providers/traits.rs
@@ -503,6 +503,6 @@ mod tests {
             StreamEvent::TextDelta(chunk) => assert_eq!(chunk.delta, "hello"),
             other => panic!("expected text delta event, got {other:?}"),
         }
-        assert!(matches!(second, StreamEvent::Final));
+        assert!(matches!(second, StreamEvent::Final { .. }));
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: OTEL traces are incomplete — WebSocket sessions only show tool.call spans; no LLM calls, no agent invocation, no parent-child hierarchy, no token counts, no content visibility
- Why it matters: In multi-tenant enterprise deployments, operators need full trace visibility for conversation auditing, prompt injection detection, quality debugging, and cost tracking across backends like Langfuse and Datadog
- What changed: Five fixes combined into a single coherent patch
- What did **not** change: Observer trait shape, gateway/WebSocket handler code, CLI behavior, provider implementations (except Anthropic streaming token propagation)
- Supersedes #5783 and #5744

## Supersede Attribution

- Superseded PRs: #5783 by @joshuamoreno1, #5744 by @joshuamoreno1
- All code rewritten on latest master — no direct cherry-picks
- \`Co-authored-by\` trailer: Yes

<img width="905" height="760" alt="image" src="https://github.com/user-attachments/assets/76f8ff54-74e5-4e8b-8d7d-5e5b9f8781fb" />

<img width="951" height="955" alt="image" src="https://github.com/user-attachments/assets/701c0375-2555-4504-ae93-b4251ade21e2" />


## Fixes included

### 1. Singleton OTLP providers (OnceLock)
OtelObserver::new() is called per agent session, replacing the global tracer/meter provider each time and dropping buffered spans. Fix: OnceLock ensures providers are initialized once.

### 2. Observer events in turn/turn_streamed
turn_streamed() (WebSocket path) never emitted AgentStart, LlmRequest, LlmResponse, AgentEnd, or ToolCallStart. Only ToolCall fired from execute_tool_call. Fix: emit full lifecycle in both turn() and turn_streamed(), and ToolCallStart in execute_tool_call().

### 3. Span parenting + token attributes
All spans were independent roots (parent_id=0). Fix: AgentStart creates root span stored in Mutex\<Option\<Context\>\>; children use build_with_context(). LLM spans include gen_ai.usage.{input,output,total}_tokens and messages_count.

### 4. Streaming token propagation
Anthropic streaming reports input_tokens (message_start) and output_tokens (message_delta) but these were logged and discarded. Fix: StreamEvent::Final now carries Option\<TokenUsage\>. Cached tokens (cache_read_input_tokens, cache_creation_input_tokens) are included in totals.

### 5. Optional content tracing (ZEROCLAW_OTEL_TRACE_CONTENT)
When \`ZEROCLAW_OTEL_TRACE_CONTENT=true\`:
- gen_ai.content.prompt on llm.call spans (LLM input)
- gen_ai.content.completion on llm.call spans (LLM output)
- tool.arguments on tool.call spans (tool input)
- tool.output on tool.call spans (tool result)

Disabled by default. Valuable in enterprise environments for:
- Auditing agent conversations for compliance
- Detecting prompt injection attempts across tenants
- Debugging conversation quality without reproduction
- Monitoring tool execution patterns at scale
- Full trace correlation in Langfuse/Datadog/LangSmith

## Trace hierarchy

\`\`\`
agent.invocation (root, kind=Server)
├── llm.call (child, kind=Client)
│   ├── gen_ai.usage.input_tokens = 4200 (includes cached)
│   ├── gen_ai.usage.output_tokens = 350
│   ├── gen_ai.content.prompt = "..." (opt-in)
│   └── gen_ai.content.completion = "..." (opt-in)
├── tool.call [shell] (child, kind=Internal)
│   ├── tool.arguments = "{...}" (opt-in)
│   └── tool.output = "..." (opt-in)
├── llm.call (child)
└── agent.invocation closes with:
    └── gen_ai.usage.total_tokens
\`\`\`

## Breaking Changes
*(Added by @singlerider)*

- `StreamEvent::Final` changed from a unit variant to a named struct variant (`Final { usage: Option<TokenUsage> }`). Downstream consumers pattern-matching `StreamEvent::Final` without a wildcard arm will fail to compile.
- `ObserverEvent::LlmRequest`, `ObserverEvent::LlmResponse`, and `ObserverEvent::ToolCall` have new optional fields (`prompt_content`, `response_content`, `output`). Exhaustive struct patterns without `..` will fail to compile.

Semver impact: confirm with @JordanTheJet before merge.

## Label Snapshot
- Risk: \`risk: medium\`
- Size: \`size: M\`
- Scope: \`observability\`, \`agent\`, \`provider\`
- Module: \`observability: otel\`, \`agent: agent\`, \`provider: anthropic\`

## Change Metadata
- Change type: \`bug\` + \`feature\`
- Primary scope: \`multi\`

## Linked Issue
- Closes #5710
- Supersedes #5783, #5744

## Validation Evidence
\`\`\`bash
cargo fmt --all -- --check     # ✅
cargo clippy --all-targets -- -D warnings  # ✅
cargo test                     # ✅ 821 passed
\`\`\`
Validated in production (La Haus CX agents on EKS) with Langfuse and Datadog backends. Full trace hierarchy confirmed via diagnostic logging.

## Security Impact
- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
- ZEROCLAW_OTEL_TRACE_CONTENT: opt-in, disabled by default. Content truncated (32 KiB prompts, 4 KiB tool output)

## Privacy and Data Hygiene
- Status: pass
- Content tracing opt-in via env var. No PII added beyond what LLM processes.

## Compatibility / Migration
- Backward compatible? No — `StreamEvent::Final` unit→struct and new `ObserverEvent` fields are breaking changes for exhaustive pattern-match consumers. See Breaking Changes section above.
- Config/env changes? One new optional env var: ZEROCLAW_OTEL_TRACE_CONTENT
- Migration needed? No

## Rollback Plan
- Revert single commit
- ZEROCLAW_OTEL_TRACE_CONTENT=false disables content tracing

## Risks and Mitigations
- Risk: Concurrent sessions share agent_context Mutex
  - Mitigation: Each Agent instance has its own OtelObserver with its own Mutex. Sessions are isolated.
- Risk: OnceLock providers can't be reconfigured
  - Mitigation: All sessions share same config. Not a current use case.
