### PR TITLE
fix(runtime): detect memcg availability at daemon startup

### DIFF
--- a/crates/zeroclaw-runtime/src/security/detect.rs
+++ b/crates/zeroclaw-runtime/src/security/detect.rs
@@ -275,17 +275,14 @@ mod tests {
     #[test]
     fn linux_memcg_proc_cgroups_parses_without_panic() {
         if let Ok(content) = std::fs::read_to_string("/proc/cgroups") {
-            let _found = content
-                .lines()
-                .filter(|l| !l.starts_with('#'))
-                .any(|l| {
-                    let mut f = l.split_whitespace();
-                    let name = f.next().unwrap_or("");
-                    let _hier = f.next();
-                    let _num = f.next();
-                    let enabled = f.next().unwrap_or("0");
-                    name == "memory" && enabled == "1"
-                });
+            let _found = content.lines().filter(|l| !l.starts_with('#')).any(|l| {
+                let mut f = l.split_whitespace();
+                let name = f.next().unwrap_or("");
+                let _hier = f.next();
+                let _num = f.next();
+                let enabled = f.next().unwrap_or("0");
+                name == "memory" && enabled == "1"
+            });
         }
     }
 }

--- a/crates/zeroclaw-runtime/src/security/detect.rs
+++ b/crates/zeroclaw-runtime/src/security/detect.rs
@@ -152,6 +152,46 @@ fn detect_best_sandbox(runtime_kind: &str) -> Arc<dyn Sandbox> {
     Arc::new(super::traits::NoopSandbox)
 }
 
+/// Returns true if the Linux kernel has the memory cgroup controller enabled.
+///
+/// Probes cgroup v2 (`/sys/fs/cgroup/memory.max`), then cgroup v1
+/// (`/sys/fs/cgroup/memory/memory.limit_in_bytes`), then `/proc/cgroups`.
+/// Any read error is treated as "absent" (conservative/safe direction).
+#[cfg(target_os = "linux")]
+pub fn linux_memcg_available() -> bool {
+    use std::path::Path;
+
+    if Path::new("/sys/fs/cgroup/memory.max").exists() {
+        return true;
+    }
+    if Path::new("/sys/fs/cgroup/memory/memory.limit_in_bytes").exists() {
+        return true;
+    }
+    if let Ok(content) = std::fs::read_to_string("/proc/cgroups") {
+        for line in content.lines() {
+            if line.starts_with('#') {
+                continue;
+            }
+            let mut cols = line.split_whitespace();
+            let name = cols.next().unwrap_or("");
+            let _hierarchy = cols.next();
+            let _num_cgroups = cols.next();
+            let enabled = cols.next().unwrap_or("0");
+            if name == "memory" && enabled == "1" {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Non-Linux stub — always returns false.
+/// Exists so the symbol compiles on all platforms (used in cross-platform tests).
+#[cfg(not(target_os = "linux"))]
+pub fn linux_memcg_available() -> bool {
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -218,5 +258,34 @@ mod tests {
         // If Docker is available, it will be selected; if not, NoopSandbox fallback.
         // The point is that runtime.kind doesn't override explicit `backend = "docker"`.
         assert!(sandbox.is_available());
+    }
+
+    #[test]
+    fn linux_memcg_available_returns_bool() {
+        let _result: bool = linux_memcg_available();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_memcg_cgroup_v2_path_probe_does_not_panic() {
+        let _ = std::path::Path::new("/sys/fs/cgroup/memory.max").exists();
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_memcg_proc_cgroups_parses_without_panic() {
+        if let Ok(content) = std::fs::read_to_string("/proc/cgroups") {
+            let _found = content
+                .lines()
+                .filter(|l| !l.starts_with('#'))
+                .any(|l| {
+                    let mut f = l.split_whitespace();
+                    let name = f.next().unwrap_or("");
+                    let _hier = f.next();
+                    let _num = f.next();
+                    let enabled = f.next().unwrap_or("0");
+                    name == "memory" && enabled == "1"
+                });
+        }
     }
 }

--- a/crates/zeroclaw-runtime/src/security/mod.rs
+++ b/crates/zeroclaw-runtime/src/security/mod.rs
@@ -52,6 +52,7 @@ pub mod workspace_boundary;
 pub use audit::{AuditEvent, AuditEventType, AuditLogger};
 #[allow(unused_imports)]
 pub use detect::create_sandbox;
+pub use detect::linux_memcg_available;
 pub use domain_matcher::DomainMatcher;
 #[allow(unused_imports)]
 pub use estop::{EstopLevel, EstopManager, EstopState, ResumeSelector};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1388,7 +1388,7 @@ async fn main() -> Result<()> {
                         .runtime
                         .docker
                         .memory_limit_mb
-                        .map_or(false, |mb| mb > 0);
+                        .is_some_and(|mb| mb > 0);
                 if (sandbox_docker || runtime_docker_mem)
                     && !zeroclaw_runtime::security::linux_memcg_available()
                 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1381,14 +1381,21 @@ async fn main() -> Result<()> {
             #[cfg(target_os = "linux")]
             {
                 use zeroclaw_config::schema::SandboxBackend;
-                let sandbox_docker = matches!(config.security.sandbox.backend, SandboxBackend::Docker);
+                let sandbox_docker =
+                    matches!(config.security.sandbox.backend, SandboxBackend::Docker);
                 let runtime_docker_mem = config.runtime.kind == "docker"
-                    && config.runtime.docker.memory_limit_mb.map_or(false, |mb| mb > 0);
+                    && config
+                        .runtime
+                        .docker
+                        .memory_limit_mb
+                        .map_or(false, |mb| mb > 0);
                 if (sandbox_docker || runtime_docker_mem)
                     && !zeroclaw_runtime::security::linux_memcg_available()
                 {
                     let which = match (sandbox_docker, runtime_docker_mem) {
-                        (true, true) => "security.sandbox.backend = \"docker\" and runtime.kind = \"docker\"",
+                        (true, true) => {
+                            "security.sandbox.backend = \"docker\" and runtime.kind = \"docker\""
+                        }
                         (true, false) => "security.sandbox.backend = \"docker\"",
                         _ => "runtime.kind = \"docker\"",
                     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1377,6 +1377,31 @@ async fn main() -> Result<()> {
             } else {
                 info!("🧠 Starting ZeroClaw Daemon on {host}:{port}");
             }
+
+            #[cfg(target_os = "linux")]
+            {
+                use zeroclaw_config::schema::SandboxBackend;
+                let sandbox_docker = matches!(config.security.sandbox.backend, SandboxBackend::Docker);
+                let runtime_docker_mem = config.runtime.kind == "docker"
+                    && config.runtime.docker.memory_limit_mb.map_or(false, |mb| mb > 0);
+                if (sandbox_docker || runtime_docker_mem)
+                    && !zeroclaw_runtime::security::linux_memcg_available()
+                {
+                    let which = match (sandbox_docker, runtime_docker_mem) {
+                        (true, true) => "security.sandbox.backend = \"docker\" and runtime.kind = \"docker\"",
+                        (true, false) => "security.sandbox.backend = \"docker\"",
+                        _ => "runtime.kind = \"docker\"",
+                    };
+                    warn!(
+                        "Docker memory limits are configured but the Linux kernel has no memcg support. \
+                         Affected config: {which}. \
+                         Consequence: --memory limits are silently ignored; agents can OOM the host. \
+                         Fix: add 'cgroup_memory=1 cgroup_enable=memory' to /boot/firmware/cmdline.txt \
+                         (Raspberry Pi) or enable CONFIG_MEMCG in your kernel, then reboot."
+                    );
+                }
+            }
+
             // Wire CLI channel for interactive mode
             #[cfg(feature = "agent-runtime")]
             zeroclaw_runtime::agent::loop_::register_cli_channel_fn(Box::new(|| {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Daemon now detects Linux memory cgroup (memcg) support at startup.
  - When Docker sandbox or runtime is configured with memory limits but the kernel lacks memcg (e.g., stock Raspberry Pi OS), the daemon emits a `tracing::warn!` explaining which config is affected, why it matters (agents can OOM the host), and how to fix (kernel boot params / `CONFIG_MEMCG`).
  - Prevents silent misconfiguration — Docker's `--memory` flag is ignored without memcg, leaving users to discover the problem via OOM kills rather than a warning at startup.
- **Scope boundary:** Only adds a startup probe + one structured warn log. No change to sandbox runtime behavior, no attempt to enable memcg, no change to how Docker commands are built.
- **Blast radius:** Near-zero. One extra boot-time log line on Linux when the specific misconfiguration is detected. No-op on non-Linux hosts (cfg-gated). No existing behavior altered.
- **Linked issue(s):** `Closes #5895`.

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:** `cargo fmt --all -- --check` clean. `cargo clippy --all-targets -- -D warnings` clean. `cargo test` passes — Linux-only cfg-gated code compiles away cleanly on macOS dev host; no existing tests affected.
- **Beyond CI — what did you manually verify?** Verified on a local Raspberry Pi 4 (64-bit Raspberry Pi OS Lite, Trixie, kernel 6.12.75):
  - `/sys/fs/cgroup/memory.max` — absent
  - `/sys/fs/cgroup/memory/memory.limit_in_bytes` — absent
  - `/proc/cgroups` — no memory controller (field 4 == 0 as expected for stock RPi OS)
  - `linux_memcg_available()` correctly returns `false`
  - Warn fires at daemon startup with the expected content when Docker sandbox memory limits are configured.
  - Also verified on a host with memcg enabled (x86_64 Ubuntu): `linux_memcg_available()` returns `true`, no warn emitted.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No** — reads only `/sys/fs/cgroup/memory.max`, `/sys/fs/cgroup/memory/memory.limit_in_bytes`, and `/proc/cgroups`. These are world-readable kernel informational paths; no new capability, no write, no privileged operation.
- New external network calls? **No**.
- Secrets / tokens / credentials handling changed? **No**.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**.

## Compatibility (required)

- Backward compatible? **Yes**. Pure addition — no existing behavior altered.
- Config / env / CLI surface changed? **No**.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk. `git revert <sha>` reverts cleanly. No state/config/DB migration.

