### PR TITLE
ci: fix Dockerfile COPY fragility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,21 +23,23 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # 1. Copy manifests to cache dependencies
 COPY Cargo.toml Cargo.lock ./
-# Include every workspace member: Cargo.lock is generated for the full workspace.
-# Previously we used sed to drop `crates/robot-kit`, which made the manifest disagree
-# with the lockfile and caused `cargo --locked` to fail (Cargo refused to rewrite the lock).
-COPY crates/robot-kit/ crates/robot-kit/
-COPY crates/aardvark-sys/ crates/aardvark-sys/
-# Include tauri workspace member manifest (desktop app, but needed for workspace resolution).
-# .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
+# Copy every workspace-member manifest in one glob — adding or removing a crate
+# no longer requires editing this file.  --parents preserves the
+# crates/<name>/Cargo.toml directory structure.
+# aardvark-sys has an implicit build script (build.rs at its crate root) that
+# Cargo must compile during the dependency pre-fetch step; copy it explicitly.
+COPY --parents crates/*/Cargo.toml ./
+COPY --parents crates/aardvark-sys/build.rs ./
+# apps/tauri: .dockerignore whitelists only Cargo.toml; src and build.rs are stubbed below.
 COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
-# Create dummy targets declared in Cargo.toml so manifest parsing succeeds.
+# Create dummy targets for all workspace members so manifest parsing succeeds.
 RUN mkdir -p src benches apps/tauri/src \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
     && echo "fn main() {}" > benches/agent_benchmarks.rs \
     && echo "fn main() {}" > apps/tauri/src/main.rs \
-    && echo "fn main() {}" > apps/tauri/build.rs
+    && echo "fn main() {}" > apps/tauri/build.rs \
+    && for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -38,19 +38,22 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # 1. Copy manifests to cache dependencies
 COPY Cargo.toml Cargo.lock ./
-# Include every workspace member: Cargo.lock is generated for the full workspace.
-# Previously we used sed to drop `crates/robot-kit`, which made the manifest disagree
-# with the lockfile and caused `cargo --locked` to fail (Cargo refused to rewrite the lock).
-COPY crates/robot-kit/ crates/robot-kit/
-COPY crates/aardvark-sys/ crates/aardvark-sys/
-COPY crates/zeroclaw-macros/ crates/zeroclaw-macros/
-COPY apps/tauri/ apps/tauri/
-# Create dummy targets declared in Cargo.toml so manifest parsing succeeds.
+# Copy every workspace-member manifest in one glob — adding or removing a crate
+# no longer requires editing this file.  --parents preserves the
+# crates/<name>/Cargo.toml directory structure.
+# aardvark-sys has an implicit build script (build.rs at its crate root) that
+# Cargo must compile during the dependency pre-fetch step; copy it explicitly.
+COPY --parents crates/*/Cargo.toml ./
+COPY --parents crates/aardvark-sys/build.rs ./
+# apps/tauri: .dockerignore whitelists only Cargo.toml; src is stubbed below.
+COPY apps/tauri/Cargo.toml apps/tauri/Cargo.toml
+# Create dummy targets for all workspace members so manifest parsing succeeds.
 RUN mkdir -p src benches apps/tauri/src \
     && echo "fn main() {}" > src/main.rs \
     && echo "" > src/lib.rs \
     && echo "fn main() {}" > benches/agent_benchmarks.rs \
-    && echo "fn main() {}" > apps/tauri/src/main.rs
+    && echo "fn main() {}" > apps/tauri/src/main.rs \
+    && for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done
 RUN --mount=type=cache,id=zeroclaw-cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,id=zeroclaw-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=zeroclaw-target,target=/app/target,sharing=locked \


### PR DESCRIPTION
## What was fragile

The builder stages in `Dockerfile` and `Dockerfile.debian` had two independent COPY problems:

### 1. Hardcoded per-crate full-directory COPYs — busts dep-cache on every source edit

```dockerfile
# Dockerfile
COPY crates/robot-kit/ crates/robot-kit/       # copies full src tree
COPY crates/aardvark-sys/ crates/aardvark-sys/ # copies full src tree

# Dockerfile.debian (additionally)
COPY crates/zeroclaw-macros/ crates/zeroclaw-macros/
COPY apps/tauri/ apps/tauri/
```

Copying the entire directory (including `src/`) into the manifest-copy layer means *any* source-file edit in those crates invalidates the Docker layer cache for the full dependency fetch/compile step — exactly the expensive step caching is supposed to protect.

### 2. Missing manifests for every other workspace crate — breaks fresh builds when crates are added

Only 2–3 specific crates were listed; all 13+ other workspace members (`zeroclaw-api`, `zeroclaw-channels`, `zeroclaw-config`, `zeroclaw-gateway`, `zeroclaw-hardware`, `zeroclaw-infra`, `zeroclaw-memory`, `zeroclaw-macros`, `zeroclaw-plugins`, `zeroclaw-providers`, `zeroclaw-runtime`, `zeroclaw-tool-call-parser`, `zeroclaw-tools`, `zeroclaw-tui`) had no `Cargo.toml` in the image at all. Cargo cannot resolve the workspace without all member manifests, so every newly-added crate silently broke fresh (non-cached) builds.

---

## What was changed

**`Dockerfile` and `Dockerfile.debian` — builder stage only:**

```dockerfile
# Before (hardcoded list, copies full source trees)
COPY crates/robot-kit/ crates/robot-kit/
COPY crates/aardvark-sys/ crates/aardvark-sys/

# After (single glob, manifests only)
COPY --parents crates/*/Cargo.toml ./
COPY --parents crates/aardvark-sys/build.rs ./
```

- `--parents` (Dockerfile syntax 1.7, already declared) preserves the `crates/<name>/Cargo.toml` directory structure.
- `aardvark-sys/build.rs` is still copied explicitly because that crate uses an implicit build script that Cargo must compile during the dep pre-fetch step.
- The dummy-stub `RUN` step gains a one-liner loop — `for d in crates/*/; do mkdir -p "${d}src" && printf '' > "${d}src/lib.rs"; done` — so every current and future workspace crate gets a stub `lib.rs` without any per-crate hardcoding.

**`Dockerfile.ci` and `Dockerfile.debian.ci`:** unchanged — these use pre-built binaries with no Rust compilation.

---

## Risk

- No runtime behaviour change; build-stage restructuring only.
- Dockerfile syntax 1.7 (`--parents`) is already declared at the top of both affected files.
- The glob `crates/*/Cargo.toml` matches exactly the same set of paths that were previously hardcoded, plus all previously-missing members.

Closes #5885
Part of #5877