### PR TITLE
feat(channels): add Inworld TTS and STT providers

### DIFF
--- a/crates/zeroclaw-channels/src/line.rs
+++ b/crates/zeroclaw-channels/src/line.rs
@@ -1830,6 +1830,7 @@ mod tests {
                 max_audio_bytes: 25 * 1024 * 1024,
                 timeout_secs: 300,
             }),
+            inworld: None,
             transcribe_non_ptt_audio: true,
         };
 

--- a/crates/zeroclaw-channels/src/mattermost.rs
+++ b/crates/zeroclaw-channels/src/mattermost.rs
@@ -1213,6 +1213,7 @@ mod tests {
                 assemblyai: None,
                 google: None,
                 local_whisper: None,
+                inworld: None,
                 transcribe_non_ptt_audio: false,
             },
         );
@@ -1236,6 +1237,7 @@ mod tests {
                 assemblyai: None,
                 google: None,
                 local_whisper: None,
+                inworld: None,
                 transcribe_non_ptt_audio: false,
             },
         );
@@ -1379,6 +1381,7 @@ mod tests {
                 assemblyai: None,
                 google: None,
                 local_whisper: None,
+                inworld: None,
                 transcribe_non_ptt_audio: false,
             },
         );
@@ -1452,6 +1455,7 @@ mod tests {
                     max_audio_bytes: 25_000_000,
                     timeout_secs: 300,
                 }),
+                inworld: None,
                 transcribe_non_ptt_audio: false,
             });
 
@@ -1502,6 +1506,7 @@ mod tests {
                     max_audio_bytes: 25_000_000,
                     timeout_secs: 300,
                 }),
+                inworld: None,
                 transcribe_non_ptt_audio: false,
             });
 

--- a/crates/zeroclaw-channels/src/transcription.rs
+++ b/crates/zeroclaw-channels/src/transcription.rs
@@ -552,6 +552,108 @@ impl TranscriptionProvider for GoogleSttProvider {
     }
 }
 
+// ── InworldProvider ─────────────────────────────────────────────
+
+/// Inworld STT provider (`POST https://api.inworld.ai/stt/v1/transcribe`).
+///
+/// Uses HTTP Basic auth with a Base64-encoded API key from Inworld Studio.
+/// Sends audio as Base64-encoded bytes in the JSON body and returns the
+/// `transcription.transcript` field.
+pub struct InworldProvider {
+    api_key: String,
+    model_id: String,
+    audio_encoding: String,
+    language: Option<String>,
+    include_word_timestamps: bool,
+}
+
+impl InworldProvider {
+    /// Build from `[transcription.inworld]` config. Resolves the API key from
+    /// the config field or the `INWORLD_API_KEY` environment variable.
+    pub fn from_config(config: &zeroclaw_config::schema::InworldSttConfig) -> Result<Self> {
+        let api_key = config
+            .api_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                std::env::var("INWORLD_API_KEY")
+                    .ok()
+                    .map(|v| v.trim().to_string())
+                    .filter(|v| !v.is_empty())
+            })
+            .context(
+                "Missing Inworld STT API key: set [transcription.inworld].api_key or INWORLD_API_KEY",
+            )?;
+
+        Ok(Self {
+            api_key,
+            model_id: config.model_id.clone(),
+            audio_encoding: config.audio_encoding.clone(),
+            language: config.language.clone(),
+            include_word_timestamps: config.include_word_timestamps,
+        })
+    }
+}
+
+#[async_trait]
+impl TranscriptionProvider for InworldProvider {
+    fn name(&self) -> &str {
+        "inworld"
+    }
+
+    async fn transcribe(&self, audio_data: &[u8], file_name: &str) -> Result<String> {
+        validate_audio(audio_data, file_name)?;
+
+        let client = zeroclaw_config::schema::build_runtime_proxy_client("transcription.inworld");
+
+        let audio_content =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, audio_data);
+
+        let mut transcribe_config = serde_json::json!({
+            "modelId": self.model_id,
+            "audioEncoding": self.audio_encoding,
+            "includeWordTimestamps": self.include_word_timestamps,
+        });
+        if let Some(ref lang) = self.language {
+            transcribe_config["language"] = serde_json::Value::String(lang.clone());
+        }
+
+        let body = serde_json::json!({
+            "transcribeConfig": transcribe_config,
+            "audioData": { "content": audio_content },
+        });
+
+        let resp = client
+            .post("https://api.inworld.ai/stt/v1/transcribe")
+            .header("Authorization", format!("Basic {}", self.api_key))
+            .json(&body)
+            .timeout(std::time::Duration::from_secs(TRANSCRIPTION_TIMEOUT_SECS))
+            .send()
+            .await
+            .context("Failed to send transcription request to Inworld")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body_text = resp.text().await.unwrap_or_default();
+            bail!("Inworld STT API error ({}): {}", status, body_text.trim());
+        }
+
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .context("Failed to parse Inworld STT response")?;
+
+        let text = body["transcription"]["transcript"]
+            .as_str()
+            .context("Inworld STT response missing 'transcription.transcript' field")?
+            .to_string();
+
+        Ok(text)
+    }
+}
+
 // ── LocalWhisperProvider ────────────────────────────────────────
 
 /// Self-hosted faster-whisper-compatible STT provider.
@@ -734,6 +836,12 @@ impl TranscriptionManager {
             }
         }
 
+        if let Some(ref inworld_cfg) = config.inworld
+            && let Ok(p) = InworldProvider::from_config(inworld_cfg)
+        {
+            providers.insert("inworld".to_string(), Box::new(p));
+        }
+
         let default_provider = config.default_provider.clone();
 
         if config.enabled && !providers.contains_key(&default_provider) {
@@ -836,6 +944,13 @@ pub async fn transcribe_audio(
             )?;
             let google = GoogleSttProvider::from_config(google_cfg)?;
             google.transcribe(&audio_data, file_name).await
+        }
+        "inworld" => {
+            let inworld_cfg = config.inworld.as_ref().context(
+                "Default transcription provider 'inworld' is not configured. Add [transcription.inworld]",
+            )?;
+            let inworld = InworldProvider::from_config(inworld_cfg)?;
+            inworld.transcribe(&audio_data, file_name).await
         }
         other => bail!("Unsupported transcription provider '{other}'"),
     }
@@ -1135,7 +1250,59 @@ mod tests {
         assert!(config.assemblyai.is_none());
         assert!(config.google.is_none());
         assert!(config.local_whisper.is_none());
+        assert!(config.inworld.is_none());
         assert!(!config.transcribe_non_ptt_audio);
+    }
+
+    // ── InworldProvider tests ────────────────────────────────────
+
+    #[test]
+    fn inworld_provider_requires_api_key() {
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("INWORLD_API_KEY") };
+
+        let cfg = zeroclaw_config::schema::InworldSttConfig::default();
+        let err = InworldProvider::from_config(&cfg).err().unwrap();
+        assert!(
+            err.to_string().contains("Inworld STT API key"),
+            "expected missing-key error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn inworld_provider_accepts_config_api_key() {
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("INWORLD_API_KEY") };
+
+        let cfg = zeroclaw_config::schema::InworldSttConfig {
+            api_key: Some("test-base64-key".into()),
+            ..zeroclaw_config::schema::InworldSttConfig::default()
+        };
+        let provider = InworldProvider::from_config(&cfg).ok().unwrap();
+        assert_eq!(provider.name(), "inworld");
+    }
+
+    #[test]
+    fn manager_registers_inworld_when_configured() {
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("GROQ_API_KEY") };
+        unsafe { std::env::remove_var("INWORLD_API_KEY") };
+
+        let config = TranscriptionConfig {
+            default_provider: "inworld".to_string(),
+            inworld: Some(zeroclaw_config::schema::InworldSttConfig {
+                api_key: Some("test-base64-key".into()),
+                ..zeroclaw_config::schema::InworldSttConfig::default()
+            }),
+            ..TranscriptionConfig::default()
+        };
+
+        let manager = TranscriptionManager::new(&config).unwrap();
+        assert!(
+            manager.available_providers().contains(&"inworld"),
+            "expected inworld in {:?}",
+            manager.available_providers()
+        );
     }
 
     // ── LocalWhisperProvider tests (TDD — added below as red/green cycles) ──

--- a/crates/zeroclaw-channels/src/tts.rs
+++ b/crates/zeroclaw-channels/src/tts.rs
@@ -1,7 +1,7 @@
 //! Multi-provider Text-to-Speech (TTS) subsystem.
 //!
 //! Supports OpenAI, ElevenLabs, Google Cloud TTS, Edge TTS (free, subprocess-based),
-//! and Piper TTS (local GPU-accelerated, OpenAI-compatible endpoint).
+//! Piper TTS (local GPU-accelerated, OpenAI-compatible endpoint), and Inworld TTS.
 //! Provider selection is driven by [`TtsConfig`] in `config.toml`.
 
 use std::collections::HashMap;
@@ -526,6 +526,135 @@ impl TtsProvider for PiperTtsProvider {
     }
 }
 
+// ── Inworld TTS ──────────────────────────────────────────────────
+
+/// Inworld TTS provider (`POST https://api.inworld.ai/tts/v1/voice`).
+///
+/// Uses HTTP Basic auth with a Base64-encoded API key from Inworld Studio
+/// and returns raw audio bytes decoded from the Base64 `audioContent` field.
+pub struct InworldTtsProvider {
+    api_key: String,
+    model_id: String,
+    audio_encoding: String,
+    sample_rate_hertz: u32,
+    speaking_rate: f64,
+    client: reqwest::Client,
+}
+
+impl InworldTtsProvider {
+    /// Create a new Inworld TTS provider from config, resolving the API key
+    /// from config or the `INWORLD_API_KEY` env var.
+    pub fn new(config: &zeroclaw_config::schema::InworldTtsConfig) -> Result<Self> {
+        let api_key = config
+            .api_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|k| !k.is_empty())
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                std::env::var("INWORLD_API_KEY")
+                    .ok()
+                    .map(|v| v.trim().to_string())
+                    .filter(|v| !v.is_empty())
+            })
+            .context("Missing Inworld TTS API key: set [tts.inworld].api_key or INWORLD_API_KEY")?;
+
+        Ok(Self {
+            api_key,
+            model_id: config.model_id.clone(),
+            audio_encoding: config.audio_encoding.clone(),
+            sample_rate_hertz: config.sample_rate_hertz,
+            speaking_rate: config.speaking_rate,
+            client: reqwest::Client::builder()
+                .timeout(TTS_HTTP_TIMEOUT)
+                .build()
+                .context("Failed to build HTTP client for Inworld TTS")?,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl TtsProvider for InworldTtsProvider {
+    fn name(&self) -> &str {
+        "inworld"
+    }
+
+    async fn synthesize(&self, text: &str, voice: &str) -> Result<Vec<u8>> {
+        let body = serde_json::json!({
+            "text": text,
+            "voiceId": voice,
+            "modelId": self.model_id,
+            "audioConfig": {
+                "audioEncoding": self.audio_encoding,
+                "sampleRateHertz": self.sample_rate_hertz,
+                "speakingRate": self.speaking_rate,
+            },
+        });
+
+        let resp = self
+            .client
+            .post("https://api.inworld.ai/tts/v1/voice")
+            .header("Authorization", format!("Basic {}", self.api_key))
+            .json(&body)
+            .send()
+            .await
+            .context("Failed to send Inworld TTS request")?;
+
+        let status = resp.status();
+        let resp_body: serde_json::Value = resp
+            .json()
+            .await
+            .context("Failed to parse Inworld TTS response")?;
+
+        if !status.is_success() {
+            let msg = resp_body["error"]["message"]
+                .as_str()
+                .or_else(|| resp_body["message"].as_str())
+                .unwrap_or("unknown error");
+            bail!("Inworld TTS API error ({}): {}", status, msg);
+        }
+
+        let audio_b64 = resp_body["audioContent"]
+            .as_str()
+            .context("Inworld TTS response missing 'audioContent' field")?;
+
+        use base64::Engine;
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(audio_b64)
+            .context("Failed to decode Inworld TTS base64 audio")?;
+        Ok(bytes)
+    }
+
+    fn supported_voices(&self) -> Vec<String> {
+        // Inworld exposes 22+ preset voices. Return a representative subset.
+        // Use GET /tts/v1/voices for the full live list.
+        [
+            "Alex",
+            "Ashley",
+            "Dennis",
+            "Elizabeth",
+            "Julia",
+            "Mark",
+            "Olivia",
+            "Priya",
+            "Sarah",
+            "Theodore",
+        ]
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect()
+    }
+
+    fn supported_formats(&self) -> Vec<String> {
+        [
+            "mp3", "pcm", "wav", "linear16", "ogg_opus", "alaw", "mulaw", "flac",
+        ]
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect()
+    }
+}
+
 // ── TtsManager ───────────────────────────────────────────────────
 
 /// Central manager for multi-provider TTS synthesis.
@@ -588,6 +717,17 @@ impl TtsManager {
         if let Some(ref piper_cfg) = config.piper {
             let provider = PiperTtsProvider::new(&piper_cfg.api_url);
             providers.insert("piper".to_string(), Box::new(provider));
+        }
+
+        if let Some(ref inworld_cfg) = config.inworld {
+            match InworldTtsProvider::new(inworld_cfg) {
+                Ok(p) => {
+                    providers.insert("inworld".to_string(), Box::new(p));
+                }
+                Err(e) => {
+                    tracing::warn!("Skipping Inworld TTS provider: {e}");
+                }
+            }
         }
 
         let max_text_length = if config.max_text_length == 0 {
@@ -793,6 +933,51 @@ mod tests {
         assert!(config.google.is_none());
         assert!(config.edge.is_none());
         assert!(config.piper.is_none());
+        assert!(config.inworld.is_none());
+    }
+
+    #[test]
+    fn inworld_provider_requires_api_key() {
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("INWORLD_API_KEY") };
+
+        let cfg = zeroclaw_config::schema::InworldTtsConfig::default();
+        let err = InworldTtsProvider::new(&cfg).err().unwrap();
+        assert!(
+            err.to_string().contains("Inworld TTS API key"),
+            "expected missing-key error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn inworld_provider_accepts_config_api_key() {
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("INWORLD_API_KEY") };
+
+        let cfg = zeroclaw_config::schema::InworldTtsConfig {
+            api_key: Some("test-base64-key".into()),
+            ..zeroclaw_config::schema::InworldTtsConfig::default()
+        };
+        let provider = InworldTtsProvider::new(&cfg).ok().unwrap();
+        assert_eq!(provider.name(), "inworld");
+        assert!(provider.supported_formats().iter().any(|f| f == "mp3"));
+        assert!(!provider.supported_voices().is_empty());
+    }
+
+    #[test]
+    fn tts_manager_registers_inworld_when_configured() {
+        // SAFETY: test-only, single-threaded test runner.
+        unsafe { std::env::remove_var("INWORLD_API_KEY") };
+
+        let mut config = default_tts_config();
+        config.default_provider = "inworld".to_string();
+        config.inworld = Some(zeroclaw_config::schema::InworldTtsConfig {
+            api_key: Some("test-base64-key".into()),
+            ..zeroclaw_config::schema::InworldTtsConfig::default()
+        });
+
+        let manager = TtsManager::new(&config).unwrap();
+        assert_eq!(manager.available_providers(), vec!["inworld"]);
     }
 
     #[test]

--- a/crates/zeroclaw-channels/src/wati.rs
+++ b/crates/zeroclaw-channels/src/wati.rs
@@ -729,6 +729,7 @@ mod tests {
             assemblyai: None,
             google: None,
             local_whisper: None,
+            inworld: None,
             transcribe_non_ptt_audio: false,
         };
 
@@ -759,6 +760,7 @@ mod tests {
             assemblyai: None,
             google: None,
             local_whisper: None,
+            inworld: None,
             transcribe_non_ptt_audio: false,
         };
 
@@ -802,6 +804,7 @@ mod tests {
             assemblyai: None,
             google: None,
             local_whisper: None,
+            inworld: None,
             transcribe_non_ptt_audio: false,
         };
 
@@ -949,6 +952,7 @@ mod tests {
                 max_audio_bytes: 25 * 1024 * 1024,
                 timeout_secs: 300,
             }),
+            inworld: None,
             transcribe_non_ptt_audio: false,
         };
 
@@ -1002,6 +1006,7 @@ mod tests {
                 max_audio_bytes: 25 * 1024 * 1024,
                 timeout_secs: 300,
             }),
+            inworld: None,
             transcribe_non_ptt_audio: false,
         };
 

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -846,6 +846,14 @@ fn default_google_stt_language_code() -> String {
     "en-US".into()
 }
 
+fn default_inworld_stt_model_id() -> String {
+    "inworld/inworld-stt-1".into()
+}
+
+fn default_inworld_stt_audio_encoding() -> String {
+    "AUTO_DETECT".into()
+}
+
 /// Voice transcription configuration with multi-provider support.
 ///
 /// The top-level `api_url`, `model`, and `api_key` fields remain for backward
@@ -857,7 +865,7 @@ pub struct TranscriptionConfig {
     /// Enable voice transcription for channels that support it.
     #[serde(default)]
     pub enabled: bool,
-    /// Default STT provider: "groq", "openai", "deepgram", "assemblyai", "google".
+    /// Default STT provider: "groq", "openai", "deepgram", "assemblyai", "google", "inworld".
     #[serde(default = "default_transcription_provider")]
     pub default_provider: String,
     /// API key used for transcription requests (Groq provider).
@@ -903,6 +911,10 @@ pub struct TranscriptionConfig {
     #[serde(default)]
     #[nested]
     pub local_whisper: Option<LocalWhisperConfig>,
+    /// Inworld STT provider configuration.
+    #[serde(default)]
+    #[nested]
+    pub inworld: Option<InworldSttConfig>,
     /// Also transcribe non-PTT (forwarded/regular) audio messages on WhatsApp,
     /// not just voice notes.  Default: `false` (preserves legacy behavior).
     #[serde(default)]
@@ -925,6 +937,7 @@ impl Default for TranscriptionConfig {
             assemblyai: None,
             google: None,
             local_whisper: None,
+            inworld: None,
             transcribe_non_ptt_audio: false,
         }
     }
@@ -1122,6 +1135,22 @@ fn default_piper_tts_api_url() -> String {
     "http://127.0.0.1:5000/v1/audio/speech".into()
 }
 
+fn default_inworld_tts_model_id() -> String {
+    "inworld-tts-1.5-max".into()
+}
+
+fn default_inworld_tts_audio_encoding() -> String {
+    "MP3".into()
+}
+
+fn default_inworld_tts_sample_rate_hertz() -> u32 {
+    24_000
+}
+
+fn default_inworld_tts_speaking_rate() -> f64 {
+    1.0
+}
+
 /// Text-to-Speech configuration (`[tts]`).
 #[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
@@ -1130,7 +1159,7 @@ pub struct TtsConfig {
     /// Enable TTS synthesis.
     #[serde(default)]
     pub enabled: bool,
-    /// Default TTS provider (`"openai"`, `"elevenlabs"`, `"google"`, `"edge"`).
+    /// Default TTS provider (`"openai"`, `"elevenlabs"`, `"google"`, `"edge"`, `"piper"`, `"inworld"`).
     #[serde(default = "default_tts_provider")]
     pub default_provider: String,
     /// Default voice ID passed to the selected provider.
@@ -1162,6 +1191,10 @@ pub struct TtsConfig {
     #[serde(default)]
     #[nested]
     pub piper: Option<PiperTtsConfig>,
+    /// Inworld TTS provider configuration (`[tts.inworld]`).
+    #[serde(default)]
+    #[nested]
+    pub inworld: Option<InworldTtsConfig>,
 }
 
 impl Default for TtsConfig {
@@ -1177,6 +1210,7 @@ impl Default for TtsConfig {
             google: None,
             edge: None,
             piper: None,
+            inworld: None,
         }
     }
 }
@@ -1264,6 +1298,48 @@ impl Default for PiperTtsConfig {
     fn default() -> Self {
         Self {
             api_url: default_piper_tts_api_url(),
+        }
+    }
+}
+
+/// Inworld TTS provider configuration (`[tts.inworld]`).
+///
+/// Authenticates with a Base64-encoded API key from Inworld Studio
+/// ("Copy Base64" button under Settings → API Keys), sent as
+/// `Authorization: Basic <key>`.
+#[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "tts.inworld"]
+pub struct InworldTtsConfig {
+    /// API key for Inworld TTS (Base64-encoded, as copied from Inworld Studio).
+    /// Falls back to the `INWORLD_API_KEY` environment variable when unset.
+    #[serde(default)]
+    #[secret]
+    pub api_key: Option<String>,
+    /// Model identifier (default `"inworld-tts-1.5-max"`; `"inworld-tts-1.5-mini"` is also available).
+    #[serde(default = "default_inworld_tts_model_id")]
+    pub model_id: String,
+    /// Audio encoding — one of `"MP3"`, `"PCM"`, `"WAV"`, `"LINEAR16"`,
+    /// `"OGG_OPUS"`, `"ALAW"`, `"MULAW"`, `"FLAC"`. Default `"MP3"`.
+    #[serde(default = "default_inworld_tts_audio_encoding")]
+    pub audio_encoding: String,
+    /// Output sample rate in Hz. Inworld accepts one of
+    /// `8000`, `16000`, `22050`, `24000`, `32000`, `44100`, `48000`. Default `24000`.
+    #[serde(default = "default_inworld_tts_sample_rate_hertz")]
+    pub sample_rate_hertz: u32,
+    /// Speaking rate multiplier (0.5–1.5). Default `1.0`.
+    #[serde(default = "default_inworld_tts_speaking_rate")]
+    pub speaking_rate: f64,
+}
+
+impl Default for InworldTtsConfig {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            model_id: default_inworld_tts_model_id(),
+            audio_encoding: default_inworld_tts_audio_encoding(),
+            sample_rate_hertz: default_inworld_tts_sample_rate_hertz(),
+            speaking_rate: default_inworld_tts_speaking_rate(),
         }
     }
 }
@@ -1369,6 +1445,50 @@ pub struct GoogleSttConfig {
     /// BCP-47 language code (default: "en-US").
     #[serde(default = "default_google_stt_language_code")]
     pub language_code: String,
+}
+
+/// Inworld STT provider configuration (`[transcription.inworld]`).
+///
+/// Authenticates with a Base64-encoded API key from Inworld Studio
+/// ("Copy Base64" button under Settings → API Keys), sent as
+/// `Authorization: Basic <key>`.
+#[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "transcription.inworld"]
+pub struct InworldSttConfig {
+    /// API key for Inworld STT (Base64-encoded, as copied from Inworld Studio).
+    /// Falls back to the `INWORLD_API_KEY` environment variable when unset.
+    #[serde(default)]
+    #[secret]
+    pub api_key: Option<String>,
+    /// STT model identifier (default `"inworld/inworld-stt-1"`).
+    /// Alternatives include `"groq/whisper-large-v3"` and
+    /// `"assemblyai/universal-streaming-multilingual"`.
+    #[serde(default = "default_inworld_stt_model_id")]
+    pub model_id: String,
+    /// Audio encoding hint (default `"AUTO_DETECT"`). Other accepted values:
+    /// `"LINEAR16"`, `"MP3"`, `"OGG_OPUS"`, `"FLAC"`.
+    #[serde(default = "default_inworld_stt_audio_encoding")]
+    pub audio_encoding: String,
+    /// Optional BCP-47 language code (e.g. `"en-US"`, `"ko-KR"`).
+    /// Omit to let Inworld auto-detect.
+    #[serde(default)]
+    pub language: Option<String>,
+    /// Request word-level timestamps in the response.
+    #[serde(default)]
+    pub include_word_timestamps: bool,
+}
+
+impl Default for InworldSttConfig {
+    fn default() -> Self {
+        Self {
+            api_key: None,
+            model_id: default_inworld_stt_model_id(),
+            audio_encoding: default_inworld_stt_audio_encoding(),
+            language: None,
+            include_word_timestamps: false,
+        }
+    }
 }
 
 /// Local/self-hosted Whisper-compatible STT endpoint (`[transcription.local_whisper]`).


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds Inworld as an optional provider to both the TTS and STT subsystems. Inworld's TTS-1.5 is a real-time voice synthesis API with Korean, phoneme/viseme timestamps for lipsync, and sub-200 ms P90 latency; its STT bundles speaker profiling (emotion/age/pitch) at base price. Supporting it gives operators another swappable voice-pipeline choice alongside OpenAI, ElevenLabs, Google, Edge, Piper, Groq, Deepgram, and AssemblyAI.
- **Scope boundary:** Only adds new provider code paths. Does NOT change trait definitions, manager dispatch logic for other providers, default config values, or any existing channel behavior. WebSocket streaming (`voice:stream`, `streamBidirectional`) is intentionally deferred — this PR ships the synchronous HTTP endpoints only.
- **Blast radius:** New optional config sections (`[tts.inworld]`, `[transcription.inworld]`). Users without those sections see zero behavior change. `TranscriptionConfig` gains an `inworld: Option<InworldSttConfig>` field; fixed up 11 existing test sites that construct it without `..Default::default()` spread.
- **Linked issue(s):** None (direct contribution).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-config -p zeroclaw-channels --all-targets -- -D warnings
cargo test -p zeroclaw-channels --lib inworld
```

- **Commands run and tail output:**
  - `fmt --check`: clean (no diff)
  - `clippy -D warnings`: clean, no warnings
  - `test inworld`: `6 passed; 0 failed; 0 ignored; 0 measured; 926 filtered out` (all 6 new Inworld tests pass: `inworld_provider_requires_api_key`, `inworld_provider_accepts_config_api_key`, `tts_manager_registers_inworld_when_configured`, and the STT counterparts)
  - Full `cargo test -p zeroclaw-channels --lib`: `930 passed; 2 failed`. The 2 pre-existing failures (`orchestrator::tests::build_channel_by_id_configured_telegram_succeeds`, `..._unconfigured_telegram_returns_error`) also fail on unmodified `master` and are unrelated to this PR.

- **Beyond CI — what did you manually verify?** Schema round-trip via `TranscriptionConfig::default()` / `TtsConfig::default()` in existing tests. Struct literal fixups in `mattermost.rs` / `wati.rs` / `line.rs` still compile and their tests still pass. Did NOT verify against a live Inworld API (no token in this environment) — the wire schema was built from the official `docs.inworld.ai` reference.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **Yes** — `https://api.inworld.ai/tts/v1/voice` and `https://api.inworld.ai/stt/v1/transcribe`, gated behind explicit `[tts.inworld]` / `[transcription.inworld]` config. Reuses the existing `build_runtime_proxy_client` for STT so proxy/egress rules apply.
- Secrets / tokens / credentials handling changed? **Yes** — adds `INWORLD_API_KEY` env var fallback and `api_key` config field (marked `#[secret]`). Matches the pattern already used by OpenAI / ElevenLabs / Groq providers.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes** — both `TtsConfig` and `TranscriptionConfig` gain `inworld: Option<...>` fields defaulting to `None`. Existing config files are unchanged in behavior.
- Config / env / CLI surface changed? **Yes, additive only** — new optional sections `[tts.inworld]` and `[transcription.inworld]`, plus a new optional env var `INWORLD_API_KEY`. No existing keys renamed or removed.
- If `No` or `Yes` to either: exact upgrade steps for existing users: none required unless you want to enable Inworld; in that case, add the relevant config section and an API key from Inworld Studio (Settings → API Keys → "Copy Base64").

## Rollback (required for `risk: medium` and `risk: high`)

Low risk. `git revert <sha>` removes both providers cleanly; no migration.