### PR TITLE
chore(release): update CHANGELOG-next.md contributors via GraphQL

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -212,6 +212,7 @@ extension point — all other crates are Beta or Experimental.
 
 Thank you to everyone who contributed to this release:
 
+- @abhijeet117
 - @aliasliao
 - @ArgenisDLR
 - @Audacity88
@@ -223,7 +224,9 @@ Thank you to everyone who contributed to this release:
 - @JordanTheJet
 - @kunalk16
 - @markuman
+- @micookie
 - @nayrosk
+- @niedbalski
 - @ninenox
 - @singlerider
 - @theonlyhennygod
@@ -232,6 +235,7 @@ Thank you to everyone who contributed to this release:
 - @vernonstinebaker
 - @WareWolf-MoonWall
 - @wlh320
+- @zavertiaev
 
 ---
 


### PR DESCRIPTION
## Summary

- Resolved all contributors via GitHub GraphQL API `authors` field (captures both direct authors and Co-Authored-By trailers)
- Added 4 missing contributors: @abhijeet117, @micookie, @niedbalski, @zavertiaev
- Total: 24 contributors attributed with GitHub `@login` handles

## Test plan

- [ ] Merge to master before v0.7.1 release workflow reaches the "Generate Release Notes" step