### PR TITLE
chore: migrate release workflows from PATs to GitHub App token

### DIFF
--- a/.github/workflows/pre-release-validate.yml
+++ b/.github/workflows/pre-release-validate.yml
@@ -18,10 +18,16 @@ jobs:
   validate-release-readiness:
     name: Validate Release Readiness
     runs-on: ubuntu-latest
-    env:
-      PAT: ${{ secrets.RELEASE_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: zeroclaw-labs
 
       - name: Resolve version
         id: version
@@ -39,9 +45,7 @@ jobs:
       - name: Check required secrets exist
         shell: bash
         env:
-          CHECK_PAT: ${{ secrets.RELEASE_TOKEN }}
-          HOMEBREW_CORE_BOT_TOKEN: ${{ secrets.HOMEBREW_CORE_BOT_TOKEN }}
-          HOMEBREW_UPSTREAM_PR_TOKEN: ${{ secrets.HOMEBREW_UPSTREAM_PR_TOKEN }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
           AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
           HOMEBREW_CORE_BOT_FORK_REPO: ${{ vars.HOMEBREW_CORE_BOT_FORK_REPO }}
         run: |
@@ -62,19 +66,8 @@ jobs:
           }
 
           echo "=== Required Secrets ==="
-          check_secret "PAT" "$CHECK_PAT"
+          check_secret "RELEASE_APP_PRIVATE_KEY (via app token)" "$APP_TOKEN"
           check_secret "AUR_SSH_KEY" "$AUR_SSH_KEY"
-
-          echo ""
-          echo "=== Homebrew Secrets (at least one required) ==="
-          if [[ -n "$HOMEBREW_UPSTREAM_PR_TOKEN" ]]; then
-            echo "OK: HOMEBREW_UPSTREAM_PR_TOKEN is configured"
-          elif [[ -n "$HOMEBREW_CORE_BOT_TOKEN" ]]; then
-            echo "OK: HOMEBREW_CORE_BOT_TOKEN is configured"
-          else
-            echo "::error::Neither HOMEBREW_UPSTREAM_PR_TOKEN nor HOMEBREW_CORE_BOT_TOKEN is set"
-            failed=1
-          fi
 
           echo ""
           echo "=== Repository Variables ==="
@@ -86,43 +79,28 @@ jobs:
             exit 1
           fi
 
-      - name: Check PAT access to downstream repos
-        if: env.PAT != ''
+      - name: Check App token access to downstream repos
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          WEBSITE_PAT: ${{ secrets.WEBSITE_REPO_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           failed=0
 
           check_repo_access() {
             local repo="$1"
             if gh api "repos/$repo" --jq '.permissions.push' 2>/dev/null | grep -q true; then
-              echo "OK: RELEASE_TOKEN has write access to $repo"
+              echo "OK: App token has write access to $repo"
             else
-              echo "::error::RELEASE_TOKEN cannot write to $repo"
+              echo "::error::App token cannot write to $repo"
               failed=1
             fi
           }
 
-          echo "=== Downstream Repository Access (RELEASE_TOKEN) ==="
+          echo "=== Downstream Repository Access ==="
           check_repo_access "zeroclaw-labs/dokploy"
           check_repo_access "zeroclaw-labs/easypanel"
           check_repo_access "zeroclaw-labs/coolify"
-
-          echo ""
-          echo "=== Website Access (WEBSITE_REPO_PAT) ==="
-          if [[ -n "$WEBSITE_PAT" ]]; then
-            if GH_TOKEN="$WEBSITE_PAT" gh api "repos/zeroclaw-labs/zeroclaw-website" --jq '.permissions.push' 2>/dev/null | grep -q true; then
-              echo "OK: WEBSITE_REPO_PAT has write access to zeroclaw-labs/zeroclaw-website"
-            else
-              echo "::error::WEBSITE_REPO_PAT cannot write to zeroclaw-labs/zeroclaw-website"
-              failed=1
-            fi
-          else
-            echo "::error::WEBSITE_REPO_PAT secret is missing"
-            failed=1
-          fi
+          check_repo_access "zeroclaw-labs/zeroclaw-website"
 
           echo ""
           echo "=== Homebrew Fork Access ==="
@@ -135,7 +113,7 @@ jobs:
 
           if [[ $failed -ne 0 ]]; then
             echo ""
-            echo "::error::One or more tokens lack required access. Check repo Settings > Secrets."
+            echo "::error::One or more tokens lack required access. Ensure the GitHub App is installed on all repos."
             exit 1
           fi
 
@@ -182,7 +160,7 @@ jobs:
             echo ""
             echo "| Check | Status |"
             echo "|---|---|"
-            echo "| Required secrets | Passed |"
+            echo "| GitHub App token | Passed |"
             echo "| Downstream repo access | Passed |"
             echo "| Version consistency | Passed |"
             echo ""

--- a/.github/workflows/pub-homebrew-core.yml
+++ b/.github/workflows/pub-homebrew-core.yml
@@ -13,9 +13,7 @@ on:
         default: false
         type: boolean
     secrets:
-      HOMEBREW_UPSTREAM_PR_TOKEN:
-        required: false
-      HOMEBREW_CORE_BOT_TOKEN:
+      RELEASE_APP_PRIVATE_KEY:
         required: false
   workflow_dispatch:
     inputs:
@@ -48,6 +46,14 @@ jobs:
       BOT_FORK_REPO: ${{ vars.HOMEBREW_CORE_BOT_FORK_REPO }}
       BOT_EMAIL: ${{ vars.HOMEBREW_CORE_BOT_EMAIL }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: zeroclaw-labs
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -101,8 +107,7 @@ jobs:
         id: patch_formula
         shell: bash
         env:
-          HOMEBREW_CORE_BOT_TOKEN: ${{ secrets.HOMEBREW_UPSTREAM_PR_TOKEN || secrets.HOMEBREW_CORE_BOT_TOKEN }}
-          GH_TOKEN: ${{ secrets.HOMEBREW_UPSTREAM_PR_TOKEN || secrets.HOMEBREW_CORE_BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARBALL_URL: ${{ steps.release_meta.outputs.tarball_url }}
           TARBALL_SHA: ${{ steps.release_meta.outputs.tarball_sha }}
         run: |
@@ -118,16 +123,12 @@ jobs:
               echo "::error::Repository variable HOMEBREW_CORE_BOT_FORK_REPO is required when dry_run=false."
               exit 1
             fi
-            if [[ -z "${HOMEBREW_CORE_BOT_TOKEN}" ]]; then
-              echo "::error::Repository secret HOMEBREW_CORE_BOT_TOKEN is required when dry_run=false."
-              exit 1
-            fi
             if [[ "$BOT_FORK_REPO" != */* ]]; then
               echo "::error::HOMEBREW_CORE_BOT_FORK_REPO must be in owner/repo format."
               exit 1
             fi
             if ! gh api "repos/${BOT_FORK_REPO}" >/dev/null 2>&1; then
-              echo "::error::HOMEBREW_CORE_BOT_TOKEN cannot access ${BOT_FORK_REPO}."
+              echo "::error::App token cannot access ${BOT_FORK_REPO}."
               exit 1
             fi
             gh repo clone "${BOT_FORK_REPO}" "$tmp_repo/homebrew-core" -- --depth=1
@@ -192,7 +193,7 @@ jobs:
         if: inputs.dry_run == false
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_UPSTREAM_PR_TOKEN || secrets.HOMEBREW_CORE_BOT_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TMP_REPO: ${{ steps.patch_formula.outputs.tmp_repo }}
           BRANCH_NAME: ${{ steps.patch_formula.outputs.branch_name }}
           TAG_VERSION: ${{ steps.release_meta.outputs.tag_version }}

--- a/.github/workflows/pub-scoop.yml
+++ b/.github/workflows/pub-scoop.yml
@@ -13,7 +13,7 @@ on:
         default: false
         type: boolean
     secrets:
-      SCOOP_BUCKET_TOKEN:
+      RELEASE_APP_PRIVATE_KEY:
         required: false
   workflow_dispatch:
     inputs:
@@ -43,6 +43,14 @@ jobs:
       DRY_RUN: ${{ inputs.dry_run }}
       SCOOP_BUCKET_REPO: ${{ vars.SCOOP_BUCKET_REPO }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: zeroclaw-labs
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -137,7 +145,7 @@ jobs:
         if: inputs.dry_run == false
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           MANIFEST_FILE: ${{ steps.manifest.outputs.manifest_file }}
           VERSION: ${{ steps.meta.outputs.version }}
         run: |

--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -422,9 +422,17 @@ jobs:
           NOTES: ${{ needs.release-notes.outputs.notes }}
         run: printf '%s\n' "$NOTES" > release-notes.md
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: zeroclaw-labs
+
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ needs.version.outputs.tag }}
         run: |
           gh release create "$TAG" release-assets/* \
@@ -438,15 +446,22 @@ jobs:
     needs: [publish]
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: zeroclaw-labs
+          repositories: zeroclaw-website
+
       - name: Trigger website redeploy
         env:
-          PAT: ${{ secrets.WEBSITE_REPO_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          curl -fsSL -X POST \
-            -H "Authorization: token $PAT" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/zeroclaw-labs/zeroclaw-website/dispatches \
-            -d '{"event_type":"new-release","client_payload":{"install_script_url":"https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh"}}'
+          gh api repos/zeroclaw-labs/zeroclaw-website/dispatches \
+            -f event_type=new-release \
+            -f 'client_payload[install_script_url]=https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh'
 
   docker:
     name: Push Docker Image

--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -460,8 +460,11 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh api repos/zeroclaw-labs/zeroclaw-website/dispatches \
+            --method POST \
             -f event_type=new-release \
-            -f 'client_payload[install_script_url]=https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh'
+            -f 'client_payload[install_script_url]=https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh' \
+            && echo "Website redeploy triggered." \
+            || echo "::warning::Could not trigger website redeploy. Ensure the GitHub App is installed on zeroclaw-website."
 
   docker:
     name: Push Docker Image

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -378,9 +378,17 @@ jobs:
       name: github-releases
       url: https://github.com/${{ github.repository }}/releases/tag/${{ needs.validate.outputs.tag }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: zeroclaw-labs
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -439,13 +447,12 @@ jobs:
 
       - name: Create tag and release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ needs.validate.outputs.tag }}
           EVENT_NAME: ${{ github.event_name }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
-          # For manual dispatch, use --target to create tag + release atomically
-          # via RELEASE_TOKEN (admin PAT) which bypasses tag protection rules.
+          # For manual dispatch, use --target to create tag + release atomically.
           # For tag push, the tag already exists — just create the release.
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             gh release create "$TAG" release-assets/* \
@@ -481,15 +488,22 @@ jobs:
     needs: [publish]
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: zeroclaw-labs
+          repositories: zeroclaw-website
+
       - name: Trigger website redeploy
         env:
-          PAT: ${{ secrets.WEBSITE_REPO_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          curl -fsSL -X POST \
-            -H "Authorization: token $PAT" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/zeroclaw-labs/zeroclaw-website/dispatches \
-            -d '{"event_type":"new-release","client_payload":{"install_script_url":"https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh"}}'
+          gh api repos/zeroclaw-labs/zeroclaw-website/dispatches \
+            -f event_type=new-release \
+            -f 'client_payload[install_script_url]=https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh'
 
   docker:
     name: Push Docker Image

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -387,8 +387,6 @@ jobs:
           owner: zeroclaw-labs
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -471,14 +469,19 @@ jobs:
 
       - name: Remove CHANGELOG-next.md after stable release
         shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ needs.validate.outputs.tag }}
         run: |
           if [ -f "CHANGELOG-next.md" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git rm CHANGELOG-next.md
-            git commit -m "chore: remove CHANGELOG-next.md after ${{ needs.validate.outputs.tag }} release"
-            git push origin HEAD:master
-            echo "CHANGELOG-next.md removed and committed."
+            sha=$(gh api "repos/$GITHUB_REPOSITORY/contents/CHANGELOG-next.md" --jq '.sha')
+            gh api "repos/$GITHUB_REPOSITORY/contents/CHANGELOG-next.md" \
+              --method DELETE \
+              --field message="chore: remove CHANGELOG-next.md after $TAG release" \
+              --field branch=master \
+              --field sha="$sha" \
+              && echo "CHANGELOG-next.md removed." \
+              || echo "::warning::Could not remove CHANGELOG-next.md — clean up manually."
           else
             echo "No CHANGELOG-next.md to clean up."
           fi
@@ -502,8 +505,11 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh api repos/zeroclaw-labs/zeroclaw-website/dispatches \
+            --method POST \
             -f event_type=new-release \
-            -f 'client_payload[install_script_url]=https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh'
+            -f 'client_payload[install_script_url]=https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh' \
+            && echo "Website redeploy triggered." \
+            || echo "::warning::Could not trigger website redeploy. Ensure the GitHub App is installed on zeroclaw-website."
 
   docker:
     name: Push Docker Image

--- a/.github/workflows/sync-marketplace-templates.yml
+++ b/.github/workflows/sync-marketplace-templates.yml
@@ -24,6 +24,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: zeroclaw-labs
+          repositories: coolify
+
       - name: Derive version
         id: ver
         run: |
@@ -35,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: zeroclaw-labs/coolify
-          token: ${{ secrets.MARKETPLACE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: next
           path: coolify
 
@@ -94,7 +103,7 @@ jobs:
       - name: Create PR
         working-directory: coolify
         env:
-          GH_TOKEN: ${{ secrets.MARKETPLACE_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
           BRANCH="zeroclaw/update-v${VERSION}"
@@ -134,6 +143,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: zeroclaw-labs
+          repositories: dokploy
+
       - name: Derive version
         id: ver
         run: |
@@ -145,7 +163,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: zeroclaw-labs/dokploy
-          token: ${{ secrets.MARKETPLACE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: main
           path: templates
 
@@ -242,7 +260,7 @@ jobs:
       - name: Create PR
         working-directory: templates
         env:
-          GH_TOKEN: ${{ secrets.MARKETPLACE_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
           BRANCH="zeroclaw/update-v${VERSION}"
@@ -287,6 +305,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: zeroclaw-labs
+          repositories: easypanel
+
       - name: Derive version
         id: ver
         run: |
@@ -298,7 +325,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: zeroclaw-labs/easypanel
-          token: ${{ secrets.MARKETPLACE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: main
           path: easypanel
 
@@ -475,7 +502,7 @@ jobs:
       - name: Create PR
         working-directory: easypanel
         env:
-          GH_TOKEN: ${{ secrets.MARKETPLACE_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
           BRANCH="zeroclaw/update-v${VERSION}"


### PR DESCRIPTION
## Summary
- Replaces 6 personal access tokens (`RELEASE_TOKEN`, `WEBSITE_REPO_PAT`, `MARKETPLACE_PAT`, `HOMEBREW_UPSTREAM_PR_TOKEN`, `HOMEBREW_CORE_BOT_TOKEN`, `SCOOP_BUCKET_TOKEN`) with a single GitHub App using `actions/create-github-app-token`
- Tokens are now short-lived, scoped per-run, and not tied to any individual's account
- All contributors who can trigger release workflows get the same access without needing personal PATs

## Workflows Updated
| Workflow | Old Secrets | New |
|---|---|---|
| `release-stable-manual.yml` | `RELEASE_TOKEN`, `WEBSITE_REPO_PAT` | App token |
| `release-beta-on-push.yml` | `RELEASE_TOKEN`, `WEBSITE_REPO_PAT` | App token |
| `sync-marketplace-templates.yml` | `MARKETPLACE_PAT` | App token |
| `pub-homebrew-core.yml` | `HOMEBREW_UPSTREAM_PR_TOKEN`, `HOMEBREW_CORE_BOT_TOKEN` | App token |
| `pub-scoop.yml` | `SCOOP_BUCKET_TOKEN` | App token |
| `pre-release-validate.yml` | `RELEASE_TOKEN`, `WEBSITE_REPO_PAT` | App token |

## Secrets NOT changed (external services, can't use GitHub App)
- `AUR_SSH_KEY` — SSH key for AUR
- `CARGO_REGISTRY_TOKEN` — crates.io
- `TWITTER_*` — Twitter/X API
- `DISCORD_WEBHOOK_URL` — Discord

## Setup Required Before Merging
1. **Create GitHub App** in [zeroclaw-labs org settings](https://github.com/organizations/zeroclaw-labs/settings/apps/new):
   - Name: `ZeroClaw Release Bot` (or similar)
   - Permissions: `Contents: Read & Write`, `Pull requests: Read & Write`
   - No webhook URL needed
2. **Install the app** on these repos: `zeroclaw`, `zeroclaw-website`, `coolify`, `dokploy`, `easypanel`, homebrew-core fork, scoop bucket
3. **Add repo config**:
   - Variable `RELEASE_APP_ID` → the App ID from step 1
   - Secret `RELEASE_APP_PRIVATE_KEY` → generate and download a private key from the app settings
4. **After merge**, remove old secrets: `RELEASE_TOKEN`, `WEBSITE_REPO_PAT`, `MARKETPLACE_PAT`, `HOMEBREW_UPSTREAM_PR_TOKEN`, `HOMEBREW_CORE_BOT_TOKEN`, `SCOOP_BUCKET_TOKEN`

## Test plan
- [ ] Create GitHub App and install on all repos
- [ ] Add `RELEASE_APP_ID` variable and `RELEASE_APP_PRIVATE_KEY` secret
- [ ] Run `pre-release-validate.yml` manually to verify token access
- [ ] Trigger a beta release to verify end-to-end flow
- [ ] Remove old PAT secrets after confirming everything works