### PR TITLE
fix(ci): replace RELEASE_TOKEN with GITHUB_TOKEN in release workflows

### DIFF
--- a/.github/workflows/release-beta-on-push.yml
+++ b/.github/workflows/release-beta-on-push.yml
@@ -424,7 +424,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.version.outputs.tag }}
         run: |
           gh release create "$TAG" release-assets/* \

--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -380,7 +380,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -439,14 +439,16 @@ jobs:
 
       - name: Create tag and release
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.validate.outputs.tag }}
           EVENT_NAME: ${{ github.event_name }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
-          # For manual dispatch, use --target to create tag + release atomically
-          # via RELEASE_TOKEN (admin PAT) which bypasses tag protection rules.
+          # For manual dispatch, use --target to create tag + release atomically.
           # For tag push, the tag already exists — just create the release.
+          # GITHUB_TOKEN with contents:write is sufficient for both paths.
+          # Note: workflow_dispatch requires github-actions[bot] to be on the
+          # tag protection allowlist if v* tags are protected.
           if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             gh release create "$TAG" release-assets/* \
               --repo "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
## Summary

Replaces `RELEASE_TOKEN` (PAT) with the built-in `GITHUB_TOKEN` in both release workflows. The workflow already declares `permissions: contents: write` at the top level — `GITHUB_TOKEN` is sufficient for `gh release create` and the post-release `git push` cleanup step.

Root cause of every release failure since v0.7.1: `RELEASE_TOKEN` returned HTTP 403.

## Changes
- `release-stable-manual.yml`: 2 occurrences replaced
- `release-beta-on-push.yml`: 1 occurrence replaced
- Stale PAT comment removed

## One-time repo settings change required
Add `github-actions[bot]` to the branch protection bypass list on `master` so the post-release CHANGELOG cleanup push succeeds.

## Note on `workflow_dispatch`
If `v*` tags are protected, `github-actions[bot]` must also be on the tag protection allowlist for the manual dispatch path to create tags. The tag-push path is unaffected.

## Blast radius
Release pipeline only. No runtime changes.

## Risk / Size
- risk: low
- size: XS

Supersedes #5881 (closed).