### PR TITLE
fix: remove PAT dependency from release workflows

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -424,7 +424,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.version.outputs.tag }}
         run: |
           gh release create "$TAG" release-assets/* \
@@ -440,13 +440,14 @@ jobs:
     steps:
       - name: Trigger website redeploy
         env:
-          PAT: ${{ secrets.WEBSITE_REPO_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -fsSL -X POST \
-            -H "Authorization: token $PAT" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/zeroclaw-labs/zeroclaw-website/dispatches \
-            -d '{"event_type":"new-release","client_payload":{"install_script_url":"https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh"}}'
+          gh api repos/zeroclaw-labs/zeroclaw-website/dispatches \
+            --method POST \
+            --field event_type=new-release \
+            -f 'client_payload[install_script_url]=https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh' \
+            && echo "Website redeploy triggered." \
+            || echo "::warning::Could not trigger website redeploy. Trigger manually or use a GitHub App for cross-repo access."
 
   docker:
     name: Push Docker Image

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -379,8 +379,6 @@ jobs:
       url: https://github.com/${{ github.repository }}/releases/tag/${{ needs.validate.outputs.tag }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          token: ${{ secrets.RELEASE_TOKEN }}
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -439,14 +437,14 @@ jobs:
 
       - name: Create tag and release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.validate.outputs.tag }}
           EVENT_NAME: ${{ github.event_name }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
-          # For manual dispatch, use --target to create tag + release atomically
-          # via RELEASE_TOKEN (admin PAT) which bypasses tag protection rules.
-          # For tag push, the tag already exists — just create the release.
+          # Tag must be pushed before triggering this workflow.
+          # GITHUB_TOKEN has contents:write permission, which is sufficient
+          # to create releases. No personal access token needed.
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             gh release create "$TAG" release-assets/* \
               --repo "$GITHUB_REPOSITORY" \
@@ -464,14 +462,18 @@ jobs:
 
       - name: Remove CHANGELOG-next.md after stable release
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.validate.outputs.tag }}
         run: |
           if [ -f "CHANGELOG-next.md" ]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git rm CHANGELOG-next.md
-            git commit -m "chore: remove CHANGELOG-next.md after ${{ needs.validate.outputs.tag }} release"
-            git push origin HEAD:master
-            echo "CHANGELOG-next.md removed and committed."
+            gh api repos/"$GITHUB_REPOSITORY"/contents/CHANGELOG-next.md \
+              --method DELETE \
+              --field message="chore: remove CHANGELOG-next.md after $TAG release" \
+              --field branch=master \
+              --field sha="$(gh api repos/"$GITHUB_REPOSITORY"/contents/CHANGELOG-next.md --jq '.sha')" \
+              && echo "CHANGELOG-next.md removed via API." \
+              || echo "::warning::Could not remove CHANGELOG-next.md — clean up manually."
           else
             echo "No CHANGELOG-next.md to clean up."
           fi
@@ -483,13 +485,14 @@ jobs:
     steps:
       - name: Trigger website redeploy
         env:
-          PAT: ${{ secrets.WEBSITE_REPO_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          curl -fsSL -X POST \
-            -H "Authorization: token $PAT" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/zeroclaw-labs/zeroclaw-website/dispatches \
-            -d '{"event_type":"new-release","client_payload":{"install_script_url":"https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh"}}'
+          gh api repos/zeroclaw-labs/zeroclaw-website/dispatches \
+            --method POST \
+            --field event_type=new-release \
+            -f 'client_payload[install_script_url]=https://raw.githubusercontent.com/zeroclaw-labs/zeroclaw/master/install.sh' \
+            && echo "Website redeploy triggered." \
+            || echo "::warning::Could not trigger website redeploy. GITHUB_TOKEN may lack cross-repo access. Trigger manually or use a GitHub App."
 
   docker:
     name: Push Docker Image


### PR DESCRIPTION
## Summary

- Replaces `RELEASE_TOKEN` (personal access token) with `GITHUB_TOKEN` in both stable and beta release workflows
- Any maintainer or admin with push access can now trigger releases — no personal tokens needed
- CHANGELOG-next.md cleanup uses GitHub API instead of `git push` (works with GITHUB_TOKEN)
- Website redeploy switched to `gh api` with graceful fallback if cross-repo access isn't available

## What changed

| Component | Before | After |
|-----------|--------|-------|
| Create release | `RELEASE_TOKEN` (PAT) | `GITHUB_TOKEN` (built-in) |
| CHANGELOG cleanup | `git push` with PAT | GitHub Contents API |
| Website redeploy | `WEBSITE_REPO_PAT` | `GITHUB_TOKEN` with warning fallback |

## Prerequisites

- **Tag must be pushed before triggering `workflow_dispatch`** — `GITHUB_TOKEN` can create releases but cannot push tags past org-level restrictions
- For tag-push triggered releases (`on: push: tags:`), no change needed — tag already exists

## What still needs a token

- **Marketplace sync** (coolify, dokploy, easypanel) — requires cross-repo write access. Use `MARKETPLACE_PAT` or the GitHub App from PR #5881
- **Website redeploy** — will warn if `GITHUB_TOKEN` lacks cross-repo access

## Test plan

- [ ] Push a tag and verify Release Stable triggers and publishes successfully
- [ ] Verify CHANGELOG-next.md is removed after release
- [ ] Verify website redeploy triggers (or gracefully warns)
- [ ] Test beta release on push to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)