### PR TITLE
chore(cargo): add aarch64-unknown-linux-gnu linker config for RPi cross-compilation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,13 @@
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-C", "link-arg=-static"]
 
+# ARM64 Linux (Raspberry Pi 4/5, AWS Graviton, etc.)
+# Prerequisite: aarch64-linux-gnu-gcc must be installed.
+#   Arch:   sudo pacman -S aarch64-linux-gnu-gcc
+#   Debian: sudo apt install gcc-aarch64-linux-gnu
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
 [target.aarch64-unknown-linux-musl]
 rustflags = ["-C", "link-arg=-static", "-C", "link-arg=-Wl,-z,stack-size=8388608"]
 


### PR DESCRIPTION
## Summary

- **Base branch:** \`master\`
- **What changed and why:** Added \`[target.aarch64-unknown-linux-gnu]\` linker entry to \`.cargo/config.toml\` pointing to \`aarch64-linux-gnu-gcc\`. Without this, cargo's default lld linker attempts to link ARM64 objects against x86_64 ELF, failing immediately. This unblocks native cross-compilation to ARM64 Linux (Raspberry Pi 4/5, AWS Graviton) without requiring \`cross\` or Docker.
- **Scope boundary:** Dev tooling only — no source, CI, or runtime changes. Does not affect any existing build targets.
- **Blast radius:** None for existing users. Contributors without \`aarch64-linux-gnu-gcc\` installed will get a clear missing-tool error rather than a silent wrong-architecture link failure.
- **Linked issue(s):** N/A. Follow-up: wiki entry documenting ARM64 cross-compilation prerequisites and workflow.

**Prerequisite:** \`aarch64-linux-gnu-gcc\` must be installed before cross-compiling:
- Arch: \`sudo pacman -S aarch64-linux-gnu-gcc\`
- Debian/Ubuntu: \`sudo apt install gcc-aarch64-linux-gnu\`

Then:
```bash
rustup target add aarch64-unknown-linux-gnu
cargo build --release --target aarch64-unknown-linux-gnu
```

## Validation Evidence (required)

- **Commands run:** Successful \`cargo build --release --target aarch64-unknown-linux-gnu\` on x86_64 host targeting Raspberry Pi 5.
- **Beyond CI — what did you manually verify?** Binary produced at \`target/aarch64-unknown-linux-gnu/release/zeroclaw\`. CI does not exercise cross-compilation targets.
- **If any command was intentionally skipped, why:** \`cargo fmt\`, \`cargo clippy\`, \`cargo test\` — config-only change, no Rust source modified.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff? No

## Compatibility (required)

- Backward compatible? Yes — existing targets unaffected.
- Config / env / CLI surface changed? No — \`.cargo/config.toml\` is dev tooling only.

## Rollback (required for \`risk: medium\` and \`risk: high\`)

\`git revert <sha>\` — single-line config change, no side effects.