### PR TITLE
feat(plugins): wire up Extism WASM execution bridge (Phase 2 D2 plumbing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,6 +238,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "archery"
@@ -364,7 +385,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -395,7 +416,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.1",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -421,7 +442,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -808,6 +829,15 @@ dependencies = [
 
 [[package]]
 name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "bitmaps"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
@@ -913,6 +943,9 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytecount"
@@ -1002,6 +1035,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "cap-fs-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
+name = "cap-rand"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
+dependencies = [
+ "ambient-authority",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "cap-std"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "cap-time-ext"
+version = "3.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+dependencies = [
+ "ambient-authority",
+ "cap-primitives",
+ "iana-time-zone",
+ "once_cell",
+ "rustix 1.1.4",
+ "winx",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1158,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbindgen"
+version = "0.29.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
+dependencies = [
+ "heck 0.5.0",
+ "indexmap 2.13.0",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+ "tempfile",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,7 +1226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
 ]
 
 [[package]]
@@ -1288,6 +1405,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1536,6 +1662,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,6 +1687,144 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a04121a197fde2fe896f8e7cac9812fc41ed6ee9c63e1906090f9f497845f6"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a09e699a94f477303820fb2167024f091543d6240783a2d3b01a3f21c42bc744"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f07732c662a9755529e332d86f8c5842171f6e98ba4d5976a178043dad838654"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18391da761cf362a06def7a7cf11474d79e55801dd34c2e9ba105b33dc0aef88"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b3a09b3042c69810d255aef59ddc3b3e4c0644d1d90ecfd6e3837798cc88a3c"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli",
+ "hashbrown 0.15.5",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75817926ec812241889208d1b190cadb7fedded4592a4bb01b8524babb9e4849"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck 0.5.0",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859158f87a59476476eda3884d883c32e08a143cf3d315095533b362a3250a63"
+
+[[package]]
+name = "cranelift-control"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b65a9aec442d715cbf54d14548b8f395476c09cef7abe03e104a378291ab88"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8334c99a7e86060c24028732efd23bac84585770dcb752329c69f135d64f2fc1"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43ac6c095aa5b3e845d7ca3461e67e2b65249eb5401477a5ff9100369b745111"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon 0.13.5",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d3d992870ed4f0f2e82e2175275cb3a123a46e9660c6558c46417b822c91fa"
+
+[[package]]
+name = "cranelift-native"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee32e36beaf80f309edb535274cfe0349e1c5cf5799ba2d9f42e828285c6b52e"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon 0.13.5",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.128.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "903adeaf4938e60209a97b53a2e4326cd2d356aab9764a1934630204bae381c9"
 
 [[package]]
 name = "crc32fast"
@@ -1656,7 +1929,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1938,6 +2211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "decancer"
 version = "3.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,6 +2395,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,8 +2421,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -2337,6 +2640,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,7 +2774,7 @@ dependencies = [
  "md-5",
  "miette",
  "nix 0.30.1",
- "object",
+ "object 0.38.1",
  "serde",
  "sha2",
  "strum",
@@ -2509,6 +2824,73 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener 5.4.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "extism"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed8c5859bdab81d2eb4cd963eeacd8031d353b1ffb2fde43ee9179a0d6295120"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "cbindgen",
+ "extism-convert",
+ "extism-manifest",
+ "glob",
+ "libc",
+ "serde",
+ "serde_json",
+ "sha2",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+ "tracing-subscriber",
+ "ureq",
+ "url",
+ "uuid",
+ "wasi-common",
+ "wasmtime",
+ "wiggle",
+]
+
+[[package]]
+name = "extism-convert"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1a8eac059a1730a21aa47f99a0c2075ba0ab88fd0c4e52e35027cf99cdf3e7"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytemuck",
+ "extism-convert-macros",
+ "prost 0.14.3",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "extism-convert-macros"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "848f105dd6e1af2ea4bb4a76447658e8587167df3c4e4658c4258e5b14a5b051"
+dependencies = [
+ "manyhow",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "extism-manifest"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953a22ad322939ae4567ec73a34913a3a43dcbdfa648b8307d38fe56bb3a0acd"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2598,6 +2980,17 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "fdeflate"
@@ -2747,6 +3140,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2885,6 +3289,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "fxprof-processed-profile"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
+dependencies = [
+ "bitflags 2.11.0",
+ "debugid",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -3312,6 +3730,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash 0.1.5",
+ "serde",
 ]
 
 [[package]]
@@ -3855,6 +4274,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "365a784774bb381e8c19edb91190a90d7f2625e057b55de2bc0f6b57bc779ff2"
 
 [[package]]
+name = "im-rc"
+version = "15.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
+dependencies = [
+ "bitmaps 2.1.0",
+ "rand_core 0.6.4",
+ "rand_xoshiro 0.6.0",
+ "sized-chunks",
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3885,10 +4318,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fade8ae6828627ad1fa094a891eccfb25150b383047190a3648d66d06186501"
 dependencies = [
  "archery",
- "bitmaps",
+ "bitmaps 3.2.1",
  "imbl-sized-chunks",
  "rand_core 0.9.5",
- "rand_xoshiro",
+ "rand_xoshiro 0.7.0",
  "serde",
  "version_check",
 ]
@@ -3899,7 +4332,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
 dependencies = [
- "bitmaps",
+ "bitmaps 3.2.1",
 ]
 
 [[package]]
@@ -4022,6 +4455,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
+dependencies = [
+ "io-lifetimes",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "io-kit-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4040,6 +4483,12 @@ dependencies = [
  "core-foundation-sys",
  "mach2 0.5.0",
 ]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "ipnet"
@@ -4114,6 +4563,26 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "javascriptcore-rs"
@@ -4337,6 +4806,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,6 +4927,12 @@ checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.0",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4624,6 +5105,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f82a3d6522697593ba4c683e0a6ee5a40fee93bc1a525e3cc6eeb3da11fd8897"
 dependencies = [
  "hashify",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -5004,6 +5508,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5024,6 +5534,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.1.4",
+]
 
 [[package]]
 name = "memmem"
@@ -5498,10 +6017,10 @@ dependencies = [
  "core-foundation-sys",
  "futures-core",
  "io-kit-sys 0.5.0",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "log",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -5713,6 +6232,18 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]
@@ -6074,6 +6605,16 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset 0.4.2",
+ "indexmap 2.13.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
@@ -6430,7 +6971,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -6468,6 +7009,18 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs 0.3.0",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
 
 [[package]]
 name = "postscript"
@@ -6526,7 +7079,7 @@ dependencies = [
  "bincode",
  "bitfield",
  "bitvec",
- "cobs",
+ "cobs 0.5.1",
  "docsplay",
  "dunce",
  "espflash",
@@ -6537,7 +7090,7 @@ dependencies = [
  "itertools 0.14.0",
  "jep106",
  "nusb",
- "object",
+ "object 0.38.1",
  "parking_lot",
  "probe-rs-target",
  "rmp-serde",
@@ -6646,6 +7199,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
+name = "proc-macro-utils"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6698,7 +7262,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.8.3",
  "prost 0.14.3",
  "prost-types",
  "regex",
@@ -6777,6 +7341,29 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "pulley-interpreter"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9812652c1feb63cf39f8780cecac154a32b22b3665806c733cd4072547233a4"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56000349b6896e3d44286eb9c330891237f40b27fd43c1ccc84547d0b463cb40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pxfm"
@@ -7019,6 +7606,15 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
@@ -7191,6 +7787,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -7218,6 +7825,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -7581,6 +8202,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7597,6 +8224,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -7604,8 +8244,18 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -8333,6 +8983,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "sized-chunks"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
+dependencies = [
+ "bitmaps 2.1.0",
+ "typenum",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8608,6 +9268,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-interface"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
+dependencies = [
+ "bitflags 2.11.0",
+ "cap-fs-ext",
+ "cap-std",
+ "fd-lock",
+ "io-lifetimes",
+ "rustix 0.38.44",
+ "windows-sys 0.59.0",
+ "winx",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8684,6 +9360,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri"
@@ -8978,7 +9660,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -9001,6 +9683,15 @@ checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
  "utf-8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -9571,6 +10262,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -9975,6 +10667,7 @@ checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
+ "flate2",
  "log",
  "percent-encoding",
  "rustls",
@@ -10404,6 +11097,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi-common"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49ffbbd04665d04028f66aee8f24ae7a1f46063f59a28fddfa52ca3091754a2"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.11.0",
+ "cap-fs-ext",
+ "cap-rand",
+ "cap-std",
+ "cap-time-ext",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes",
+ "log",
+ "rustix 1.1.4",
+ "system-interface",
+ "thiserror 2.0.18",
+ "tracing",
+ "wasmtime",
+ "wiggle",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10477,13 +11196,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-compose"
+version = "0.243.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af801b6f36459023eaec63fdbaedad2fd5a4ab7dc74ecc110a8b5d375c5775e4"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "im-rc",
+ "indexmap 2.13.0",
+ "log",
+ "petgraph 0.6.5",
+ "serde",
+ "serde_derive",
+ "serde_yaml",
+ "smallvec",
+ "wasm-encoder 0.243.0",
+ "wasmparser 0.243.0",
+ "wat",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.243.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55db9c896d70bd9fa535ce83cd4e1f2ec3726b0edd2142079f594fc3be1cb35"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.243.0",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
@@ -10494,8 +11254,8 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap 2.13.0",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -10544,6 +11304,19 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.243.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
@@ -10552,6 +11325,319 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+dependencies = [
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.243.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2b6035559e146114c29a909a3232928ee488d6507a1504d8934e8607b36d7b"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.243.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a83182bf04af87571b4c642300479501684f26bab5597f68f68cded5b098fd"
+dependencies = [
+ "addr2line",
+ "anyhow",
+ "async-trait",
+ "bitflags 2.11.0",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "futures",
+ "fxprof-processed-profile",
+ "gimli",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+ "ittapi",
+ "libc",
+ "log",
+ "mach2 0.4.3",
+ "memfd",
+ "object 0.37.3",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rayon",
+ "rustix 1.1.4",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "tempfile",
+ "wasm-compose",
+ "wasm-encoder 0.243.0",
+ "wasmparser 0.243.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-slab",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
+ "wat",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb201c41aa23a3642365cfb2e4a183573d85127a3c9d528f56b9997c984541ab"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap 2.13.0",
+ "log",
+ "object 0.37.3",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasm-encoder 0.243.0",
+ "wasmparser 0.243.0",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+]
+
+[[package]]
+name = "wasmtime-internal-cache"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5b3069d1a67ba5969d0eb1ccd7e141367d4e713f4649aa90356c98e8f19bea"
+dependencies = [
+ "base64 0.22.1",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix 1.1.4",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml 0.9.12+spec-1.1.0",
+ "wasmtime-environ",
+ "windows-sys 0.61.2",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c924400db7b6ca996fef1b23beb0f41d5c809836b1ec60fc25b4057e2d25d9b"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser 0.243.0",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3f65daf4bf3d74ca2fbbe20af0589c42e2b398a073486451425d94fd4afef4"
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633e889cdae76829738db0114ab3b02fce51ea4a1cd9675a67a65fce92e8b418"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli",
+ "itertools 0.14.0",
+ "log",
+ "object 0.37.3",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "thiserror 2.0.18",
+ "wasmparser 0.243.0",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb126adc5d0c72695cfb77260b357f1b81705a0f8fa30b3944e7c2219c17341"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.1.4",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e66ff7f90a8002187691ff6237ffd09f954a0ebb9de8b2ff7f5c62632134120"
+dependencies = [
+ "cc",
+ "object 0.37.3",
+ "rustix 1.1.4",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b96df23179ae16d54fb3a420f84ffe4383ec9dd06fad3e5bc782f85f66e8e08"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d1380926682b44c383e9a67f47e7a95e60c6d3fa8c072294dab2c7de6168a0"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-slab"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b63cbea1c0192c7feb7c0dfb35f47166988a3742f29f46b585ef57246c65764"
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25c392c7e5fb891a7416e3c34cfbd148849271e8c58744fda875dde4bec4d6a"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object 0.37.3",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f8b9796a3f0451a7b702508b303d654de640271ac80287176de222f187a237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0063e61f1d0b2c20e9cfc58361a6513d074a23c80b417aac3033724f51648a0"
+dependencies = [
+ "cranelift-codegen",
+ "gimli",
+ "log",
+ "object 0.37.3",
+ "target-lexicon 0.13.5",
+ "wasmparser 0.243.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "587699ca7cae16b4a234ffcc834f37e75675933d533809919b52975f5609e2ef"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "heck 0.5.0",
+ "indexmap 2.13.0",
+ "wit-parser 0.243.0",
+]
+
+[[package]]
+name = "wast"
+version = "35.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wast"
+version = "246.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width 0.2.2",
+ "wasm-encoder 0.246.2",
+]
+
+[[package]]
+name = "wat"
+version = "1.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
+dependencies = [
+ "wast 246.0.2",
 ]
 
 [[package]]
@@ -10805,6 +11891,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "wiggle"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69a60bcbe1475c5dc9ec89210ade54823d44f742e283cba64f98f89697c4cec"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "thiserror 2.0.18",
+ "tracing",
+ "wasmtime",
+ "wiggle-macro",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-generate"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f3dc0fd4dcfc7736434bb216179a2147835309abc09bf226736a40d484548f"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "witx",
+]
+
+[[package]]
+name = "wiggle-macro"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea2aea744eded58ae092bf57110c27517dab7d5a300513ff13897325c5c5021"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wiggle-generate",
+]
+
+[[package]]
 name = "wildmatch"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10840,6 +11967,26 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "41.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55de3ac5b8bd71e5f6c87a9e511dd3ceb194bdb58183c6a7bf21cd8c0e46fbc"
+dependencies = [
+ "anyhow",
+ "cranelift-assembler-x64",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "thiserror 2.0.18",
+ "wasmparser 0.243.0",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-math",
+]
 
 [[package]]
 name = "window-vibrancy"
@@ -11320,6 +12467,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.11.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11359,7 +12516,7 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -11406,10 +12563,28 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.244.0",
  "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.243.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df983a8608e513d8997f435bb74207bf0933d0e49ca97aa9d8a6157164b9b7fc"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.13.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.243.0",
 ]
 
 [[package]]
@@ -11427,7 +12602,19 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "witx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
+dependencies = [
+ "anyhow",
+ "log",
+ "thiserror 1.0.69",
+ "wast 35.0.2",
 ]
 
 [[package]]
@@ -11535,7 +12722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -11622,7 +12809,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "serde_repr",
  "tracing",
@@ -11931,6 +13118,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "extism",
+ "reqwest 0.12.28",
  "ring",
  "serde",
  "serde_json",
@@ -12381,6 +13570,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/crates/zeroclaw-plugins/AGENTS.md
+++ b/crates/zeroclaw-plugins/AGENTS.md
@@ -1,0 +1,43 @@
+# zeroclaw-plugins
+
+## What this crate is
+
+WASM plugin host for ZeroClaw. Handles plugin discovery, manifest parsing,
+Ed25519 signature verification, and Extism-based WASM execution. Bridges
+plugin-exported functions into ZeroClaw's `Tool` and `Channel` traits so
+plugins appear as native capabilities to the agent runtime.
+
+## What this crate is allowed to depend on
+
+- `zeroclaw-api` (traits only — `Tool`, `Channel`, `ToolResult`)
+- `extism` (WASM runtime)
+- `reqwest` (blocking, for host function HTTP support)
+- `ring` (Ed25519 signatures)
+- `serde`, `serde_json`, `toml` (serialization)
+- `tokio` (async bridging via `spawn_blocking`)
+- `tracing` (logging)
+- `anyhow`, `thiserror` (error handling)
+
+Do not add dependencies on specific tools, channels, providers, or config
+schemas. This crate knows how to run plugins, not what they do.
+
+## Extension points
+
+- **New host functions:** Add to `runtime.rs` alongside `zc_http_request` and
+  `zc_env_read`. Register in `create_plugin()`. Gate on a `PluginPermission`
+  variant (add to `lib.rs` if needed).
+- **New capability bridges:** Add alongside `wasm_tool.rs` and
+  `wasm_channel.rs` (e.g., `wasm_memory.rs` for memory backend plugins).
+- **New permissions:** Add variants to `PluginPermission` in `lib.rs`.
+
+## What does NOT belong here
+
+- Concrete tool or channel implementations (those go in `zeroclaw-tools` or
+  `zeroclaw-channels`, or in a WASM plugin)
+- Plugin business logic (that belongs in the plugin's own crate)
+- Config schema definitions (those go in `zeroclaw-config`)
+- Plugin registry client or distribution (future separate crate)
+
+## Related ADRs
+
+- ADR-003: WASM + Extism plugin execution model

--- a/crates/zeroclaw-plugins/Cargo.toml
+++ b/crates/zeroclaw-plugins/Cargo.toml
@@ -14,8 +14,10 @@ base64 = "0.22"
 ring = "0.17"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0", default-features = false, features = ["std"] }
+extism = "1.21"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "blocking"] }
 thiserror = "2.0"
-tokio = { version = "1.50", default-features = false, features = ["sync", "macros"] }
+tokio = { version = "1.50", default-features = false, features = ["sync", "macros", "rt"] }
 toml = "1.0"
 tracing = { version = "0.1", default-features = false }
 

--- a/crates/zeroclaw-plugins/src/host.rs
+++ b/crates/zeroclaw-plugins/src/host.rs
@@ -240,6 +240,16 @@ impl PluginHost {
             .collect()
     }
 
+    /// Get tool-capable plugins with their resolved WASM file paths.
+    /// Returns `(manifest, resolved_wasm_path)` tuples for building `WasmTool`s.
+    pub fn tool_plugin_details(&self) -> Vec<(&PluginManifest, &Path)> {
+        self.loaded
+            .values()
+            .filter(|p| p.manifest.capabilities.contains(&PluginCapability::Tool))
+            .map(|p| (&p.manifest, p.wasm_path.as_path()))
+            .collect()
+    }
+
     /// Get channel-capable plugins.
     pub fn channel_plugins(&self) -> Vec<&PluginManifest> {
         self.loaded

--- a/crates/zeroclaw-plugins/src/lib.rs
+++ b/crates/zeroclaw-plugins/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod error;
 pub mod host;
+pub mod runtime;
 pub mod signature;
 pub mod wasm_channel;
 pub mod wasm_tool;
@@ -54,7 +55,7 @@ pub enum PluginCapability {
 }
 
 /// Permissions a plugin may request.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginPermission {
     /// Can make HTTP requests

--- a/crates/zeroclaw-plugins/src/runtime.rs
+++ b/crates/zeroclaw-plugins/src/runtime.rs
@@ -163,10 +163,7 @@ fn handle_env_read(
 // ── Plugin creation and invocation ────────────────────────────────
 
 /// Create an Extism plugin from a WASM file with the given permissions.
-pub fn create_plugin(
-    wasm_path: &Path,
-    permissions: &[PluginPermission],
-) -> Result<extism::Plugin> {
+pub fn create_plugin(wasm_path: &Path, permissions: &[PluginPermission]) -> Result<extism::Plugin> {
     let perm_set: HashSet<PluginPermission> = permissions.iter().cloned().collect();
     let ctx = UserData::new(HostContext {
         permissions: perm_set,
@@ -180,13 +177,7 @@ pub fn create_plugin(
         handle_http_request,
     );
 
-    let env_fn = Function::new(
-        "zc_env_read",
-        [PTR],
-        [PTR],
-        ctx,
-        handle_env_read,
-    );
+    let env_fn = Function::new("zc_env_read", [PTR], [PTR], ctx, handle_env_read);
 
     let manifest = Manifest::new([Wasm::file(wasm_path)]);
 
@@ -205,8 +196,7 @@ pub fn call_tool_metadata(plugin: &mut extism::Plugin) -> Result<ToolMetadata> {
 
 /// Call the `execute` export with the given args JSON and return a `ToolResult`.
 pub fn call_execute(plugin: &mut extism::Plugin, args_json: &[u8]) -> Result<ToolResult> {
-    let input =
-        std::str::from_utf8(args_json).context("plugin args are not valid UTF-8")?;
+    let input = std::str::from_utf8(args_json).context("plugin args are not valid UTF-8")?;
 
     let output = plugin
         .call::<&str, String>("execute", input)

--- a/crates/zeroclaw-plugins/src/runtime.rs
+++ b/crates/zeroclaw-plugins/src/runtime.rs
@@ -82,6 +82,12 @@ fn handle_http_request(
     let req: HttpRequest = serde_json::from_str(&request_json)
         .map_err(|e| Error::msg(format!("invalid HTTP request JSON: {e}")))?;
 
+    // 120s ceiling covers legitimate slow cases: large file downloads and slow
+    // model-inference endpoints (fal.ai image generation routinely takes 20-60s
+    // on cold models). A per-plugin override or tighter default is a candidate
+    // follow-up — see ADR-003 §"Known gaps". Note: this runs inside
+    // spawn_blocking, so a stalled request holds a blocking-pool thread for
+    // the full duration.
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(120))
         .build()

--- a/crates/zeroclaw-plugins/src/runtime.rs
+++ b/crates/zeroclaw-plugins/src/runtime.rs
@@ -1,0 +1,285 @@
+//! Extism-based WASM execution bridge.
+//!
+//! Creates Extism plugin instances with permission-gated host functions
+//! (`zc_http_request`, `zc_env_read`) and calls plugin-exported functions
+//! (`tool_metadata`, `execute`).
+
+use crate::PluginPermission;
+use anyhow::{Context, Result};
+use extism::*;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::Path;
+use zeroclaw_api::tool::ToolResult;
+
+// ── Host function context ─────────────────────────────────────────
+
+/// Permissions available to a single plugin invocation.
+#[derive(Debug, Clone)]
+struct HostContext {
+    permissions: HashSet<PluginPermission>,
+}
+
+// ── Data types exchanged with plugins ─────────────────────────────
+
+/// HTTP request sent from plugin to host via `zc_http_request`.
+#[derive(Debug, Serialize, Deserialize)]
+struct HttpRequest {
+    method: String,
+    url: String,
+    #[serde(default)]
+    headers: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    body: Option<String>,
+}
+
+/// HTTP response returned from host to plugin.
+#[derive(Debug, Serialize, Deserialize)]
+struct HttpResponse {
+    status: u16,
+    body: String,
+    #[serde(default)]
+    headers: std::collections::HashMap<String, String>,
+}
+
+/// Tool metadata returned by the `tool_metadata` export.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ToolMetadata {
+    pub name: String,
+    pub description: String,
+    pub parameters_schema: serde_json::Value,
+}
+
+/// Result returned by the `execute` export.
+#[derive(Debug, Serialize, Deserialize)]
+struct PluginToolResult {
+    success: bool,
+    output: String,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+// ── Host function implementations ─────────────────────────────────
+
+fn handle_http_request(
+    plugin: &mut CurrentPlugin,
+    inputs: &[Val],
+    outputs: &mut [Val],
+    user_data: UserData<HostContext>,
+) -> Result<(), Error> {
+    let ctx = user_data.get()?;
+    let ctx = ctx.lock().unwrap();
+
+    if !ctx.permissions.contains(&PluginPermission::HttpClient) {
+        return Err(Error::msg(
+            "permission denied: plugin does not have 'http_client' permission",
+        ));
+    }
+
+    // Read input string from WASM memory
+    let request_json: String = plugin.memory_get_val(&inputs[0])?;
+
+    let req: HttpRequest = serde_json::from_str(&request_json)
+        .map_err(|e| Error::msg(format!("invalid HTTP request JSON: {e}")))?;
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .build()
+        .map_err(|e| Error::msg(format!("failed to create HTTP client: {e}")))?;
+
+    let mut builder = match req.method.to_uppercase().as_str() {
+        "GET" => client.get(&req.url),
+        "POST" => client.post(&req.url),
+        "PUT" => client.put(&req.url),
+        "DELETE" => client.delete(&req.url),
+        "PATCH" => client.patch(&req.url),
+        "HEAD" => client.head(&req.url),
+        other => {
+            return Err(Error::msg(format!("unsupported HTTP method: {other}")));
+        }
+    };
+
+    for (k, v) in &req.headers {
+        builder = builder.header(k.as_str(), v.as_str());
+    }
+
+    if let Some(body) = req.body {
+        builder = builder.body(body);
+    }
+
+    let resp = builder
+        .send()
+        .map_err(|e| Error::msg(format!("HTTP request failed: {e}")))?;
+
+    let status = resp.status().as_u16();
+    let headers: std::collections::HashMap<String, String> = resp
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+    let body = resp
+        .text()
+        .map_err(|e| Error::msg(format!("failed to read response body: {e}")))?;
+
+    let response = HttpResponse {
+        status,
+        body,
+        headers,
+    };
+
+    let response_json = serde_json::to_string(&response)
+        .map_err(|e| Error::msg(format!("failed to serialize response: {e}")))?;
+
+    plugin.memory_set_val(&mut outputs[0], response_json)?;
+
+    Ok(())
+}
+
+fn handle_env_read(
+    plugin: &mut CurrentPlugin,
+    inputs: &[Val],
+    outputs: &mut [Val],
+    user_data: UserData<HostContext>,
+) -> Result<(), Error> {
+    let ctx = user_data.get()?;
+    let ctx = ctx.lock().unwrap();
+
+    if !ctx.permissions.contains(&PluginPermission::EnvRead) {
+        return Err(Error::msg(
+            "permission denied: plugin does not have 'env_read' permission",
+        ));
+    }
+
+    let var_name: String = plugin.memory_get_val(&inputs[0])?;
+
+    let value = std::env::var(&var_name)
+        .map_err(|_| Error::msg(format!("environment variable '{var_name}' not set")))?;
+
+    plugin.memory_set_val(&mut outputs[0], value)?;
+
+    Ok(())
+}
+
+// ── Plugin creation and invocation ────────────────────────────────
+
+/// Create an Extism plugin from a WASM file with the given permissions.
+pub fn create_plugin(
+    wasm_path: &Path,
+    permissions: &[PluginPermission],
+) -> Result<extism::Plugin> {
+    let perm_set: HashSet<PluginPermission> = permissions.iter().cloned().collect();
+    let ctx = UserData::new(HostContext {
+        permissions: perm_set,
+    });
+
+    let http_fn = Function::new(
+        "zc_http_request",
+        [PTR],
+        [PTR],
+        ctx.clone(),
+        handle_http_request,
+    );
+
+    let env_fn = Function::new(
+        "zc_env_read",
+        [PTR],
+        [PTR],
+        ctx,
+        handle_env_read,
+    );
+
+    let manifest = Manifest::new([Wasm::file(wasm_path)]);
+
+    Plugin::new(manifest, [http_fn, env_fn], true)
+        .with_context(|| format!("failed to load WASM plugin from {}", wasm_path.display()))
+}
+
+/// Call the `tool_metadata` export and parse the result.
+pub fn call_tool_metadata(plugin: &mut extism::Plugin) -> Result<ToolMetadata> {
+    let output = plugin
+        .call::<&str, String>("tool_metadata", "")
+        .context("failed to call tool_metadata export")?;
+
+    serde_json::from_str(&output).context("failed to parse tool_metadata JSON")
+}
+
+/// Call the `execute` export with the given args JSON and return a `ToolResult`.
+pub fn call_execute(plugin: &mut extism::Plugin, args_json: &[u8]) -> Result<ToolResult> {
+    let input =
+        std::str::from_utf8(args_json).context("plugin args are not valid UTF-8")?;
+
+    let output = plugin
+        .call::<&str, String>("execute", input)
+        .context("failed to call plugin execute export")?;
+
+    let result: PluginToolResult =
+        serde_json::from_str(&output).context("failed to parse plugin execute result")?;
+
+    Ok(ToolResult {
+        success: result.success,
+        output: result.output,
+        error: result.error,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_context_permission_check() {
+        let ctx = HostContext {
+            permissions: HashSet::from([PluginPermission::HttpClient]),
+        };
+        assert!(ctx.permissions.contains(&PluginPermission::HttpClient));
+        assert!(!ctx.permissions.contains(&PluginPermission::EnvRead));
+    }
+
+    #[test]
+    fn http_request_serde_roundtrip() {
+        let req = HttpRequest {
+            method: "POST".into(),
+            url: "https://example.com/api".into(),
+            headers: [("Authorization".into(), "Bearer tok".into())]
+                .into_iter()
+                .collect(),
+            body: Some(r#"{"key":"value"}"#.into()),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        let parsed: HttpRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.method, "POST");
+        assert_eq!(parsed.url, "https://example.com/api");
+        assert_eq!(parsed.body.as_deref(), Some(r#"{"key":"value"}"#));
+    }
+
+    #[test]
+    fn tool_metadata_serde() {
+        let meta = ToolMetadata {
+            name: "test_tool".into(),
+            description: "A test tool".into(),
+            parameters_schema: serde_json::json!({"type": "object"}),
+        };
+        let json = serde_json::to_string(&meta).unwrap();
+        let parsed: ToolMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.name, "test_tool");
+    }
+
+    #[test]
+    fn plugin_tool_result_serde() {
+        let result = PluginToolResult {
+            success: true,
+            output: "hello".into(),
+            error: None,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        let parsed: PluginToolResult = serde_json::from_str(&json).unwrap();
+        assert!(parsed.success);
+        assert_eq!(parsed.output, "hello");
+    }
+
+    #[test]
+    fn missing_wasm_file_returns_error() {
+        let result = create_plugin(Path::new("/nonexistent/plugin.wasm"), &[]);
+        assert!(result.is_err());
+    }
+}

--- a/crates/zeroclaw-plugins/src/wasm_channel.rs
+++ b/crates/zeroclaw-plugins/src/wasm_channel.rs
@@ -1,4 +1,9 @@
 //! Bridge between WASM plugins and the Channel trait.
+//!
+//! **Status:** Placeholder — `send` and `listen` are not yet wired to the
+//! Extism runtime.  Channel plugin support is a Phase 3 (v0.9.0) deliverable
+//! per the [Intentional Architecture RFC](https://github.com/zeroclaw-labs/zeroclaw/wiki/14.1-Intentional-Architecture).
+//! See `wasm_tool.rs` and `runtime.rs` for the working tool plugin bridge.
 
 use async_trait::async_trait;
 use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};

--- a/crates/zeroclaw-plugins/src/wasm_tool.rs
+++ b/crates/zeroclaw-plugins/src/wasm_tool.rs
@@ -53,16 +53,7 @@ impl WasmTool {
                     (
                         fallback_name.clone(),
                         fallback_description.clone(),
-                        serde_json::json!({
-                            "type": "object",
-                            "properties": {
-                                "input": {
-                                    "type": "string",
-                                    "description": "Input for the plugin"
-                                }
-                            },
-                            "required": ["input"]
-                        }),
+                        default_schema(),
                     )
                 }
             },
@@ -74,16 +65,7 @@ impl WasmTool {
                 (
                     fallback_name.clone(),
                     fallback_description.clone(),
-                    serde_json::json!({
-                        "type": "object",
-                        "properties": {
-                            "input": {
-                                "type": "string",
-                                "description": "Input for the plugin"
-                            }
-                        },
-                        "required": ["input"]
-                    }),
+                    default_schema(),
                 )
             }
         };
@@ -96,6 +78,22 @@ impl WasmTool {
             permissions,
         }
     }
+}
+
+/// The JSON Schema returned when a plugin lacks a `tool_metadata` export or fails
+/// to load at discovery time. Single source of truth so the fallback shape stays
+/// consistent across code paths.
+fn default_schema() -> Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "input": {
+                "type": "string",
+                "description": "Input for the plugin"
+            }
+        },
+        "required": ["input"]
+    })
 }
 
 #[async_trait]

--- a/crates/zeroclaw-plugins/src/wasm_tool.rs
+++ b/crates/zeroclaw-plugins/src/wasm_tool.rs
@@ -1,32 +1,100 @@
 //! Bridge between WASM plugins and the Tool trait.
 
+use crate::runtime;
+use crate::PluginPermission;
 use async_trait::async_trait;
 use serde_json::Value;
+use std::path::PathBuf;
 use zeroclaw_api::tool::{Tool, ToolResult};
 
 /// A tool backed by a WASM plugin function.
 pub struct WasmTool {
     name: String,
     description: String,
-    plugin_name: String,
-    function_name: String,
     parameters_schema: Value,
+    wasm_path: PathBuf,
+    permissions: Vec<PluginPermission>,
 }
 
 impl WasmTool {
     pub fn new(
         name: String,
         description: String,
-        plugin_name: String,
-        function_name: String,
         parameters_schema: Value,
+        wasm_path: PathBuf,
+        permissions: Vec<PluginPermission>,
     ) -> Self {
         Self {
             name,
             description,
-            plugin_name,
-            function_name,
             parameters_schema,
+            wasm_path,
+            permissions,
+        }
+    }
+
+    /// Create a WasmTool by loading metadata from the plugin's `tool_metadata` export.
+    /// Falls back to manifest-supplied values if the export is missing.
+    pub fn from_wasm(
+        wasm_path: PathBuf,
+        permissions: Vec<PluginPermission>,
+        fallback_name: String,
+        fallback_description: String,
+    ) -> Self {
+        // Try to load metadata from the WASM module itself.
+        let (name, description, schema) =
+            match runtime::create_plugin(&wasm_path, &permissions) {
+                Ok(mut plugin) => match runtime::call_tool_metadata(&mut plugin) {
+                    Ok(meta) => (meta.name, meta.description, meta.parameters_schema),
+                    Err(e) => {
+                        tracing::debug!(
+                            "plugin at {} has no tool_metadata export ({e}), using fallback",
+                            wasm_path.display()
+                        );
+                        (
+                            fallback_name.clone(),
+                            fallback_description.clone(),
+                            serde_json::json!({
+                                "type": "object",
+                                "properties": {
+                                    "input": {
+                                        "type": "string",
+                                        "description": "Input for the plugin"
+                                    }
+                                },
+                                "required": ["input"]
+                            }),
+                        )
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        "failed to load WASM plugin at {} for metadata: {e}",
+                        wasm_path.display()
+                    );
+                    (
+                        fallback_name.clone(),
+                        fallback_description.clone(),
+                        serde_json::json!({
+                            "type": "object",
+                            "properties": {
+                                "input": {
+                                    "type": "string",
+                                    "description": "Input for the plugin"
+                                }
+                            },
+                            "required": ["input"]
+                        }),
+                    )
+                }
+            };
+
+        Self {
+            name,
+            description,
+            parameters_schema: schema,
+            wasm_path,
+            permissions,
         }
     }
 }
@@ -46,18 +114,15 @@ impl Tool for WasmTool {
     }
 
     async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
-        // TODO: Call into Extism plugin runtime
-        // For now, return a placeholder indicating the plugin system is available
-        // but not yet wired to actual WASM execution.
-        Ok(ToolResult {
-            success: false,
-            output: format!(
-                "[plugin:{}/{}] WASM execution not yet connected. Args: {}",
-                self.plugin_name,
-                self.function_name,
-                serde_json::to_string(&args).unwrap_or_default()
-            ),
-            error: Some("WASM execution bridge not yet implemented".into()),
+        let wasm_path = self.wasm_path.clone();
+        let permissions = self.permissions.clone();
+        let args_json = serde_json::to_vec(&args)?;
+
+        // Extism Plugin is !Send, so we must create it inside spawn_blocking.
+        tokio::task::spawn_blocking(move || {
+            let mut plugin = runtime::create_plugin(&wasm_path, &permissions)?;
+            runtime::call_execute(&mut plugin, &args_json)
         })
+        .await?
     }
 }

--- a/crates/zeroclaw-plugins/src/wasm_tool.rs
+++ b/crates/zeroclaw-plugins/src/wasm_tool.rs
@@ -1,7 +1,7 @@
 //! Bridge between WASM plugins and the Tool trait.
 
-use crate::runtime;
 use crate::PluginPermission;
+use crate::runtime;
 use async_trait::async_trait;
 use serde_json::Value;
 use std::path::PathBuf;
@@ -42,34 +42,12 @@ impl WasmTool {
         fallback_description: String,
     ) -> Self {
         // Try to load metadata from the WASM module itself.
-        let (name, description, schema) =
-            match runtime::create_plugin(&wasm_path, &permissions) {
-                Ok(mut plugin) => match runtime::call_tool_metadata(&mut plugin) {
-                    Ok(meta) => (meta.name, meta.description, meta.parameters_schema),
-                    Err(e) => {
-                        tracing::debug!(
-                            "plugin at {} has no tool_metadata export ({e}), using fallback",
-                            wasm_path.display()
-                        );
-                        (
-                            fallback_name.clone(),
-                            fallback_description.clone(),
-                            serde_json::json!({
-                                "type": "object",
-                                "properties": {
-                                    "input": {
-                                        "type": "string",
-                                        "description": "Input for the plugin"
-                                    }
-                                },
-                                "required": ["input"]
-                            }),
-                        )
-                    }
-                },
+        let (name, description, schema) = match runtime::create_plugin(&wasm_path, &permissions) {
+            Ok(mut plugin) => match runtime::call_tool_metadata(&mut plugin) {
+                Ok(meta) => (meta.name, meta.description, meta.parameters_schema),
                 Err(e) => {
-                    tracing::warn!(
-                        "failed to load WASM plugin at {} for metadata: {e}",
+                    tracing::debug!(
+                        "plugin at {} has no tool_metadata export ({e}), using fallback",
                         wasm_path.display()
                     );
                     (
@@ -87,7 +65,28 @@ impl WasmTool {
                         }),
                     )
                 }
-            };
+            },
+            Err(e) => {
+                tracing::warn!(
+                    "failed to load WASM plugin at {} for metadata: {e}",
+                    wasm_path.display()
+                );
+                (
+                    fallback_name.clone(),
+                    fallback_description.clone(),
+                    serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "input": {
+                                "type": "string",
+                                "description": "Input for the plugin"
+                            }
+                        },
+                        "required": ["input"]
+                    }),
+                )
+            }
+        };
 
         Self {
             name,

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -927,14 +927,12 @@ pub fn all_tools_with_runtime(
                     let details = host.tool_plugin_details();
                     let count = details.len();
                     for (manifest, wasm_path) in details {
-                        tool_arcs.push(Arc::new(
-                            zeroclaw_plugins::wasm_tool::WasmTool::from_wasm(
-                                wasm_path.to_path_buf(),
-                                manifest.permissions.clone(),
-                                manifest.name.clone(),
-                                manifest.description.clone().unwrap_or_default(),
-                            ),
-                        ));
+                        tool_arcs.push(Arc::new(zeroclaw_plugins::wasm_tool::WasmTool::from_wasm(
+                            wasm_path.to_path_buf(),
+                            manifest.permissions.clone(),
+                            manifest.name.clone(),
+                            manifest.description.clone().unwrap_or_default(),
+                        )));
                     }
                     tracing::info!("Loaded {count} WASM plugin tools");
                 }

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -924,25 +924,17 @@ pub fn all_tools_with_runtime(
                 plugin_path.parent().unwrap_or(&plugin_path),
             ) {
                 Ok(host) => {
-                    let tool_manifests = host.tool_plugins();
-                    let count = tool_manifests.len();
-                    for manifest in tool_manifests {
-                        tool_arcs.push(Arc::new(zeroclaw_plugins::wasm_tool::WasmTool::new(
-                            manifest.name.clone(),
-                            manifest.description.clone().unwrap_or_default(),
-                            manifest.name.clone(),
-                            "call".to_string(),
-                            serde_json::json!({
-                                "type": "object",
-                                "properties": {
-                                    "input": {
-                                        "type": "string",
-                                        "description": "Input for the plugin"
-                                    }
-                                },
-                                "required": ["input"]
-                            }),
-                        )));
+                    let details = host.tool_plugin_details();
+                    let count = details.len();
+                    for (manifest, wasm_path) in details {
+                        tool_arcs.push(Arc::new(
+                            zeroclaw_plugins::wasm_tool::WasmTool::from_wasm(
+                                wasm_path.to_path_buf(),
+                                manifest.permissions.clone(),
+                                manifest.name.clone(),
+                                manifest.description.clone().unwrap_or_default(),
+                            ),
+                        ));
                     }
                     tracing::info!("Loaded {count} WASM plugin tools");
                 }

--- a/docs/architecture/decisions/adr-003-wasm-extism-plugin-model.md
+++ b/docs/architecture/decisions/adr-003-wasm-extism-plugin-model.md
@@ -1,0 +1,134 @@
+---
+type: adr
+status: accepted
+last-reviewed: 2026-04-19
+relates-to:
+  - crates/zeroclaw-plugins
+  - crates/zeroclaw-api
+---
+
+# ADR-003: WASM + Extism Plugin Execution Model
+
+**Status:** Accepted
+
+**Date:** 2026-03-15
+
+**Note:** This retroactively records a decision made prior to the formal ADR
+process. The date reflects when the decision was made, not when this record
+was written.
+
+## Context
+
+ZeroClaw compiles 70+ tools and 30+ channels into a single monolithic binary.
+Every user pays the compile time and binary size for capabilities they may never
+use. Third-party developers cannot extend ZeroClaw without forking the
+repository and writing Rust code against internal APIs.
+
+The [Intentional Architecture RFC](https://github.com/zeroclaw-labs/zeroclaw/wiki/14.1-Intentional-Architecture)
+defines a microkernel target where non-core tools and channels become loadable
+plugins. This requires a sandboxed execution model that:
+
+1. Runs untrusted code without compromising the host process.
+2. Works on all targets (Linux, macOS, Windows, ARM, x86_64).
+3. Supports capability-based permissions (HTTP access, env var reads, file I/O).
+4. Allows plugins to be written in any language that compiles to WASM.
+5. Adds minimal binary size when the feature is unused.
+
+Three WASM runtime options were evaluated:
+
+| Runtime | Pros | Cons |
+|---------|------|------|
+| **Extism** (wraps wasmtime) | High-level SDK, built-in host function system, PDK for Rust/Go/C/JS, active maintenance | Adds ~20-30 MB behind feature flag |
+| **wasmtime** (raw) | Maximum control, mature | Requires building ABI, memory protocol, and host function system from scratch |
+| **wasmer** | LLVM and Cranelift backends | Smaller ecosystem, less Rust-native host function ergonomics |
+
+## Decision
+
+We will use **Extism 1.x** as the WASM plugin runtime, accessed through the
+`plugins-wasm` feature flag.
+
+### Plugin protocol
+
+Plugins are WASM modules that export two functions:
+
+- `tool_metadata(String) -> String` — returns JSON with `name`, `description`,
+  and `parameters_schema` fields.
+- `execute(String) -> String` — receives tool arguments as JSON, returns a JSON
+  result with `success`, `output`, and optional `error` fields.
+
+### Host functions
+
+The runtime provides two permission-gated host functions:
+
+- `zc_http_request(String) -> String` — makes HTTP requests on behalf of the
+  plugin. Gated on `PluginPermission::HttpClient`.
+- `zc_env_read(String) -> String` — reads environment variables. Gated on
+  `PluginPermission::EnvRead`.
+
+Extism's built-in HTTP support (`extism_http_request`) is deliberately not used
+because it bypasses permission enforcement.
+
+### Plugin manifest
+
+Each plugin ships a `manifest.toml` alongside its `.wasm` file declaring name,
+version, capabilities (`tool`, `channel`, `memory`, `observer`), and required
+permissions (`http_client`, `env_read`, `file_read`, `file_write`,
+`memory_read`, `memory_write`).
+
+### Signature verification
+
+Plugin manifests support optional Ed25519 signatures with three enforcement
+modes: `disabled` (default), `permissive` (warn), and `strict` (reject
+unsigned). Signatures use the `ring` crate.
+
+### Plugin authoring
+
+Plugin authors depend on `extism-pdk` (the Extism project's guest SDK) and
+compile to `wasm32-wasip1`. No ZeroClaw-specific SDK crate is required — the
+protocol is documented and the JSON contracts are simple enough to implement
+directly.
+
+## Consequences
+
+### Positive
+
+- **Sandboxing:** WASM linear memory isolation prevents plugins from accessing
+  host memory. Permission-gated host functions enforce capability boundaries.
+- **Portability:** WASM modules run on any platform wasmtime supports.
+- **Language freedom:** Any language with a `wasm32-wasip1` target can produce
+  plugins (Rust, Go, C, AssemblyScript, Zig).
+- **Feature-gated cost:** Users who disable `plugins-wasm` pay zero binary size
+  or compile time overhead.
+- **Ecosystem:** Extism's existing PDK ecosystem reduces plugin authoring
+  friction.
+
+### Negative
+
+- **Binary size:** The `extism` crate (wrapping wasmtime) adds ~20-30 MB to the
+  binary when the `plugins-wasm` feature is enabled.
+- **External dependency:** Plugin authors must depend on `extism-pdk`, a
+  third-party crate outside our control.
+- **Incomplete:** The channel plugin bridge (`wasm_channel.rs`) is not yet
+  connected to the Extism runtime — only tool plugins are functional.
+  Channel plugins are Phase 3 (v0.9.0) per the Intentional Architecture RFC.
+- **Sync bridging:** Extism plugin calls are synchronous; the `Tool` trait is
+  async. Each call uses `tokio::task::spawn_blocking`, creating a fresh plugin
+  instance per invocation since Extism `Plugin` is `!Send`.
+
+### Neutral
+
+- Plugin discovery uses the existing `~/.zeroclaw/plugins/` directory
+  convention. No registry server is required yet (registry is a Phase 4
+  deliverable).
+
+## References
+
+- `crates/zeroclaw-plugins/src/runtime.rs` — Extism execution bridge
+- `crates/zeroclaw-plugins/src/wasm_tool.rs` — Tool trait bridge
+- `crates/zeroclaw-plugins/src/host.rs` — Plugin discovery and manifest loading
+- `crates/zeroclaw-plugins/src/signature.rs` — Ed25519 verification
+- `crates/zeroclaw-config/src/schema.rs` — `PluginsConfig`, `ImageGenConfig`
+- `crates/zeroclaw-runtime/src/tools/mod.rs` — Plugin tool registration
+- `plugins/image-gen-wasm/` — Reference plugin implementation
+- [Extism documentation](https://extism.org/docs/overview)
+- [Intentional Architecture RFC](https://github.com/zeroclaw-labs/zeroclaw/wiki/14.1-Intentional-Architecture)

--- a/docs/architecture/decisions/adr-003-wasm-extism-plugin-model.md
+++ b/docs/architecture/decisions/adr-003-wasm-extism-plugin-model.md
@@ -121,6 +121,33 @@ directly.
   convention. No registry server is required yet (registry is a Phase 4
   deliverable).
 
+### Known gaps (tracked follow-ups)
+
+The host-function surface is intentionally minimal in this initial version.
+Three gaps are acknowledged and have tracking issues filed; they do not block
+the v1 bridge but must be closed before plugins can be treated as a
+lower-trust surface than native tools:
+
+- **SSRF in `zc_http_request`** — the host function forwards any plugin-supplied
+  URL to `reqwest` without private-IP, loopback, or link-local restriction. A
+  plugin granted `http_client` can reach cloud IMDS endpoints, local admin
+  services, or the ZeroClaw gateway itself. Tracked in [#5918](https://github.com/zeroclaw-labs/zeroclaw/issues/5918).
+  Native `HttpRequestTool::is_private_or_local_host()` is the reuse target.
+- **Unbounded `zc_env_read`** — `env_read` permission grants access to *any*
+  variable by name, including unrelated secrets (`AWS_SECRET_ACCESS_KEY`,
+  `ANTHROPIC_API_KEY`, etc.). Tracked in [#5919](https://github.com/zeroclaw-labs/zeroclaw/issues/5919).
+  Preferred fix: per-plugin manifest allowlist (`env_read_vars = [...]`).
+- **CPU exhaustion** — no fuel limit or epoch interruption on Extism plugins.
+  An adversarial plugin can loop indefinitely and hold a blocking-pool thread
+  until the 120s HTTP timeout (if any request is outstanding) or forever (if
+  no host call is in flight). Out of scope for D2; to be addressed when
+  plugins are exposed to untrusted authors.
+
+The first two are the operational prerequisites for accepting plugins from
+third-party sources. Until they land, the permission model is a documentation
+contract, not a hardened boundary — operators should only install plugins
+from sources they already trust at the manifest level.
+
 ## References
 
 - `crates/zeroclaw-plugins/src/runtime.rs` — Extism execution bridge
@@ -129,6 +156,6 @@ directly.
 - `crates/zeroclaw-plugins/src/signature.rs` — Ed25519 verification
 - `crates/zeroclaw-config/src/schema.rs` — `PluginsConfig`, `ImageGenConfig`
 - `crates/zeroclaw-runtime/src/tools/mod.rs` — Plugin tool registration
-- `plugins/image-gen-wasm/` — Reference plugin implementation
+- `plugins/image-gen-fal/` — Reference plugin implementation (lands in a follow-up PR)
 - [Extism documentation](https://extism.org/docs/overview)
 - [Intentional Architecture RFC](https://github.com/zeroclaw-labs/zeroclaw/wiki/14.1-Intentional-Architecture)

--- a/docs/reference/api/plugin-protocol.md
+++ b/docs/reference/api/plugin-protocol.md
@@ -1,0 +1,279 @@
+---
+type: reference
+status: accepted
+last-reviewed: 2026-04-19
+relates-to:
+  - ADR-003
+  - crates/zeroclaw-plugins
+---
+
+# WASM Plugin Protocol Reference
+
+This document defines the protocol between ZeroClaw's plugin host and WASM
+plugin modules. See [ADR-003](../../architecture/decisions/adr-003-wasm-extism-plugin-model.md)
+for the architectural rationale.
+
+## Plugin structure
+
+A plugin is a directory containing:
+
+```
+my-plugin/
+  manifest.toml    # Plugin metadata and permissions
+  plugin.wasm      # Compiled WASM module
+```
+
+Plugins are discovered from `~/.zeroclaw/plugins/` (configurable via
+`plugins.plugins_dir` in config).
+
+## Manifest format
+
+```toml
+name = "my-plugin"                    # Unique identifier (required)
+version = "0.1.0"                     # Semver version (required)
+description = "What this plugin does" # Human-readable (optional)
+author = "Your Name"                  # Author (optional)
+wasm_path = "plugin.wasm"             # Path to .wasm relative to manifest (required)
+capabilities = ["tool"]               # What the plugin provides (required)
+permissions = ["http_client"]          # What the plugin needs (optional)
+signature = "base64url..."            # Ed25519 signature (optional)
+publisher_key = "hex..."              # Publisher public key (optional)
+```
+
+### Capabilities
+
+| Value | Description |
+|-------|-------------|
+| `tool` | Provides tools callable by the LLM |
+| `channel` | Provides a communication channel (not yet implemented) |
+| `memory` | Provides a memory backend (not yet implemented) |
+| `observer` | Provides an observability backend (not yet implemented) |
+
+### Permissions
+
+| Value | Description |
+|-------|-------------|
+| `http_client` | Can make HTTP requests via `zc_http_request` |
+| `env_read` | Can read environment variables via `zc_env_read` |
+| `file_read` | Can read files (not yet implemented) |
+| `file_write` | Can write files (not yet implemented) |
+| `memory_read` | Can read agent memory (not yet implemented) |
+| `memory_write` | Can write agent memory (not yet implemented) |
+
+## Required WASM exports
+
+### `tool_metadata`
+
+**Signature:** `(String) -> String`
+
+Called once at plugin load time to retrieve tool metadata. The input string is
+ignored (pass empty string). Returns JSON:
+
+```json
+{
+  "name": "my_tool",
+  "description": "What this tool does",
+  "parameters_schema": {
+    "type": "object",
+    "required": ["prompt"],
+    "properties": {
+      "prompt": {
+        "type": "string",
+        "description": "The input prompt"
+      }
+    }
+  }
+}
+```
+
+The `parameters_schema` follows JSON Schema format and is presented to the LLM
+for tool calling.
+
+### `execute`
+
+**Signature:** `(String) -> String`
+
+Called each time the tool is invoked. Input is JSON matching the
+`parameters_schema`. Returns JSON:
+
+```json
+{
+  "success": true,
+  "output": "Result text shown to the LLM",
+  "error": null
+}
+```
+
+On failure:
+
+```json
+{
+  "success": false,
+  "output": "",
+  "error": "Description of what went wrong"
+}
+```
+
+## Host functions
+
+Host functions are provided by the ZeroClaw runtime and callable from within
+the WASM plugin. Each is gated on a manifest permission — calling without the
+required permission returns an error.
+
+### `zc_http_request`
+
+**Permission:** `http_client`
+
+**Input:** JSON string
+
+```json
+{
+  "method": "POST",
+  "url": "https://api.example.com/v1/generate",
+  "headers": {
+    "Authorization": "Bearer token123",
+    "Content-Type": "application/json"
+  },
+  "body": "{\"prompt\": \"hello\"}"
+}
+```
+
+Supported methods: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`.
+Timeout: 120 seconds.
+
+**Output:** JSON string
+
+```json
+{
+  "status": 200,
+  "body": "{\"result\": \"world\"}",
+  "headers": {
+    "content-type": "application/json"
+  }
+}
+```
+
+### `zc_env_read`
+
+**Permission:** `env_read`
+
+**Input:** Environment variable name (plain string, not JSON).
+
+**Output:** Environment variable value (plain string). Returns an error if the
+variable is not set.
+
+## Writing a plugin in Rust
+
+### Dependencies
+
+```toml
+[package]
+name = "my-plugin"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+extism-pdk = "1.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+[workspace]
+```
+
+The `[workspace]` table is needed to prevent Cargo from searching for a parent
+workspace.
+
+### Declaring host functions
+
+```rust
+use extism_pdk::*;
+
+#[host_fn]
+extern "ExtismHost" {
+    fn zc_http_request(input: String) -> String;
+    fn zc_env_read(input: String) -> String;
+}
+```
+
+Call them with `unsafe { zc_http_request(json_string)? }`.
+
+### Implementing exports
+
+```rust
+#[plugin_fn]
+pub fn tool_metadata(_input: String) -> FnResult<String> {
+    Ok(serde_json::to_string(&serde_json::json!({
+        "name": "my_tool",
+        "description": "Does something useful",
+        "parameters_schema": {
+            "type": "object",
+            "required": ["input"],
+            "properties": {
+                "input": { "type": "string" }
+            }
+        }
+    }))?)
+}
+
+#[plugin_fn]
+pub fn execute(input: String) -> FnResult<String> {
+    let args: serde_json::Value = serde_json::from_str(&input)?;
+    let input_val = args["input"].as_str().unwrap_or("");
+
+    // ... do work, call host functions as needed ...
+
+    Ok(serde_json::to_string(&serde_json::json!({
+        "success": true,
+        "output": format!("Processed: {input_val}")
+    }))?)
+}
+```
+
+### Building
+
+```bash
+# Install the WASM target (once)
+rustup target add wasm32-wasip1
+
+# Build
+cargo build --target wasm32-wasip1 --release
+```
+
+The output `.wasm` file is at
+`target/wasm32-wasip1/release/<crate_name>.wasm`. Copy it alongside your
+`manifest.toml`.
+
+### Installing
+
+```bash
+# Copy to plugin directory
+zeroclaw plugin install /path/to/my-plugin/
+
+# Or manually
+cp -r my-plugin/ ~/.zeroclaw/plugins/my-plugin/
+```
+
+## Reference implementation
+
+See `plugins/image-gen-wasm/` in the repository for a complete example that
+generates images via the fal.ai API using `zc_http_request` and `zc_env_read`.
+
+## Configuration
+
+Enable the plugin system in your ZeroClaw config:
+
+```toml
+[plugins]
+enabled = true
+plugins_dir = "~/.zeroclaw/plugins"
+auto_discover = true
+
+[plugins.security]
+signature_mode = "disabled"  # or "permissive", "strict"
+trusted_publisher_keys = []
+```
+
+The `plugins-wasm` feature flag must be enabled at compile time (included in the
+default `ci-all` feature set).


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `WasmTool::execute` was a TODO placeholder returning `"WASM execution bridge not yet implemented"`. This PR wires Extism 1.21 into the plugin runtime so WASM plugins can actually execute inside ZeroClaw, implementing Phase 2 D2 of the Intentional Architecture RFC.
  - Two permission-gated host functions (`zc_http_request` for `HttpClient`, `zc_env_read` for `EnvRead`) enforce the `PluginPermission` model at the host boundary — this is the first deliverable that actually validates the permission enum.
  - `WasmTool::from_wasm` loads tool metadata (name, description, JSON Schema) from the plugin's `tool_metadata` export, replacing the hardcoded placeholder schema previously used in `all_tools_with_runtime()`.
  - Async `Tool` trait bridges to Extism's sync calls via `tokio::task::spawn_blocking` — Extism `Plugin` is `!Send`, so a fresh instance is created per call (instantiation is fast; module caching handles the expensive compile step).
  - Documentation follows RFC #5576 standards: ADR-003 records the Extism vs wasmtime/wasmer decision retroactively; `docs/reference/api/plugin-protocol.md` specifies the JSON contracts so plugin authors can build against `extism-pdk` directly with no ZeroClaw-specific SDK; `crates/zeroclaw-plugins/AGENTS.md` follows the per-crate template.
- **Scope boundary:** This PR does NOT add a reference plugin, does NOT wire `WasmChannel` (channel plugin bridge is Phase 3 per the RFC), and does NOT introduce a plugin registry client. The reference plugin lands in a follow-up stacked PR (`feat/wasm-image-gen-plugin`).
- **Blast radius:** Only code paths gated by `--features plugins-wasm` change. Default builds, CI without `plugins-wasm`, and users who haven't enabled plugins see zero behavior change. The `extism` dependency adds ~20-30 MB to builds that opt in.
- **Linked issue(s):** `Closes #5912`, `Related #5574`, `Related #5576`, `Related #5617`

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-plugins --all-targets -- -D warnings
cargo clippy -p zeroclaw-runtime --features plugins-wasm --all-targets -- -D warnings
cargo test -p zeroclaw-plugins
```

- **Commands run and tail output:**

  `cargo fmt --all -- --check` — clean (no output).

  `cargo clippy -p zeroclaw-plugins --all-targets -- -D warnings`:
  ```
      Checking zeroclaw-api v0.7.3 (/Users/jordantian/zeroclaw/crates/zeroclaw-api)
      Checking zeroclaw-plugins v0.7.3 (/Users/jordantian/zeroclaw/crates/zeroclaw-plugins)
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.49s
  ```

  `cargo clippy -p zeroclaw-runtime --features plugins-wasm --all-targets -- -D warnings`:
  ```
      Checking zeroclaw-plugins v0.7.3 (/Users/jordantian/zeroclaw/crates/zeroclaw-plugins)
      Checking zeroclaw-runtime v0.7.3 (/Users/jordantian/zeroclaw/crates/zeroclaw-runtime)
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 24s
  ```

  `cargo test -p zeroclaw-plugins`:
  ```
  test runtime::tests::missing_wasm_file_returns_error ... ok

  test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s
  ```

- **Beyond CI — what did you manually verify?**
  - Built the stacked image-gen reference plugin against this branch (`cargo build --target wasm32-wasip1 --release` → 285 KB `.wasm`).
  - Exercised end-to-end on the stacked branch: the WASM plugin's `tool_metadata` export is invoked, JSON Schema is parsed, and `execute` runs with permission enforcement. 4 integration tests load the built plugin and verify error paths (missing prompt, invalid size, model traversal protection, metadata roundtrip).
  - Verified `cargo check -p zeroclaw-runtime` WITHOUT `plugins-wasm` still compiles — the feature gate is clean.
  - Did NOT verify: behavior under WASM module with a deliberately malformed export (Extism error reporting is assumed correct based on its test suite).

- **If any command was intentionally skipped, why:** Full workspace `cargo test` not run; the only code path touched is under `plugins-wasm` feature and is exercised by the crate-scoped run above.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No` — WASM plugins run in Extism's sandbox with no filesystem access by default. Future `file_read`/`file_write` host functions are declared in `PluginPermission` but not implemented here.
- New external network calls? `Yes` — `zc_http_request` host function allows WASM plugins to make HTTP calls via `reqwest::blocking`, but only when the plugin's manifest declares `http_client` permission. Without that permission, the host function returns a permission-denied error without touching the network.
- Secrets / tokens / credentials handling changed? `Yes` — `zc_env_read` host function lets plugins read environment variables (e.g., API keys), gated on the `env_read` permission. This is the same mechanism native tools already use; WASM plugins are no more privileged than native tool code.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`.
- **Risk and mitigation:** The WASM sandbox + permission-gated host functions mean a plugin can do less than a native tool, not more. Signature verification (landed in #4520) provides a separate trust boundary. ADR-003 captures the threat model in full.

## Compatibility (required)

- Backward compatible? `Yes` — changes are gated behind the existing `plugins-wasm` feature flag. Users without `plugins-wasm` see no difference.
- Config / env / CLI surface changed? `No` — existing `[plugins]` config schema, CLI subcommands, and gateway API are unchanged.
- Upgrade steps: none required. Users who want to author plugins should consult the new `docs/reference/api/plugin-protocol.md`.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk. `git revert <sha>` is the plan — reverting reinstates the TODO placeholder in `WasmTool::execute`; existing plugin scaffolding (discovery, signatures, CLI) continues to work unchanged.

## i18n Follow-Through (required only when docs or user-facing wording change)

- Locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales? `N.A.`
- Localized runtime-contract docs updated? `N.A.`
- Vietnamese canonical docs synced? `N.A.`
- **Scope decision:** New docs (`adr-003-*.md`, `plugin-protocol.md`, `AGENTS.md`) are architecture/contributor-facing English-only per RFC #5576 Documentation Standards ("All repository documents: English only"). No user-facing README/CLI/config wording changed.