### PR TITLE
feat(infra): add clear_messages to SessionBackend trait for O(1) session reset

### DIFF
--- a/crates/zeroclaw-infra/src/session_backend.rs
+++ b/crates/zeroclaw-infra/src/session_backend.rs
@@ -1,8 +1,8 @@
 //! Trait abstraction for session persistence backends.
 //!
 //! Backends store per-sender conversation histories. The trait is intentionally
-//! minimal — load, append, remove_last, list — so that JSONL and SQLite (and
-//! future backends) share a common interface.
+//! minimal — load, append, remove_last, clear_messages, list — so that JSONL
+//! and SQLite (and future backends) share a common interface.
 
 use chrono::{DateTime, Utc};
 use zeroclaw_api::provider::ChatMessage;
@@ -92,6 +92,17 @@ pub trait SessionBackend: Send + Sync {
     /// Search sessions by keyword. Default returns empty (backends with FTS override).
     fn search(&self, _query: &SessionQuery) -> Vec<SessionMetadata> {
         Vec::new()
+    }
+
+    /// Clear all messages from a session, keeping the session itself alive.
+    /// Returns the number of messages removed. Backends should override for
+    /// O(1) bulk clearing; the default falls back to iterative `remove_last`.
+    fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
+        let count = self.load(session_key).len();
+        for _ in 0..count {
+            self.remove_last(session_key)?;
+        }
+        Ok(count)
     }
 
     /// Delete all messages for a session. Returns `true` if the session existed.

--- a/crates/zeroclaw-infra/src/session_backend.rs
+++ b/crates/zeroclaw-infra/src/session_backend.rs
@@ -98,9 +98,9 @@ pub trait SessionBackend: Send + Sync {
     /// Returns the number of messages removed. Backends should override for
     /// O(1) bulk clearing; the default falls back to iterative `remove_last`.
     fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
-        let count = self.load(session_key).len();
-        for _ in 0..count {
-            self.remove_last(session_key)?;
+        let mut count = 0;
+        while self.remove_last(session_key)? {
+            count += 1;
         }
         Ok(count)
     }

--- a/crates/zeroclaw-infra/src/session_backend.rs
+++ b/crates/zeroclaw-infra/src/session_backend.rs
@@ -95,8 +95,11 @@ pub trait SessionBackend: Send + Sync {
     }
 
     /// Clear all messages from a session, keeping the session itself alive.
-    /// Returns the number of messages removed. Backends should override for
-    /// O(1) bulk clearing; the default falls back to iterative `remove_last`.
+    /// Returns the number of messages removed.
+    ///
+    /// Override for production use. The default is O(n²) via iterative
+    /// `remove_last` — acceptable for tests but may cause latency on
+    /// sessions with >100 messages.
     fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
         let mut count = 0;
         while self.remove_last(session_key)? {

--- a/crates/zeroclaw-infra/src/session_sqlite.rs
+++ b/crates/zeroclaw-infra/src/session_sqlite.rs
@@ -361,6 +361,38 @@ impl SessionBackend for SqliteSessionBackend {
         Ok(count)
     }
 
+    fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
+        let conn = self.conn.lock();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE session_key = ?1",
+                params![session_key],
+                |row| row.get(0),
+            )
+            .unwrap_or(0);
+
+        if count == 0 {
+            return Ok(0);
+        }
+
+        conn.execute(
+            "DELETE FROM sessions WHERE session_key = ?1",
+            params![session_key],
+        )
+        .map_err(std::io::Error::other)?;
+
+        // Keep metadata row alive but reset message count
+        conn.execute(
+            "UPDATE session_metadata SET message_count = 0, last_activity = ?1 WHERE session_key = ?2",
+            params![Utc::now().to_rfc3339(), session_key],
+        )
+        .map_err(std::io::Error::other)?;
+
+        #[allow(clippy::cast_sign_loss)]
+        Ok(count as usize)
+    }
+
     fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
         let conn = self.conn.lock();
 
@@ -763,6 +795,62 @@ mod tests {
         let sessions = backend.list_sessions();
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0], "new_session");
+    }
+
+    #[test]
+    fn clear_messages_removes_rows_keeps_metadata() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        backend.append("s1", &ChatMessage::user("hello")).unwrap();
+        backend.append("s1", &ChatMessage::assistant("hi")).unwrap();
+        backend.set_session_name("s1", "My Session").unwrap();
+
+        let cleared = backend.clear_messages("s1").unwrap();
+        assert_eq!(cleared, 2);
+        assert!(backend.load("s1").is_empty());
+        // Session still exists in metadata with name preserved
+        let meta = backend.list_sessions_with_metadata();
+        assert_eq!(meta.len(), 1);
+        assert_eq!(meta[0].message_count, 0);
+        assert_eq!(meta[0].name.as_deref(), Some("My Session"));
+    }
+
+    #[test]
+    fn clear_messages_empty_returns_zero() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+        assert_eq!(backend.clear_messages("nonexistent").unwrap(), 0);
+    }
+
+    #[test]
+    fn clear_messages_does_not_affect_other_sessions() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        backend.append("s1", &ChatMessage::user("hello")).unwrap();
+        backend.append("s2", &ChatMessage::user("world")).unwrap();
+
+        backend.clear_messages("s1").unwrap();
+        assert!(backend.load("s1").is_empty());
+        assert_eq!(backend.load("s2").len(), 1);
+    }
+
+    #[test]
+    fn clear_messages_then_append_works() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        backend.append("s1", &ChatMessage::user("old")).unwrap();
+        backend.clear_messages("s1").unwrap();
+        backend.append("s1", &ChatMessage::user("new")).unwrap();
+
+        let messages = backend.load("s1");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].content, "new");
+        // Metadata count should reflect the new message
+        let meta = backend.list_sessions_with_metadata();
+        assert_eq!(meta[0].message_count, 1);
     }
 
     #[test]

--- a/crates/zeroclaw-infra/src/session_sqlite.rs
+++ b/crates/zeroclaw-infra/src/session_sqlite.rs
@@ -364,33 +364,23 @@ impl SessionBackend for SqliteSessionBackend {
     fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
         let conn = self.conn.lock();
 
-        let count: i64 = conn
-            .query_row(
-                "SELECT COUNT(*) FROM sessions WHERE session_key = ?1",
-                params![session_key],
-                |row| row.get(0),
-            )
-            .unwrap_or(0);
-
-        if count == 0 {
-            return Ok(0);
-        }
-
         conn.execute(
             "DELETE FROM sessions WHERE session_key = ?1",
             params![session_key],
         )
         .map_err(std::io::Error::other)?;
 
-        // Keep metadata row alive but reset message count
-        conn.execute(
-            "UPDATE session_metadata SET message_count = 0, last_activity = ?1 WHERE session_key = ?2",
-            params![Utc::now().to_rfc3339(), session_key],
-        )
-        .map_err(std::io::Error::other)?;
+        let count = conn.changes() as usize;
 
-        #[allow(clippy::cast_sign_loss)]
-        Ok(count as usize)
+        if count > 0 {
+            conn.execute(
+                "UPDATE session_metadata SET message_count = 0, last_activity = ?1 WHERE session_key = ?2",
+                params![Utc::now().to_rfc3339(), session_key],
+            )
+            .map_err(std::io::Error::other)?;
+        }
+
+        Ok(count)
     }
 
     fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {

--- a/crates/zeroclaw-infra/src/session_store.rs
+++ b/crates/zeroclaw-infra/src/session_store.rs
@@ -110,6 +110,16 @@ impl SessionStore {
         Ok(())
     }
 
+    /// Clear all messages from a session by truncating its JSONL file.
+    /// The file is preserved (empty) so the session key remains in `list_sessions`.
+    pub fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
+        let count = self.load(session_key).len();
+        if count > 0 {
+            self.rewrite(session_key, &[])?;
+        }
+        Ok(count)
+    }
+
     /// Delete a session's JSONL file. Returns `true` if the file existed.
     pub fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
         let path = self.session_path(session_key);
@@ -163,6 +173,10 @@ impl SessionBackend for SessionStore {
 
     fn compact(&self, session_key: &str) -> std::io::Result<()> {
         self.compact(session_key)
+    }
+
+    fn clear_messages(&self, session_key: &str) -> std::io::Result<usize> {
+        self.clear_messages(session_key)
     }
 
     fn delete_session(&self, session_key: &str) -> std::io::Result<bool> {
@@ -328,6 +342,59 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].content, "hello");
         assert_eq!(messages[1].content, "world");
+    }
+
+    #[test]
+    fn clear_messages_truncates_file() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+        let key = "clear_test";
+
+        store.append(key, &ChatMessage::user("hello")).unwrap();
+        store.append(key, &ChatMessage::assistant("world")).unwrap();
+
+        let cleared = store.clear_messages(key).unwrap();
+        assert_eq!(cleared, 2);
+        assert!(store.load(key).is_empty());
+        // File still exists — session key remains in list_sessions
+        assert!(store.session_path(key).exists());
+    }
+
+    #[test]
+    fn clear_messages_empty_returns_zero() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+        assert_eq!(store.clear_messages("nonexistent").unwrap(), 0);
+    }
+
+    #[test]
+    fn clear_messages_does_not_affect_other_sessions() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+
+        store
+            .append("alice", &ChatMessage::user("alice msg"))
+            .unwrap();
+        store.append("bob", &ChatMessage::user("bob msg")).unwrap();
+
+        store.clear_messages("alice").unwrap();
+        assert!(store.load("alice").is_empty());
+        assert_eq!(store.load("bob").len(), 1);
+    }
+
+    #[test]
+    fn clear_messages_then_append_works() {
+        let tmp = TempDir::new().unwrap();
+        let store = SessionStore::new(tmp.path()).unwrap();
+        let key = "reuse_test";
+
+        store.append(key, &ChatMessage::user("old")).unwrap();
+        store.clear_messages(key).unwrap();
+        store.append(key, &ChatMessage::user("new")).unwrap();
+
+        let messages = store.load(key);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].content, "new");
     }
 
     #[test]

--- a/crates/zeroclaw-tools/src/sessions.rs
+++ b/crates/zeroclaw-tools/src/sessions.rs
@@ -884,6 +884,8 @@ mod tests {
 
     /// Delegates everything except delete_session, which uses the trait
     /// default (returns Ok(false) without deleting anything).
+    /// Coupled to SessionBackend's default — if that default changes,
+    /// this wrapper's behavior changes too.
     struct NoOpDeleteBackend(Arc<dyn SessionBackend>);
 
     impl SessionBackend for NoOpDeleteBackend {

--- a/crates/zeroclaw-tools/src/sessions.rs
+++ b/crates/zeroclaw-tools/src/sessions.rs
@@ -354,34 +354,23 @@ impl Tool for SessionResetTool {
             return Ok(result);
         }
 
-        // TOCTOU: a message appended between load() and the last remove_last()
-        // will also be removed. Acceptable until clear_messages lands (#5701).
-        let messages = self.backend.load(session_id);
-        if messages.is_empty() {
-            return Ok(ToolResult {
+        match self.backend.clear_messages(session_id) {
+            Ok(0) => Ok(ToolResult {
                 success: true,
                 output: format!("Session '{session_id}' is already empty."),
                 error: None,
-            });
+            }),
+            Ok(count) => Ok(ToolResult {
+                success: true,
+                output: format!("Session '{session_id}' reset ({count} messages cleared)."),
+                error: None,
+            }),
+            Err(e) => Ok(ToolResult {
+                success: false,
+                output: String::new(),
+                error: Some(format!("Failed to reset session: {e}")),
+            }),
         }
-
-        // Remove messages one by one via remove_last until empty
-        let msg_count = messages.len();
-        for _ in 0..msg_count {
-            if let Err(e) = self.backend.remove_last(session_id) {
-                return Ok(ToolResult {
-                    success: false,
-                    output: String::new(),
-                    error: Some(format!("Failed to reset session: {e}")),
-                });
-            }
-        }
-
-        Ok(ToolResult {
-            success: true,
-            output: format!("Session '{session_id}' reset ({msg_count} messages cleared)."),
-            error: None,
-        })
     }
 }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `SessionResetTool` cleared sessions via iterative `remove_last` — O(n²) on the file backend. Added `clear_messages(session_key) -> io::Result<usize>` to `SessionBackend` with O(1) overrides for both backends (file: single rewrite, SQLite: `DELETE` + `conn.changes()`). `SessionResetTool` now calls `clear_messages` instead of the loop. Default trait impl uses `while remove_last()` loop per the #5701 proposal for backward compatibility with custom backends.
- **Scope boundary:** Does not change `delete_session`, required trait methods, config schema, or gateway.
- **Blast radius:** `zeroclaw-infra` (trait + both backends), `zeroclaw-tools` (SessionResetTool). Custom backends that don't override get the default impl — working but O(n²), same as before.
- **Linked issue(s):** Closes #5701. Related #5696 (SessionResetTool). Depends on #5696 (stacked). Related #5769 (session backend mismatch, discovered during e2e testing).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check              # ok
cargo clippy --all-targets -D warnings  # ok (0 warnings)
cargo test -p zeroclaw-infra -- session # ok (44 passed, 8 new)
cargo test -p zeroclaw-tools -- sessions # ok (30 passed)
```

- **Commands run and tail output:** All four commands green. 8 new tests across both backends: clear + verify empty, empty returns zero, isolation, clear-then-append round-trip.
- **Beyond CI — what did you manually verify?** End-to-end test via [Eyrie](https://github.com/Audacity88/eyrie) dashboard: registered `SessionResetTool` in a debug build, created a 5-message JSONL session, asked the agent to reset it via WebSocket. Tool returned "Session 'gw_e2e-jsonl-test' reset (5 messages cleared)." File preserved at 0 bytes, session key remains in `list_sessions`. SQLite e2e not verified — blocked by #5769 (tools use JSONL backend regardless of config).
- **If any command was intentionally skipped, why:** Full `cargo test` (all crates) skipped — change is scoped to `zeroclaw-infra` and `zeroclaw-tools` only, no cross-crate effects.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes — `clear_messages` has a default impl, existing `SessionBackend` impls compile unchanged.
- Config / env / CLI surface changed? No

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert` — default impl means removing the method doesn't break existing code. SessionResetTool would need one-file revert to the `remove_last` loop.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** `sessions_reset` tool returns error instead of success. Grep logs for `"Failed to reset session"`.