### PR TITLE
fix(telegram): forward message_thread_id in request_approval

### DIFF
--- a/crates/zeroclaw-channels/src/telegram.rs
+++ b/crates/zeroclaw-channels/src/telegram.rs
@@ -3116,8 +3116,10 @@ Ensure only one `zeroclaw` process is using this bot token."
     ) -> anyhow::Result<Option<zeroclaw_api::channel::ChannelApprovalResponse>> {
         use zeroclaw_api::channel::ChannelApprovalResponse;
 
-        // Parse recipient for chat_id (may contain ":thread_id" suffix).
-        let chat_id = recipient.split_once(':').map_or(recipient, |(c, _)| c);
+        // Parse recipient for chat_id + optional thread_id ("chat_id:thread_id" format).
+        let (chat_id, thread_id) = recipient
+            .split_once(':')
+            .map_or((recipient, None), |(c, t)| (c, Some(t)));
 
         // Unique key embedded in callback_data so listen() can route the tap.
         let approval_id = uuid::Uuid::new_v4().to_string();
@@ -3139,12 +3141,15 @@ Ensure only one `zeroclaw` process is using this bot token."
             ]]
         });
 
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "chat_id": chat_id,
             "text": text,
             "parse_mode": "HTML",
             "reply_markup": reply_markup,
         });
+        if let Some(tid) = thread_id {
+            body["message_thread_id"] = serde_json::Value::String(tid.to_string());
+        }
 
         // Register the oneshot BEFORE sending the message to avoid a race
         // where the user taps the button before the sender is in the map.


### PR DESCRIPTION
## Problem

`TelegramChannel::request_approval` accepts a `recipient` in the same `chat_id[:thread_id]` format that every other send path in this file uses. It parses out the `chat_id` correctly but discards the `thread_id`, so the `sendMessage` call that posts the inline-keyboard approval prompt has no `message_thread_id` field.

Symptom: when a tool (e.g. `memory_store`, `shell`, custom approval-gated tools) asks for approval while a turn is running in a non-General forum topic, the approval prompt appears in the **General** topic instead. The user who triggered the turn never sees the buttons; an unrelated audience sees a `🔧 Tool approval required` message for a turn they know nothing about.

Observed with v0.7.3 bot in a Telegram supergroup with Topics enabled (2026-04-21):

```
[General topic, unprompted]
🔧 Tool approval required

Tool: memory_store
category: daily, content: User had a meeting with Anna at 9am about project Helios., key: meeting_anna_helios_9am_2026-04-21
```

— while the triggering message was sent in a separate topic.

## Fix

Parse the optional `:thread_id` suffix via `split_once` destructuring, and append `message_thread_id` to the outgoing body when present. This matches the pattern already used by every other `sendMessage` / `sendVoice` / `sendMedia` site in this file (e.g. around the markdown/plain sendMessage paths, and in `send_media_by_url`).

## Tests

No unit test added — the approval flow spans `request_approval` + a `tokio::sync::oneshot` + a callback-query handler and is hard to cover in isolation without a network double. The fix is minimal (3-line structural change matching the pre-existing pattern used elsewhere in the file).

Happy to add one if reviewers prefer.

## Notes

Paired with #5969 which fixes a related forum-topic reply-context bug surfaced during the same diagnostic session.