### PR TITLE
fix(matrix): restrict outbound attachment uploads

### DIFF
--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -920,32 +920,82 @@ impl Channel for MatrixChannel {
             room.send(content).await?;
         }
 
+        let outbound_workspace = std::path::PathBuf::from(
+            shellexpand::tilde(
+                &std::env::var("ZEROCLAW_WORKSPACE")
+                    .unwrap_or_else(|_| "/tmp/zeroclaw-uploads".to_string()),
+            )
+            .as_ref(),
+        );
+        let _ = tokio::fs::create_dir_all(&outbound_workspace).await;
+        let outbound_workspace_root = tokio::fs::canonicalize(&outbound_workspace)
+            .await
+            .unwrap_or_else(|_| outbound_workspace.clone());
+
         for (_kind, target) in &attachments {
             let path = std::path::Path::new(target.as_str());
-            if let Ok(data) = tokio::fs::read(path).await {
-                let mime = mime_guess::from_path(path).first_or_octet_stream();
-                let name = path
-                    .file_name()
-                    .unwrap_or(path.as_os_str())
-                    .to_string_lossy();
-                let mut attachment_config = matrix_sdk::attachment::AttachmentConfig::new();
-                if let Some(ref thread_ts) = message.thread_ts
-                    && let Ok(event_id) = thread_ts.parse::<OwnedEventId>()
-                {
-                    attachment_config =
-                        attachment_config.reply(Some(matrix_sdk::room::reply::Reply {
-                            event_id,
-                            enforce_thread: matrix_sdk::room::reply::EnforceThread::Threaded(
-                                ReplyWithinThread::Yes,
-                            ),
-                        }));
+            if !path.is_absolute() {
+                tracing::warn!(
+                    target = %target,
+                    "Matrix: outbound attachment refused (path must be absolute in workspace)"
+                );
+                continue;
+            }
+
+            let canonical_path = match tokio::fs::canonicalize(path).await {
+                Ok(resolved) => resolved,
+                Err(e) => {
+                    tracing::warn!(
+                        target = %target,
+                        err = %e,
+                        "Matrix: outbound attachment read failed"
+                    );
+                    continue;
                 }
-                if let Err(e) = room
-                    .send_attachment(&*name, &mime, data, attachment_config)
-                    .await
-                {
-                    tracing::warn!(file = %name, err = %e, "Matrix: attachment upload failed");
+            };
+
+            if !canonical_path.starts_with(&outbound_workspace_root) {
+                tracing::warn!(
+                    target = %target,
+                    workspace = %outbound_workspace_root.display(),
+                    "Matrix: outbound attachment refused (outside workspace)"
+                );
+                continue;
+            }
+
+            let data = match tokio::fs::read(&canonical_path).await {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    tracing::warn!(
+                        target = %canonical_path.display(),
+                        err = %e,
+                        "Matrix: outbound attachment read failed"
+                    );
+                    continue;
                 }
+            };
+
+            let mime = mime_guess::from_path(&canonical_path).first_or_octet_stream();
+            let name = canonical_path
+                .file_name()
+                .unwrap_or(canonical_path.as_os_str())
+                .to_string_lossy();
+            let mut attachment_config = matrix_sdk::attachment::AttachmentConfig::new();
+            if let Some(ref thread_ts) = message.thread_ts
+                && let Ok(event_id) = thread_ts.parse::<OwnedEventId>()
+            {
+                attachment_config = attachment_config.reply(Some(matrix_sdk::room::reply::Reply {
+                    event_id,
+                    enforce_thread: matrix_sdk::room::reply::EnforceThread::Threaded(
+                        ReplyWithinThread::Yes,
+                    ),
+                }));
+            }
+            if let Err(e) = room
+                .send_attachment(&*name, &mime, data, attachment_config)
+                .await
+            {
+                tracing::warn!(file = %name, err = %e, "Matrix: attachment upload failed");
             }
         }
 


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: Matrix outbound attachment markers could read and upload any readable local path referenced in an agent response.
- Why it matters: This created a file exfiltration risk if untrusted or tool-generated content produced attachment markers pointing outside the intended upload workspace.
- What changed: Matrix outbound attachments now require absolute paths that canonicalize inside `ZEROCLAW_WORKSPACE`, defaulting to `/tmp/zeroclaw-uploads`; unsafe, missing, or unreadable paths are logged and skipped.
- Scope boundary: No Matrix message routing, threading behavior, voice replies, inbound media handling, non-Matrix channels, or config schema behavior was changed.

## Label Snapshot

- Risk label: `risk: high`
- Size label: `size: S`
- Scope labels: `channel, security`
- Module labels: `channel: matrix`
- Contributor tier label: auto-managed/read-only
- Requested label corrections: None

## Change Metadata

- Change type: `security`
- Primary scope: `channel`

## Linked Issue

- Closes #
- Related #
- Depends on #
- Supersedes #

## Supersede Attribution

- Superseded PRs + authors: N/A
- Integrated scope by source PR: N/A
- Co-authored-by trailers added: N/A
- If `No`, explain why: N/A
- Trailer format check: N/A

## Validation Evidence

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided: `cargo fmt --all -- --check` passed. `cargo check -p zeroclaw-channels` passed. `cargo check -p zeroclaw-channels --features channel-matrix` was attempted, but did not complete because `matrix-sdk` failed with a dependency-level `queries overflow the depth limit` error in `matrix_sdk::client::sync()` before compiling this crate's Matrix source.
- Skipped commands: `cargo clippy --all-targets -- -D warnings` and `cargo test` were not run locally. The Matrix feature-specific compile check was attempted as the most relevant validation, but was blocked by the upstream `matrix-sdk` recursion overflow noted above.

## Security Impact

- New permissions/capabilities: No
- New external network calls: No
- Secrets/tokens handling changed: No
- File system access scope changed: Yes
- Risk and mitigation: Matrix outbound attachment reads are now restricted to absolute paths inside the canonicalized outbound workspace. This reduces file exfiltration risk by refusing relative paths, missing paths, symlink escapes, and paths outside `ZEROCLAW_WORKSPACE`.

## Privacy and Data Hygiene

- Data-hygiene status: `pass`
- Redaction/anonymization notes: No personal data, secrets, tokens, or real identity test data added.
- Neutral wording confirmation: Confirmed.

## Compatibility / Migration

- Backward compatible: Yes
- Config/env changes: Yes
- Migration needed: No
- Upgrade steps: Matrix outbound attachment markers must reference absolute file paths inside `ZEROCLAW_WORKSPACE`. If `ZEROCLAW_WORKSPACE` is unset, the allowed workspace defaults to `/tmp/zeroclaw-uploads`.

## i18n Follow-Through

- i18n follow-through triggered: No
- Locale navigation parity updated: N/A
- Localized runtime-contract docs updated: N/A
- Vietnamese canonical docs synced and compatibility shims validated: N/A
- Scope decision: Code-only security hardening; no docs or user-facing localization changes.

## Human Verification

- Verified scenarios: Reviewed Matrix outbound attachment send flow and confirmed attachment reads now canonicalize both workspace and target path before upload.
- Edge cases checked: Relative paths are refused; unreadable or missing paths are skipped with warnings; canonicalized paths outside the workspace are refused; thread reply attachment config is preserved.
- What was not verified: End-to-end Matrix upload against a live homeserver was not run. Full workspace clippy/test suite was not run locally.

## Side Effects / Blast Radius

- Affected subsystems/workflows: Matrix channel outbound attachment uploads from attachment markers.
- Potential unintended effects: Existing Matrix workflows that referenced relative paths or files outside `ZEROCLAW_WORKSPACE` will no longer upload those files.
- Guardrails/monitoring: Refused attachments emit structured warning logs with the target path and, where relevant, the workspace boundary or read error.

## Agent Collaboration Notes

- Agent tools used: Codex local shell and patch tools.
- Workflow summary: Applied the requested Matrix channel security patch, formatted, ran targeted checks, committed, and pushed the branch.
- Verification focus: Formatting, non-Matrix default channel compile path, and feature-specific Matrix compile attempt.
- Architecture confirmation: Confirmed. Change is scoped to `zeroclaw-channels` Matrix attachment handling.

## Rollback Plan

- Fast rollback command/path: `git revert a8c3fa0e`
- Feature flags or config toggles: None. `ZEROCLAW_WORKSPACE` controls the allowed outbound attachment workspace.
- Observable failure symptoms: Matrix outbound attachment markers fail to upload files that previously uploaded, with warning logs indicating relative path, outside-workspace path, or read failure.

## Risks and Mitigations

- Risk: Users relying on relative attachment paths or paths outside the workspace will see skipped Matrix uploads.
  - Mitigation: Warnings explain why the attachment was refused; users can place outbound files under `ZEROCLAW_WORKSPACE` and reference them by absolute path.

- Risk: A misconfigured `ZEROCLAW_WORKSPACE` could block legitimate uploads.
  - Mitigation: The code creates the workspace if needed, canonicalizes it when possible, and falls back to `/tmp/zeroclaw-uploads` when the environment variable is unset.
