### PR TITLE
fix(security): distinguish git -C from git -c in security policy

### DIFF
--- a/crates/zeroclaw-config/src/policy.rs
+++ b/crates/zeroclaw-config/src/policy.rs
@@ -1162,9 +1162,13 @@ impl SecurityPolicy {
                 return false;
             }
 
-            // Validate arguments for the command
-            let args: Vec<String> = words.map(|w| w.to_ascii_lowercase()).collect();
-            if !self.is_args_safe(base_cmd, &args) {
+            // Validate arguments for the command.
+            // Both case-preserved and lowercased argument lists are provided:
+            //   - `args_cased` for case-sensitive comparisons (e.g. git -C vs -c)
+            //   - `args` (lowercased) for case-insensitive matches (e.g. subcommand names)
+            let args_cased: Vec<String> = words.map(|w| w.to_string()).collect();
+            let args: Vec<String> = args_cased.iter().map(|w| w.to_ascii_lowercase()).collect();
+            if !self.is_args_safe(base_cmd, &args, &args_cased) {
                 return false;
             }
         }
@@ -1186,7 +1190,7 @@ impl SecurityPolicy {
     /// - ZeptoClaw GHSA-5wp8-q9mx-8jx8 (CVSS 9.8): same vulnerability class
     /// - OpenClaw strictInlineEval: blocks python -c, node -e, etc.
     /// - OWASP OS Command Injection Defense Cheat Sheet
-    fn is_args_safe(&self, base: &str, args: &[String]) -> bool {
+    fn is_args_safe(&self, base: &str, args: &[String], args_cased: &[String]) -> bool {
         let base = base.to_ascii_lowercase();
         match base.as_str() {
             "find" => {
@@ -1195,14 +1199,18 @@ impl SecurityPolicy {
             }
             "git" => {
                 // git config, alias, and -c can be used to set dangerous options
-                // (e.g. git config core.editor "rm -rf /")
-                !args.iter().any(|arg| {
-                    arg == "config"
-                        || arg.starts_with("config.")
-                        || arg == "alias"
-                        || arg.starts_with("alias.")
-                        || arg == "-c"
-                })
+                // (e.g. git config core.editor "rm -rf /").
+                // NOTE: `-c` (lowercase) is compared case-sensitively against
+                // `args_cased` because git's `-C` (uppercase, change directory)
+                // is a distinct, benign option that must not be conflated with
+                // `-c` (set config override). See #5809.
+                !args_cased.iter().any(|arg| arg == "-c")
+                    && !args.iter().any(|arg| {
+                        arg == "config"
+                            || arg.starts_with("config.")
+                            || arg == "alias"
+                            || arg.starts_with("alias.")
+                    })
             }
             "python" | "python3" => {
                 // -c executes arbitrary code from argument string
@@ -2631,6 +2639,26 @@ mod tests {
         assert!(p.is_command_allowed("echo \"A&B\""));
         assert!(p.is_command_allowed("echo \"A>B\""));
         assert!(p.is_command_allowed("echo \"A<B\""));
+    }
+
+    #[test]
+    fn git_dash_c_uppercase_is_allowed() {
+        // Regression test for #5809: git -C (change directory) must not be
+        // conflated with git -c (set config override) after arg lowercasing.
+        let p = default_policy();
+        assert!(
+            p.is_command_allowed("git -C /home/user/repo status --short"),
+            "git -C is benign and should be allowed"
+        );
+        assert!(
+            p.is_command_allowed("git -C /home/user/repo log --oneline -1"),
+            "git -C with log should be allowed"
+        );
+        // git -c (lowercase) is still blocked — config override injection
+        assert!(
+            !p.is_command_allowed("git -c core.editor=\"rm -rf /\" commit"),
+            "git -c must remain blocked"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Before this change, all command arguments were lowercased before checking, causing `git -C` (change directory) to be conflated with `git -c` (set config override). This resulted in legitimate `git -C` commands being blocked by the security policy.

Now the policy maintains both case-preserved and lowercased argument lists, using the cased version for case-sensitive flag comparisons (like `-C` vs `-c`) and the lowercased version for case-insensitive matches (like subcommand names).

Closes #5809

## Summary

- **Base branch:** `master`
- **What changed and why:** `policy.rs` now splits parsed command arguments into two lists — `args_cased` (preserves original case) and `args` (lowercased). The `-c` config override check uses `args_cased` for exact case-sensitive comparison, so `-C` (uppercase, change directory) no longer matches. Subcommand matching and other case-insensitive checks continue using the lowercased `args` list. A regression test `git_dash_c_uppercase_is_allowed` was added covering both the allow case (`git -C /path status`) and the block case (`git -c core.editor="rm -rf /" commit`).
- **Scope boundary:** Does NOT change any other security rules, channel logic, tool registry, configuration schema, or CLI surface. Only modifies the command-line policy validation path in `policy.rs`.
- **Blast radius:** All tool invocations that rely on `git -C` to specify a working directory outside the default workspace. The `git -c` blocking rule (config override injection) continues to work as before.
- **Linked issue(s):** Closes #5809

## Validation Evidence (required)

- **Commands run and tail output:**

```
$ cargo fmt --all -- --check
(no output — clean)

$ cargo clippy -p zeroclaw-config --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 00s

$ cargo test -p zeroclaw-config policy
running 146 tests
test policy::tests::git_dash_c_uppercase_is_allowed ... ok
...
test result: ok. 146 passed; 0 failed; 0 ignored; 0 measured; 408 filtered out; finished in 0.20s
```

- **Beyond CI — what did you manually verify?**
  - Verified `git -C /home/user/repo status --short` → allowed ✅
  - Verified `git -C /home/user/repo log --oneline -1` → allowed ✅
  - Verified `git -c core.editor="rm -rf /" commit` → still blocked ✅
  - All 146 existing policy tests pass with no regressions
  - Did NOT verify: full workspace `cargo test` / `cargo clippy` across all crates (resource-constrained environment, only zeroclaw-config package tested)

- **If any command was intentionally skipped, why:**
N/A

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (**Yes**)
  This PR *relaxes* an overly strict policy: `git -C` was incorrectly blocked, and is now correctly allowed. This grants the shell tool the ability to run `git -C` as intended, not a new capability.
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation:
  The relaxation is scoped to `git -C` only. The `git -c` config override vector remains blocked. Regression test confirms both cases.

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:
  N/A — no config changes required. Users who previously worked around `git -C` being blocked can remove their workarounds.

## Rollback (required for `risk: medium` and `risk: high`)

Rollback risk: low. `git revert <sha>` is the rollback plan. The change is a single-file, single-concern patch with no migration, no config, and no feature flags.

## Supersede Attribution

N/A

## i18n Follow-Through

N/A — no docs or user-facing wording changes.

---

## Maintainer note (added 2026-04-30 by @singlerider)

Marking this PR as **`Supersedes #5468`** at merge time. PR #5468 by @lesserevil targets the same bug (#5809) on the pre-extraction `src/security/policy.rs` layout and is now conflict-blocked against current master.

### Supersede Attribution
- Superseded PRs + authors: `#5468 by @lesserevil`
- Scope materially carried forward: same bug, same conceptual fix (distinguish `git -C` from `git -c` via case-sensitive comparison). Implementation is independent — #5939 uses a parallel `args_cased` slice with the lowercased `args` retained for `config`/`alias` matches; #5468 dropped the lowercasing entirely and case-folded inside each match arm. Both achieve the same external behavior.
- `Co-authored-by` trailer added? **No.** Independent parallel implementation against the current crate layout, not a code port from #5468. Filing as inspiration-only.
- #5468 will be closed as duplicate of this PR with credit to @lesserevil for filing first.

