### PR TITLE
fix(provider): only send tool_stream for Z.AI providers in streaming path

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -2164,7 +2164,11 @@ impl Provider for OpenAiCompatibleProvider {
                 messages: Self::convert_messages_for_native(&effective_messages, !merge),
                 temperature,
                 reasoning_effort: self.reasoning_effort.clone(),
-                tool_stream: if options.enabled { Some(true) } else { None },
+                tool_stream: if options.enabled {
+                    self.tool_stream_for_tools(true)
+                } else {
+                    None
+                },
                 stream: Some(options.enabled),
                 tools: tools.clone(),
                 tool_choice: tools.as_ref().map(|_| "auto".to_string()),
@@ -2184,7 +2188,11 @@ impl Provider for OpenAiCompatibleProvider {
                 messages,
                 temperature,
                 reasoning_effort: self.reasoning_effort.clone(),
-                tool_stream: if options.enabled { Some(true) } else { None },
+                tool_stream: if options.enabled {
+                    self.tool_stream_for_tools(false)
+                } else {
+                    None
+                },
                 stream: Some(options.enabled),
                 tools: None,
                 tool_choice: None,
@@ -3445,6 +3453,14 @@ mod tests {
 
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("\"tool_stream\""));
+    }
+
+    #[test]
+    fn non_zai_provider_omits_tool_stream_regardless_of_streaming() {
+        let provider = make_provider("custom", "https://proxy.example.com/v1", None);
+        // tool_stream_for_tools should return None for non-Z.AI providers
+        assert_eq!(provider.tool_stream_for_tools(true), None);
+        assert_eq!(provider.tool_stream_for_tools(false), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Base branch target: `master`
- Problem: `stream_chat_with_tools` unconditionally set `tool_stream: true` for all providers when streaming was enabled, causing 400 Bad Request on non-Z.AI OpenAI-compatible endpoints (e.g. litellm proxies) that reject the unrecognized `tool_stream` key.
- Why it matters: Any user with a custom OpenAI-compatible provider (litellm, vLLM, etc.) cannot use streaming tool calls — every request fails with 400.
- What changed: Streaming payload now uses `self.tool_stream_for_tools()` (same guard as non-streaming path) so `tool_stream` is only serialized for Z.AI providers.
- What did **not** change (scope boundary): Non-streaming paths, Z.AI provider behavior, request structure for any other fields.
## Label Snapshot (required)
- Risk label: `sk: low`
- Size label: `size: XS`
- Scope labels: `provider`
- Module labels: `provider: compatible`
- Contributor tier label: (auto-managed)
- If any auto-label is incorrect: N/A
## Change Metadata
- Change type: `bug`
- Primary scope: `provider`
## Linked Issue
- Related #2901
## Supersede Attribution (required when Supersedes is used)
N/A
## Validation Evidence (required)
Commands and result summary:
\`\`\`bash
cargo fmt --all -- --check       # exit 0, no output
cargo clippy --all-targets -- -D warnings # exit 0, Finished dev profile
cargo test -p zeroclaw-providers # 762 passed; 0 failed; 0 ignored
\`\`\`
- Evidence provided: local test run output
- If any command is intentionally skipped: N/A
## Security Impact (required)
- New permissions/capabilities? No
- New external network calls? No
- Secrets/tokens handling changed? No
- File system access scope changed? No
## Privacy and Data Hygiene (required)
- Data-hygiene status: `pass`
- Redaction/anonymization notes: N/A
- Neutral wording confirmation: Yes
## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
## i18n Follow-Through (required when docs or user-facing wording changes)
- i18n follow-through triggered? No
## Human Verification (required)
- Verified scenarios: Custom OpenAI-compatible provider (litellm proxy) previously returned 400 due to `tool_stream` key — confirmed root cause via docker logs.
- Edge cases checked: Z.AI providers still get `tool_stream: true` (existing tests pass). Non-Z.AI providers with/without tools get `None`.
- What was not verified: Live streaming with Z.AI provider (no access).
## Side Effects / Blast Radius (required)
- Affected subsystems: `OpenAiCompatibleProvider::stream_chat_with_tools` only
- Potential unintended effects: None — Z.AI behavior preserved via existing `requires_tool_stream()` gate
- Guardrails: Existing test suite (762 tests), plus new `non_zai_provider_omits_tool_stream_regardless_of_streaming` test
## Agent Collaboration Notes (recommended)
- Agent s used: Cursor AI
- Workflow: Docker log analysis → root cause in streaming path → fix + test
- Confirmation: naming + architecture boundaries followed (AGENTS.md)
## Rollback Plan (required)
- Fast rollback command: `git revert <commit>`
- Feature flags or config toggles: None
- Observable failure symptoms: 400 errors from non-Z.AI OpenAI-compatible proxies with `Unrecognized key(s) in object: 'tool_stream'`
## Risks and Mitigations
- Risk: Z.AI streaming could regress if `requires_tool_stream()` has a bug
  - Mitigation: Existing `zai_tool_requests_enable_tool_stream` and `z_ai_host_enables_tool_stream_for_custom_profiles` tests cover this