### PR TITLE
fix(telegram): skip auto-injected topic-root reply context in forum topics

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -1393,6 +1393,22 @@ Allowlist Telegram username (without '@') or numeric user ID.",
     fn extract_reply_context(&self, message: &serde_json::Value) -> Option<String> {
         let reply = message.get("reply_to_message")?;
 
+        // Skip the auto-injected topic-root reference Telegram adds to every
+        // message in a non-General forum topic. Its message_id equals the
+        // parent message's message_thread_id. Treating it as a real reply
+        // produces a spurious `> @user:\n> [Message]` blockquote prefix that
+        // downstream reply-intent classification reads as "user is replying
+        // to someone else" and rejects.
+        let reply_mid = reply.get("message_id").and_then(serde_json::Value::as_i64);
+        let thread_id = message
+            .get("message_thread_id")
+            .and_then(serde_json::Value::as_i64);
+        if let (Some(rmid), Some(tid)) = (reply_mid, thread_id)
+            && rmid == tid
+        {
+            return None;
+        }
+
         let reply_sender = reply
             .get("from")
             .and_then(|from| from.get("username"))
@@ -4470,6 +4486,43 @@ mod tests {
             "text": "just a regular message"
         });
         assert!(ch.extract_reply_context(&msg).is_none());
+    }
+
+    #[test]
+    fn extract_reply_context_skips_topic_root() {
+        // Telegram auto-injects a reply_to_message pointing at the topic-root
+        // message on every message in a non-General forum topic. The injected
+        // reply's message_id equals the parent's message_thread_id. It is
+        // not a real reply and must not produce a blockquote prefix.
+        let ch = TelegramChannel::new("t".into(), vec!["*".into()], false);
+        let msg = serde_json::json!({
+            "message_thread_id": 42,
+            "text": "hello in topic",
+            "reply_to_message": {
+                "message_id": 42,
+                "from": { "username": "alice" },
+                "forum_topic_created": { "name": "General Discussion", "icon_color": 0 }
+            }
+        });
+        assert!(ch.extract_reply_context(&msg).is_none());
+    }
+
+    #[test]
+    fn extract_reply_context_real_reply_in_topic() {
+        // A genuine reply inside a forum topic (reply.message_id differs from
+        // the parent's message_thread_id) should still produce a blockquote.
+        let ch = TelegramChannel::new("t".into(), vec!["*".into()], false);
+        let msg = serde_json::json!({
+            "message_thread_id": 42,
+            "text": "I agree",
+            "reply_to_message": {
+                "message_id": 100,
+                "from": { "username": "alice" },
+                "text": "What do you think?"
+            }
+        });
+        let ctx = ch.extract_reply_context(&msg).unwrap();
+        assert_eq!(ctx, "> @alice:\n> What do you think?");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In any non-General Telegram forum topic, Telegram auto-injects a `reply_to_message` pointing at the topic-root message on every incoming update. The injected reply carries the `forum_topic_created` field (and no `text`/`voice`/`photo`/etc.), so `extract_reply_context` falls through to the `"[Message]"` placeholder branch at the end of its match chain and emits

```
> @<username>:
> [Message]

<actual user message>
```

as the message content passed to downstream components. For the reply-intent classifier that ZeroClaw uses in group/forum chats, that looks like *"the user is replying to someone else, not the bot"* → classifier returns `NO_REPLY` → the bot posts an ack reaction and silently drops the turn. End-user symptom: bot reacts to messages in topics but never replies.

Reproducible in any Telegram supergroup with Topics enabled, in any topic other than General.

## Fix

Detect the auto-injected case: when `reply_to_message.message_id` equals `message.message_thread_id`, the reply is the topic-root pointer, not a real reply. Return `None` from `extract_reply_context` so no blockquote prefix is added.

A genuine reply inside a topic (different `message_id`) is unchanged — the prefix is still built normally.

## Tests

Adds two unit tests alongside the existing `extract_reply_context_*` suite:

- `extract_reply_context_skips_topic_root` — covers the bug.
- `extract_reply_context_real_reply_in_topic` — positive sanity check that a genuine reply inside a forum topic still produces the blockquote.

All 7 `extract_reply_context_*` tests pass locally with
```
cargo test -p zeroclaw-channels --lib --features channel-telegram telegram::tests::extract_reply_context
```

## Notes

- Discovered while diagnosing per-topic isolation behaviour of a ZeroClaw bot running in a Telegram supergroup with Topics enabled on v0.7.3 (2026-04-21).
- Paired with a separate PR for `request_approval` which drops `message_thread_id` when sending tool-approval prompts, so approvals always land in General — filed separately to keep review scope small.