### PR TITLE
feat(channels/webhook): add retry logic with exponential backoff

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -7066,6 +7066,9 @@ fn collect_configured_channels(
                 wh.send_method.clone(),
                 wh.auth_header.clone(),
                 wh.secret.clone(),
+                wh.max_retries,
+                wh.retry_base_delay_ms,
+                wh.retry_max_delay_ms,
             )),
         });
     }

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -8395,6 +8395,9 @@ pub async fn deliver_announcement(
                 wh.send_method.clone(),
                 wh.auth_header.clone(),
                 wh.secret.clone(),
+                wh.max_retries,
+                wh.retry_base_delay_ms,
+                wh.retry_max_delay_ms,
             );
             zeroclaw_api::channel::Channel::send(&ch, &make_msg(&safe_output)).await?;
         }

--- a/crates/zeroclaw-channels/src/webhook.rs
+++ b/crates/zeroclaw-channels/src/webhook.rs
@@ -86,7 +86,8 @@ impl WebhookChannel {
     }
 
     /// Compute the backoff delay for a given attempt, bounded by `retry_max_delay_ms`
-    /// and with ±25% jitter applied.
+    /// and with ±25% jitter applied. The cap is approximate: jitter is applied after
+    /// capping, so the returned delay may exceed `retry_max_delay_ms` by up to 25%.
     fn compute_backoff(&self, attempt: u32) -> Duration {
         let multiplier = 1_u64.checked_shl(attempt).unwrap_or(u64::MAX);
         let base = self.retry_base_delay_ms.saturating_mul(multiplier);
@@ -200,7 +201,6 @@ impl Channel for WebhookChannel {
             },
         };
 
-        let mut last_err: Option<String> = None;
         let total_attempts = self.max_retries.saturating_add(1);
 
         for attempt in 0..total_attempts {
@@ -225,7 +225,6 @@ impl Channel for WebhookChannel {
                     tokio::time::sleep(capped).await;
                 }
                 AttemptOutcome::Retry(err_msg) => {
-                    last_err = Some(err_msg.clone());
                     if attempt + 1 >= total_attempts {
                         bail!(
                             "Webhook send failed after {total_attempts} attempt(s); last error: {err_msg}"
@@ -244,11 +243,7 @@ impl Channel for WebhookChannel {
             }
         }
 
-        // Unreachable in practice: loop always returns or bails on the last attempt.
-        bail!(
-            "Webhook send failed after {total_attempts} attempt(s){}",
-            last_err.map(|e| format!(": {e}")).unwrap_or_default()
-        )
+        unreachable!("send loop exits via return or bail on the final attempt")
     }
 
     async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
@@ -443,7 +438,9 @@ impl WebhookChannel {
             .await
             .unwrap_or_else(|e| format!("<failed to read response: {e}>"));
 
-        // 429 and 503 may include Retry-After; honor it if present.
+        // 429 and 503 may include Retry-After; honor it if present. 429 appears here
+        // *and* in the branch below: here we take the server-supplied delay, below we
+        // fall back to exponential backoff when no Retry-After header was sent.
         if (code == 429 || code == 503)
             && let Some(ms) = retry_after
         {
@@ -829,6 +826,49 @@ mod tests {
         assert!(
             elapsed >= Duration::from_millis(900),
             "expected to wait ~1s for Retry-After, elapsed = {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn send_honors_retry_after_on_503() {
+        use std::time::Instant;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cb"))
+            .respond_with(ResponseTemplate::new(503).insert_header("Retry-After", "1"))
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/cb"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let ch = WebhookChannel::new(
+            8080,
+            None,
+            Some(format!("{}/cb", mock.uri())),
+            None,
+            None,
+            None,
+            Some(2),
+            Some(10),
+            Some(2_000),
+        );
+
+        let start = Instant::now();
+        ch.send(&test_message()).await.unwrap();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(900),
+            "expected to wait ~1s for Retry-After on 503, elapsed = {:?}",
             elapsed
         );
     }

--- a/crates/zeroclaw-channels/src/webhook.rs
+++ b/crates/zeroclaw-channels/src/webhook.rs
@@ -76,8 +76,13 @@ impl WebhookChannel {
             auth_header,
             secret,
             max_retries: max_retries.unwrap_or(DEFAULT_MAX_RETRIES),
-            retry_base_delay_ms: retry_base_delay_ms.unwrap_or(DEFAULT_RETRY_BASE_DELAY_MS),
-            retry_max_delay_ms: retry_max_delay_ms.unwrap_or(DEFAULT_RETRY_MAX_DELAY_MS),
+            // Clamp delays to >=1ms so a misconfigured `0` does not busy-retry without yielding.
+            retry_base_delay_ms: retry_base_delay_ms
+                .unwrap_or(DEFAULT_RETRY_BASE_DELAY_MS)
+                .max(1),
+            retry_max_delay_ms: retry_max_delay_ms
+                .unwrap_or(DEFAULT_RETRY_MAX_DELAY_MS)
+                .max(1),
         }
     }
 
@@ -124,6 +129,63 @@ impl WebhookChannel {
         };
 
         mac.verify_slice(&expected).is_ok()
+    }
+
+    async fn attempt_send(
+        &self,
+        client: &reqwest::Client,
+        send_url: &str,
+        payload: &OutgoingWebhook,
+    ) -> AttemptOutcome {
+        let mut request = match self.send_method.as_str() {
+            "PUT" => client.put(send_url),
+            _ => client.post(send_url),
+        };
+
+        if let Some(ref auth) = self.auth_header {
+            request = request.header("Authorization", auth);
+        }
+
+        let resp = match request.json(payload).send().await {
+            Ok(r) => r,
+            Err(e) => return AttemptOutcome::Retry(format!("network error: {e}")),
+        };
+
+        let status = resp.status();
+        if status.is_success() {
+            return AttemptOutcome::Success;
+        }
+
+        let code = status.as_u16();
+        let retry_after = resp
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_retry_after_ms);
+
+        // 429 and 503 may include Retry-After; honor it if present. 429 appears here
+        // *and* in the branch below: here we take the server-supplied delay, below we
+        // fall back to exponential backoff when no Retry-After header was sent.
+        // Reading the body is deferred until after this early-return so hot 429 loops
+        // against large pages don't pay the I/O cost.
+        if (code == 429 || code == 503)
+            && let Some(ms) = retry_after
+        {
+            return AttemptOutcome::RetryAfter(Duration::from_millis(ms));
+        }
+
+        let body = resp
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("<failed to read response: {e}>"));
+
+        // Retry 429 (rate limit) and 5xx (server errors).
+        if code == 429 || (500..600).contains(&code) {
+            return AttemptOutcome::Retry(format!("Webhook send failed ({status}): {body}"));
+        }
+
+        // Other 4xx → do not retry.
+        AttemptOutcome::Fatal(anyhow::anyhow!("Webhook send failed ({status}): {body}"))
     }
 }
 
@@ -397,63 +459,6 @@ impl Channel for WebhookChannel {
         // Webhook channel is healthy if the port can be bound (basic check).
         // In practice, once listen() starts the server is running.
         true
-    }
-}
-
-impl WebhookChannel {
-    async fn attempt_send(
-        &self,
-        client: &reqwest::Client,
-        send_url: &str,
-        payload: &OutgoingWebhook,
-    ) -> AttemptOutcome {
-        let mut request = match self.send_method.as_str() {
-            "PUT" => client.put(send_url),
-            _ => client.post(send_url),
-        };
-
-        if let Some(ref auth) = self.auth_header {
-            request = request.header("Authorization", auth);
-        }
-
-        let resp = match request.json(payload).send().await {
-            Ok(r) => r,
-            Err(e) => return AttemptOutcome::Retry(format!("network error: {e}")),
-        };
-
-        let status = resp.status();
-        if status.is_success() {
-            return AttemptOutcome::Success;
-        }
-
-        let code = status.as_u16();
-        let retry_after = resp
-            .headers()
-            .get(reqwest::header::RETRY_AFTER)
-            .and_then(|v| v.to_str().ok())
-            .and_then(parse_retry_after_ms);
-
-        let body = resp
-            .text()
-            .await
-            .unwrap_or_else(|e| format!("<failed to read response: {e}>"));
-
-        // 429 and 503 may include Retry-After; honor it if present. 429 appears here
-        // *and* in the branch below: here we take the server-supplied delay, below we
-        // fall back to exponential backoff when no Retry-After header was sent.
-        if (code == 429 || code == 503)
-            && let Some(ms) = retry_after
-        {
-            return AttemptOutcome::RetryAfter(Duration::from_millis(ms));
-        }
-
-        // Retry 429 (rate limit) and 5xx (server errors).
-        if code == 429 || (500..600).contains(&code) {
-            return AttemptOutcome::Retry(format!("Webhook send failed ({status}): {body}"));
-        }
-
-        // Other 4xx → do not retry.
-        AttemptOutcome::Fatal(anyhow::anyhow!("Webhook send failed ({status}): {body}"))
     }
 }
 

--- a/crates/zeroclaw-channels/src/webhook.rs
+++ b/crates/zeroclaw-channels/src/webhook.rs
@@ -1,7 +1,12 @@
 use anyhow::{Result, bail};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+
+const DEFAULT_MAX_RETRIES: u32 = 3;
+const DEFAULT_RETRY_BASE_DELAY_MS: u64 = 500;
+const DEFAULT_RETRY_MAX_DELAY_MS: u64 = 30_000;
 
 /// Generic Webhook channel — receives messages via HTTP POST and sends replies
 /// to a configurable outbound URL. This is the "universal adapter" for any system
@@ -14,6 +19,9 @@ pub struct WebhookChannel {
     send_method: String,
     auth_header: Option<String>,
     secret: Option<String>,
+    max_retries: u32,
+    retry_base_delay_ms: u64,
+    retry_max_delay_ms: u64,
 }
 
 /// Incoming webhook payload format.
@@ -36,6 +44,7 @@ struct OutgoingWebhook {
 }
 
 impl WebhookChannel {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         alias: String,
         listen_port: u16,
@@ -44,6 +53,9 @@ impl WebhookChannel {
         send_method: Option<String>,
         auth_header: Option<String>,
         secret: Option<String>,
+        max_retries: Option<u32>,
+        retry_base_delay_ms: Option<u64>,
+        retry_max_delay_ms: Option<u64>,
     ) -> Self {
         let path = listen_path.unwrap_or_else(|| "/webhook".to_string());
         // Ensure path starts with /
@@ -63,11 +75,24 @@ impl WebhookChannel {
                 .to_uppercase(),
             auth_header,
             secret,
+            max_retries: max_retries.unwrap_or(DEFAULT_MAX_RETRIES),
+            retry_base_delay_ms: retry_base_delay_ms.unwrap_or(DEFAULT_RETRY_BASE_DELAY_MS),
+            retry_max_delay_ms: retry_max_delay_ms.unwrap_or(DEFAULT_RETRY_MAX_DELAY_MS),
         }
     }
 
     fn http_client(&self) -> reqwest::Client {
         zeroclaw_config::schema::build_runtime_proxy_client("channel.webhook")
+    }
+
+    /// Compute the backoff delay for a given attempt, bounded by `retry_max_delay_ms`
+    /// and with ±25% jitter applied.
+    fn compute_backoff(&self, attempt: u32) -> Duration {
+        let multiplier = 1_u64.checked_shl(attempt).unwrap_or(u64::MAX);
+        let base = self.retry_base_delay_ms.saturating_mul(multiplier);
+        let capped = base.min(self.retry_max_delay_ms);
+        let jittered = apply_jitter(capped);
+        Duration::from_millis(jittered)
     }
 
     /// Verify an incoming request's signature if a secret is configured.
@@ -112,6 +137,42 @@ impl ::zeroclaw_api::attribution::Attributable for WebhookChannel {
     }
 }
 
+/// Apply ±25% jitter to a delay so parallel senders do not thunder-herd.
+fn apply_jitter(delay_ms: u64) -> u64 {
+    if delay_ms == 0 {
+        return 0;
+    }
+    let jitter_factor = 0.75 + (rand::random::<f64>() * 0.5);
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let jittered = ((delay_ms as f64) * jitter_factor) as u64;
+    jittered
+}
+
+/// Parse a `Retry-After` header value. Supports integer seconds and
+/// decimal seconds (truncated to whole seconds). HTTP-date form is not supported.
+fn parse_retry_after_ms(value: &str) -> Option<u64> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Ok(seconds) = trimmed.parse::<u64>() {
+        return Some(seconds.saturating_mul(1000));
+    }
+    let whole = trimmed
+        .split_once('.')
+        .map(|(whole, _)| whole)
+        .unwrap_or(trimmed);
+    whole.parse::<u64>().ok().map(|s| s.saturating_mul(1000))
+}
+
+/// Outcome of a single send attempt.
+enum AttemptOutcome {
+    Success,
+    RetryAfter(Duration),
+    Retry(String),
+    Fatal(anyhow::Error),
+}
+
 #[async_trait]
 impl Channel for WebhookChannel {
     fn name(&self) -> &str {
@@ -139,27 +200,55 @@ impl Channel for WebhookChannel {
             },
         };
 
-        let mut request = match self.send_method.as_str() {
-            "PUT" => client.put(send_url),
-            _ => client.post(send_url),
-        };
+        let mut last_err: Option<String> = None;
+        let total_attempts = self.max_retries.saturating_add(1);
 
-        if let Some(ref auth) = self.auth_header {
-            request = request.header("Authorization", auth);
+        for attempt in 0..total_attempts {
+            let outcome = self.attempt_send(&client, send_url, &payload).await;
+
+            match outcome {
+                AttemptOutcome::Success => return Ok(()),
+                AttemptOutcome::Fatal(err) => return Err(err),
+                AttemptOutcome::RetryAfter(delay) => {
+                    if attempt + 1 >= total_attempts {
+                        bail!(
+                            "Webhook send failed after {total_attempts} attempt(s); last error: rate limited / server error with Retry-After"
+                        );
+                    }
+                    let capped = delay.min(Duration::from_millis(self.retry_max_delay_ms));
+                    tracing::warn!(
+                        "Webhook send: server requested retry after {}ms (attempt {}/{}), waiting...",
+                        capped.as_millis(),
+                        attempt + 1,
+                        total_attempts
+                    );
+                    tokio::time::sleep(capped).await;
+                }
+                AttemptOutcome::Retry(err_msg) => {
+                    last_err = Some(err_msg.clone());
+                    if attempt + 1 >= total_attempts {
+                        bail!(
+                            "Webhook send failed after {total_attempts} attempt(s); last error: {err_msg}"
+                        );
+                    }
+                    let delay = self.compute_backoff(attempt);
+                    tracing::warn!(
+                        "Webhook send failed (attempt {}/{}): {}; retrying in {}ms",
+                        attempt + 1,
+                        total_attempts,
+                        err_msg,
+                        delay.as_millis()
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+            }
         }
 
-        let resp = request.json(&payload).send().await?;
-
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp
-                .text()
-                .await
-                .unwrap_or_else(|e| format!("<failed to read response: {e}>"));
-            bail!("Webhook send failed ({status}): {body}");
-        }
-
-        Ok(())
+        // Unreachable in practice: loop always returns or bails on the last attempt.
+        bail!(
+            "Webhook send failed after {total_attempts} attempt(s){}",
+            last_err.map(|e| format!(": {e}")).unwrap_or_default()
+        )
     }
 
     async fn listen(&self, tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> Result<()> {
@@ -316,6 +405,61 @@ impl Channel for WebhookChannel {
     }
 }
 
+impl WebhookChannel {
+    async fn attempt_send(
+        &self,
+        client: &reqwest::Client,
+        send_url: &str,
+        payload: &OutgoingWebhook,
+    ) -> AttemptOutcome {
+        let mut request = match self.send_method.as_str() {
+            "PUT" => client.put(send_url),
+            _ => client.post(send_url),
+        };
+
+        if let Some(ref auth) = self.auth_header {
+            request = request.header("Authorization", auth);
+        }
+
+        let resp = match request.json(payload).send().await {
+            Ok(r) => r,
+            Err(e) => return AttemptOutcome::Retry(format!("network error: {e}")),
+        };
+
+        let status = resp.status();
+        if status.is_success() {
+            return AttemptOutcome::Success;
+        }
+
+        let code = status.as_u16();
+        let retry_after = resp
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(parse_retry_after_ms);
+
+        let body = resp
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("<failed to read response: {e}>"));
+
+        // 429 and 503 may include Retry-After; honor it if present.
+        if (code == 429 || code == 503)
+            && let Some(ms) = retry_after
+        {
+            return AttemptOutcome::RetryAfter(Duration::from_millis(ms));
+        }
+
+        // Retry 429 (rate limit) and 5xx (server errors).
+        if code == 429 || (500..600).contains(&code) {
+            return AttemptOutcome::Retry(format!("Webhook send failed ({status}): {body}"));
+        }
+
+        // Other 4xx → do not retry.
+        AttemptOutcome::Fatal(anyhow::anyhow!("Webhook send failed ({status}): {body}"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -326,6 +470,9 @@ mod tests {
             8080,
             Some("/webhook".into()),
             Some("https://example.com/callback".into()),
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -341,12 +488,31 @@ mod tests {
             None,
             None,
             Some("mysecret".into()),
+            None,
+            None,
+            None,
+        )
+    }
+
+    fn make_channel_to(url: &str) -> WebhookChannel {
+        // Fast retries to keep tests snappy.
+        WebhookChannel::new(
+            8080,
+            None,
+            Some(url.into()),
+            None,
+            None,
+            None,
+            Some(2),
+            Some(10),
+            Some(100),
         )
     }
 
     #[test]
     fn default_path() {
-        let ch = WebhookChannel::new("test-hook".into(), 8080, None, None, None, None, None);
+        let ch =
+            WebhookChannel::new("test-hook".into(), 8080, None, None, None, None, None, None, None, None);
         assert_eq!(ch.listen_path, "/webhook");
     }
 
@@ -356,6 +522,9 @@ mod tests {
             "test-hook".into(),
             8080,
             Some("hooks/incoming".into()),
+            None,
+            None,
+            None,
             None,
             None,
             None,
@@ -380,8 +549,80 @@ mod tests {
             Some("put".into()),
             None,
             None,
+            None,
+            None,
+            None,
         );
         assert_eq!(ch.send_method, "PUT");
+    }
+
+    #[test]
+    fn retry_defaults_applied() {
+        let ch = make_channel();
+        assert_eq!(ch.max_retries, DEFAULT_MAX_RETRIES);
+        assert_eq!(ch.retry_base_delay_ms, DEFAULT_RETRY_BASE_DELAY_MS);
+        assert_eq!(ch.retry_max_delay_ms, DEFAULT_RETRY_MAX_DELAY_MS);
+    }
+
+    #[test]
+    fn retry_overrides_applied() {
+        let ch = WebhookChannel::new(
+            8080,
+            None,
+            Some("https://example.com".into()),
+            None,
+            None,
+            None,
+            Some(0),
+            Some(50),
+            Some(1_000),
+        );
+        assert_eq!(ch.max_retries, 0);
+        assert_eq!(ch.retry_base_delay_ms, 50);
+        assert_eq!(ch.retry_max_delay_ms, 1_000);
+    }
+
+    #[test]
+    fn backoff_capped_by_max_delay() {
+        let ch = WebhookChannel::new(
+            8080,
+            None,
+            Some("https://example.com".into()),
+            None,
+            None,
+            None,
+            Some(5),
+            Some(1_000),
+            Some(2_000),
+        );
+        let d = ch.compute_backoff(10); // 1_000 * 2^10 = 1_024_000, capped at 2_000
+        // With ±25% jitter: [1500, 2500]
+        assert!(d.as_millis() >= 1_500 && d.as_millis() <= 2_500);
+    }
+
+    #[test]
+    fn parse_retry_after_integer_seconds() {
+        assert_eq!(parse_retry_after_ms("5"), Some(5_000));
+    }
+
+    #[test]
+    fn parse_retry_after_decimal_seconds() {
+        assert_eq!(parse_retry_after_ms("2.9"), Some(2_000));
+    }
+
+    #[test]
+    fn parse_retry_after_rejects_non_numeric() {
+        assert_eq!(parse_retry_after_ms("later"), None);
+    }
+
+    #[test]
+    fn parse_retry_after_empty() {
+        assert_eq!(parse_retry_after_ms("  "), None);
+    }
+
+    #[test]
+    fn parse_retry_after_zero() {
+        assert_eq!(parse_retry_after_ms("0"), Some(0));
     }
 
     #[test]
@@ -460,5 +701,162 @@ mod tests {
     fn verify_signature_invalid() {
         let ch = make_channel_with_secret();
         assert!(!ch.verify_signature(b"body", Some("badhex")));
+    }
+
+    fn test_message() -> SendMessage {
+        SendMessage::new("hello", "zeroclaw_user")
+    }
+
+    #[tokio::test]
+    async fn send_happy_path_returns_ok() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cb"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let ch = make_channel_to(&format!("{}/cb", mock.uri()));
+        ch.send(&test_message()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_retries_on_5xx_then_succeeds() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cb"))
+            .respond_with(ResponseTemplate::new(503))
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/cb"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let ch = make_channel_to(&format!("{}/cb", mock.uri()));
+        ch.send(&test_message()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_does_not_retry_on_4xx() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cb"))
+            .respond_with(ResponseTemplate::new(400))
+            .expect(1) // exactly one call — must not retry
+            .mount(&mock)
+            .await;
+
+        let ch = make_channel_to(&format!("{}/cb", mock.uri()));
+        let err = ch.send(&test_message()).await.unwrap_err();
+        assert!(err.to_string().contains("400"));
+    }
+
+    #[tokio::test]
+    async fn send_retries_on_429_then_exhausts() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cb"))
+            .respond_with(ResponseTemplate::new(429))
+            .expect(3) // max_retries=2 → 3 total attempts
+            .mount(&mock)
+            .await;
+
+        let ch = make_channel_to(&format!("{}/cb", mock.uri()));
+        let err = ch.send(&test_message()).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("3 attempt"),
+            "expected attempt count in error: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_honors_retry_after_header() {
+        use std::time::Instant;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cb"))
+            .respond_with(ResponseTemplate::new(429).insert_header("Retry-After", "1"))
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&mock)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/cb"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        // Use a channel whose retry_max_delay_ms is high enough to let us actually
+        // wait the full Retry-After (cap at 2s so we honor the 1s instruction).
+        let ch = WebhookChannel::new(
+            8080,
+            None,
+            Some(format!("{}/cb", mock.uri())),
+            None,
+            None,
+            None,
+            Some(2),
+            Some(10),
+            Some(2_000),
+        );
+
+        let start = Instant::now();
+        ch.send(&test_message()).await.unwrap();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(900),
+            "expected to wait ~1s for Retry-After, elapsed = {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test]
+    async fn send_max_retries_zero_disables_retry() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cb"))
+            .respond_with(ResponseTemplate::new(503))
+            .expect(1) // only one attempt when max_retries=0
+            .mount(&mock)
+            .await;
+
+        let ch = WebhookChannel::new(
+            8080,
+            None,
+            Some(format!("{}/cb", mock.uri())),
+            None,
+            None,
+            None,
+            Some(0),
+            Some(10),
+            Some(100),
+        );
+        assert!(ch.send(&test_message()).await.is_err());
     }
 }

--- a/crates/zeroclaw-channels/src/webhook.rs
+++ b/crates/zeroclaw-channels/src/webhook.rs
@@ -206,6 +206,7 @@ fn apply_jitter(delay_ms: u64) -> u64 {
         return 0;
     }
     let jitter_factor = 0.75 + (rand::random::<f64>() * 0.5);
+    // Safe: jitter_factor > 0 keeps the product non-negative; f64→u64 cast saturates on overflow.
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     let jittered = ((delay_ms as f64) * jitter_factor) as u64;
     jittered

--- a/crates/zeroclaw-channels/src/webhook.rs
+++ b/crates/zeroclaw-channels/src/webhook.rs
@@ -638,9 +638,9 @@ mod tests {
 
     #[test]
     fn incoming_payload_without_thread() {
-        let json = r#"{"sender": "bob", "content": "hi"}"#;
+        let json = r#"{"sender": "zeroclaw_user", "content": "hi"}"#;
         let payload: IncomingWebhook = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.sender, "bob");
+        assert_eq!(payload.sender, "zeroclaw_user");
         assert_eq!(payload.content, "hi");
         assert!(payload.thread_id.is_none());
     }

--- a/crates/zeroclaw-channels/src/webhook.rs
+++ b/crates/zeroclaw-channels/src/webhook.rs
@@ -91,14 +91,14 @@ impl WebhookChannel {
     }
 
     /// Compute the backoff delay for a given attempt, bounded by `retry_max_delay_ms`
-    /// and with ±25% jitter applied. The cap is approximate: jitter is applied after
-    /// capping, so the returned delay may exceed `retry_max_delay_ms` by up to 25%.
+    /// and with ±25% jitter applied. Jitter is applied before the final cap, so the
+    /// returned delay is strictly `<= retry_max_delay_ms`.
     fn compute_backoff(&self, attempt: u32) -> Duration {
         let multiplier = 1_u64.checked_shl(attempt).unwrap_or(u64::MAX);
         let base = self.retry_base_delay_ms.saturating_mul(multiplier);
-        let capped = base.min(self.retry_max_delay_ms);
-        let jittered = apply_jitter(capped);
-        Duration::from_millis(jittered)
+        let jittered = apply_jitter(base);
+        let capped = jittered.min(self.retry_max_delay_ms);
+        Duration::from_millis(capped)
     }
 
     /// Verify an incoming request's signature if a secret is configured.
@@ -597,9 +597,37 @@ mod tests {
             Some(1_000),
             Some(2_000),
         );
-        let d = ch.compute_backoff(10); // 1_000 * 2^10 = 1_024_000, capped at 2_000
-        // With ±25% jitter: [1500, 2500]
-        assert!(d.as_millis() >= 1_500 && d.as_millis() <= 2_500);
+        // Base for attempt=10 is 1_000 * 2^10 = 1_024_000ms. Jitter scales it by
+        // [0.75, 1.25] → still well above the 2_000ms cap. The strict cap clamps
+        // the jittered value, so the returned delay must equal `retry_max_delay_ms`.
+        let d = ch.compute_backoff(10);
+        assert_eq!(d.as_millis(), 2_000);
+    }
+
+    #[test]
+    fn backoff_never_exceeds_max_delay_near_cap() {
+        // When the un-capped base is close to `retry_max_delay_ms`, jitter could
+        // historically push the result above the cap. With strict capping the
+        // returned delay must stay `<= retry_max_delay_ms` on every draw.
+        let ch = WebhookChannel::new(
+            8080,
+            None,
+            Some("https://example.com".into()),
+            None,
+            None,
+            None,
+            Some(5),
+            Some(1_000),
+            Some(2_000),
+        );
+        for _ in 0..256 {
+            let d = ch.compute_backoff(1); // base = 2_000ms, jitter ∈ [1_500, 2_500]
+            assert!(
+                d.as_millis() <= 2_000,
+                "compute_backoff exceeded retry_max_delay_ms: {}ms",
+                d.as_millis()
+            );
+        }
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/webhook.rs
+++ b/crates/zeroclaw-channels/src/webhook.rs
@@ -185,7 +185,9 @@ impl WebhookChannel {
         }
 
         // Other 4xx → do not retry.
-        AttemptOutcome::Fatal(anyhow::anyhow!("Webhook send failed ({status}): {body}"))
+        AttemptOutcome::Fatal(anyhow::Error::msg(format!(
+            "Webhook send failed ({status}): {body}"
+        )))
     }
 }
 
@@ -279,11 +281,15 @@ impl Channel for WebhookChannel {
                         );
                     }
                     let capped = delay.min(Duration::from_millis(self.retry_max_delay_ms));
-                    tracing::warn!(
-                        "Webhook send: server requested retry after {}ms (attempt {}/{}), waiting...",
-                        capped.as_millis(),
-                        attempt + 1,
-                        total_attempts
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                        &format!(
+                            "Webhook send: server requested retry after {}ms (attempt {}/{}), waiting...",
+                            capped.as_millis(),
+                            attempt + 1,
+                            total_attempts
+                        )
                     );
                     tokio::time::sleep(capped).await;
                 }
@@ -294,12 +300,16 @@ impl Channel for WebhookChannel {
                         );
                     }
                     let delay = self.compute_backoff(attempt);
-                    tracing::warn!(
-                        "Webhook send failed (attempt {}/{}): {}; retrying in {}ms",
-                        attempt + 1,
-                        total_attempts,
-                        err_msg,
-                        delay.as_millis()
+                    ::zeroclaw_log::record!(
+                        WARN,
+                        ::zeroclaw_log::Event::new(module_path!(), ::zeroclaw_log::Action::Note),
+                        &format!(
+                            "Webhook send failed (attempt {}/{}): {}; retrying in {}ms",
+                            attempt + 1,
+                            total_attempts,
+                            err_msg,
+                            delay.as_millis()
+                        )
                     );
                     tokio::time::sleep(delay).await;
                 }
@@ -500,6 +510,7 @@ mod tests {
     fn make_channel_to(url: &str) -> WebhookChannel {
         // Fast retries to keep tests snappy.
         WebhookChannel::new(
+            "test-hook".into(),
             8080,
             None,
             Some(url.into()),
@@ -514,8 +525,18 @@ mod tests {
 
     #[test]
     fn default_path() {
-        let ch =
-            WebhookChannel::new("test-hook".into(), 8080, None, None, None, None, None, None, None, None);
+        let ch = WebhookChannel::new(
+            "test-hook".into(),
+            8080,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
         assert_eq!(ch.listen_path, "/webhook");
     }
 
@@ -570,6 +591,7 @@ mod tests {
     #[test]
     fn retry_overrides_applied() {
         let ch = WebhookChannel::new(
+            "test-hook".into(),
             8080,
             None,
             Some("https://example.com".into()),
@@ -588,6 +610,7 @@ mod tests {
     #[test]
     fn backoff_capped_by_max_delay() {
         let ch = WebhookChannel::new(
+            "test-hook".into(),
             8080,
             None,
             Some("https://example.com".into()),
@@ -611,6 +634,7 @@ mod tests {
         // historically push the result above the cap. With strict capping the
         // returned delay must stay `<= retry_max_delay_ms` on every draw.
         let ch = WebhookChannel::new(
+            "test-hook".into(),
             8080,
             None,
             Some("https://example.com".into()),
@@ -843,6 +867,7 @@ mod tests {
         // Use a channel whose retry_max_delay_ms is high enough to let us actually
         // wait the full Retry-After (cap at 2s so we honor the 1s instruction).
         let ch = WebhookChannel::new(
+            "test-hook".into(),
             8080,
             None,
             Some(format!("{}/cb", mock.uri())),
@@ -886,6 +911,7 @@ mod tests {
             .await;
 
         let ch = WebhookChannel::new(
+            "test-hook".into(),
             8080,
             None,
             Some(format!("{}/cb", mock.uri())),
@@ -921,6 +947,7 @@ mod tests {
             .await;
 
         let ch = WebhookChannel::new(
+            "test-hook".into(),
             8080,
             None,
             Some(format!("{}/cb", mock.uri())),

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -10662,6 +10662,17 @@ pub struct WebhookConfig {
     /// are not exposed to the model when responding via this channel.
     #[serde(default)]
     pub excluded_tools: Vec<String>,
+
+    /// Maximum number of retry attempts for outbound sends on transient failures
+    /// (network errors, 429, 5xx). Set to `0` to disable retries. Default: `3`.
+    #[serde(default)]
+    pub max_retries: Option<u32>,
+    /// Base delay in milliseconds for exponential backoff between retries. Default: `500`.
+    #[serde(default)]
+    pub retry_base_delay_ms: Option<u64>,
+    /// Maximum delay cap in milliseconds for any single retry wait. Default: `30000` (30s).
+    #[serde(default)]
+    pub retry_max_delay_ms: Option<u64>,
 }
 
 impl ChannelConfig for WebhookConfig {

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -17865,6 +17865,7 @@ bot_token = "xoxb-tok"
             send_method: None,
             auth_header: None,
             secret: None,
+            excluded_tools: vec![],
             max_retries: Some(5),
             retry_base_delay_ms: Some(250),
             retry_max_delay_ms: Some(10_000),

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -17844,6 +17844,43 @@ bot_token = "xoxb-tok"
         assert_eq!(parsed.port, 8080);
     }
 
+    #[test]
+    async fn webhook_config_retry_fields_default_to_none() {
+        let json = r#"{"port":8080}"#;
+        let parsed: WebhookConfig = serde_json::from_str(json).unwrap();
+        assert!(parsed.max_retries.is_none());
+        assert!(parsed.retry_base_delay_ms.is_none());
+        assert!(parsed.retry_max_delay_ms.is_none());
+    }
+
+    #[test]
+    async fn webhook_config_retry_fields_roundtrip() {
+        let wc = WebhookConfig {
+            enabled: true,
+            port: 8080,
+            listen_path: None,
+            send_url: Some("https://example.com/cb".into()),
+            send_method: None,
+            auth_header: None,
+            secret: None,
+            max_retries: Some(5),
+            retry_base_delay_ms: Some(250),
+            retry_max_delay_ms: Some(10_000),
+        };
+
+        let json = serde_json::to_string(&wc).unwrap();
+        let parsed: WebhookConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.max_retries, Some(5));
+        assert_eq!(parsed.retry_base_delay_ms, Some(250));
+        assert_eq!(parsed.retry_max_delay_ms, Some(10_000));
+
+        let toml_str = toml::to_string(&wc).unwrap();
+        let parsed: WebhookConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.max_retries, Some(5));
+        assert_eq!(parsed.retry_base_delay_ms, Some(250));
+        assert_eq!(parsed.retry_max_delay_ms, Some(10_000));
+    }
+
     // ── WhatsApp config ──────────────────────────────────────
 
     #[test]

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -10668,9 +10668,11 @@ pub struct WebhookConfig {
     #[serde(default)]
     pub max_retries: Option<u32>,
     /// Base delay in milliseconds for exponential backoff between retries. Default: `500`.
+    /// Values below `1` are clamped to `1ms` at runtime to avoid busy-retry loops.
     #[serde(default)]
     pub retry_base_delay_ms: Option<u64>,
     /// Maximum delay cap in milliseconds for any single retry wait. Default: `30000` (30s).
+    /// Values below `1` are clamped to `1ms` at runtime to avoid busy-retry loops.
     #[serde(default)]
     pub retry_max_delay_ms: Option<u64>,
 }

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -1379,6 +1379,9 @@ mod tests {
                 auth_header: None,
                 secret: None,
                 excluded_tools: vec![],
+                max_retries: None,
+                retry_base_delay_ms: None,
+                retry_max_delay_ms: None,
             },
         );
         assert!(has_supervised_channels(&config));

--- a/docs/book/src/channels/webhook.md
+++ b/docs/book/src/channels/webhook.md
@@ -84,6 +84,24 @@ The channel binds to `0.0.0.0` directly. To expose it on the public internet:
 
 Always pair public exposure with `secret`. An unauthenticated webhook listener is an open ingress to the agent.
 
+## Outbound sends
+
+Webhook channels can also POST/PUT *outbound* messages to a configured `send_url` — used when the agent replies through the channel rather than only receiving inbound events. Outbound delivery is configured under the singular `[channels.webhook]` prefix (a separate schema surface from the inbound `[channels.webhooks.<name>]` blocks above; reconciling that shape difference in this page is tracked separately):
+
+```toml
+[channels.webhook]
+send_url = "https://example.com/callback"
+send_method = "POST"        # or "PUT"; default: "POST"
+auth_header = "Bearer ..."  # optional Authorization header
+
+# Retry tunables (all optional):
+max_retries = 3             # default: 3; set to 0 to disable retries
+retry_base_delay_ms = 500   # exponential-backoff base; default: 500
+retry_max_delay_ms = 30000  # per-wait cap; default: 30000 (30s)
+```
+
+Outbound sends retry transient failures — network errors, HTTP `429`, and HTTP `5xx` — with exponential backoff (±25% jitter) capped by `retry_max_delay_ms`. Non-`429` `4xx` responses fail immediately without retrying. When the server returns a `Retry-After` header on `429` or `503`, that value is honored and also clamped by `retry_max_delay_ms`. Setting `max_retries = 0` preserves the prior fire-and-forget behavior byte-for-byte.
+
 ## Code
 
 - Channel: `crates/zeroclaw-channels/src/webhook.rs`


### PR DESCRIPTION
Closes #5761.

WebhookChannel::send now retries transient failures (network errors, 429, 5xx) with exponential backoff + jitter, honoring Retry-After on 429/503 and capping waits by retry_max_delay_ms. Non-429 4xx responses still fail immediately. Tunable via three optional WebhookConfig fields (max_retries=3, retry_base_delay_ms=500, retry_max_delay_ms=30000); set max_retries=0 to keep the previous fire-and-forget behavior.

## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Outbound webhook sends silently dropped on transient upstream blips; added a bounded retry loop (exponential backoff + ±25% jitter) so users get at-least-one-retry semantics without rewiring call sites.
  - Added `max_retries`, `retry_base_delay_ms`, `retry_max_delay_ms` to `WebhookConfig` (all `Option`, `#[serde(default)]`) so operators can tune or disable the behavior per-deployment.
  - `Retry-After` is honored on 429/503 (integer seconds, clamped by `retry_max_delay_ms`) to avoid hammering rate-limited endpoints.
  - `max_retries = 0` preserves the prior fire-and-forget contract byte-for-byte for anyone who prefers it.
- **Scope boundary:** Does not touch inbound webhook handling, other channels, or the gateway transport — only the outbound `WebhookChannel::send` path and its config surface.
- **Blast radius:** Webhook outbound users only. The retry loop can extend the lifetime of the outbound send task/caller; the configured `max_retries` and `retry_max_delay_ms` cap bound that effect. Most existing call sites already wrap `Channel::send` in `tokio::spawn`, so they keep the agent loop off the wait — but that isolation is a caller-side contract, not something this PR guarantees universally.
- **Linked issue(s):** Closes #5761.
- **Labels:** `enhancement`, `size: M`, `risk: medium`, `docs`, `channel`, `config`, `daemon`, `runtime`, `channel:webhook`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test -p zeroclaw-channels --lib webhook::
cargo test -p zeroclaw-config --lib webhook_config
bash scripts/ci/docs_quality_gate.sh
```

- **Commands run and tail output:**

```
$ cargo fmt --all -- --check
(clean — no output)

$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 57.04s

$ cargo test -p zeroclaw-channels --lib webhook::
test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 914 filtered out; finished in 1.04s

$ cargo test -p zeroclaw-config --lib webhook_config
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 551 filtered out; finished in 0.02s

$ bash scripts/ci/docs_quality_gate.sh
No blocking markdown issues on changed lines.
```

- **Beyond CI — what did you manually verify?** Exercised the new behavior with `wiremock`-backed integration tests (happy path, 5xx-then-success, 4xx no-retry, 429 exhaustion, `Retry-After` on both 429 and 503, `max_retries=0` opt-out, backoff cap). Not verified: live delivery against a real upstream webhook receiver — mocked only.
- **If any command was intentionally skipped, why:** Workspace-wide `cargo test` is redundant here since changes are confined to `zeroclaw-channels::webhook` and the three new `WebhookConfig` fields in `zeroclaw-config`; ran targeted suites for both plus fmt/clippy across all targets.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` — same HTTP POST that already existed, just retried on transient failures.
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No` — test fixture renamed from `"bob"` to `"zeroclaw_user"` to satisfy the project-scoped-placeholder rule.
- If any `Yes`, describe the risk and mitigation: N.A.

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` — three new `Option` fields on `WebhookConfig` (`max_retries`, `retry_base_delay_ms`, `retry_max_delay_ms`); all default to `None` and use `#[serde(default)]`.
- Upgrade steps: none. Existing configs continue to work; defaults are `max_retries=3`, `retry_base_delay_ms=500`, `retry_max_delay_ms=30000`. To restore the previous single-shot behavior explicitly, set `max_retries = 0`.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** Set `max_retries = 0` in `[channels_config.webhook]` to disable retries without redeploying. Hard rollback: `git revert <merge-sha>`.
- **Feature flags or config toggles:** `max_retries = 0` is the runtime kill-switch.
- **Observable failure symptoms:** Sustained webhook delivery failures would show as elevated error logs from `WebhookChannel::send` (tracing target `zeroclaw_channels::webhook`). Watch for unusual tail latency on the sender task — a pathological combination of `max_retries` and `retry_max_delay_ms` could stretch a single send to tens of seconds.

## i18n Follow-Through (required only when docs or user-facing wording change)

This PR now adds a narrow outbound-send section to `docs/book/src/channels/webhook.md`, plus schema doc-comments on the new `WebhookConfig` fields in `crates/zeroclaw-config/src/schema.rs`. The docs update covers the current singular `[channels.webhook]` outbound-send shape, `send_url` / `send_method` / `auth_header`, the three retry tunables, transient-only retry semantics, `Retry-After` handling, and `max_retries = 0` as the opt-out.

- Locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales? `N.A.` — no doc pages added or renamed.
- Localized runtime-contract docs updated where equivalents exist? `N.A.` — no equivalent files exist in this repo. The book uses mdbook with `.po`-file translations (`docs/book/po/{es,fr,ja,zh-CN}.po`), not separate `docs/i18n/<locale>/...` doc trees; `find docs -name "*channels-reference*"` returns no results and `docs/i18n/` does not exist. The original review's referenced paths (`docs/reference/api/channels-reference.md`, `docs/i18n/vi/...`, `docs/i18n/zh-CN/...`) are stale from a prior repo layout.
- Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? `N.A.` — `docs/i18n/vi/` does not exist in this repo.
- If any `N.A.`, explain scope decision: This PR updates only the current English mdBook source and schema doc-comments. The translation source is maintained through the existing mdBook `.po` workflow, and there is no separate Vietnamese or zh-CN runtime-contract Markdown page to update in this repo. Reconciling the pre-existing inbound `[channels.webhooks.<name>]` / outbound `[channels.webhook]` layout drift across the full webhook page remains out of scope for this retry-logic PR.

