### PR TITLE
ci: pin all unpinned action refs in surviving workflows

### DIFF
--- a/.github/workflows/cross-platform-build-manual.yml
+++ b/.github/workflows/cross-platform-build-manual.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: web/package-lock.json
       - name: Build web dashboard
         run: cd web && npm ci && npm run build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: web-dist
           path: web/dist/
@@ -62,7 +62,7 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
         if: runner.os != 'Windows'
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: web-dist
           path: web/dist/

--- a/.github/workflows/pub-aur.yml
+++ b/.github/workflows/pub-aur.yml
@@ -42,7 +42,7 @@ jobs:
       RELEASE_TAG: ${{ inputs.release_tag }}
       DRY_RUN: ${{ inputs.dry_run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pub-homebrew-core.yml
+++ b/.github/workflows/pub-homebrew-core.yml
@@ -48,7 +48,7 @@ jobs:
       BOT_FORK_REPO: ${{ vars.HOMEBREW_CORE_BOT_FORK_REPO }}
       BOT_EMAIL: ${{ vars.HOMEBREW_CORE_BOT_EMAIL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pub-scoop.yml
+++ b/.github/workflows/pub-scoop.yml
@@ -43,7 +43,7 @@ jobs:
       DRY_RUN: ${{ inputs.dry_run }}
       SCOOP_BUCKET_REPO: ${{ vars.SCOOP_BUCKET_REPO }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/sync-marketplace-templates.yml
+++ b/.github/workflows/sync-marketplace-templates.yml
@@ -32,7 +32,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Coolify fork
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: zeroclaw-labs/coolify
           token: ${{ secrets.MARKETPLACE_PAT }}
@@ -142,7 +142,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout Dokploy templates fork
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: zeroclaw-labs/dokploy
           token: ${{ secrets.MARKETPLACE_PAT }}
@@ -295,7 +295,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout EasyPanel templates fork
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: zeroclaw-labs/easypanel
           token: ${{ secrets.MARKETPLACE_PAT }}

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -184,7 +184,7 @@ jobs:
           MARKER_FILE="/tmp/tweet-dedup-${TWEET_HASH}"
           echo "$TWEET_HASH" > "$MARKER_FILE"
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: steps.check.outputs.skip != 'true'
         id: tweet-cache
         with:


### PR DESCRIPTION
## Summary

Replace every floating `uses:` tag in the surviving workflow files with a pinned commit SHA, per the repo's **actions-source-policy** (#5872). Tag names are kept as inline comments so humans can still read the version at a glance.

Closes #5872
Part of v0.7.4 — see #5877

---

## Files changed and refs pinned

| Workflow | Refs pinned |
|---|---|
| `.github/workflows/cross-platform-build-manual.yml` | 4 |
| `.github/workflows/sync-marketplace-templates.yml` | 3 |
| `.github/workflows/pub-aur.yml` | 1 |
| `.github/workflows/pub-homebrew-core.yml` | 1 |
| `.github/workflows/pub-scoop.yml` | 1 |
| `.github/workflows/tweet-release.yml` | 1 |
| **Total** | **11** |

**Not modified** (already fully SHA-pinned): `ci-run.yml`, `pr-path-labeler.yml`, `discord-release.yml`

> **@singlerider maintainer note:** `release-stable-manual.yml` and `publish-crates.yml` were listed in the original description but are not in the diff — `publish-crates.yml` was removed by #5929 and `release-stable-manual.yml` was not modified by this PR. Scope and totals updated to reflect the actual six-file diff.

---

## Pin map (old → new)

| Floating ref | Pinned SHA | Comment |
|---|---|---|
| `actions/checkout@v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | `# v4` |
| `actions/setup-node@v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | `# v4` |
| `actions/upload-artifact@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | `# v4` |
| `actions/download-artifact@v8` | `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` | `# v8` |
| `actions/cache@v4` | `0057852bfaa89a56745cba8c7296529d2fc39830` | `# v4` |

All SHAs verified via `gh api repos/{owner}/{repo}/git/ref/tags/{tag}`.

> **Note:** `actions/setup-node@v4`, `dtolnay/rust-toolchain@stable`, and `Swatinem/rust-cache@v2` currently resolve to different SHAs than the ones already pinned in `ci-run.yml` — those floating tags have moved since `ci-run.yml` was last updated. The existing pinned refs in `ci-run.yml` are left untouched per task scope; a follow-up pass can harmonise all refs to a single SHA per action.

---

## Risk

**Low.** Pure ref substitution — no logic, no config, no dependency changes. Functionally identical to the current floating-tag behaviour (same code is run), with the supply-chain guarantee that a tag move cannot silently swap in different code.