### PR TITLE
fix(desktop): initialize rustls provider before reqwest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12979,6 +12979,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation",
  "reqwest 0.12.28",
+ "rustls",
  "serde",
  "serde_json",
  "tauri",

--- a/apps/tauri/Cargo.toml
+++ b/apps/tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-plugin-single-instance = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots-no-provider"] }
+rustls = { version = "0.23", features = ["ring"] }
 tokio = { version = "1.50", features = ["rt-multi-thread", "macros", "sync", "time"] }
 anyhow = "1.0"
 

--- a/apps/tauri/src/gateway_client.rs
+++ b/apps/tauri/src/gateway_client.rs
@@ -10,6 +10,7 @@ pub struct GatewayClient {
 
 impl GatewayClient {
     pub fn new(base_url: &str, token: Option<&str>) -> Self {
+        let _ = rustls::crypto::ring::default_provider().install_default();
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(10))
             .build()

--- a/apps/tauri/src/main.rs
+++ b/apps/tauri/src/main.rs
@@ -4,5 +4,12 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Install default crypto provider for Rustls TLS.
+    // The desktop app uses reqwest's `rustls-tls-webpki-roots-no-provider`
+    // feature, which requires selecting a process-wide provider explicitly
+    // before any HTTP client is constructed.
+    if let Err(e) = rustls::crypto::ring::default_provider().install_default() {
+        eprintln!("Warning: Failed to install default crypto provider: {e:?}");
+    }
     zeroclaw_desktop::run();
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Add explicit Rustls provider initialization to the desktop app startup path in `apps/tauri/src/main.rs`.
  - Add direct `rustls` dependency with the `ring` feature in `apps/tauri/Cargo.toml` so the selected provider is available at compile time.
  - Initialize the provider in `GatewayClient::new()` as a defensive fallback so direct construction paths and tests do not panic before `main()` runs.
  - This mirrors the earlier CLI-side fix for the same Rustls/reqwest failure mode, but applies it to the Tauri desktop app where it was still missing.
- **Scope boundary:**
  - Does not change gateway behavior, pairing logic, or any provider/network request logic beyond preventing reqwest from panicking during client construction.
  - Does not address signing/notarization of the macOS app bundle.
- **Blast radius:**
  - Desktop app startup and desktop gateway HTTP client construction.
  - Desktop package tests that instantiate `GatewayClient` directly.
- **Linked issue(s):** Related #147

## Validation Evidence (required)

```bash
cargo fmt --manifest-path "/Users/dm/Workspace/zeroclaw/apps/tauri/Cargo.toml" --all -- --check
cargo clippy --manifest-path "/Users/dm/Workspace/zeroclaw/apps/tauri/Cargo.toml" --all-targets -- -D warnings
cargo test --manifest-path "/Users/dm/Workspace/zeroclaw/apps/tauri/Cargo.toml"
cd "/Users/dm/Workspace/zeroclaw/apps/tauri" && cargo tauri build -b app --no-sign
```

- **Commands run and tail output:**
  - `cargo fmt ... --check` ✅
  - `cargo clippy ... -D warnings` ✅
  - `cargo test --manifest-path "/Users/dm/Workspace/zeroclaw/apps/tauri/Cargo.toml"` ✅ `18 passed; 0 failed`
  - `cargo tauri build -b app --no-sign` ✅ produced `target/release/bundle/macos/ZeroClaw.app`
- **Beyond CI — what did you manually verify?**
  - Reproduced the original desktop crash locally from the installed app bundle (`reqwest` panic: `No provider set`).
  - Built the patched desktop binary and confirmed it stayed running instead of aborting.
  - Built a fresh `ZeroClaw.app` bundle locally and confirmed its release binary stayed running for 5 seconds without reproducing the prior panic.
- **If any command was intentionally skipped, why:**
  - Skipped the full workspace `cargo clippy --all-targets -- -D warnings` and `cargo test` battery because this change is isolated to `apps/tauri` and the targeted desktop package validation exercised the affected code paths directly.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation:

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: exact upgrade steps for existing users:

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

## Supersede Attribution (required only when `Supersedes #` is used)

- N.A.

## i18n Follow-Through (required only when docs or user-facing wording change)

- Locale navigation parity updated in `README*`, `docs/README*`, and `docs/SUMMARY.md` for supported locales (`en`, `zh-CN`, `ja`, `ru`, `fr`, `vi`)? (`N.A.`)
- Localized runtime-contract docs updated where equivalents exist (minimum for `fr`/`vi`: `commands-reference`, `config-reference`, `troubleshooting`)? (`N.A.`)
- Vietnamese canonical docs under `docs/i18n/vi/**` synced and compatibility shims under `docs/*.vi.md` validated? (`N.A.`)
- If any `N.A.`, explain scope decision:
  - No docs or user-facing wording changed.

---

Warp conversation: https://app.warp.dev/conversation/bc4363c5-61f1-448c-9f92-4006d26f6dd1