### PR TITLE
feat(config): allow Composio credentials via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,3 +120,11 @@ PROVIDER=openrouter
 # Optional: SearXNG (self-hosted, requires instance URL)
 # WEB_SEARCH_PROVIDER=searxng
 # SEARXNG_INSTANCE_URL=https://searx.example.com
+
+# ── Composio (managed OAuth tools) ─────────────────────────────
+# Enable the Composio integration for 1000+ OAuth-connected tools.
+# Setting a non-empty COMPOSIO_API_KEY auto-enables the integration.
+# See docs/reference/api/config-reference.md#composio for details.
+#
+# COMPOSIO_API_KEY=your-composio-api-key
+# COMPOSIO_ENTITY_ID=default

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -10771,6 +10771,29 @@ impl Config {
             }
         }
 
+        // Composio API key: ZEROCLAW_COMPOSIO_API_KEY or COMPOSIO_API_KEY.
+        // Setting a non-empty key also enables the integration (mirrors how
+        // provider API-key env vars activate their providers).
+        if let Ok(api_key) = std::env::var("ZEROCLAW_COMPOSIO_API_KEY")
+            .or_else(|_| std::env::var("COMPOSIO_API_KEY"))
+        {
+            let api_key = api_key.trim();
+            if !api_key.is_empty() {
+                self.composio.api_key = Some(api_key.to_string());
+                self.composio.enabled = true;
+            }
+        }
+
+        // Composio entity id: ZEROCLAW_COMPOSIO_ENTITY_ID or COMPOSIO_ENTITY_ID
+        if let Ok(entity_id) = std::env::var("ZEROCLAW_COMPOSIO_ENTITY_ID")
+            .or_else(|_| std::env::var("COMPOSIO_ENTITY_ID"))
+        {
+            let entity_id = entity_id.trim();
+            if !entity_id.is_empty() {
+                self.composio.entity_id = entity_id.to_string();
+            }
+        }
+
         // SearXNG instance URL: ZEROCLAW_SEARXNG_INSTANCE_URL or SEARXNG_INSTANCE_URL
         if let Ok(instance_url) = std::env::var("ZEROCLAW_SEARXNG_INSTANCE_URL")
             .or_else(|_| std::env::var("SEARXNG_INSTANCE_URL"))
@@ -14913,6 +14936,69 @@ default_model = "persisted-profile"
         unsafe { std::env::remove_var("WEB_SEARCH_TIMEOUT_SECS") };
         // SAFETY: test-only, single-threaded test runner.
         unsafe { std::env::remove_var("BRAVE_API_KEY") };
+    }
+
+    #[test]
+    async fn env_override_composio_api_key_sets_and_enables() {
+        let _env_guard = env_override_lock().await;
+        let mut config = Config::default();
+        assert!(!config.composio.enabled);
+        assert!(config.composio.api_key.is_none());
+
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::set_var("COMPOSIO_API_KEY", "comp-env-key-123") };
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::set_var("COMPOSIO_ENTITY_ID", "env-entity") };
+
+        config.apply_env_overrides();
+
+        assert!(config.composio.enabled);
+        assert_eq!(config.composio.api_key.as_deref(), Some("comp-env-key-123"));
+        assert_eq!(config.composio.entity_id, "env-entity");
+
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("COMPOSIO_API_KEY") };
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("COMPOSIO_ENTITY_ID") };
+    }
+
+    #[test]
+    async fn env_override_composio_api_key_prefixed_variant_wins() {
+        let _env_guard = env_override_lock().await;
+        let mut config = Config::default();
+
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::set_var("ZEROCLAW_COMPOSIO_API_KEY", "prefixed-key") };
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::set_var("COMPOSIO_API_KEY", "plain-key") };
+
+        config.apply_env_overrides();
+
+        assert_eq!(config.composio.api_key.as_deref(), Some("prefixed-key"));
+        assert!(config.composio.enabled);
+
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("ZEROCLAW_COMPOSIO_API_KEY") };
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("COMPOSIO_API_KEY") };
+    }
+
+    #[test]
+    async fn env_override_composio_empty_key_ignored() {
+        let _env_guard = env_override_lock().await;
+        let mut config = Config::default();
+        assert!(!config.composio.enabled);
+
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::set_var("COMPOSIO_API_KEY", "   ") };
+
+        config.apply_env_overrides();
+
+        assert!(!config.composio.enabled, "empty key must not enable");
+        assert!(config.composio.api_key.is_none());
+
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("COMPOSIO_API_KEY") };
     }
 
     #[test]

--- a/docs/i18n/vi/config-reference.md
+++ b/docs/i18n/vi/config-reference.md
@@ -161,6 +161,7 @@ Lưu ý:
 
 - Tương thích ngược: `enable = true` kiểu cũ được chấp nhận như bí danh cho `enabled = true`.
 - Nếu `enabled = false` hoặc thiếu `api_key`, tool `composio` không được đăng ký.
+- Ghi đè qua biến môi trường: `ZEROCLAW_COMPOSIO_API_KEY` hoặc `COMPOSIO_API_KEY` đặt API key (tự động bật tích hợp khi không rỗng); `ZEROCLAW_COMPOSIO_ENTITY_ID` hoặc `COMPOSIO_ENTITY_ID` ghi đè `entity_id`. Biến có tiền tố `ZEROCLAW_*` có ưu tiên cao hơn.
 - ZeroClaw yêu cầu Composio v3 tools với `toolkit_versions=latest` và thực thi với `version="latest"` để tránh bản tool mặc định cũ.
 - Luồng thông thường: gọi `connect`, hoàn tất OAuth trên trình duyệt, rồi chạy `execute` cho hành động mong muốn.
 - Nếu Composio trả lỗi thiếu connected-account, gọi `list_accounts` (tùy chọn với `app`) và truyền `connected_account_id` trả về cho `execute`.

--- a/docs/i18n/zh-CN/reference/api/config-reference.zh-CN.md
+++ b/docs/i18n/zh-CN/reference/api/config-reference.zh-CN.md
@@ -222,6 +222,7 @@ temperature = 0.2
 
 - 向后兼容性：旧版 `enable = true` 被接受为 `enabled = true` 的别名。
 - 如果 `enabled = false` 或缺少 `api_key`，则不会注册 `composio` 工具。
+- 环境变量覆盖：`ZEROCLAW_COMPOSIO_API_KEY` 或 `COMPOSIO_API_KEY` 设置 API 密钥（非空时自动启用集成）；`ZEROCLAW_COMPOSIO_ENTITY_ID` 或 `COMPOSIO_ENTITY_ID` 覆盖 `entity_id`。带前缀的 `ZEROCLAW_*` 变体优先级更高。
 - ZeroClaw 请求 Composio v3 工具时使用 `toolkit_versions=latest`，并使用 `version=\"latest\"` 执行工具，以避免过时的默认工具版本。
 - 典型流程：调用 `connect`，完成浏览器 OAuth，然后为所需工具操作运行 `execute`。
 - 如果 Composio 返回缺少连接账户引用错误，请调用 `list_accounts`（可选带 `app`）并将返回的 `connected_account_id` 传递给 `execute`。

--- a/docs/reference/api/config-reference.md
+++ b/docs/reference/api/config-reference.md
@@ -359,6 +359,7 @@ Notes:
 
 - Backward compatibility: legacy `enable = true` is accepted as an alias for `enabled = true`.
 - If `enabled = false` or `api_key` is missing, the `composio` tool is not registered.
+- Environment overrides: `ZEROCLAW_COMPOSIO_API_KEY` or `COMPOSIO_API_KEY` set the API key (and auto-enable the integration when non-empty); `ZEROCLAW_COMPOSIO_ENTITY_ID` or `COMPOSIO_ENTITY_ID` override `entity_id`. The prefixed (`ZEROCLAW_*`) variants take precedence.
 - ZeroClaw requests Composio v3 tools with `toolkit_versions=latest` and executes tools with `version="latest"` to avoid stale default tool revisions.
 - Typical flow: call `connect`, complete browser OAuth, then run `execute` for the desired tool action.
 - If Composio returns a missing connected-account reference error, call `list_accounts` (optionally with `app`) and pass the returned `connected_account_id` to `execute`.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Add `ZEROCLAW_COMPOSIO_API_KEY` / `COMPOSIO_API_KEY` and `ZEROCLAW_COMPOSIO_ENTITY_ID` / `COMPOSIO_ENTITY_ID` overrides in `apply_env_overrides`, mirroring the existing `BRAVE_API_KEY` pattern.
  - A non-empty API key also flips `composio.enabled = true`, so the integration can be enabled purely from the environment — useful for Docker/CI/12-factor deployments where persisting secrets into `config.toml` is undesirable.
  - Prefixed `ZEROCLAW_*` variants win over bare names; empty/whitespace values are ignored and never enable the integration.
- **Scope boundary:** does not change how `composio.api_key` is read elsewhere (runtime/gateway/orchestrator still consume `config.composio.api_key` as before), does not change encryption behaviour, does not tch the Composio tool/API client.
- **Blast radius:** only `apply_env_overrides` — behaviour is strictly additive. Users who already set `composio.api_key` in `config.toml` are unaffected unless they also set the new env vars (in which case env wins, consistent with all other env overrides).
- **Linked issue(s):** none — no existing issue/PR for this on the repo.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test -p zeroclaw-config --lib
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean.
  - `cargo clippy --all-targets -- -D warnings` — `Finished dev profile ... target(s) in 50.86s` (no warnings across workspace).
  - `cargo test -p zeroclaw-config --lib` — `test result: ok. 556 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.16s`.
  - New tests: `env_override_composio_api_key_sets_and_enables`, `env_override_composio_api_key_prefixed_variant_wins`, `env_override_composio_ignored` — all pass.
- **Beyond CI — what did you manually verify?** Confirmed the new overrides live in the same block as `BRAVE_API_KEY` and follow the same trim-then-check-empty contract. Did not manually exercise the Composio tool against a live API key (out of scope — only config resolution changed).
- **If any command was intentionally skipped, why:** Full `cargo test` (workspace) skipped locally for time; clippy covers the workspace and config tests cover the touched code path. Happy to run it if requested.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes` — adds env-var ingestion for the Composio API key. This is the same handling model as `BRAVE_API_KEY`/`ZEROCLAW_API_KEY`: the value lands in memory on `Config`, is masked by existing `mask_optional_secret` in the gateway API, and is never written back to `config.toml` unless the user saves colicitly.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` — four new optional env vars (`ZEROCLAW_COMPOSIO_API_KEY`, `COMPOSIO_API_KEY`, `ZEROCLAW_COMPOSIO_ENTITY_ID`, `COMPOSIO_ENTITY_ID`). No removals, no renames.
- Upgrade steps: none required. Existing `[composio]` TOML continues to work; env vars only take effect when set.

## Rollback

Low-risk — `git revert <sha>` is sufficient. No data migration, no feature flag, behaviour is purely additive in `apply_env_overrides`.

## i18n Follow-Through

- Locale navigation parity updated? `N.A.` — no navigation/README changes.
- Localized runtime-contract docs updated? `Yes` — `docs/reference/api/config-reference.md`, `docs/i18n/zh-CN/reference/api/config-reference.zh-CN.md`, and `docs/i18n/vi/config-reference.md` all got the new env-override note in the `[composio]` section.
- Vietnamese canonical docs under `docs/i18n/ynced? `Yes`.