### PR TITLE
fix(provider): abort OpenRouter stream task when consumer drops the stream

### DIFF
--- a/crates/zeroclaw-providers/src/openrouter.rs
+++ b/crates/zeroclaw-providers/src/openrouter.rs
@@ -44,6 +44,22 @@ enum MessageContent {
     Parts(Vec<MessagePart>),
 }
 
+/// RAII guard that aborts a spawned tokio task when dropped.
+///
+/// Used by `stream_chat` to bind the SSE-forwarding task's lifetime to the
+/// returned stream. When a caller cancels the stream (timeout, user abort,
+/// client disconnect), the guard is dropped together with the stream state
+/// and the in-flight HTTP request is cancelled so it stops consuming
+/// bandwidth and connection-pool slots. `AbortHandle::abort` is a no-op
+/// after the task has finished naturally, so the happy path is unaffected.
+struct AbortOnDrop(tokio::task::AbortHandle);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum MessagePart {
@@ -608,7 +624,7 @@ impl Provider for OpenRouterProvider {
 
         let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(100);
 
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             let response = match client
                 .post("https://openrouter.ai/api/v1/chat/completions")
                 .header("Authorization", format!("Bearer {credential}"))
@@ -646,8 +662,17 @@ impl Provider for OpenRouterProvider {
             }
         });
 
-        stream::unfold(rx, |mut rx| async move {
-            rx.recv().await.map(|event| (event, rx))
+        // Bind the task's lifetime to the returned stream so dropping the
+        // stream cancels the in-flight HTTP request. Without this guard the
+        // spawned task keeps reading the response body to completion after
+        // the consumer is gone, holding a connection-pool slot and
+        // consuming OpenRouter quota for a request the caller no longer
+        // wants. `AbortHandle::abort` is a no-op if the task has already
+        // finished, so the happy path is unaffected. See #5822.
+        let guard = AbortOnDrop(handle.abort_handle());
+
+        stream::unfold((rx, guard), |(mut rx, guard)| async move {
+            rx.recv().await.map(|event| (event, (rx, guard)))
         })
         .boxed()
     }
@@ -1438,5 +1463,56 @@ mod tests {
         }];
 
         assert!(OpenRouterProvider::convert_tools(Some(&tools)).is_none());
+    }
+
+    /// Regression for #5822.
+    ///
+    /// `AbortOnDrop` must cancel the bound tokio task when it is dropped.
+    /// This guards the `stream_chat` invariant that a dropped stream stops
+    /// the in-flight SSE-forwarding task instead of letting it run to
+    /// completion.
+    #[tokio::test]
+    async fn abort_on_drop_cancels_long_running_task() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use tokio::time::{Duration, timeout};
+
+        let finished = Arc::new(AtomicBool::new(false));
+        let finished_clone = Arc::clone(&finished);
+
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            finished_clone.store(true, Ordering::SeqCst);
+        });
+        let raw_handle = handle.abort_handle();
+        let guard = AbortOnDrop(handle.abort_handle());
+
+        // Sanity: the task is live and has not finished synchronously.
+        assert!(!raw_handle.is_finished());
+
+        drop(guard);
+
+        // After dropping the guard the task should be cancelled promptly.
+        // Poll `is_finished` within a generous bound; 2 seconds is far more
+        // than necessary but keeps the test robust on loaded CI runners.
+        let cancelled = timeout(Duration::from_secs(2), async {
+            loop {
+                if raw_handle.is_finished() {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+
+        assert!(
+            cancelled.is_ok(),
+            "task should be aborted within 2 s of AbortOnDrop being dropped"
+        );
+        // The task was cancelled, not completed — the flag must stay false.
+        assert!(
+            !finished.load(Ordering::SeqCst),
+            "cancelled task must not have run its completion side effect"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target: `master`
- Problem: `OpenRouterProvider::stream_chat` (`crates/zeroclaw-providers/src/openrouter.rs:611`) spawned a `tokio::spawn` task that drove the SSE stream through an `mpsc::channel(100)` and discarded the `JoinHandle`. Cancellation only propagated through `tx.send(..).is_err()`, which required at least one event already in flight. If the consumer dropped the returned `BoxStream` early (timeout, user cancel, client disconnect), the spawned task kept reading the HTTP response body to completion — holding a connection-pool slot, consuming OpenRouter quota for a request the caller no longer wanted, and silently swallowing any task panic (the handle was never awaited).
- Why it matters: This is a Tokio anti-pattern that bites the exact deployments that benefit from streaming (long-running agent turns, heavy tool use, reasoning models). Under sustained cancellations it produces a real resource leak. It also conflicts with AGENTS.md's stated goals — "Rust-first autonomous agent runtime optimized for performance, efficiency, stability, …" — and diverges from the `OpenAiCompatibleProvider` pattern, which does not spawn a detached task.
- What changed: Introduce a small RAII guard `AbortOnDrop(tokio::task::AbortHandle)` at module scope. `stream_chat` now holds the `JoinHandle` returned by `tokio::spawn`, takes an `AbortHandle`, and wraps it in the guard. The guard is moved into the `stream::unfold` state alongside the receiver. When the returned stream is dropped, the state drops, the guard runs, and the in-flight HTTP request is cancelled. `AbortHandle::abort` is a no-op after the task has finished naturally, so the happy path (stream polled to completion) is unaffected.
- What did **not** change (scope boundary): The SSE payload, the `reqwest` request shape (headers, body, URL), `sse_bytes_to_events`, `mpsc::channel(100)` buffer size, the return type of `stream_chat`, or any other public surface. Non-streaming paths (`chat_with_tools`, `chat`, etc.) and `supports_streaming*` capabilities are untouched.

## Label Snapshot

- Risk label: `risk: low`
- Size label: `size: S`
- Scope labels: `provider`
- Module labels: `provider: openrouter`
- Contributor tier label: (auto-managed)

## Change Metadata

- Change type: `bug`
- Primary scope: `provider`

## Linked Issue

- Closes #5822
- Related — PR #5717 (introduced the OpenRouter streaming implementation).

## Supersede Attribution

N/A

## Validation Evidence

```text
$ cargo fmt --all -- --check
# exit 0, no output

$ cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.17s
# exit 0

$ cargo test -p zeroclaw-providers --lib abort_on_drop
running 1 test
test openrouter::tests::abort_on_drop_cancels_long_running_task ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 765 filtered out; finished in 0.01s

$ cargo test -p zeroclaw-providers --lib stream_chat
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 757 filtered out; finished in 0.00s
```

New test added by this PR:
- `abort_on_drop_cancels_long_running_task` — spawns a 30-second sleep task, captures an `AbortHandle`, wraps it in `AbortOnDrop`, drops the guard, and asserts (a) `AbortHandle::is_finished()` reports true within 2 seconds, and (b) the task's post-sleep completion side effect (a `Relaxed` atomic flag) never ran.

The existing `stream_chat_without_key_returns_error_event` and `stream_chat_disabled_options_returns_final` tests continue to pass — both early-return without spawning, which is unchanged.

## Security Impact

- New permissions / capabilities: No
- New external network calls: No — the set of HTTP endpoints called is unchanged. The change is purely around cancellation of the same request.
- Secrets / tokens handling changed: No — the `credential` string is still only used to build the `Authorization` header.
- File-system access scope changed: No.
- Risk and mitigation: The guard narrows the process's footprint under cancellation (fewer open sockets, faster quota release). No new attack surface.

## Privacy and Data Hygiene

- Data-hygiene status: pass
- Redaction / anonymization notes: No new log or error text touches sensitive fields. The `Authorization` header is still built via the existing `format!("Bearer {credential}")` and never logged.

## Compatibility / Migration

- Backward compatible: Yes — behaviour only changes when the consumer drops the stream early. Callers that poll to completion observe no difference.
- Config / env changes: None.
- Migration needed: No.

## i18n Follow-Through

- Not applicable — no user-facing strings touched.

## Human Verification

- [x] Ran `cargo fmt --all -- --check`.
- [x] Ran `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings`.
- [x] Ran focused tests: `cargo test -p zeroclaw-providers --lib abort_on_drop` (1 passed) and `cargo test -p zeroclaw-providers --lib stream_chat` (9 passed).
- [x] Verified `AbortHandle::abort` is a no-op after a task has finished, so polling the stream to natural completion is unaffected (guard.abort runs after rx has closed).
- [x] Reviewed `OpenAiCompatibleProvider` — it does not spawn, so no similar fix is needed there. This PR leaves all non-OpenRouter providers untouched.