### PR TITLE
fix(provider): coalesce adjacent assistants in strip_native_tool_messages

### DIFF
--- a/crates/zeroclaw-providers/src/compatible.rs
+++ b/crates/zeroclaw-providers/src/compatible.rs
@@ -1590,30 +1590,51 @@ impl OpenAiCompatibleProvider {
         if self.native_tool_calling {
             return messages.to_vec();
         }
-        messages
-            .iter()
-            .filter_map(|msg| {
-                if msg.role == "tool" {
-                    return None;
+        let intermediate = messages.iter().filter_map(|msg| {
+            if msg.role == "tool" {
+                return None;
+            }
+            if msg.role == "assistant"
+                && let Ok(value) = serde_json::from_str::<serde_json::Value>(&msg.content)
+                && value.get("tool_calls").is_some()
+            {
+                let text = value
+                    .get("content")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                return if text.is_empty() {
+                    None
+                } else {
+                    Some(ChatMessage::assistant(&text))
+                };
+            }
+            Some(msg.clone())
+        });
+
+        // Coalesce adjacent assistant messages.
+        //
+        // A typical trace is:
+        //     user → assistant{content, tool_calls} → tool{result} → assistant{reply}
+        // After the filter_map above the `tool` message is gone and the first
+        // assistant has been rewritten to plain text, leaving two assistant
+        // messages in a row. Providers targeted by the `native_tool_calling =
+        // false` path (Anthropic upstream, MiniMax, and other OpenAI-compat
+        // wrappers) reject consecutive same-role messages with HTTP 400, so we
+        // merge them here. See #5825.
+        let mut coalesced: Vec<ChatMessage> = Vec::with_capacity(messages.len());
+        for msg in intermediate {
+            match coalesced.last_mut() {
+                Some(last) if last.role == "assistant" && msg.role == "assistant" => {
+                    if !last.content.is_empty() && !msg.content.is_empty() {
+                        last.content.push_str("\n\n");
+                    }
+                    last.content.push_str(&msg.content);
                 }
-                if msg.role == "assistant"
-                    && let Ok(value) = serde_json::from_str::<serde_json::Value>(&msg.content)
-                    && value.get("tool_calls").is_some()
-                {
-                    let text = value
-                        .get("content")
-                        .and_then(serde_json::Value::as_str)
-                        .unwrap_or("")
-                        .to_string();
-                    return if text.is_empty() {
-                        None
-                    } else {
-                        Some(ChatMessage::assistant(&text))
-                    };
-                }
-                Some(msg.clone())
-            })
-            .collect()
+                _ => coalesced.push(msg),
+            }
+        }
+        coalesced
     }
 
     fn with_prompt_guided_tool_instructions(
@@ -3291,21 +3312,32 @@ mod tests {
             AuthStyle::Bearer,
         );
         let stripped = p.strip_native_tool_messages(&messages);
-        assert_eq!(stripped.len(), 5);
+        // tool message dropped; the pre-tool narration and the reply that
+        // follows the tool result are now coalesced into a single assistant
+        // message so the output never contains consecutive assistants (see
+        // #5825).
+        assert_eq!(stripped.len(), 4);
         assert_eq!(stripped[0].role, "system");
         assert_eq!(stripped[1].role, "user");
         assert_eq!(stripped[1].content, "search for cats");
-        // Assistant with tool_calls → plain text with only content
         assert_eq!(stripped[2].role, "assistant");
-        assert_eq!(stripped[2].content, "I'll search");
+        assert!(
+            stripped[2].content.starts_with("I'll search"),
+            "coalesced assistant must preserve the pre-tool narration; got {:?}",
+            stripped[2].content
+        );
+        assert!(
+            stripped[2]
+                .content
+                .contains("Here are the results about cats"),
+            "coalesced assistant must preserve the post-tool reply; got {:?}",
+            stripped[2].content
+        );
         assert!(
             !stripped[2].content.contains("tool_calls"),
             "tool_calls structure must be stripped"
         );
-        // tool message → dropped
-        assert_eq!(stripped[3].role, "assistant");
-        assert_eq!(stripped[3].content, "Here are the results about cats");
-        assert_eq!(stripped[4].role, "user");
+        assert_eq!(stripped[3].role, "user");
     }
 
     #[test]
@@ -4258,5 +4290,77 @@ mod tests {
     #[test]
     fn proxy_tool_event_done_sentinel_returns_none() {
         assert!(parse_proxy_tool_event("data: [DONE]").is_none());
+    }
+
+    /// Regression for #5825.
+    ///
+    /// When `native_tool_calling = false`, the filter pass rewrites
+    /// `assistant{tool_calls, content="I'll search"}` into `assistant("I'll
+    /// search")` and drops the following `tool{result}`. That leaves two
+    /// adjacent assistant messages in the output, which providers targeted
+    /// by this path (Anthropic upstream, MiniMax, other OpenAI-compat
+    /// wrappers) reject with HTTP 400.
+    #[test]
+    fn strip_native_tool_messages_coalesces_adjacent_assistants() {
+        let messages = vec![
+            ChatMessage::user("search for cats"),
+            ChatMessage::assistant(
+                r#"{"content":"I'll search","tool_calls":[{"id":"t1","name":"web_search","arguments":"{}"}]}"#,
+            ),
+            ChatMessage::tool(r#"{"tool_call_id":"t1","content":"Found 10 results"}"#),
+            ChatMessage::assistant("Here are the results about cats"),
+        ];
+        let p = OpenAiCompatibleProvider::new_merge_system_into_user(
+            "MiniMax",
+            "https://api.minimax.chat/v1",
+            Some("k"),
+            AuthStyle::Bearer,
+        );
+        let stripped = p.strip_native_tool_messages(&messages);
+        let roles: Vec<&str> = stripped.iter().map(|m| m.role.as_str()).collect();
+        assert!(
+            !roles.windows(2).any(|w| w[0] == w[1]),
+            "no two consecutive messages should share a role; got {roles:?}"
+        );
+        // Sanity: user turn and merged assistant content both survive.
+        assert_eq!(roles, vec!["user", "assistant"]);
+        assert_eq!(stripped[0].content, "search for cats");
+        assert!(
+            stripped[1].content.contains("I'll search")
+                && stripped[1]
+                    .content
+                    .contains("Here are the results about cats"),
+            "merged assistant should preserve both the pre-tool narration and the final reply; \
+             got {:?}",
+            stripped[1].content
+        );
+    }
+
+    /// Complementary regression for #5825: when the narration content is
+    /// empty, the pre-tool assistant is dropped entirely and no coalesce is
+    /// needed. This test documents that the coalesce pass does not produce
+    /// spurious blank-line concatenation.
+    #[test]
+    fn strip_native_tool_messages_drops_empty_narration_cleanly() {
+        let messages = vec![
+            ChatMessage::user("search for cats"),
+            ChatMessage::assistant(
+                r#"{"content":"","tool_calls":[{"id":"t1","name":"web_search","arguments":"{}"}]}"#,
+            ),
+            ChatMessage::tool(r#"{"tool_call_id":"t1","content":"Found"}"#),
+            ChatMessage::assistant("Here are the results"),
+        ];
+        let p = OpenAiCompatibleProvider::new_merge_system_into_user(
+            "MiniMax",
+            "https://api.minimax.chat/v1",
+            Some("k"),
+            AuthStyle::Bearer,
+        );
+        let stripped = p.strip_native_tool_messages(&messages);
+        assert_eq!(
+            stripped.iter().map(|m| m.role.as_str()).collect::<Vec<_>>(),
+            vec!["user", "assistant"]
+        );
+        assert_eq!(stripped[1].content, "Here are the results");
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `strip_native_tool_messages` (`crates/zeroclaw-providers/src/compatible.rs:1589`) filters tool-role messages and rewrites `assistant{tool_calls, content}` into plain `assistant{content}`. In the canonical trace `user → assistant{narration, tool_calls} → tool{result} → assistant{reply}`, the output becomes `user → assistant(narration) → assistant(reply)`. Two consecutive `assistant` messages violate the role-alternation invariant enforced by Anthropic and several OpenAI-compat wrappers (MiniMax among them) — they respond with `HTTP 400 "consecutive messages with same role"`. The function is invoked exactly on the code path where `native_tool_calling = false`, i.e. the path taken by those strict providers.
- Why it matters: PR #5762 closed the original MiniMax 400 caused by native tool messages surviving into the OpenAI-compat payload, but the fallback trace still produces a fresh 400 for the same deployments. The regression shows up only once conversation history accumulates a completed tool turn, which is routine for daemon-mode MiniMax/Anthropic instances.
- What changed: Added a post-filter coalesce pass. After the existing `filter_map`, adjacent `assistant` messages are merged with a blank-line separator. The pass is idempotent (a single assistant is unchanged) and does not concatenate empty strings, so the existing drop-empty-narration behaviour is preserved verbatim.
- What did **not** change (scope boundary): The filter predicate itself, the `self.native_tool_calling` short-circuit at the top of the function, provider capabilities (`supports_*`), `chat`/`stream_chat`/`chat_with_tools` control flow, the `flatten_system_messages` merge pipeline. No public API changes.

## Label Snapshot

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `provider`
- Module labels: `provider: compatible`
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `bug`
- Primary scope: `provider`

## Linked Issue

- Closes #5825
- Related — PR #5762 (introduced `strip_native_tool_messages`); issue #2232 (closed, earlier role-alternation regression class).

## Supersede Attribution

N/A

## Validation Evidence

```text
$ cargo fmt --all -- --check
# exit 0, no output

$ cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.40s
# exit 0

$ cargo test -p zeroclaw-providers --lib strip_native_tool
running 6 tests
test compatible::tests::strip_native_tool_messages_preserves_regular_messages ... ok
test compatible::tests::strip_native_tool_messages_passthrough_when_native_tool_calling_enabled ... ok
test compatible::tests::strip_native_tool_messages_removes_tool_and_tool_calls ... ok
test compatible::tests::strip_native_tool_messages_drops_empty_assistant_tool_calls ... ok
test compatible::tests::strip_native_tool_messages_drops_empty_narration_cleanly ... ok
test compatible::tests::strip_native_tool_messages_coalesces_adjacent_assistants ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 761 filtered out; finished in 0.00s
```

New tests added by this PR:
- `strip_native_tool_messages_coalesces_adjacent_assistants` — the canonical narration + reply trace; asserts no two consecutive messages share a role and that both contents survive in the merged assistant.
- `strip_native_tool_messages_drops_empty_narration_cleanly` — documents the empty-narration path still drops the pre-tool assistant (so the coalesce pass has nothing to merge); guards against a regression where the empty string gets spuriously concatenated.

Existing test updated:
- `strip_native_tool_messages_removes_tool_and_tool_calls` — previously asserted `len == 5` with two consecutive assistants (the output shape the bug produces). Now asserts `len == 4` with a single merged assistant carrying both the pre-tool narration (`"I'll search"`) and the post-tool reply (`"Here are the results about cats"`). The `tool_calls` structure is still stripped.

### Pre-existing unrelated failures on `master`

`cargo test -p zeroclaw-providers --lib flatten_system_messages` fails 4 tests on unmodified `master` (`0 passed; 4 failed`). Those failures are independent of this PR and are addressed by PR #5821 (a one-line-per-site test fix). They are intentionally not touched here to keep the scope boundary narrow.

## Security Impact

- New permissions / capabilities: No
- New external network calls: No
- Secrets / tokens handling changed: No
- File-system access scope changed: No
- Risk and mitigation: Message contents never leave the process in this function; the change only affects which messages survive into the provider payload.

## Privacy and Data Hygiene

- Data-hygiene status: pass
- Redaction / anonymization notes: No PII or tokens introduced into new log/error text.

## Compatibility / Migration

- Backward compatible: Yes — behaviour changes only in the case where the filter pass would have produced adjacent assistants, which is exactly the buggy payload providers rejected.
- Config / env changes: None.
- Migration needed: No.

## i18n Follow-Through

- Not applicable — no user-facing or localised strings touched.

## Human Verification

- [x] Ran `cargo fmt --all -- --check`.
- [x] Ran `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings`.
- [x] Ran focused tests: `cargo test -p zeroclaw-providers --lib strip_native_tool` (6 passed).
- [x] Verified the new coalesce test fails on unmodified `master` (consecutive assistants in the output).
- [x] Reviewed `chat` / `stream_chat` / `chat_with_tools` / `chat_with_history` callsites for `strip_native_tool_messages` — they consume the return value as a plain `Vec<ChatMessage>` with no order-index assumptions, so the length change is safe.
- [x] Confirmed the `self.native_tool_calling` passthrough at the top of the function still bypasses the coalesce pass (native-tool providers like OpenAI are untouched).