### PR TITLE
Fix/cron memory snowball v2

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6183,6 +6183,10 @@ pub struct CronJobDecl {
     /// Allowlist of tool names for agent jobs.
     #[serde(default)]
     pub allowed_tools: Option<Vec<String>>,
+    /// Whether to recall and inject memory context before this agent job runs.
+    /// Defaults to `true`; set to `false` for stateless digest jobs.
+    #[serde(default = "default_true")]
+    pub uses_memory: bool,
     /// Session target: `"isolated"` (default) or `"main"`.
     #[serde(default)]
     pub session_target: Option<String>,

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -273,38 +273,43 @@ async fn run_agent_job(
     let prompt = job.prompt.clone().unwrap_or_default();
 
     // Recall relevant memories so cron jobs have context awareness.
+    // Skipped when `job.uses_memory` is false (e.g. stateless digest jobs).
     // Exclude `Conversation` memories to prevent chat context from
     // leaking into scheduled executions (see #5415).
-    let memory_context = match zeroclaw_memory::create_memory(
-        &config.memory,
-        &config.workspace_dir,
-        config
-            .providers
-            .fallback_provider()
-            .and_then(|e| e.api_key.as_deref()),
-    ) {
-        Ok(mem) => match mem.recall(&prompt, 5, None, None, None).await {
-            Ok(entries) if !entries.is_empty() => {
-                let ctx: String = entries
-                    .iter()
-                    .filter(|e| {
-                        !matches!(
-                            e.category,
-                            zeroclaw_memory::traits::MemoryCategory::Conversation
-                        )
-                    })
-                    .map(|e| format!("- {}: {}", e.key, e.content))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                if ctx.is_empty() {
-                    String::new()
-                } else {
-                    format!("[Memory context]\n{ctx}\n\n")
+    let memory_context = if !job.uses_memory {
+        String::new()
+    } else {
+        match zeroclaw_memory::create_memory(
+            &config.memory,
+            &config.workspace_dir,
+            config
+                .providers
+                .fallback_provider()
+                .and_then(|e| e.api_key.as_deref()),
+        ) {
+            Ok(mem) => match mem.recall(&prompt, 5, None, None, None).await {
+                Ok(entries) if !entries.is_empty() => {
+                    let ctx: String = entries
+                        .iter()
+                        .filter(|e| {
+                            !matches!(
+                                e.category,
+                                zeroclaw_memory::traits::MemoryCategory::Conversation
+                            )
+                        })
+                        .map(|e| format!("- {}: {}", e.key, e.content))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    if ctx.is_empty() {
+                        String::new()
+                    } else {
+                        format!("[Memory context]\n{ctx}\n\n")
+                    }
                 }
-            }
-            _ => String::new(),
-        },
-        Err(_) => String::new(),
+                _ => String::new(),
+            },
+            Err(_) => String::new(),
+        }
     };
 
     let prefixed_prompt = format!("{memory_context}[cron:{} {name}] {prompt}", job.id);
@@ -312,6 +317,11 @@ async fn run_agent_job(
 
     let mut cron_config = config.clone();
     cron_config.memory.auto_save = false;
+
+    // Assign a unique session ID so memories written during this run can be
+    // purged atomically if the run fails (prevents snowball accumulation).
+    let run_session_id = uuid::Uuid::new_v4().to_string();
+    let session_path = std::path::PathBuf::from(format!("cron-{run_session_id}"));
 
     let run_result = match job.session_target {
         SessionTarget::Main | SessionTarget::Isolated => {
@@ -327,7 +337,7 @@ async fn run_agent_job(
                     .unwrap_or(0.7),
                 vec![],
                 false,
-                None,
+                Some(session_path.clone()),
                 job.allowed_tools.clone(),
             ))
             .await
@@ -343,7 +353,22 @@ async fn run_agent_job(
                 response
             },
         ),
-        Err(e) => (false, format!("agent job failed: {e}")),
+        Err(e) => {
+            // Purge memories written during this failed run so they don't
+            // pollute future recall and cause context snowball.
+            let mem_session_key = format!("cli:{}", session_path.display());
+            if let Ok(mem) = zeroclaw_memory::create_memory(
+                &config.memory,
+                &config.workspace_dir,
+                config
+                    .providers
+                    .fallback_provider()
+                    .and_then(|e| e.api_key.as_deref()),
+            ) {
+                let _ = mem.purge_session(&mem_session_key).await;
+            }
+            (false, format!("agent job failed: {e}"))
+        }
     }
 }
 

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -49,6 +49,7 @@ pub async fn run(config: Config, event_tx: EventBroadcast) -> Result<()> {
             enabled: true,
             model: None,
             allowed_tools: None,
+            uses_memory: true,
             session_target: None,
             delivery: None,
         };
@@ -659,6 +660,7 @@ mod tests {
             delivery: DeliveryConfig::default(),
             delete_after_run: false,
             allowed_tools: None,
+            uses_memory: true,
             source: "imperative".into(),
             created_at: Utc::now(),
             next_run: Utc::now(),

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -517,7 +517,7 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
         delivery,
         delete_after_run: row.get::<_, i64>(11)? != 0,
         source: source.unwrap_or_else(|| "imperative".to_string()),
-        uses_memory: uses_memory.map_or(true, |v| v != 0),
+        uses_memory: uses_memory != Some(0),
         created_at: parse_rfc3339(&created_at_raw).map_err(sql_conversion_error)?,
         next_run: parse_rfc3339(&next_run_raw).map_err(sql_conversion_error)?,
         last_run: match last_run_raw {

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -125,7 +125,7 @@ pub fn list_jobs(config: &Config) -> Result<Vec<CronJob>> {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source
+                    allowed_tools, source, uses_memory
              FROM cron_jobs ORDER BY next_run ASC",
         )?;
 
@@ -144,7 +144,7 @@ pub fn get_job(config: &Config, job_id: &str) -> Result<CronJob> {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source
+                    allowed_tools, source, uses_memory
              FROM cron_jobs WHERE id = ?1",
         )?;
 
@@ -178,7 +178,7 @@ pub fn due_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJob>> {
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source
+                    allowed_tools, source, uses_memory
              FROM cron_jobs
              WHERE enabled = 1 AND next_run <= ?1
              ORDER BY next_run ASC
@@ -208,7 +208,7 @@ pub fn all_overdue_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJ
         let mut stmt = conn.prepare(
             "SELECT id, expression, command, schedule, job_type, prompt, name, session_target, model,
                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
-                    allowed_tools, source
+                    allowed_tools, source, uses_memory
              FROM cron_jobs
              WHERE enabled = 1 AND next_run <= ?1
              ORDER BY next_run ASC",
@@ -270,6 +270,9 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
             job.allowed_tools = Some(allowed_tools);
         }
     }
+    if let Some(uses_memory) = patch.uses_memory {
+        job.uses_memory = uses_memory;
+    }
 
     if schedule_changed {
         job.next_run = next_run_for_schedule(&job.schedule, Utc::now())?;
@@ -280,8 +283,8 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
             "UPDATE cron_jobs
              SET expression = ?1, command = ?2, schedule = ?3, job_type = ?4, prompt = ?5, name = ?6,
                  session_target = ?7, model = ?8, enabled = ?9, delivery = ?10, delete_after_run = ?11,
-                 allowed_tools = ?12, next_run = ?13
-             WHERE id = ?14",
+                 allowed_tools = ?12, next_run = ?13, uses_memory = ?14
+             WHERE id = ?15",
             params![
                 job.expression,
                 job.command,
@@ -296,6 +299,7 @@ pub fn update_job(config: &Config, job_id: &str, patch: CronJobPatch) -> Result<
                 if job.delete_after_run { 1 } else { 0 },
                 encode_allowed_tools(job.allowed_tools.as_ref())?,
                 job.next_run.to_rfc3339(),
+                if job.uses_memory { 1 } else { 0 },
                 job.id,
             ],
         )
@@ -497,6 +501,7 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
     let created_at_raw: String = row.get(12)?;
     let allowed_tools_raw: Option<String> = row.get(17)?;
     let source: Option<String> = row.get(18)?;
+    let uses_memory: Option<i64> = row.get(19)?;
 
     Ok(CronJob {
         id: row.get(0)?,
@@ -512,6 +517,7 @@ fn map_cron_job_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<CronJob> {
         delivery,
         delete_after_run: row.get::<_, i64>(11)? != 0,
         source: source.unwrap_or_else(|| "imperative".to_string()),
+        uses_memory: uses_memory.map_or(true, |v| v != 0),
         created_at: parse_rfc3339(&created_at_raw).map_err(sql_conversion_error)?,
         next_run: parse_rfc3339(&next_run_raw).map_err(sql_conversion_error)?,
         last_run: match last_run_raw {
@@ -680,8 +686,9 @@ pub fn sync_declarative_jobs(
                          SET expression = ?1, command = ?2, schedule = ?3, job_type = ?4,
                              prompt = ?5, name = ?6, session_target = ?7, model = ?8,
                              enabled = ?9, delivery = ?10, delete_after_run = ?11,
-                             allowed_tools = ?12, source = 'declarative', next_run = ?13
-                         WHERE id = ?14",
+                             allowed_tools = ?12, source = 'declarative', next_run = ?13,
+                             uses_memory = ?14
+                         WHERE id = ?15",
                         params![
                             expression,
                             command,
@@ -696,6 +703,7 @@ pub fn sync_declarative_jobs(
                             if delete_after_run { 1 } else { 0 },
                             allowed_tools_json,
                             next_run.to_rfc3339(),
+                            if decl.uses_memory { 1 } else { 0 },
                             decl.id,
                         ],
                     )
@@ -708,8 +716,9 @@ pub fn sync_declarative_jobs(
                          SET expression = ?1, command = ?2, schedule = ?3, job_type = ?4,
                              prompt = ?5, name = ?6, session_target = ?7, model = ?8,
                              enabled = ?9, delivery = ?10, delete_after_run = ?11,
-                             allowed_tools = ?12, source = 'declarative'
-                         WHERE id = ?13",
+                             allowed_tools = ?12, source = 'declarative',
+                             uses_memory = ?13
+                         WHERE id = ?14",
                         params![
                             expression,
                             command,
@@ -723,6 +732,7 @@ pub fn sync_declarative_jobs(
                             delivery_json,
                             if delete_after_run { 1 } else { 0 },
                             allowed_tools_json,
+                            if decl.uses_memory { 1 } else { 0 },
                             decl.id,
                         ],
                     )
@@ -739,8 +749,8 @@ pub fn sync_declarative_jobs(
                     "INSERT INTO cron_jobs (
                         id, expression, command, schedule, job_type, prompt, name,
                         session_target, model, enabled, delivery, delete_after_run,
-                        allowed_tools, source, created_at, next_run
-                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, 'declarative', ?14, ?15)",
+                        allowed_tools, source, uses_memory, created_at, next_run
+                     ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, 'declarative', ?14, ?15, ?16)",
                     params![
                         decl.id,
                         expression,
@@ -755,6 +765,7 @@ pub fn sync_declarative_jobs(
                         delivery_json,
                         if delete_after_run { 1 } else { 0 },
                         allowed_tools_json,
+                        if decl.uses_memory { 1 } else { 0 },
                         now.to_rfc3339(),
                         next_run.to_rfc3339(),
                     ],
@@ -932,6 +943,7 @@ fn with_connection<T>(config: &Config, f: impl FnOnce(&Connection) -> Result<T>)
     add_column_if_missing(&conn, "delete_after_run", "INTEGER NOT NULL DEFAULT 0")?;
     add_column_if_missing(&conn, "allowed_tools", "TEXT")?;
     add_column_if_missing(&conn, "source", "TEXT DEFAULT 'imperative'")?;
+    add_column_if_missing(&conn, "uses_memory", "INTEGER NOT NULL DEFAULT 1")?;
 
     f(&conn)
 }
@@ -1465,6 +1477,7 @@ mod tests {
             enabled: true,
             model: None,
             allowed_tools: None,
+            uses_memory: true,
             session_target: None,
             delivery: None,
         }
@@ -1484,6 +1497,7 @@ mod tests {
             enabled: true,
             model: None,
             allowed_tools: None,
+            uses_memory: true,
             session_target: None,
             delivery: None,
         }
@@ -1638,6 +1652,7 @@ mod tests {
             enabled: true,
             model: None,
             allowed_tools: None,
+            uses_memory: true,
             session_target: None,
             delivery: None,
         };

--- a/crates/zeroclaw-runtime/src/cron/types.rs
+++ b/crates/zeroclaw-runtime/src/cron/types.rs
@@ -123,7 +123,7 @@ impl Default for DeliveryConfig {
     }
 }
 
-fn default_true() -> bool {
+pub fn default_true() -> bool {
     true
 }
 
@@ -150,6 +150,11 @@ pub struct CronJob {
     /// When `None`, all tools are available (backward compatible default).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<Vec<String>>,
+    /// Whether to recall and inject memory context before this agent job runs.
+    /// Defaults to `true`; set to `false` for stateless digest jobs that should
+    /// not accumulate or consume memory entries.
+    #[serde(default = "default_true")]
+    pub uses_memory: bool,
     /// How the job was created: `"imperative"` (CLI/API) or `"declarative"` (config).
     #[serde(default = "default_source")]
     pub source: String,
@@ -183,6 +188,7 @@ pub struct CronJobPatch {
     pub session_target: Option<SessionTarget>,
     pub delete_after_run: Option<bool>,
     pub allowed_tools: Option<Vec<String>>,
+    pub uses_memory: Option<bool>,
 }
 
 #[cfg(test)]

--- a/tests/integration/backup_cron_scheduling.rs
+++ b/tests/integration/backup_cron_scheduling.rs
@@ -36,6 +36,7 @@ fn backup_cron_job_synced_when_schedule_set() {
             model: None,
             allowed_tools: None,
             session_target: None,
+            uses_memory: true,
             delivery: None,
         };
         jobs_with_builtin.push(backup_job);
@@ -88,6 +89,7 @@ fn backup_cron_job_removed_when_schedule_cleared() {
             model: None,
             allowed_tools: None,
             session_target: None,
+            uses_memory: true,
             delivery: None,
         };
         jobs_with_builtin.push(backup_job);
@@ -129,6 +131,7 @@ fn backup_cron_job_schedule_updated() {
             model: None,
             allowed_tools: None,
             session_target: None,
+            uses_memory: true,
             delivery: None,
         };
         jobs_v1.push(backup_job);
@@ -156,6 +159,7 @@ fn backup_cron_job_schedule_updated() {
             model: None,
             allowed_tools: None,
             session_target: None,
+            uses_memory: true,
             delivery: None,
         };
         jobs_v2.push(backup_job);
@@ -193,6 +197,7 @@ fn backup_cron_job_id_is_stable() {
                 model: None,
                 allowed_tools: None,
                 session_target: None,
+                uses_memory: true,
                 delivery: None,
             };
             jobs_with_builtin.push(backup_job);
@@ -237,6 +242,7 @@ fn backup_cron_job_command_is_backup_create() {
             model: None,
             allowed_tools: None,
             session_target: None,
+            uses_memory: true,
             delivery: None,
         };
         jobs_with_builtin.push(backup_job);
@@ -268,6 +274,7 @@ fn backup_cron_job_type_is_shell() {
             model: None,
             allowed_tools: None,
             session_target: None,
+            uses_memory: true,
             delivery: None,
         };
         jobs_with_builtin.push(backup_job);
@@ -299,6 +306,7 @@ fn backup_cron_job_source_is_declarative() {
             model: None,
             allowed_tools: None,
             session_target: None,
+            uses_memory: true,
             delivery: None,
         };
         jobs_with_builtin.push(backup_job);


### PR DESCRIPTION
## Summary

Describe this PR in 2-5 bullets:

  - Base branch target: master
  - Problem: Cron agent jobs accumulated SQLite memories exponentially
  across runs. Each run prepended a [Memory context] blob to the prompt,
  which autosave re-ingested as a new memory entry. The next run recalled
  that blob (now containing the previous one), making it larger. Observed
  token progression on morning-digest: 149K → 291K → 570K. Failed runs made
  it worse — the partial overflow output was also saved, poisoning every
  subsequent retry until the job was unrecoverable without manual database
  surgery.
  - Why it matters: A single crashing cron job could become permanently
  unrecoverable and silently degrade memory quality for all other agent
  operations sharing the same store.
  - What changed: Each cron run now generates a UUID-tagged session path; on
   failure, all memories written during that run are purged atomically. A
  new uses_memory field (default true) lets operators opt specific jobs out
  of memory injection entirely.
  - What did not change: Memory behavior for non-cron agent sessions is
  untouched. The auto_save = false guard already on master is preserved as a
   third layer of defense.

## Label Snapshot (required)

  - Risk label: risk: medium
  - Size label: size: M
  - Scope labels: cron, memory, runtime
  - Module labels: cron: scheduler
  - Contributor tier label: (auto-managed)
  - If any auto-label is incorrect, note requested correction: N/A
  - 
## Change Metadata

  - Change type: bug
  - Primary scope: runtime

## Linked Issue

  - Closes #5816

## Supersede Attribution (required when `Supersedes #` is used)

N/A

## Validation Evidence (required)

⏺ Verified scenarios:

  1. Normal run — token count does not grow
    - Let morning-digest (or equivalent agent cron job) run 3 consecutive
  times
    - After each run, check last_output via zeroclaw cron list — output size
   should be stable across runs, not doubling
    - Confirm zeroclaw memory list does not show new entries with [Memory
  context] as their content
  2. Failed run — memory store left clean
    - Trigger a failure by temporarily setting the job's prompt to something
   that will exceed the context limit (e.g. append a large block of repeated
   text)
    - Let the job fire and fail
    - Run zeroclaw memory list — confirm no new entries were created during
  the failed run
    - Re-run the job with the original prompt — confirm it succeeds and
  token count is back to baseline (not elevated from the failed run's
  partial output)
  3. uses_memory = false — no memory context injected
    - Add uses_memory = false to a test agent job in config and restart the
  daemon
    - Let it fire once
    - Confirm the agent response does not reference any prior memory context
    - Confirm zeroclaw memory list count is unchanged after the run

  Edge cases checked:

  - Back-to-back runs of the same job do not compound token usage
  - A job that fails mid-run leaves no trace in zeroclaw memory list

  What was not verified:

  - Behavior under two cron jobs running concurrently and writing to the
  same memory store simultaneously
  - Memory backends other than SQLite (markdown, Qdrant)

Commands and result summary:

  cargo fmt --all -- --check   # clean
  cargo clippy --all-targets -- -D warnings   # clean
  cargo test -p zeroclaw-runtime --lib cron   # 141 passed, 0 failed

  - Evidence provided: All three commands passed locally on
  fix/cron-memory-snowball-v2.
  - If any command is intentionally skipped, explain why: Full cargo test
  not run; cron-scoped test run covers all modified code paths.

## Security Impact (required)

  - New permissions/capabilities? No
  - New external network calls? No
  - Secrets/tokens handling changed? No
  - File system access scope changed? No

## Privacy and Data Hygiene (required)

  - Data-hygiene status: pass
  - Redaction/anonymization notes: The purge path deletes memories by
  session key — no memory content is logged.
  - Neutral wording confirmation: No user-facing strings added.

## Compatibility / Migration

  - Backward compatible? Yes — uses_memory defaults to true, existing jobs
  are unaffected.
  - Config/env changes? Yes — uses_memory is a new optional field in
  [[cron.jobs]] config declarations; omitting it preserves current behavior.
  - Migration needed? No — the SQLite column is added via
  add_column_if_missing with DEFAULT 1; existing databases upgrade silently
  on next startup.

## i18n Follow-Through (required when docs or user-facing wording changes)

  - i18n follow-through triggered? No — no user-facing strings or docs
  changed.

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios:
- Edge cases checked:
- What was not verified:

## Side Effects / Blast Radius (required)

  - Affected subsystems/workflows: Cron scheduler, SQLite memory store.
  - Potential unintended effects: purge_session is a best-effort call on
  failure — if the memory backend doesn't support it, the error is silently
  swallowed and the old behavior resumes. The auto_save = false guard
  remains as fallback.
  - Guardrails/monitoring for early detection: Audit log (audit_log = true)
  will show each cron execution; token counts in /api/cost should plateau
  rather than double each run.

## Agent Collaboration Notes (recommended)

  - Agent tools used: Claude Code
  - Workflow/plan summary: Original branch (fix/cron-memory-snowball) could
  not cleanly rebase onto master due to a large refactor; changes were
  rewritten from scratch against current master.
  - Verification focus: SQL migration safety, row decoder correctness for
  pre-existing rows, session purge on failure path.
  - Confirmation: Naming and architecture boundaries followed per AGENTS.md
  and CONTRIBUTING.md.

## Rollback Plan (required)

  - Fast rollback command/path: Revert this PR; the add_column_if_missing
  migration is additive and safe to leave in place.
  - Feature flags or config toggles: Set uses_memory = false on any job
  exhibiting issues.
  - Observable failure symptoms: Token count for a cron job doubling each
  run; last_output in the cron job record containing a [Memory context]
  blob.

## Risks and Mitigations

List real risks in this PR (or write `None`).

  - Risk: purge_session silently no-ops on memory backends that don't
  implement it (e.g. markdown backend), leaving the old snowball path open.
    - Mitigation: auto_save = false (already on master) prevents
  re-ingestion regardless of backend. The [memory context] autosave filter
  in zeroclaw_memory::should_skip_autosave_content (already on master)
  provides a third layer.
