### PR TITLE
ci: remove crates-io publish job from release workflow

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -474,66 +474,6 @@ jobs:
             echo "No CHANGELOG-next.md to clean up."
           fi
 
-  crates-io:
-    name: Publish to crates.io
-    needs: [validate, publish]
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    environment:
-      name: crates-io
-      url: https://crates.io/crates/zeroclawlabs/${{ needs.validate.outputs.version }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: 1.93.0
-
-      - uses: Swatinem/rust-cache@v2
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: web/package-lock.json
-
-      - name: Build web dashboard
-        run: cd web && npm ci && npm run build
-
-      - name: Clean web build artifacts
-        run: rm -rf web/node_modules web/src web/package.json web/package-lock.json web/tsconfig*.json web/vite.config.ts web/index.html
-
-      - name: Publish aardvark-sys to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          OUTPUT=$(cargo publish --locked --allow-dirty --no-verify -p aardvark-sys 2>&1) && exit 0
-          echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -q 'already exists'; then
-            echo "::notice::aardvark-sys already on crates.io — skipping"
-            exit 0
-          fi
-          exit 1
-
-      - name: Wait for aardvark-sys to index
-        run: sleep 15
-
-      - name: Publish to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          # Publish to crates.io; treat "already exists" as success
-          # (auto-publish workflow may have already published this version)
-          CRATE_NAME=$(sed -n 's/^name = "\([^"]*\)"/\1/p' Cargo.toml | head -1)
-          OUTPUT=$(cargo publish --locked --allow-dirty --no-verify 2>&1) && exit 0
-          echo "$OUTPUT"
-          if echo "$OUTPUT" | grep -q 'already exists'; then
-            echo "::notice::${CRATE_NAME}@${VERSION} already on crates.io — skipping"
-            exit 0
-          fi
-          exit 1
-
   redeploy-website:
     name: Trigger Website Redeploy
     needs: [publish]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Removed the entire `crates-io` job from `release-stable-manual.yml`. The job publishes the main crate and `aardvark-sys` to crates.io, but workspace sub-crates added during the microkernel split all carry `publish = false`, so the job fails on every release run with a hard error.
  - This is an **intentional, permanent removal** for the v0.7.4 cycle — not a skip or a suppression. The team is not publishing crates to crates.io until there is a proper integration story for the community. The existing workflow was not purpose-built for this workspace layout.
  - Proper crates.io publishing (with correct ordering across the workspace) will be introduced in v0.7.5 via `release-plz`.
- **Scope boundary:** Only `release-stable-manual.yml` is touched. No other workflow, Cargo manifest, or source file is modified.
- **Blast radius:** None for the release itself — `crates-io` was already a downstream-only job with no downstream dependents in the `needs:` graph. Removing it does not affect `publish`, `docker`, `scoop`, `aur`, `homebrew`, `marketplace`, `tweet`, or `discord`. The GitHub Release will continue to complete cleanly.
- **Linked issue(s):** Closes #5811 · Part of v0.7.4 — see #5877

## Validation Evidence (required)

This is a YAML deletion only — no Rust code, no compiled artifacts, no scripts.

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:** Rust checks pass unchanged (no Rust source modified). YAML validated with `yamllint` locally — no syntax errors.
- **Beyond CI — what did you manually verify?** Confirmed with `grep -n "crates-io" release-stable-manual.yml` that zero references remain in the file. Audited every downstream job's `needs:` list — none referenced `crates-io`, so no `needs:` list surgery was required anywhere.
- **If any command was intentionally skipped, why:** N/A.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No — `CARGO_REGISTRY_TOKEN` was only consumed by the deleted job; it is not referenced anywhere else in this workflow.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes — crates.io was not being successfully published anyway.
- Config / env / CLI surface changed? No

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR — `git revert d6e6c517` restores the block if the decision is reversed.