### PR TITLE
fix(channels/ACP): suppress INFO logs, implement missing parts of ACP spec protocol

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
@@ -224,7 +224,8 @@ impl AcpServer {
     // ── Method handlers ──────────────────────────────────────────
 
     fn handle_initialize(&self, _params: &Value) -> RpcResult {
-        let default_model = self.config
+        let default_model = self
+            .config
             .providers
             .fallback_provider()
             .and_then(|e| e.model.clone())
@@ -514,11 +515,7 @@ impl AcpServer {
 
         let event_type = params
             .get("type")
-            .or_else(|| {
-                params
-                    .get("update")
-                    .and_then(|u| u.get("sessionUpdate"))
-            })
+            .or_else(|| params.get("update").and_then(|u| u.get("sessionUpdate")))
             .and_then(|v| v.as_str())
             .unwrap_or("unknown")
             .to_string();

--- a/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/acp_server.rs
@@ -10,10 +10,11 @@
 //!
 //! | Method            | Description                              |
 //! |-------------------|------------------------------------------|
-//! | `initialize`      | Handshake — returns server capabilities  |
+//! | `initialize`      | Handshake — returns server capabilities (incl. defaultModel) |
 //! | `session/new`     | Create an isolated agent session          |
-//! | `session/prompt`  | Send a prompt, stream back events         |
+//! | `session/prompt`  | Send a prompt, stream back `session/update` events |
 //! | `session/stop`    | Gracefully terminate a session            |
+//! | `session/update`  | Streaming events and bidirectional events |
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -23,7 +24,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::Mutex;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 use zeroclaw_config::schema::Config;
 use zeroclaw_runtime::agent::agent::{Agent, TurnEvent};
@@ -127,7 +128,7 @@ impl AcpServer {
     /// Run the ACP server, reading JSON-RPC requests from stdin and writing
     /// responses/notifications to stdout.
     pub async fn run(&self) -> Result<()> {
-        info!(
+        debug!(
             "ACP server starting (max_sessions={}, timeout={}s)",
             self.acp_config.max_sessions, self.acp_config.session_timeout_secs
         );
@@ -148,7 +149,7 @@ impl AcpServer {
                 sessions.retain(|id, session| {
                     let expired = session.last_active.elapsed() > timeout;
                     if expired {
-                        info!("Session {id} expired after inactivity");
+                        debug!("Session {id} expired after inactivity");
                     }
                     !expired
                 });
@@ -163,7 +164,7 @@ impl AcpServer {
             line.clear();
             let bytes_read = reader.read_line(&mut line).await?;
             if bytes_read == 0 {
-                info!("ACP server: stdin closed, shutting down");
+                debug!("ACP server: stdin closed, shutting down");
                 break;
             }
 
@@ -203,6 +204,7 @@ impl AcpServer {
             "session/new" => self.handle_session_new(&request.params).await,
             "session/prompt" => self.handle_session_prompt(&request.params, &id).await,
             "session/stop" => self.handle_session_stop(&request.params).await,
+            "session/event" | "session/update" => self.handle_session_event(&request.params).await,
             _ => Err(RpcError {
                 code: METHOD_NOT_FOUND,
                 message: format!("Method not found: {}", request.method),
@@ -222,6 +224,12 @@ impl AcpServer {
     // ── Method handlers ──────────────────────────────────────────
 
     fn handle_initialize(&self, _params: &Value) -> RpcResult {
+        let default_model = self.config
+            .providers
+            .fallback_provider()
+            .and_then(|e| e.model.clone())
+            .unwrap_or_else(|| "anthropic/claude-sonnet-4.6".to_string());
+
         Ok(serde_json::json!({
             "protocolVersion": "1.0",
             "serverInfo": {
@@ -232,12 +240,15 @@ impl AcpServer {
                 "streaming": true,
                 "maxSessions": self.acp_config.max_sessions,
                 "sessionTimeoutSecs": self.acp_config.session_timeout_secs,
+                "defaultModel": default_model,
             },
             "methods": [
                 "initialize",
                 "session/new",
                 "session/prompt",
                 "session/stop",
+                "session/update",
+                "session/event",  // legacy
             ],
         }))
     }
@@ -286,7 +297,7 @@ impl AcpServer {
             },
         );
 
-        info!("Created session {session_id} (workspace: {workspace_dir})");
+        debug!("Created session {session_id} (workspace: {workspace_dir})");
 
         Ok(serde_json::json!({
             "sessionId": session_id,
@@ -306,15 +317,7 @@ impl AcpServer {
             })?
             .to_string();
 
-        let prompt = params
-            .get("prompt")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| RpcError {
-                code: INVALID_PARAMS,
-                message: "Missing required parameter: prompt".to_string(),
-                data: None,
-            })?
-            .to_string();
+        let prompt = Self::parse_prompt(params)?;
 
         // Remove the session from the map so we can take mutable ownership of
         // the Agent for the duration of the turn. It will be reinserted after.
@@ -340,45 +343,65 @@ impl AcpServer {
             (session, result)
         });
 
-        // Forward events as they arrive
+        // Forward events as they arrive. Use standard ACP `session/update`
+        // notifications with `sessionUpdate` + structured `content` so that
+        // clients like agentic.nvim route them to MessageWriter.
         while let Some(event) = event_rx.recv().await {
             let notification = match &event {
                 TurnEvent::Chunk { delta } => JsonRpcNotification {
                     jsonrpc: "2.0",
-                    method: "session/event",
+                    method: "session/update",
                     params: serde_json::json!({
                         "sessionId": session_id,
-                        "type": "chunk",
-                        "content": delta,
+                        "update": {
+                            "sessionUpdate": "agent_message_chunk",
+                            "content": {
+                                "type": "text",
+                                "text": delta
+                            }
+                        }
                     }),
                 },
                 TurnEvent::ToolCall { name, args } => JsonRpcNotification {
                     jsonrpc: "2.0",
-                    method: "session/event",
+                    method: "session/update",
                     params: serde_json::json!({
                         "sessionId": session_id,
-                        "type": "tool_call",
-                        "name": name,
-                        "args": args,
+                        "update": {
+                            "sessionUpdate": "tool_call",
+                            "toolCallId": name,  // simplistic; full impl would generate UUID
+                            "name": name,
+                            "kind": "other",
+                            "argument": args,
+                            "status": "pending"
+                        }
                     }),
                 },
                 TurnEvent::ToolResult { name, output } => JsonRpcNotification {
                     jsonrpc: "2.0",
-                    method: "session/event",
+                    method: "session/update",
                     params: serde_json::json!({
                         "sessionId": session_id,
-                        "type": "tool_result",
-                        "name": name,
-                        "output": output,
+                        "update": {
+                            "sessionUpdate": "tool_call_update",
+                            "toolCallId": name,
+                            "status": "completed",
+                            "body": output
+                        }
                     }),
                 },
                 TurnEvent::Thinking { delta } => JsonRpcNotification {
                     jsonrpc: "2.0",
-                    method: "session/event",
+                    method: "session/update",
                     params: serde_json::json!({
                         "sessionId": session_id,
-                        "type": "thinking",
-                        "content": delta,
+                        "update": {
+                            "sessionUpdate": "agent_thought_chunk",
+                            "content": {
+                                "type": "text",
+                                "text": delta
+                            }
+                        }
                     }),
                 },
             };
@@ -407,8 +430,41 @@ impl AcpServer {
 
         Ok(serde_json::json!({
             "sessionId": session_id,
-            "content": result,
+            "stopReason": "end_turn",
+            "content": result,  // full assembled response for clients that expect it
         }))
+    }
+
+    fn parse_prompt(params: &Value) -> std::result::Result<String, RpcError> {
+        match params.get("prompt") {
+            Some(Value::String(s)) => Ok(s.clone()),
+            Some(Value::Array(arr)) => {
+                let mut joined = String::new();
+                for part in arr {
+                    if let Some(text) = part.get("text").and_then(|v| v.as_str()) {
+                        if !joined.is_empty() {
+                            joined.push_str("\n\n");
+                        }
+                        joined.push_str(text);
+                    }
+                }
+                if joined.is_empty() {
+                    return Err(RpcError {
+                        code: INVALID_PARAMS,
+                        message: "Parameter 'prompt' array must contain at least one text part"
+                            .to_string(),
+                        data: None,
+                    });
+                }
+                Ok(joined)
+            }
+            _ => Err(RpcError {
+                code: INVALID_PARAMS,
+                message: "Missing required parameter: prompt (must be string or array of parts)"
+                    .to_string(),
+                data: None,
+            }),
+        }
     }
 
     async fn handle_session_stop(&self, params: &Value) -> RpcResult {
@@ -424,10 +480,58 @@ impl AcpServer {
 
         let mut sessions = self.sessions.lock().await;
         if sessions.remove(session_id).is_some() {
-            info!("Stopped session {session_id}");
+            debug!("Stopped session {session_id}");
             Ok(serde_json::json!({
                 "sessionId": session_id,
                 "stopped": true,
+            }))
+        } else {
+            Err(RpcError {
+                code: SESSION_NOT_FOUND,
+                message: format!("Session not found: {session_id}"),
+                data: None,
+            })
+        }
+    }
+
+    /// Handle incoming `session/update` (or legacy `session/event`) notifications.
+    ///
+    /// This processes bidirectional events for an active session (e.g. tool results,
+    /// status updates, or client-side events). Currently updates session activity
+    /// to prevent premature reaping; future extensions can route specific event
+    /// types into the Agent.
+    async fn handle_session_event(&self, params: &Value) -> RpcResult {
+        let session_id = params
+            .get("sessionId")
+            .or_else(|| params.get("session_id"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| RpcError {
+                code: INVALID_PARAMS,
+                message: "Missing required parameter: sessionId".to_string(),
+                data: None,
+            })?
+            .to_string();
+
+        let event_type = params
+            .get("type")
+            .or_else(|| {
+                params
+                    .get("update")
+                    .and_then(|u| u.get("sessionUpdate"))
+            })
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        debug!("Received session update (type={event_type}) for session {session_id}");
+
+        let mut sessions = self.sessions.lock().await;
+        if let Some(session) = sessions.get_mut(&session_id) {
+            session.last_active = Instant::now();
+            Ok(serde_json::json!({
+                "sessionId": session_id,
+                "type": event_type,
+                "status": "processed"
             }))
         } else {
             Err(RpcError {
@@ -494,6 +598,7 @@ impl AcpServer {
 
 // ── Error helper ─────────────────────────────────────────────────
 
+#[derive(Debug)]
 struct RpcError {
     code: i32,
     message: String,
@@ -540,9 +645,9 @@ mod tests {
 
     #[test]
     fn json_rpc_request_parse_notification() {
-        let json = r#"{"jsonrpc":"2.0","method":"session/event","params":{}}"#;
+        let json = r#"{"jsonrpc":"2.0","method":"session/update","params":{}}"#;
         let req: JsonRpcRequest = serde_json::from_str(json).unwrap();
-        assert_eq!(req.method, "session/event");
+        assert_eq!(req.method, "session/update");
         assert!(req.id.is_none());
     }
 
@@ -585,11 +690,55 @@ mod tests {
     fn json_rpc_notification_serialize() {
         let notif = JsonRpcNotification {
             jsonrpc: "2.0",
-            method: "session/event",
-            params: serde_json::json!({"type": "chunk", "content": "hello"}),
+            method: "session/update",
+            params: serde_json::json!({
+                "sessionId": "test-sid",
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": { "type": "text", "text": "hello" }
+                }
+            }),
         };
         let json = serde_json::to_string(&notif).unwrap();
-        assert!(json.contains(r#""method":"session/event""#));
-        assert!(json.contains(r#""content":"hello""#));
+        assert!(json.contains(r#""method":"session/update""#));
+        assert!(json.contains(r#""sessionUpdate":"agent_message_chunk""#));
+        assert!(json.contains(r#""text":"hello""#));
+    }
+
+    #[test]
+    fn test_prompt_parsing() {
+        // String prompt
+        let string_params = serde_json::json!({"prompt": "hello world"});
+        let result = AcpServer::parse_prompt(&string_params).unwrap();
+        assert_eq!(result, "hello world");
+
+        // Array prompt (valid)
+        let array_params = serde_json::json!({
+            "prompt": [
+                {"type": "text", "text": "part 1"},
+                {"type": "text", "text": "part 2"}
+            ]
+        });
+        let result = AcpServer::parse_prompt(&array_params).unwrap();
+        assert_eq!(result, "part 1\n\npart 2");
+
+        // Array prompt (empty or no text)
+        let empty_array_params = serde_json::json!({"prompt": []});
+        let result = AcpServer::parse_prompt(&empty_array_params);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, INVALID_PARAMS);
+
+        let no_text_params = serde_json::json!({
+            "prompt": [
+                {"type": "image", "data": "..."}
+            ]
+        });
+        let result = AcpServer::parse_prompt(&no_text_params);
+        assert!(result.is_err());
+
+        // Missing prompt
+        let missing_params = serde_json::json!({});
+        let result = AcpServer::parse_prompt(&missing_params);
+        assert!(result.is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -978,10 +978,8 @@ async fn main() -> Result<()> {
     let subscriber = fmt::Subscriber::builder()
         .with_writer(std::io::stderr)
         .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| {
-                    EnvFilter::new(default_log_level)
-                }))
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_log_level)),
+        )
         .finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");

--- a/src/main.rs
+++ b/src/main.rs
@@ -963,13 +963,25 @@ async fn main() -> Result<()> {
     }
 
     // Initialize logging - respects RUST_LOG env var, defaults to INFO.
-    // matrix_sdk crates are suppressed to warn because they are extremely
-    // noisy at info level. To restore SDK-level output for Matrix debugging:
-    //   RUST_LOG=info,matrix_sdk=info,matrix_sdk_base=info,matrix_sdk_crypto=info
+    // For the ACP command, we default to WARN to avoid INFO logs corrupting the stdio protocol.
+    // We also always redirect logs to stderr so stdout remains clean for data.
+    let default_log_level = if matches!(cli.command, Commands::Acp { .. }) {
+        "warn"
+    } else {
+        // matrix_sdk crates are suppressed to warn because they are extremely
+        // noisy at info level. To restore SDK-level output for Matrix debugging:
+        //   RUST_LOG=info,matrix_sdk=info,matrix_sdk_base=info,matrix_sdk_crypto=info
+        // acp_server has to be WARN because INFO injects junk data into the JSON stream.
+        "info,matrix_sdk=warn,matrix_sdk_base=warn,matrix_sdk_crypto=warn"
+    };
+
     let subscriber = fmt::Subscriber::builder()
-        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            EnvFilter::new("info,matrix_sdk=warn,matrix_sdk_base=warn,matrix_sdk_crypto=warn")
-        }))
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| {
+                    EnvFilter::new(default_log_level)
+                }))
         .finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
- suppress "INFO" logging on ACP server to stop injecting it into event stream
- ACP server was broken, fixed it so it works with agentic.nvim.
- **Scope boundary:** 
- channels other than ACP are untouched
- **Blast radius:**
- if the logging change is configured incorrectly INFO logging could be dropped for things besides Matrix and ACP.
- **Linked issue(s):** 
- solves #5948 
- solves #5949
## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
$ cargo fmt --all -- --check
<no output, all passed>
$ cargo clippy --all-targets -- -D warnings | tail -n9
    Checking zeroclaw-config v0.7.3 (/Users/jlane/src/zeroclaw/crates/zeroclaw-config)
    Checking zeroclaw-memory v0.7.3 (/Users/jlane/src/zeroclaw/crates/zeroclaw-memory)
    Checking zeroclaw-providers v0.7.3 (/Users/jlane/src/zeroclaw/crates/zeroclaw-providers)
    Checking zeroclaw-tui v0.7.3 (/Users/jlane/src/zeroclaw/crates/zeroclaw-tui)
    Checking zeroclaw-tools v0.7.3 (/Users/jlane/src/zeroclaw/crates/zeroclaw-tools)
    Checking zeroclaw-runtime v0.7.3 (/Users/jlane/src/zeroclaw/crates/zeroclaw-runtime)
    Checking zeroclaw-hardware v0.7.3 (/Users/jlane/src/zeroclaw/crates/zeroclaw-hardware)
    Checking zeroclaw-channels v0.7.3 (/Users/jlane/src/zeroclaw/crates/zeroclaw-channels)
    Finished [`dev` profile [unoptimized + debuginfo]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 53.43s
$ cargo test
Finished [`test` profile [unoptimized + debuginfo]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 1m 11s
     Running unittests src/lib.rs (target/debug/deps/zeroclaw-2c7956b0c31c0a91)
     Running unittests src/main.rs (target/debug/deps/zeroclaw-7c88c24e0bd74a59)
     Running tests/test_component.rs (target/debug/deps/component-6e9b779432853b88)
     Running tests/test_integration.rs (target/debug/deps/integration-a7e0c0e704646a0f)
     Running tests/test_live.rs (target/debug/deps/live-499e94625cf199e2)
     Running tests/test_system.rs (target/debug/deps/system-4edafebf969f29ff)
   Doc-tests zeroclaw
test system::full_stack::system_multi_turn_conversation ... ok
test system::full_stack::system_tool_execution_flow ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Screenshot of the changes working as expected.

<img width="1508" height="880" alt="Screenshot 2026-04-20 at 9 00 55 PM" src="https://github.com/user-attachments/assets/39003c6f-e1e0-4a14-936f-99741cda8ae0" />

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 021d6664a4e653e7f735fe1fbab2425e085ed1e2` restores both the logging behavior and the old session/prompt handler in a single commit.
- **Feature flags or config toggles:** None
- **Observable failure symptoms:** INFO-level ACP startup and session lifecycle messages appearing on stdout (observable as "invalid JSON" errors in the editor client); session/prompt calls with array-format prompts returning INVALID_PARAMS -32602 instead of executing, editor client displaying errors about unknown `session/update` or `session/event` types.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line):
- Scope materially carried forward:
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`Yes/No`)
- If `No`, why (inspiration-only, no direct code/design carry-over):

## i18n Follow-Through (required only when docs or user-facing wording change)

- Locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`Yes/No/N.A.`)
- Localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`Yes/No/N.A.`)
- Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`Yes/No/N.A.`)
- If any `N.A.`, explain scope decision:

---

**Labels** live in the GitHub label UI, not in the body. Set `risk:*`, `size:*`, and scope labels via the sidebar. Auto-label corrections: add `risk: manual` and the intended label.

**Commit trailers** capture AI-assisted collaboration (`Co-Authored-By: Claude ...`) — no separate section needed.

**Privacy contract** (`docs/contributing/pr-discipline.md`) is a merge gate. Never commit real identities, secrets, personal emails, or PII in diff, tests, fixtures, or docs.
