### PR TITLE
chore: bump version to 0.7.3 and update release changelog

### DIFF
--- a/CHANGELOG-next.md
+++ b/CHANGELOG-next.md
@@ -1,4 +1,4 @@
-# Changelog — v0.6.9 → v0.7.1
+# Changelog — v0.6.9 → v0.7.3
 
 > Changes since the **v0.6.9** stable release. This release represents the largest
 > structural overhaul in ZeroClaw's history: the entire codebase has been split into a
@@ -173,6 +173,12 @@
 - `rustls-webpki` and `rumqttc` bumped to resolve RUSTSEC-2026-0098 and
   RUSTSEC-2026-0099 (#5786).
 
+### Deployment
+
+- Sample Kubernetes and OpenShift deployment manifests added in `deploy-k8s/` with
+  hardened security context (`runAsNonRoot`, `readOnlyRootFilesystem`, `drop ALL` caps,
+  `seccompProfile: RuntimeDefault`) and pairing auth enabled by default (#5880).
+
 ---
 
 ## Bug Fixes (summary)
@@ -199,6 +205,8 @@
 | Install | install.sh broken after workspace split |
 | Runtime | Windows console window visible in background mode |
 | Distribution | Web dashboard missing from AUR and cargo install builds |
+| Docker | Workspace crate manifests missing from multi-stage build after workspace split (#5879) |
+| Agent | Streamed reasoning content lost during tool replay (#5606) |
 | Web | Theme mode switch not applying light/dark correctly |
 | Web | Theme mode selector missing visual preview swatches |
 
@@ -257,9 +265,11 @@ Thank you to everyone who contributed to this release:
 - @nayrosk
 - @niedbalski
 - @ninenox
+- @pavelanni
 - @singlerider
 - @theonlyhennygod
 - @titulus
+- @tompro
 - @UtopiaX
 - @vernonstinebaker
 - @WareWolf-MoonWall

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11663,7 +11663,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-api"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11679,7 +11679,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-channels"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -11746,7 +11746,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-config"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "chacha20poly1305",
@@ -11804,7 +11804,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-gateway"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11850,7 +11850,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-hardware"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "aardvark-sys",
  "anyhow",
@@ -11878,7 +11878,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-infra"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -11895,7 +11895,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-macros"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11904,7 +11904,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-memory"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11926,7 +11926,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-plugins"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11944,7 +11944,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-providers"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12001,7 +12001,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-runtime"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "aardvark-sys",
  "anyhow",
@@ -12080,7 +12080,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-tool-call-parser"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "regex",
  "serde",
@@ -12090,7 +12090,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-tools"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12133,7 +12133,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclaw-tui"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -12148,7 +12148,7 @@ dependencies = [
 
 [[package]]
 name = "zeroclawlabs"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "aardvark-sys",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,27 +3,27 @@ members = [".", "crates/zeroclaw-api", "crates/zeroclaw-infra", "crates/zeroclaw
 resolver = "2"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zeroclaw-labs/zeroclaw"
 rust-version = "1.87"
 
 [workspace.dependencies]
-zeroclaw-api = { path = "crates/zeroclaw-api", version = "0.7.1" }
-zeroclaw-infra = { path = "crates/zeroclaw-infra", version = "0.7.1" }
-zeroclaw-config = { path = "crates/zeroclaw-config", version = "0.7.1", default-features = false }
-zeroclaw-providers = { path = "crates/zeroclaw-providers", version = "0.7.1" }
-zeroclaw-memory = { path = "crates/zeroclaw-memory", version = "0.7.1" }
-zeroclaw-channels = { path = "crates/zeroclaw-channels", version = "0.7.1", default-features = false }
-zeroclaw-tools = { path = "crates/zeroclaw-tools", version = "0.7.1" }
-zeroclaw-runtime = { path = "crates/zeroclaw-runtime", version = "0.7.1", default-features = false }
-zeroclaw-tui = { path = "crates/zeroclaw-tui", version = "0.7.1" }
-zeroclaw-plugins = { path = "crates/zeroclaw-plugins", version = "0.7.1" }
-zeroclaw-gateway = { path = "crates/zeroclaw-gateway", version = "0.7.1" }
-zeroclaw-hardware = { path = "crates/zeroclaw-hardware", version = "0.7.1" }
-zeroclaw-tool-call-parser = { path = "crates/zeroclaw-tool-call-parser", version = "0.7.1" }
-zeroclaw-macros = { path = "crates/zeroclaw-macros", version = "0.7.1" }
+zeroclaw-api = { path = "crates/zeroclaw-api", version = "0.7.3" }
+zeroclaw-infra = { path = "crates/zeroclaw-infra", version = "0.7.3" }
+zeroclaw-config = { path = "crates/zeroclaw-config", version = "0.7.3", default-features = false }
+zeroclaw-providers = { path = "crates/zeroclaw-providers", version = "0.7.3" }
+zeroclaw-memory = { path = "crates/zeroclaw-memory", version = "0.7.3" }
+zeroclaw-channels = { path = "crates/zeroclaw-channels", version = "0.7.3", default-features = false }
+zeroclaw-tools = { path = "crates/zeroclaw-tools", version = "0.7.3" }
+zeroclaw-runtime = { path = "crates/zeroclaw-runtime", version = "0.7.3", default-features = false }
+zeroclaw-tui = { path = "crates/zeroclaw-tui", version = "0.7.3" }
+zeroclaw-plugins = { path = "crates/zeroclaw-plugins", version = "0.7.3" }
+zeroclaw-gateway = { path = "crates/zeroclaw-gateway", version = "0.7.3" }
+zeroclaw-hardware = { path = "crates/zeroclaw-hardware", version = "0.7.3" }
+zeroclaw-tool-call-parser = { path = "crates/zeroclaw-tool-call-parser", version = "0.7.3" }
+zeroclaw-macros = { path = "crates/zeroclaw-macros", version = "0.7.3" }
 aardvark-sys = { path = "crates/aardvark-sys", version = "0.1.0" }
 
 [package]


### PR DESCRIPTION
## Summary

- Bump `[workspace.package].version` and all `[workspace.dependencies]` internal crate references from `0.7.1` → `0.7.3`
- Update `Cargo.lock` to match
- Update `CHANGELOG-next.md`: retitle to `v0.6.9 → v0.7.3`, add Deployment section (feat #5880), two Bug Fix rows (fix #5879, fix #5606), two new contributors

- **Scope boundary:** version and changelog files only — no source changes
- **Blast radius:** none; purely mechanical bump
- **Linked issues:** Closes #5877, Closes #5878

## Validation Evidence (required)

- **Commands run:** `grep -c 'version = "0.7.3"' Cargo.toml` → 15 ✅ · `grep -c 'version = "0.7.1"' Cargo.toml` → 0 ✅
- **Beyond CI:** version bump is mechanical; Cargo.lock internal-crate entries confirmed updated, no external dependencies altered
- **Skipped:** `cargo test` — no source changes; CI will confirm build integrity

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes — version bump only
- Config / env / CLI surface changed? No

## Rollback (required)

Low-risk. `git revert` restores `0.7.1` across all three files.

## i18n Follow-Through

- Locale navigation parity updated? N/A — changelog is English-only release artifact