### PR TITLE
fix(#5719): respect runtime.kind = "native" in sandbox auto-detection

### DIFF
--- a/crates/zeroclaw-runtime/src/security/detect.rs
+++ b/crates/zeroclaw-runtime/src/security/detect.rs
@@ -4,8 +4,13 @@ use crate::security::traits::Sandbox;
 use std::sync::Arc;
 use zeroclaw_config::schema::{SandboxBackend, SecurityConfig};
 
-/// Create a sandbox based on auto-detection or explicit config
-pub fn create_sandbox(config: &SecurityConfig) -> Arc<dyn Sandbox> {
+/// Create a sandbox based on auto-detection or explicit config.
+///
+/// `runtime_kind` is the `runtime.kind` string from the top-level config
+/// (e.g. `"native"`, `"docker"`). When the caller has set `runtime.kind = "native"`,
+/// Docker must never be selected as the sandbox backend during auto-detection —
+/// the user explicitly opted out of container wrapping.
+pub fn create_sandbox(config: &SecurityConfig, runtime_kind: &str) -> Arc<dyn Sandbox> {
     let backend = &config.sandbox.backend;
 
     // If explicitly disabled, return noop
@@ -77,14 +82,20 @@ pub fn create_sandbox(config: &SecurityConfig) -> Arc<dyn Sandbox> {
             Arc::new(super::traits::NoopSandbox)
         }
         SandboxBackend::Auto | SandboxBackend::None => {
-            // Auto-detect best available
-            detect_best_sandbox()
+            // Auto-detect best available, skipping Docker when native runtime is in use
+            detect_best_sandbox(runtime_kind)
         }
     }
 }
 
-/// Auto-detect the best available sandbox
-fn detect_best_sandbox() -> Arc<dyn Sandbox> {
+/// Auto-detect the best available sandbox.
+///
+/// When `runtime_kind` is `"native"` the caller has explicitly opted out of
+/// container wrapping, so Docker is excluded from consideration even if it is
+/// installed on the host.
+fn detect_best_sandbox(runtime_kind: &str) -> Arc<dyn Sandbox> {
+    let skip_docker = runtime_kind == "native";
+
     #[cfg(target_os = "linux")]
     {
         // Try Landlock first (native, no dependencies)
@@ -121,10 +132,19 @@ fn detect_best_sandbox() -> Arc<dyn Sandbox> {
         }
     }
 
-    // Docker is heavy but works everywhere if docker is installed
-    if let Ok(sandbox) = super::docker::DockerSandbox::probe() {
-        tracing::info!("Docker sandbox enabled");
-        return Arc::new(sandbox);
+    // Docker is heavy but works everywhere if docker is installed.
+    // Skip it when runtime.kind = "native" — the user explicitly opted out of
+    // container wrapping, and forcing Docker would break Python skills (Alpine
+    // has no python3) and workspace access on resource-constrained hosts.
+    if !skip_docker {
+        if let Ok(sandbox) = super::docker::DockerSandbox::probe() {
+            tracing::info!("Docker sandbox enabled");
+            return Arc::new(sandbox);
+        }
+    } else {
+        tracing::debug!(
+            "Docker sandbox skipped: runtime.kind = \"native\" overrides auto-detection"
+        );
     }
 
     // Fallback: application-layer security only
@@ -139,7 +159,7 @@ mod tests {
 
     #[test]
     fn detect_best_sandbox_returns_something() {
-        let sandbox = detect_best_sandbox();
+        let sandbox = detect_best_sandbox("");
         // Should always return at least NoopSandbox
         assert!(sandbox.is_available());
     }
@@ -154,7 +174,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let sandbox = create_sandbox(&config);
+        let sandbox = create_sandbox(&config, "");
         assert_eq!(sandbox.name(), "none");
     }
 
@@ -168,8 +188,35 @@ mod tests {
             },
             ..Default::default()
         };
-        let sandbox = create_sandbox(&config);
+        let sandbox = create_sandbox(&config, "");
         // Should return some sandbox (at least NoopSandbox)
+        assert!(sandbox.is_available());
+    }
+
+    #[test]
+    fn native_runtime_with_auto_sandbox_never_selects_docker() {
+        // When runtime.kind = "native", Docker must be skipped in auto-detection
+        // even when Docker is installed on the host. The sandbox must be
+        // NoopSandbox or something OS-native (Landlock, Firejail, Seatbelt).
+        let sandbox = detect_best_sandbox("native");
+        assert_ne!(sandbox.name(), "docker");
+    }
+
+    #[test]
+    fn explicit_docker_backend_is_not_blocked_by_native_runtime() {
+        // Even with runtime.kind = "native", explicit `backend = "docker"` in config
+        // is respected. Only the auto-detect path is gated by runtime_kind.
+        let config = SecurityConfig {
+            sandbox: SandboxConfig {
+                enabled: None,
+                backend: SandboxBackend::Docker,
+                firejail_args: Vec::new(),
+            },
+            ..Default::default()
+        };
+        let sandbox = create_sandbox(&config, "native");
+        // If Docker is available, it will be selected; if not, NoopSandbox fallback.
+        // The point is that runtime.kind doesn't override explicit `backend = "docker"`.
         assert!(sandbox.is_available());
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -331,7 +331,8 @@ pub fn all_tools_with_runtime(
     Option<ChannelMapHandle>,
 ) {
     let has_shell_access = runtime.has_shell_access();
-    let sandbox = create_sandbox(&root_config.security);
+    let runtime_kind = root_config.runtime.as_ref().map(|r| r.kind.as_str()).unwrap_or("docker");
+    let sandbox = create_sandbox(&root_config.security, runtime_kind);
     let mut tool_arcs: Vec<Arc<dyn Tool>> = vec![
         Arc::new(RateLimitedTool::new(
             PathGuardedTool::new(

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -331,7 +331,7 @@ pub fn all_tools_with_runtime(
     Option<ChannelMapHandle>,
 ) {
     let has_shell_access = runtime.has_shell_access();
-    let runtime_kind = root_config.runtime.as_ref().map(|r| r.kind.as_str()).unwrap_or("docker");
+    let runtime_kind = root_config.runtime.kind.as_str();
     let sandbox = create_sandbox(&root_config.security, runtime_kind);
     let mut tool_arcs: Vec<Arc<dyn Tool>> = vec![
         Arc::new(RateLimitedTool::new(


### PR DESCRIPTION
## Problem

When `runtime.kind = "native"` is set (explicitly signaling intent for native execution), `detect_best_sandbox()` still selects Docker if installed, contradicting the user's intent.

## Why It Matters

- Python agentic skills require host Python with external deps (pandas, requests, etc.)
- Alpine Linux (default container) has Python 3.11 with no pip—can't install anything
- Users are forced to either build 1GB custom images or discover the undocumented `backend = "none"` workaround
- Blocks realistic data science / analysis skills on edge devices (Raspberry Pi, NUC, etc.)

## What This Fixes

- Makes `runtime.kind = "native"` behavior match its name and user intent
- Enables Python skills to work on resource-constrained hosts
- Validates zeroclaw's "edge agent runtime" positioning

## Technical Detail

`detect_best_sandbox()` now receives `runtime_kind` and skips Docker probe when `runtime_kind == "native"`. Explicit `backend = "docker"` config still works (orthogonal subsystems).

## Changes

- `crates/zeroclaw-runtime/src/security/detect.rs`: Add `runtime_kind` parameter to `create_sandbox()` and `detect_best_sandbox()`. Skip Docker when native runtime detected.
- `crates/zeroclaw-runtime/src/tools/mod.rs`: Extract `runtime_kind` from config and pass to `create_sandbox()`.
- Tests: Validate native-gating and explicit-config-override behavior.