### PR TITLE
chore(skills): neutralize pr-review-session voice, detect reviewer via gh auth

### DIFF
--- a/.claude/skills/github-pr-review-session/SKILL.md
+++ b/.claude/skills/github-pr-review-session/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: github-pr-review-session
-description: "Human-reviewer co-pilot for ZeroClaw PR reviews. Use this skill when the user wants to review a specific PR as themselves, re-review a PR after author changes, work through a queue of PRs, check what's still open on a PR, or post a formal review verdict. Trigger on: 'review 1234', 'can you look at PR #1234', 're-review 1234', 'check 1234', 'what's still open on 1234', 'go through the queue', 'next PR', 'review the open PRs'. This skill posts reviews in the voice of the human reviewer (WareWolf-MoonWall) using gh CLI."
+description: "Human-reviewer co-pilot for ZeroClaw PR reviews. Use this skill when the user wants to review a specific PR as themselves, re-review a PR after author changes, work through a queue of PRs, check what's still open on a PR, or post a formal review verdict. Trigger on: 'review 1234', 'can you look at PR #1234', 're-review 1234', 'check 1234', 'what's still open on 1234', 'go through the queue', 'next PR', 'review the open PRs'. This skill posts reviews in the voice of the active `gh` account holder using gh CLI."
 ---
 
 # ZeroClaw PR Review Session — Human Reviewer Co-Pilot
 
-You are assisting **WareWolf-MoonWall** in conducting PR reviews for the
-`zeroclaw-labs/zeroclaw` repository. You read everything, cross-check against
-the local source, write the review body, and post it via `gh` — but the
-judgment and identity are the reviewer's. Every review is posted as
-WareWolf-MoonWall, not as an AI agent.
+You are assisting the **active `gh` account holder** in conducting PR reviews
+for the `zeroclaw-labs/zeroclaw` repository. You read everything, cross-check
+against the local source, write the review body, and post it via `gh` — but
+the judgment and identity are the reviewer's. Every review is posted under
+the logged-in account, in the first-person voice of that reviewer — never as
+"an AI" or in a third party's voice.
 
 ---
 
@@ -60,11 +61,15 @@ is 1234 ready to merge
 
 ### Phase 1 — Load context
 
-1. Read `tmp/handoff.md`. Establish which PRs have already been reviewed this
+1. **Identify the reviewer.** Run `gh auth status` and capture the active
+   account login. That login is the reviewer — write every review body in
+   the first-person voice of that account. Never sign with another person's
+   name, and never frame the review as AI-generated.
+2. Read `tmp/handoff.md`. Establish which PRs have already been reviewed this
    session, which verdict was posted, and what commit that verdict was on.
-2. For the target PR, check if `tmp/review-<number>.md` already exists. If it
+3. For the target PR, check if `tmp/review-<number>.md` already exists. If it
    does, read it — this session already posted a review for this PR.
-3. If working in queue mode, identify the next PR that needs attention based on
+4. If working in queue mode, identify the next PR that needs attention based on
    the handoff.
 
 ### Phase 2 — Execute the protocol
@@ -112,8 +117,10 @@ After every posted review, update `tmp/handoff.md`:
 
 ## Review voice and tone
 
-Every review is written as WareWolf-MoonWall — a thoughtful, senior
-contributor who has read everything and cares about the outcome.
+Every review is written in the first-person voice of the `gh`-authenticated
+reviewer (whoever ran Phase 1's `gh auth status` check) — a thoughtful,
+senior contributor who has read everything and cares about the outcome. No
+third-party signatures, no "AI generated" framing.
 
 - **Be specific.** Vague feedback creates anxiety without direction.
   Explain the principle behind every finding, not just the verdict.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - The `github-pr-review-session` skill hardcoded a specific reviewer's name in four places. Running it from a different `gh`-authenticated account posted formal reviews with the wrong signature (surfaced while reviewing #5960).
  - Description, intro, Phase 1, and the voice section now detect the reviewer via `gh auth status` and use first-person language scoped to whoever is logged in.
- **Scope boundary:** No change to the review protocol, feedback taxonomy, handoff shape, or posting convention. Only the reviewer-identity assumption is generalized.
- **Blast radius:** `.claude/skills/github-pr-review-session/SKILL.md` only. No code, tests, or docs-system changes.
- **Linked issue(s):** None (behavior drift surfaced during #5960 review).

## Validation Evidence (required)

Docs/skills-only change — no Rust compilation surface touched.

- `grep -i 'warewolf\|moonwall' .claude/skills/github-pr-review-session/SKILL.md` → no matches
- Manual read of the edited file to confirm first-person / \`gh\`-detect language reads coherently

**Commands intentionally skipped:** `cargo fmt`, `cargo clippy`, `cargo test` — zero Rust files touched, so these gates don't apply. Markdown-lint / link-integrity were not separately invoked because the edit preserves all existing headings and links; the diff is word-level.

**Beyond CI — manually verified:** Re-ran the edited skill mentally against the #5960 flow: Phase 1 now prescribes `gh auth status` before writing anything, which would have caught the mis-attribution up front.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — this change *removes* a specific identity from the skill.

## Compatibility (required)

- Backward compatible? **Yes.** The skill still reads `tmp/handoff.md`, still writes to `tmp/review-<number>.md`, still posts via the same `gh pr review` invocation. The only behavioral change is *whose* name appears in the body — which now matches the account actually posting.
- Config / env / CLI surface changed? **No.**

## Rollback

Low-risk docs edit — `git revert <sha>` is the plan.

## Supersede Attribution

N/A.

## i18n Follow-Through

N.A. — `.claude/skills/**` is internal tooling, not user-facing locale-parity content.

---

**Labels requested:** \`risk: low\`, \`size: xs\`, \`scope: skills\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)