### PR TITLE
feat(config): expose Vec<String> fields via zeroclaw config get/set/list

### DIFF
--- a/crates/zeroclaw-config/src/helpers.rs
+++ b/crates/zeroclaw-config/src/helpers.rs
@@ -53,6 +53,7 @@ pub fn make_prop_field(
     let display_value = if is_secret {
         match table.and_then(|t| t.get(serde_name)) {
             Some(toml::Value::String(s)) if !s.is_empty() => "****".to_string(),
+            Some(toml::Value::Array(arr)) if !arr.is_empty() => format!("[{}]", vec!["****"; arr.len()].join(", ")),
             _ => "<unset>".to_string(),
         }
     } else {
@@ -179,5 +180,14 @@ mod tests {
         let arr = result.as_array().unwrap();
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0].as_str(), Some("alice"));
+    }
+
+    #[test]
+    fn parse_string_array_quote_in_value_is_literal() {
+        let result = parse_prop_value(r#"tok1, p@ss"word"#, PropKind::StringArray).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str(), Some("tok1"));
+        assert_eq!(arr[1].as_str(), Some(r#"p@ss"word"#));
     }
 }

--- a/crates/zeroclaw-config/src/helpers.rs
+++ b/crates/zeroclaw-config/src/helpers.rs
@@ -142,5 +142,42 @@ fn parse_prop_value(value_str: &str, kind: PropKind) -> anyhow::Result<toml::Val
             })?))
         }
         PropKind::String | PropKind::Enum => Ok(toml::Value::String(value_str.to_string())),
+        PropKind::StringArray => {
+            let items = value_str
+                .split(',')
+                .map(|s| toml::Value::String(s.trim().to_string()))
+                .filter(|v| v.as_str().is_some_and(|s| !s.is_empty()))
+                .collect();
+            Ok(toml::Value::Array(items))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_string_array_splits_on_comma() {
+        let result = parse_prop_value("alice, bob, charlie", PropKind::StringArray).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_str(), Some("alice"));
+        assert_eq!(arr[1].as_str(), Some("bob"));
+        assert_eq!(arr[2].as_str(), Some("charlie"));
+    }
+
+    #[test]
+    fn parse_string_array_empty_input_gives_empty_array() {
+        let result = parse_prop_value("", PropKind::StringArray).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn parse_string_array_single_value() {
+        let result = parse_prop_value("alice", PropKind::StringArray).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0].as_str(), Some("alice"));
     }
 }

--- a/crates/zeroclaw-config/src/helpers.rs
+++ b/crates/zeroclaw-config/src/helpers.rs
@@ -53,7 +53,9 @@ pub fn make_prop_field(
     let display_value = if is_secret {
         match table.and_then(|t| t.get(serde_name)) {
             Some(toml::Value::String(s)) if !s.is_empty() => "****".to_string(),
-            Some(toml::Value::Array(arr)) if !arr.is_empty() => format!("[{}]", vec!["****"; arr.len()].join(", ")),
+            Some(toml::Value::Array(arr)) if !arr.is_empty() => {
+                format!("[{}]", vec!["****"; arr.len()].join(", "))
+            }
             _ => "<unset>".to_string(),
         }
     } else {

--- a/crates/zeroclaw-config/src/traits.rs
+++ b/crates/zeroclaw-config/src/traits.rs
@@ -18,6 +18,8 @@ pub enum PropKind {
     Float,
     /// An enum or other serde-serializable type (parsed as TOML string).
     Enum,
+    /// A `Vec<String>` field; set via comma-separated input.
+    StringArray,
 }
 
 /// Maps Rust types to PropKind at compile time.
@@ -49,6 +51,9 @@ impl_prop_kind!(
     i64,
     isize
 );
+impl HasPropKind for Vec<String> {
+    const PROP_KIND: PropKind = PropKind::StringArray;
+}
 
 /// Describes a single property field discovered via `#[derive(Configurable)]`.
 #[derive(Clone)]

--- a/crates/zeroclaw-macros/src/lib.rs
+++ b/crates/zeroclaw-macros/src/lib.rs
@@ -380,8 +380,11 @@ pub fn derive_configurable(input: TokenStream) -> TokenStream {
         let is_option = is_option_type(&field.ty);
         let inner_ty = extract_option_inner(&field.ty).unwrap_or(&field.ty);
 
-        // Skip compound types (Vec, HashMap, PathBuf)
-        if is_compound_type(inner_ty) {
+        // Skip compound types (Vec, HashMap, PathBuf), but expose Vec<String> as StringArray.
+        let is_vec_string = extract_vec_inner(inner_ty)
+            .map(|t| t.to_token_stream().to_string() == "String")
+            .unwrap_or(false);
+        if is_compound_type(inner_ty) && !is_vec_string {
             continue;
         }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -103,6 +103,7 @@ pub fn make_prop_field(
     let display_value = if is_secret {
         match table.and_then(|t| t.get(serde_name)) {
             Some(toml::Value::String(s)) if !s.is_empty() => "****".to_string(),
+            Some(toml::Value::Array(arr)) if !arr.is_empty() => format!("[{}]", vec!["****"; arr.len()].join(", ")),
             _ => "<unset>".to_string(),
         }
     } else {
@@ -229,6 +230,15 @@ mod tests {
         let arr = result.as_array().unwrap();
         assert_eq!(arr.len(), 1);
         assert_eq!(arr[0].as_str(), Some("alice"));
+    }
+
+    #[test]
+    fn parse_string_array_quote_in_value_is_literal() {
+        let result = parse_prop_value(r#"tok1, p@ss"word"#, PropKind::StringArray).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0].as_str(), Some("tok1"));
+        assert_eq!(arr[1].as_str(), Some(r#"p@ss"word"#));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -192,12 +192,44 @@ fn parse_prop_value(value_str: &str, kind: PropKind) -> anyhow::Result<toml::Val
             })?))
         }
         PropKind::String | PropKind::Enum => Ok(toml::Value::String(value_str.to_string())),
+        PropKind::StringArray => {
+            let items = value_str
+                .split(',')
+                .map(|s| toml::Value::String(s.trim().to_string()))
+                .filter(|v| v.as_str().is_some_and(|s| !s.is_empty()))
+                .collect();
+            Ok(toml::Value::Array(items))
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_string_array_splits_on_comma() {
+        let result = parse_prop_value("alice, bob, charlie", PropKind::StringArray).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0].as_str(), Some("alice"));
+        assert_eq!(arr[1].as_str(), Some("bob"));
+        assert_eq!(arr[2].as_str(), Some("charlie"));
+    }
+
+    #[test]
+    fn parse_string_array_empty_input_gives_empty_array() {
+        let result = parse_prop_value("", PropKind::StringArray).unwrap();
+        assert_eq!(result.as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn parse_string_array_single_value() {
+        let result = parse_prop_value("alice", PropKind::StringArray).unwrap();
+        let arr = result.as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0].as_str(), Some("alice"));
+    }
 
     #[test]
     fn reexported_config_default_is_constructible() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -103,7 +103,9 @@ pub fn make_prop_field(
     let display_value = if is_secret {
         match table.and_then(|t| t.get(serde_name)) {
             Some(toml::Value::String(s)) if !s.is_empty() => "****".to_string(),
-            Some(toml::Value::Array(arr)) if !arr.is_empty() => format!("[{}]", vec!["****"; arr.len()].join(", ")),
+            Some(toml::Value::Array(arr)) if !arr.is_empty() => {
+                format!("[{}]", vec!["****"; arr.len()].join(", "))
+            }
             _ => "<unset>".to_string(),
         }
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1982,14 +1982,29 @@ async fn main() -> Result<()> {
                         .as_ref()
                         .is_some_and(|f| f.kind == crate::config::PropKind::StringArray)
                     {
-                        let current = field_info
+                        let current_items: Vec<String> = field_info
                             .as_ref()
-                            .map(|f| f.display_value.trim_matches(|c| c == '[' || c == ']').replace('"', ""))
+                            .and_then(|f| {
+                                let raw = toml::from_str::<toml::Value>(&format!(
+                                    "v = {}",
+                                    if f.display_value == "<unset>" { "[]".to_string() } else { f.display_value.clone() }
+                                ))
+                                .ok();
+                                raw.and_then(|v| v.get("v").cloned())
+                                    .and_then(|v| v.as_array().cloned())
+                                    .map(|arr| arr.iter().filter_map(|x| x.as_str().map(|s| s.to_string())).collect())
+                            })
                             .unwrap_or_default();
-                        let val = dialoguer::Input::<String>::new()
-                            .with_prompt(format!("Enter comma-separated values for {path}"))
-                            .with_initial_text(current)
-                            .interact_text()?;
+                        let editor_content = current_items.join("\n");
+                        let edited = dialoguer::Editor::new()
+                            .edit(&editor_content)?
+                            .unwrap_or(editor_content);
+                        let val = edited
+                            .lines()
+                            .map(|l| l.trim())
+                            .filter(|l| !l.is_empty())
+                            .collect::<Vec<_>>()
+                            .join(", ");
                         config.set_prop(&path, &val)?;
                     } else {
                         anyhow::bail!("Value required. Usage: zeroclaw config set {path} <value>");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1961,19 +1961,16 @@ async fn main() -> Result<()> {
                 } else if let Some(val) = value {
                     config.set_prop(&path, &val)?;
                 } else {
-                    let variants = config
-                        .prop_fields()
-                        .into_iter()
-                        .find(|f| f.name == path)
-                        .and_then(|info| {
-                            let get_variants = info.enum_variants?;
-                            let variants = get_variants();
-                            let current_index = variants
-                                .iter()
-                                .position(|v| v == &info.display_value)
-                                .unwrap_or(0);
-                            Some((variants, current_index))
-                        });
+                    let field_info = config.prop_fields().into_iter().find(|f| f.name == path);
+                    let variants = field_info.as_ref().and_then(|info| {
+                        let get_variants = info.enum_variants?;
+                        let variants = get_variants();
+                        let current_index = variants
+                            .iter()
+                            .position(|v| v == &info.display_value)
+                            .unwrap_or(0);
+                        Some((variants, current_index))
+                    });
                     if let Some((variants, current_index)) = variants {
                         let selected = Select::new()
                             .with_prompt(format!("Select value for {path}"))
@@ -1981,6 +1978,19 @@ async fn main() -> Result<()> {
                             .default(current_index)
                             .interact()?;
                         config.set_prop(&path, &variants[selected])?;
+                    } else if field_info
+                        .as_ref()
+                        .is_some_and(|f| f.kind == crate::config::PropKind::StringArray)
+                    {
+                        let current = field_info
+                            .as_ref()
+                            .map(|f| f.display_value.trim_matches(|c| c == '[' || c == ']').replace('"', ""))
+                            .unwrap_or_default();
+                        let val = dialoguer::Input::<String>::new()
+                            .with_prompt(format!("Enter comma-separated values for {path}"))
+                            .with_initial_text(current)
+                            .interact_text()?;
+                        config.set_prop(&path, &val)?;
                     } else {
                         anyhow::bail!("Value required. Usage: zeroclaw config set {path} <value>");
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1987,12 +1987,20 @@ async fn main() -> Result<()> {
                             .and_then(|f| {
                                 let raw = toml::from_str::<toml::Value>(&format!(
                                     "v = {}",
-                                    if f.display_value == "<unset>" { "[]".to_string() } else { f.display_value.clone() }
+                                    if f.display_value == "<unset>" {
+                                        "[]".to_string()
+                                    } else {
+                                        f.display_value.clone()
+                                    }
                                 ))
                                 .ok();
                                 raw.and_then(|v| v.get("v").cloned())
                                     .and_then(|v| v.as_array().cloned())
-                                    .map(|arr| arr.iter().filter_map(|x| x.as_str().map(|s| s.to_string())).collect())
+                                    .map(|arr| {
+                                        arr.iter()
+                                            .filter_map(|x| x.as_str().map(|s| s.to_string()))
+                                            .collect()
+                                    })
                             })
                             .unwrap_or_default();
                         let editor_content = current_items.join("\n");


### PR DESCRIPTION
## Summary

- **What changed and why:** `Vec<String>` config fields were silently skipped by the `Configurable` derive macro — `zeroclaw config get/set/list` could not touch them at all. This exposes them as `PropKind::StringArray`, making fields like `allowed_users`, `allowed_commands`, `forbidden_paths`, `allowed_domains`, and dozens more first-class config citizens. Part of the migration infrastructure required by the schema v3 tracker (#5947).
- **Scope boundary:** Only `Vec<String>` fields. `Vec<T>` where T is not String, `HashMap`, and `PathBuf` remain excluded. No runtime behavior changes — config shape and CLI surface only.
- **Blast radius:** All structs deriving `Configurable` with `Vec<String>` fields now emit property entries. Secret `Vec<String>` fields (currently only `gateway.paired_tokens`) are exposed with masked display (`[****, ****]`, count-visible).
- **Linked issue(s):** Related #5947

## Validation Evidence (required)

- **Commands run and tail output:**
```
cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 12s
```
- **Beyond CI — what did you manually verify?** Traced the full macro codegen path for `Vec<String>` fields. Verified secret array masked display logic. Verified quote characters in comma-separated input are stored literally, consistent with scalar `String` field handling. Editor interactive path requires a live terminal — not verified at runtime.
- **If any command was intentionally skipped, why:** `cargo fmt` and `cargo test` run by maintainer per project convention.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? Yes — `#[secret] Vec<String>` fields are now surfaced in `zeroclaw config list` with masked display. Setting them via CLI uses the existing masked Password prompt. No secret values are exposed.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes — purely additive. Fields invisible before are now visible; no existing field changes shape or meaning.
- Config / env / CLI surface changed? Yes — `zeroclaw config list` now surfaces `Vec<String>` fields; `zeroclaw config get/set` accepts them via comma-separated input or `$EDITOR` in interactive mode.
- Upgrade steps: none required. Existing configs deserialize unchanged.

## Rollback (required for `risk: medium` and `risk: high`)

`git revert 5c053183..4289e82a`

## i18n Follow-Through (required only when docs or user-facing wording change)

- Locale navigation parity updated? N/A
- Localized runtime-contract docs updated? N/A
- Vietnamese canonical docs synced? N/A
- N/A rationale: CLI behavior change only — no documentation files modified in this PR. Config reference docs (`config-reference`) may warrant a follow-up to document `StringArray` field semantics.