### PR TITLE
ci: consolidate ci-run.yml and rewrite CI docs

### DIFF
--- a/.github/workflows/daily-audit.yml
+++ b/.github/workflows/daily-audit.yml
@@ -2,7 +2,7 @@ name: Daily Advisory Scan
 
 on:
   schedule:
-    - cron: '0 9 * * *'
+    - cron: "0 9 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -62,24 +62,22 @@ jobs:
 
           advisory_output=$(cat /tmp/advisory-output.txt)
 
+          {
+            printf '## Advisory scan failed\n\n'
+            printf 'Workflow run: %s\n\n' "${RUN_URL}"
+            printf '```\n%s\n```\n\n' "${advisory_output}"
+            printf 'Review `deny.toml` for the current ignore list. If this advisory is a known\n'
+            printf 'acceptable risk, add an entry with a `reason` field. If it requires a\n'
+            printf 'dependency update, open a tracking issue and link it here.\n\n'
+            printf 'cc @JordanTheJet @theonlyhennygod\n'
+          } > /tmp/issue-body.md
+
           gh issue create \
             --repo "$GITHUB_REPOSITORY" \
             --title "ci: Advisory scan failed — $(date -u +%Y-%m-%d)" \
             --label "security" \
             --label "risk: high" \
-            --body "## Advisory scan failed
-
-Workflow run: ${RUN_URL}
-
-\`\`\`
-${advisory_output}
-\`\`\`
-
-Review \`deny.toml\` for the current ignore list. If this advisory is a known
-acceptable risk, add an entry with a \`reason\` field. If it requires a
-dependency update, open a tracking issue and link it here.
-
-cc @JordanTheJet @theonlyhennygod"
+            --body-file /tmp/issue-body.md
 
       - name: Propagate scan failure
         if: steps.scan.outcome == 'failure'

--- a/.github/workflows/master-branch-flow.md
+++ b/.github/workflows/master-branch-flow.md
@@ -1,133 +1,148 @@
 # Master Branch Delivery Flows
 
-This document explains what runs when code is proposed to `master` and released.
+How code moves from a PR to a shipped release.
 
-Use this with:
+Use with:
 
-- [`docs/ci-map.md`](../../docs/contributing/ci-map.md)
-- [`docs/pr-workflow.md`](../../docs/contributing/pr-workflow.md)
-- [`docs/release-process.md`](../../docs/contributing/release-process.md)
+- [`docs/contributing/ci-map.md`](../../docs/contributing/ci-map.md)
+- [`docs/maintainers/release-runbook.md`](../../docs/maintainers/release-runbook.md)
+
+Last updated: **May 2026** (post-v0.7.4 cleanup).
+
+---
 
 ## Branching Model
 
-ZeroClaw uses a single default branch: `master`. All contributor PRs target `master` directly. There is no `dev` or promotion branch.
+ZeroClaw uses a single default branch: `master`. All contributor PRs target
+`master` directly. There is no `dev` or promotion branch.
 
-Current maintainers with PR approval authority: `theonlyhennygod` and `JordanTheJet`.
+Maintainers with merge authority: `theonlyhennygod` and `JordanTheJet`.
+
+---
 
 ## Active Workflows
 
 | File | Trigger | Purpose |
-| --- | --- | --- |
-| `checks-on-pr.yml` | `pull_request` → `master` | Lint + test + build + security audit on every PR |
-| `cross-platform-build-manual.yml` | `workflow_dispatch` | Full platform build matrix (manual) |
-| `release-beta-on-push.yml` | `push` → `master` | Beta release on every master commit |
-| `release-stable-manual.yml` | `workflow_dispatch` | Stable release (manual, version-gated) |
+|---|---|---|
+| `ci-run.yml` | `pull_request` → `master`, `push` → `master` | Lint + test + build on every PR and every master commit |
+| `release-stable-manual.yml` | `workflow_dispatch`, tag push `v*` | Stable release (manual, version-gated) |
+| `cross-platform-build-manual.yml` | `workflow_dispatch` | Full platform build matrix (manual smoke check) |
+| `pr-path-labeler.yml` | `pull_request` lifecycle | Automatic path-based PR labeling |
+
+---
 
 ## Event Summary
 
-| Event | Workflows triggered |
-| --- | --- |
-| PR opened or updated against `master` | `checks-on-pr.yml` |
-| Push to `master` (including after merge) | `release-beta-on-push.yml` |
-| Manual dispatch | `cross-platform-build-manual.yml`, `release-stable-manual.yml` |
+| Event | What runs |
+|---|---|
+| PR opened or updated against `master` | `ci-run.yml` (full lint + test + build + strict delta) |
+| Push to `master` (after merge) | `ci-run.yml` (lint + test + build; no strict delta) |
+| Manual dispatch | `cross-platform-build-manual.yml` or `release-stable-manual.yml` |
+| Tag push `vX.Y.Z` | `release-stable-manual.yml` (full release pipeline) |
 
-## Step-By-Step
+There is no automatic release on push to master. Releases are always
+intentional — either a manual dispatch or a deliberate tag push.
+
+---
+
+## Step-by-Step
 
 ### 1) PR → `master`
 
-1. Contributor opens or updates a PR against `master`.
-2. `checks-on-pr.yml` starts:
-   - `lint` job: runs `cargo fmt --check` and `cargo clippy -D warnings`.
-   - `test` job: runs `cargo nextest run --locked` on `ubuntu-latest` with Rust 1.92.0 and mold linker.
-   - `build` job (matrix): compiles release binary on `x86_64-unknown-linux-gnu` and `aarch64-apple-darwin`.
-   - `security` job: runs `cargo audit` and `cargo deny check licenses sources`.
-   - Concurrency group cancels in-progress runs for the same PR on new pushes.
-3. All jobs must pass before merge.
-4. Maintainer (`theonlyhennygod` or `JordanTheJet`) merges PR once checks and review policy are satisfied.
-5. Merge emits a `push` event on `master` (see section 2).
+1. Contributor opens or updates a PR targeting `master`.
+2. `ci-run.yml` runs:
+   - `lint` — `cargo fmt --check`, `cargo clippy -D warnings`,
+     `cargo check --features ci-all`, strict delta lint on changed lines.
+   - `test` — `cargo nextest run --locked` on `ubuntu-latest`.
+   - `build` — `cargo build --profile ci --locked` on Linux, macOS, and
+     Windows. Benchmarks are verified to compile on the Linux leg.
+   - `CI Required Gate` — composite job; branch protection requires this.
+3. Maintainer reviews and merges once the gate is green and review policy is
+   satisfied.
+4. Merge emits a `push` event on `master`.
 
-### 2) Push to `master` (including after merge)
+### 2) Push to `master` (after merge)
 
-1. Commit reaches `master`.
-2. `release-beta-on-push.yml` (Release Beta) starts:
-   - `version` job: computes beta tag as `v{cargo_version}-beta.{run_number}`.
-   - `build` job (matrix, 6 targets): `x86_64-linux`, `aarch64-linux`, `armv7-linux`, `aarch64-darwin`, `aarch64-android`, `x86_64-windows`.
-   - `publish` job: generates `SHA256SUMS`, creates a GitHub pre-release with all artifacts. Artifact retention: 7 days.
-   - `docker` job: builds multi-platform image (`linux/amd64,linux/arm64`) and pushes to `ghcr.io` with `:beta` and the versioned beta tag.
-3. This runs on every push to `master` without filtering. Every merged PR produces a beta pre-release.
+1. `ci-run.yml` runs again on the merged commit.
+   - Same jobs as above, except strict delta lint is skipped (no PR base SHA).
+2. If the gate is red on master, the team treats it as a P0 — nothing else
+   merges until it is green again.
+3. No release is triggered automatically.
 
 ### 3) Stable Release (manual)
 
-1. Maintainer runs `release-stable-manual.yml` via `workflow_dispatch` with a version input (e.g. `0.2.0`).
-2. `validate` job checks:
-   - Input matches semver `X.Y.Z` format.
-   - `Cargo.toml` version matches input exactly.
-   - Tag `vX.Y.Z` does not already exist on the remote.
-3. `build` job (matrix, 7 targets): `x86_64-linux`, `aarch64-linux`, `armv7-linux`, `arm-unknown-linux-gnueabihf (ARMv6)`, `aarch64-darwin`, `aarch64-android`, `x86_64-windows`.
-4. `publish` job: generates `SHA256SUMS`, creates a stable GitHub Release (not pre-release). Artifact retention: 14 days.
-5. `docker` job: pushes to `ghcr.io` with `:latest` and `:vX.Y.Z`.
+See [`docs/maintainers/release-runbook.md`](../../docs/maintainers/release-runbook.md)
+for the full procedure. In summary:
+
+1. Maintainer verifies CI is green on master.
+2. Version bump PR is merged.
+3. Maintainer triggers `release-stable-manual.yml` via `workflow_dispatch`
+   with the version number, or pushes an annotated tag `vX.Y.Z`.
+4. Workflow builds all targets, creates the GitHub Release, publishes to
+   crates.io, pushes Docker images, and notifies distribution channels.
+5. Maintainer approves the three environment gates
+   (`github-releases`, `crates-io`, `docker`) when prompted.
 
 ### 4) Full Platform Build (manual)
 
 1. Maintainer runs `cross-platform-build-manual.yml` via `workflow_dispatch`.
-2. `build` job (matrix, 3 targets): `aarch64-linux-gnu`, `x86_64-darwin` (macOS 15 Intel), `x86_64-windows-msvc`.
-3. Build-only, no tests, no publish. Used to verify cross-compilation on platforms not covered by `checks-on-pr.yml`.
+2. Build-only across additional targets not covered by the PR build matrix.
+3. No tests, no publish. Used to verify cross-compilation health.
+
+---
 
 ## Build Targets by Workflow
 
-| Target | `checks-on-pr.yml` | `cross-platform-build-manual.yml` | `release-beta-on-push.yml` | `release-stable-manual.yml` |
-| --- | :---: | :---: | :---: | :---: |
-| `x86_64-unknown-linux-gnu` | ✓ | | ✓ | ✓ |
-| `aarch64-unknown-linux-gnu` | | ✓ | ✓ | ✓ |
-| `armv7-unknown-linux-gnueabihf` | | | ✓ | ✓ |
-| `arm-unknown-linux-gnueabihf` | | | | ✓ |
-| `aarch64-apple-darwin` | ✓ | | ✓ | ✓ |
-| `aarch64-linux-android` | | | ✓ | ✓ |
-| `x86_64-apple-darwin` | | ✓ | | |
-| `x86_64-pc-windows-msvc` | ✓ | ✓ | ✓ | ✓ |
+| Target | `ci-run.yml` | `cross-platform-build-manual.yml` | `release-stable-manual.yml` |
+|---|:---:|:---:|:---:|
+| `x86_64-unknown-linux-gnu` | ✓ | | ✓ |
+| `aarch64-unknown-linux-gnu` | | ✓ | ✓ |
+| `armv7-unknown-linux-gnueabihf` | | | ✓ |
+| `arm-unknown-linux-gnueabihf` | | | ✓ |
+| `aarch64-apple-darwin` | ✓ | | ✓ |
+| `aarch64-linux-android` | | | ✓ (experimental) |
+| `x86_64-apple-darwin` | | ✓ | |
+| `x86_64-pc-windows-msvc` | ✓ | ✓ | ✓ |
 
-## Mermaid Diagrams
+---
 
-### PR to Master
+## Diagrams
 
-```mermaid
-flowchart TD
-  A["PR opened or updated → master"] --> B["checks-on-pr.yml"]
-  B --> B0["lint: fmt + clippy"]
-  B --> B1["test: cargo nextest (ubuntu-latest)"]
-  B --> B2["build: x86_64-linux + aarch64-darwin"]
-  B --> B3["security: audit + deny"]
-  B0 & B1 & B2 & B3 --> C{"Checks pass?"}
-  C -->|No| D["PR stays open"]
-  C -->|Yes| E["Maintainer merges"]
-  E --> F["push event on master"]
-```
-
-### Beta Release (on every master push)
+### PR to master
 
 ```mermaid
 flowchart TD
-  A["Push to master"] --> B["release-beta-on-push.yml"]
-  B --> B1["version: compute v{x.y.z}-beta.{N}"]
-  B1 --> B2["build: 6 targets"]
-  B2 --> B3["publish: GitHub pre-release + SHA256SUMS"]
-  B2 --> B4["docker: push ghcr.io :beta + versioned tag"]
+  A["PR opened or updated → master"] --> B["ci-run.yml"]
+  B --> L["lint\nfmt · clippy · check-features · strict-delta"]
+  L --> T["test\ncargo nextest"]
+  L --> BLD["build\nLinux · macOS · Windows"]
+  T & BLD --> G["CI Required Gate"]
+  G -->|red| D["PR stays open"]
+  G -->|green| R["Maintainer merges"]
+  R --> P["push event on master → ci-run.yml runs again"]
 ```
 
-### Stable Release (manual)
+### Stable release
 
 ```mermaid
 flowchart TD
-  A["workflow_dispatch: version=X.Y.Z"] --> B["release-stable-manual.yml"]
-  B --> B1["validate: semver + Cargo.toml + tag uniqueness"]
-  B1 --> B2["build: 7 targets"]
-  B2 --> B3["publish: GitHub stable release + SHA256SUMS"]
-  B2 --> B4["docker: push ghcr.io :latest + :vX.Y.Z"]
+  A["workflow_dispatch: version=X.Y.Z\nor tag push vX.Y.Z"] --> V["validate\nsemver · Cargo.toml match · tag uniqueness"]
+  V --> BLD["build all targets"]
+  BLD --> PUB["publish\nGitHub Release · SHA256SUMS"]
+  PUB --> CR["crates-io"]
+  PUB --> DOC["docker\nGHCR :vX.Y.Z + :latest"]
+  PUB --> DIST["scoop · aur · homebrew"]
+  PUB --> ANN["discord · tweet"]
 ```
 
-## Quick Troubleshooting
+---
 
-1. **Quality gate failing on PR**: check `lint` job for formatting/clippy issues; check `test` job for test failures; check `build` job for compile errors; check `security` job for audit/deny failures.
-2. **Beta release not appearing**: confirm the push landed on `master` (not another branch); check `release-beta-on-push.yml` run status.
-3. **Stable release failing at validate**: ensure `Cargo.toml` version matches the input version and the tag does not already exist.
-4. **Full matrix build needed**: run `cross-platform-build-manual.yml` manually from the Actions tab.
+## Troubleshooting
+
+1. **Gate red on PR** — check the `lint` job first (fmt/clippy failures are
+   the most common cause), then `test`, then `build`.
+2. **Gate red on master after merge** — treat as P0; stop merging until fixed.
+3. **Release validate failed** — `Cargo.toml` version does not match the
+   input, or the tag already exists. Fix the version bump PR and re-trigger.
+4. **Need a full cross-platform build** — run `cross-platform-build-manual.yml`
+   manually from the Actions tab.

--- a/.github/workflows/master-branch-flow.md
+++ b/.github/workflows/master-branch-flow.md
@@ -24,7 +24,7 @@ Maintainers with merge authority: `theonlyhennygod` and `JordanTheJet`.
 
 | File | Trigger | Purpose |
 |---|---|---|
-| `ci-run.yml` | `pull_request` → `master`, `push` → `master` | Lint + test + build on every PR and every master commit |
+| `ci.yml` | `pull_request` → `master` | Lint + test + build on every PR |
 | `release-stable-manual.yml` | `workflow_dispatch`, tag push `v*` | Stable release (manual, version-gated) |
 | `cross-platform-build-manual.yml` | `workflow_dispatch` | Full platform build matrix (manual smoke check) |
 | `pr-path-labeler.yml` | `pull_request` lifecycle | Automatic path-based PR labeling |
@@ -35,13 +35,13 @@ Maintainers with merge authority: `theonlyhennygod` and `JordanTheJet`.
 
 | Event | What runs |
 |---|---|
-| PR opened or updated against `master` | `ci-run.yml` (full lint + test + build + strict delta) |
-| Push to `master` (after merge) | `ci-run.yml` (lint + test + build; no strict delta) |
+| PR opened or updated against `master` | `ci.yml` (full lint + test + build + strict delta) |
 | Manual dispatch | `cross-platform-build-manual.yml` or `release-stable-manual.yml` |
 | Tag push `vX.Y.Z` | `release-stable-manual.yml` (full release pipeline) |
 
-There is no automatic release on push to master. Releases are always
-intentional — either a manual dispatch or a deliberate tag push.
+There is no automatic CI run on push to master and no automatic release on
+merge. Releases are always intentional — either a manual dispatch or a
+deliberate tag push.
 
 ---
 
@@ -50,31 +50,27 @@ intentional — either a manual dispatch or a deliberate tag push.
 ### 1) PR → `master`
 
 1. Contributor opens or updates a PR targeting `master`.
-2. `ci-run.yml` runs:
-   - `lint` — `cargo fmt --check`, `cargo clippy -D warnings`,
-     `cargo check --features ci-all`, strict delta lint on changed lines.
+2. `ci.yml` runs:
+   - `lint` — `cargo fmt --all -- --check`, `cargo clippy -D warnings`,
+     `cargo check --features ci-all`, strict delta lint on changed lines
+     (PRs only).
+   - `build` — matrix across `x86_64-unknown-linux-gnu`,
+     `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`.
+   - `check` — matrix: all features + no default features.
+   - `check-32bit` — `i686-unknown-linux-gnu`, no default features.
+   - `bench` — benchmarks compile check.
    - `test` — `cargo nextest run --locked` on `ubuntu-latest`.
-   - `build` — `cargo build --profile ci --locked` on Linux, macOS, and
-     Windows. Benchmarks are verified to compile on the Linux leg.
+   - `security` — `cargo deny check`.
    - `CI Required Gate` — composite job; branch protection requires this.
 3. Maintainer reviews and merges once the gate is green and review policy is
    satisfied.
-4. Merge emits a `push` event on `master`.
 
-### 2) Push to `master` (after merge)
-
-1. `ci-run.yml` runs again on the merged commit.
-   - Same jobs as above, except strict delta lint is skipped (no PR base SHA).
-2. If the gate is red on master, the team treats it as a P0 — nothing else
-   merges until it is green again.
-3. No release is triggered automatically.
-
-### 3) Stable Release (manual)
+### 2) Stable Release (manual)
 
 See [`docs/maintainers/release-runbook.md`](../../docs/maintainers/release-runbook.md)
 for the full procedure. In summary:
 
-1. Maintainer verifies CI is green on master.
+1. Maintainer verifies CI is green on the version bump PR.
 2. Version bump PR is merged.
 3. Maintainer triggers `release-stable-manual.yml` via `workflow_dispatch`
    with the version number, or pushes an annotated tag `vX.Y.Z`.
@@ -83,7 +79,7 @@ for the full procedure. In summary:
 5. Maintainer approves the three environment gates
    (`github-releases`, `crates-io`, `docker`) when prompted.
 
-### 4) Full Platform Build (manual)
+### 3) Full Platform Build (manual)
 
 1. Maintainer runs `cross-platform-build-manual.yml` via `workflow_dispatch`.
 2. Build-only across additional targets not covered by the PR build matrix.
@@ -93,7 +89,7 @@ for the full procedure. In summary:
 
 ## Build Targets by Workflow
 
-| Target | `ci-run.yml` | `cross-platform-build-manual.yml` | `release-stable-manual.yml` |
+| Target | `ci.yml` | `cross-platform-build-manual.yml` | `release-stable-manual.yml` |
 |---|:---:|:---:|:---:|
 | `x86_64-unknown-linux-gnu` | ✓ | | ✓ |
 | `aarch64-unknown-linux-gnu` | | ✓ | ✓ |
@@ -112,14 +108,17 @@ for the full procedure. In summary:
 
 ```mermaid
 flowchart TD
-  A["PR opened or updated → master"] --> B["ci-run.yml"]
+  A["PR opened or updated → master"] --> B["ci.yml"]
   B --> L["lint\nfmt · clippy · check-features · strict-delta"]
   L --> T["test\ncargo nextest"]
   L --> BLD["build\nLinux · macOS · Windows"]
-  T & BLD --> G["CI Required Gate"]
+  L --> CHK["check\nall features · no default features"]
+  L --> C32["check-32bit\ni686-unknown-linux-gnu"]
+  L --> BCH["bench\ncompile check"]
+  L --> SEC["security\ncargo deny check"]
+  T & BLD & CHK & C32 & BCH & SEC --> G["CI Required Gate"]
   G -->|red| D["PR stays open"]
   G -->|green| R["Maintainer merges"]
-  R --> P["push event on master → ci-run.yml runs again"]
 ```
 
 ### Stable release
@@ -141,8 +140,7 @@ flowchart TD
 
 1. **Gate red on PR** — check the `lint` job first (fmt/clippy failures are
    the most common cause), then `test`, then `build`.
-2. **Gate red on master after merge** — treat as P0; stop merging until fixed.
-3. **Release validate failed** — `Cargo.toml` version does not match the
+2. **Release validate failed** — `Cargo.toml` version does not match the
    input, or the tag already exists. Fix the version bump PR and re-trigger.
-4. **Need a full cross-platform build** — run `cross-platform-build-manual.yml`
+3. **Need a full cross-platform build** — run `cross-platform-build-manual.yml`
    manually from the Actions tab.

--- a/docs/contributing/ci-map.md
+++ b/docs/contributing/ci-map.md
@@ -1,136 +1,133 @@
 # CI Workflow Map
 
-This document explains what each GitHub workflow does, when it runs, and whether it should block merges.
+What each GitHub workflow does, when it runs, and whether it blocks merges.
 
-For event-by-event delivery behavior across PR, merge, push, and release, see [`.github/workflows/master-branch-flow.md`](../../.github/workflows/master-branch-flow.md).
+Last updated: **May 2026** (post-v0.7.4 cleanup).
 
-## Merge-Blocking vs Optional
+For event-by-event delivery behavior, see
+[`.github/workflows/master-branch-flow.md`](../../.github/workflows/master-branch-flow.md).
 
-Merge-blocking checks should stay small and deterministic. Optional checks are useful for automation and maintenance, but should not block normal development.
+---
 
-### Merge-Blocking
+## Merge-Blocking
 
-- `.github/workflows/ci-run.yml` (`CI`)
-    - Purpose: Rust validation (`cargo fmt --all -- --check`, `cargo clippy --locked --all-targets -- -D clippy::correctness`, strict delta lint gate on changed Rust lines, `test`, release build smoke) + docs quality checks when docs change (`markdownlint` blocks only issues on changed lines; link check scans only links added on changed lines)
-    - Additional behavior: for Rust-impacting PRs and pushes, `CI Required Gate` requires `lint` + `test` + `build` (no PR build-only bypass)
-    - Additional behavior: PRs that change `.github/workflows/**` require at least one approving review from a login in `WORKFLOW_OWNER_LOGINS` (repository variable fallback: `theonlyhennygod,JordanTheJet`)
-    - Additional behavior: lint gates run before `test`/`build`; when lint/docs gates fail on PRs, CI posts an actionable feedback comment with failing gate names and local fix commands
-    - Merge gate: `CI Required Gate`
-- `.github/workflows/workflow-sanity.yml` (`Workflow Sanity`)
-    - Purpose: lint GitHub workflow files (`actionlint`, tab checks)
-    - Recommended for workflow-changing PRs
-- `.github/workflows/pr-intake-checks.yml` (`PR Intake Checks`)
-    - Purpose: safe pre-CI PR checks (template completeness, added-line tabs/trailing-whitespace/conflict markers) with immediate sticky feedback comment
-### Non-Blocking but Important
+### `ci-run.yml` — CI
 
-- `.github/workflows/pub-docker-img.yml` (`Docker`)
-    - Purpose: PR Docker smoke check on `master` PRs and publish images on tag pushes (`v*`) only
-- `.github/workflows/sec-audit.yml` (`Security Audit`)
-    - Purpose: dependency advisories (`rustsec/audit-check`, pinned SHA) and policy/license checks (`cargo deny`)
-- `.github/workflows/sec-codeql.yml` (`CodeQL Analysis`)
-    - Purpose: scheduled/manual static analysis for security findings
-- `.github/workflows/sec-vorpal-reviewdog.yml` (`Sec Vorpal Reviewdog`)
-    - Purpose: manual secure-coding feedback scan for supported non-Rust files (`.py`, `.js`, `.jsx`, `.ts`, `.tsx`) using reviewdog annotations
-    - Noise control: excludes common test/fixture paths and test file patterns by default (`include_tests=false`)
-- `.github/workflows/pub-release.yml` (`Release`)
-    - Purpose: build release artifacts in verification mode (manual/scheduled) and publish GitHub releases on tag push or manual publish mode
-- `.github/workflows/pub-homebrew-core.yml` (`Pub Homebrew Core`)
-    - Purpose: manual, bot-owned Homebrew core formula bump PR flow for tagged releases
-    - Guardrail: release tag must match `Cargo.toml` version
-- `.github/workflows/pub-scoop.yml` (`Pub Scoop Manifest`)
-    - Purpose: Scoop bucket manifest update for Windows; auto-called by stable release, also manual dispatch
-    - Guardrail: release tag must be `vX.Y.Z` format; Windows binary hash extracted from `SHA256SUMS`
-- `.github/workflows/pub-aur.yml` (`Pub AUR Package`)
-    - Purpose: AUR PKGBUILD push for Arch Linux; auto-called by stable release, also manual dispatch
-    - Guardrail: release tag must be `vX.Y.Z` format; source tarball SHA256 computed at publish time
-- `.github/workflows/pr-label-policy-check.yml` (`Label Policy Sanity`)
-    - Purpose: validate shared contributor-tier policy in `.github/label-policy.json` and ensure label workflows consume that policy
-- `.github/workflows/test-rust-build.yml` (`Rust Reusable Job`)
-    - Purpose: reusable Rust setup/cache + command runner for workflow-call consumers
+**Trigger:** `pull_request` → `master`, `push` → `master`
 
-### Optional Repository Automation
+**Required status check:** `CI Required Gate`
 
-- `.github/workflows/pr-labeler.yml` (`PR Labeler`)
-    - Purpose: scope/path labels + size/risk labels + fine-grained module labels (`<module>: <component>`)
-    - Additional behavior: label descriptions are auto-managed as hover tooltips to explain each auto-judgment rule
-    - Additional behavior: provider-related keywords in provider/config/onboard/integration changes are promoted to `provider:*` labels (for example `provider:kimi`, `provider:deepseek`)
-    - Additional behavior: hierarchical de-duplication keeps only the most specific scope labels (for example `tool:composio` suppresses `tool:core` and `tool`)
-    - Additional behavior: module namespaces are compacted — one specific module keeps `prefix:component`; multiple specifics collapse to just `prefix`
-    - Additional behavior: applies contributor tiers on PRs by merged PR count (`trusted` >=5, `experienced` >=10, `principal` >=20, `distinguished` >=50)
-    - Additional behavior: final label set is priority-sorted (`risk:*` first, then `size:*`, then contributor tier, then module/path labels)
-    - Additional behavior: managed label colors follow display order to produce a smooth left-to-right gradient when many labels are present
-    - Manual governance: supports `workflow_dispatch` with `mode=audit|repair` to inspect/fix managed label metadata drift across the whole repository
-    - Additional behavior: risk + size labels are auto-corrected on manual PR label edits (`labeled`/`unlabeled` events); apply `risk: manual` when maintainers intentionally override automated risk selection
-    - High-risk heuristic paths: `src/security/**`, `src/runtime/**`, `src/gateway/**`, `src/tools/**`, `.github/workflows/**`
-    - Guardrail: maintainers can apply `risk: manual` to freeze automated risk recalculation
-- `.github/workflows/pr-auto-response.yml` (`PR Auto Responder`)
-    - Purpose: first-time contributor onboarding + label-driven response routing (`r:support`, `r:needs-repro`, etc.)
-    - Additional behavior: applies contributor tiers on issues by merged PR count (`trusted` >=5, `experienced` >=10, `principal` >=20, `distinguished` >=50), matching PR tier thresholds exactly
-    - Additional behavior: contributor-tier labels are treated as automation-managed (manual add/remove on PR/issue is auto-corrected)
-    - Guardrail: label-based close routes are issue-only; PRs are never auto-closed by route labels
-- `.github/workflows/pr-check-stale.yml` (`Stale`)
-    - Purpose: stale issue/PR lifecycle automation
-- `.github/dependabot.yml` (`Dependabot`)
-    - Purpose: grouped, rate-limited dependency update PRs (Cargo + GitHub Actions)
-- `.github/workflows/pr-check-status.yml` (`PR Hygiene`)
-    - Purpose: nudge stale-but-active PRs to rebase/re-run required checks before queue starvation
+The single source of truth for PR and post-merge quality. Three staged jobs:
 
-## Trigger Map
+- `lint` — `cargo fmt --all -- --check`, `cargo clippy -D warnings`,
+  `cargo check --features ci-all`, strict delta lint on changed lines (PRs only).
+- `test` — `cargo nextest run --locked` on `ubuntu-latest` with mold linker.
+- `build` — `cargo build --profile ci --locked` on Linux, macOS, and Windows.
+  Benchmarks are verified to compile on the Linux leg.
 
-- `CI`: push to `master`, PRs to `master`
-- `Docker`: tag push (`v*`) for publish, matching PRs to `master` for smoke build, manual dispatch for smoke only
-- `Release`: tag push (`v*`), weekly schedule (verification-only), manual dispatch (verification or publish)
-- `Pub Homebrew Core`: manual dispatch only
-- `Pub Scoop Manifest`: auto-called by stable release, also manual dispatch
-- `Pub AUR Package`: auto-called by stable release, also manual dispatch
-- `Security Audit`: push to `master`, PRs to `master`, weekly schedule
-- `Sec Vorpal Reviewdog`: manual dispatch only
-- `Workflow Sanity`: PR/push when `.github/workflows/**`, `.github/*.yml`, or `.github/*.yaml` change
-- `Dependabot`: all update PRs target `master`
-- `PR Intake Checks`: `pull_request_target` on opened/reopened/synchronize/edited/ready_for_review
-- `Label Policy Sanity`: PR/push when `.github/label-policy.json`, `.github/workflows/pr-labeler.yml`, or `.github/workflows/pr-auto-response.yml` changes
-- `PR Labeler`: `pull_request_target` lifecycle events
-- `PR Auto Responder`: issue opened/labeled, `pull_request_target` opened/labeled
-- `Stale PR Check`: daily schedule, manual dispatch
-- `PR Hygiene`: every 12 hours schedule, manual dispatch
+`lint` must pass before `test` and `build` start. `CI Required Gate` is the
+composite job that branch protection requires — it passes only if all three
+upstream jobs passed.
 
-## Fast Triage Guide
+**Concurrency:** in-flight runs are cancelled on new PR pushes. Master push
+runs are not cancelled.
 
-1. `CI Required Gate` failing: start with `.github/workflows/ci-run.yml`.
-2. Docker failures on PRs: inspect `.github/workflows/pub-docker-img.yml` `pr-smoke` job.
-3. Release failures (tag/manual/scheduled): inspect `.github/workflows/pub-release.yml` and the `prepare` job outputs.
-4. Homebrew formula publish failures: inspect `.github/workflows/pub-homebrew-core.yml` summary output and bot token/fork variables.
-5. Scoop manifest publish failures: inspect `.github/workflows/pub-scoop.yml` summary output and `SCOOP_BUCKET_REPO`/`SCOOP_BUCKET_TOKEN` settings.
-6. AUR package publish failures: inspect `.github/workflows/pub-aur.yml` summary output and `AUR_SSH_KEY` secret.
-7. Security failures: inspect `.github/workflows/sec-audit.yml` and `deny.toml`.
-8. Workflow syntax/lint failures: inspect `.github/workflows/workflow-sanity.yml`.
-9. PR intake failures: inspect `.github/workflows/pr-intake-checks.yml` sticky comment and run logs.
-10. Label policy parity failures: inspect `.github/workflows/pr-label-policy-check.yml`.
-11. Docs failures in CI: inspect `docs-quality` job logs in `.github/workflows/ci-run.yml`.
-12. Strict delta lint failures in CI: inspect `lint-strict-delta` job logs and compare with `BASE_SHA` diff scope.
+---
+
+## Non-Blocking — Release
+
+### `release-stable-manual.yml` — Release Stable
+
+**Trigger:** `workflow_dispatch` (version input), tag push `v[0-9]+.[0-9]+.[0-9]+`
+
+**Frozen:** do not extend until v0.7.5.
+
+Full stable release pipeline. Jobs in order:
+
+1. `validate` — semver format, `Cargo.toml` version match, tag uniqueness guard.
+2. `web` — builds the web dashboard artifact.
+3. `release-notes` — generates release notes from git log.
+4. `build` — 7-target cross-platform matrix (Linux x86\_64, Linux aarch64,
+   ARMv7, ARM, macOS aarch64, Android (experimental), Windows x86\_64).
+5. `build-desktop` — macOS universal Tauri app.
+6. `publish` — GitHub Release, `SHA256SUMS`, `install.sh`. Removes
+   `CHANGELOG-next.md` from master after release.
+7. `crates-io` — publishes workspace crates to crates.io.
+8. `docker` — pushes multi-arch images to GHCR.
+9. Distribution: `scoop`, `aur`, `homebrew`, `marketplace`.
+10. Announcements: `discord`, `tweet`.
+
+`publish`, `crates-io`, and `docker` are gated by GitHub environment
+protection rules requiring maintainer approval.
+
+See [`docs/maintainers/release-runbook.md`](../maintainers/release-runbook.md)
+for the step-by-step procedure.
+
+---
+
+## Non-Blocking — Utilities
+
+### `cross-platform-build-manual.yml` — Cross-Platform Build
+
+**Trigger:** `workflow_dispatch`
+
+Manual build-only smoke check across targets not covered by the PR matrix.
+No tests. No publish. Used to verify cross-compilation health before a release
+or after a significant dependency change.
+
+### `pr-path-labeler.yml` — PR Path Labeler
+
+**Trigger:** `pull_request` lifecycle events
+
+Applies scope and path labels to PRs automatically based on changed files.
+All action refs are SHA-pinned. Low noise, no side effects beyond label
+application.
+
+---
+
+## Frozen Sub-Workflows
+
+Called by `release-stable-manual.yml`. Do not modify or extend until v0.7.5.
+Each can also be triggered manually with `dry_run: true` for verification.
+
+| File | Purpose |
+|---|---|
+| `pub-aur.yml` | Pushes updated PKGBUILD to AUR |
+| `pub-homebrew-core.yml` | Opens Homebrew Core formula bump PR via bot account |
+| `pub-scoop.yml` | Updates Scoop bucket manifest |
+| `publish-crates.yml` | Manual crates.io publish (backup for the release pipeline) |
+| `discord-release.yml` | Posts release announcement to Discord |
+| `tweet-release.yml` | Posts release announcement to Twitter/X |
+| `sync-marketplace-templates.yml` | Updates Dokploy and EasyPanel marketplace templates |
+
+---
+
+## Fast Triage
+
+1. **`CI Required Gate` red on a PR** — start with the `lint` job (fmt/clippy
+   failures are most common), then `test`, then `build`.
+2. **`CI Required Gate` red on master after a merge** — treat as P0; nothing
+   else merges until it is green.
+3. **Release `validate` failed** — `Cargo.toml` version does not match the
+   workflow input, or the tag already exists.
+4. **Release build failed** — check the specific target's job log. Android is
+   `experimental` and runs with `continue-on-error`.
+5. **Environment gate timed out** — re-run only the timed-out job from the
+   workflow run page.
+6. **Distribution channel failed** — re-run the corresponding sub-workflow
+   manually with `dry_run: true` first.
+
+---
 
 ## Maintenance Rules
 
-- Keep merge-blocking checks deterministic and reproducible (`--locked` where applicable).
-- Follow [`docs/contributing/release-process.md`](./release-process.md) for verify-before-publish release cadence and tag discipline.
-- Keep merge-blocking rust quality policy aligned across `.github/workflows/ci-run.yml`, `dev/ci.sh`, and `.githooks/pre-push` (`./scripts/ci/rust_quality_gate.sh` + `./scripts/ci/rust_strict_delta_gate.sh`).
-- Use `./scripts/ci/rust_strict_delta_gate.sh` (or `./dev/ci.sh lint-delta`) as the incremental strict merge gate for changed Rust lines.
-- Run full strict lint audits regularly via `./scripts/ci/rust_quality_gate.sh --strict` (for example through `./dev/ci.sh lint-strict`) and track cleanup in focused PRs.
-- Keep docs markdown gating incremental via `./scripts/ci/docs_quality_gate.sh` (block changed-line issues, report baseline issues separately).
-- Keep docs link gating incremental via `./scripts/ci/collect_changed_links.py` + lychee (check only links added on changed lines).
-- Prefer explicit workflow permissions (least privilege).
-- Keep Actions source policy restricted to approved allowlist patterns (see [`docs/contributing/actions-source-policy.md`](./actions-source-policy.md)).
-- Use path filters for expensive workflows when practical.
-- Keep docs quality checks low-noise (incremental markdown + incremental added-link checks).
-- Keep dependency update volume controlled (grouping + PR limits).
-- Avoid mixing onboarding/community automation with merge-gating logic.
-- Test levels: `cargo test --test component`, `cargo test --test integration`, `cargo test --test system`.
-- Live tests (manual only): `cargo test --test live -- --ignored`.
-
-## Automation Side-Effect Controls
-
-- Prefer deterministic automation that can be manually overridden (`risk: manual`) when context is nuanced.
-- Keep auto-response comments deduplicated to prevent triage noise.
-- Keep auto-close behavior scoped to issues; maintainers own PR close/merge decisions.
-- If automation is wrong, correct labels first, then continue review with explicit rationale.
-- Use `superseded` / `stale-candidate` labels to prune duplicate or dormant PRs before deep review.
+- Keep `CI Required Gate` deterministic and small. Do not add jobs to the gate
+  without a clear quality argument.
+- All third-party action refs must be pinned to a full commit SHA
+  (see [`actions-source-policy.md`](./actions-source-policy.md)).
+- Keep `ci-run.yml`, `dev/ci.sh`, and `.githooks/pre-push` aligned — the same
+  quality gates should run locally and in CI.
+- Do not modify the frozen sub-workflows until the v0.7.5 structured release
+  pipeline work begins.
+- `docs-quality` checks are not in the required gate. They can be run locally
+  with `bash scripts/ci/docs_quality_gate.sh`.

--- a/docs/contributing/ci-map.md
+++ b/docs/contributing/ci-map.md
@@ -11,26 +11,30 @@ For event-by-event delivery behavior, see
 
 ## Merge-Blocking
 
-### `ci-run.yml` — CI
+### `ci.yml` — CI
 
-**Trigger:** `pull_request` → `master`, `push` → `master`
+**Trigger:** `pull_request` → `master`
 
 **Required status check:** `CI Required Gate`
 
-The single source of truth for PR and post-merge quality. Three staged jobs:
+The single source of truth for PR quality. Jobs:
 
 - `lint` — `cargo fmt --all -- --check`, `cargo clippy -D warnings`,
   `cargo check --features ci-all`, strict delta lint on changed lines (PRs only).
-- `test` — `cargo nextest run --locked` on `ubuntu-latest` with mold linker.
-- `build` — `cargo build --profile ci --locked` on Linux, macOS, and Windows.
-  Benchmarks are verified to compile on the Linux leg.
+- `build` — matrix across `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`,
+  `x86_64-pc-windows-msvc`.
+- `check` — matrix: all features + no default features.
+- `check-32bit` — `i686-unknown-linux-gnu`, no default features.
+- `bench` — benchmarks compile check.
+- `test` — `cargo nextest run --locked` on `ubuntu-latest`.
+- `security` — `cargo deny check`.
+- `gate` — `CI Required Gate`: composite job; branch protection requires this.
+  Passes only if all upstream jobs passed.
 
-`lint` must pass before `test` and `build` start. `CI Required Gate` is the
-composite job that branch protection requires — it passes only if all three
-upstream jobs passed.
+`lint` must pass before `build`, `check`, `check-32bit`, `bench`, `test`, and
+`security` start.
 
-**Concurrency:** in-flight runs are cancelled on new PR pushes. Master push
-runs are not cancelled.
+**Concurrency:** in-flight runs are cancelled on new PR pushes.
 
 ---
 
@@ -106,15 +110,13 @@ Each can also be triggered manually with `dry_run: true` for verification.
 
 1. **`CI Required Gate` red on a PR** — start with the `lint` job (fmt/clippy
    failures are most common), then `test`, then `build`.
-2. **`CI Required Gate` red on master after a merge** — treat as P0; nothing
-   else merges until it is green.
-3. **Release `validate` failed** — `Cargo.toml` version does not match the
+2. **Release `validate` failed** — `Cargo.toml` version does not match the
    workflow input, or the tag already exists.
-4. **Release build failed** — check the specific target's job log. Android is
+3. **Release build failed** — check the specific target's job log. Android is
    `experimental` and runs with `continue-on-error`.
-5. **Environment gate timed out** — re-run only the timed-out job from the
+4. **Environment gate timed out** — re-run only the timed-out job from the
    workflow run page.
-6. **Distribution channel failed** — re-run the corresponding sub-workflow
+5. **Distribution channel failed** — re-run the corresponding sub-workflow
    manually with `dry_run: true` first.
 
 ---
@@ -125,7 +127,7 @@ Each can also be triggered manually with `dry_run: true` for verification.
   without a clear quality argument.
 - All third-party action refs must be pinned to a full commit SHA
   (see [`actions-source-policy.md`](./actions-source-policy.md)).
-- Keep `ci-run.yml`, `dev/ci.sh`, and `.githooks/pre-push` aligned — the same
+- Keep `ci.yml`, `dev/ci.sh`, and `.githooks/pre-push` aligned — the same
   quality gates should run locally and in CI.
 - Do not modify the frozen sub-workflows until the v0.7.5 structured release
   pipeline work begins.

--- a/docs/contributing/ci-map.md
+++ b/docs/contributing/ci-map.md
@@ -38,6 +38,40 @@ The single source of truth for PR quality. Jobs:
 
 ---
 
+## Build Cache
+
+All jobs in `ci.yml` use `Swatinem/rust-cache@v2` to cache compiled
+dependencies between runs. Key behaviors:
+
+**Cache writes are master-only.** The `save-if` condition is
+`github.ref == 'refs/heads/master'`, so cache is only written when a PR
+merges. PR runs read the cache seeded by the most recent master commit but
+never update it. This prevents PR branches from polluting the shared cache
+with branch-specific artifacts.
+
+**Cache is saved on failure.** `cache-on-failure: true` is set on every job.
+A run that fails part-way through still saves whatever it compiled, so a
+retry or a follow-up fix PR starts warm rather than cold.
+
+**Windows has no Rust cache.** The `build` job applies
+`if: runner.os != 'Windows'` to the cache step. Windows path handling causes
+cache poisoning with `rust-cache`, so the Windows build target always runs
+cold.
+
+**Incremental compilation is disabled globally.** `CARGO_INCREMENTAL: 0` is
+set in the workflow-level `env` block. Incremental builds are counterproductive
+in CI — they consume extra cache space and can produce incorrect results when
+the cache is partially stale. Disabling it keeps the cache smaller and
+results reproducible.
+
+**`cargo-deny` is not cached.** The `security` job installs it fresh each run
+via `cargo install cargo-deny --locked`. This compiles from source on every
+run. A future improvement would be to use a pre-built binary
+(e.g. `taiki-e/install-action`) to match the approach already used for
+`cargo-nextest`.
+
+---
+
 ## Non-Blocking — Release
 
 ### `release-stable-manual.yml` — Release Stable


### PR DESCRIPTION
## What

Two files changed. Both land together because the docs must describe the workflow accurately.

### `ci-run.yml`

| Change | Why |
|---|---|
| Add `push: master` trigger | Master commits had no CI status — a broken merge was invisible until someone opened a new PR |
| Cancel-in-progress on PRs only | Master push runs should always complete; only PR runs should cancel on new pushes |
| Fold `lint-strict-delta` into `lint` job | Same toolchain, same runner — no reason to pay for a separate job and runner spin-up |
| Fold `check-all-features` into `lint` job | Same rationale |
| Fold `bench-compile` into Linux `build` leg | Benchmarks compile check belongs with the build, not as a parallel gate entry |
| Remove `docs-quality` from gate | Per #5914 decision — blocked three v0.7.4 docs PRs with markdown lint failures |
| Gate now requires exactly `lint + test + build` | Simpler, explainable, still covers all quality dimensions |

### `master-branch-flow.md`

Rewrote to reflect reality post-v0.7.4:
- Removed all references to `checks-on-pr.yml` and `release-beta-on-push.yml` (both deleted in #5922)
- Master pushes now show in the trigger table (ci-run.yml fires on both PR and push)
- Build target matrix updated
- Mermaid diagrams updated
- Release procedure now points to the runbook (#5920) instead of an inline description

### `docs/contributing/ci-map.md`

Rewrote from scratch. The previous version described ~15 workflows that did not exist. The new version describes only what actually exists: one merge-blocking workflow, the release pipeline, two utilities, and the frozen sub-workflows.

## Depends on

- #5922 (workflow deletions) — the deleted workflows are removed from this doc
- #5920 (release runbook) — referenced in both docs

## Risk

**Medium** — changes to `ci-run.yml` affect every PR's CI. The job graph is simpler but the quality bar is unchanged. The push trigger addition is the highest-impact change.

Closes #5870
Closes #5917
Part of v0.7.4 — see #5877
