### PR TITLE
fix(docker): copy all workspace crate manifests for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,21 +23,39 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # 1. Copy manifests to cache dependencies
 COPY Cargo.toml Cargo.lock ./
-# Include every workspace member: Cargo.lock is generated for the full workspace.
-# Previously we used sed to drop `crates/robot-kit`, which made the manifest disagree
-# with the lockfile and caused `cargo --locked` to fail (Cargo refused to rewrite the lock).
+# Include every workspace member manifest so Cargo can resolve the full workspace.
+# Full source crates (small, no stub needed):
 COPY crates/robot-kit/ crates/robot-kit/
 COPY crates/aardvark-sys/ crates/aardvark-sys/
-# Include tauri workspace member manifest (desktop app, but needed for workspace resolution).
-# .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
+# Manifest-only copies for all other workspace crates + tauri app:
+COPY crates/zeroclaw-api/Cargo.toml crates/zeroclaw-api/Cargo.toml
+COPY crates/zeroclaw-config/Cargo.toml crates/zeroclaw-config/Cargo.toml
+COPY crates/zeroclaw-providers/Cargo.toml crates/zeroclaw-providers/Cargo.toml
+COPY crates/zeroclaw-memory/Cargo.toml crates/zeroclaw-memory/Cargo.toml
+COPY crates/zeroclaw-channels/Cargo.toml crates/zeroclaw-channels/Cargo.toml
+COPY crates/zeroclaw-tools/Cargo.toml crates/zeroclaw-tools/Cargo.toml
+COPY crates/zeroclaw-runtime/Cargo.toml crates/zeroclaw-runtime/Cargo.toml
+COPY crates/zeroclaw-infra/Cargo.toml crates/zeroclaw-infra/Cargo.toml
+COPY crates/zeroclaw-gateway/Cargo.toml crates/zeroclaw-gateway/Cargo.toml
+COPY crates/zeroclaw-hardware/Cargo.toml crates/zeroclaw-hardware/Cargo.toml
+COPY crates/zeroclaw-tui/Cargo.toml crates/zeroclaw-tui/Cargo.toml
+COPY crates/zeroclaw-plugins/Cargo.toml crates/zeroclaw-plugins/Cargo.toml
+COPY crates/zeroclaw-tool-call-parser/Cargo.toml crates/zeroclaw-tool-call-parser/Cargo.toml
+COPY crates/zeroclaw-macros/Cargo.toml crates/zeroclaw-macros/Cargo.toml
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
-# Create dummy targets declared in Cargo.toml so manifest parsing succeeds.
+# Create dummy source files so Cargo can compile the stub workspace.
 RUN mkdir -p src benches apps/tauri/src \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
     && echo "fn main() {}" > benches/agent_benchmarks.rs \
     && echo "fn main() {}" > apps/tauri/src/main.rs \
-    && echo "fn main() {}" > apps/tauri/build.rs
+    && echo "fn main() {}" > apps/tauri/build.rs \
+    && for crate in zeroclaw-api zeroclaw-config zeroclaw-providers zeroclaw-memory \
+         zeroclaw-channels zeroclaw-tools zeroclaw-runtime zeroclaw-infra \
+         zeroclaw-gateway zeroclaw-hardware zeroclaw-tui zeroclaw-plugins \
+         zeroclaw-tool-call-parser zeroclaw-macros; do \
+         mkdir -p "crates/$crate/src" && echo "" > "crates/$crate/src/lib.rs"; \
+       done
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
@@ -52,13 +70,17 @@ RUN rm -rf src benches
 COPY src/ src/
 COPY benches/ benches/
 COPY *.rs .
+COPY crates/ crates/
 RUN touch src/main.rs
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \
     rm -rf target/release/.fingerprint/zeroclawlabs-* \
            target/release/deps/zeroclawlabs-* \
-           target/release/incremental/zeroclawlabs-* && \
+           target/release/incremental/zeroclawlabs-* \
+           target/release/.fingerprint/zeroclaw[-_]* \
+           target/release/deps/zeroclaw[-_]* \
+           target/release/incremental/zeroclaw[-_]* && \
     if [ -n "$ZEROCLAW_CARGO_FEATURES" ]; then \
       cargo build --release --locked --features "$ZEROCLAW_CARGO_FEATURES"; \
     else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,10 @@ COPY Cargo.toml Cargo.lock ./
 # Full source crates (small, no stub needed):
 COPY crates/robot-kit/ crates/robot-kit/
 COPY crates/aardvark-sys/ crates/aardvark-sys/
-# Manifest-only copies for all other workspace crates + tauri app:
+# Manifest-only copies for all workspace crates.
+# If a new crate is added to the workspace, add a COPY line here and
+# a matching entry in the stub-creation loop below.
+# Tracked for automation in #5885.
 COPY crates/zeroclaw-api/Cargo.toml crates/zeroclaw-api/Cargo.toml
 COPY crates/zeroclaw-config/Cargo.toml crates/zeroclaw-config/Cargo.toml
 COPY crates/zeroclaw-providers/Cargo.toml crates/zeroclaw-providers/Cargo.toml


### PR DESCRIPTION
## Summary

- The v0.7.0 microkernel refactor split the codebase into 14 workspace crates, but the Dockerfile only copies `robot-kit` and `aardvark-sys` manifests. Cargo fails at workspace resolution because it can't find the other 14 `Cargo.toml` files.
- Add `COPY` instructions for each crate manifest, create dummy `lib.rs` stubs for the dependency-caching stage, copy real crate sources in stage 2, and invalidate all workspace crate fingerprints for rebuild.

## Test plan

- [x] Built successfully on ARM64 (57.6 MB distroless release image)
- [x] Built successfully on x86_64 (51.4 MB distroless release image)
- [x] Deployed on OpenShift — pod starts, gateway responds on `/health`, web UI works
- [ ] Verify dependency caching layer works on incremental rebuilds (source-only changes should reuse cached deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)