### PR TITLE
docs(foundations): ratify and commit the ZeroClaw Maturity Framework

### DIFF
--- a/docs/contributing/label-registry.md
+++ b/docs/contributing/label-registry.md
@@ -174,6 +174,19 @@ Defined in `.github/label-policy.json`. Based on the author's merged PR count qu
 
 ---
 
+## Status labels
+
+Track the lifecycle state of RFCs and work items. Applied manually.
+
+| Label | Color | Description | Applied by |
+|---|---|---|---|
+| `status:in-progress` | `0075ca` (blue) | An open PR is actively targeting this issue. | Manual |
+| `status:accepted` | `0e8a16` (green) | RFC or work item accepted and ratified by the team. | Manual |
+
+**Automation:** none. Applied manually when an RFC transitions from active discussion to ratified, or when a PR is opened against a tracked issue.
+
+---
+
 ## Response and triage labels
 
 Defined in `pr-workflow.md` §8. Applied manually.
@@ -201,8 +214,9 @@ Defined in `pr-workflow.md` §8. Applied manually.
 | Size | 5 | No | Manual |
 | Risk | 4 | No | Manual |
 | Contributor tier | 4 | No | Manual |
+| Status | 2 | No | Manual |
 | Response/triage | 7 | No | Manual |
-| **Total** | **99** | | |
+| **Total** | **101** | | |
 
 ---
 

--- a/docs/foundations/README.md
+++ b/docs/foundations/README.md
@@ -1,0 +1,105 @@
+# The ZeroClaw Maturity Framework
+
+*A letter to whoever finds this.*
+
+---
+
+If you are reading this, you have found your way into a folder that represents something
+this team is genuinely proud of — not because the documents here are perfect, but
+because they are honest.
+
+ZeroClaw started as something accidental. It was bootstrapped from an existing codebase,
+shaped by AI tools working faster than anyone could fully understand, and grew into a
+codebase that was impressively functional and architecturally unplanned. Nobody chose
+that outcome. It accumulated. Most software does.
+
+What happened next is less common. A small team — many of them students, early-career
+engineers, and people learning in public for the first time — chose to stop and look
+clearly at what they had built, and then chose to build differently. Not by throwing
+away the work that came before, but by growing intention around it. These documents are
+the record of that choice.
+
+The series is called the Maturity Framework because that is exactly what it is: a set
+of foundational documents that describe how this team thinks about building software
+together. Not rules to follow, but thinking to internalize. Not a process to comply
+with, but a set of mental models that travel with you — through every language, every
+tool, every team you will ever join — because they are about craft and judgment and
+care, not about any specific technology.
+
+They were written for a team of people with a wide range of experience. Some brought
+decades of professional practice. Some were writing their first production code. All of
+them were working at a moment when AI tools were becoming powerful enough to change
+what was possible — and when the question of how to work well alongside those tools was
+genuinely open. They were written by people who believed that investing in people was a
+better investment than investing in code, because people carry what they learn forward,
+and code does not.
+
+---
+
+## Reading Order
+
+Read these in order if you can. Each document builds on the ones before it, and the
+sequence tells a story. You can enter anywhere and learn something useful, but reading
+them from the beginning gives you the full arc: from the shape of the architecture, to
+how we record and coordinate and ship and collaborate, to what it means to write the
+code well at the sentence level.
+
+| # | Document | What It Answers | Discussion Thread |
+|---|----------|-----------------|-------------------|
+| 1 | [Intentional Architecture — Microkernel Transition](./fnd-001-intentional-architecture.md) | What are we building, and what shape should it take? | [#5574](https://github.com/zeroclaw-labs/zeroclaw/issues/5574) |
+| 2 | [Documentation Standards and Knowledge Architecture](./fnd-002-documentation-standards.md) | How do we record and transfer what we know? | [#5576](https://github.com/zeroclaw-labs/zeroclaw/issues/5576) |
+| 3 | [Team Organization and Project Governance](./fnd-003-governance.md) | How do we coordinate and make decisions together? | [#5577](https://github.com/zeroclaw-labs/zeroclaw/issues/5577) |
+| 4 | [Engineering Infrastructure — CI/CD Pipeline](./fnd-004-engineering-infrastructure.md) | How do we build, test, and ship reliably? | [#5579](https://github.com/zeroclaw-labs/zeroclaw/issues/5579) |
+| 5 | [Contribution Culture — Human Collaboration and AI Partnership](./fnd-005-contribution-culture.md) | How do we work together and grow? | [#5615](https://github.com/zeroclaw-labs/zeroclaw/issues/5615) |
+| 6 | [Zero Compromise in Practice — Code Health, Error Discipline, and the Production Readiness Standard](./fnd-006-zero-compromise-in-practice.md) | How do we write code that lasts? | [#5653](https://github.com/zeroclaw-labs/zeroclaw/issues/5653) |
+
+The first five documents answer structural and human questions. The sixth answers the
+question that sits inside all of them: given the structure, given the team, given the
+tools — what does it mean to write the code well?
+
+---
+
+## How These Documents Got Here
+
+Each document in this series began as a GitHub issue — an RFC, open for discussion,
+challenge, and refinement by the whole team. The linked discussion threads above are the
+living record of that process: the questions asked, the pushback offered, and the
+thinking that shaped the final form.
+
+The files in this folder are the ratified versions — documents the team discussed, stood
+behind, and chose to carry forward as canonical references. They live in this repository,
+versioned alongside the code, because the thinking they represent influences every
+decision made within it. An AI assistant reading this codebase, a new contributor
+finding their footing, or a maintainer revisiting a decision made two years ago should
+all be able to trace a line from the code back to the reasoning that shaped it.
+
+The GitHub issues remain open as permanent discussion records. If you have a question,
+a disagreement, or a perspective these documents do not capture, the right place for it
+is one of those threads — or, if you are reading this long after those conversations
+closed, a new discussion in the community. These documents are references, not verdicts.
+The conversation they started is meant to continue.
+
+---
+
+## A Note to Future Contributors
+
+You may be joining this project years after these were written. The tools will have
+changed. The codebase will look different. Some of what is described here will have been
+superseded, refined, or replaced by documents that came after.
+
+The judgment these documents are trying to develop in you has not changed, and will not.
+The questions they are asking — what should happen when this fails, what does this
+interface promise, what does my test actually prove, what would the person who inherits
+this problem need to know — are not Rust questions or software questions. They are
+questions about how to build things that other people can trust. Those questions are
+the same in every language, every system, and every discipline you will ever work in.
+They compound quietly, in the background, for as long as you practice asking them.
+
+That is the investment this series is making in you. Welcome to the team.
+
+---
+
+*The ZeroClaw Maturity Framework is a living body of work. New documents are added when
+the team has learned something worth preserving. Each begins as a public RFC discussion
+and earns its place here through the same process as the six above: open conversation,
+honest disagreement, and the team's collective decision to carry it forward.*

--- a/docs/foundations/fnd-001-intentional-architecture.md
+++ b/docs/foundations/fnd-001-intentional-architecture.md
@@ -1,0 +1,871 @@
+# FND-001: Intentional Architecture — ZeroClaw Microkernel Transition
+### Starting v0.7.0 · Type: Architecture · Rev. 3
+
+> **Canonical reference** · Ratified by the team · Rev. 3
+> Discussion thread and full revision history: [#5574](https://github.com/zeroclaw-labs/zeroclaw/issues/5574)
+
+
+---
+
+> **A note to the team before you read this.**
+>
+> This document was written to help us move from a codebase that grew reactively into one that is built with intention. If some of the concepts here are new to you, that is not a problem — it means this document is doing its job. Every senior engineer you will ever work with has learned these lessons the hard way, on a codebase that got too big to understand. We have the rare opportunity to recognize the pattern early and course-correct before it becomes painful. This is a good thing. Take your time with it.
+
+---
+
+## Table of Contents
+
+1. [A Development Philosophy: Vision First](#1-a-development-philosophy-vision-first)
+2. [The Vision — What ZeroClaw Is](#2-the-vision--what-zeroclaw-is)
+3. [Honest Assessment: Where We Are Today](#3-honest-assessment-where-we-are-today)
+4. [The Target Architecture](#4-the-target-architecture)
+   - [4.4.1 Versioning Policy](#441-versioning-policy)
+   - [4.4.2 Release Artifacts](#442-release-artifacts)
+5. [Standards We Should Adopt](#5-standards-we-should-adopt)
+6. [Phased Roadmap: v0.7.0 → v1.0.0](#6-phased-roadmap-v070--v100)
+7. [Code and Complexity Metrics](#7-code-and-complexity-metrics)
+8. [What This Means for Contributors](#8-what-this-means-for-contributors)
+
+---
+
+## Revision History
+
+| Rev | Date | Summary |
+|---|---|---|
+| 1 | 2026-04-09 | Initial draft |
+| 2 | 2026-04-09 | Added §4.4.1 Versioning Policy (unified workspace inheritance, stability tiers, product-level breaking change definition); added §4.4.2 Release Artifacts (feature flag fate, canonical release binary profile, release artifact matrix); added Discussion Questions for versioning strategy and observability defaults |
+| 3 | 2026-04-10 | Terminology correction per implementation feedback from PR #5559: "kernel" → "runtime" for the agent orchestration layer throughout; "kernel" now refers specifically to the irreducible foundation (`--no-default-features` build); §4.1 updated to describe the explicit two-layer architecture (foundation + runtime); §4.2–§4.3 dependency diagram and component map updated to show `zeroclaw-runtime`; Phase 2 renamed from "The Kernel" to "The Runtime"; binary size targets reframed as aspirational north stars with measured progress tracking rather than hard gates; §7 updated with actual Phase 1 measurement (6.6 MB foundation build) and explicit note that architectural decomposition enables optimization but optimization is a dedicated second pass |
+
+---
+
+## 1. A Development Philosophy: Vision First
+
+Every decision we make in software — what to build, how to build it, what to skip — should flow downward from a hierarchy of intent:
+
+```
+Vision
+  └── Architecture
+        └── Design
+              └── Implementation
+                    └── Testing
+                          └── Documentation
+                                └── Release
+```
+
+This is not a waterfall process. It is a **decision hierarchy**. It means that when you are writing a function, you should be able to trace a straight line upward: this function exists because of this design decision, which exists because of this architectural choice, which exists because of this vision. If you cannot draw that line, the code probably should not exist.
+
+**What each layer means in practice:**
+
+| Layer | The Question It Answers | What Goes Wrong Without It |
+|---|---|---|
+| **Vision** | *Why does this project exist? Who is it for? What does success look like?* | You build things nobody needs, or contradict yourself across releases |
+| **Architecture** | *What are the structural decisions that make the vision possible?* | You end up with a "Big Ball of Mud" — code that works but cannot be changed without breaking something else |
+| **Design** | *How do the components relate? What are the interfaces between them?* | You get tight coupling — components that know too much about each other's internals |
+| **Implementation** | *How do we build this specific component?* | Bugs, performance issues, security holes |
+| **Testing** | *Does the implementation match the design? Does the design serve the architecture?* | You ship broken things and don't know why |
+| **Documentation** | *How do we transfer this knowledge to the next person?* | Every contributor has to rediscover everything from scratch |
+| **Release** | *How do we get this to users safely and sustainably?* | Users get broken or confusing software |
+
+### The Problem With Skipping the Top
+
+ZeroClaw was bootstrapped by AI tools working from OpenClaw's TypeScript codebase. AI code generation works at the **Implementation** layer. It writes functions, structs, and modules that do things. It does not set Vision. It does not make Architecture decisions. It does not define Design contracts.
+
+The result is a codebase that is impressively functional but architecturally accidental. The code does what it needs to do today, but it was not designed — it accumulated. This pattern has a name in our industry: **the Big Ball of Mud**. It is the most common architecture in software, not because anyone chose it, but because it is what you get when you skip the top of the hierarchy.
+
+This RFC is our chance to fix that — not by throwing away what works, but by growing an intentional architecture around it using a technique called the **Strangler Fig Pattern**: we build the new structure around the edges of the old one, migrating inward over time, until the old structure is gone. No "big bang" rewrite. No throwing away working code. Just steady, intentional improvement.
+
+---
+
+## 2. The Vision — What ZeroClaw Is
+
+Before we talk about architecture, we need to be precise about what we are building. This is the Vision layer. Everything that follows must serve this.
+
+> **ZeroClaw is a personal AI assistant runtime that any person can run on any hardware — from a $10 embedded board to a cloud server — with zero configuration overhead, zero external service requirements, and zero compromise on capability or security.**
+
+Breaking that down into concrete commitments:
+
+**Zero overhead.** The core agent starts in milliseconds and uses less memory than a browser tab. This is not a marketing claim — it is an architectural constraint. Every decision we make must be tested against it.
+
+**Zero external requirements.** A user who downloads ZeroClaw and has an LLM provider configured should have a working, useful AI assistant without installing anything else. Channels, dashboards, and integrations are things you add when you want them — not things you need before it works.
+
+**Zero compromise.** Lean does not mean weak. ZeroClaw must have a serious security model, real observability, and genuine extensibility. The tension between "small binary" and "full capability" is resolved through composition: a small core, extended by components you choose.
+
+**For every skill level.** A student on a $10 Raspberry Pi and a team running a production deployment should both feel like ZeroClaw was designed for them. This means the default experience must be simple, and the advanced experience must be powerful — not two different products.
+
+**User-owned.** Your data, your hardware, your configuration. ZeroClaw does not require an account, does not phone home, and does not lock you into a platform.
+
+---
+
+## 3. Honest Assessment: Where We Are Today
+
+This section is not criticism of anyone's work. It is a diagnosis, and you cannot fix what you do not name.
+
+### 3.1 The Structural Problem
+
+The entire ZeroClaw codebase currently lives in a single Rust crate. This means:
+
+- A Telegram channel and the core agent loop are compiled from the same source tree whether you use Telegram or not
+- The web dashboard (a full React application) is embedded in the binary using `rust-embed`, making every binary include the web UI even for users who only ever use the CLI
+- The gateway HTTP server contains webhook handlers for WhatsApp, WATI, Linq, Nextcloud Talk, and Gmail — meaning specific channel integrations are baked into the web server
+- Every one of the 70+ tools is compiled into the binary, regardless of which tools a user will ever call
+- The only mechanism for excluding code is a Cargo feature flag, which requires users to have a Rust development environment and recompile from source
+
+**The consequence for users:** The stated goal is a lean binary for $10 hardware. But the binary ships with code for 27 messaging channels, 70+ tools, a full web server, a React application, and integrations with Jira, Notion, Google Workspace, LinkedIn, and more — most of which any given user will never touch.
+
+**The consequence for contributors:** When a file is 9,500 lines long, it is not possible to understand it. When every feature is in one crate, touching anything risks breaking everything.
+
+### 3.2 The Evidence
+
+These are measured facts from the current codebase, not estimates:
+
+| File | Lines | What It Does | What It Should Do |
+|---|---|---|---|
+| `src/agent/loop_.rs` | ~9,500 | Tool call parsing, streaming, history, cost tracking, model routing, memory, credential scrubbing, context building | Orchestrate a single agent turn |
+| `src/gateway/mod.rs` | ~2,260 | Web server + React app server + WhatsApp webhooks + WATI webhooks + Linq webhooks + Nextcloud webhooks + Gmail webhooks + pairing + rate limiting + WebAuthn | Serve the web dashboard API |
+| `src/providers/mod.rs` | ~3,750 | Factory + 40+ provider implementations + OAuth flows + credential resolution + error scrubbing | Route to a provider |
+| `src/tools/mod.rs` | `all_tools_with_runtime()` at L387–L1066 | Instantiate all 70+ tools unconditionally | Register the tools the user configured |
+
+**A 9,500-line file is not a module. It is a monolith that happens to have a `.rs` extension.**
+
+### 3.3 What Is Already Good
+
+This diagnosis should not obscure what is genuinely well-designed:
+
+- **The trait layer is excellent.** `Provider`, `Channel`, `Tool`, `Memory`, `Observer`, `RuntimeAdapter`, and `Peripheral` are clean, well-documented Rust traits. These are the right seams. The problem is they do not correspond to crate boundaries, so the compiler cannot enforce the layering.
+- **The WASM plugin system is partially built.** `PluginHost`, `WasmTool`, `WasmChannel`, `PluginManifest`, and Ed25519 signature verification all exist in `src/plugins/`. The execution bridge is a stub, but the structure is correct.
+- **The observability system is mature.** OpenTelemetry, Prometheus, and DORA metrics are all implemented against a clean `Observer` trait. This is production-quality work.
+- **The security model is thoughtful.** Pairing codes, autonomy levels, sandboxing, and policy enforcement show real design intent.
+
+We are not rewriting ZeroClaw. We are giving its existing good ideas a structure they can grow in.
+
+---
+
+## 4. The Target Architecture
+
+### 4.1 The Microkernel Model
+
+A microkernel architecture separates a minimal, stable core from optional subsystems that extend it. In operating systems, the classic example is a kernel that only handles memory and scheduling, with everything else — filesystems, device drivers, network stacks — running as separate processes that communicate through a well-defined interface.
+
+For an AI agent runtime, the mapping reveals **two distinct internal layers** that the OS analogy conflates:
+
+| OS Microkernel Concept | ZeroClaw Equivalent |
+|---|---|
+| Kernel | **Foundation layer** — API traits, config, providers, memory backends, infra, tool-call parser. The irreducible core: builds with `--no-default-features`. Can exchange messages with an LLM and store memory. Nothing more. |
+| Init / runtime system | **Agent runtime layer** — Orchestration loop, security policy enforcement, plugin host, core tools, IPC API. The `zeroclaw-runtime` crate, gated by the `agent-runtime` feature. This is what makes ZeroClaw an *agent*, not just a library. |
+| IPC | Local socket / IPC API between the runtime and external components |
+| Device drivers | Channel plugins (Telegram, Discord, etc.) |
+| Filesystem drivers | Memory backend plugins (SQLite, Markdown) |
+| User processes | Gateway binary, Tauri desktop app |
+
+The distinction matters: the **foundation** is the minimum that must exist for any ZeroClaw binary to function. The **runtime** is the minimum that must exist for it to function *as an agent*. Everything else is composed in.
+
+This two-layer split was identified during the Phase 1 workspace decomposition (PR #5559) and is reflected in the crate naming: `zeroclaw-runtime` (the crate) is gated by `agent-runtime` (the feature). The earlier revisions of this RFC used "kernel" loosely to refer to what is now correctly named the runtime layer. This revision corrects that terminology throughout.
+
+### 4.2 The Dependency Rule
+
+The most important architectural rule in this design — the one that, if broken, collapses the whole structure — is this:
+
+> **Dependencies flow inward. The runtime knows nothing about the plugins. Plugins know about the API. Nothing knows about everything.**
+
+```
+    zeroclaw-api          ← defines all traits (Provider, Channel, Tool, ...)
+         ▲                  no implementations, no heavy dependencies
+         │ depends on
+  foundation crates       ← zeroclaw-config, zeroclaw-providers, zeroclaw-memory,
+         ▲                  zeroclaw-infra, zeroclaw-tool-call-parser
+         │ depends on        all depend on zeroclaw-api; no cross-dependencies
+    zeroclaw-runtime      ← implements the agent loop (agent-runtime feature)
+         ▲                  depends on zeroclaw-api + foundation crates
+         │ depends on        knows nothing about specific channels or tools
+  plugin crates           ← zeroclaw-channel-discord, zeroclaw-tools-web, ...
+         ▲                  depend on zeroclaw-api (not the runtime)
+         │ depends on
+  zeroclaw binary         ← thin wiring layer
+                             reads config, registers plugins, starts runtime
+```
+
+If `zeroclaw-runtime` ever imports `TelegramChannel`, the architecture has been violated. The compiler will enforce this once crate boundaries are drawn.
+
+### 4.3 Component Map
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    zeroclaw (binary crate)                          │
+│  Reads config → registers only configured components → starts       │
+│                                                                     │
+│   ┌──────────────────────────────────────────────────────────────┐  │
+│   │              zeroclaw-runtime  (agent-runtime feature)       │  │
+│   │                                                              │  │
+│   │  Agent Loop · CLI Channel · Security Policy                  │  │
+│   │  Plugin Host · Local IPC API                                 │  │
+│   │  Core Tools: shell, file, git, memory recall/store           │  │
+│   │                                                              │  │
+│   │  ┌──────────────────────────────────────────────────────┐   │  │
+│   │  │   Foundation  (--no-default-features)                │   │  │
+│   │  │                                                      │   │  │
+│   │  │  zeroclaw-api · zeroclaw-config · zeroclaw-infra     │   │  │
+│   │  │  zeroclaw-providers · zeroclaw-memory                │   │  │
+│   │  │  zeroclaw-tool-call-parser                           │   │  │
+│   │  │                                                      │   │  │
+│   │  │  Vision target: <5 MB RAM at runtime                 │   │  │
+│   │  └──────────────────────────────────────────────────────┘   │  │
+│   └──────────────────────────────────────────────────────────────┘  │
+│                              ▲                                      │
+│                   zeroclaw-api (traits only)                        │
+│                              ▲                                      │
+│   ┌──────────────┐  ┌────────┴────────┐  ┌─────────────────────┐   │
+│   │  zeroclaw-gw │  │  Channel plugins│  │   Tool plugins      │   │
+│   │  (opt-in     │  │                 │  │                     │   │
+│   │   binary)    │  │  channel-discord│  │  tools-web          │   │
+│   │              │  │  channel-slack  │  │  tools-integrations │   │
+│   │  HTTP/WS/SSE │  │  channel-tg     │  │  tools-hardware     │   │
+│   │  Web UI      │  │  channel-email  │  │  tools-mcp          │   │
+│   │  REST API    │  │  ...            │  │  ...                │   │
+│   └──────┬───────┘  └─────────────────┘  └─────────────────────┘   │
+│          │                                                          │
+│          ▼                                                          │
+│   ┌─────────────────┐                                               │
+│   │ zeroclaw-desktop│   ← Tauri app (already exists in apps/tauri)  │
+│   │ System tray app │     bundles zeroclaw-gw as a sidecar          │
+│   │ Native GUI      │                                               │
+│   └─────────────────┘                                               │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### 4.4 The Distribution Model
+
+The architecture enables a clean distribution story that requires no Rust toolchain from end users:
+
+| User wants | What they download | What `zeroclaw onboard` does |
+|---|---|---|
+| CLI only | `zeroclaw` runtime binary | Configure provider, done |
+| CLI + Discord | `zeroclaw` runtime binary | Download + install `channel-discord.wasm` |
+| Local web UI | `zeroclaw` + `zeroclaw-gw` | Configure both, open browser |
+| Desktop app | `zeroclaw-desktop` installer | Bundles runtime + gateway + UI |
+| Everything | `zeroclaw-desktop` or `zeroclaw --profile full` | Downloads all plugins |
+
+The `zeroclaw plugin install` command (backed by `PluginHost`, which already exists) becomes the package manager. The `zeroclaw onboard` wizard integrates it so non-technical users never see `cargo`.
+
+#### 4.4.1 Versioning Policy
+
+As ZeroClaw transitions from a single crate to a multi-crate workspace, two concerns must be kept separate from the start:
+
+- **The product version** — what `zeroclaw --version` reports, what GitHub Releases, changelogs, and package managers (Homebrew, apt, cargo-binstall) track. This is the version operators and users reason about.
+- **Component stability** — how mature and reliable a given component is. A single version number cannot carry this signal on its own.
+
+These are orthogonal. Conflating them creates misleading semver noise and erodes trust in the version number. This policy defines both.
+
+---
+
+**Crate versioning: unified with intentional exceptions**
+
+All application crates — the kernel, the gateway, tool plugin crates, channel plugin crates, and the CLI — use Cargo workspace package inheritance:
+
+```toml
+# Cargo.toml (workspace root)
+[workspace.package]
+version = "0.8.0"
+
+# crates/zeroclaw-kernel/Cargo.toml
+[package]
+version.workspace = true
+```
+
+A single version in the root `Cargo.toml` is the authoritative product version. This is the right model because:
+
+- Users, operators, and packagers deal with one version, not twelve
+- Release automation via `release-plz` is straightforward: one PR, one bump, one changelog entry
+- It reflects ZeroClaw's identity as a **product**, not a library ecosystem
+- The WIT interface version — not the Rust crate version — is the actual plugin ABI contract (see §5.2)
+
+Three crate classes are intentionally excluded from workspace inheritance and maintain independent versions on their own cadence:
+
+| Crate | Reason for independence |
+|---|---|
+| `zeroclaw-api` | Starts at `0.1.0`; its `1.0.0` release is a formal milestone deliverable of v1.0.0, signalling a stable Rust trait surface for plugin SDK authors |
+| `aardvark-sys`, `zeroclaw-robot-kit` | Hardware library crates with their own user audiences and maintenance cadences; not application components |
+| WIT interface files (`wit/*.wit`) | Versioned via `@since` and `@unstable` annotations per the WASI component model spec; these are the primary plugin ABI contract and are independent of Cargo semver entirely |
+
+---
+
+**What "breaking" means for the product version**
+
+Because application crates share a unified version, the team needs a product-level definition of a breaking change — distinct from a breaking change inside a single crate's internal implementation. A breaking change within a plugin crate that does not cross any of the boundaries below is **not** a product-level breaking change and does not warrant a MAJOR bump.
+
+| Bump | Warranted when |
+|---|---|
+| **MAJOR** | WIT interface changes incompatibly (existing plugins must recompile); kernel IPC API changes incompatibly (gateway or external clients break); config file schema requires a migration; CLI commands or flags are removed or renamed |
+| **MINOR** | New capabilities anywhere in the workspace; new plugins available in the registry; new stable APIs; stability tier promotions; deprecation announcements (not removals) |
+| **PATCH** | Bug fixes; security patches; documentation corrections; no new capabilities and no deprecations |
+
+---
+
+**Stability tiers**
+
+The product version answers *"what release is this?"* A stability tier answers *"how much can I rely on this component?"* Every component — kernel, gateway, plugin crate, WIT interface — carries one of three tiers. Tiers are documented in the component's `AGENTS.md` and in its plugin registry manifest.
+
+| Tier | Meaning | Implication |
+|---|---|---|
+| **Stable** | Covered by the product's breaking-change policy. No breaking changes without a MAJOR version bump and a published migration guide. | Kernel (target: v0.8.0), `zeroclaw-api` WIT interface (target: v0.9.0), kernel IPC API (target: v1.0.0) |
+| **Beta** | Functional and tested. Breaking changes are permitted in MINOR releases but are announced in the changelog with upgrade notes. | `zeroclaw-gw` (v0.9.0 → v1.0.0), mature channel and tool plugins |
+| **Experimental** | No stability guarantee. May break in PATCH releases. Must be clearly marked as `experimental` in docs and plugin registry manifests. | New tool integrations, new channel implementations, early hardware plugins |
+
+Stability tiers are **promoted, never demoted** through a deliberate team decision. Promotions are recorded in the changelog and, for architectural components, in an ADR. A component must hold its current tier for at least one full release cycle before promotion is considered.
+
+---
+
+**Release automation**
+
+Releases use [`release-plz`](https://release-plz.eplant.org/), which opens a release PR on push to `master`, bumps the workspace version, and generates a changelog from conventional commit titles. `release-plz` natively understands workspace inheritance and handles the crate publication order automatically. Crates with independent versions (`zeroclaw-api`, hardware library crates) are managed separately using the same tool's per-crate configuration.
+
+#### 4.4.2 Release Artifacts
+
+The microkernel transition changes the fundamental nature of the question "which features are compiled in?" Today that question has one answer: whatever feature flags you passed to `cargo build`. After the transition it splits into two separate concerns:
+
+- **What is in the kernel binary** — fixed at compile time, determined per platform, published to GitHub Releases
+- **What capabilities are available** — determined at runtime by which plugins are installed via `zeroclaw plugin install`
+
+These are no longer the same question, and the current `[features]` section of `Cargo.toml` must be interpreted through that lens.
+
+---
+
+**Fate of the current compile-time feature flags**
+
+The 20+ feature flags in the current `Cargo.toml` fall into three buckets as the architecture matures:
+
+| Bucket | Flags | Outcome |
+|---|---|---|
+| **Retire → plugin** | `channel-nostr`, `channel-matrix`, `channel-lark`, `channel-feishu`, `whatsapp-web`, `browser-native` | Removed from the kernel. Each becomes a WASM plugin crate published to the plugin registry. No compile-time decision required. |
+| **Always-on** | `plugins-wasm`, `skill-creation` | Compiled into every kernel binary unconditionally. `plugins-wasm` is the kernel's core mechanism; `skill-creation` is a zero-overhead code path. Neither belongs behind a flag. |
+| **Stay → platform/infrastructure flag** | `peripheral-rpi`, `hardware`, `sandbox-landlock`, `sandbox-bubblewrap`, `voice-wake`, `probe` | Remain as compile-time flags because they require native library linking or OS-level access that cannot be provided by a WASM plugin. `peripheral-rpi` and `hardware` appear only in platform-specific release targets. |
+
+Two flags require a deliberate team decision before the v0.8.0 release and are surfaced here rather than resolved unilaterally:
+
+- **`observability-prometheus`** — currently in `default`. Prometheus metrics add measurable binary size overhead. The question is whether a production runtime should ship observability on by default, or whether operators opt in. Recommendation: keep in `default` for the standard release; operators on severely size-constrained targets can build with `--no-default-features`.
+- **`observability-otel`** — OTLP export carries a larger dependency footprint (opentelemetry + reqwest blocking client). Recommendation: remains opt-in, not in `default`. Production deployments that need trace export enable it explicitly.
+
+The `ci-all` meta-feature simplifies substantially as channel and tool flags retire. By v1.0.0 it covers only the remaining platform and infrastructure flags.
+
+---
+
+**The canonical release kernel binary**
+
+The binary published to GitHub Releases for each platform target is built with the following profile:
+
+| Compiled in | Not compiled in |
+|---|---|
+| Core agent loop | Any channel implementation |
+| 10–12 core tools (see Phase 2 D2) | Any non-core tool |
+| SQLite + Markdown memory backends | Browser automation |
+| Plugin host (`plugins-wasm`, always-on) | `observability-otel` (operator opt-in) |
+| `observability-prometheus` | `voice-wake` (libasound2 dependency) |
+| `skill-creation` (zero-overhead) | `probe` (niche hardware debugging) |
+| IPC server | Web assets (moved to `zeroclaw-gw`) |
+| Platform sandbox where supported | `peripheral-rpi` (separate hardware build) |
+
+There is no longer a "build with everything" binary. That mental model is replaced by `zeroclaw plugin install --profile full`, which downloads the full plugin catalog after installing the lean kernel binary.
+
+---
+
+**Release artifact matrix**
+
+Each GitHub Release publishes the following artifacts:
+
+| Artifact | Targets | Notes |
+|---|---|---|
+| `zeroclaw` kernel binary | `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-gnu`, `armv7-unknown-linux-gnueabihf`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc` | Static musl build for Linux x86_64; GNU for ARM targets |
+| `zeroclaw` kernel binary (hardware) | `aarch64-unknown-linux-gnu`, `armv7-unknown-linux-gnueabihf` | Same targets, compiled with `peripheral-rpi` and `hardware` flags for Raspberry Pi deployments |
+| `zeroclaw-gw` gateway binary | Same platform matrix as kernel | Published alongside the kernel; users install separately |
+| WASM plugin files | `wasm32-wasip1` | Published to the plugin registry (not GitHub Releases); installable via `zeroclaw plugin install` |
+| `zeroclaw-desktop` installer | `x86_64` and `aarch64` for macOS, Windows, Linux (AppImage/deb) | Bundles kernel + gateway + full plugin set; built by the Tauri workflow |
+
+The `wasm32-wasip1` plugin builds run in a separate CI job and are published to the plugin registry on their own cadence. A plugin release does not require a kernel release.
+
+---
+
+### 4.5 The Gateway Separation
+
+The current gateway conflates two things that must be separated:
+
+```
+Current (wrong):
+  zeroclaw binary
+    └── gateway
+          ├── Web UI server (serves React app)
+          ├── REST/WS/SSE API
+          ├── WhatsApp webhook handler  ← this is a channel, not a web server
+          ├── WATI webhook handler      ← this is a channel, not a web server
+          ├── Linq webhook handler      ← this is a channel, not a web server
+          ├── Nextcloud webhook handler ← this is a channel, not a web server
+          └── Gmail push handler        ← this is a channel, not a web server
+
+Target (correct):
+  zeroclaw-kernel
+    └── Local IPC API (Unix socket / 127.x HTTP)
+
+  zeroclaw-gw (separate binary, optional)
+    └── Connects to kernel IPC API
+    └── Web UI server
+    └── REST/WS/SSE API
+    └── Generic webhook proxy → routes to channel plugins
+
+  channel-whatsapp.wasm
+    └── Registers its own webhook route with the gateway
+    └── Handles WhatsApp-specific message parsing
+```
+
+**Why this matters:** When the gateway is a separate process, it can crash, restart, or be absent without affecting the agent. The kernel keeps running. This is especially important for the edge hardware use case — a Raspberry Pi running the kernel can have its web UI served from a VPS, with the kernel connecting outbound via a channel plugin. No inbound firewall rules needed.
+
+---
+
+## 5. Standards We Should Adopt
+
+Standards are agreements that have been made by many smart people over many years. Adopting them means we get those years of thinking for free, and it means our software integrates naturally with the rest of the ecosystem. Here are the ones that apply directly to ZeroClaw.
+
+### 5.1 Observability: OpenTelemetry
+
+**What it is:** OpenTelemetry (OTel) is the industry standard for collecting traces, metrics, and logs from software systems. It is maintained by the Cloud Native Computing Foundation and supported by every major cloud provider and monitoring tool.
+
+**Why it matters for ZeroClaw:** We have already implemented `OtelObserver` against our `Observer` trait. We have Prometheus metrics and DORA metrics. The issue is that these are not yet standardized across the codebase — some modules log with `tracing::info!`, others emit `ObserverEvent`s, and the two are not connected.
+
+**What we should do:**
+- Adopt OpenTelemetry as the single observability interface for all components
+- Ensure every plugin emits OTel spans when it executes, so a user can see a full trace from "message received on Discord" through "agent called shell tool" to "response sent"
+- Adopt W3C Trace Context (`traceparent`/`tracestate` headers) for propagating trace IDs across the kernel ↔ gateway ↔ plugin boundary
+- Structured log output should be JSON when `ZEROCLAW_LOG_FORMAT=json` is set (already using the `tracing` crate, just needs a JSON subscriber)
+
+**Standards:** OpenTelemetry specification · W3C Trace Context (REC) · RFC 5424 (Syslog, for system log integration)
+
+### 5.2 Plugin Interface: WASI and WIT
+
+**What it is:** WASI (WebAssembly System Interface) is the standard API that WebAssembly modules use to interact with the host system. WIT (WebAssembly Interface Types) is the interface definition language for describing what a WASM component exports and imports — think of it as a `.proto` file but for WASM plugins.
+
+**Why it matters for ZeroClaw:** Our `WasmTool` and `WasmChannel` bridges currently have no formal contract for what a plugin WASM binary must export. This means a plugin author has to guess. WIT files define that contract precisely and enable automatic code generation for plugin authors in any language.
+
+**What we should do:**
+- Define WIT interface files for `Tool`, `Channel`, and `Memory` plugin types (a `wit/` directory at the root of the workspace)
+- Use `wit-bindgen` to generate the Rust host-side bindings from those WIT files
+- Document the WIT interfaces as the official plugin SDK
+- A plugin author writes Rust (or Go, or C, or Python) against the WIT interface and `cargo build --target wasm32-wasi` — the result drops into `~/.zeroclaw/plugins/`
+
+**Standards:** WASI 0.2 · W3C WebAssembly Component Model · WIT IDL
+
+### 5.3 Local API: OpenAPI 3.1
+
+**What it is:** OpenAPI is the standard for describing HTTP APIs. Version 3.1 aligns with JSON Schema Draft 2020-12.
+
+**Why it matters for ZeroClaw:** The kernel's local IPC API (the socket that the gateway and other components connect to) needs a stable, documented contract. Without a formal spec, the gateway and kernel will drift apart silently over time.
+
+**What we should do:**
+- Write an OpenAPI 3.1 spec for the kernel's local IPC API before implementing it
+- Generate the Rust server stubs from the spec using `utoipa` or `aide`
+- Publish the spec as `docs/reference/api/kernel-ipc-api.yaml`
+- The gateway's external API should also have an OpenAPI spec
+
+**Standards:** OpenAPI 3.1 · JSON Schema Draft 2020-12
+
+### 5.4 Security: OWASP ASVS
+
+**What it is:** The OWASP Application Security Verification Standard is a checklist of security requirements organized by risk level (L1 basic, L2 standard, L3 advanced).
+
+**Why it matters for ZeroClaw:** The gateway handles webhooks from external services, processes untrusted user input, and manages secrets. The pairing system, WebAuthn support, and rate limiting all exist — but there is no framework for verifying that they are complete or correct.
+
+**What we should do:**
+- Target ASVS Level 2 for the gateway and security module
+- Work through the Level 2 checklist and document which requirements we meet, which we partially meet, and which are out of scope
+- Use this as the basis for security-related issues and PRs
+
+**Standards:** OWASP ASVS 4.0 · OWASP Top 10
+
+### 5.5 Quality Model: ISO/IEC 25010
+
+**What it is:** ISO/IEC 25010 defines a model for software product quality with eight top-level characteristics: functional suitability, performance efficiency, compatibility, usability, reliability, security, maintainability, and portability.
+
+**Why it matters for ZeroClaw:** When someone asks "is this good enough to merge?" the answer is currently subjective. ISO 25010 gives us a vocabulary for that conversation. The vision commitments map directly: "zero overhead" → performance efficiency; "any hardware" → portability; "zero compromise" → security + reliability.
+
+**What we should do:**
+- Use the eight quality characteristics as a lens in PR reviews for significant changes
+- Include a brief quality impact statement in the PR template for architectural changes (e.g., "This change improves maintainability by reducing coupling between the gateway and channel implementations, at no impact to performance efficiency")
+
+**Standards:** ISO/IEC 25010:2023
+
+### 5.6 Already Adopted — Keep These
+
+These are already in place and should be maintained:
+
+| Standard | Status | Where |
+|---|---|---|
+| Semantic Versioning 2.0.0 | ✅ Adopted | `Cargo.toml`, releases |
+| Conventional Commits | ✅ Adopted | `AGENTS.md`, commit history |
+| RFC 3339 / ISO 8601 timestamps | ✅ Adopted | `MemoryEntry`, all timestamps |
+| XDG Base Directory Specification | ✅ Adopted | `directories` crate in use |
+| Keep a Changelog | ✅ Adopted | `CHANGELOG.md` |
+| Rust API Guidelines | ✅ Partially | Clippy config enforces many |
+
+---
+
+## 6. Phased Roadmap: v0.7.0 → v1.0.0
+
+Each phase follows the Vision → Architecture → Design → Implementation → Testing → Documentation → Release hierarchy. No phase begins implementation until its design is reviewed and agreed upon.
+
+The overall migration strategy is the **Strangler Fig Pattern**: we grow the new architecture around the edges of the existing code, migrating inward steadily, until the old structure is fully replaced. We never have a "stop the world" rewrite. The application is always shippable.
+
+---
+
+### Phase 1 · v0.7.0 — "The Seams"
+
+**Theme:** Make the architecture visible without changing any behavior. Draw the lines first.
+
+**Why this phase:** You cannot migrate to a layered architecture until the layers exist as real boundaries. Right now, the traits define logical seams but the compiler does not enforce them — everything is in one crate, so anything can import anything. This phase makes the seams real.
+
+**Vision alignment:** None of the vision properties change for users. This is entirely internal. The value is that every future contribution now has a structural home, and new contributors can understand the codebase in parts rather than all at once.
+
+#### Deliverables
+
+**D1: Extract `zeroclaw-api` crate**
+
+Create a new crate `crates/zeroclaw-api` containing only trait definitions and their supporting types. No implementations. No heavy dependencies. This crate should compile in under two seconds.
+
+Move into this crate:
+- `src/providers/traits.rs` → `Provider`, `ChatMessage`, `ChatResponse`, `ToolCall`, `StreamChunk`, `ProviderCapabilities`
+- `src/channels/traits.rs` → `Channel`, `ChannelMessage`, `SendMessage`
+- `src/tools/traits.rs` → `Tool`, `ToolResult`, `ToolSpec`
+- `src/memory/traits.rs` → `Memory`, `MemoryEntry`, `MemoryCategory`
+- `src/observability/traits.rs` → `Observer`, `ObserverEvent`, `ObserverMetric`
+- `src/runtime/traits.rs` → `RuntimeAdapter`
+- `src/peripherals/traits.rs` → `Peripheral`
+
+Every other crate in the workspace that needs these types adds `zeroclaw-api` as a dependency. The compiler now enforces that no implementation crate can import another implementation crate without going through the API layer.
+
+**D2: Extract `zeroclaw-tool-call-parser` crate**
+
+The tool call parsing logic in `src/agent/loop_.rs` is approximately 1,400 lines of pure text transformation: it takes a string from the LLM and returns a list of structured tool calls. It has no dependency on agent state, memory, providers, or channels. It handles a dozen different LLM output formats (JSON, XML, GLM-style, MiniMax, Perl-style, markdown fences, and more).
+
+This logic is:
+1. Self-contained — perfect for its own crate
+2. The most fuzz-testable code in the project — property-based tests belong here
+3. A genuine contribution to the Rust ecosystem — no other crate does this comprehensively
+
+Create `crates/zeroclaw-tool-call-parser` with a public API of approximately:
+
+```rust
+pub fn parse(text: &str, specs: &[ToolSpec]) -> ParseResult
+
+pub struct ParseResult {
+    pub calls: Vec<ParsedToolCall>,
+    pub remaining_text: Option<String>,
+}
+
+pub struct ParsedToolCall {
+    pub name: String,
+    pub arguments: serde_json::Value,
+    pub tool_call_id: Option<String>,
+}
+```
+
+The ~300 parsing tests currently in `loop_.rs` move into this crate. `loop_.rs` shrinks by approximately 1,400 lines.
+
+**D3: Adopt OpenTelemetry as the observability standard**
+
+Formalize what is already implemented: document that `ObserverEvent` and `ObserverMetric` are the internal event bus, and that `OtelObserver` is the canonical production backend. Add a JSON structured logging subscriber for `ZEROCLAW_LOG_FORMAT=json`. Adopt W3C Trace Context for future cross-component tracing.
+
+**D4: Write WIT interface files**
+
+Before we implement WASM plugin execution, define the contracts. Create a `wit/` directory at the workspace root with interface definitions for:
+- `zeroclaw:tool/tool.wit` — the Tool plugin interface
+- `zeroclaw:channel/channel.wit` — the Channel plugin interface
+
+These become the official plugin SDK. The implementation in v0.8.0 will be generated from these files.
+
+#### Success Metrics for v0.7.0
+
+- `zeroclaw-api` compiles in < 2 seconds with zero implementation dependencies
+- `zeroclaw-tool-call-parser` has ≥ 95% test coverage (the logic is fully testable in isolation)
+- `loop_.rs` is under 8,000 lines
+- Zero user-facing behavior changes
+- Zero performance regressions (benchmark suite passes)
+
+---
+
+### Phase 2 · v0.8.0 — "The Runtime"
+
+**Theme:** Formalize the agent runtime as a clean, independently deployable unit. Everything that is not the runtime becomes a guest.
+
+**Why this phase:** Once the seams exist (v0.7.0), we can draw the runtime boundary explicitly. This phase extracts `zeroclaw-runtime` as a standalone crate, completes the WASM plugin execution bridge, and wires the plugin registry client — the mechanism by which everything outside the runtime connects to it.
+
+**Vision alignment:** This is where the composition model becomes real for users. A user who wants only a CLI agent downloads one binary, runs `zeroclaw onboard`, and is done — no Rust toolchain, no compilation. The `zeroclaw onboard` wizard gains the ability to download plugin components on demand.
+
+#### Deliverables
+
+**D1: Formalize `zeroclaw-runtime` crate**
+
+Extract the agent orchestration loop, CLI channel, security policy, plugin host, and IPC API into `crates/zeroclaw-runtime`, gated by the `agent-runtime` feature. This crate depends on `zeroclaw-api` and the foundation crates. It has no knowledge of Telegram, Discord, Anthropic, or any specific tool implementation.
+
+The runtime exports a clean public API:
+
+```rust
+pub struct Runtime { ... }
+
+pub struct Registry {
+    pub fn register_channel(&mut self, ch: Arc<dyn Channel>);
+    pub fn register_tool(&mut self, t: Box<dyn Tool>);
+    pub fn set_provider(&mut self, p: Arc<dyn Provider>);
+    pub fn set_memory(&mut self, m: Arc<dyn Memory>);
+    pub fn set_observer(&mut self, o: Arc<dyn Observer>);
+}
+
+pub async fn run(runtime: Runtime, registry: Registry) -> anyhow::Result<()>;
+```
+
+The binary crate becomes a thin wiring layer that reads config and calls `run`.
+
+**D2: Complete the WASM execution bridge**
+
+Wire Extism into `WasmTool::execute` and `WasmChannel`. The `PluginHost` already handles discovery and installation. The execution bridge is the missing piece. With WIT interfaces defined in v0.7.0, use `wit-bindgen` to generate the host-side bindings.
+
+A complete `WasmTool::execute` implementation using Extism is approximately 30–50 lines. The bulk of the work is defining the host functions that WASM plugins can call (HTTP requests, memory access, logging) within the permission model already defined in `PluginPermission`.
+
+**D3: Component registry client**
+
+Add a `zeroclaw plugin` subcommand backed by a simple registry client:
+
+```
+zeroclaw plugin list              # list installed plugins
+zeroclaw plugin search <query>    # search the component registry
+zeroclaw plugin install <name>    # download, verify, and install a plugin
+zeroclaw plugin remove <name>     # remove an installed plugin
+zeroclaw plugin update            # update all installed plugins
+```
+
+The registry is a JSON index file served from a known URL (e.g., `https://plugins.zeroclawlabs.ai/index.json`). Each entry includes name, version, download URL, SHA-256 checksum, and the publisher's Ed25519 public key. The `PluginHost` signature verification already handles the security model.
+
+**D4: Integrate `zeroclaw onboard` with the plugin system**
+
+The onboarding wizard should ask the user which channels and integrations they want, then call `PluginRegistry::install` for each. No compilation required. The user downloads a binary, runs `zeroclaw onboard`, and has a working configured agent in under two minutes.
+
+**D5: Reduce `all_tools_with_runtime` to core tools only**
+
+The kernel includes exactly the tools a user needs for a useful agent with no plugins installed: `shell`, `file_read`, `file_write`, `file_edit`, `git_operations`, `glob_search`, `content_search`, `memory_recall`, `memory_store`, `memory_forget`, and `web_fetch`. Everything else is registered by installed plugins.
+
+#### Success Metrics for v0.8.0
+
+- `zeroclaw-runtime` compiles independently with no channel or tool implementation code
+- `zeroclaw plugin install channel-discord` works end-to-end
+- `zeroclaw onboard` installs plugins without requiring a Rust toolchain
+- Runtime binary size is **tracked and reported** in the release notes; the aspiration is downward progress toward the vision target (see §7)
+- A WASM tool plugin written in Rust using the WIT interface executes correctly
+
+---
+
+### Phase 3 · v0.9.0 — "The Gateway"
+
+**Theme:** Separate the web surface from the agent core.
+
+**Why this phase:** The gateway is currently the largest structural coupling in the codebase. It embeds a compiled React application, handles channel-specific webhook logic, and is compiled into every binary — including binaries intended for $10 edge hardware that will never serve a web page.
+
+**Vision alignment:** This phase delivers the "zero external requirements" promise fully. A user on a Raspberry Pi gets a kernel binary with no web server, no React app, and no HTTP listener. A user who wants the web dashboard installs `zeroclaw-gw` separately.
+
+#### Deliverables
+
+**D1: Define the kernel IPC API**
+
+Before extracting the gateway, define the OpenAPI 3.1 spec for the local API the kernel exposes on a Unix socket or loopback port. This API is what the gateway, the Tauri app, and any future client connects to. It is the stable contract between the kernel and the outside world.
+
+Endpoints include: send a message, receive a streaming response, list active sessions, list installed plugins, get agent status, manage memory, trigger cron jobs. This is a design document first — the spec should be reviewed and agreed upon before a line of implementation is written.
+
+**D2: Implement the kernel IPC server**
+
+Add the IPC server to `zeroclaw-kernel` behind a feature flag (`--features ipc`). On platforms that support it, the kernel listens on a Unix socket at `~/.zeroclaw/kernel.sock`. On Windows, use a named pipe. The `zeroclaw gateway` command (the current entrypoint for the web server) becomes `zeroclaw-gw` connecting to this socket.
+
+**D3: Extract `zeroclaw-gw` as a separate binary**
+
+Move `src/gateway/` to a new `crates/zeroclaw-gw/` crate with its own binary. It depends on `zeroclaw-api` and connects to the kernel via the IPC API. The embedded React application via `rust-embed` moves entirely into this crate — the kernel binary no longer contains any web assets.
+
+**D4: Migrate channel webhook handlers out of the gateway**
+
+The WhatsApp, WATI, Linq, Nextcloud Talk, and Gmail webhook handlers currently in `gateway/mod.rs` move to their respective channel plugins. The gateway provides a generic webhook registration API: a channel plugin, when loaded, registers its webhook path prefix and its handler function. The gateway routes incoming webhooks to the registered handler. The gateway no longer knows about WhatsApp.
+
+**D5: Formalize the Tauri sidecar relationship**
+
+Update `apps/tauri/` to bundle `zeroclaw-gw` as a Tauri sidecar binary. The Tauri app becomes the "full experience" distribution: it starts the kernel and gateway automatically and opens the web UI. Users who download the Tauri app get everything working without touching a terminal.
+
+#### Success Metrics for v0.9.0
+
+- Kernel binary (release) does not contain any web assets or HTTP server code
+- `zeroclaw-gw` starts, connects to the kernel via IPC, and serves the web dashboard
+- Removing `zeroclaw-gw` does not break the kernel or any channel plugins
+- WhatsApp, WATI, Linq, Nextcloud Talk, and Gmail channel code has moved to plugin crates
+- Tauri desktop app bundles and starts both binaries correctly
+
+---
+
+### Phase 4 · v1.0.0 — "The Platform"
+
+**Theme:** ZeroClaw becomes a composable platform, not a monolithic application.
+
+**Why this phase:** With the kernel stable, the gateway separate, and the plugin system working, v1.0.0 is the release where the architecture becomes the product. External developers can write and publish plugins. Users can assemble exactly the ZeroClaw they want. The binary can credibly claim the lean profile the vision promises.
+
+#### Deliverables
+
+**D1: Migrate all remaining channels to plugins**
+
+Each of the 27+ channel implementations becomes a standalone WASM plugin crate. They are published to the component registry with signed releases. The kernel binary contains zero channel implementations except the CLI.
+
+**D2: Migrate long-tail tools to plugins**
+
+Approximately 60 of the 70+ tools move to plugin crates, grouped by domain: `zeroclaw-tools-web` (browser, search, screenshot, PDF), `zeroclaw-tools-integrations` (Jira, Notion, Google Workspace, MS365, LinkedIn), `zeroclaw-tools-hardware` (board info, GPIO), `zeroclaw-tools-cloud` (cloud ops, security ops). The kernel retains only the 10–12 core tools identified in v0.8.0.
+
+**D3: Plugin SDK and developer documentation**
+
+Publish a plugin development guide. A developer should be able to write a new tool plugin in an afternoon:
+1. Add `zeroclaw-plugin-sdk` as a dependency
+2. Implement the WIT-generated trait
+3. `cargo build --target wasm32-wasi`
+4. `zeroclaw plugin install ./my-plugin/`
+
+The SDK handles the host function bindings, the manifest format, and the permissions model.
+
+**D4: Stabilize the kernel IPC API at v1.0**
+
+The kernel IPC API gets a version prefix (`/v1/`) and a stability guarantee. Breaking changes in v1.x are not permitted to this API. This is the contract that third-party clients and the gateway depend on.
+
+**D5: Extract the versioning policy and stability tier definitions to `docs/contributing/stability-tiers.md`**
+
+The versioning policy and stability tier table defined in §4.4.1 of this RFC become a standing contributor reference document at `docs/contributing/stability-tiers.md`. This document is the day-to-day reference contributors use when assigning a tier to a new plugin crate, and that maintainers consult when making release decisions. The RFC itself remains the historical record of *why* these decisions were made; the extracted document is *what* contributors look up.
+
+#### Success Metrics for v1.0.0
+
+- Runtime binary size is **tracked against the vision target** (see §7); a dedicated optimization pass through each crate is expected as a v1.0.0 workstream
+- A third-party developer can publish a working plugin using only public documentation
+- All 27+ channel implementations are available as downloadable plugins in the registry
+- `zeroclaw onboard` completes a full setup in under 2 minutes on a Raspberry Pi Zero 2W with no Rust toolchain installed
+- The full plugin catalog is installable with `zeroclaw plugin install --profile full`
+
+---
+
+## 7. Code and Complexity Metrics
+
+These are estimates based on direct code analysis of the current codebase. They are meant to give a sense of scale, not to be exact predictions.
+
+### Lines of Code Moving Out of the Runtime
+
+| What moves | Approximate lines | Destination |
+|---|---|---|
+| Tool call parser (from `loop_.rs`) | ~1,400 | `zeroclaw-tool-call-parser` crate |
+| 60+ non-core tool implementations | ~30,000 | Plugin crates |
+| 24+ non-core channel implementations | ~7,200 | Plugin crates |
+| Gateway HTTP server | ~2,260 | `zeroclaw-gw` crate |
+| Embedded React app (binary weight) | — | `zeroclaw-gw` crate |
+| Channel webhook handlers from gateway | ~500 | Channel plugin crates |
+| **Estimated total removed from runtime** | **~41,000 lines** | — |
+
+### File-Level Complexity Reduction
+
+| File | Current lines | Target after migration | Reduction |
+|---|---|---|---|
+| `src/agent/loop_.rs` | ~9,500 | ~5,000 | ~47% |
+| `src/gateway/mod.rs` | ~2,260 | Moves to `zeroclaw-gw` | 100% |
+| `src/tools/mod.rs` | `all_tools_with_runtime` is ~680 lines | ~80 lines (core tools only) | ~88% |
+| `src/providers/mod.rs` | ~3,750 | ~1,200 (providers self-register) | ~68% |
+| `src/channels/mod.rs` | ~200 + 44 channel files | CLI channel only | ~90% |
+
+### Binary Size — Measured Progress and Vision Target
+
+The project's vision is expressed in runtime terms: **<5 MB RAM** on $10 hardware. Binary size on disk and runtime memory footprint (RSS) are related but not identical — demand paging means only executed code paths are resident. Both are tracked.
+
+> **Two-pass model:** Architectural decomposition (Phases 1–3) and binary size optimization are separate workstreams. Decomposition *enables* optimization by isolating dependencies to their owning crates. Maximizing efficiency crate-by-crate is the expected second pass, not a deliverable of the structural work itself.
+
+| Configuration | Pre-decomposition (v0.6.x) | Phase 1 result (v0.7.0) | Vision target |
+|---|---|---|---|
+| Full monolith binary | ~8.8 MB | N/A (replaced by plugin model) | N/A |
+| Foundation only (`--no-default-features`) | N/A | **6.6 MB** *(measured, stripped)* | TBD after optimization pass |
+| Runtime binary (foundation + `agent-runtime`) | N/A | tracked → | aspiration: ≤ 5 MB RAM at runtime |
+| Runtime + gateway | N/A | tracked → | ~5–7 MB on disk |
+| Runtime + gateway + top 5 channels | N/A | tracked → | ~8–10 MB (plugins are separate files) |
+| Tauri desktop app (bundles all) | N/A | tracked → | ~20–25 MB installer |
+
+The 6.6 MB Phase 1 foundation build represents real progress from the 8.8 MB monolith and proves the decomposition is working. Reaching the vision target requires a dedicated dependency-audit and optimization pass through each crate after the structural decomposition is complete — reviewing each crate's `Cargo.toml` for unnecessary or over-featured dependencies, validating LTO and strip profiles, and auditing which tokio/serde feature flags are actually needed.
+
+The key structural shift: binary size stops being a function of "features compiled in at build time" and becomes a function of "plugins installed at runtime," which the user controls. That shift is the architectural goal of Phases 1–3. The size numbers are the optimization goal of the pass that follows.
+
+### Compilation Time Improvement
+
+Currently, a full `cargo build --release` on this codebase compiles every channel, every tool, every provider, and the embedded React app in a single compilation unit. Crate decomposition means:
+
+- The kernel compiles independently and its compiled output is cached
+- A change to `channel-discord` does not recompile the kernel
+- Contributors working on a plugin only recompile their plugin
+- CI can parallelize crate compilation across jobs
+
+Estimated wall-clock time improvement for incremental builds: 60–75% reduction for changes that do not touch the kernel.
+
+---
+
+## 8. What This Means for Contributors
+
+### For new contributors
+
+The most common complaint from new contributors to large codebases is: "I don't know where to start." With the current architecture, the answer to "where does a Discord message go?" requires tracing through `channels/discord.rs` → `channels/mod.rs` → `gateway/mod.rs` → `agent/loop_.rs` → dozens of other files.
+
+With the microkernel architecture, the answer is: "it goes to the kernel's `Channel` receiver, via the `channel-discord` plugin." A new contributor can understand the Discord channel completely by reading one plugin crate. They can understand the full agent loop by reading `zeroclaw-kernel` without any channel or tool code in scope.
+
+**A good rule of thumb for new contributors:** if you can describe your change in one sentence without mentioning more than one component, you are working at the right level. "Fix a bug in how the Discord channel handles thread replies" is one component. "Refactor the agent loop and update the Discord channel and also fix the memory backend" is three components — it should be three PRs.
+
+### For maintainers
+
+Every bug report will have a clear home. "The agent is calling tools incorrectly" → `zeroclaw-tool-call-parser` or `zeroclaw-runtime`. "The Discord integration is broken" → `channel-discord` plugin. "The web dashboard is not loading" → `zeroclaw-gw`. Right now, any of those bugs could be anywhere in 50,000+ lines.
+
+### For the release process
+
+The plugin model means channels and tools can have independent release cycles. A bug fix in the Telegram channel does not require a new kernel release. The kernel's stability becomes the foundation that everything else builds on. Rapid iteration on plugins does not risk kernel stability.
+
+### For the community
+
+A published WIT interface and plugin SDK means anyone can extend ZeroClaw without forking it. A company that needs a specific integration can write a plugin against the public interface. This is how ecosystems are built.
+
+---
+
+
+---
+
+## Appendix A: Glossary
+
+Terms used in this document that may be unfamiliar:
+
+**Big Ball of Mud** — An architecture (or lack thereof) in which the codebase has grown organically without structural planning. The name comes from a 1997 paper by Brian Foote and Joseph Yoder. It is the most common architecture in software, not because anyone chooses it, but because it is what you get by default.
+
+**Conway's Law** — "Any organization that designs a system will produce a design whose structure is a mirror image of the organization's communication structure." (Mel Conway, 1968) If contributors work in isolated silos without talking to each other, the code will reflect that. If contributors collaborate with clear interfaces between their work, the code will reflect that too.
+
+**Dependency Inversion Principle** — High-level modules should not depend on low-level modules. Both should depend on abstractions. This is why `zeroclaw-runtime` depends on `zeroclaw-api` (abstractions) and not on `channel-discord` (a specific implementation).
+
+**Microkernel** — An architecture in which the core system contains only the minimum necessary functionality, and all other capabilities are provided by separate components that communicate with the core through well-defined interfaces.
+
+**Strangler Fig Pattern** — A migration strategy in which you incrementally replace parts of an existing system by building new components alongside the old ones. Named for the strangler fig plant, which grows around an existing tree until the original tree has been fully replaced. The key property: the system is always running and always deployable during the migration.
+
+**Technical Debt** — The accumulated cost of taking shortcuts in software design. Like financial debt, a small amount can be productive (you ship faster now). A large amount becomes crippling (you spend all your time on interest payments — i.e., bug fixes and workarounds — instead of new features).
+
+**WIT (WebAssembly Interface Types)** — An interface definition language for describing what WASM components export and import. Think of it as a contract: "a Tool plugin must export a function called `execute` that takes JSON and returns JSON." WIT makes that contract precise and machine-readable.
+
+---
+
+## Appendix B: Further Reading
+
+These are resources the team may find valuable. They are not required reading, but each one has directly influenced this proposal.
+
+- **"A Philosophy of Software Design"** — John Ousterhout. The best short book on managing complexity in software. His concept of "deep modules" (simple interfaces, powerful implementations) is exactly what the microkernel model aims for.
+
+- **"Clean Architecture"** — Robert C. Martin. The Dependency Rule described in Section 4.2 of this document comes from this book.
+
+- **"Release It!"** — Michael Nygard. Practical patterns for building software that stays up in production. The gateway separation and circuit-breaker patterns discussed here are drawn from this book.
+
+- **The Rust API Guidelines** — https://rust-lang.github.io/api-guidelines/ — The official guide for designing idiomatic Rust libraries. Our trait interfaces should follow these conventions.
+
+- **The WebAssembly Component Model** — https://component-model.bytecodealliance.org/ — The technical foundation for the plugin system proposed in this RFC.
+
+- **OpenTelemetry specification** — https://opentelemetry.io/docs/specs/ — The full specification for the observability standard we are adopting.
+
+---
+
+*This proposal was developed from a detailed analysis of the ZeroClaw codebase at v0.6.8. The code metrics cited are based on direct measurement of the source files. The architectural recommendations reflect established patterns in systems software design applied to the specific constraints and goals of the ZeroClaw project.*
+
+*Feedback, corrections, and counterproposals are welcome. The best architecture is the one the team understands and believes in — not the one any single person dictated.*

--- a/docs/foundations/fnd-002-documentation-standards.md
+++ b/docs/foundations/fnd-002-documentation-standards.md
@@ -1,0 +1,758 @@
+# FND-002: Intentional Documentation — Standards, Structure, and i18n Strategy
+### Starting v0.7.0 · Type: Documentation · Rev. 1
+
+> **Canonical reference** · Ratified by the team · Rev. 1
+> Discussion thread and full revision history: [#5576](https://github.com/zeroclaw-labs/zeroclaw/issues/5576)
+
+
+---
+
+> **A note to the team before you read this.**
+>
+> Documentation is not what you write after the code is done. It is a product surface in its own right — the interface between the project and every person who will ever contribute to it, use it, or build on it. A codebase with no documentation forces every new person to rediscover everything from scratch. A codebase with bad documentation is often worse, because it gives people false confidence. This RFC proposes treating documentation with the same intentionality we are applying to the architecture: Vision first, then structure, then content.
+
+---
+
+## Table of Contents
+
+1. [The Documentation Philosophy](#1-the-documentation-philosophy)
+2. [Honest Assessment: Where We Are Today](#2-honest-assessment-where-we-are-today)
+3. [A Classification Framework: EA Artifacts on a Page](#3-a-classification-framework-ea-artifacts-on-a-page)
+4. [The i18n Problem](#4-the-i18n-problem)
+5. [The Repo / Wiki Split](#5-the-repo--wiki-split)
+6. [ADR Standards](#6-adr-standards)
+7. [AGENTS.md as the AI Development Layer](#7-agentsmd-as-the-ai-development-layer)
+8. [The Target Structure](#8-the-target-structure)
+9. [The Replacement docs-contract](#9-the-replacement-docs-contract)
+10. [Standards We Should Adopt](#10-standards-we-should-adopt)
+11. [Phased Roadmap](#11-phased-roadmap)
+
+---
+
+## 1. The Documentation Philosophy
+
+Documentation problems almost always come from skipping a question that should have been asked before writing the first sentence: **what kind of document is this, and who is it for?**
+
+Without an answer to that question, documentation accumulates as a pile of pages that are all slightly different shapes of the same vague category: "stuff about the project." Setup guides live next to architecture decisions. User-facing how-tos sit alongside internal coding standards. Thirty language translations of the README compete for space with the single security policy document. Nobody can find anything, everything goes stale at a different rate, and every PR that touches documentation becomes a negotiation about which pages need updating.
+
+The fix is not to write more documentation. The fix is to decide, before writing anything, what type of artifact you are creating. Type determines format, audience, location, lifecycle, and who is responsible for keeping it current. Once type is established, the rest follows naturally.
+
+This RFC adopts the **EA Artifacts on a Page** framework by Svyatoslav Kotusev (https://eaonapage.com) as the classification lens for all ZeroClaw documentation. The framework is evidence-based, deliberately non-prescriptive, and maps directly onto the kinds of documents an open source infrastructure project actually needs.
+
+The core principle, borrowed from the broader development philosophy this team is adopting:
+
+> **Documents, like code, should trace a line upward through Vision → Architecture → Design → Implementation. If you cannot name the artifact type and its audience before writing, you are not ready to write.**
+
+---
+
+## 2. Honest Assessment: Where We Are Today
+
+### 2.1 The i18n Footprint
+
+The most immediately measurable problem in the current documentation is the localization system:
+
+| Metric | Value |
+|---|---|
+| Non-English README files at repo root | 31 |
+| Files in `docs/i18n/` | 169 |
+| Disk space consumed by `docs/i18n/` | 2.2 MB |
+| Actively "supported" locales per `docs-contract.md` | 6 (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`) |
+| Locales with README files at root | 31 |
+
+The i18n system creates a **contributor tax on every documentation PR**. The current `docs-contract.md` contains this requirement:
+
+> *If a change touches docs IA, runtime-contract references, or user-facing wording in shared docs, perform i18n follow-through for supported locales in the same PR.*
+
+This means a contributor fixing a typo in a setup guide must update up to six language versions of that document, or the PR fails review. This is a significant barrier to contribution, particularly for the students and early-career engineers who make up most of this project's contributor base.
+
+### 2.2 The Structure Problem
+
+The current `docs/` hierarchy mixes three fundamentally different document types at the same level:
+
+- **Code-adjacent documents** that must version with the codebase (ADRs, API specs, security policy, contribution process)
+- **User-facing operational documents** that should update independently of code releases (setup guides, troubleshooting, deployment how-tos)
+- **Community documents** that should be community-maintained and need no formal review process (translations, FAQ, community guides)
+
+All three live in `docs/` with no structural distinction between them. The result is a flat pile with a hand-maintained `SUMMARY.md` that someone has to update every time anything changes.
+
+### 2.3 The ADR Gap
+
+The project has exactly one Architecture Decision Record: `ADR-004-tool-shared-state-ownership.md`. It is excellent — well-structured, code-referenced, specific. But the project has made at least five or six architectural decisions of equal or greater consequence that have never been recorded:
+
+- The choice of Rust over TypeScript
+- The trait-driven extensibility model
+- The WASM plugin system design
+- The choice of SQLite and Markdown as the two memory backends
+- The security model (pairing codes, autonomy levels, sandbox layers)
+
+Without these records, every new contributor must rediscover the reasoning through code archaeology. Every AI coding assistant that reads the codebase gets the *what* but not the *why*. This is one of the most expensive forms of undocumented technical debt.
+
+### 2.4 What Is Already Good
+
+The `docs-contract.md` concept — treating documentation as a governed product surface — is the right instinct. It just needs the right rules. The `AGENTS.md` at the root is excellent and sets the right precedent for AI-assisted development. ADR-004 proves the team can write high-quality architectural records.
+
+---
+
+## 3. A Classification Framework: EA Artifacts on a Page
+
+The **EA Artifacts on a Page** framework defines five families of architecture artifacts. Every document in the ZeroClaw repository should belong to one of these families, and that family determines everything about where it lives, how it is formatted, and when it becomes stale.
+
+| EA Artifact Family | The Question It Answers | Examples in ZeroClaw | Location |
+|---|---|---|---|
+| **Considerations** | What principles and standards guide our decisions? | `AGENTS.md` files, coding standards, security policy, this doc | `docs/contributing/` or per-crate |
+| **Landscapes** | What does the system look like right now? | Component maps, crate topology, dependency diagrams | `docs/architecture/` |
+| **Outlines** | Where are we going? | RFCs and roadmap proposals | `docs/proposals/` |
+| **Designs** | How exactly are we doing this specific thing? | ADRs, OpenAPI specs, WIT interface files | `docs/architecture/decisions/` |
+| **Standards** | What are the specific rules for how we build? | PR workflow, testing standards, release process | `docs/contributing/` |
+
+**What is notably absent from this table:** user guides, setup instructions, channel-specific how-tos, troubleshooting, FAQ. These are **operational content**, not EA artifacts. They do not version with the code. They belong on the GitHub Wiki.
+
+### Using the Framework
+
+Before writing any document, ask and answer these two questions:
+
+1. **What artifact family is this?** If you cannot answer this, you are not ready to write.
+2. **Does it need to version with the code?** If yes, it goes in the repository. If no, it goes on the Wiki.
+
+A useful test for the second question: *would this document become wrong or misleading if someone read it against a different version of the codebase?* If yes, it lives in the repo, versioned with the code. If no, it lives on the Wiki.
+
+---
+
+## 4. The i18n Problem
+
+### 4.1 The Argument for Removal
+
+The case for removing all non-English content from the repository rests on four pillars:
+
+**1. The audience has on-demand translation.** ZeroClaw's primary users are people running an AI assistant. Every such person has access to instant, high-quality machine translation — either through the agent they are running, through their browser, or through any of dozens of free translation services. The practical benefit of shipping translations in the repository is marginal.
+
+**2. The translations are almost certainly stale.** Machine-translated content was likely generated once and has not been kept synchronised with the English source. Stale documentation is worse than no documentation for AI-assisted development, because language models will confidently derive incorrect conclusions from outdated information.
+
+**3. The contributor tax is real and measurable.** The `docs-contract.md` parity requirement means every documentation PR must touch up to six language versions. This makes documentation contributions expensive and discourages exactly the kind of small, incremental improvements (fixing a typo, clarifying a step, updating a stale reference) that keep documentation healthy.
+
+**4. Localization is community work, not core project work.** The communities best positioned to maintain Japanese documentation are Japanese-speaking contributors. Putting localized content in the main repository with a parity requirement places the burden on the core maintainers instead of the communities who benefit. The GitHub Wiki inverts this correctly: community members can edit and maintain their language's pages without opening PRs.
+
+### 4.2 What Stays
+
+One thing worth preserving: the _structure_ of the i18n approach. The idea of making ZeroClaw accessible in multiple languages is right. Only the _location_ and _ownership model_ is wrong.
+
+### 4.3 The Replacement Strategy
+
+1. **Remove** all `README.*.md` files from the repository root, except `README.md`
+2. **Remove** `docs/i18n/` entirely
+3. **Remove** all non-English hub files from `docs/` (e.g. `docs/README.zh-CN.md`)
+4. **Add** a `Languages` section to the main `README.md`:
+
+   > **Translations:** Community-maintained translations are available in the [GitHub Wiki](https://github.com/zeroclaw-labs/zeroclaw/wiki). To contribute a translation or improve an existing one, edit the Wiki directly. All languages are welcome.
+
+5. **Create** a `Translations` page on the GitHub Wiki with a table of available languages, their completeness, and the contributors maintaining them
+6. **Optionally:** add a `zeroclaw docs --translate` CLI feature that uses the configured LLM provider to translate any doc page on demand — a natural fit for a product whose entire purpose is AI assistance
+
+### 4.4 The AGENTS.md Impact
+
+Remove the i18n follow-through requirement from `docs-contract.md`. Replace it with: *Documentation PRs are reviewed in English only. Translations are community-maintained on the Wiki and are not subject to PR review.*
+
+---
+
+## 5. The Repo / Wiki Split
+
+### 5.1 The Decision Rule
+
+> **A document lives in the repository if it would become wrong when the code changes. It lives on the Wiki if it would not.**
+
+This is not a fuzzy rule. Apply it literally.
+
+An ADR records why a specific architectural decision was made at a specific point in time. If the code changes, the ADR still accurately describes what was decided and when. The code may have evolved away from it, but the record remains accurate. → **Repository.**
+
+A setup guide for configuring the Telegram channel describes steps a user takes against the current version of the software. If the configuration format changes, the guide becomes wrong. → **This sounds like it should be in the repo — but it shouldn't.** Setup guides should update on their own timeline, not be coupled to code commits. The right model is: the API reference (which maps directly to configuration structs) lives in the repo, and the setup guide that walks a user through using that API lives on the Wiki, updated by anyone when the steps change.
+
+### 5.2 The Split in Practice
+
+**Stays in the repository (`docs/`):**
+
+| Current location | Artifact family | Notes |
+|---|---|---|
+| `docs/architecture/` | Designs | ADRs, component diagrams |
+| `docs/proposals/` | Outlines | RFCs, roadmap documents |
+| `docs/contributing/` | Considerations + Standards | PR workflow, testing, coding standards |
+| `docs/security/` | Considerations + Designs | Security policy, sandboxing design, audit logging |
+| `docs/hardware/` | Designs | Peripheral design docs, datasheets |
+| `docs/reference/api/` | Designs | Config reference, providers reference — generated from or tightly coupled to code |
+| `docs/reference/cli/` | Designs | Commands reference |
+
+**Moves to the GitHub Wiki:**
+
+| Current location | Reason for moving |
+|---|---|
+| `docs/setup-guides/` | User-facing how-tos that change independently of code |
+| `docs/ops/operations-runbook.md` | Operational, user-maintained |
+| `docs/ops/troubleshooting.md` | Operational, changes frequently |
+| `docs/ops/network-deployment.md` | Operational, deployment-specific |
+| `docs/setup-guides/mattermost-setup.md` (and similar per-channel guides) | User-facing, change with upstream platform APIs |
+
+**Deleted (i18n removal):**
+
+| Item | Size impact |
+|---|---|
+| `docs/i18n/` (169 files) | −2.2 MB from repo |
+| 31 × `README.*.md` at root | −significant root clutter |
+| Non-English hub files in `docs/` | −31 files |
+| i18n coverage map, i18n index | −2 files |
+
+### 5.3 The Wiki Structure
+
+```
+Home
+│
+├── Getting Started
+│     ├── Installation
+│     ├── Quick Start (TL;DR)
+│     ├── Migrating from OpenClaw
+│     └── Onboarding Walkthrough
+│
+├── Configuration
+│     ├── Providers
+│     ├── Channels
+│     ├── Memory
+│     ├── Security & Pairing
+│     └── Tunnels
+│
+├── Channels
+│     ├── Telegram
+│     ├── Discord
+│     ├── Slack
+│     ├── WhatsApp
+│     └── ... (one page per channel)
+│
+├── Operations
+│     ├── Troubleshooting
+│     ├── Deployment
+│     ├── Network Setup
+│     └── Performance Tuning
+│
+├── Hardware
+│     ├── Getting Started with Peripherals
+│     ├── ESP32 Setup
+│     ├── STM32 Nucleo Setup
+│     └── Arduino Setup
+│
+└── Community
+      ├── FAQ
+      ├── Translations
+      └── How to Contribute
+```
+
+---
+
+## 6. ADR Standards
+
+### 6.1 The Format
+
+All Architecture Decision Records use the **Nygard format**, extended with YAML frontmatter for machine readability. ADR-004 is the existing model — this section formalizes it.
+
+Every ADR has three sections and five frontmatter fields:
+
+```
+---
+id: ADR-NNN
+title: Short imperative sentence describing the decision
+date: YYYY-MM-DD
+status: proposed | accepted | deprecated | superseded-by-ADR-NNN
+relates-to:
+  - ADR-XXX (optional, list of related decisions)
+  - crates/zeroclaw-api (optional, affected code paths)
+---
+
+# ADR-NNN: Title
+
+## Context
+
+What is the situation, constraint, or problem that required a decision?
+What forces were at play? What options were considered?
+
+## Decision
+
+What was decided? State it in the active voice.
+"We will..." not "It was decided that..."
+
+## Consequences
+
+What are the results of this decision?
+List both positive consequences and negative ones — every decision has tradeoffs.
+Note any follow-up decisions or actions this creates.
+
+## References
+
+Links to the relevant code files, issues, and external resources.
+```
+
+### 6.2 ADR Lifecycle Rules
+
+- **ADRs are immutable once accepted.** If a decision changes, the old ADR is marked `superseded-by-ADR-NNN` and a new ADR is written describing the new decision and why it superseded the old one.
+- **ADRs are numbered sequentially and never renumbered.** Gaps in the sequence are acceptable (a proposed ADR that was rejected can be withdrawn, leaving a gap).
+- **ADRs live in `docs/architecture/decisions/`.** They are named `ADR-NNN-short-slug.md`.
+- **Significant architectural changes require an ADR.** "Significant" means: a decision that would be surprising to a new contributor, a decision that constrains future choices, or a decision that involves a non-obvious tradeoff.
+
+### 6.3 Retroactive ADRs
+
+The following key decisions should be documented retroactively. They represent the foundational reasoning a new contributor or AI tool needs to understand the codebase:
+
+| Proposed ADR | Decision to record |
+|---|---|
+| ADR-001 | Rust as the implementation language (replacing TypeScript/OpenClaw) |
+| ADR-002 | Trait-driven extensibility as the primary architectural pattern |
+| ADR-003 | WASM + Extism as the plugin execution model |
+| ADR-004 | Tool shared state ownership contract *(already exists)* |
+| ADR-005 | SQLite + Markdown as the two memory backends |
+| ADR-006 | CLI as the only built-in channel; all others as plugins |
+| ADR-007 | Gateway extraction as a separate optional binary |
+
+Retroactive ADRs should be marked with a note:
+
+> *This is a retroactive record of a decision made prior to the formal ADR process. The date reflects when the decision was made, not when this record was written.*
+
+### 6.4 Why This Matters for AI-Assisted Development
+
+When an AI coding assistant reads a repository, it sees the code as it is now. It does not see the choices that were rejected, the tradeoffs that were weighed, or the reasons a particular structure was chosen over alternatives. Without ADRs, the AI will suggest changes that violate architectural constraints it has no way of knowing about. With ADRs, the reasoning is explicit and machine-readable. The frontmatter makes ADRs queryable: an AI tool can find all ADRs related to `zeroclaw-api` and load them as context before editing that crate.
+
+---
+
+## 7. AGENTS.md as the AI Development Layer
+
+### 7.1 The Pattern
+
+The root `AGENTS.md` is the project's strongest existing contribution to AI-assisted development. It tells AI coding assistants the commands to run, the architecture to respect, the risk tiers to apply, and the anti-patterns to avoid. It works because it is specific, opinionated, and short.
+
+As the workspace decomposes into crates (per the microkernel architecture RFC), each crate should have its own `AGENTS.md`. This is the mechanism by which architectural boundaries become enforceable at the AI-assistance layer — not just at compile time through crate dependencies, but at the reasoning layer before any code is written.
+
+### 7.2 What Each Crate AGENTS.md Contains
+
+Keep them short. An `AGENTS.md` that is longer than 60 lines will not be read. Each file answers five questions:
+
+```markdown
+# <crate-name>
+
+## What this crate is
+One or two sentences. What problem does this crate solve?
+
+## What this crate is allowed to depend on
+List the crates this crate may import. Be explicit.
+If a dependency is not listed here, do not add it without an ADR.
+
+## Extension points
+Where can new implementations be added? What trait do they implement?
+Link to the relevant traits.
+
+## What does NOT belong here
+Explicit anti-patterns. What would be a mistake to add to this crate?
+
+## Related ADRs
+- ADR-NNN: Short title
+```
+
+### 7.3 Examples
+
+**For `crates/zeroclaw-api` (once extracted):**
+
+```markdown
+# zeroclaw-api
+
+## What this crate is
+Trait definitions and shared data types for the ZeroClaw plugin and kernel
+interfaces. This is the contract layer. Everything else depends on it.
+
+## What this crate is allowed to depend on
+- serde, serde_json (serialization)
+- async-trait (async trait support)
+- anyhow (error types)
+- tokio (async runtime types, minimal)
+Nothing else. No HTTP clients. No database drivers. No external services.
+
+## Extension points
+All traits in this crate are extension points:
+- `Provider` (src/providers/traits.rs) — LLM provider implementations
+- `Channel` (src/channels/traits.rs) — messaging platform integrations
+- `Tool` (src/tools/traits.rs) — agent tool implementations
+- `Memory` (src/memory/traits.rs) — persistence backends
+- `Observer` (src/observability/traits.rs) — observability backends
+- `RuntimeAdapter` (src/runtime/traits.rs) — execution environments
+- `Peripheral` (src/peripherals/traits.rs) — hardware integrations
+
+## What does NOT belong here
+- Any concrete implementation of any trait
+- Any dependency on a specific messaging platform, LLM provider, or database
+- Any network I/O or filesystem access
+- Any binary or executable target
+
+## Related ADRs
+- ADR-002: Trait-driven extensibility
+```
+
+**For `crates/zeroclaw-kernel` (once extracted):**
+
+```markdown
+# zeroclaw-kernel
+
+## What this crate is
+The orchestration engine. Runs the agent loop, manages the service registry,
+exposes the local IPC API. The kernel knows nothing about specific channels,
+providers, or tools — only their abstract interfaces.
+
+## What this crate is allowed to depend on
+- zeroclaw-api (traits only)
+- zeroclaw-tool-call-parser (parsing, no agent state)
+- Standard async/runtime crates (tokio, anyhow, tracing)
+- Config and storage crates (toml, serde, rusqlite for core memory)
+NOT: any specific channel, provider, or tool implementation crate.
+
+## Extension points
+- `Registry::register_channel()` — add a channel at startup
+- `Registry::register_tool()` — add a tool at startup
+- `Registry::set_provider()` — set the active provider at startup
+Implementations are registered by the binary crate, not by the kernel.
+
+## What does NOT belong here
+- Any import of TelegramChannel, DiscordChannel, or any named channel
+- Any import of AnthropicProvider, OpenAIProvider, or any named provider
+- Any tool implementation beyond the 10-12 designated core tools
+- The gateway HTTP server or any web serving code
+
+## Related ADRs
+- ADR-002: Trait-driven extensibility
+- ADR-006: CLI as the only built-in channel
+- ADR-007: Gateway extraction
+```
+
+### 7.4 The AGENTS.md Hierarchy
+
+The root `AGENTS.md` sets project-wide policy. Crate-level `AGENTS.md` files narrow that policy for their specific scope. When an AI tool reads a file in `crates/zeroclaw-api/`, it should read both the root `AGENTS.md` (project policy) and `crates/zeroclaw-api/AGENTS.md` (crate policy). Crate policy is more specific and takes precedence where they conflict.
+
+---
+
+## 8. The Target Structure
+
+After the changes proposed in this RFC, the repository's documentation layout becomes:
+
+```
+docs/
+│
+├── README.md                    ← Hub: links to wiki for user guides,
+│                                  to proposals/ for roadmap, to
+│                                  architecture/ for decisions
+├── SUMMARY.md                   ← Canonical TOC (English only, repo docs only)
+│
+├── architecture/
+│   ├── README.md                ← Overview: what decisions have been made,
+│   │                              current system landscape
+│   ├── decisions/               ← ADRs (immutable once accepted)
+│   │   ├── ADR-001-rust-first.md
+│   │   ├── ADR-002-trait-driven-extensibility.md
+│   │   ├── ADR-003-wasm-plugin-model.md
+│   │   ├── ADR-004-tool-shared-state-ownership.md  (already exists)
+│   │   ├── ADR-005-memory-backends.md
+│   │   ├── ADR-006-cli-only-built-in-channel.md
+│   │   └── ADR-007-gateway-extraction.md
+│   └── diagrams/
+│       ├── component-map.md     ← Mermaid: crate topology
+│       └── data-flow.md         ← Mermaid: message lifecycle
+│
+├── proposals/                   ← RFCs (living until accepted/rejected)
+│   ├── microkernel-architecture.md    (already exists)
+│   └── documentation-standards.md    (this document)
+│
+├── contributing/
+│   ├── README.md
+│   ├── docs-contract.md         ← Replaced (see Section 9)
+│   ├── pr-workflow.md
+│   ├── reviewer-playbook.md
+│   ├── ci-map.md
+│   ├── actions-source-policy.md
+│   ├── testing.md
+│   ├── extension-examples.md
+│   ├── change-playbooks.md
+│   └── pr-discipline.md
+│
+├── reference/
+│   ├── README.md
+│   ├── api/
+│   │   ├── config-reference.md
+│   │   ├── providers-reference.md
+│   │   └── channels-reference.md
+│   └── cli/
+│       └── commands-reference.md
+│
+├── security/
+│   ├── README.md
+│   ├── agnostic-security.md
+│   ├── frictionless-security.md
+│   ├── sandboxing.md
+│   ├── audit-logging.md
+│   └── security-roadmap.md
+│
+└── hardware/
+    ├── README.md
+    ├── hardware-peripherals-design.md
+    ├── adding-boards-and-tools.md
+    └── datasheets/
+        ├── nucleo-f401re.md
+        ├── arduino-uno.md
+        └── esp32.md
+```
+
+**Deleted from current structure:**
+
+```
+docs/i18n/                       ← 169 files, 2.2 MB — removed entirely
+docs/maintainers/                ← project snapshots and i18n coverage maps
+                                   moved to Wiki (operational, not code-adjacent)
+docs/setup-guides/               ← moved to Wiki
+docs/ops/                        ← moved to Wiki
+README.ar.md (and 30 others)     ← removed from repo root
+docs/README.ar.md (and 30 others)← removed
+```
+
+The root of the repository becomes clean:
+
+```
+README.md
+AGENTS.md
+CHANGELOG.md
+CLAUDE.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+SECURITY.md
+LICENSE-APACHE
+LICENSE-MIT
+NOTICE
+Cargo.toml
+Cargo.lock
+... (build and config files)
+```
+
+No language variants. No duplicated READMEs. One authoritative English README that links to the Wiki for user guides and the docs/ tree for technical reference.
+
+---
+
+## 9. The Replacement docs-contract
+
+The current `docs/contributing/docs-contract.md` encodes the i18n parity requirement and a structure that will be obsolete after this RFC is implemented. It should be replaced in full.
+
+The replacement governs three things: artifact classification, the repo/wiki split, and ADR governance. It says nothing about i18n.
+
+**Replacement `docs-contract.md` (abbreviated here for clarity; full version to be written as a follow-up PR):**
+
+```markdown
+# Documentation Contract
+
+## Document Classification
+
+Every document in `docs/` belongs to one artifact family:
+
+- **Considerations** — principles and standards that guide decisions
+- **Landscapes** — descriptions of the current system state
+- **Outlines** — proposals and roadmaps for future work
+- **Designs** — ADRs, API specs, and detailed technical decisions
+- **Standards** — specific rules for how we build and operate
+
+If you cannot name the family before writing, do not write yet.
+
+## The Repo / Wiki Rule
+
+A document lives in the repository if it would become wrong when the
+code changes. It lives on the Wiki if it would not.
+
+Reference documentation (config reference, CLI reference) lives in the
+repository because it maps directly to code structures.
+
+User guides, setup instructions, and operational how-tos live on the Wiki
+because they update on their own timeline.
+
+## ADR Governance
+
+See docs/architecture/decisions/ for the ADR format and lifecycle rules.
+
+Major architectural changes require an ADR before implementation begins,
+not after.
+
+## Language
+
+All documents in this repository are written in English.
+Community-maintained translations live on the GitHub Wiki.
+Documentation PRs are reviewed in English only.
+
+## Freshness
+
+Documents should be updated in the same PR as the code change that makes
+them stale. A PR that changes a configuration format must update the
+config reference. A PR that adds a new command must update the CLI reference.
+
+Proposals in docs/proposals/ are exempt — they describe intent and may
+precede implementation by multiple releases.
+```
+
+---
+
+## 10. Standards We Should Adopt
+
+These documentation-specific standards complement the broader standards proposed in the architecture RFC.
+
+### Diátaxis Framework (Documentation Structure)
+
+**What it is:** Diátaxis (https://diataxis.fr) is a systematic framework for technical documentation that divides content into four types: tutorials, how-to guides, reference, and explanation. It is the documentation framework behind the Python documentation, Django docs, and many others. It is highly compatible with the EA Artifacts approach — they answer different questions (Diátaxis: how to structure the content of a document; EA Artifacts: what type of document is this and where does it live).
+
+**How it applies:** User-facing documentation on the Wiki should follow Diátaxis structure. Code-adjacent documentation in the repository follows EA Artifacts. The two frameworks operate at different levels and do not conflict.
+
+| Diátaxis Type | Purpose | Example in ZeroClaw | Location |
+|---|---|---|---|
+| **Tutorial** | Learning-oriented, leads through an experience | "Build your first tool plugin" | Wiki |
+| **How-to Guide** | Goal-oriented, solves a specific problem | "Set up Telegram integration" | Wiki |
+| **Reference** | Information-oriented, describes the machinery | Config reference, CLI reference | Repo |
+| **Explanation** | Understanding-oriented, explains why | ADRs, architecture docs | Repo |
+
+### Markdown Frontmatter for Machine Readability
+
+All documents in `docs/` should include YAML frontmatter. This makes them queryable by AI tools, CI checks, and future tooling:
+
+```yaml
+---
+type: adr | proposal | reference | contributing | security | hardware
+status: draft | proposed | accepted | deprecated | superseded
+last-reviewed: YYYY-MM-DD
+relates-to:
+  - ADR-NNN
+  - crates/zeroclaw-api
+---
+```
+
+A CI check should verify that all documents in `docs/` have valid frontmatter. This prevents documents from being written without first declaring their type and status — enforcing the classification discipline at the tooling level.
+
+### CommonMark + GitHub Flavored Markdown
+
+All documentation uses CommonMark (the standardized Markdown specification) with GitHub Flavored Markdown extensions (tables, task lists, fenced code blocks, Mermaid diagrams). No custom extensions, no MDX, no ReStructuredText. Mermaid diagrams are preferred over image files for architecture diagrams because they version cleanly with the code.
+
+### Vale for Prose Linting
+
+**What it is:** Vale (https://vale.sh) is a prose linter — it checks writing style, consistency, and readability using configurable rules. It can enforce things like: always use "you" not "the user", avoid passive voice in imperative sections, use consistent terminology ("plugin" not "extension" not "module").
+
+**Why it matters:** The current documentation is inconsistent in tone, terminology, and style. Some pages say "plugin", some say "module", some say "extension". Vale makes these rules automatic and enforces them at CI time, the same way Clippy enforces code quality.
+
+---
+
+## 11. Phased Roadmap
+
+The documentation migration follows the same Strangler Fig pattern as the architecture migration: incremental, always in a working state, no big-bang rewrites.
+
+---
+
+### Phase 1 · v0.7.0 — "Clean the Root"
+
+**Deliverables:**
+
+- [ ] Remove all `README.*.md` files from the repo root (keep only `README.md`)
+- [ ] Remove `docs/i18n/` entirely
+- [ ] Remove all non-English hub files from `docs/`
+- [ ] Add the `Languages` section to `README.md` with Wiki link
+- [ ] Create the GitHub Wiki with the structural skeleton (Home + top-level pages, content stubs)
+- [ ] Remove the i18n parity requirement from `docs-contract.md`
+- [ ] Add YAML frontmatter to all existing `docs/` files
+- [ ] Create `docs/architecture/decisions/` directory and move ADR-004 into it as `ADR-004-tool-shared-state-ownership.md`
+
+**Success metrics:**
+- Repo root contains exactly one README file
+- `docs/i18n/` does not exist
+- All `docs/` files have valid YAML frontmatter (CI-enforced)
+- GitHub Wiki is live and publicly linked from README
+
+---
+
+### Phase 2 · v0.7.0–v0.8.0 — "Write the Missing ADRs"
+
+**Deliverables:**
+
+- [ ] Write ADR-001 through ADR-003 and ADR-005 through ADR-007 (retroactive, see Section 6.3)
+- [ ] Add a Vale configuration (`.vale.ini` + style rules) and CI check
+- [ ] Replace `docs-contract.md` in full with the version specified in Section 9
+- [ ] Migrate `docs/setup-guides/` content to the GitHub Wiki
+- [ ] Migrate `docs/ops/` content to the GitHub Wiki
+- [ ] Update `SUMMARY.md` to reflect the new structure (repo-only content)
+- [ ] Write root-level `AGENTS.md` for `crates/zeroclaw-api` (in anticipation of extraction)
+
+**Success metrics:**
+- ADR-001 through ADR-007 exist and are accepted
+- Vale CI check passes on all docs
+- Wiki has complete content for all migrated sections
+- No dead links in `docs/`
+
+---
+
+### Phase 3 · v0.8.0–v0.9.0 — "The AI Layer"
+
+**Deliverables:**
+
+- [ ] Write `AGENTS.md` for each new crate as the workspace decomposes (per architecture RFC phases)
+- [ ] Write `docs/architecture/diagrams/component-map.md` (Mermaid, reflects target crate topology)
+- [ ] Write `docs/architecture/diagrams/data-flow.md` (Mermaid, message lifecycle)
+- [ ] Write the plugin SDK documentation in `docs/contributing/plugin-sdk.md`
+- [ ] Write the WIT interface documentation alongside the `wit/` files (generated from WIT + hand-written explanation)
+- [ ] Update the OpenAPI spec documentation as the kernel IPC API stabilizes
+
+**Success metrics:**
+- Every crate in the workspace has an `AGENTS.md`
+- Architecture diagrams are Mermaid (no binary image files in docs/)
+- Plugin SDK documentation is sufficient for an external contributor to write a working tool plugin
+
+---
+
+### Phase 4 · v1.0.0 — "The Stable Platform"
+
+**Deliverables:**
+
+- [ ] Mark ADR-001 through ADR-007 as `accepted` (not `proposed`) once the corresponding code is shipped
+- [ ] Version the kernel IPC API documentation at `v1` with a stability guarantee
+- [ ] Write the Plugin Registry governance document (who controls the registry, how plugins are reviewed, how compromised plugins are revoked)
+- [ ] Publish the plugin SDK as a standalone document site (from `docs/contributing/plugin-sdk.md`)
+- [ ] Establish the Wiki translation coordinator role (a community member who maintains the Translations page and coordinates volunteer translators)
+
+**Success metrics:**
+- All foundational ADRs are accepted
+- Plugin SDK is complete and externally linked from the README
+- Wiki has active community-maintained translations in at least two languages
+- Documentation CI (frontmatter check + Vale) passes on every PR
+
+---
+
+
+---
+
+## Appendix A: Glossary
+
+**ADR (Architecture Decision Record)** — An immutable record of a significant architectural decision: the context that prompted it, what was decided, and the consequences. ADRs do not change once accepted; superseded decisions are recorded as new ADRs.
+
+**Diátaxis** — A systematic framework for technical documentation structure that divides content into tutorials (learning), how-to guides (goal-oriented), reference (information), and explanation (understanding). See https://diataxis.fr.
+
+**EA Artifacts on a Page** — A classification framework for enterprise architecture documents developed by Svyatoslav Kotusev. Classifies artifacts into five families: Considerations, Landscapes, Outlines, Designs, and Standards. See https://eaonapage.com.
+
+**Frontmatter** — YAML metadata at the top of a Markdown file, delimited by `---`. Makes documents machine-readable and queryable by tools, CI checks, and AI assistants.
+
+**Nygard Format** — The ADR format introduced by Michael Nygard: three sections (Context, Decision, Consequences) that capture the essential reasoning without unnecessary ceremony.
+
+**Strangler Fig Pattern** — A migration strategy in which new structure is built incrementally around the old, replacing it piece by piece rather than all at once. The system remains functional throughout the migration.
+
+**Vale** — A prose linter for technical documentation. Enforces style, consistency, and readability rules at CI time, the way Clippy enforces Rust code quality. See https://vale.sh.
+
+---
+
+## Appendix B: Further Reading
+
+- **Diátaxis documentation framework** — https://diataxis.fr — The definitive reference for structuring technical documentation by type.
+- **EA Artifacts on a Page (v2.2)** — https://eaonapage.com — The classification framework used in Section 3.
+- **"Docs for Developers"** — Jared Bhatti et al. — A practical guide to technical documentation written by engineers who have maintained large documentation systems.
+- **Vale documentation** — https://vale.sh/docs — Setup guide and configuration reference for the prose linter proposed in Section 10.
+- **Michael Nygard on ADRs** — https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions — The original post that introduced the ADR format used in Section 6.
+- **GitHub Wikis documentation** — https://docs.github.com/en/communities/documenting-your-project-with-wikis — Reference for setting up and governing the GitHub Wiki proposed in Section 5.
+
+---
+
+*This proposal was developed from direct analysis of the ZeroClaw documentation system at v0.6.8. The metrics cited (169 i18n files, 2.2 MB, 31 language README variants) are based on direct measurement. The recommendations reflect established practices in technical documentation for open source infrastructure projects, adapted to the specific constraints and goals of ZeroClaw.*
+
+*Feedback, corrections, and counterproposals are welcome. Good documentation is a community effort, and the best structure is the one the team will actually maintain.*

--- a/docs/foundations/fnd-003-governance.md
+++ b/docs/foundations/fnd-003-governance.md
@@ -1,0 +1,1078 @@
+# FND-003: Team Organization, Project Governance, and Contribution Pipeline
+### Starting v0.7.0 · Type: Governance · Rev. 2
+
+> **Canonical reference** · Ratified by the team · Rev. 2
+> Discussion thread and full revision history: [#5577](https://github.com/zeroclaw-labs/zeroclaw/issues/5577)
+
+
+---
+
+> **A note to the team before you read this.**
+>
+> Software projects do not fail because the code is bad. They fail because the people writing the code cannot coordinate. Features get built twice. Bugs get lost. Good ideas evaporate because nobody wrote them down. New contributors show up wanting to help and cannot find where to start. This RFC is about building the lightweight scaffolding that prevents those failures — not so the project feels organized, but so the team can move faster, with more confidence, and with less friction. Every recommendation here is chosen specifically for a small, growing, student-led open source team. Nothing here requires a project manager, a Scrum Master, or a formal committee.
+
+---
+
+---
+
+## Revision History
+
+| Rev | Date | Summary |
+|---|---|---|
+| 1 | 2026-04-09 | Initial draft |
+| 2 | 2026-04-09 | Added §6.4 Architectural Compliance: Human Review, AI Support; added Discussion Question on AI automation of architecture reviews |
+
+---
+
+## Table of Contents
+
+1. [The Coordination Problem](#1-the-coordination-problem)
+2. [The Three-Part System](#2-the-three-part-system)
+3. [GitHub Projects: The Work Pipeline](#3-github-projects-the-work-pipeline)
+4. [GitHub Discussions: The Ideas Parking Lot](#4-github-discussions-the-ideas-parking-lot)
+5. [Team Tiers and Contribution Authority](#5-team-tiers-and-contribution-authority)
+6. [CODEOWNERS and Branch Protection](#6-codeowners-and-branch-protection)
+   - [6.4 Architectural Compliance: Human Review, AI Support](#64-architectural-compliance-human-review-ai-support)
+7. [Issue Templates](#7-issue-templates)
+8. [The RFC Governance Loop](#8-the-rfc-governance-loop)
+9. [Label Taxonomy](#9-label-taxonomy)
+10. [Definition of Done](#10-definition-of-done)
+11. [Automation](#11-automation)
+12. [Phased Rollout](#12-phased-rollout)
+
+---
+
+## 1. The Coordination Problem
+
+Every project without an intentional coordination system develops an accidental one. The accidental system for most open source projects looks like this:
+
+- Ideas live in someone's head, or in a chat message that scrolls off the screen
+- Issues pile up in the tracker with no priority, no owner, and no clear definition of done
+- Contributors open PRs for things nobody asked for, or ask to help and get no response
+- The team works reactively — whoever shouts loudest gets attention, whatever breaks gets fixed, nothing gets planned more than a week out
+- Architectural decisions get made in PR comments and are never recorded anywhere
+
+This is not a criticism of anyone's effort. It is a description of what happens by default. The solution is not more process — it is the right process, applied at the right level for the size and maturity of the team.
+
+ZeroClaw needs three things:
+
+1. **A pipeline** for turning ideas into shipped code, with visible stages and clear gates at each transition
+2. **A parking lot** for capturing ideas that are not ready for the pipeline yet, without losing them or cluttering the active work
+3. **A governance model** that defines who can decide what, how architectural decisions get made, and how the team grows
+
+These are three distinct concerns. Conflating them — putting everything in one board, or relying on informal chat for decisions — is what creates the chaos the team is trying to escape.
+
+---
+
+## 2. The Three-Part System
+
+| Concern | Tool | Why This Tool |
+|---|---|---|
+| Work pipeline (backlog → release) | **GitHub Projects v2** | Custom fields, multiple views, Kanban + roadmap, built-in automation, milestone tracking |
+| Ideas parking lot | **GitHub Discussions** | Community-votable, no PR required, separates "maybe someday" from committed work, converts to issues when ready |
+| Governance and decision authority | **RFC process + Team Tiers + CODEOWNERS** | Already partially established via `docs/proposals/`; needs formalization and close loop |
+
+The key principle: **the Project board contains only work the team has committed to thinking about.** Ideas that have not been evaluated live in Discussions. Work that has been evaluated, accepted, and scoped lives in the Project. This distinction is what keeps the board useful.
+
+---
+
+## 3. GitHub Projects: The Work Pipeline
+
+### 3.1 The Pipeline Stages
+
+The Project board has a single **Status** field with seven values. Each value is a stage in the pipeline. The sequence is linear but items can be moved back:
+
+```
+💡 Idea
+    ↓  Gate: Vision alignment check
+📋 Backlog
+    ↓  Gate: Architecture fit + acceptance criteria
+🎯 Defined
+    ↓  Gate: Assignee, size, risk tier confirmed
+🚧 In Progress
+    ↓  Gate: Tests written, CI passing
+👀 In Review
+    ↓  Gate: Correct reviewer tier approved, docs updated
+✅ Done
+```
+
+Plus one terminal state that can be reached from anywhere:
+
+```
+🚫 Won't Do  ← explicit decision not to pursue; never silently closed
+```
+
+### 3.2 The Gate Questions
+
+Every transition has a gate question. The question must be answered "yes" before the item moves forward. This is the project board made operational — the Vision → Architecture → Design → Implementation → Testing → Documentation hierarchy becomes a checklist at each stage.
+
+| Transition | Gate Question | Who Checks |
+|---|---|---|
+| Idea → Backlog | Does this align with the Vision statement? Does it fit the target architecture? | Core Team triage |
+| Backlog → Defined | Is there a clear acceptance criteria? Does it need an ADR or design note? Is the risk tier assigned? | Assignee + reviewer |
+| Defined → In Progress | Is there an assignee? Is it sized? Are the related ADRs or docs identified? | Assignee |
+| In Progress → In Review | Do tests exist for the new behavior? Is CI passing? Is the PR description complete? | Author (self-check) |
+| In Review → Done | Has the correct reviewer tier approved? Is documentation updated? Is the CHANGELOG entry written? | Reviewer |
+| Any → Won't Do | Has the decision not to pursue been explained in the item's comments? | Core Team |
+
+**Why explicit gates matter for a student team:** Without gates, cards move because someone feels done, not because done has a definition. This is the single most common source of "done" work that is not actually done. The gates make the definition visible and shared.
+
+### 3.3 Custom Fields
+
+Create these fields in the GitHub Project settings:
+
+| Field | Type | Values |
+|---|---|---|
+| **Status** | Single select | 💡 Idea · 📋 Backlog · 🎯 Defined · 🚧 In Progress · 👀 In Review · ✅ Done · 🚫 Won't Do |
+| **Type** | Single select | Feature · Bug · Refactor · ADR · Docs · Security · Infrastructure · RFC |
+| **Priority** | Single select | 🔴 Critical · 🟠 High · 🟡 Medium · 🟢 Low |
+| **Size** | Single select | XS · S · M · L · XL |
+| **Risk Tier** | Single select | Low · Medium · High (mirrors `AGENTS.md` risk tiers) |
+| **Component** | Single select | Kernel · Gateway · Channels · Tools · Memory · Security · Hardware · Docs · Infrastructure |
+| **Milestone** | Milestone | v0.7.0 · v0.8.0 · v0.9.0 · v1.0.0 · Icebox |
+
+**On sizing (T-shirt sizes):** Story points require calibration and historical data the team does not have yet. T-shirt sizes are immediately intuitive and good enough for a team at this stage:
+
+| Size | What It Means | Approximate Scope |
+|---|---|---|
+| XS | Under 2 hours | A typo fix, a config tweak, a one-line change |
+| S | Half a day | A small bug fix, a minor feature addition, a docs update |
+| M | 1–3 days | A meaningful feature, a refactor of one module, a new test suite |
+| L | 1–2 weeks | A significant feature, a new crate extraction, a cross-cutting change |
+| XL | More than 2 weeks | An architectural change; should be broken into smaller items |
+
+XL items should almost always be broken down before they enter In Progress. If you cannot break it down, the design is not complete enough.
+
+### 3.4 Views
+
+Create four named views in the Project:
+
+**View 1: Roadmap**
+- Type: Roadmap (timeline)
+- Grouped by: Milestone
+- Visible fields: Title, Type, Size, Component, Assignee
+- Purpose: Public-facing. "Here is what is coming and when." Share this link in the README and with the community. Keep it updated.
+
+**View 2: Board**
+- Type: Board (Kanban)
+- Columns: Status field values
+- Filtered to: Current milestone only
+- Visible fields: Title, Assignee, Size, Risk Tier
+- Purpose: Day-to-day work visibility. What is everyone working on right now? What is blocked?
+
+**View 3: Backlog**
+- Type: Table
+- Sorted by: Priority (descending), then Size (ascending)
+- Filtered to: Status = Backlog OR Defined
+- Visible fields: Title, Type, Priority, Size, Component, Milestone, Risk Tier
+- Purpose: Used during grooming sessions. What needs to be worked on next? What is sized and ready to pick up?
+
+**View 4: My Work**
+- Type: Board
+- Filtered to: Assignee = @me
+- Purpose: Personal dashboard. Each contributor can see their own items without noise.
+
+### 3.5 Pinned Items
+
+GitHub allows up to six pinned issues per repository. Use them for high-signal, always-visible communication:
+
+1. The current active RFC under discussion
+2. The most wanted community feature (highest-voted Discussion)
+3. The next release milestone tracking issue
+4. The good-first-issue index (an issue that links to all current `good-first-issue` items)
+
+Pinned issues are a promise to the community: these are the things that matter most right now. Update them when priorities shift.
+
+---
+
+## 4. GitHub Discussions: The Ideas Parking Lot
+
+### 4.1 Enable Discussions and Create Categories
+
+Enable GitHub Discussions on the repository. Create the following categories:
+
+| Category | Format | Purpose |
+|---|---|---|
+| 📣 **Announcements** | Announcement | Core team posts; community cannot create, only react and comment |
+| 💡 **Ideas** | Open-ended discussion | Community feature requests and suggestions; the ideas parking lot |
+| 🏗️ **Architecture** | Open-ended discussion | Questions and proposals about system design; feeds the RFC process |
+| ❓ **Q&A** | Question/Answer | How do I do X? Answered by contributors and core team |
+| 🐛 **Bug Reports (pre-triage)** | Open-ended discussion | For bug reports that need more information before becoming issues |
+| 🌐 **Translations** | Open-ended discussion | Community-maintained translations and localization coordination |
+| 🎉 **Show and Tell** | Open-ended discussion | What are you building with ZeroClaw? Community showcases |
+
+### 4.2 The Idea-to-Issue Promotion Process
+
+Discussions in the **Ideas** category follow a lightweight promotion process:
+
+```
+Community member posts an idea in Discussions → Ideas
+         ↓
+Community votes with 👍 reactions
+         ↓
+Threshold: 5 👍 from Contributors or Core Team members
+         ↓
+Core Team member converts to Issue using GitHub's
+"Create issue from discussion" feature
+         ↓
+Issue enters Project board as 💡 Idea status
+         ↓
+Discussion is marked Answered with a link to the new issue
+```
+
+The threshold of five votes from Contributors or Core Team (not anonymous community members) prevents low-signal requests from flooding the backlog while still giving the community a real voice. Reactions from unaffiliated accounts count as community sentiment data but not toward the threshold.
+
+**Why this process matters:** It separates signal from noise. Not every idea is a good idea, and not every good idea is the right idea for now. The Discussions layer lets the community express what they want without creating the false expectation that every request becomes a ticket.
+
+### 4.3 Ideas That Should Not Wait for Votes
+
+Some items bypass the Discussions promotion process and enter the backlog directly:
+
+- Security vulnerabilities (via private security report, never public)
+- Confirmed bugs with reproduction steps (go directly to Bug Report issue template)
+- RFC-accepted architecture items (spawned directly from the RFC close loop)
+- Items from the project roadmap (placed directly by Core Team)
+
+### 4.4 The Architecture Category
+
+The **Architecture** Discussions category is specifically for questions and proposals that are not yet ready to be formal RFCs. A contributor who notices a problem with the current design or wants to explore an idea can open an Architecture discussion before committing to writing a full RFC. This lowers the barrier to raising concerns.
+
+If an Architecture discussion develops sufficient detail and consensus, a Core Team member can promote it to a formal RFC by moving the content to `docs/proposals/` and opening an RFC issue.
+
+---
+
+## 5. Team Tiers and Contribution Authority
+
+### 5.1 The Three Tiers
+
+Open source projects run on **meritocracy** — influence and authority come from demonstrated contribution, not from seniority, title, or who you know. This is one of the things that makes open source different from corporate software, and it is worth teaching explicitly.
+
+The three tiers reflect increasing demonstrated commitment to the project:
+
+---
+
+**Tier 1: Community**
+
+Anyone. No approval required.
+
+*What they can do:*
+- Open issues using the issue templates
+- Comment on any issue or PR
+- React to Discussions and vote on ideas
+- Submit pull requests (which will be reviewed before merging)
+- Edit the GitHub Wiki
+
+*What they cannot do:*
+- Be assigned issues (can request to be assigned)
+- Approve PRs
+- Merge PRs
+- Vote on RFCs with binding authority
+
+---
+
+**Tier 2: Contributor**
+
+Community members who have had at least two PRs merged into the `master` branch.
+
+*How to become one:* Have two PRs merged. A Core Team member adds you to the Contributors team in GitHub and to `CONTRIBUTORS.md`.
+
+*What they gain beyond Community:*
+- Can be assigned issues
+- Can be requested as a reviewer on PRs (non-required review)
+- Vote on Ideas in Discussions counts toward the promotion threshold
+- Can request RFC discussions without going through Discussions first
+
+*What they still cannot do:*
+- Approve PRs for High Risk paths
+- Merge PRs
+- Cast binding RFC votes
+
+*Why this tier exists:* It creates a visible, achievable first milestone for new contributors. "How do I get more involved?" has a clear answer: get two PRs merged. This motivates good early contributions and gives the team a way to recognize contributors publicly.
+
+---
+
+**Tier 3: Core Team**
+
+Contributors who have demonstrated consistent, high-quality contributions over time and have been invited by existing Core Team members.
+
+*How to become one:* Invitation from existing Core Team members, announced publicly in Discussions. There is no formal threshold — it is a judgment call based on the quality, consistency, and alignment of past contributions.
+
+*What they gain beyond Contributor:*
+- Write access to the repository
+- Can merge PRs that have met review requirements
+- Can approve PRs for High Risk paths (subject to CODEOWNERS requirements)
+- Cast binding votes on RFCs
+- Can move items through the Project pipeline
+- Can cut releases
+- Participate in governance decisions (Core Team discussions)
+
+*Responsibilities:*
+- Triage new issues within 3 business days
+- Review PRs in their area of expertise within 5 business days
+- Participate in RFC votes
+- Uphold the project's Code of Conduct
+
+---
+
+### 5.2 The Lazy Consensus Rule
+
+For routine decisions — adding a label, closing a stale issue, updating documentation — Core Team members operate under **lazy consensus**: if you announce your intention in the relevant issue and no Core Team member objects within 48 hours, you proceed. This prevents the paralysis of requiring explicit approval for everything while maintaining visibility.
+
+Lazy consensus does not apply to:
+- RFC acceptance or rejection
+- Releases
+- Changes to CODEOWNERS or branch protection rules
+- Changes to this governance document
+- Additions to the Core Team
+
+These always require explicit Core Team votes.
+
+### 5.3 Recording Team Membership
+
+Team membership is recorded in two places:
+
+**`CONTRIBUTORS.md`** at the repository root — a public record of everyone who has contributed, organized by tier. Updated by Core Team members as contributors are recognized.
+
+**GitHub Teams** in the organization settings — `zeroclaw-core` and `zeroclaw-contributors` teams, referenced in CODEOWNERS and used for notification routing.
+
+---
+
+## 6. CODEOWNERS and Branch Protection
+
+### 6.1 CODEOWNERS
+
+The `CODEOWNERS` file makes governance automatic. It defines which paths require review from which team before a PR can merge. GitHub enforces this as a required review — the PR cannot be merged until the requirement is satisfied.
+
+Create `.github/CODEOWNERS`:
+
+```
+# CODEOWNERS — Automatic review routing by risk tier
+# See AGENTS.md for risk tier definitions.
+# See docs/proposals/project-governance.md for team tier definitions.
+
+# ── High Risk: requires Core Team approval ──────────────────────────────────
+
+src/security/**                 @zeroclaw-labs/zeroclaw-core
+src/gateway/**                  @zeroclaw-labs/zeroclaw-core
+src/runtime/**                  @zeroclaw-labs/zeroclaw-core
+src/tools/shell.rs              @zeroclaw-labs/zeroclaw-core
+src/tools/file_write.rs         @zeroclaw-labs/zeroclaw-core
+src/tools/security_ops.rs       @zeroclaw-labs/zeroclaw-core
+
+# ── Governance and configuration: requires Core Team approval ───────────────
+
+.github/**                      @zeroclaw-labs/zeroclaw-core
+CODEOWNERS                      @zeroclaw-labs/zeroclaw-core
+Cargo.toml                      @zeroclaw-labs/zeroclaw-core
+deny.toml                       @zeroclaw-labs/zeroclaw-core
+
+# ── Architecture documents: requires Core Team review ───────────────────────
+
+docs/proposals/**               @zeroclaw-labs/zeroclaw-core
+docs/architecture/decisions/**  @zeroclaw-labs/zeroclaw-core
+AGENTS.md                       @zeroclaw-labs/zeroclaw-core
+
+# ── Default: any Contributor or Core Team member can review ─────────────────
+
+*                               @zeroclaw-labs/zeroclaw-contributors
+```
+
+As specific Core Team members take ownership of components, add their individual handles alongside the team handle. Specificity wins in CODEOWNERS — a more specific path rule overrides a more general one.
+
+### 6.2 Branch Protection Rules
+
+Configure the following branch protection rules for `master`:
+
+| Rule | Setting | Reason |
+|---|---|---|
+| Require a pull request before merging | Enabled | No direct pushes to master — ever |
+| Require approvals | 1 for Low/Medium risk; 2 for High risk | CODEOWNERS enforcement handles the "who" |
+| Require status checks to pass | `cargo fmt`, `cargo clippy`, `cargo test` | CI must be green before merge |
+| Require branches to be up to date | Enabled | Prevents merging stale code |
+| Require conversation resolution | Enabled | All review comments must be resolved |
+| Do not allow bypassing the above settings | Enabled | Applies to everyone, including admins |
+| Allow force pushes | Disabled | Preserve commit history |
+| Allow deletions | Disabled | Protect the branch |
+
+**Why admins cannot bypass:** One of the most common mistakes in small team projects is treating branch protection as "for other people." When an admin can bypass, they will — under time pressure, in an emergency, "just this once." Then it becomes the norm. The rule must apply to everyone for it to mean anything. If there is a genuine emergency, the right response is to follow the process faster, not to skip it.
+
+### 6.3 Required Status Checks
+
+The CI checks that must pass before any PR can merge:
+
+```
+build (stable)          ← cargo build --release
+test                    ← cargo test
+fmt                     ← cargo fmt --all -- --check
+clippy                  ← cargo clippy --all-targets -- -D warnings
+```
+
+As the workspace decomposes into crates (per the architecture RFC), add per-crate checks. A change to `crates/zeroclaw-api` should run that crate's test suite independently.
+
+### 6.4 Architectural Compliance: Human Review, AI Support
+
+This section exists because the question will come up — it already has — and it deserves a clear, documented answer rather than a debate on every PR.
+
+**The question:** Should we add an automated gate that checks whether a PR conforms to the architecture and design patterns defined in the RFCs?
+
+**The answer:** No. And understanding why is important.
+
+---
+
+**There are two fundamentally different kinds of quality enforcement, and they require different mechanisms.**
+
+The first kind is *structural compliance*: does this code violate a mechanical rule? Does `zeroclaw-kernel` import `TelegramChannel`? Do the dependency graph edges point the wrong way? Are there clippy warnings? These are binary questions. Either the code violates the rule or it does not. The compiler, `cargo deny`, and `cargo clippy --workspace` already enforce this. No human is needed. No AI is needed. The machine is authoritative, fast, and never wrong about a factual violation.
+
+The second kind is *architectural intent*: does this decision belong here? Is this abstraction at the right layer? Does this trade-off align with the vision? Is this coupling going to be painful in Phase 3? Will this PR create a maintenance burden that isn't visible in the diff today? These questions require judgment, context, and an understanding of *why* the architecture exists — not just what the rules are. No automated tool can answer them reliably, because the answer depends on information that is not in the diff: the roadmap, the team's current priorities, the contributor's intent, and the long-term cost of the decision.
+
+**The failure modes of automating architectural judgment are both bad.**
+
+A gate that passes subtle architectural violations creates false confidence. The developer sees ✅ and assumes their decision was validated. The most damaging architectural drift — the kind that takes years to untangle — looks structurally correct. It compiles. It passes lint. The dependency graph is fine. The problem is that it violated the spirit of the design in a way that only becomes apparent later, when the cost of unwinding it is high.
+
+A gate that flags valid architectural decisions because the tool misread the context teaches developers to dismiss the gate entirely. Once a team learns to click past a noisy automated check, the check is gone in practice even if it is still running in CI. The project has spent CI minutes to achieve negative value.
+
+**CODEOWNERS is the architectural compliance gate. The reviewer is the tool.**
+
+The `CODEOWNERS` configuration in §6.1 already enforces that PRs touching high-risk paths — crate boundaries, trait definitions, the dependency graph, `src/security/`, `.github/` — require review from a Core Team member. That Core Team member, equipped with the RFCs as their reference framework, is the architectural compliance check. They bring the contextual judgment that no automation can replicate.
+
+This is why the RFCs, the AGENTS.md files, and the documentation standards exist: not so a machine can parse them and produce a score, but so a human reviewer has a consistent, documented framework to apply. The RFC answers "why does this architecture exist." The reviewer answers "does this PR serve or undermine that why."
+
+**AI belongs in the development loop, not the merge gate.**
+
+AI tools — Claude, Copilot, Cursor, and whatever comes next — are genuinely useful for architectural work when they are used in the right place. The right place is *during development*, not *during the merge gate*.
+
+During development, an AI assistant equipped with the RFC and the crate's AGENTS.md can help a contributor understand which crate a new piece of functionality belongs in before they write it, flag a potential dependency inversion while the code is still being shaped, explain why a design pattern exists, and suggest whether a new abstraction is at the right layer. This is additive. It makes contributors more capable.
+
+During a review, an AI assistant can help a human reviewer draft structured feedback, cross-reference a change against the RFC, and identify which discussion questions in the RFC are relevant to the PR. This is also additive. The reviewer brings the judgment; the AI brings speed and recall.
+
+What AI cannot do is replace the judgment. "AI helps me assess this PR" and "AI automatically gates this PR" are categorically different, and only the first one works for architectural decisions. The day the project routes architectural compliance through an automated gate — however sophisticated — is the day the architecture starts drifting in ways nobody notices until it is too late.
+
+**The practical policy, stated plainly:**
+
+- Structural compliance (import direction, dependency graph, lint, format) is enforced by CI. This is non-negotiable and automated.
+- Architectural intent compliance is enforced by CODEOWNERS routing to a Core Team reviewer. This is non-negotiable and human.
+- AI tools support contributors during development and support reviewers during review. They do not gate merges on their own authority.
+- If the team wants to evaluate AI-assisted review tooling in the future, that evaluation goes through the RFC process first. It does not get added to `.github/workflows/` without a documented decision.
+
+This policy is not a limitation on AI or on automation. It is a recognition that different problems require different tools, and using the right tool in the right place is exactly what the architecture RFC is asking of the codebase.
+
+---
+
+## 7. Issue Templates
+
+Issue templates route incoming reports to the right process before they reach a human. A well-written template gathers the information needed for triage automatically. A missing or ignored template results in issues that take three comment exchanges to understand.
+
+Create the following templates in `.github/ISSUE_TEMPLATE/`:
+
+### Template 1: Bug Report (`bug_report.yml`)
+
+```yaml
+name: Bug Report
+description: Something is not working as expected
+labels: ["type:bug", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting: search existing issues to avoid duplicates.
+        For security vulnerabilities, use the private security report
+        process described in SECURITY.md — do not open a public issue.
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: The exact steps to reproduce the bug.
+      placeholder: |
+        1. Run `zeroclaw ...`
+        2. With config `...`
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        - ZeroClaw version:
+        - OS and version:
+        - Rust version (if built from source):
+        - Provider:
+    validations:
+      required: true
+  - type: dropdown
+    id: risk
+    attributes:
+      label: Does this bug have security implications?
+      options:
+        - "No"
+        - "Yes — I have already filed a private security report"
+        - "I am not sure"
+    validations:
+      required: true
+```
+
+### Template 2: Feature Request (`feature_request.yml`)
+
+```yaml
+name: Feature Request
+description: Suggest a new capability or improvement
+labels: ["type:feature", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature requests that have been discussed and upvoted in GitHub
+        Discussions → Ideas are more likely to be prioritized. Consider
+        posting there first if you want community feedback before filing.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the problem or limitation you are experiencing.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: What would you like to happen?
+      description: Describe the feature or change you are proposing.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What alternatives have you considered?
+      description: Other ways to solve the problem, including doing nothing.
+  - type: dropdown
+    id: component
+    attributes:
+      label: Which component does this affect?
+      options:
+        - Kernel / Agent Loop
+        - Gateway / Web UI
+        - Channels
+        - Tools
+        - Memory
+        - Security
+        - Hardware / Peripherals
+        - Documentation
+        - Infrastructure / CI
+        - Not sure
+    validations:
+      required: true
+```
+
+### Template 3: RFC / Architecture Proposal (`rfc.yml`)
+
+```yaml
+name: RFC / Architecture Proposal
+description: Propose a significant architectural or behavioral change
+labels: ["type:rfc", "status:discussion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        RFCs are for significant changes that affect architecture, public
+        interfaces, or project direction. Before filing an RFC issue:
+        1. Write the proposal document and add it to `docs/proposals/`
+        2. Open a PR with that document
+        3. Then open this issue to start the formal discussion period
+
+        For smaller changes, open a regular feature request or just a PR.
+  - type: input
+    id: proposal-pr
+    attributes:
+      label: Link to the proposal document PR
+      placeholder: "https://github.com/zeroclaw-labs/zeroclaw/pull/..."
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: One-paragraph summary
+      description: What is being proposed and why?
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact and tradeoffs
+      description: What does this change affect? What are the tradeoffs?
+    validations:
+      required: true
+  - type: dropdown
+    id: breaking
+    attributes:
+      label: Is this a breaking change?
+      options:
+        - "No"
+        - "Yes — existing configurations or APIs change"
+        - "Potentially — needs investigation"
+    validations:
+      required: true
+```
+
+### Template 4: Documentation Issue (`docs_issue.yml`)
+
+```yaml
+name: Documentation Issue
+description: Something in the docs is missing, wrong, or confusing
+labels: ["type:docs", "status:needs-triage"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Where is the documentation issue?
+      placeholder: "URL or file path (e.g. docs/reference/api/config-reference.md)"
+    validations:
+      required: true
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Type of issue
+      options:
+        - Missing documentation
+        - Incorrect information
+        - Confusing or unclear
+        - Outdated (code has changed)
+        - Broken link
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the problem
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement (optional)
+      description: If you know what the correct content should be, share it here.
+```
+
+### Template 5: Security Report Redirect
+
+Create `.github/ISSUE_TEMPLATE/security.md` as a redirect — GitHub will show it as a template option but the content redirects rather than creating an issue:
+
+```yaml
+name: Security Vulnerability
+description: ⚠️ Do not use this template. See SECURITY.md for private reporting.
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## ⚠️ Do not report security vulnerabilities as public issues.
+
+        Security vulnerabilities disclosed publicly before a fix is available
+        put all ZeroClaw users at risk. Please follow the private disclosure
+        process described in [SECURITY.md](../SECURITY.md).
+
+        If you have already filed this as a public issue by mistake, please
+        delete it and re-report privately. A Core Team member will contact
+        you to confirm receipt.
+```
+
+### Template 6: Good First Issue (`good_first_issue.yml`)
+
+```yaml
+name: Good First Issue (Core Team only)
+description: Tag an issue as a good entry point for new contributors
+labels: ["good-first-issue", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is for Core Team members identifying good entry
+        points for new contributors. A good first issue must have:
+        - A clear, self-contained scope (no cross-cutting changes)
+        - Size of XS or S
+        - Links to the relevant code files
+        - A named mentor the new contributor can ping for help
+  - type: textarea
+    id: description
+    attributes:
+      label: What needs to be done?
+      description: Be specific. Include file paths and function names where known.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context and background
+      description: What does a new contributor need to understand to work on this?
+    validations:
+      required: true
+  - type: input
+    id: mentor
+    attributes:
+      label: Mentor / point of contact
+      placeholder: "@username"
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: How will we know when this is done?
+    validations:
+      required: true
+```
+
+---
+
+## 8. The RFC Governance Loop
+
+The RFC process was established in the documentation RFC and the architecture RFC. This section defines the close loop — how an RFC moves from proposal to decision to action.
+
+### 8.1 The Full RFC Lifecycle
+
+```
+1. AUTHOR writes proposal → docs/proposals/<slug>.md
+           ↓
+2. AUTHOR opens PR with the proposal document
+           ↓
+3. AUTHOR opens RFC issue using the RFC issue template
+   linking to the PR
+           ↓
+4. DISCUSSION PERIOD — minimum 7 days
+   Anyone can comment. Core Team members engage substantively.
+   Discussions happen on the issue, not the PR.
+           ↓
+5. CORE TEAM VOTE on the issue
+   Format: comment with one of:
+     ✅ APPROVE — with brief rationale
+     ❌ REJECT — with specific objections
+     🔄 REVISE — with specific requests
+           ↓
+   ┌── Majority APPROVE ──────────────────────────────────────┐
+   │  RFC is accepted                                          │
+   │  PR is merged                                            │
+   │  Issue labeled rfc:accepted                              │
+   │  Author writes ADR(s) in docs/architecture/decisions/    │
+   │  ADR issue(s) linked back to RFC issue                   │
+   │  RFC issue closed                                        │
+   └──────────────────────────────────────────────────────────┘
+           ↓
+   ┌── Any REJECT ────────────────────────────────────────────┐
+   │  RFC is rejected                                          │
+   │  PR is closed (not merged)                               │
+   │  Issue labeled rfc:rejected                              │
+   │  Rejecting members document specific objections          │
+   │  RFC issue closed with rejection summary comment         │
+   └──────────────────────────────────────────────────────────┘
+           ↓
+   ┌── REVISE requested ──────────────────────────────────────┐
+   │  RFC is not voted on until revisions are complete        │
+   │  Issue labeled rfc:revision-requested                    │
+   │  Author revises proposal document                        │
+   │  Author re-requests review via issue comment             │
+   │  Process returns to step 4                               │
+   └──────────────────────────────────────────────────────────┘
+```
+
+### 8.2 Vote Thresholds
+
+| Change Type | Vote Required | Rationale |
+|---|---|---|
+| Documentation, tooling, non-breaking features | Simple majority of active Core Team members | Low stakes, fast iteration |
+| API changes, new subsystems, behavioral changes | Two-thirds majority of Core Team | Moderate stakes, needs real consensus |
+| Architecture changes, security model changes, breaking changes | Unanimous agreement of all Core Team members | High stakes, affects everyone |
+
+"Active" Core Team members are those who have participated in at least one vote in the past 90 days. Inactive members do not count against majority thresholds but are notified of votes.
+
+### 8.3 The ADR Connection
+
+Every accepted RFC must produce at least one ADR before the corresponding implementation can begin. The ADR is not a summary of the RFC — it is the permanent record of the specific decision made, in the Nygard format defined in the documentation RFC. The RFC can be long and exploratory. The ADR is short and definitive.
+
+RFCs are proposals. ADRs are decisions. Both are necessary. Neither replaces the other.
+
+### 8.4 Existing RFCs in This Repository
+
+The following RFCs have been filed as of this writing and should be converted to formal RFC issues immediately:
+
+| RFC Document | Issue to create | Priority |
+|---|---|---|
+| `docs/proposals/microkernel-architecture.md` | Microkernel Architecture RFC (v0.7.0+) | High |
+| `docs/proposals/documentation-standards.md` | Documentation Standards and i18n RFC | High |
+| `docs/proposals/project-governance.md` | Team Organization and Governance RFC | Medium |
+
+---
+
+## 9. Label Taxonomy
+
+Labels are the metadata layer on issues and PRs. A consistent, well-designed label system makes filtering, reporting, and automation possible. An inconsistent label system (the common case — labels added ad hoc by whoever creates an issue) creates noise.
+
+Use a **namespaced** label system. Each label has a prefix that identifies its category:
+
+### `type:` — What kind of work is this?
+
+| Label | Color | Use |
+|---|---|---|
+| `type:feature` | `#0075ca` Blue | New capability or enhancement |
+| `type:bug` | `#d73a4a` Red | Something is not working correctly |
+| `type:refactor` | `#e4e669` Yellow | Code restructuring without behavior change |
+| `type:docs` | `#0075ca` Blue | Documentation changes only |
+| `type:security` | `#e11d48` Dark red | Security-related changes |
+| `type:infrastructure` | `#6366f1` Purple | CI, tooling, build system |
+| `type:adr` | `#a855f7` Light purple | Architecture Decision Record |
+| `type:rfc` | `#f59e0b` Amber | Request for Comments / proposal |
+
+### `priority:` — How urgent is this?
+
+| Label | Color | Use |
+|---|---|---|
+| `priority:critical` | `#b91c1c` Dark red | Blocking release or causing data loss |
+| `priority:high` | `#f97316` Orange | Important, should be in next milestone |
+| `priority:medium` | `#eab308` Yellow | Normal priority |
+| `priority:low` | `#22c55e` Green | Nice to have, low urgency |
+
+### `size:` — How large is this work item?
+
+| Label | Color | Use |
+|---|---|---|
+| `size:xs` | `#dcfce7` Light green | Under 2 hours |
+| `size:s` | `#bbf7d0` Green | Half a day |
+| `size:m` | `#86efac` Medium green | 1–3 days |
+| `size:l` | `#4ade80` Dark green | 1–2 weeks |
+| `size:xl` | `#16a34a` Deep green | More than 2 weeks; should be broken down |
+
+### `component:` — Which part of the system?
+
+`component:kernel` · `component:gateway` · `component:channels` · `component:tools` · `component:memory` · `component:security` · `component:hardware` · `component:docs` · `component:infra`
+
+Use `#f1f5f9` (light gray) for all component labels to distinguish them visually from other categories.
+
+### `risk:` — What is the risk tier? (mirrors `AGENTS.md`)
+
+| Label | Color | Use |
+|---|---|---|
+| `risk:low` | `#dcfce7` | Docs, tests, minor changes |
+| `risk:medium` | `#fef9c3` | Most `src/**` changes |
+| `risk:high` | `#fee2e2` | Security, gateway, runtime, CI |
+
+### `status:` — Where is this in the process?
+
+| Label | Color | Use |
+|---|---|---|
+| `status:needs-triage` | `#f8fafc` White | Newly opened, not yet reviewed |
+| `status:blocked` | `#dc2626` Red | Waiting on something external |
+| `status:help-wanted` | `#059669` Green | Looking for a contributor |
+| `status:good-first-issue` | `#059669` Green | Suitable for new contributors |
+| `status:discussion` | `#a78bfa` Purple | Needs team discussion before work begins |
+| `status:wont-fix` | `#9ca3af` Gray | Explicitly decided not to pursue |
+| `status:duplicate` | `#9ca3af` Gray | Duplicate of another issue |
+
+### `rfc:` — RFC-specific status
+
+`rfc:accepted` · `rfc:rejected` · `rfc:revision-requested`
+
+---
+
+## 10. Definition of Done
+
+**"Done" means something specific. If you do not define it, everyone will have a different definition, and the disagreements will surface at the worst possible time — during review, during release, or after a user files a bug.**
+
+An item is **Done** when all of the following are true:
+
+### For code changes:
+
+- [ ] The PR has been reviewed and approved by the required reviewer tier (per CODEOWNERS and risk level)
+- [ ] All CI checks pass: `cargo fmt`, `cargo clippy`, `cargo test`
+- [ ] Tests exist for the new or changed behavior (unit tests at minimum; integration tests for user-facing features)
+- [ ] No test coverage that was passing before the PR was lost
+- [ ] The PR description explains *what* changed and *why* (not just "fixed bug" — what bug, what was wrong, what was changed)
+- [ ] If the change affects user-facing behavior: the relevant reference documentation is updated in the same PR
+- [ ] If the change is significant: a CHANGELOG.md entry is added under the correct milestone section
+- [ ] If the change requires an ADR: the ADR is written, linked, and merged before or with the implementation PR
+
+### For documentation changes:
+
+- [ ] YAML frontmatter is present and valid
+- [ ] All internal links resolve correctly
+- [ ] If the document describes a current behavior: it is accurate against the current `master` branch
+- [ ] If the document is an ADR: it follows the Nygard format and has a `status` field
+
+### For releases:
+
+- [ ] All items in the milestone are in `Done` status or explicitly moved to the next milestone with a comment explaining why
+- [ ] The CHANGELOG.md entry for the release is complete
+- [ ] All ADRs spawned by accepted RFCs in this milestone are written and accepted
+- [ ] The release has been tested on at least one platform (Linux x86_64 at minimum)
+- [ ] The release tag follows Semantic Versioning
+
+### The "Done Done" rule
+
+There is a concept in software teams of work that is "done" but not "done done." Done means the code is written. Done done means it is tested, documented, reviewed, merged, and released. The Definition of Done above describes done done. Nothing should be called done until it meets the full definition.
+
+---
+
+## 11. Automation
+
+GitHub Projects v2 and GitHub Actions together enable significant automation that reduces manual coordination overhead. Here is what to implement, ordered by value-to-effort ratio.
+
+### 11.1 Project Board Automation (Built-in, No Actions Required)
+
+Configure these in the Project's built-in automation settings:
+
+| Trigger | Action |
+|---|---|
+| Issue opened | Add to Project; set Status = 💡 Idea |
+| Issue labeled `type:bug` | Set Priority = 🟠 High (if no priority set) |
+| PR opened that references an issue | Set linked issue Status = 👀 In Review |
+| PR merged | Set linked issue Status = ✅ Done; close linked issue |
+| Issue closed as not planned | Set Status = 🚫 Won't Do |
+
+### 11.2 GitHub Actions Workflows
+
+**Auto-label by changed files (`.github/workflows/label-by-path.yml`):**
+
+Automatically add component and risk labels to PRs based on which files were changed. A PR touching `src/security/` gets `component:security` and `risk:high`. A PR touching `docs/` gets `type:docs` and `risk:low`. This eliminates the requirement for PR authors to remember to label their own PRs and gives reviewers immediate context.
+
+**Auto-request CODEOWNERS review (built into CODEOWNERS — no Action needed):**
+
+GitHub enforces CODEOWNERS automatically when the file exists and branch protection requires it. No Action required.
+
+**Stale issue management (`.github/workflows/stale.yml`):**
+
+Issues with no activity for 45 days are labeled `status:stale` and a comment is posted asking if the issue is still relevant. Issues with no activity for 15 days after the stale label is applied are closed. This prevents the backlog from accumulating hundreds of issues that are months old and no longer relevant. Exclude `status:blocked`, `priority:critical`, and `type:rfc` from the stale process.
+
+**PR size labeling (`.github/workflows/pr-size.yml`):**
+
+Automatically label PRs with `size:xs` through `size:xl` based on lines changed. This gives reviewers and maintainers an immediate sense of scope without opening the diff. Use these thresholds as a starting point: XS < 10 lines, S < 50, M < 250, L < 1000, XL ≥ 1000.
+
+**Milestone check on PR merge (`.github/workflows/milestone-check.yml`):**
+
+Warn (not block) if a PR is merged without a linked issue that has a milestone assigned. This is a gentle nudge, not a hard gate — the goal is to prevent work from happening without being tracked to a release.
+
+### 11.3 What NOT to Automate Yet
+
+- **Automated release drafts:** GitHub's release-drafter is useful but adds configuration overhead. Add it after the team has established a stable release rhythm.
+- **Automated dependency updates (Dependabot PRs):** Enable Dependabot security updates (free, low noise), but defer automated version bumps until the team has CI stability. Bumping versions creates noise before the CI foundation is solid.
+- **Sprint planning automation:** Do not automate sprint planning. It requires human judgment about capacity, priority, and team context that no automation can replace at this team size.
+
+---
+
+## 12. Phased Rollout
+
+Governance and tooling must be introduced incrementally. Introducing everything at once creates overhead before the team understands why each piece exists.
+
+---
+
+### Phase 1 · This Week — "Foundations"
+
+The minimum viable governance setup. Gets the team coordinating immediately.
+
+- [ ] Create the GitHub Project with Status, Type, Priority, and Milestone fields
+- [ ] Create the four Project views (Roadmap, Board, Backlog, My Work)
+- [ ] Enable GitHub Discussions with the seven categories defined in Section 4.1
+- [ ] Create the three RFC issues for the existing proposals (Section 8.4)
+- [ ] Add the six issue templates (Section 7)
+- [ ] Create the `CODEOWNERS` file (Section 6.1)
+- [ ] Enable branch protection rules on `master` (Section 6.2)
+- [ ] Add the remaining label taxonomy (Section 9) to the repository
+- [ ] Pin the three RFC issues and the next release milestone issue
+
+**Success signal:** New issues automatically appear in the Project. The team knows where to look for active work and where to post ideas.
+
+---
+
+### Phase 2 · v0.7.0 Milestone — "The Pipeline"
+
+Establish the full workflow and populate the backlog from the accepted RFCs.
+
+- [ ] Add Size, Risk Tier, and Component fields to the Project
+- [ ] Populate the Backlog with deliverables from the microkernel architecture RFC
+- [ ] Populate the Backlog with deliverables from the documentation standards RFC
+- [ ] Conduct the first formal RFC votes on the three existing proposals
+- [ ] Write ADRs for accepted RFCs (ADR-001 through ADR-007 per the docs RFC)
+- [ ] Add the `CONTRIBUTORS.md` file with current team members in their tiers
+- [ ] Implement the auto-label by path Actions workflow
+- [ ] Implement the stale issue management workflow
+- [ ] Create the `zeroclaw-core` and `zeroclaw-contributors` GitHub Teams
+
+**Success signal:** The team is using the board daily. Items move through stages with visible gate checks. The RFC for the microkernel architecture has a recorded vote outcome.
+
+---
+
+### Phase 3 · v0.8.0 Milestone — "Growing the Community"
+
+As the plugin system becomes usable, external contributors will start arriving. The contribution infrastructure must be ready.
+
+- [ ] Implement the PR size labeling workflow
+- [ ] Create the first batch of `good-first-issue` items (minimum 5) for the plugin SDK work
+- [ ] Add the `Good First Issue Index` as a pinned issue with links to current good-first-issues
+- [ ] Establish the idea promotion threshold and promote the first Discussion idea to an issue
+- [ ] Document the Core Team expansion process — criteria for inviting new Core Team members
+
+**Success signal:** At least one external contributor (not on the current team) submits a PR via a good-first-issue. The Discussions Ideas category has active community participation.
+
+---
+
+### Phase 4 · v1.0.0 — "Sustainable Governance"
+
+By v1.0.0, the governance model should be self-sustaining — the team should not need to think about it, it should just work.
+
+- [ ] Review and update the governance document based on what has worked and what has not
+- [ ] Establish the release cadence (how often are releases cut, who cuts them)
+- [ ] Publish the plugin registry governance document (per the architecture RFC)
+- [ ] Consider introducing time-boxed cycles (two or four weeks) if milestone-only planning feels too loose
+- [ ] Document the process for a Core Team member to step down or become inactive
+
+**Success signal:** The last six months of development history shows consistent use of the pipeline. Issues are triaged within 3 days. PRs are reviewed within 5 days. The CHANGELOG is updated on every merge.
+
+---
+
+
+---
+
+## Appendix A: Glossary
+
+**Backlog grooming** — A regular team activity (typically weekly or bi-weekly) in which the team reviews the backlog, reprioritizes items, closes stale ones, and ensures that the top items are "Defined" and ready to be picked up.
+
+**Branch protection** — A GitHub feature that prevents direct pushes to protected branches and enforces requirements (reviews, CI checks) before merging.
+
+**CODEOWNERS** — A GitHub file that automatically requests reviews from specified individuals or teams when files they own are changed in a PR.
+
+**Definition of Done** — A shared checklist that specifies exactly what "done" means for a work item. Without a shared definition, "done" means something different to everyone.
+
+**Lazy consensus** — A decision-making approach in which a proposed action proceeds unless someone objects within a defined time period. Reduces the overhead of requiring explicit approval for routine decisions.
+
+**Meritocracy** — A governance model in which authority and influence are earned through demonstrated contribution, not through seniority or title. Standard in open source projects.
+
+**Milestone** — A GitHub feature that groups issues and PRs by release target. A milestone represents a version of the software.
+
+**T-shirt sizing** — An estimation technique that uses abstract sizes (XS, S, M, L, XL) rather than numeric story points. Easier to use without historical calibration data and sufficient for teams at an early stage.
+
+**Triage** — The process of reviewing new issues to confirm they are valid, assign labels and priority, link them to milestones, and determine whether they belong in the backlog or should be closed.
+
+---
+
+## Appendix B: Further Reading
+
+- **GitHub Projects documentation** — https://docs.github.com/en/issues/planning-and-tracking-with-projects — Complete reference for GitHub Projects v2 features.
+- **GitHub Discussions documentation** — https://docs.github.com/en/discussions — Setup guide and governance options for GitHub Discussions.
+- **CODEOWNERS syntax reference** — https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners — The full syntax for CODEOWNERS files.
+- **"Producing Open Source Software"** — Karl Fogel — The definitive book on running an open source project. Free online at https://producingoss.com. Chapters on governance, contributor management, and communication are directly applicable.
+- **"An Introduction to Open Source Governance Models"** — The Apache Software Foundation's governance documentation is a good model for how a mature open source project formalizes authority and decision-making: https://www.apache.org/foundation/governance/
+- **Vale prose linter** — https://vale.sh — Referenced in the documentation RFC; integrates with the `good-first-issue` documentation improvement workflow.
+
+---
+
+*This proposal was developed in the context of ZeroClaw v0.6.8 and the two preceding architecture and documentation RFCs. The governance model proposed here is intentionally lightweight for a student-led project at an early stage of community growth. It is designed to scale — adding process as the team grows, not all at once.*
+
+*The best governance model is the simplest one the team will actually follow. Start here. Adjust based on what you learn.*

--- a/docs/foundations/fnd-004-engineering-infrastructure.md
+++ b/docs/foundations/fnd-004-engineering-infrastructure.md
@@ -1,0 +1,610 @@
+# FND-004: Engineering Infrastructure — CI/CD Pipeline and Release Automation
+### Supporting v0.7.0 → v1.0.0 · Type: Architecture · Rev. 1
+
+> **Canonical reference** · Ratified by the team · Rev. 1
+> Discussion thread and full revision history: [#5579](https://github.com/zeroclaw-labs/zeroclaw/issues/5579)
+
+
+---
+
+> **A note to the team before you read this.**
+>
+> This document is about the scaffolding around the code — the automation that builds it, tests it, audits it, and ships it. That scaffolding is invisible when it works well and painful when it does not. Most teams do not think about it until it is painful, and by then it has grown into something nobody fully understands. This RFC is an attempt to get ahead of that. If you have never thought deeply about CI/CD before, this is a good place to start. If you have, you will recognise the patterns. Either way, the goal is the same: a pipeline that gives the team confidence without getting in the way.
+
+---
+
+## Table of Contents
+
+1. [Context: Pipelines Are Architecture](#1-context-pipelines-are-architecture)
+2. [Honest Assessment: Where We Are Today](#2-honest-assessment-where-we-are-today)
+3. [The Target Pipeline Design](#3-the-target-pipeline-design)
+4. [Security Scanning as a Lifecycle](#4-security-scanning-as-a-lifecycle)
+5. [Release Automation Aligned to the Distribution Model](#5-release-automation-aligned-to-the-distribution-model)
+6. [Standards We Should Adopt](#6-standards-we-should-adopt)
+7. [Phased Roadmap](#7-phased-roadmap)
+8. [What This Means for Contributors](#8-what-this-means-for-contributors)
+
+---
+
+## Revision History
+
+| Rev | Date | Summary |
+|---|---|---|
+| 1 | 2026-04-09 | Initial draft |
+
+---
+
+## 1. Context: Pipelines Are Architecture
+
+The architecture RFC (#5574) established a principle: *dependencies flow inward, and structure is enforced by the compiler.* The same principle applies to the pipeline that surrounds the code. A pipeline is not just automation — it is a set of architectural decisions about what you trust, what you verify, when you verify it, and how you ship.
+
+Those decisions have consequences. A pipeline that was designed for a monolith will actively resist a microkernel. A security gate that has no triage process will either block everything or get bypassed. A release workflow built around one binary will not survive a distribution model with five artifact types. These are not configuration problems. They are design problems, and they deserve the same intentional treatment as the code architecture.
+
+The current pipeline grew reactively, the same way `loop_.rs` grew to 9,500 lines. Nobody chose the current state. It accumulated. PR #5559 — the first major step of the microkernel transition — exposed several places where the pipeline's assumptions no longer hold. That is a useful signal. It means now is exactly the right moment to stop, assess, and design intentionally.
+
+This RFC does for the pipeline what the architecture RFC does for the codebase: names what exists, identifies the structural problems, and proposes a path forward that is consistent with where the project is going.
+
+---
+
+## 2. Honest Assessment: Where We Are Today
+
+This section is not criticism. It is a diagnosis. The current pipeline reflects the decisions that made sense at the time. The goal is to understand it clearly enough to improve it.
+
+### 2.1 Two Workflows Doing the Same Work
+
+The repository currently has two separate workflows that run on pull requests against `master`:
+
+- `checks-on-pr.yml` — branded as "Quality Gate"
+- `ci-run.yml` — branded as "CI"
+
+Both run Lint, Build, Test, and Security jobs independently on every PR. This means every PR triggers two full pipeline runs in parallel. For a monolith with a single compilation unit, this was expensive but manageable. For a multi-crate workspace, it doubles an already significant CI budget with no additional signal.
+
+The duplication has a subtler cost beyond compute minutes: when a check fails in one workflow but not the other, contributors do not know which result to trust. When a new check needs to be added, it must be added in two places. When behaviour needs to change, it must change in two places. Two sources of truth is the same problem as two sources of truth in code.
+
+### 2.2 Single-Binary Assumptions Are Baked In Everywhere
+
+The release automation — `release-stable-manual.yml`, `release-beta-on-push.yml`, `publish-crates.yml`, `pub-aur.yml`, `pub-homebrew-core.yml`, `pub-scoop.yml`, `discord-release.yml`, `tweet-release.yml` — was designed around the assumption that a release is one binary. You build it, sign it, push it to package managers, and announce it.
+
+The architecture RFC defines a distribution model with five distinct artifact types: the kernel binary (multiple platform targets), the hardware-variant kernel binary, the gateway binary, WASM plugin files, and the Tauri desktop installer. None of the current release workflows account for this structure. When the architecture transition reaches Phase 3 and Phase 4, every one of these workflows will need to change — unless they are redesigned now with that model in mind.
+
+### 2.3 Security Scanning Without a Lifecycle
+
+The security job runs `cargo audit` as a hard gate. If any advisory is present in the dependency tree, the gate fails and the PR cannot merge. The intent is correct. The implementation has a structural problem.
+
+`cargo audit` reports all advisories in the dependency tree: active vulnerabilities, unmaintained crates, and informational notices. It does not distinguish between:
+
+- A critical vulnerability in a crate the project actively calls
+- A vulnerability in a transitive dependency three levels deep in an optional feature
+- An "unmaintained" notice for a crate the project depends on indirectly through a third-party library it cannot control
+- A pre-existing advisory that was present before this PR was opened
+
+When all of these produce the same hard failure, the gate becomes noise. The realistic response to noise is to lower the gate, ignore the failures, or suppress the checks. All three of those responses make the project less secure, not more. A security gate that cannot be maintained will not be maintained.
+
+PR #5559 surfaced twelve RUSTSEC-2026 advisories simultaneously. Without tooling to distinguish "new advisory introduced by this PR" from "pre-existing advisory present on master," the PR author and reviewers cannot know whether this PR made the security posture worse.
+
+### 2.4 The Strict Delta Lint Script
+
+`ci-run.yml` includes a job that runs `scripts/ci/rust_strict_delta_gate.sh` — a custom script that compares clippy output against the base SHA of the PR. The concept is sound: you want to know whether this PR introduced new warnings, not just whether warnings exist in the codebase. The implementation works well for small, focused PRs against a monolithic crate.
+
+A PR that moves 260,000 lines of code across 10 new crates, touching hundreds of files, puts this script in territory it was not designed for. The changed-file surface is too large for an incremental comparison to produce a meaningful signal. The script needs to understand workspace structure — specifically that a change to a file in `crates/zeroclaw-channels/` should be evaluated in the context of that crate, not the root.
+
+### 2.5 No Workspace-Aware Caching or Scoping
+
+The current Rust cache configuration (`Swatinem/rust-cache`) is adequate for a single crate. For a multi-crate workspace, cache effectiveness depends on understanding which crates changed and which compiled artifacts can be reused. Without explicit workspace scoping, a change to any crate can invalidate caches that other crates depend on, producing full recompilation on every PR.
+
+More significantly, there is no mechanism for running CI only against the crates affected by a given change. A PR that fixes a typo in `zeroclaw-tool-call-parser` does not need to rebuild and retest the gateway. As the workspace grows toward the 30+ crate model the architecture RFC envisions, the cost of running the full pipeline on every PR becomes a meaningful obstacle to contribution.
+
+### 2.6 Action Pinning Is Good — But Undocumented
+
+The existing workflows do pin actions to full commit SHAs, which is correct security practice and worth acknowledging. But there is no documented policy explaining why, no process for reviewing when those SHAs should be updated, and no automation for keeping them current. Good behaviour without a policy is fragile — the next contributor to add a workflow step may not know why SHA pinning matters and will use a mutable tag instead.
+
+---
+
+## 3. The Target Pipeline Design
+
+### 3.1 One Pipeline, One Source of Truth
+
+The two parallel workflows should be consolidated into a single, well-structured pipeline. The distinction between "Quality Gate" and "CI" is not meaningful to contributors — both are checks a PR must pass. The consolidation creates one place to find check results, one place to update when behaviour changes, and one place to document what each check is doing and why.
+
+The consolidated pipeline follows a staged structure where fast, cheap checks run first and gate slower, more expensive ones:
+
+```
+Stage 1: Format + Lint (2–5 min)
+  └── cargo fmt --check
+  └── cargo clippy --workspace --all-targets -- -D warnings
+  └── Docs quality gate
+
+Stage 2: Build + Check (parallel, 5–15 min)
+  └── Build matrix (Linux x86_64, macOS ARM, Windows)
+  └── cargo check --features ci-all
+  └── cargo check --no-default-features (kernel profile)
+  └── cargo check --target i686 (32-bit)
+
+Stage 3: Test (10–30 min, gated on Stage 1)
+  └── cargo nextest run --workspace
+
+Stage 4: Security (parallel with Stage 3)
+  └── cargo deny check (licenses, sources, advisories)
+  └── Advisory triage gate (see §4)
+
+Stage 5: Required Gate
+  └── Composite status — branch protection requires only this job
+```
+
+Stages 2, 3, and 4 run in parallel after Stage 1 passes. This means a formatting error fails fast without burning compute on a build that will be thrown away. The Required Gate job aggregates all results so branch protection needs to track only one job name — a pattern already present in both current workflows.
+
+### 3.2 Workspace-Aware Clippy
+
+The current clippy invocation runs against the default feature set of the root crate. The correct invocation for a multi-crate workspace is:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+The `--workspace` flag ensures every crate in the workspace is linted, not just the root. The `--all-targets` flag includes tests, benchmarks, and examples. Combined with `--features ci-all` for the feature-gated check, this gives a complete picture.
+
+The strict delta lint concept — checking whether this PR introduced new warnings rather than whether warnings exist at all — is worth preserving. The implementation should move from a shell script comparing diff output to a proper workspace-aware invocation that evaluates each affected crate independently. A simpler and more reliable approach: require `--workspace -D warnings` to pass clean at all times, making the delta concept implicit. If the baseline is always clean, any PR that introduces a warning fails. This removes the need for a custom comparison script entirely.
+
+### 3.3 Changed-Crate Detection
+
+For a workspace growing toward 30+ crates, running the full test suite on every PR regardless of what changed is wasteful. The pipeline should detect which crates were affected by the PR and scope test execution accordingly.
+
+The mechanism is straightforward: compare the files changed in the PR against the workspace member list, identify which crates contain changed files, expand the set to include all crates that depend on any changed crate (downstream impact), and run tests only for that set.
+
+```
+PR changes: crates/zeroclaw-tool-call-parser/src/lib.rs
+
+Affected crates:
+  zeroclaw-tool-call-parser     ← directly changed
+  zeroclaw-misc                 ← depends on it
+  zeroclawlabs (root)           ← depends on it
+
+Not affected:
+  zeroclaw-channels             ← no dependency path
+  zeroclaw-memory               ← no dependency path
+  zeroclaw-providers            ← no dependency path
+```
+
+This is implemented using `cargo metadata` to extract the dependency graph and a short script to walk it. The full test suite continues to run on pushes to `master` and on release branches. PRs run the affected-crate subset.
+
+### 3.4 Caching Strategy
+
+`Swatinem/rust-cache` supports workspace-aware caching through its `workspaces` configuration. The cache key should incorporate the workspace member list so that adding a new crate invalidates appropriately without invalidating unrelated crate caches.
+
+```yaml
+- uses: Swatinem/rust-cache@<sha>
+  with:
+    workspaces: |
+      . -> target
+    cache-on-failure: true
+    save-if: ${{ github.ref == 'refs/heads/master' }}
+```
+
+The `save-if` condition means cache is only written on `master` pushes, not on every PR. PRs read from the cache but do not write competing versions. This avoids cache thrashing when multiple PRs are open simultaneously.
+
+---
+
+## 4. Security Scanning as a Lifecycle
+
+### 4.1 The Problem With a Binary Gate
+
+A security gate that blocks on any advisory, without context, trains the team to treat security failures as noise. That is the opposite of the intended effect. The goal is a gate that is:
+
+- **High signal** — failures mean something real that this PR affected
+- **Actionable** — the contributor knows what to do and why
+- **Sustainable** — the gate can be maintained without constant manual intervention
+
+`cargo audit` alone does not achieve this. `cargo deny` does.
+
+### 4.2 cargo-deny as the Primary Security Tool
+
+`cargo deny` is a more capable successor to `cargo audit` for project-level dependency policy. It enforces:
+
+- **Advisories** — RUSTSEC database, with the ability to deny, warn, or explicitly ignore specific advisories with a documented justification
+- **Licenses** — ensures all dependencies use acceptable licenses (important as the workspace grows and new contributors add deps)
+- **Sources** — ensures dependencies come only from approved registries (crates.io, path, git with specific hosts)
+- **Duplicates** — warns when multiple versions of the same crate appear in the dependency tree
+
+The key capability is the `[advisories]` section of `deny.toml`, which allows explicit ignores:
+
+```toml
+[advisories]
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+unsound = "deny"
+notice = "warn"
+
+ignore = [
+    # RUSTSEC-2024-0388: `derivative` unmaintained — pulled in transitively
+    # through matrix-sdk; no direct usage, no active exploit. Tracked in #XXXX.
+    { id = "RUSTSEC-2024-0388", reason = "Transitive dep via matrix-sdk; no direct usage" },
+]
+```
+
+This approach transforms security scanning from a binary pass/fail into a documented, auditable policy. Every ignored advisory has a written justification and a tracking issue. Reviewers can see exactly which advisories are being suppressed and why. When a suppressed advisory escalates (a new exploit is found, a fix is available), the tracking issue is the reminder.
+
+### 4.3 Advisory Triage Process
+
+When a new advisory appears in the dependency tree — whether from a PR or from the daily advisory database update — the process is:
+
+1. **Classify the advisory**: Is the affected crate a direct dependency or transitive? Does ZeroClaw call the vulnerable code path? Is there a fixed version available?
+2. **Determine the response**:
+   - *Vulnerability in a direct dep with a fix available* → update the dep, no ignore needed
+   - *Vulnerability in a transitive dep with a fix available* → pin the transitive version or wait for the direct dep to update; open a tracking issue
+   - *Unmaintained notice, no active exploit* → add to `deny.toml` ignore list with justification and tracking issue
+   - *Critical vulnerability with no fix* → assess workaround; may block the PR
+3. **Record the decision** in `deny.toml` with the advisory ID, a brief rationale, and a link to the tracking issue
+
+This process means a PR like #5559 that surfaces twelve pre-existing advisories does not fail the gate without context. The advisories are triaged, the pre-existing ones are documented, and the gate reports only on new un-triaged advisories introduced by the PR.
+
+### 4.4 Daily Advisory Scan
+
+Security advisories are published continuously. A PR that passed the security gate when it merged may contain a vulnerability published the following week. The pipeline should include a scheduled daily run against `master` that checks the advisory database and opens a GitHub Issue if new un-triaged advisories are found.
+
+```yaml
+on:
+  schedule:
+    - cron: '0 9 * * *'  # 09:00 UTC daily
+```
+
+This separates the advisory triage cycle from the PR merge cycle. Contributors are not blocked by advisories that appeared after their PR was written. The security team (or whoever is on rotation) handles the daily scan output as a regular maintenance task.
+
+---
+
+## 5. Release Automation Aligned to the Distribution Model
+
+### 5.1 The Current Mismatch
+
+The architecture RFC §4.4.2 defines the following release artifacts:
+
+| Artifact | Build target | Published to |
+|---|---|---|
+| Kernel binary (standard) | x86_64-linux-musl, aarch64-linux-gnu, armv7-linux-gnueabihf, x86_64-darwin, aarch64-darwin, x86_64-windows | GitHub Releases |
+| Kernel binary (hardware) | aarch64-linux-gnu, armv7-linux-gnueabihf | GitHub Releases |
+| Gateway binary | Same platform matrix | GitHub Releases |
+| WASM plugin files | wasm32-wasip1 | Plugin registry |
+| Desktop installer | x86_64 + aarch64, macOS/Windows/Linux | GitHub Releases, platform stores |
+
+The current release workflows know about exactly one of these: the standard binary. The rest do not exist in the automation yet. This is appropriate for now — the plugin system is not yet complete. But the release workflows should be designed with this model in mind so they do not need to be rewritten as each new artifact type is introduced.
+
+### 5.2 A Release Pipeline Structure
+
+The target release pipeline is a directed graph of jobs, not a monolithic workflow:
+
+```
+version-bump (release-plz PR merged)
+    │
+    ├── build-kernel-standard (matrix: 6 targets)
+    ├── build-kernel-hardware (matrix: 2 ARM targets + hardware flags)
+    ├── build-gateway (matrix: 6 targets)
+    ├── build-plugins-wasm (matrix: all plugin crates → wasm32-wasip1)
+    └── build-desktop (matrix: macOS, Windows, Linux AppImage/deb)
+            │
+            ├── publish-github-release (attaches all kernel + gateway binaries)
+            ├── publish-plugin-registry (uploads WASM files)
+            ├── publish-aur (kernel binary for Arch Linux)
+            ├── publish-homebrew (kernel binary for macOS)
+            ├── publish-scoop (kernel binary for Windows)
+            └── announce (Discord, social)
+```
+
+Each build job is independent and can be triggered separately for hotfix releases. The publish jobs depend on all relevant build jobs succeeding. The announce job runs last.
+
+This structure means a plugin-only release (a new version of `channel-discord.wasm`) can run only the `build-plugins-wasm` and `publish-plugin-registry` jobs without triggering a full kernel rebuild. A kernel patch release runs `build-kernel-*` and the downstream publish jobs without touching the plugin registry.
+
+### 5.3 Release-plz for Workspace-Aware Version Management
+
+The architecture RFC §4.4.1 specifies `release-plz` as the release automation tool. `release-plz` integrates directly with this pipeline model:
+
+- On push to `master`, `release-plz` opens a "Release PR" that bumps the workspace version, updates changelogs from conventional commit history, and lists all crates that have changed since the last release
+- When the Release PR is merged, the release pipeline triggers automatically
+- Crates with `version.workspace = true` are bumped together; independently-versioned crates (`zeroclaw-api`, hardware library crates) are handled separately per the versioning policy
+
+The Release PR serves as a review checkpoint: the team sees exactly what version will be published and what the changelog says before anything goes out. This replaces manual version bumps and the `version-sync.yml` workflow.
+
+### 5.4 Action Pinning Policy
+
+The current workflows already pin actions to full commit SHAs. This is correct and should be formalised as an explicit policy so it survives contributor turnover:
+
+**Policy:** All `uses:` references in workflow files must be pinned to a full commit SHA with a version comment. Mutable tags (`@v4`, `@main`, `@latest`) are not permitted. No exceptions.
+
+```yaml
+# Correct
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+# Not permitted
+- uses: actions/checkout@v4
+- uses: actions/checkout@main
+```
+
+**Rationale:** A mutable tag is a promise from a third party that the action's behaviour will not change. That promise has been broken repeatedly across the GitHub Actions ecosystem. A SHA pin means the workflow runs exactly what was reviewed, regardless of what the action author does after the fact. This is especially important for actions that have write permissions or access to secrets.
+
+The update process: use `dependabot` or `renovate` configured for GitHub Actions to open PRs when new SHA versions are available. The team reviews and merges those PRs. This keeps actions current without requiring manual monitoring.
+
+---
+
+## 6. Standards We Should Adopt
+
+### 6.1 SLSA: Supply Chain Security Framework
+
+SLSA (Supply-chain Levels for Software Artifacts, pronounced "salsa") is a framework developed by Google and adopted across the industry for securing the software supply chain. It defines four levels of build integrity, from basic to hermetic.
+
+For ZeroClaw's current scale and team size, **SLSA Level 2** is the appropriate target:
+
+- Builds run on a hosted CI platform (already true — GitHub Actions)
+- Build scripts are version-controlled (already true)
+- Build provenance is generated and attached to release artifacts (the step to add)
+
+SLSA Level 2 provenance means each release artifact ships with a cryptographically signed attestation that records: what source commit produced it, which workflow produced it, and that the workflow ran on the expected platform. Users and package managers can verify this attestation. It closes the gap between "we say this binary came from this source" and "this binary provably came from this source."
+
+GitHub Actions supports SLSA Level 2 provenance generation natively through the `actions/attest-build-provenance` action. The cost to add it is one step per build job.
+
+### 6.2 Conventional Commits (Already Implied — Formalise It)
+
+The architecture RFC's versioning policy and release-plz integration both depend on conventional commit format for changelog generation. The governance RFC already references PR title conventions. This RFC formalises the connection: conventional commit format in commit messages and PR titles is a requirement, not a suggestion, because it is the input that drives automated changelog generation.
+
+The categories that matter for ZeroClaw's changelog:
+
+| Prefix | Changelog section | Version impact |
+|---|---|---|
+| `feat:` | New features | MINOR |
+| `fix:` | Bug fixes | PATCH |
+| `feat!:` or `fix!:` | Breaking changes | MAJOR |
+| `chore:` | Maintenance | No release entry |
+| `docs:` | Documentation | No release entry |
+| `perf:` | Performance | PATCH |
+| `security:` | Security fixes | PATCH (at minimum) |
+
+CI enforces this with a PR title lint job that validates the title matches the conventional commit format before any other check runs.
+
+### 6.3 Reusable Workflows
+
+As the number of crates and artifact types grows, workflow duplication becomes a maintenance problem. GitHub Actions supports reusable workflows — a workflow that can be called from another workflow like a function. The build matrix, the security scan, and the test runner should each be extracted as reusable workflows.
+
+```
+.github/
+  workflows/
+    ci.yml               ← PR checks (calls reusable workflows)
+    release.yml          ← Release pipeline (calls reusable workflows)
+    daily-audit.yml      ← Scheduled security scan
+  _workflows/            ← Reusable workflow definitions
+    build-rust.yml       ← Parameterised build job
+    test-workspace.yml   ← Parameterised test job
+    security-scan.yml    ← cargo-deny invocation + triage
+    publish-release.yml  ← Parameterised publish job
+```
+
+A reusable workflow is called with parameters:
+
+```yaml
+jobs:
+  build-kernel:
+    uses: ./.github/_workflows/build-rust.yml
+    with:
+      target: x86_64-unknown-linux-musl
+      features: ""
+      profile: dist
+```
+
+This means the CI workflow and the release workflow share the same build definition. A fix to the build process applies everywhere at once.
+
+---
+
+## 7. Phased Roadmap
+
+The pipeline migration follows the same Strangler Fig approach as the code migration: build alongside, migrate steadily, never break the existing gate.
+
+---
+
+### Phase 1 · v0.7.0 — "Rationalise"
+
+**Theme:** One pipeline, clean signal, no duplication.
+
+**Why this phase:** The architectural transition is already underway. The pipeline needs to stop fighting it before it makes implementation work harder than it needs to be.
+
+#### Deliverables
+
+**D1: Consolidate `checks-on-pr.yml` and `ci-run.yml` into a single workflow**
+
+Merge the two PR workflows into one. The consolidated workflow keeps the staged structure defined in §3.1. The `Quality Gate` and `CI` naming distinction disappears. There is one workflow, one set of results, one place to look.
+
+The composite gate job (`CI Required Gate`) is preserved. Branch protection continues to require only that single job. This means the internal structure of the pipeline can change without requiring branch protection rule updates.
+
+**D2: Replace `cargo audit` with `cargo deny`**
+
+Add `deny.toml` to the repository root. Configure the `[advisories]`, `[licenses]`, and `[sources]` sections. Triage all current RUSTSEC advisories on `master`: update what can be updated, document what cannot with justification and tracking issues. The security gate passes clean on `master` before this phase is complete.
+
+**D3: Fix workspace-aware clippy invocation**
+
+Change `cargo clippy --all-targets -- -D warnings` to `cargo clippy --workspace --all-targets -- -D warnings` in the consolidated workflow. Remove the `rust_strict_delta_gate.sh` script — with `--workspace -D warnings` always enforced clean, the delta concept is implicit.
+
+**D4: Formalise action pinning policy**
+
+Add a `SECURITY.md` note and a CI check that validates all `uses:` references in workflow files are SHA-pinned. Add `dependabot` configuration for GitHub Actions updates.
+
+**D5: Add daily advisory scan workflow**
+
+Add `daily-audit.yml` as a scheduled workflow running `cargo deny check advisories` against `master` at 09:00 UTC. On failure, open a GitHub Issue with the advisory details using `gh issue create`.
+
+#### Success Metrics for Phase 1
+
+- Single PR workflow file, no duplication
+- Security gate passes clean on `master` with documented triage for all pre-existing advisories
+- `cargo clippy --workspace` runs and passes clean
+- No mutable action tag references in any workflow file
+- Daily advisory scan operational
+
+---
+
+### Phase 2 · v0.8.0 — "Workspace-Aware"
+
+**Theme:** The pipeline understands the workspace. Fast feedback for focused changes.
+
+**Why this phase:** By v0.8.0 the workspace will have grown further. Running the full pipeline on every PR will be increasingly expensive. Contributors to `zeroclaw-tool-call-parser` should not wait 30 minutes for a gateway rebuild.
+
+#### Deliverables
+
+**D1: Changed-crate detection**
+
+Add a `scripts/ci/affected_crates.sh` script that uses `cargo metadata` to build the dependency graph and returns the set of crates affected by the PR's changed files. The CI workflow uses this output to scope test execution.
+
+**D2: Per-crate test scoping**
+
+Add `--package` flags to `cargo nextest` based on the affected-crate output. Full workspace tests continue to run on `master` pushes and nightly. PRs run the affected subset.
+
+**D3: Workspace-aware cache configuration**
+
+Update `Swatinem/rust-cache` configuration with explicit workspace scoping and `save-if: ${{ github.ref == 'refs/heads/master' }}` to prevent cache thrashing from concurrent PRs.
+
+**D4: Extract reusable workflow definitions**
+
+Extract the build, test, and security jobs into reusable workflow files under `.github/_workflows/`. Update `ci.yml` and the new `release.yml` skeleton to call them.
+
+#### Success Metrics for Phase 2
+
+- A PR touching only `zeroclaw-tool-call-parser` runs tests for that crate and its dependents, not the full workspace
+- Cache hit rate on CI above 80% for incremental builds
+- Reusable workflows in place for build, test, and security jobs
+
+---
+
+### Phase 3 · v0.9.0 — "Release Pipeline"
+
+**Theme:** Release automation that matches the distribution model.
+
+**Why this phase:** Phase 3 of the architecture RFC extracts `zeroclaw-gw` as a separate binary. The first multi-artifact release happens here. The release pipeline must be ready before it is needed.
+
+#### Deliverables
+
+**D1: Introduce `release-plz` and remove `version-sync.yml`**
+
+Configure `release-plz` for the workspace. Workspace application crates use `version.workspace = true`. `zeroclaw-api` and hardware library crates are configured with independent release settings. The `version-sync.yml` workflow is retired.
+
+**D2: Build the structured release pipeline in `release.yml`**
+
+Implement the directed release graph from §5.2: `build-kernel-standard`, `build-kernel-hardware`, `build-gateway`, with downstream publish jobs. Plugin build jobs are stubbed — they succeed with no-op until Phase 4.
+
+**D3: Add SLSA Level 2 provenance**
+
+Add `actions/attest-build-provenance` to each build job. Provenance attestations are attached to GitHub Release assets. Document verification instructions in `SECURITY.md`.
+
+**D4: Retire redundant release workflows**
+
+Consolidate `release-stable-manual.yml`, `release-beta-on-push.yml`, `pub-aur.yml`, `pub-homebrew-core.yml`, `pub-scoop.yml`, `discord-release.yml`, `tweet-release.yml` into the structured `release.yml` pipeline. These workflows grew independently; the structured pipeline replaces them with a single, auditable flow.
+
+#### Success Metrics for Phase 3
+
+- `release-plz` opens and manages Release PRs on `master`
+- Kernel and gateway binaries are built and published from a single `release.yml` workflow
+- SLSA Level 2 provenance attached to all release assets
+- Redundant release workflows retired
+
+---
+
+### Phase 4 · v1.0.0 — "Platform Pipeline"
+
+**Theme:** The pipeline ships the platform, not just the binary.
+
+**Why this phase:** v1.0.0 is when WASM plugins become publishable. The pipeline must handle plugin publishing, registry upload, and the Tauri desktop installer as first-class release artifacts.
+
+#### Deliverables
+
+**D1: Activate WASM plugin build jobs**
+
+Implement `build-plugins-wasm` in the release pipeline. Each plugin crate builds to `wasm32-wasip1` in a dedicated job. Plugin manifests are generated and signed. The `publish-plugin-registry` job uploads signed WASM files to the plugin registry.
+
+**D2: Desktop installer build and publish**
+
+Complete the Tauri build jobs for macOS, Windows, and Linux. The installer bundles the kernel and gateway binaries. Code signing credentials for macOS and Windows are documented as required repository secrets with a setup guide.
+
+**D3: Publish the CI/CD standards to `docs/contributing/ci-standards.md`**
+
+The action pinning policy, advisory triage process, conventional commit requirements, and release pipeline structure defined in this RFC are extracted to `docs/contributing/ci-standards.md` as a standing reference. This RFC remains the historical record of the decisions; the extracted document is what contributors look up day-to-day.
+
+**D4: Contributor onboarding for the pipeline**
+
+Add a `Running CI Locally` section to the contributing documentation that shows contributors how to replicate the CI checks on their own machine before pushing:
+
+```bash
+# What CI runs — run these before pushing
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --workspace
+cargo deny check
+```
+
+#### Success Metrics for Phase 4
+
+- WASM plugin files are published to the registry as part of the release pipeline
+- Tauri desktop installer is built and published automatically on release
+- `docs/contributing/ci-standards.md` exists and covers action pinning, advisory triage, and conventional commits
+- A contributor can replicate all CI checks locally with four commands
+
+---
+
+## 8. What This Means for Contributors
+
+### For contributors opening PRs
+
+The consolidated pipeline means one place to look for results. Stage 1 (format and lint) fails fast — if you have a formatting error, you know in two minutes without waiting for a build. If Stage 1 passes, the build and test stages run in parallel and you have a full result in under 30 minutes for most changes.
+
+The conventional commit requirement on PR titles is enforced by CI. If your title does not match the format, the lint job fails immediately with a clear message. This is not bureaucracy — it is the input that generates the changelog automatically, which means releases happen faster and with less manual work.
+
+### For contributors adding dependencies
+
+Every new dependency passes through `cargo deny`. If the dependency has a known vulnerability, an unacceptable license, or comes from an untrusted source, the security gate fails and tells you why. This is by design. The right response is to investigate the dependency, not to suppress the check.
+
+If a dependency carries an advisory that is not fixable (a transitive dep with no available update), the triage process in §4.3 is how you document that. Open a tracking issue, add the ignore entry to `deny.toml` with your justification, and move forward. The security posture is maintained through documentation, not through hoping the advisory goes away.
+
+### For contributors adding workflow files
+
+New workflow files follow three rules without exception:
+1. All `uses:` references are SHA-pinned with a version comment
+2. New jobs are extracted as reusable workflows if they duplicate logic from an existing job
+3. New release-related jobs are added to `release.yml`, not as new workflow files
+
+When in doubt, ask before adding. Workflow files are high-risk changes — they run with elevated permissions on CI infrastructure and can affect supply chain security. They deserve the same review standard as `src/security/`.
+
+### For maintainers
+
+The daily advisory scan means security is a regular maintenance task, not a crisis. When a new advisory fires, the triage process is well-defined and the outcome is documented in `deny.toml` and a tracking issue. Reviewers can audit the full history of advisory decisions in git history.
+
+The Release PR from `release-plz` is the release review checkpoint. Before anything is published, the team sees the version, the changelog, and the list of changed crates. Releases do not happen by accident.
+
+---
+
+
+---
+
+## Appendix A: Glossary
+
+**SLSA (Supply-chain Levels for Software Artifacts)** — A security framework that defines levels of build integrity, from basic provenance to fully hermetic builds. Developed by Google and adopted by the OpenSSF. Level 2 is the practical target for most open-source projects: hosted build platform, version-controlled build scripts, signed provenance attached to artifacts.
+
+**Provenance** — A cryptographically signed record of where a build artifact came from: which source commit, which workflow, which platform. Allows users and package managers to verify that a binary was produced from the claimed source by the claimed process.
+
+**`cargo deny`** — A Cargo plugin that enforces dependency policy across three dimensions: security advisories (from the RustSec database), software licenses (against a defined allowlist), and source registries (ensuring deps come only from approved locations). More configurable than `cargo audit` and better suited to policy management at scale.
+
+**`release-plz`** — A Rust-ecosystem release automation tool that creates "Release PRs" on push to the default branch, bumping versions and generating changelogs from conventional commit history. Workspace-aware; understands which crates changed and which need new versions.
+
+**Reusable workflow** — A GitHub Actions workflow that can be called as a job from another workflow, with parameters. Allows build, test, and security logic to be defined once and called from both the PR pipeline and the release pipeline.
+
+**Conventional commits** — A commit message convention (`feat:`, `fix:`, `chore:`, etc.) that enables automated changelog generation and version determination. The input that tools like `release-plz` use to decide whether a release is a patch, minor, or major bump.
+
+**Strangler Fig (in pipeline context)** — The same migration strategy applied to workflows: build the new pipeline structure alongside the existing one, migrate jobs one at a time, retire the old files only when the new structure is complete and verified.
+
+---
+
+## Appendix B: Further Reading
+
+- **SLSA Framework** — https://slsa.dev — The full specification and implementation guides for supply chain security levels.
+
+- **`cargo deny` documentation** — https://embarkstudios.github.io/cargo-deny/ — Configuration reference for the `deny.toml` policy file, including all advisory, license, and source options.
+
+- **`release-plz` documentation** — https://release-plz.eplant.org — Workspace configuration, changelog format customisation, and GitHub Actions integration guide.
+
+- **GitHub Actions security hardening** — https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions — Official guidance on SHA pinning, token permissions, and supply chain risk in Actions workflows.
+
+- **Conventional Commits specification** — https://www.conventionalcommits.org — The full specification for commit message format and its relationship to semantic versioning.
+
+- **OpenSSF Scorecard** — https://securityscorecards.dev — An automated tool that scores open-source projects on security practices including dependency pinning, branch protection, code review requirements, and more. Useful as a baseline assessment and ongoing health metric.

--- a/docs/foundations/fnd-005-contribution-culture.md
+++ b/docs/foundations/fnd-005-contribution-culture.md
@@ -1,0 +1,642 @@
+# FND-005: Contribution Culture — Human Collaboration, AI Partnership, and Team Growth
+### Starting v0.7.0 · Type: Culture · Rev. 1
+
+> **Canonical reference** · Ratified by the team · Rev. 1
+> Discussion thread and full revision history: [#5615](https://github.com/zeroclaw-labs/zeroclaw/issues/5615)
+
+
+---
+
+> **A note to the team before you read this.**
+>
+> This is the fifth document in ZeroClaw's maturity framework. The other four address
+> architecture, documentation, governance, and engineering infrastructure — the structural
+> layers that make a project work. This one addresses something those four take for granted
+> but never explicitly teach: how to work together.
+>
+> The tools and processes in the other RFCs only function as well as the team using them.
+> A perfect CI pipeline does not help a team that cannot give honest feedback. A clean
+> architecture does not survive a team that cannot disagree productively. A governance
+> model does not build ownership in people who have never been taught what ownership means.
+>
+> This document is about building that team — not just technically capable individuals,
+> but people who know how to give and receive feedback, how to ask for help, how to use
+> powerful tools responsibly, and how to grow together over time. These are learnable
+> skills. Nobody arrives with them fully formed. This document names them clearly enough
+> that you can start practicing them deliberately, here, in the context of real work that
+> matters.
+>
+> Nothing in this document is criticism of who you are or where you started. It is a map
+> for where we are trying to go together.
+
+---
+
+## The Maturity Framework Suite
+
+This RFC is the fifth in a set of five documents that together form ZeroClaw's maturity
+framework. They are designed to be read as a whole, though each stands on its own.
+
+| RFC | Scope | Issue |
+|-----|-------|-------|
+| Intentional Architecture — Microkernel Transition | What we are building and how it is structured | #5574 |
+| Documentation Standards and Knowledge Architecture | How we document what we build | #5576 |
+| Team Organization and Project Governance | How we coordinate and make decisions | #5577 |
+| Engineering Infrastructure — CI/CD Pipeline | How we build, test, and ship reliably | #5579 |
+| **Contribution Culture — Human Collaboration and AI Partnership** | **How we work together and grow** | **FND-005** |
+
+The first four RFCs answer structural questions. This one answers a human question: given
+the structure, how do the people inside it behave toward each other and toward their tools?
+That question does not have a compiler, a linter, or a CI gate. It has only the habits we
+build, the examples we set, and the intentionality we bring to it.
+
+---
+
+## Table of Contents
+
+1. [Why this document exists](#1-why-this-document-exists)
+2. [The work before the work](#2-the-work-before-the-work)
+3. [Working with people](#3-working-with-people)
+   - [Giving feedback](#giving-feedback)
+   - [Receiving feedback](#receiving-feedback)
+   - [Asking for help](#asking-for-help)
+   - [Disagreeing productively](#disagreeing-productively)
+   - [Ownership](#ownership)
+   - [Supporting someone who is struggling](#supporting-someone-who-is-struggling)
+4. [Working with AI](#4-working-with-ai)
+   - [The delegation mental model](#the-delegation-mental-model)
+   - [AI works at the implementation layer](#ai-works-at-the-implementation-layer)
+   - [Amplification is not magic](#amplification-is-not-magic)
+   - [The review discipline](#the-review-discipline)
+   - [What this means for your career](#what-this-means-for-your-career)
+5. [The feedback taxonomy](#5-the-feedback-taxonomy)
+6. [A note to reviewers and mentors](#6-a-note-to-reviewers-and-mentors)
+
+---
+
+## 1. Why this document exists
+
+Most contributing guides tell you how to open a PR. They tell you what labels to use,
+how to run the test suite, and what goes in the commit message. Those things matter, and
+we have documents that cover them.
+
+This document covers something different: the skills that determine whether a group of
+talented people becomes a functional team or a collection of individuals who happen to
+share a repository.
+
+These are learnable skills. They are not personality traits you either have or do not
+have. They are not things that come automatically with technical ability. They are
+practiced — slowly, with feedback, over time — the same way any other skill is learned.
+Most software engineering education focuses almost entirely on the technical layer and
+leaves the human layer to chance. The result is that a lot of technically capable people
+end up in teams that do not work well together, without any clear understanding of what
+is missing or how to fix it.
+
+The goal of this document is to name those skills clearly enough that you can start
+practicing them deliberately, here, in the context of real work that matters.
+
+---
+
+## 2. The work before the work
+
+Before you write a line of code, open a PR, or ask an AI to generate anything, there is
+a set of questions you should be able to answer. This project uses a decision hierarchy
+to describe them:
+
+```
+Vision
+  └── Architecture
+        └── Design
+              └── Implementation
+                    └── Testing
+                          └── Documentation
+                                └── Release
+```
+
+The hierarchy is described in full in the architecture RFC (#5574). What matters here is
+the principle behind it: **every decision you make should be traceable back up to the top.**
+
+In practice, this means asking yourself before you start building:
+
+- **What problem am I solving?** Not "what ticket am I closing" — what actual problem
+  does this solve for someone?
+- **Does this fit the architecture?** If you cannot describe where this belongs in the
+  system structure, you do not yet understand the system well enough to change it.
+- **What does done look like?** Before you write the code, write the acceptance criteria.
+  "It works" is not an acceptance criterion. "A user can install a plugin without a Rust
+  toolchain and it runs correctly" is.
+- **Who needs to know about this?** Changes that touch other people's work, or that make
+  decisions the whole team should make, need visibility before implementation — not after.
+
+This is not bureaucracy. It is the difference between building something and building the
+right thing. It also applies directly to how you work with AI tools, which we cover in
+Section 4.
+
+The honest version of what happens when you skip this step: you build something that
+works, open a PR, and then learn in the review that it solves the wrong problem, or
+solves the right problem in a way that conflicts with a decision that was already made
+somewhere else. That wastes your time, the reviewer's time, and delays the people who
+depend on the work. The pre-work is not extra — it is how you protect your own effort.
+
+---
+
+## 3. Working with people
+
+### Giving feedback
+
+Feedback is one of the highest-leverage things you can do for another engineer. A
+well-written review comment can teach something that takes years to learn on your own.
+A poorly written one can discourage someone from contributing again.
+
+**Be specific.** Vague feedback creates anxiety without direction.
+
+> ❌ "This is hard to read."
+>
+> ✅ "This function is handling three separate concerns — input validation, business logic,
+> and formatting the response. Consider splitting them so each function does one thing.
+> That makes it easier to test each piece and easier to understand at a glance what each
+> one does."
+
+The second version is longer, but it teaches something. The reader now knows what the
+problem is, why it matters, and what to do about it.
+
+**Explain the principle, not just the verdict.** If you ask someone to change something,
+tell them why. "Change X to Y" produces a fix. "Change X to Y because Z" produces
+understanding that applies to the next ten situations where the same principle applies.
+
+**Separate the work from the person.** "This approach has a problem" and "you made a
+mistake" are not the same statement. The first is about the code. The second is about
+the person. Keep your feedback pointed at the work.
+
+**Name what is good.** This is not about being nice — it is about being useful. When you
+tell someone what they got right and explain why it is right, you teach them what
+patterns to repeat. Generic praise ("great work!") teaches nothing. Specific praise
+("extracting this into its own crate was the right call because it means we can now test
+this logic in isolation without standing up the whole agent loop") teaches the principle
+and reinforces the decision.
+
+**Use the feedback taxonomy.** The four-bucket model in Section 5 gives every comment a
+clear weight. Reviewers who mix blocking issues with minor suggestions without
+distinguishing between them force the author to guess which things actually need to
+change. Do not make people guess.
+
+---
+
+### Receiving feedback
+
+This is harder than giving feedback for most people, and it is worth being honest about
+why.
+
+When you have spent hours on something — working through a problem, making decisions,
+writing the code — and someone tells you it has issues, the natural human response is
+to feel like the criticism is about you. It is not. It is about the work. Learning to
+hold those two things as separate is a skill, and it takes practice.
+
+A few things that help:
+
+**Read the feedback before you respond to it.** Not just the summary line — the whole
+comment, including the explanation. Many feedback responses are written in reaction to
+the verdict before the person has absorbed the reasoning. Read the why before you decide
+how you feel about the what.
+
+**Distinguish between "I disagree" and "I do not understand."** These require different
+responses. If you do not understand the feedback, ask a clarifying question. If you
+understand it and disagree, say so with evidence. Both are good outcomes. What is not
+useful is staying silent when you have questions, or saying "ok fine" when you actually
+disagree.
+
+**You do not have to agree with every piece of feedback to learn from it.** Sometimes
+feedback is wrong. Sometimes it reflects a different set of tradeoffs than the ones you
+were optimising for. You are allowed to push back — see Disagreeing productively below.
+But even feedback you ultimately reject is worth understanding fully before you decide
+to reject it.
+
+**Close the loop.** When someone takes time to review your work, tell them when you have
+addressed their feedback. You do not have to thank them effusively — a simple "addressed
+in the latest commit" is enough. It tells them their time was worthwhile and keeps the
+PR moving.
+
+**Feedback on your code is not feedback on your worth.** This sounds obvious. It is not
+obvious when you are in the middle of it. Every experienced engineer has code reviewed by
+people who are more experienced, and that process is uncomfortable every time. The
+discomfort is the sensation of learning. It does not go away; you just get better at
+sitting with it.
+
+---
+
+### Asking for help
+
+In school, asking for help can feel like admitting you are behind, or that you do not
+belong. In a team, asking for help is one of the most professional things you can do.
+
+**The cost of being stuck and not asking is almost always higher than the cost of
+asking.** Three hours of spinning on a problem that a five-minute conversation would
+resolve is three hours of your time and your team's time that is gone. Knowing when to
+ask is a skill, not a weakness.
+
+A good help request has three parts:
+
+1. **What you are trying to do.** Not just "it's broken" — what is the goal?
+2. **What you have already tried.** This shows you have engaged with the problem and
+   gives the person helping you a starting point that is not zero.
+3. **Where you are stuck specifically.** "I don't know what's wrong" is a different
+   problem than "I know what's wrong but I don't know how to fix it" and "I fixed it
+   but I don't know why my fix works."
+
+A help request that has these three components gets answered faster and teaches you more,
+because the person helping you can calibrate to exactly where you are.
+
+**Ask publicly when you can.** A question asked in a shared channel or on a PR benefits
+everyone who has the same question later. A question asked privately benefits only you.
+There are times when private is right — sensitive feedback, personal circumstances — but
+technical questions about the codebase are almost always better asked in the open.
+
+**Not knowing something is not shameful.** Nobody knows everything. The engineers who
+appear to know everything have asked a lot of questions over a long time, and the answers
+accumulated. The only way to get there is to start asking.
+
+---
+
+### Disagreeing productively
+
+Architecture disagreements are healthy. They mean people care about how the system is
+built and are paying attention to the decisions being made. A team where nobody disagrees
+is not a team where everyone agrees — it is a team where people have stopped engaging.
+
+The difference between a productive disagreement and an unproductive one is usually in
+the framing.
+
+**Lead with the concern, not the verdict.**
+
+> ❌ "This approach is wrong."
+>
+> ✅ "I have a concern about this approach — specifically, if we wire the gateway directly
+> into the runtime here, we break the dependency rule in RFC §4.2. Can we talk through
+> whether there is a way to achieve the same result without that coupling?"
+
+The second version opens a conversation. The first closes one.
+
+**Bring evidence.** An architecture disagreement backed by a measured fact, a specific
+RFC section, or a concrete failure scenario is a contribution. An architecture
+disagreement backed by "I just feel like" is an opinion. Both are worth expressing, but
+only one moves the conversation forward quickly.
+
+**Be genuinely open to being wrong.** If you go into a disagreement having already
+decided you are right, you are not having a conversation — you are lobbying. People can
+tell the difference, and it makes them less likely to engage seriously with your concerns.
+The goal is the best outcome for the project, not being right.
+
+**When the team decides, move with the team.** You can note your dissent on the record —
+in the issue, in the RFC comments, in the PR thread — and then you build what was
+decided. This is not capitulation. It is how teams function. A team that keeps
+relitigating settled decisions does not ship.
+
+**Some decisions are reversible and some are not.** Know which kind you are arguing about.
+A naming decision is reversible. A wire protocol decision that will be in production
+binaries for two years is not. Weight your energy accordingly.
+
+---
+
+### Ownership
+
+Ownership is one of those words that gets used a lot without a clear definition. Here
+is what it means in practice on this project:
+
+**Ownership means you see the problem before you are asked to.** It means reading a PR
+that touches your area and noticing a side effect the author did not notice. It means
+seeing a follow-up issue sitting without an assignee and picking it up. It means not
+waiting to be told.
+
+**Ownership means your word means something.** If you file a follow-up issue with your
+name on it, that issue is your commitment. Not "someone should do this" — you will do
+this. If circumstances change and you cannot, you say so early and you find a handoff.
+A tracker full of filed-and-forgotten issues with names attached is a broken trust
+register.
+
+**Ownership is not "I did my part."** It is "I care whether the whole thing works." You
+can own a crate without being indifferent to whether the system that crate lives in is
+healthy. You can own a feature without being indifferent to whether users can actually
+use it. Narrow ownership — "I did my bit, the rest is someone else's problem" — produces
+systems that technically have owners for every piece and functionally have no one
+responsible for anything.
+
+**Ownership includes the follow-through.** Shipping code is not the end of ownership.
+It is the beginning of the responsibility to make sure it works, to fix what breaks,
+and to teach the next person who works in that area what you learned.
+
+---
+
+### Supporting someone who is struggling
+
+At some point in this project you will be more experienced than someone else in a thread.
+Maybe you have been here longer. Maybe you happen to know the part of the codebase they
+are working in. Maybe you have seen this particular failure mode before.
+
+What you do with that position matters.
+
+**Do not just fix it for them.** Giving someone a working solution without explaining
+what was wrong or why your solution works produces a merged PR and zero learning. The
+next time they hit a similar problem, they will be in the same place. Take the extra
+five minutes to explain what you saw and why the fix works.
+
+**Review with intent to teach.** A bad PR is not just a problem to close — it is a
+teaching opportunity. A dismissive review ("this doesn't follow the architecture") is
+less useful than a review that names what was missed, explains the principle it violates,
+and points to where the contributor can learn more. The extra effort is an investment in
+a contributor who writes better PRs from that point forward.
+
+**If someone is blocked and not asking for help, say something.** Sometimes people do
+not ask because they do not want to look like they are struggling. Sometimes they are not
+sure who to ask. Sometimes they have been struggling long enough that they have stopped
+noticing how stuck they are. A quiet "looks like this one has been open for a while —
+is there anything I can help unblock?" costs almost nothing and can mean everything to
+someone who is spinning.
+
+**Make it safe to not know things.** If people in your team feel judged for not knowing
+something, they will pretend to know things. That produces worse decisions, not better
+ones. The team that makes it safe to say "I don't know, let me find out" makes better
+decisions than the team where everyone performs confidence.
+
+---
+
+## 4. Working with AI
+
+This section is about something that most contributing guides do not cover: how to work
+with AI coding tools in a way that makes you better, not just faster.
+
+### The delegation mental model
+
+Here is the most useful reframe for working with AI effectively:
+
+**Working with an AI is the same skill as delegating to a person.**
+
+When you delegate work to a colleague or a junior engineer, you provide context. You
+explain the goal, the constraints, what good looks like, and what the boundaries are.
+You do not just say "build me a feature." You say: here is what the user is trying to
+do, here is how it fits into the system, here is how we will know it is done, and here
+are the things you should not do.
+
+Then — critically — you review what comes back. You do not accept a junior engineer's
+PR without reading it. You check whether it does what was asked, whether it fits the
+architecture, whether it has test coverage, whether the error handling is correct. You
+give feedback. You may iterate.
+
+AI tools work exactly the same way. The quality of what you get back is determined
+almost entirely by the quality of what you put in. A vague prompt produces vague output.
+A prompt with clear context, specific constraints, and concrete acceptance criteria
+produces output that is actually useful as a starting point.
+
+The engineers who struggle with AI tools are usually the ones who are still learning
+to give clear direction to anything — human or AI. The engineers who thrive with them
+are the ones who already know what they want before they ask for it.
+
+This mental model also means that the output is your responsibility. You cannot submit
+a PR and say "the AI wrote it." You reviewed it. You opened the PR. It is your work.
+
+---
+
+### AI works at the implementation layer
+
+This is the most important technical limitation to understand.
+
+AI code generation works at the **implementation layer** of the decision hierarchy:
+
+```
+Vision          ← AI cannot set this. You must.
+Architecture    ← AI cannot make these decisions. You must.
+Design          ← AI will sometimes guess. You must verify.
+Implementation  ← AI can help here.
+Testing         ← AI can help, but you define what to test.
+Documentation   ← AI can draft. You must review for accuracy.
+Release         ← Human judgment required.
+```
+
+An AI tool will generate a function that does what you described. It will not tell you
+whether that function belongs in this crate or a different one. It will not flag that
+the approach contradicts an architectural decision made three months ago. It will not
+ask whether you have thought through the security implications. It will not notice that
+you are solving the wrong problem.
+
+ZeroClaw itself is a useful example. The initial codebase was bootstrapped with AI
+assistance. The result, as the architecture RFC describes it, is "impressively functional
+but architecturally accidental." The code does what it needs to do today — but it was
+not designed, it accumulated. That is not a failure of AI tools. It is a predictable
+outcome of using implementation-layer tooling without first doing the vision,
+architecture, and design work that gives implementation its direction.
+
+The solution is not to use AI less. It is to do the top-of-hierarchy work yourself,
+always, before you ask the AI to build anything.
+
+---
+
+### Amplification is not magic
+
+AI tools amplify your existing capabilities. That is the honest description of what
+they do.
+
+If you have a clear vision, a defined architecture, quality criteria you can articulate,
+and the ability to evaluate output critically — AI is a genuine force multiplier. You
+move faster. You explore more options. You write more tests. You draft more documentation.
+
+If you do not have those things — AI generates a lot of code that looks convincing and
+does not hold together. It generates tests that pass without testing anything meaningful.
+It generates documentation that describes the code but not the intent. It generates
+architecture that is locally consistent and globally incoherent.
+
+The amplification is neutral. It amplifies good inputs and bad inputs with equal
+enthusiasm.
+
+This means the most valuable skill in an AI-assisted workflow is not prompt engineering.
+It is the ability to evaluate the output. That requires knowing what good looks like
+before you ask for anything. Which brings you back, every time, to the top of the
+decision hierarchy.
+
+A useful self-check before using an AI tool to implement something:
+
+- Can I describe the problem in one sentence without mentioning implementation details?
+- Can I name the RFC section or design decision that this implementation serves?
+- Can I describe what a correct implementation looks like before I see one?
+- Can I explain why a generated implementation is or is not correct after I see one?
+
+If the answer to any of these is no, you are not ready to implement yet. You are still
+in the design phase.
+
+---
+
+### The review discipline
+
+AI-generated code requires the same review discipline as human-written code. In some
+ways it requires more, because the surface area of issues you are checking for is wider.
+
+When you review AI-generated output — your own or someone else's — check for:
+
+**Architectural fit.** Does this respect the dependency rules? Does it live in the right
+crate? Does it introduce a coupling that the design explicitly avoids?
+
+**Correctness at the boundary.** AI models are very good at the common case and
+frequently wrong at the edge case. Check what happens when inputs are empty, null,
+malformed, or at the maximum expected size. Check what happens when a dependency is
+unavailable.
+
+**Security implications.** AI tools do not have a security mindset by default. They
+will generate code that accepts user input without validation, that logs sensitive
+values, that uses deprecated cryptographic primitives, that opens file paths without
+checking them. You have to bring the security lens explicitly.
+
+**Test quality.** AI-generated tests frequently test the implementation rather than the
+behaviour. A test that asserts a function returns a specific internal struct value is
+not a behaviour test — it is a snapshot of the implementation that will break whenever
+the implementation changes. Ask: does this test verify that the system does what the
+user or caller needs, or does it verify that the code does what it currently does?
+
+**Completeness.** AI tools optimise for plausible-looking completeness. They will
+generate code that handles the happy path thoroughly and the error path superficially.
+Check that errors are propagated, handled, or surfaced in a way that is actually useful
+to the caller.
+
+---
+
+### What this means for your career
+
+The skills being described here — giving direction clearly, evaluating output critically,
+understanding where a component fits in a larger system, knowing what good looks like
+before you build — are not AI-specific skills. They are the skills that make someone
+an effective engineer, an effective tech lead, and eventually an effective engineering
+manager.
+
+The engineers who will be most valuable in a world saturated with AI-generated code are
+not the ones who can write the most code fastest. They are the ones who can tell whether
+the code is right. That requires system thinking, architectural judgment, and the
+ability to evaluate work against a standard you have internalised.
+
+Everything you practice here — understanding the RFC before you implement, asking "why"
+before you build, reviewing AI output with the same eye you would bring to a junior
+engineer's PR — is practice for that kind of judgment. It compounds. Every PR where you
+engage seriously with the architecture is a data point that makes the next architectural
+decision easier.
+
+The contributors on this project have an unusual advantage: you are building these habits
+on a real system, with real architectural constraints, with people who will review your
+work and explain why. That combination is rare. It is worth taking seriously.
+
+---
+
+## 5. The feedback taxonomy
+
+Every review comment on this project carries one of four weights. Using them consistently
+means reviewers communicate clearly and authors know exactly what requires action.
+
+---
+
+### ✅ Commendation
+
+Something the author got right, named specifically and explained so the pattern gets
+repeated.
+
+This is not politeness. Generic praise ("nice work!") teaches nothing. Specific praise
+with an explanation teaches the principle behind what was done well, which applies to
+every future decision in the same category.
+
+**Commendations require no action.** Their purpose is to reinforce.
+
+> *Example: "Extracting the tool call parser into its own crate was the right call — this
+> code has zero dependencies on agent state and is now independently testable. The 91
+> tests you added are exactly the kind of coverage that would be impossible to achieve
+> when this logic lived inside `loop_.rs`."*
+
+---
+
+### 🔴 Blocking
+
+Something that must be resolved before the PR merges. Blocking items fall into two
+categories:
+
+- **Architectural violations**: code that crosses a dependency boundary the design
+  explicitly prohibits, or that contradicts a decision recorded in an RFC or ADR.
+- **Quality regressions**: missing test coverage for new behaviour, security issues,
+  broken contract compatibility, or code that introduces a defect.
+
+A blocking comment explains what the issue is, why it matters, and — where possible —
+what a resolution path looks like. A blocking comment is not a judgment of the author.
+It is the reviewer's responsibility to the codebase and the users who depend on it.
+
+**Authors should not interpret a blocking comment as rejection.** It is a specific,
+resolvable problem. Address it and move forward.
+
+---
+
+### 🟡 Conditional
+
+Something acceptable to defer, but only with a committed tracked issue and an assignee.
+A conditional item is the reviewer saying: *I trust that this will be addressed, but I
+need that commitment on record before we merge.*
+
+The distinction between blocking and conditional is often about timing and risk. A
+missing feature that will be delivered in the next PR is conditional. A missing feature
+that creates a security gap is blocking.
+
+**A conditional deferral without an assignee is not a deferral — it is a wish.** Tracked
+issues with no owner tend to stay open indefinitely. When a reviewer marks something
+conditional, they are asking for a named commitment, not a theoretical future intention.
+
+---
+
+### 🔵 Team Decision
+
+A question the PR surfaces that no single reviewer or author should answer unilaterally.
+Team decisions involve tradeoffs that affect the project's direction, its architecture,
+or its users — and they belong to the group.
+
+Using this label is how reviewers avoid holding up individual contributors with questions
+that are really about shared direction. It surfaces the decision, frames the tradeoffs,
+and asks the team to weigh in — without making the author feel like their PR is blocked
+on something that is not in their control.
+
+**Team decisions should be answered in the PR thread, on the record, by the people who
+need to own the outcome.** A decision answered in a side conversation that does not
+appear in the PR thread does not exist for anyone who reads the history later.
+
+---
+
+## 6. A note to reviewers and mentors
+
+If you are in a position of reviewing someone else's work — whether as a code owner, a
+more experienced contributor, or simply someone who has been here longer — this section
+is for you.
+
+**You are modelling what collaboration looks like.** Every review you write teaches the
+author how to review. Every question you ask in a PR thread teaches newer contributors
+what questions are worth asking. You cannot opt out of this — the only choice is whether
+to do it intentionally or accidentally.
+
+**Thoroughness is respect.** A thorough review that explains its reasoning is more
+respectful of the author's effort than a quick approval. The author put time into the
+work. They deserve to understand why it is or is not ready to merge, and what they can
+take forward from the interaction.
+
+**The goal of every review interaction is to leave the author better equipped than they
+were before.** Not just to produce a merged PR. Not to demonstrate your own knowledge.
+Not to enforce rules. To leave the author with something they can use — a principle,
+a pattern, an understanding of a tradeoff — that applies beyond the immediate PR.
+
+**Name the pattern, not just the instance.** When you ask for a change, explain the
+principle behind it. "Rename this variable to something that describes what it contains"
+is less useful than "variable names should describe their purpose from the caller's
+perspective, not the implementation's — what does the caller of this function actually
+care that this value represents?" The second version applies to every variable in every
+function the author will ever write.
+
+**Be honest about what is your preference and what is a requirement.** "I would write
+this differently" is not the same as "this must change." If you are expressing a
+preference, say so. If you are citing a hard requirement — architecture, security,
+compatibility — cite the specific reason. Authors who cannot tell the difference between
+reviewer preference and architectural necessity will either change everything or change
+nothing. Neither serves them well.
+
+**The team you are helping build is the team you will work in.** The investment you make
+in a careful, educational review today compounds into a contributor who writes better
+code, opens better PRs, and reviews others more thoughtfully. That makes the project
+better. It also makes your own work easier, because the people around you are growing.
+
+This is not a soft skill. It is engineering work.
+
+---

--- a/docs/foundations/fnd-006-zero-compromise-in-practice.md
+++ b/docs/foundations/fnd-006-zero-compromise-in-practice.md
@@ -1,0 +1,794 @@
+# FND-006: Zero Compromise in Practice — Code Health, Error Discipline, and the Production Readiness Standard
+
+### Starting v0.7.0 · Type: Quality · Rev. 1
+
+> **Canonical reference** · Ratified by the team · Rev. 1
+> Discussion thread and full revision history: [#5653](https://github.com/zeroclaw-labs/zeroclaw/issues/5653)
+
+
+--------
+
+│ A note to the team before you read this.
+│
+│ This is the sixth document in ZeroClaw's maturity framework. The five before it
+│ addressed architecture, documentation, governance, engineering infrastructure, and
+│ collaboration — the structural and human scaffolding that surrounds the work. Each
+│ one answered a different question about how we build this project together. If you
+│ have read them all, you may have noticed a question none of them answered: yes, but
+│ how do we actually write it well? The architecture RFC told you what shape to build
+│ in. The documentation RFC told you how to record it. The governance RFC told you how
+│ to coordinate. The CI/CD RFC told you how to gate it. The culture RFC told you how
+│ to work with the people around you. None of them told you what quality looks like at
+│ the sentence level — inside a function, at the moment you are making a choice.
+│
+│ That is what this document is for.
+│
+│ The specific topics here — error handling, API documentation, test design, technical
+│ debt — are Rust topics on the surface. The skills they develop are not. Technology
+│ changes. It changes faster with each iteration than it did the time before. The tools
+│ you are using today — this language, this framework, this AI assistant — will be
+│ superseded. Some of them within the lifetime of this project. The judgment this
+│ document is trying to help you build will not be superseded. It will compound quietly
+│ in the background of every decision you make, in every language you will ever write,
+│ in every system you will ever build, and in work that may have nothing to do with
+│ software at all. That is the investment we are making in you. Not in your ability to
+│ write Rust. In your ability to think about quality, failure, and craft — and to carry
+│ that thinking with you into every tool you ever pick up, including the AI tools you
+│ are using today and the ones that do not exist yet.
+│
+│ Take your time with it.
+
+--------
+
+## The Maturity Framework Suite
+
+This RFC is the sixth in a set of documents that together form ZeroClaw's maturity
+framework. They are designed to be read as a whole, though each stands on its own.
+
+| RFC | Scope | Issue |
+|-----|-------|-------|
+| Intentional Architecture — Microkernel Transition | What we are building and how it is structured | #5574 |
+| Documentation Standards and Knowledge Architecture | How we document what we build | #5576 |
+| Team Organization and Project Governance | How we coordinate and make decisions | #5577 |
+| Engineering Infrastructure — CI/CD Pipeline | How we build, test, and ship reliably | #5579 |
+| Contribution Culture — Human Collaboration, AI Partnership, and Team Growth | How we work together and grow | #5615 |
+| Zero Compromise in Practice — Code Health, Error Discipline, and the Production Readiness Standard | How we write code that lasts | this RFC |
+
+The first five RFCs answer structural and human questions. This one answers the question
+that sits inside all of them: given the structure, given the team, given the tools —
+what does it mean to write the code well?
+
+--------
+
+## Table of Contents
+
+1. A Development Philosophy: The Investment in Judgment
+2. Honest Assessment: What the Codebase Is Telling Us
+   - 2.1 The Evidence
+   - 2.2 What the Numbers Do Not Show
+   - 2.3 What Is Already Good
+3. Gates and Standards: The Central Distinction
+4. The Seven Disciplines
+   - 4.1 Error Handling as a Design Concern
+   - 4.2 Public API Surface as a Promise
+   - 4.3 Tests as Design Feedback
+   - 4.4 Technical Debt Triage
+   - 4.5 Security at the Application Layer
+   - 4.6 Observability as Debuggability
+   - 4.7 Working Above the Floor
+5. What This Means for AI-Assisted Development
+6. The Portability of Craft
+7. What This Means for Contributors
+
+--------
+
+## Revision History
+
+| Rev | Date | Summary |
+|-----|------|---------|
+| 1 | 2026-04-12 | Initial draft |
+
+--------
+
+## 1. A Development Philosophy: The Investment in Judgment
+
+The architecture RFC introduced a decision hierarchy that describes how every choice
+in this project should flow:
+
+```
+Vision
+  └── Architecture
+        └── Design
+              └── Implementation
+                    └── Testing
+                          └── Documentation
+                                └── Release
+```
+
+That hierarchy answers the question of *what* to build at each layer. This RFC lives
+inside the Implementation and Testing layers and asks a different question: *how well?*
+
+The answer to "how well" is not a checklist. Checklists can be satisfied without being
+understood, and in software, understanding is what creates durable results. A contributor
+who has memorized the rules will follow them until the situation is slightly different.
+A contributor who has internalized the judgment behind the rules will apply it correctly
+to situations the rules did not anticipate — including the situations that matter most,
+which are always the ones nobody planned for.
+
+This distinction matters especially in this project's context. ZeroClaw is operated in
+an environment of powerful tools: AI code generation, CI gates that catch a wide range
+of common errors, IDE linters, automated security scanners. These tools are genuinely
+valuable. They define a floor — a minimum below which code should not be merged. But
+what they cannot do is think. They cannot decide whether an error is operational or a
+programmer error. They cannot evaluate whether a test is asserting the right behavior.
+They cannot tell whether a public API is documented clearly enough for a future
+contributor to implement against correctly. They can only check what they were
+programmed to check.
+
+The gap between "what the tools can verify" and "quality that serves users, contributors,
+and the project over time" is filled by judgment. That judgment is what this document
+is trying to help you build — not to replace the tools, but to direct them.
+
+--------
+
+## 2. Honest Assessment: What the Codebase Is Telling Us
+
+This section is not criticism. It is a diagnosis. The same framing that applied in the
+architecture RFC applies here: you cannot improve what you cannot name, and the
+specifics are useful precisely because they are specific.
+
+### 2.1 The Evidence
+
+The workspace decomposition from RFC §5574 succeeded. The crates exist, the trait
+boundaries are real, and the compiler enforces the dependency direction. That is
+genuinely good work. And within those new crates, the same patterns that characterized
+the original monolith have been carried forward — because the codebase moved before
+the team had a shared model for what "quality at the implementation level" looks like.
+
+These are measured facts, not estimates:
+
+| Metric | Value | What It Indicates |
+|--------|-------|-------------------|
+| `zeroclaw-config/src/schema.rs` | 16,800 lines | Now the largest file in the codebase; the original `loop_.rs` was called out at 9,500 lines in the architecture RFC — this surpasses it |
+| `zeroclaw-channels/src/orchestrator/mod.rs` | 11,813 lines | Second-largest file; a single module carrying concentrated responsibility |
+| `zeroclaw-runtime/src/onboard/wizard.rs` | 7,988 lines | A single workflow in a single file |
+| `zeroclaw-runtime/src/agent/loop_.rs` | 6,101 lines | Reduced from ~9,500 in the monolith — real, measurable progress; still large |
+| `zeroclaw-channels/src/orchestrator/telegram.rs` | 5,122 lines | One channel implementation; one file |
+| `.unwrap()` / `.expect()` calls in crates | 5,630 | Each one is a deferred judgment call about error handling — see §4.1 |
+| `.unwrap()` / `.expect()` calls in legacy `src/` | 240 | The migration carried the pattern forward at scale |
+| Public functions in `zeroclaw-api` | 371 | The entire foundational API surface — every other crate depends on this |
+| Doc comment lines in `zeroclaw-api` | ~27 | Roughly 14:1 ratio of undocumented public API — see §4.2 |
+| `#[allow(unused_imports)]` / `#[allow(dead_code)]` in legacy `src/` modules | ~30+ instances | The compiler has identified code that is no longer being used; it has been asked not to say so |
+| `TODO` / `FIXME` / `todo!()` / `unimplemented!()` across the full codebase | 20 | Notably low — suggests most debt is silent rather than marked |
+
+The last row deserves its own note. Twenty explicit markers of incomplete work in a
+codebase of this size is not a sign that the work is nearly finished. It is a sign that
+most of the incomplete work is not being labeled as such. Unmarked debt is harder to
+find, harder to prioritize, and harder to assign than debt that has been named. Silence
+is not the same as completeness.
+
+### 2.2 What the Numbers Do Not Show
+
+These numbers measure what is countable. The more consequential quality questions cannot
+be counted:
+
+- Whether the 5,630 `.unwrap()` calls are in critical paths or in test utilities
+- Whether the tests that exist are testing behavior or testing implementation details
+- Whether the public functions in `zeroclaw-api` can be correctly implemented by someone
+  reading only the signature and type
+- Whether a log message emitted during a production failure would contain enough context
+  to diagnose the failure
+- Whether a contributor working in the security module understands which data has crossed
+  a trust boundary and which has not
+
+These are judgment questions. They do not have a CI gate. They have the standards this
+document is proposing to name, and the culture of review and mentorship we are building
+together.
+
+### 2.3 What Is Already Good
+
+The diagnosis should not obscure what is genuinely well-built.
+
+The trait layer in `zeroclaw-api` is the right architecture. `Provider`, `Channel`,
+`Tool`, `Memory`, `Observer`, `RuntimeAdapter`, and `Peripheral` are clean, well-reasoned
+abstractions. They are the right seams. The problem is not the design — it is that the
+design is not yet fully expressed in documentation, test coverage, and error handling
+discipline. This RFC is about closing that gap.
+
+The security model is thoughtful. Pairing codes, autonomy levels, sandboxing layers, and
+policy enforcement show real design intent. That intent needs to be understood by every
+contributor who writes code near a trust boundary — and this RFC exists partly to give
+contributors the vocabulary to recognize where those boundaries are.
+
+The observability infrastructure is mature. OpenTelemetry, Prometheus, and DORA metrics
+are all implemented against a clean `Observer` trait. The infrastructure is in place.
+The teaching gap is in how contributors use it so that it actually helps when something
+goes wrong.
+
+The test suite is not absent. The existing test investment is real. The work this RFC
+describes is about the quality and distribution of that investment — what gets tested,
+how, and whether the tests prove what they appear to prove.
+
+`ADR-004-tool-shared-state-ownership.md` is an excellent piece of architectural record.
+It proves the team can produce high-quality design documentation when the expectation
+is clear. This RFC is proposing an equivalent expectation for the code itself.
+
+--------
+
+## 3. Gates and Standards: The Central Distinction
+
+This is the organizing idea of the entire document. Understanding it clearly matters
+more than any specific technique in §4.
+
+A **gate** is binary. Pass or fail. It is automated, enforced by tooling, and defines
+the minimum below which no code merges. The CI/CD RFC built the gates. They are real
+and working.
+
+| Gate | What It Checks |
+|------|----------------|
+| `cargo fmt --check` | Code is formatted consistently across the workspace |
+| `cargo clippy --workspace --all-targets -D warnings` | No Clippy-known antipatterns; workspace-wide |
+| `cargo deny check` | No unacknowledged security advisories; license and source compliance |
+| `cargo nextest run --workspace` | Tests that exist, pass |
+
+A **standard** is aspirational. It describes what quality looks like above the floor.
+It is enforced by judgment, peer review, and the habits the team builds together.
+
+| Standard | What It Describes |
+|----------|-------------------|
+| Error handling discipline | Failures are categorized; operational errors surface with context at the right layer |
+| API documentation | Every public item has enough documentation to use correctly without reading the implementation |
+| Test quality | Tests assert behavior, not implementation; test difficulty is treated as design feedback |
+| Debt triage | Unaddressed debt is labeled, located, and risk-weighted; high-risk debt has an owner |
+| Security posture | Trust boundaries are explicit at the implementation level, not only at the policy level |
+| Observability discipline | Log messages answer the diagnostic question; spans bound meaningful units of work |
+
+Gates and standards are not in competition. They are complementary layers. Gates without
+standards produce code that passes every check and still fails users. Standards without
+gates are unenforceable. You need both. The project currently has good gates and
+underdeveloped standards.
+
+│ A codebase can pass every gate and still be incomprehensible to the next contributor,
+│ silent where it should surface errors, impossible to test in isolation, and insecure
+│ at the boundary where user input meets business logic. The green checkmark answers the
+│ question "did this code pass the rules we wrote down?" It does not answer the question
+│ "is this code good?" Those are not the same question.
+
+This is not a criticism of the gates. The gates are valuable precisely because they
+define a shared, enforceable baseline that every contributor works within. The goal of
+this document is to build the shared vocabulary and judgment that defines what good looks
+like above that baseline — and to explain clearly why that judgment cannot be delegated
+to a tool.
+
+--------
+
+## 4. The Seven Disciplines
+
+### 4.1 Error Handling as a Design Concern
+
+Every `.unwrap()` call is a decision. Most of the 5,630 in the codebase were not made
+consciously — they were made by default, because `.unwrap()` is the path of least
+resistance when you need a value out of a `Result` or `Option` and want to move on. The
+problem with decisions made by default is that they are not decisions — they are
+deferrals. And what they defer is a real question: *what should happen here when this
+fails?*
+
+The answer depends on what kind of failure you are dealing with. There are three kinds,
+and they have three different correct responses.
+
+**Programmer errors** are violations of invariants that should be impossible in correct
+code. A function that requires a non-empty `Vec`, called with an empty one. An enum
+match that reaches an arm the type system should have made unreachable. These represent
+bugs — not operational failures, but incorrect logic. `panic!` is the correct response,
+because the goal is to find these at development time, not in front of a user at runtime.
+`assert!` and `debug_assert!` are the right tools. `.expect()` with a message explaining
+why this state is impossible is also appropriate here — it makes the reasoning explicit
+and searchable, so the next person who reads the code understands why the panic was
+intentional.
+
+**Operational errors** are expected failure modes. Network timeouts. Files that do not
+exist. API keys that have expired. Provider responses that carry an error status. Users
+who provide malformed input. These are not bugs — they are the normal operating
+conditions of a system that interacts with the world. The correct response is
+`Result<T, E>`. The `?` operator propagates the failure to a caller who is in a better
+position to decide what to do about it. A `.unwrap()` on an operational error is a
+deferred panic: it will fire, eventually, under real conditions, in front of a real user,
+with no useful context and no opportunity to recover.
+
+**Configuration errors** are malformed or missing configuration discovered at startup.
+The correct response is to fail fast — but specifically. Not a panic with a stack trace,
+not a vague "invalid config" message. A message that points at the specific field,
+explains what was expected, and tells the operator what to provide. A user who cannot
+start ZeroClaw because of a misconfiguration should leave the process with a clear
+understanding of exactly what to fix.
+
+| Failure kind | What it means | Correct response |
+|---|---|---|
+| Programmer error | Invariant violated; should be impossible in correct code | `panic!`, `assert!`, `.expect("reason this is safe")` |
+| Operational error | Expected failure mode; the world is not cooperating | `Result<T, E>`, `?`, structured error type with context |
+| Configuration error | Invalid or missing startup configuration | Fail fast with a specific, actionable message |
+
+Before every `.unwrap()` or `.expect()`, ask yourself: which kind of failure is this?
+If the answer is "programmer error — this state cannot occur in correct code," then
+`.expect()` with a comment explaining why is the right choice, and it communicates your
+reasoning to every future reader. If the answer is anything else, use `?` or handle the
+failure explicitly.
+
+The `?` operator is worth understanding for what it *says*, not just what it does. It
+says: I acknowledge this operation can fail. I am explicitly propagating that failure to
+my caller, who is better positioned to decide what to do about it. That acknowledgment
+is architecturally meaningful — it makes the error handling contract visible at the call
+site and pushes decisions to the layer that has the most context.
+
+The goal is not zero `.unwrap()` calls. Some are correct. The goal is that every one
+represents a conscious decision, with the reasoning visible to anyone who reads the code.
+The difference between `.unwrap()` and `.expect("this vec is guaranteed non-empty by the
+caller — see §4.2 of the SOP engine invariants")` is not just style. It is the
+difference between deferred judgment and documented judgment.
+
+### 4.2 Public API Surface as a Promise
+
+`pub` is a contract.
+
+When you mark a function, struct, trait, or module as public, you are making a promise
+to every caller. That includes the contributor who implements against it next month with
+no memory of your original intent. It includes the AI assistant that reads your crate
+to generate an implementation. It includes the person debugging a production incident
+who needs to understand what this was supposed to do. It includes yourself, returning
+to this code after two months working on something else.
+
+A public item without documentation is a promise with no terms. The caller has no way
+to know what assumptions you made when you wrote it, what error conditions it can return
+and under what circumstances, what side effects it has, whether it is safe to call
+concurrently, or what the subtle difference is between two functions with similar names.
+They are left to infer — from the name, the type signature, and the implementation body
+— something that you could have told them in three sentences.
+
+The `zeroclaw-api` situation is specific enough to name directly. This is the one crate
+the entire architecture depends on. Every provider, channel, tool, memory backend,
+observer, runtime adapter, and peripheral implementation in the workspace is built
+against these traits and types. An undocumented interface in this foundation propagates
+confusion into every crate that implements it, every test that exercises it, and every
+AI-generated code that works with it. The 14:1 ratio of undocumented public API surface
+is not a documentation style preference — it is a gap in the contract that the
+architecture RFC said was the most important layer of the system.
+
+The AI dimension here is practical and direct: when you ask an AI assistant to implement
+a trait or call a function that has no documentation, the AI infers intent from the name
+and the type signature. Sometimes that inference is correct. More often, it produces
+code that compiles, passes the type checker, and behaves incorrectly under specific
+conditions that the AI did not know to anticipate — because nobody wrote them down.
+Documentation is not just for humans. It is the specification you provide to every tool
+that will ever work with your code, and to every person who will ever depend on it.
+
+At minimum, every public item in `zeroclaw-api` should carry:
+
+- **One sentence describing what it does.** Not what it is — what it does.
+- **An `# Errors` section** (if it returns `Result`): under what conditions does this
+  fail, and what error variants does the caller need to handle?
+- **A `# Panics` section** (if it can panic): under what conditions, and why?
+- **Preconditions** (if any are non-obvious): what must be true before calling this?
+
+A three-sentence doc comment on a public trait method is worth more to the next
+implementor than a hundred lines of implementation with no explanation. The
+implementation tells them what the code does. The documentation tells them what it is
+supposed to do — which is what matters when the two diverge.
+
+### 4.3 Tests as Design Feedback
+
+The goal of a test is not to produce a green checkmark. The goal is to create a precise,
+executable record of what a piece of code is *supposed to do* — a record that fails
+loudly if that behavior ever changes.
+
+This distinction matters because there are two fundamentally different kinds of tests,
+and only one of them achieves that goal.
+
+A test that reaches into a struct's internal state, sets values directly, calls a method,
+and asserts on return values is testing the *implementation*. If the implementation
+changes — if the same behavior is achieved through a different mechanism — the test
+breaks, even though nothing the user cares about changed. This creates friction against
+refactoring without creating safety. It also tends to pass when the behavior is wrong in
+ways the test did not anticipate.
+
+A test that constructs values through public interfaces, exercises behavior through
+public methods, and asserts on observable outcomes is testing the *behavior*. If the
+implementation changes but the behavior is preserved, the test passes. If the behavior
+changes in a way that matters to users, the test fails. This is what makes confident
+refactoring possible: the tests are checking that you got the right answer, not that
+you got it a particular way.
+
+The more important principle is the diagnostic one:
+
+│ A test that is hard to write is usually telling you something about the design.
+
+If writing a unit test for a function requires standing up a database connection, mocking
+six dependencies, building a full configuration object, and starting an async runtime
+explicitly — that function is probably doing too much, depending on too much, or sitting
+at the wrong layer of the architecture. The difficulty is not a nuisance to work around.
+It is feedback. The test is being honest about something the code is not yet honest
+about.
+
+This connects directly to the crate structure the architecture RFC established. One of
+the purposes of crate decomposition was to create components that can be tested in
+isolation. `zeroclaw-tool-call-parser` should be testable with a `&str` input and no
+runtime. `zeroclaw-config` should be testable by constructing config structs directly.
+Trait implementations in `zeroclaw-api` should be testable against fake implementations
+of the trait — not against the full production stack. When you find yourself unable to
+test a component without its entire environment, ask whether a dependency has entered
+the implementation that the architecture did not intend. The test is giving you the
+answer; the question is whether you are listening to it.
+
+A practical approach to growing test quality over time:
+
+- When you fix a bug, write a test that would have caught it. This one habit, practiced
+  consistently, moves the test suite toward the failure modes that actually matter.
+- When you add behavior, write a test that proves the behavior exists and can be
+  verified in isolation.
+- When a test is hard to write, spend time asking *why* before reaching for a mock. The
+  answer to that question is usually more valuable than the test you were about to write.
+
+### 4.4 Technical Debt Triage
+
+The word "debt" is useful because it carries the right implication: it accrues interest.
+Debt left unexamined in a high-traffic area of the codebase compounds — new code adapts
+to its presence, new assumptions build on top of old ones, and the cost of addressing
+it grows with every layer added above it.
+
+The most common mistake teams make with technical debt is treating it as binary: either
+everything is debt and nothing can be done about it, or nothing is debt and no time
+should be spent on it. Both positions are wrong. The useful question is: *which debt,
+in which location, carries the most risk right now?*
+
+Two axes determine priority.
+
+**Proximity to a trust boundary.** Code that handles user input, enforces security
+policy, executes tools, manages authentication, or processes data from external sources
+is operating near a trust boundary. Failures here can be exploited, silently corrupt
+state, or produce incorrect behavior with security consequences. Debt near trust
+boundaries carries disproportionate risk relative to its size.
+
+**Blast radius.** Debt in `zeroclaw-api` — the foundation everything else depends on —
+has a larger blast radius than debt in a single channel implementation. A wrong
+assumption in a foundational type propagates wherever that type is used. Debt in a leaf
+crate affects only that crate's consumers.
+
+| | High blast radius | Low blast radius |
+|---|---|---|
+| **Near a trust boundary** | Address in the current cycle | Address in the next planned cycle |
+| **Far from a trust boundary** | Address in a planned refactor | Address opportunistically, as adjacent work passes through |
+
+This framework means that a `.unwrap()` in the security policy enforcement path is not
+the same problem as a `.unwrap()` in a CLI display formatter. Both appear in the count
+of 5,630. The count tells us the scope. The triage tells us the priority.
+
+When you are working in a file and you notice debt — an `.unwrap()` that represents an
+unhandled operational error, a function that has grown to handle four separate concerns,
+a `#[allow(dead_code)]` silencing something that nobody calls — you do not need to fix
+everything. You need to ask: is this in a high-risk location? If it is, address it in
+this PR or file a follow-up issue with the specific location, the risk, and a proposed
+owner. If it is not, you can mark it with a `// TODO(debt): <description>` comment that
+makes it visible without making it urgent. What you should not do is leave it completely
+unmarked — because silence is how 5,630 deferred decisions accumulate without anyone
+noticing the trend.
+
+The Strangler Fig pattern applies at this level too. The architecture RFC applied it at
+the crate level: build the new structure around the old one, migrate inward over time.
+The same pattern works inside a large file. You do not rewrite `schema.rs` in a single
+PR. You identify the functions that are closest to trust boundaries, most frequently
+changed, or hardest to test — and you extract them first, improving the structure
+incrementally, leaving the rest to follow at a pace the team can sustain.
+
+### 4.5 Security at the Application Layer
+
+The CI/CD RFC established the security posture for the *supply chain*: `cargo deny`
+finds known vulnerabilities in dependencies, enforces license compliance, and ensures
+dependencies come from approved sources. That is the immune system for what enters the
+project. This section is about the security posture of the code that runs.
+
+`cargo deny` cannot find a vulnerability your application logic creates. It cannot tell
+you whether user input is being validated before it reaches your business logic. It
+cannot tell you whether a tool execution is respecting the autonomy level it is supposed
+to enforce. It cannot tell you whether an error path is silently swallowing a security
+check failure. These require a contributor who understands where the trust boundaries
+are and what responsible code looks like on either side of them.
+
+Three principles that should guide any code written near a trust boundary:
+
+**Trust boundaries are explicit, not assumed.** A trust boundary is any point where data
+arrives from outside your direct control: user input from any channel, API responses
+from providers, file contents from the filesystem, plugin outputs, tool results, hardware
+readings. At every trust boundary, validate before you process. Do not assume the shape,
+size, type, or content of data you did not produce. The ZeroClaw security model defines
+these boundaries at the policy level. The implementation should reflect them at the code
+level — not because the policy will fail, but because defense in depth means each layer
+of the system is doing its part, rather than trusting that every other layer did theirs.
+
+**Minimum footprint.** A function that needs to read a file should not be able to write
+one. A trait implementation that handles one channel's messages should not have access
+to another channel's state. A tool running at autonomy level 1 should not be in a
+position to exercise capabilities that require level 3. The security model already
+defines these constraints. The discipline is in writing implementations that do not
+acquire more capability than they require for the task at hand — and in noticing when an
+implementation is reaching for something outside its intended scope.
+
+**Fail loudly near security boundaries.** An error in a security check — a failed policy
+evaluation, a signature verification failure, an unauthorized tool call attempt, a
+pairing code mismatch — should never be silently swallowed. It should be logged,
+propagated, and handled explicitly. An error in a display helper can be recovered from
+gracefully with a log message. An error in an authorization path cannot. Know which kind
+of function you are writing, and let that determination drive how aggressively you
+surface failures from it.
+
+These are not advanced security principles. They are foundational hygiene that applies
+to any code that touches something a user can influence. The architecture RFC described
+the security model as "thoughtful." The work this RFC is asking for is to make that
+thoughtfulness legible at the implementation level — in the functions that validate
+inputs, in the error paths that handle policy failures, in the boundaries between what
+the system was asked to do and what it actually does.
+
+### 4.6 Observability as Debuggability
+
+The observability infrastructure is mature: OpenTelemetry tracing, Prometheus metrics,
+DORA tracking, and a clean `Observer` trait are all in place. This is production-quality
+work. The teaching gap is between having the infrastructure and using it in a way that
+actually helps when something goes wrong — ideally before you know what went wrong.
+
+Consider two log messages. Both compile. Both pass CI. Both are syntactically correct.
+
+```rust
+error!("request failed");
+```
+
+```rust
+error!(
+    provider = %provider_name,
+    model    = %model_id,
+    user     = %sender_id,
+    tool     = %tool_name,
+    attempt  = attempt,
+    elapsed  = ?elapsed,
+    err      = %e,
+    "provider request failed — retries exhausted"
+);
+```
+
+The first is a record. It confirms that something went wrong. The second is a
+*diagnostic*. It answers the questions that matter: what were we trying to do, in what
+context, with what parameters, and exactly what went wrong. The difference between them
+is not technical sophistication — it is whether the person writing the message was
+thinking about the person who will one day need to read it.
+
+The question to ask before writing any log message at `warn` or above:
+
+│ What does the person who needs to diagnose this failure at the worst moment need to know?
+
+That person might be you, six months from now, with no memory of writing this code. It
+might be another contributor who has never seen this module. It might be a user filing a
+bug report with a log excerpt they copied from their terminal. Write for them. The fields
+that almost always matter: what were we trying to do, what context was in scope at the
+time, and what specifically went wrong.
+
+The same principle governs tracing span design. A span should represent a meaningful
+unit of work, carry the context needed to understand that work, and have a name that
+makes sense when you read it in a flame graph or a trace viewer.
+
+```rust
+// A record
+let _span = span!(Level::INFO, "process");
+
+// A diagnostic
+let _span = span!(
+    Level::INFO,
+    "agent.tool_call",
+    tool = %tool_name,
+    turn = turn_number,
+    sender = %sender_id,
+);
+```
+
+Structured logging and meaningful span design are not style preferences. They are what
+make the observability infrastructure you have actually useful — not just during
+development, but in the hands of users running ZeroClaw on hardware you will never see,
+in configurations you did not anticipate, encountering errors you did not plan for. The
+infrastructure creates the capability. The discipline in how contributors use it
+determines whether that capability translates into diagnosable systems.
+
+### 4.7 Working Above the Floor
+
+The previous six disciplines each address a specific domain. This section synthesizes
+them into a single picture of what "above the floor" looks like in practice — what a
+reviewer, a future contributor, or a user actually experiences when they encounter code
+that meets the standards described in this RFC.
+
+| Dimension | At the floor — gates pass | Above the floor — standard met |
+|---|---|---|
+| Error handling | Code compiles; no Clippy warnings | Failures are categorized; operational errors surface with context; panics are intentional and documented |
+| Documentation | Doc tests pass if they exist | Every public item can be understood and used correctly without reading the implementation |
+| Testing | Tests that exist pass | Tests assert behavior; test difficulty is treated as design feedback; the failure modes that matter are covered |
+| Debt | No compiler errors or warnings (with `#[allow]` silencing the rest) | Debt is labeled, located, and risk-weighted; high-risk debt has an owner and a timeline |
+| Security | `cargo deny` passes | Trust boundaries are explicit; security failures surface loudly; implementations respect their intended scope |
+| Observability | Code runs and emits something | Log messages answer the diagnostic question; spans bound meaningful units of work with useful context |
+| Code organization | File compiles; module structure exists | Functions do one thing; files group related concerns; large files are candidates for extraction, not the norm |
+
+None of these are achievable entirely through automation. All of them are achievable by
+contributors who understand why they matter and have built the judgment to apply them
+consistently. That is what this document is working toward.
+
+--------
+
+## 5. What This Means for AI-Assisted Development
+
+The culture RFC addressed how to work with AI tools as part of a collaborative team.
+This section addresses something more specific: what happens when AI-generated code
+encounters the standards described above — and what it takes to recognize and close the
+gap when it does not.
+
+AI tools are genuinely good at passing gates. They generate code that compiles,
+satisfies the type checker, passes Clippy, and often produces tests alongside the
+implementation. This is real value, and it is not the point of this section to minimize
+it. The problem is not that AI tools are unreliable. The problem is that they are
+reliable at the wrong thing: producing code that passes checks, rather than code that
+meets standards.
+
+The reason is structural. AI generates code against what it can infer. If a function
+has no documentation, the AI infers intent from the name and signature — and sometimes
+that inference is correct, and sometimes it produces subtly wrong behavior that only
+surfaces under conditions nobody tested. If an error type has no documentation of when
+it is returned, the AI handles it based on the name of the variant. If a test suite
+tests implementation rather than behavior, the AI generates implementations that match
+those tests — which may or may not match the intended behavior that the tests were
+supposed to capture. The quality ceiling of AI output is set by the quality of the
+context you provide. Better context — clearer documentation, more specific error types,
+behavior-focused tests — produces better output. Underdeveloped context produces output
+that passes the gates and defers the judgment to whoever reviews it next.
+
+This creates a specific and non-optional responsibility for contributors working with
+AI tools.
+
+**Review is not optional because AI wrote it.** The culture RFC named this clearly, and
+it bears repeating with specifics: when reviewing AI-generated code, the gate questions
+— does it compile, do the tests pass — are the beginning of the review, not the end. The
+standard questions are: does this handle operational errors correctly, or does it
+`.unwrap()` them? Is the new public API documented? Does the test assert the behavior or
+the implementation? Is this near a trust boundary, and if so, does it validate its
+inputs? These questions are your responsibility regardless of who wrote the code or what
+tools were used to produce it.
+
+**AI amplifies your judgment, not your absence of it.** A contributor who does not yet
+have a mental model for what good error handling looks like will accept AI-generated
+error handling at face value — `.unwrap()` and all. A contributor who has internalized
+§4.1 can look at the same output and direct the tool: "this is an operational error
+path; use `?` and propagate the failure to the caller with context." The tool will
+produce a corrected version. The same pattern applies to every discipline in §4. The
+tool is powerful in the hands of someone who knows what to ask for. Without that
+direction, it produces code that satisfies the compiler and defers the real decisions
+to the next person in the chain.
+
+**This relationship compounds in both directions.** A team that understands the standards
+gets progressively more value from AI tooling as the tools improve, because they can
+direct more capable tools more precisely. The gap between "what the tool produced" and
+"what the standard requires" becomes something they can close with direction rather than
+manual rewriting. A team that does not build that judgment gets a faster path to the
+same quality floor, without the ability to push past it. The investment described
+throughout this document is also, directly, an investment in the long-term effectiveness
+of every AI tool the team will ever use — because the value of those tools scales with
+the clarity of the judgment directing them.
+
+--------
+
+## 6. The Portability of Craft
+
+Technology changes. It changes faster with each iteration than it did the time before,
+and that rate is accelerating. The specific tools in this document — Rust, `cargo`,
+`clippy`, the OpenTelemetry SDK, the AI assistants the team uses today — will be
+superseded. Some of them within the lifetime of this project. The platforms will change.
+The languages will evolve. The tooling ecosystem will look different in five years than
+it does today, and different again in ten.
+
+The mental models in this document will not change.
+
+The question "what should happen here when this fails, and who needs to know?" does not
+expire when the language changes. You will ask it in the next language you learn. You
+will ask it when designing a distributed system where the "language" is a wire protocol.
+You will ask it when building anything that other people depend on and that you cannot
+personally supervise. The specific Rust mechanism for answering it — `Result<T, E>`, the
+`?` operator, structured error types with context — is one answer to a question that
+exists everywhere.
+
+The question "what is the public interface I am promising, and does my documentation
+reflect that promise?" — you will ask this when designing an API, when writing a
+technical specification, when defining the scope of a team's responsibilities, when
+communicating requirements to another team, to an AI tool, to a client, to a contractor.
+The promise-and-terms model of public interfaces extends far beyond Rust and far beyond
+software.
+
+The question "what does my test actually prove?" extends beyond software into any domain
+where you need to verify that a system behaves as intended. The instinct to ask it — to
+distinguish between evidence that your implementation exists and evidence that the right
+thing happens — is the skill. The syntax for expressing it in Rust is incidental.
+
+The question "what would the person who needs to diagnose this failure need to know?" is
+an engineering question that applies to anything you build that other people depend on.
+It is also, at a deeper level, a question about empathy — about remembering that the
+person on the other side of your work is a real person with a real problem, at a moment
+you cannot predict, with context you will not be there to provide.
+
+│ You are not learning Rust. You are, through the vehicle of Rust, learning to build
+│ things that can be trusted. That is portable. It will compound for as long as you
+│ practice it — across every language, every system, every team, and every domain you
+│ ever work in.
+
+This is the investment the project is making in you. Not in your specific technical
+skills, but in your ability to bring judgment, craft, and care to whatever you build
+next. And it is, in turn, the investment you make in every person who will one day
+depend on something you built.
+
+--------
+
+## 7. What This Means for Contributors
+
+**If you are new to Rust or new to software development:**
+
+The seven disciplines in §4 are not requirements to master before you can contribute.
+They are a map of the territory — things you will encounter as you work, named clearly
+enough that you know what you are looking at when you see them.
+
+Start with §4.1. The error handling mental model is the single highest-leverage thing
+you can internalize early, and it is not Rust-specific. When you read existing code and
+encounter `.unwrap()`, ask yourself which of the three categories it falls into. When
+you write new code, ask the same question about your own choices. That single habit,
+practiced consistently, improves every file it touches and develops a judgment that will
+follow you everywhere.
+
+Do not wait until you feel ready to apply these standards. Apply them imperfectly, ask
+questions when you are unsure which category something falls into, and treat the
+feedback you receive in review as the teaching it is intended to be. Nobody arrived
+knowing these things. They were learned, slowly, through exactly the kind of work you
+are doing here.
+
+**If you are using AI tools to help you contribute:**
+
+The standards in this document are what a careful review will evaluate AI-generated code
+against. They are also, practically, the context that makes AI output more correct before
+it reaches review. Before asking an AI to implement something, check whether the
+interfaces it will implement against are documented. If they are not, document them
+first — or include the documentation as part of what you ask the AI to produce. The
+output will be more correct, you will have closed a real gap in the foundation, and the
+next contributor who comes along will benefit from both.
+
+When you receive review feedback on AI-generated code, treat it as feedback on the code,
+not as feedback on your choice to use AI. The standards apply equally regardless of
+authorship. The question is always: does this code meet the standard? If it does not,
+what needs to change, and why?
+
+**If you are reviewing pull requests:**
+
+The gate questions — does it compile, do the tests pass, does Clippy accept it — are
+the floor, not the ceiling. A review that only answers those questions is an incomplete
+review. Use the framework in §3 and the disciplines in §4 to structure your observations.
+Name the standard you are applying, explain why it matters, and clearly separate
+blocking concerns from non-blocking suggestions.
+
+The goal of a review is not to find fault. It is to transfer understanding. Every
+specific piece of feedback that includes an explanation — "this is an operational error
+path; here is why `.unwrap()` creates a production risk here and what to use instead" —
+is an investment in the contributor you are reviewing. That investment compounds. The
+contributor who understands the principle will apply it correctly to the next ten
+situations where it matters, without needing to be told again.
+
+**If you are a maintainer or more experienced contributor:**
+
+You are in the best position to make these standards real — not by enforcing them from
+above, but by modeling them in your own code and naming them by name in review. The most
+effective teaching in an open source project happens in PR threads and code comments,
+not in documents. This document provides the vocabulary. Using it consistently in
+everyday review is what moves it from words on a page to shared practice.
+
+When you see a `.unwrap()` on an operational error path, name it as such. When you see
+a public function without documentation, ask the question: what does a future implementor
+need to know here? When you see a test that would break on a valid refactor, explain why
+that matters. These are not corrections — they are the ongoing mentorship that the
+culture RFC identified as one of the most important things a more experienced contributor
+can offer.
+
+--------


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Commits all six foundation RFCs and the framework README to the repository for the first time. The documents have been local-only (excluded via `.git/info/exclude`) since they were written, while the team discussed and refined them through the linked RFC issues. They are ratified, the discussion threads have been active, and the team is already implementing against them. This PR makes them canonical, versioned alongside the code they govern.
- **Scope boundary:** `docs/foundations/` only — no source, CI, workflow, or runtime changes. FND-002 header corrected to include the `Rev. 1` marker consistent with all other documents in the series.
- **Blast radius:** Additive only. No existing files modified except the FND-002 header fix.
- **Linked issue(s):** Relates to #5574, #5576, #5577, #5579, #5615, #5653

## Documents

| # | File | RFC Issue | Rev |
|---|------|-----------|-----|
| FND-001 | Intentional Architecture — Microkernel Transition | #5574 | Rev. 3 |
| FND-002 | Documentation Standards and Knowledge Architecture | #5576 | Rev. 1 |
| FND-003 | Team Organization and Project Governance | #5577 | Rev. 2 |
| FND-004 | Engineering Infrastructure — CI/CD Pipeline | #5579 | Rev. 1 |
| FND-005 | Contribution Culture — Human Collaboration and AI Partnership | #5615 | Rev. 1 |
| FND-006 | Zero Compromise in Practice — Code Health and Production Readiness | #5653 | Rev. 1 |

RFC discussion threads remain open as permanent discussion records per the `docs/foundations/README.md` convention.

## Validation Evidence (required)

- **Commands run:** Docs-only change — no Rust files modified
- **Beyond CI — what did you manually verify?** All six documents verified to carry the `> **Canonical reference** · Ratified by the team · Rev. X` header. Discussion question sections confirmed absent from all files (stripped during local preparation). README reading-order table cross-checked against all six files and their RFC issue links.
- **If any command was intentionally skipped, why:** No Rust, no workflows — markdown lint applies

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No

## Label Snapshot

- `risk: low`, `size: M`, `type: docs`, `docs`

## Change Metadata

- Change type: docs
- Primary scope: `docs/foundations/`

## Privacy and Data Hygiene

- N/A

## i18n Follow-Through

- N/A — foundation documents are English-only canonical references; no user-facing runtime strings changed

## Side Effects / Blast Radius

- `docs/foundations/` (7 new files)
- No runtime, config, or CI changes

## Rollback Plan

`git revert <sha>` removes the entire directory. No side effects.