### PR TITLE
fix(agent): treat mixed-protection tool groups as atomic in prune_history Phase 1

### DIFF
--- a/crates/zeroclaw-runtime/src/agent/history_pruner.rs
+++ b/crates/zeroclaw-runtime/src/agent/history_pruner.rs
@@ -176,20 +176,32 @@ pub fn prune_history(messages: &mut Vec<ChatMessage>, config: &HistoryPrunerConf
     // forms an atomic group (tool_use + tool_result pairing). Collapsing only
     // part of the group would orphan tool_use blocks, causing API 400 errors
     // from providers that enforce pairing (e.g., Anthropic). See #4810.
+    //
+    // The group is collapsed only when *every* tool in it is unprotected —
+    // the same all-or-nothing rule Phase 2 uses. If `keep_recent` protects
+    // any tool in the group we skip the whole group. Partial collapse would
+    // leave a protected tool behind whose parent assistant has been
+    // rewritten to a summary with no "tool_calls" marker, which Phase 3's
+    // orphan sweep then evicts — silently violating `keep_recent`. See
+    // #5823.
     if config.collapse_tool_results {
         let mut i = 0;
         while i < messages.len() {
             let protected = protected_indices(messages, config.keep_recent);
             if messages[i].role == "assistant" && !protected[i] {
                 // Count consecutive tool messages following this assistant
+                // and remember whether any of them is protected.
                 let mut tool_count = 0;
+                let mut any_tool_protected = false;
                 while i + 1 + tool_count < messages.len()
                     && messages[i + 1 + tool_count].role == "tool"
-                    && !protected[i + 1 + tool_count]
                 {
+                    if protected[i + 1 + tool_count] {
+                        any_tool_protected = true;
+                    }
                     tool_count += 1;
                 }
-                if tool_count > 0 {
+                if tool_count > 0 && !any_tool_protected {
                     let summary =
                         format!("[Tool exchange: {tool_count} tool call(s) — results collapsed]");
                     messages[i] = ChatMessage {
@@ -200,6 +212,13 @@ pub fn prune_history(messages: &mut Vec<ChatMessage>, config: &HistoryPrunerConf
                         messages.remove(i + 1);
                     }
                     collapsed_pairs += tool_count;
+                    continue;
+                }
+                if tool_count > 0 {
+                    // Protected tool inside the group → skip the whole
+                    // group intact so Phase 3's orphan sweep has no
+                    // pretext to remove those tools.
+                    i += 1 + tool_count;
                     continue;
                 }
             }
@@ -777,5 +796,60 @@ mod tests {
         assert_eq!(messages[0].role, "system");
         assert_eq!(messages[1].role, "assistant");
         assert_eq!(messages[2].role, "user");
+    }
+
+    /// Regression for #5823:
+    ///
+    /// When `keep_recent` protects the *tail* of a multi-tool group but not
+    /// the preceding assistant, Phase 1 used to collapse the unprotected
+    /// tools and rewrite the assistant to a summary that no longer contained
+    /// `"tool_calls"`. Phase 3's orphan sweep then classified the still-live
+    /// protected tool as an orphan (because the new summary does not contain
+    /// `"tool_calls"`) and removed it — silently violating `keep_recent`.
+    ///
+    /// After the fix Phase 1 treats the group as atomic: if any tool in it
+    /// is protected, the entire group is left intact.
+    #[test]
+    fn prune_does_not_evict_protected_tool_when_group_straddles_keep_recent() {
+        let mut messages = vec![
+            msg("system", "sys"),
+            msg("user", "query"),
+            msg(
+                "assistant",
+                r#"{"content":null,"tool_calls":[
+                    {"id":"t1","name":"shell","arguments":"{}"},
+                    {"id":"t2","name":"web","arguments":"{}"}
+                ]}"#,
+            ),
+            msg("tool", r#"{"tool_call_id":"t1","content":"first"}"#),
+            msg(
+                "tool",
+                r#"{"tool_call_id":"t2","content":"PROTECTED second"}"#,
+            ),
+            msg("user", "follow up"),
+            msg("assistant", "final"),
+        ];
+
+        let config = HistoryPrunerConfig {
+            enabled: true,
+            // Budget is well above the estimated token cost so Phase 2 does
+            // not drop anything; this test isolates the Phase 1 / Phase 3
+            // interaction.
+            max_tokens: 100_000,
+            keep_recent: 3,
+            collapse_tool_results: true,
+        };
+
+        let stats = prune_history(&mut messages, &config);
+
+        assert_eq!(stats.messages_before, 7);
+        assert!(
+            messages
+                .iter()
+                .any(|m| m.content.contains("PROTECTED second")),
+            "a tool message protected by keep_recent must survive; \
+             got roles {:?}",
+            messages.iter().map(|m| m.role.as_str()).collect::<Vec<_>>()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: In `crates/zeroclaw-runtime/src/agent/history_pruner.rs`, Phase 1 (`collapse_tool_results`) would collapse a *partial* tool group when `keep_recent` protected the trailing tools. The unprotected tools were merged into a summary line and the preceding assistant was rewritten to `"[Tool exchange: N tool call(s) — results collapsed]"` — which deliberately does **not** contain the substring `"tool_calls"`. Phase 3 (`remove_orphaned_tool_messages`) then walked back from the surviving protected tool, saw that "its" assistant content lacked `"tool_calls"`, classified the tool as an orphan and removed it. A message that `keep_recent` was supposed to preserve got evicted silently.
- Why it matters: `keep_recent` is the pruner's user-facing promise about the recent context window the model keeps seeing. Silently dropping protected tool results degrades the next model turn (loss of the tool_call_id ↔ tool_result pairing the model is actively reasoning over) and contradicts AGENTS.md's anti-pattern list (*"do not silently weaken … access constraints"* is the nearest declared rule; the `keep_recent` contract is of the same shape).
- What changed: Phase 1 now mirrors the same "all tools unprotected, or skip the whole group" rule Phase 2 already uses. The inner counter tracks `any_tool_protected` alongside `tool_count`; if any tool in the group is protected we advance past the whole group without collapsing. The collapsed branch is unchanged when the group is fully unprotected, so the Anthropic-400 fix from #4810 / PR #5167 is preserved.
- What did **not** change (scope boundary): `remove_orphaned_tool_messages` (Phase 3), `estimate_tokens`, `protected_indices`, the `PruneStats` struct, the `HistoryPrunerConfig` schema, and Phase 2's budget enforcement are all untouched. No public API changes.

## Label Snapshot

- Risk label: `risk: medium`
- Size label: `size: S`
- Scope labels: `runtime`, `agent`
- Module labels: `runtime: agent`, `runtime: history-pruner`
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `bug`
- Primary scope: `runtime`

## Linked Issue

- Closes #5823
- Related — PR #5167 (introduced the three-phase pruner and `remove_orphaned_tool_messages`) and issue #4810 (the original atomic-group motivation).

## Supersede Attribution

N/A

## Validation Evidence

```text
$ cargo fmt --all -- --check
# exit 0, no output

$ cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.29s
# exit 0

$ cargo test -p zeroclaw-runtime --lib prune_
running 13 tests
test agent::history_pruner::tests::prune_empty_messages ... ok
test agent::history_pruner::tests::prune_disabled_is_noop ... ok
test agent::history_pruner::tests::prune_drops_tool_group_atomically ... ok
test agent::history_pruner::tests::prune_under_budget_no_change ... ok
test agent::history_pruner::tests::prune_drops_oldest_when_over_budget ... ok
test agent::history_pruner::tests::prune_preserves_system_and_recent ... ok
test agent::history_pruner::tests::prune_never_orphans_tool_use ... ok
test agent::history_pruner::tests::prune_collapses_multi_tool_group ... ok
test agent::history_pruner::tests::prune_collapses_tool_pairs ... ok
test agent::history_pruner::tests::prune_protects_recent_tool_groups ... ok
test agent::history_pruner::tests::prune_does_not_evict_protected_tool_when_group_straddles_keep_recent ... ok
test agent::history_pruner::tests::prune_under_realistic_token_pressure_preserves_tool_pairing ... ok
test cron::store::tests::record_and_prune_runs ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 1586 filtered out; finished in 0.01s
```

The new test `prune_does_not_evict_protected_tool_when_group_straddles_keep_recent` replicates the scenario from #5823: a two-tool group with `keep_recent = 3` where the first tool is unprotected and the second is protected. Before the fix it panicked with "a tool message protected by keep_recent must survive"; after the fix it passes. All other pruner tests continue to pass, including the ones added in PR #5167 (`prune_collapses_multi_tool_group`, `prune_protects_recent_tool_groups`, `prune_never_orphans_tool_use`).

## Security Impact

- New permissions / capabilities: No
- New external network calls: No
- Secrets / tokens handling changed: No
- File-system access scope changed: No
- Risk and mitigation: History contents never leave the process; the change only affects which messages survive pruning. No new attack surface.

## Privacy and Data Hygiene

- Data-hygiene status: pass
- Redaction / anonymization notes: New log/error text is identical to pre-existing Phase 1 behaviour (same `[Tool exchange: ...]` summary). No PII or tokens added.

## Compatibility / Migration

- Backward compatible: Yes — behaviour only changes for the specific edge case where `keep_recent` splits a tool group. Pre-fix, users got a silent eviction; post-fix, the group is preserved intact. No config, schema, or API surface moves.
- Config / env changes: None.
- Migration needed: No.

## i18n Follow-Through

- Not applicable — no user-facing or localised strings touched.

## Human Verification

- [x] Ran `cargo fmt --all -- --check`.
- [x] Ran `cargo clippy -p zeroclaw-runtime --all-targets -- -D warnings`.
- [x] Ran focused tests: `cargo test -p zeroclaw-runtime --lib prune_` (13 passed, 0 failed).
- [x] Verified the new regression test fails on unmodified `master` (panics exactly as the issue describes: `surviving: [system, user, "[Tool exchange: 1 tool call(s) — results ...", user, final]`).
- [x] Checked the Phase 2 equivalent (`any_tool_protected` loop) is unchanged and still exercised by `prune_protects_recent_tool_groups`.