### PR TITLE
fix(ci): split tag push from release creation to avoid immutable-release error

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -444,23 +444,22 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
-          # For manual dispatch, use --target to create tag + release atomically
-          # via RELEASE_TOKEN (admin PAT) which bypasses tag protection rules.
-          # For tag push, the tag already exists — just create the release.
+          # For manual dispatch, push the tag explicitly via git first using
+          # the RELEASE_TOKEN checkout (admin PAT bypasses tag protection rules),
+          # then create the release for the existing tag. This avoids the GitHub
+          # "tag_name was used by an immutable release" API error that --target
+          # triggers when a same-named tag was previously used by a deleted
+          # immutable release.
+          # For tag push, the tag already exists — skip straight to release creation.
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            gh release create "$TAG" release-assets/* \
-              --repo "$GITHUB_REPOSITORY" \
-              --title "$TAG" \
-              --notes-file release-notes.md \
-              --target "$COMMIT_SHA" \
-              --latest
-          else
-            gh release create "$TAG" release-assets/* \
-              --repo "$GITHUB_REPOSITORY" \
-              --title "$TAG" \
-              --notes-file release-notes.md \
-              --latest
+            git tag "$TAG" "$COMMIT_SHA"
+            git push origin "$TAG"
           fi
+          gh release create "$TAG" release-assets/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            --latest
 
       - name: Remove CHANGELOG-next.md after stable release
         shell: bash


### PR DESCRIPTION
## What

Fixes the `Publish Stable Release` job failure on run #24600186487.

## Root cause

`gh release create --target` atomically creates a tag and release via a single GitHub API call. GitHub's Immutable Releases feature (GA Oct 2025) adds a check on this API path: if a tag name was ever used by a deleted immutable release, the check permanently blocks the operation and returns `tag_name was used by an immutable release` — even though no release currently exists for that tag.

## Fix

Split the operation into two steps for `workflow_dispatch`:
1. Push the tag explicitly via git — the `RELEASE_TOKEN` checkout (admin PAT) already has rights to bypass tag protection rules
2. Create the release for the now-existing tag without `--target` — this path does not trigger the immutability conflict check

The tag-push trigger path is unchanged (tag already exists, goes straight to release creation).

## After merge

Redispatch `release-stable-manual.yml` with `version: 0.7.0`. All build artifacts from the previous run expired with the failed run so it will rebuild, but that's unavoidable.

## Risk

`size: XS` / `risk: low` — single workflow file, publish step only, no logic changes to build or packaging.