### PR TITLE
fix(#5721): allow prompts inside [skill] TOML section

### DIFF
--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -86,6 +86,8 @@ struct SkillMeta {
     author: Option<String>,
     #[serde(default)]
     tags: Vec<String>,
+    #[serde(default)]
+    prompts: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -596,6 +598,13 @@ fn load_skill_toml(path: &Path) -> Result<Skill> {
     let content = std::fs::read_to_string(path)?;
     let manifest: SkillManifest = toml::from_str(&content)?;
 
+    // Merge prompts from both locations: inside the [skill] table (natural
+    // location for per-skill prompts) and at the manifest root (historical
+    // location). Previously, prompts placed inside [skill] were silently
+    // dropped because SkillMeta had no `prompts` field. Fixes #5721.
+    let mut prompts = manifest.skill.prompts;
+    prompts.extend(manifest.prompts);
+
     Ok(Skill {
         name: manifest.skill.name,
         description: manifest.skill.description,
@@ -603,7 +612,7 @@ fn load_skill_toml(path: &Path) -> Result<Skill> {
         author: manifest.skill.author,
         tags: manifest.skill.tags,
         tools: manifest.tools,
-        prompts: manifest.prompts,
+        prompts,
         location: Some(path.to_path_buf()),
     })
 }
@@ -1658,5 +1667,80 @@ mod registry_tests {
     fn test_is_registry_source_rejects_special_chars() {
         assert!(!is_registry_source(".hidden"));
         assert!(!is_registry_source("~tilde"));
+    }
+}
+
+#[cfg(test)]
+mod prompts_section_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_manifest(dir: &Path, toml: &str) -> std::path::PathBuf {
+        let p = dir.join("SKILL.toml");
+        std::fs::write(&p, toml).unwrap();
+        p
+    }
+
+    #[test]
+    fn prompts_inside_skill_section_are_loaded() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"
+[skill]
+name = "probe"
+description = "test"
+version = "0.1.0"
+prompts = ["If asked about XYZZY, respond YES"]
+"#,
+        );
+        let skill = load_skill_toml(&path).unwrap();
+        assert_eq!(
+            skill.prompts,
+            vec!["If asked about XYZZY, respond YES".to_string()]
+        );
+    }
+
+    #[test]
+    fn prompts_at_root_level_still_work() {
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"
+[skill]
+name = "probe"
+description = "test"
+version = "0.1.0"
+
+prompts = ["legacy root-level prompt"]
+"#,
+        );
+        let skill = load_skill_toml(&path).unwrap();
+        assert_eq!(skill.prompts, vec!["legacy root-level prompt".to_string()]);
+    }
+
+    #[test]
+    fn prompts_in_both_locations_are_merged_skill_first() {
+        // Root-level prompts must precede the [skill] header in TOML.
+        // Per the fix, [skill]-section prompts appear first in the merged
+        // list, with root-level prompts appended after.
+        let tmp = TempDir::new().unwrap();
+        let path = write_manifest(
+            tmp.path(),
+            r#"
+prompts = ["from-root"]
+
+[skill]
+name = "probe"
+description = "test"
+version = "0.1.0"
+prompts = ["from-skill-section"]
+"#,
+        );
+        let skill = load_skill_toml(&path).unwrap();
+        assert_eq!(
+            skill.prompts,
+            vec!["from-skill-section".to_string(), "from-root".to_string(),]
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - When users placed `prompts = [...]` inside the `[skill]` TOML table (the natural location for per-skill prompts), the values were silently dropped at parse time — `SkillMeta` had no `prompts` field, so serde discarded them.
  - Added `#[serde(default)] prompts: Vec<String>` to `SkillMeta`.
  - `load_skill_toml` now merges prompts from both locations: `[skill]`-section prompts appear first, followed by root-level prompts (historical location).
  - Users who write SKILL.toml manifests the obvious way now see their prompts correctly loaded and subsequently injected (under `prompt_injection_mode = "full"`).
- **Scope boundary:** Touches only `crates/zeroclaw-runtime/src/skills/mod.rs` (one file). No changes to skill audit, skill loading from `.md`, delegation, or any other subsystem.
- **Blast radius:** Near-zero for existing users — root-level `prompts` continues to work identically. Users who placed prompts inside `[skill]` previously got an empty result silently; they now get the correct behavior. Strictly additive.
- **Linked issue(s):** Closes #5721. Related: `#5155` (delegate-agent prompt_injection_mode inheritance — separate layer, not addressed here and tracked under multi-agent v1 umbrella #5891).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-runtime --no-deps --all-targets --tests -- -D warnings
cargo test -p zeroclaw-runtime --lib prompts_section_tests
```

- **Commands run and tail output:** All three gates clean on **Rust 1.93.0** (matching the toolchain pinned in `.github/workflows/`). Test output:
  ```
  running 3 tests
  test skills::prompts_section_tests::prompts_in_both_locations_are_merged_skill_first ... ok
  test skills::prompts_section_tests::prompts_at_root_level_still_work ... ok
  test skills::prompts_section_tests::prompts_inside_skill_section_are_loaded ... ok
  test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 1658 filtered out; finished in 0.01s
  ```
- **Beyond CI — what did you manually verify?** Reproduced the original bug (#5721) with the XYZZY probe-string pattern — before the fix, a skill with `prompts = [...]` inside `[skill]` never reached the model context; after the fix, it does. Also validated that pre-existing skills with root-level `prompts` (legacy location) continue to produce identical behavior to before the change.
- **If any command was intentionally skipped, why:** None. `cargo clippy` uses `--no-deps` to limit scope to the runtime crate (the change site); downstream crates compiled on newer rustc versions surface pre-existing clippy lints that are unrelated to this change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**.
- New external network calls? **No**.
- Secrets / tokens / credentials handling changed? **No**.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — test fixtures use only generic strings (`"probe"`, `"from-skill-section"`, `"from-root"`, `"If asked about XYZZY, respond YES"`).

## Compatibility (required)

- Backward compatible? **Yes**. Manifests with root-level `prompts` behave identically. Manifests with prompts inside `[skill]` previously returned empty silently; they now return the expected list. Strictly-improving change.
- Config / env / CLI surface changed? **No** (SKILL.toml schema now accepts `prompts` in both locations; old placement still works).

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk. `git revert <sha>` reverts cleanly. Users on rollback would lose `[skill]`-section injection (back to empty/silent-drop), but any root-level `prompts` config continues to work.