### PR TITLE
test(providers): pass merge=true in flatten_system_messages tests

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -3121,7 +3121,7 @@ mod tests {
             ChatMessage::assistant("post-user"),
         ];
 
-        let output = OpenAiCompatibleProvider::flatten_system_messages(&input, false);
+        let output = OpenAiCompatibleProvider::flatten_system_messages(&input, true);
         assert_eq!(output.len(), 3);
         assert_eq!(output[0].role, "assistant");
         assert_eq!(output[0].content, "ack");
@@ -3139,7 +3139,7 @@ mod tests {
             ChatMessage::assistant("ack"),
         ];
 
-        let output = OpenAiCompatibleProvider::flatten_system_messages(&input, false);
+        let output = OpenAiCompatibleProvider::flatten_system_messages(&input, true);
         assert_eq!(output.len(), 2);
         assert_eq!(output[0].role, "user");
         assert_eq!(output[0].content, "core policy");
@@ -3725,7 +3725,7 @@ mod tests {
             ChatMessage::tool(r#"{"ok":true}"#),
         ];
 
-        let flattened = OpenAiCompatibleProvider::flatten_system_messages(&messages, false);
+        let flattened = OpenAiCompatibleProvider::flatten_system_messages(&messages, true);
         assert_eq!(flattened.len(), 3);
         assert_eq!(flattened[0].role, "assistant");
         assert_eq!(
@@ -3744,7 +3744,7 @@ mod tests {
             ChatMessage::system("Synthetic system"),
         ];
 
-        let flattened = OpenAiCompatibleProvider::flatten_system_messages(&messages, false);
+        let flattened = OpenAiCompatibleProvider::flatten_system_messages(&messages, true);
         assert_eq!(flattened.len(), 2);
         assert_eq!(flattened[0].role, "user");
         assert_eq!(flattened[0].content, "Synthetic system");


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: All four `flatten_system_messages_*` tests in `crates/zeroclaw-providers/src/compatible.rs` call the function with `merge: false`. With `merge: false` the body short-circuits to `return messages.to_vec();` (compatible.rs:303-305), so the tests assert against the untouched input. Every assertion below that point expects the merged output (system messages removed, their content prepended to the first user message). Running the suite on `master` confirms the tests do not guard the code they appear to guard: `cargo test -p zeroclaw-providers --lib flatten_system_messages` → ``0 passed; 4 failed`` (see Validation Evidence).
- Why it matters: The `merge: true` path — used by MiniMax and every provider with `merge_system_into_user` — has **zero test coverage** on `master`. Any regression in system-message flattening reaches production undetected. PR #5762 introduced the `merge: bool` parameter but the tests never exercised the merge path, so the safety net for non-native-tool providers is gone.
- What changed: Four single-character edits in `#[cfg(test)]` scope — flip the `false` argument to `true` at lines 3124, 3142, 3728, 3747. No production code is touched.
- What did **not** change (scope boundary): Zero production code changes. No new tests added. No renames. No signature changes. The function's `merge: false` early-return contract is unchanged.

## Label Snapshot

- Risk label: `risk: low`
- Size label: `size: XS`
- Scope labels: `provider`, `test`
- Module labels: `provider: compatible`
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `test`, `bug`
- Primary scope: `provider`

## Linked Issue

- Closes — n/a (no separate issue filed; problem surfaced during an external audit of the v0.6.5..v0.7.0 diff window)
- Related — #5762 (introduced the \`merge: bool\` parameter)

## Supersede Attribution

N/A — no PRs superseded.

## Validation Evidence

Fresh run on the PR branch, local machine (rustc 1.93.1, macOS aarch64):

\`\`\`text
$ cargo fmt --all -- --check
# exit 0, no output

$ cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
    Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 16.37s
# exit 0

$ cargo test -p zeroclaw-providers --lib flatten_system_messages
running 4 tests
test compatible::tests::flatten_system_messages_inserts_user_when_missing ... ok
test compatible::tests::flatten_system_messages_merges_into_first_user ... ok
test compatible::tests::flatten_system_messages_inserts_synthetic_user_when_no_user_exists ... ok
test compatible::tests::flatten_system_messages_merges_into_first_user_and_removes_system_roles ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 761 filtered out; finished in 0.00s
\`\`\`

For comparison, the same command on unmodified \`master\` (d0d83198) reports \`0 passed; 4 failed\` with four concrete assertion panics:

\`\`\`text
assertion \`left == right\` failed: left: 5, right: 3           (compatible.rs:3125)
assertion \`left == right\` failed: left: \"system\", right: \"user\"  (compatible.rs:3144)
assertion \`left == right\` failed: left: 5, right: 3           (compatible.rs:3729)
assertion \`left == right\` failed: left: \"assistant\", right: \"user\"  (compatible.rs:3749)
\`\`\`

Workspace \`cargo test\` was not re-run in full because the change is test-only and scoped to four lines in a single file.

## Security Impact

- New permissions / capabilities: No
- New external network calls: No
- Secrets / tokens handling changed: No
- File-system access scope changed: No
- Risk and mitigation: Test-only patch; no runtime surface change.

## Privacy and Data Hygiene

- Data-hygiene status: pass
- Redaction / anonymization notes: No personal data or secrets touched.
- Neutral wording confirmation: Confirmed.

## Compatibility / Migration

- Backward compatible: Yes
- Config / env changes: No
- Migration needed: No
- Upgrade steps: None.

## i18n Follow-Through

- i18n follow-through triggered: No
- Scope decision: Test-only change; no docs, UI, or user-facing strings touched.

## Human Verification

- [x] Ran \`cargo fmt --all -- --check\` locally — pass.
- [x] Ran \`cargo clippy -p zeroclaw-providers --all-targets -- -D warnings\` locally — pass.
- [x] Ran \`cargo test -p zeroclaw-providers --lib flatten_system_messages\` locally — 4 passed, 0 failed.
- [x] Verified the same tests fail on unmodified \`master\` (d0d83198).
- [x] Confirmed no production code (outside \`#[cfg(test)]\`) is modified.