### PR TITLE
fix(tools): multiply embedding score by 100 before percent formatting

### DIFF
--- a/crates/zeroclaw-tools/src/discord_search.rs
+++ b/crates/zeroclaw-tools/src/discord_search.rs
@@ -127,7 +127,7 @@ impl Tool for DiscordSearchTool {
                 for entry in &entries {
                     let score = entry
                         .score
-                        .map_or_else(String::new, |s| format!(" [{s:.0}%]"));
+                        .map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
                     let _ = writeln!(output, "- {}{score}", entry.content);
                 }
                 Ok(ToolResult {
@@ -191,6 +191,21 @@ mod tests {
         let result = tool.execute(json!({})).await.unwrap();
         assert!(!result.success);
         assert!(result.error.as_ref().unwrap().contains("at least"));
+    }
+
+    #[test]
+    fn score_formatted_as_percent() {
+        let score: Option<f64> = Some(0.63);
+        let formatted = score.map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
+        assert_eq!(formatted, " [63%]");
+
+        let score: Option<f64> = Some(0.42);
+        let formatted = score.map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
+        assert_eq!(formatted, " [42%]");
+
+        let score: Option<f64> = None;
+        let formatted = score.map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
+        assert_eq!(formatted, "");
     }
 
     #[test]

--- a/crates/zeroclaw-tools/src/memory_recall.rs
+++ b/crates/zeroclaw-tools/src/memory_recall.rs
@@ -124,7 +124,7 @@ impl Tool for MemoryRecallTool {
                 for entry in &entries {
                     let score = entry
                         .score
-                        .map_or_else(String::new, |s| format!(" [{s:.0}%]"));
+                        .map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
                     let _ = writeln!(
                         output,
                         "- [{}] {}: {}{score}",
@@ -239,6 +239,29 @@ mod tests {
         let tool = MemoryRecallTool::new(mem);
         assert_eq!(tool.name(), "memory_recall");
         assert!(tool.parameters_schema()["properties"]["query"].is_object());
+    }
+
+    #[test]
+    fn score_formatted_as_percent() {
+        let score: Option<f64> = Some(0.63);
+        let formatted = score.map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
+        assert_eq!(formatted, " [63%]");
+
+        let score: Option<f64> = Some(0.42);
+        let formatted = score.map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
+        assert_eq!(formatted, " [42%]");
+
+        let score: Option<f64> = Some(1.0);
+        let formatted = score.map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
+        assert_eq!(formatted, " [100%]");
+
+        let score: Option<f64> = Some(0.0);
+        let formatted = score.map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
+        assert_eq!(formatted, " [0%]");
+
+        let score: Option<f64> = None;
+        let formatted = score.map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
+        assert_eq!(formatted, "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Cosine similarity scores (0.0–1.0) were formatted directly as percentages without multiplying by 100, causing `0.63` to display as `[1%]` instead of `[63%]`
- Fixed the format string in both `memory_recall.rs` and `discord_search.rs` to multiply the score by 100 before rendering
- Added unit tests covering typical values, boundary cases (0.0, 1.0), and the `None` case

Fixes #5536

## Test plan

- [x] `cargo test -p zeroclaw-tools -- score_formatted_as_percent` — 2 tests pass
- [ ] Manual: run embedding search and verify scores display correctly (e.g. 0.63 → `[63%]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)