### PR TITLE
feat(skills): add LLM reflection for Hermes-style SKILL.md generation

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -1683,20 +1683,51 @@ pub struct SkillCreationConfig {
     /// Enable automatic skill creation after successful multi-step tasks.
     /// Default: `false`.
     pub enabled: bool,
+    /// Minimum tool-call count before attempting skill creation (Hermes-style workflows often use 5+).
+    /// Default: `2` (legacy behavior).
+    #[serde(default = "default_skill_creation_min_tool_calls")]
+    pub min_tool_calls: usize,
     /// Maximum number of auto-generated skills to keep.
     /// When exceeded, the oldest auto-generated skill is removed (LRU eviction).
     pub max_skills: usize,
     /// Embedding similarity threshold for deduplication.
     /// Skills with descriptions more similar than this value are skipped.
     pub similarity_threshold: f64,
+    /// When `true`, run an LLM **reflection** pass to write a `SKILL.md` (agentskills-style)
+    /// from the task, tool trace, and final answer — similar to Hermes `skill_manage` narratives.
+    /// Default: `false` (only serialized `SKILL.toml` from tool calls).
+    pub reflection_enabled: bool,
+    /// When `true` and `reflection_enabled`, run a second LLM pass to refine the draft (evolver).
+    /// Default: `false`.
+    pub evolver_enabled: bool,
+    /// Temperature for reflection/evolver LLM calls (keep low for stable procedures).
+    #[serde(default = "default_skill_reflection_temperature")]
+    pub reflection_temperature: f64,
+    /// When reflection produced `SKILL.md`, also write the legacy serialized `SKILL.toml` tool list.
+    /// Default: `true`.
+    #[serde(default = "default_true")]
+    pub also_write_serialized_toml: bool,
+}
+
+fn default_skill_creation_min_tool_calls() -> usize {
+    2
+}
+
+fn default_skill_reflection_temperature() -> f64 {
+    0.2
 }
 
 impl Default for SkillCreationConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            min_tool_calls: default_skill_creation_min_tool_calls(),
             max_skills: 500,
             similarity_threshold: 0.85,
+            reflection_enabled: false,
+            evolver_enabled: false,
+            reflection_temperature: default_skill_reflection_temperature(),
+            also_write_serialized_toml: true,
         }
     }
 }

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -2595,7 +2595,15 @@ pub async fn run(
                     config.workspace_dir.clone(),
                     config.skills.skill_creation.clone(),
                 );
-                match creator.create_from_execution(&msg, &tool_calls, None).await {
+                match creator
+                    .create_from_execution(
+                        &msg,
+                        &tool_calls,
+                        None,
+                        Some((&*provider, model_name.as_str(), response.as_str())),
+                    )
+                    .await
+                {
                     Ok(Some(slug)) => {
                         tracing::info!(slug, "Auto-created skill from execution");
                     }

--- a/crates/zeroclaw-runtime/src/skills/creator.rs
+++ b/crates/zeroclaw-runtime/src/skills/creator.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use zeroclaw_config::schema::SkillCreationConfig;
 use zeroclaw_memory::embeddings::EmbeddingProvider;
 use zeroclaw_memory::vector::cosine_similarity;
+use zeroclaw_providers::Provider;
 
 /// A record of a single tool call executed during a task.
 #[derive(Debug, Clone)]
@@ -32,6 +33,11 @@ impl SkillCreator {
     }
 
     /// Attempt to create a skill from a successful multi-step task execution.
+    ///
+    /// When `reflection_enabled` is set and `reflection_llm` is `Some(provider, model, final_answer)`,
+    /// runs an LLM to produce Hermes-style `SKILL.md` (optional **evolver** pass), then optionally
+    /// still writes serialized `SKILL.toml` for tool compatibility.
+    ///
     /// Returns `Ok(Some(slug))` if a skill was created, `Ok(None)` if skipped
     /// (disabled, duplicate, or insufficient tool calls).
     pub async fn create_from_execution(
@@ -39,12 +45,13 @@ impl SkillCreator {
         task_description: &str,
         tool_calls: &[ToolCallRecord],
         embedding_provider: Option<&dyn EmbeddingProvider>,
+        reflection_llm: Option<(&dyn Provider, &str, &str)>,
     ) -> Result<Option<String>> {
         if !self.config.enabled {
             return Ok(None);
         }
 
-        if tool_calls.len() < 2 {
+        if tool_calls.len() < self.config.min_tool_calls {
             return Ok(None);
         }
 
@@ -65,6 +72,53 @@ impl SkillCreator {
         self.enforce_lru_limit().await?;
 
         let skill_dir = self.skills_dir().join(&slug);
+
+        if self.config.reflection_enabled {
+            if let Some((provider, model, final_answer)) = reflection_llm {
+                match crate::skills::skill_reflection::reflect_skill_markdown(
+                    provider,
+                    model,
+                    self.config.reflection_temperature,
+                    self.config.evolver_enabled,
+                    &slug,
+                    task_description,
+                    tool_calls,
+                    final_answer,
+                )
+                .await
+                {
+                    Ok(md) => {
+                        crate::skills::skill_reflection::write_skill_md_atomic(&skill_dir, &md)
+                            .await
+                            .with_context(|| {
+                                format!("write reflective SKILL.md under {}", skill_dir.display())
+                            })?;
+                        if self.config.also_write_serialized_toml {
+                            let toml_content =
+                                Self::generate_skill_toml(&slug, task_description, tool_calls);
+                            let toml_path = skill_dir.join("SKILL.toml");
+                            tokio::fs::write(&toml_path, toml_content.as_bytes())
+                                .await
+                                .with_context(|| {
+                                    format!("Failed to write {}", toml_path.display())
+                                })?;
+                        }
+                        tracing::info!(slug, "Auto-created reflective SKILL.md from execution");
+                        return Ok(Some(slug));
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Skill reflection failed, falling back to serialized SKILL.toml: {e:#}"
+                        );
+                    }
+                }
+            } else {
+                tracing::debug!(
+                    "skill_creation.reflection_enabled but no LLM context in this path — using serialized TOML only"
+                );
+            }
+        }
+
         tokio::fs::create_dir_all(&skill_dir)
             .await
             .with_context(|| {
@@ -187,13 +241,18 @@ impl SkillCreator {
         let mut entries = tokio::fs::read_dir(&skills_dir).await?;
         while let Some(entry) = entries.next_entry().await? {
             let toml_path = entry.path().join("SKILL.toml");
-            if !toml_path.exists() {
-                continue;
-            }
+            let md_path = entry.path().join("SKILL.md");
+            let desc_opt = if toml_path.exists() {
+                let content = tokio::fs::read_to_string(&toml_path).await?;
+                extract_description_from_toml(&content)
+            } else if md_path.exists() {
+                let content = tokio::fs::read_to_string(&md_path).await?;
+                extract_description_from_skill_md(&content)
+            } else {
+                None
+            };
 
-            let content = tokio::fs::read_to_string(&toml_path).await?;
-            // Extract description from the TOML to compare.
-            if let Some(desc) = extract_description_from_toml(&content) {
+            if let Some(desc) = desc_opt {
                 let existing_embedding = embedding_provider.embed_one(&desc).await?;
                 if !existing_embedding.is_empty() {
                     #[allow(clippy::cast_possible_truncation)]
@@ -221,13 +280,24 @@ impl SkillCreator {
         let mut entries = tokio::fs::read_dir(&skills_dir).await?;
         while let Some(entry) = entries.next_entry().await? {
             let toml_path = entry.path().join("SKILL.toml");
-            if !toml_path.exists() {
+            let md_path = entry.path().join("SKILL.md");
+            let (path_for_mtime, is_auto) = if toml_path.exists() {
+                let content = tokio::fs::read_to_string(&toml_path).await?;
+                let auto =
+                    content.contains("\"zeroclaw-auto\"") || content.contains("\"auto-generated\"");
+                (toml_path, auto)
+            } else if md_path.exists() {
+                let content = tokio::fs::read_to_string(&md_path).await?;
+                let auto = content.contains("zeroclaw-auto")
+                    && (content.contains("zeroclaw-reflection")
+                        || content.contains("auto-generated"));
+                (md_path, auto)
+            } else {
                 continue;
-            }
+            };
 
-            let content = tokio::fs::read_to_string(&toml_path).await?;
-            if content.contains("\"zeroclaw-auto\"") || content.contains("\"auto-generated\"") {
-                let modified = tokio::fs::metadata(&toml_path)
+            if is_auto {
+                let modified = tokio::fs::metadata(&path_for_mtime)
                     .await?
                     .modified()
                     .unwrap_or(std::time::UNIX_EPOCH);
@@ -282,6 +352,32 @@ fn extract_description_from_toml(content: &str) -> Option<String> {
     toml::from_str::<Partial>(content)
         .ok()
         .and_then(|p| p.skill.description)
+}
+
+/// Best-effort `description` from YAML frontmatter in `SKILL.md`.
+fn extract_description_from_skill_md(content: &str) -> Option<String> {
+    let rest = content.trim_start().strip_prefix("---")?;
+    let end = rest.find("\n---")?;
+    let fm = &rest[..end];
+    for line in fm.lines() {
+        let line = line.trim();
+        let Some(desc) = line.strip_prefix("description:") else {
+            continue;
+        };
+        let d = desc.trim();
+        let d = d
+            .strip_prefix('"')
+            .and_then(|s| s.strip_suffix('"'))
+            .unwrap_or(d);
+        let d = d
+            .strip_prefix('\'')
+            .and_then(|s| s.strip_suffix('\''))
+            .unwrap_or(d);
+        if !d.is_empty() {
+            return Some(d.to_string());
+        }
+    }
+    None
 }
 
 /// Extract `ToolCallRecord`s from the agent conversation history.
@@ -373,7 +469,10 @@ pub fn extract_tool_calls_from_history(
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use zeroclaw_memory::embeddings::{EmbeddingProvider, NoopEmbedding};
+    use zeroclaw_providers::Provider;
 
     // ── Slug generation ──────────────────────────────────────────
 
@@ -549,6 +648,21 @@ version = "0.1.0"
         assert_eq!(extract_description_from_toml("not valid toml {{"), None);
     }
 
+    #[test]
+    fn extract_description_from_skill_md_frontmatter() {
+        let md = r#"---
+name: x
+description: "Hello skill"
+author: zeroclaw-auto
+---
+# Body
+"#;
+        assert_eq!(
+            super::extract_description_from_skill_md(md),
+            Some("Hello skill".into())
+        );
+    }
+
     // ── Deduplication ────────────────────────────────────────────
 
     /// A mock embedding provider that returns deterministic embeddings.
@@ -625,6 +739,7 @@ tags = ["auto-generated"]
             enabled: true,
             max_skills: 500,
             similarity_threshold: 0.85,
+            ..Default::default()
         };
 
         // High similarity provider -> should detect as duplicate.
@@ -657,6 +772,7 @@ tags = ["auto-generated"]
             enabled: true,
             max_skills: 2,
             similarity_threshold: 0.85,
+            ..Default::default()
         };
 
         let skills_dir = dir.path().join("skills");
@@ -712,7 +828,7 @@ tags = ["auto-generated"]
             },
         ];
         let result = creator
-            .create_from_execution("List files", &calls, None)
+            .create_from_execution("List files", &calls, None, None)
             .await
             .unwrap();
         assert!(result.is_none());
@@ -731,7 +847,7 @@ tags = ["auto-generated"]
             args: serde_json::json!({"command": "ls"}),
         }];
         let result = creator
-            .create_from_execution("List files", &calls, None)
+            .create_from_execution("List files", &calls, None, None)
             .await
             .unwrap();
         assert!(result.is_none());
@@ -744,6 +860,7 @@ tags = ["auto-generated"]
             enabled: true,
             max_skills: 500,
             similarity_threshold: 0.85,
+            ..Default::default()
         };
         let creator = SkillCreator::new(dir.path().to_path_buf(), config);
         let calls = vec![
@@ -760,7 +877,7 @@ tags = ["auto-generated"]
         // Use noop embedding (no deduplication).
         let noop = NoopEmbedding;
         let result = creator
-            .create_from_execution("Build and test", &calls, Some(&noop))
+            .create_from_execution("Build and test", &calls, Some(&noop), None)
             .await
             .unwrap();
         assert_eq!(result, Some("build-and-test".into()));
@@ -782,6 +899,7 @@ tags = ["auto-generated"]
             enabled: true,
             max_skills: 500,
             similarity_threshold: 0.85,
+            ..Default::default()
         };
 
         // First, create an existing skill.
@@ -814,7 +932,7 @@ tags = ["auto-generated"]
             },
         ];
         let result = creator
-            .create_from_execution("Build and test", &calls, Some(&provider))
+            .create_from_execution("Build and test", &calls, Some(&provider), None)
             .await
             .unwrap();
         assert!(result.is_none());
@@ -904,5 +1022,144 @@ tags = ["auto-generated"]
                     .unwrap_or_else(|e| panic!("Invalid TOML for desc '{desc}': {e}\n{toml_str}"));
             }
         }
+    }
+
+    // ── Hermes-style reflection (mock LLM) ─────────────────────────
+
+    /// Counts LLM calls; returns reflection draft then optional evolver output.
+    #[derive(Clone)]
+    struct MockReflectProvider(Arc<AtomicUsize>);
+
+    #[async_trait]
+    impl Provider for MockReflectProvider {
+        async fn chat_with_system(
+            &self,
+            system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            let n = self.0.fetch_add(1, Ordering::SeqCst);
+            let evolver = system_prompt.is_some_and(|s| s.contains("You refine"));
+            if evolver {
+                return Ok(r#"---
+name: build-and-test
+description: Evolved description
+author: zeroclaw-auto
+tags: [auto-generated, zeroclaw-reflection]
+version: "0.1.0"
+---
+## Evolved
+Refined procedure.
+"#
+                .to_string());
+            }
+            assert_eq!(n, 0, "unexpected extra reflection call");
+            Ok(r#"---
+name: build-and-test
+description: Reflective skill from mock LLM
+author: zeroclaw-auto
+tags: [auto-generated, zeroclaw-reflection]
+version: "0.1.0"
+---
+## When to use
+When testing reflection.
+
+## Procedure
+1. Run shell commands.
+"#
+            .to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn create_from_execution_reflective_writes_skill_md_and_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = SkillCreationConfig {
+            enabled: true,
+            reflection_enabled: true,
+            evolver_enabled: false,
+            also_write_serialized_toml: true,
+            ..Default::default()
+        };
+        let calls = vec![
+            ToolCallRecord {
+                name: "shell".into(),
+                args: serde_json::json!({"command": "cargo build"}),
+            },
+            ToolCallRecord {
+                name: "shell".into(),
+                args: serde_json::json!({"command": "cargo test"}),
+            },
+        ];
+        let mock = MockReflectProvider(Arc::new(AtomicUsize::new(0)));
+        let creator = SkillCreator::new(dir.path().to_path_buf(), config);
+        let noop = NoopEmbedding;
+        let out = creator
+            .create_from_execution(
+                "Build and test",
+                &calls,
+                Some(&noop),
+                Some((&mock as &dyn Provider, "mock-model", "All tests passed.")),
+            )
+            .await
+            .unwrap();
+        assert_eq!(out, Some("build-and-test".into()));
+        assert_eq!(mock.0.load(Ordering::SeqCst), 1);
+
+        let skill_dir = dir.path().join("skills/build-and-test");
+        let md = tokio::fs::read_to_string(skill_dir.join("SKILL.md"))
+            .await
+            .unwrap();
+        assert!(md.contains("Reflective skill from mock LLM"));
+        assert!(md.contains("zeroclaw-reflection"));
+
+        let toml = tokio::fs::read_to_string(skill_dir.join("SKILL.toml"))
+            .await
+            .unwrap();
+        assert!(toml.contains("cargo build"));
+        assert!(toml.contains("zeroclaw-auto"));
+    }
+
+    #[tokio::test]
+    async fn create_from_execution_reflective_with_evolver_second_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = SkillCreationConfig {
+            enabled: true,
+            reflection_enabled: true,
+            evolver_enabled: true,
+            also_write_serialized_toml: false,
+            ..Default::default()
+        };
+        let calls = vec![
+            ToolCallRecord {
+                name: "shell".into(),
+                args: serde_json::json!({"command": "echo hi"}),
+            },
+            ToolCallRecord {
+                name: "shell".into(),
+                args: serde_json::json!({"command": "echo bye"}),
+            },
+        ];
+        let mock = MockReflectProvider(Arc::new(AtomicUsize::new(0)));
+        let creator = SkillCreator::new(dir.path().to_path_buf(), config);
+        let noop = NoopEmbedding;
+        let out = creator
+            .create_from_execution(
+                "Build and test",
+                &calls,
+                Some(&noop),
+                Some((&mock as &dyn Provider, "mock-model", "ok")),
+            )
+            .await
+            .unwrap();
+        assert_eq!(out, Some("build-and-test".into()));
+        assert_eq!(mock.0.load(Ordering::SeqCst), 2);
+
+        let md = tokio::fs::read_to_string(dir.path().join("skills/build-and-test/SKILL.md"))
+            .await
+            .unwrap();
+        assert!(md.contains("Evolved"));
+        assert!(!dir.path().join("skills/build-and-test/SKILL.toml").exists());
     }
 }

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -15,6 +15,7 @@ use zip::ZipArchive;
 pub mod audit;
 pub mod creator;
 pub mod improver;
+pub mod skill_reflection;
 pub mod testing;
 
 const OPEN_SKILLS_REPO_URL: &str = "https://github.com/besoeasy/open-skills";

--- a/crates/zeroclaw-runtime/src/skills/skill_reflection.rs
+++ b/crates/zeroclaw-runtime/src/skills/skill_reflection.rs
@@ -1,0 +1,132 @@
+//! Hermes-style **reflection**: turn a successful tool-using task into a `SKILL.md` via LLM,
+//! optionally followed by an **evolver** pass that tightens the document.
+
+use std::path::Path;
+
+use anyhow::Context;
+use serde_json::json;
+use zeroclaw_providers::Provider;
+
+use super::creator::ToolCallRecord;
+
+const REFLECTION_SYSTEM: &str = r#"You are writing a reusable agent skill as Markdown (agentskills.io / SKILL.md style).
+
+Given the user's task, the tool trace, and the assistant's final answer, produce ONE skill document.
+
+Rules:
+- Start with YAML frontmatter: `name`, `description`, `version` (semver), `author: zeroclaw-auto`, `tags` including `auto-generated` and `zeroclaw-reflection`.
+- Use the provided `slug` as the `name` field (hyphenated identifier).
+- Sections after frontmatter: `## When to use`, `## Procedure` (numbered steps referencing real tool names from the trace), `## Pitfalls`, `## Verification`.
+- Be concise and actionable. Do not invent tools that were not in the trace.
+- Output ONLY the markdown file content (no preamble or commentary)."#;
+
+const EVOLVER_SYSTEM: &str = r#"You refine an existing SKILL.md for a coding agent.
+
+Improve clarity, remove redundancy, strengthen Pitfalls with real edge cases, and make Verification concrete.
+Preserve YAML frontmatter; keep `author: zeroclaw-auto` and tags including `zeroclaw-reflection`.
+Output ONLY the full markdown file."#;
+
+/// Remove optional ``` / ```markdown fences if the model wrapped the file.
+pub fn strip_markdown_fences(raw: &str) -> String {
+    let t = raw.trim();
+    if !t.starts_with("```") {
+        return t.to_string();
+    }
+    let after_open = t.strip_prefix("```").unwrap_or(t);
+    let body = if let Some(idx) = after_open.find('\n') {
+        &after_open[idx + 1..]
+    } else {
+        after_open
+    };
+    if let Some(end) = body.rfind("```") {
+        body[..end].trim().to_string()
+    } else {
+        body.trim().to_string()
+    }
+}
+
+/// Run reflection (and optional evolver) and return final markdown body.
+pub async fn reflect_skill_markdown(
+    provider: &dyn Provider,
+    model: &str,
+    temperature: f64,
+    evolver: bool,
+    slug: &str,
+    task: &str,
+    tool_calls: &[ToolCallRecord],
+    final_answer: &str,
+) -> anyhow::Result<String> {
+    let trace: Vec<serde_json::Value> = tool_calls
+        .iter()
+        .map(|t| json!({ "name": t.name, "args": t.args }))
+        .collect();
+    let trace_json = serde_json::to_string_pretty(&trace).unwrap_or_else(|_| "[]".to_string());
+
+    let user = format!(
+        "Skill slug (use as frontmatter `name`): {slug}\n\n\
+         User task:\n{task}\n\n\
+         Tool call trace (JSON):\n{trace_json}\n\n\
+         Final assistant answer:\n{final_answer}\n"
+    );
+
+    let mut md = provider
+        .chat_with_system(Some(REFLECTION_SYSTEM), &user, model, temperature)
+        .await
+        .context("reflection LLM call failed")?;
+
+    if evolver {
+        md = provider
+            .chat_with_system(
+                Some(EVOLVER_SYSTEM),
+                &format!(
+                    "Improve this skill. Output the full file only.\n\n{}",
+                    strip_markdown_fences(&md)
+                ),
+                model,
+                temperature,
+            )
+            .await
+            .context("evolver LLM call failed")?;
+    }
+
+    let md = strip_markdown_fences(&md);
+    if md.trim().is_empty() {
+        anyhow::bail!("reflection produced empty skill markdown");
+    }
+    Ok(md)
+}
+
+/// Write `SKILL.md` under `skill_dir` atomically via a temp file.
+pub async fn write_skill_md_atomic(skill_dir: &Path, content: &str) -> anyhow::Result<()> {
+    tokio::fs::create_dir_all(skill_dir)
+        .await
+        .with_context(|| format!("create skill dir {}", skill_dir.display()))?;
+    let tmp = skill_dir.join(".SKILL.md.tmp");
+    let final_path = skill_dir.join("SKILL.md");
+    tokio::fs::write(&tmp, content.as_bytes())
+        .await
+        .with_context(|| format!("write {}", tmp.display()))?;
+    tokio::fs::rename(&tmp, &final_path)
+        .await
+        .with_context(|| format!("rename to {}", final_path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_markdown_fences;
+
+    #[test]
+    fn strip_fences_plain() {
+        let s = "---\nname: x\n---\n# Hi";
+        assert_eq!(strip_markdown_fences(s).trim(), s.trim());
+    }
+
+    #[test]
+    fn strip_fences_markdown_lang() {
+        let s = "```markdown\n---\nname: x\n---\nbody\n```";
+        let out = strip_markdown_fences(s);
+        assert!(out.contains("name: x"));
+        assert!(!out.contains("```"));
+    }
+}


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Add optional LLM **reflection** path that writes agentskills-style `SKILL.md` from user task, tool-call trace, and final assistant reply (Hermes/Evolver-style workflow).
  - Extend `[skills.skill_creation]` with `reflection_enabled`, `evolver_enabled`, `reflection_temperature`, `min_tool_calls`, `also_write_serialized_toml`.
  - Single-shot `zeroclaw agent -m` passes `(provider, model, response)` into `SkillCreator::create_from_execution` so reflection can run when enabled.
  - Unit tests with mock provider cover reflective `SKILL.md` and optional evolver pass.
- **Scope boundary:** Does not change interactive REPL skill-creation wiring beyond existing `agent -m` path; does not add new external endpoints.
- **Blast radius:** Opt-in via config defaults (`reflection_enabled` default `false`); existing users unchanged unless they enable skill creation + reflection.
- **Linked issue(s):** (none)

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo test -p zeroclaw-runtime skills::creator --locked
```

- **Commands run and tail output:** `cargo test -p zeroclaw-runtime skills::creator --locked` — 28 passed (local).
- **Beyond CI:** Full `cargo test` / `cargo clippy -D warnings` not run locally; CI authoritative.
- **If any command was intentionally skipped, why:** Full repo gate left to CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** (writes only under existing workspace `skills/` when skill creation already enabled).
- New external network calls? **No** (uses existing configured provider when reflection runs).
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** (new config fields have defaults; reflection off by default).
- Config / env / CLI surface changed? **Yes** — new optional keys under `[skills.skill_creation]`; no breaking changes to existing keys.
- **Upgrade steps:** To use reflection, set `enabled = true`, `reflection_enabled = true` in `config.toml` and run `zeroclaw agent -m` with enough tool calls (`min_tool_calls`, default 2).

## Rollback

- **Fast rollback command/path:** `git revert <merge-sha>` or disable `[skills.skill_creation].reflection_enabled`.
- **Feature flags or config toggles:** `[skills.skill_creation].reflection_enabled` (default off).
- **Observable failure symptoms:** Reflection LLM errors logged; falls back to serialized `SKILL.toml` when reflection fails.
