### PR TITLE
fix: Gemini/OpenRouter tool-call compatibility + google_workspace schema clarity

### DIFF
--- a/crates/zeroclaw-tool-call-parser/src/lib.rs
+++ b/crates/zeroclaw-tool-call-parser/src/lib.rs
@@ -20,11 +20,43 @@ pub struct ParsedToolCall {
 }
 
 fn parse_arguments_value(raw: Option<&serde_json::Value>) -> serde_json::Value {
-    match raw {
+    let initial = match raw {
         Some(serde_json::Value::String(s)) => serde_json::from_str::<serde_json::Value>(s)
             .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new())),
         Some(value) => value.clone(),
         None => serde_json::Value::Object(serde_json::Map::new()),
+    };
+    unwrap_nested_json_strings(initial)
+}
+
+/// Recursively unwrap stringified JSON objects/arrays nested inside tool arguments.
+/// Why: Gemini (and some other providers) sometimes double-encode nested object/array
+/// parameters as JSON strings inside the outer arguments payload, which breaks tools
+/// that expect `Value::Object` / `Value::Array` at those positions.
+fn unwrap_nested_json_strings(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                out.insert(k, unwrap_nested_json_strings(v));
+            }
+            serde_json::Value::Object(out)
+        }
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.into_iter().map(unwrap_nested_json_strings).collect())
+        }
+        serde_json::Value::String(s) => {
+            let trimmed = s.trim_start();
+            if trimmed.starts_with('{') || trimmed.starts_with('[') {
+                match serde_json::from_str::<serde_json::Value>(&s) {
+                    Ok(parsed) => unwrap_nested_json_strings(parsed),
+                    Err(_) => serde_json::Value::String(s),
+                }
+            } else {
+                serde_json::Value::String(s)
+            }
+        }
+        other => other,
     }
 }
 
@@ -1513,6 +1545,68 @@ pub fn build_native_assistant_history_from_parsed_calls(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_arguments_value_unwraps_nested_object_string() {
+        let raw = serde_json::json!({
+            "service": "gmail",
+            "params": "{\"maxResults\":3}"
+        });
+        let out = parse_arguments_value(Some(&raw));
+        assert_eq!(out["service"], serde_json::json!("gmail"));
+        assert_eq!(out["params"], serde_json::json!({"maxResults": 3}));
+    }
+
+    #[test]
+    fn parse_arguments_value_unwraps_nested_array_string() {
+        let raw = serde_json::json!({ "items": "[1,2,3]" });
+        let out = parse_arguments_value(Some(&raw));
+        assert_eq!(out["items"], serde_json::json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn parse_arguments_value_leaves_non_json_strings_alone() {
+        let raw = serde_json::json!({
+            "greeting": "hello",
+            "answer": "42",
+            "truthy": "true",
+            "broken": "{not json"
+        });
+        let out = parse_arguments_value(Some(&raw));
+        assert_eq!(out["greeting"], serde_json::json!("hello"));
+        assert_eq!(out["answer"], serde_json::json!("42"));
+        assert_eq!(out["truthy"], serde_json::json!("true"));
+        assert_eq!(out["broken"], serde_json::json!("{not json"));
+    }
+
+    #[test]
+    fn parse_arguments_value_handles_double_encoding() {
+        let inner = r#"{"params":"{\"maxResults\":3}"}"#;
+        let raw = serde_json::Value::String(inner.to_string());
+        let out = parse_arguments_value(Some(&raw));
+        assert_eq!(out["params"], serde_json::json!({"maxResults": 3}));
+    }
+
+    #[test]
+    fn parse_tool_call_value_handles_gemini_double_encoded_params() {
+        let inner = r#"{"service":"gmail","resource":"users","sub_resource":"messages","method":"list","params":"{\"maxResults\":3}"}"#;
+        let call_json = serde_json::json!({
+            "function": {
+                "name": "google_workspace",
+                "arguments": inner
+            }
+        });
+        let parsed = parse_tool_call_value(&call_json).expect("expected a parsed call");
+        assert_eq!(parsed.name, "google_workspace");
+        assert_eq!(
+            parsed.arguments["params"],
+            serde_json::json!({"maxResults": 3})
+        );
+        assert_eq!(
+            parsed.arguments["sub_resource"],
+            serde_json::json!("messages")
+        );
+    }
 
     #[test]
     fn parse_tool_calls_extracts_multiple_calls() {

--- a/crates/zeroclaw-tool-call-parser/src/lib.rs
+++ b/crates/zeroclaw-tool-call-parser/src/lib.rs
@@ -69,12 +69,12 @@ pub fn canonicalize_json_for_tool_signature(value: &serde_json::Value) -> serde_
 fn parse_tool_call_value(value: &serde_json::Value) -> Option<ParsedToolCall> {
     if let Some(function) = value.get("function") {
         let tool_call_id = parse_tool_call_id(value, Some(function));
-        let name = function
+        let raw_name = function
             .get("name")
             .and_then(|v| v.as_str())
             .unwrap_or("")
-            .trim()
-            .to_string();
+            .trim();
+        let name = map_tool_name_alias(raw_name).to_string();
         if !name.is_empty() {
             let arguments = parse_arguments_value(
                 function
@@ -90,12 +90,12 @@ fn parse_tool_call_value(value: &serde_json::Value) -> Option<ParsedToolCall> {
     }
 
     let tool_call_id = parse_tool_call_id(value, None);
-    let name = value
+    let raw_name = value
         .get("name")
         .and_then(|v| v.as_str())
         .unwrap_or("")
-        .trim()
-        .to_string();
+        .trim();
+    let name = map_tool_name_alias(raw_name).to_string();
 
     if name.is_empty() {
         return None;
@@ -696,6 +696,13 @@ fn parse_function_call_tool_calls(response: &str) -> Vec<ParsedToolCall> {
 /// Map tool name aliases from various LLM providers to ZeroClaw tool names.
 /// This handles variations like "fileread" -> "file_read", "bash" -> "shell", etc.
 fn map_tool_name_alias(tool_name: &str) -> &str {
+    // Strip Gemini-style namespace prefixes like `default_api.<name>` or `tools.<name>`.
+    // Why: OpenRouter-routed Gemini models emit function names as `default_api.foo`,
+    // which otherwise fails dispatch as "Unknown tool".
+    let tool_name = tool_name
+        .strip_prefix("default_api.")
+        .or_else(|| tool_name.strip_prefix("tools."))
+        .unwrap_or(tool_name);
     match tool_name {
         // Shell variations (including GLM aliases that map to shell)
         "shell" | "bash" | "sh" | "exec" | "command" | "cmd" | "browser_open" | "browser"

--- a/crates/zeroclaw-tool-call-parser/src/lib.rs
+++ b/crates/zeroclaw-tool-call-parser/src/lib.rs
@@ -728,12 +728,15 @@ fn parse_function_call_tool_calls(response: &str) -> Vec<ParsedToolCall> {
 /// Map tool name aliases from various LLM providers to ZeroClaw tool names.
 /// This handles variations like "fileread" -> "file_read", "bash" -> "shell", etc.
 fn map_tool_name_alias(tool_name: &str) -> &str {
-    // Strip Gemini-style namespace prefixes like `default_api.<name>` or `tools.<name>`.
-    // Why: OpenRouter-routed Gemini models emit function names as `default_api.foo`,
-    // which otherwise fails dispatch as "Unknown tool".
+    // Strip any dotted namespace prefix (keep only the final segment).
+    // Covers Gemini-emitted `default_api.<name>` and `tools.<name>`, plus
+    // MCP-server-name prefixes like `google_workspace.search_gmail_messages`
+    // that Gemini-via-OpenRouter also emits when the tool originates from
+    // an MCP server. The registry is indexed by bare tool name, so we
+    // normalize by taking the last segment.
     let tool_name = tool_name
-        .strip_prefix("default_api.")
-        .or_else(|| tool_name.strip_prefix("tools."))
+        .rsplit_once('.')
+        .map(|(_, suffix)| suffix)
         .unwrap_or(tool_name);
     match tool_name {
         // Shell variations (including GLM aliases that map to shell)
@@ -2855,6 +2858,30 @@ Let me check the result."#;
             map_tool_name_alias("totally_unknown_tool"),
             "totally_unknown_tool"
         );
+    }
+
+    #[test]
+    fn map_tool_name_alias_strips_dotted_namespaces() {
+        // Gemini-style static prefixes still work.
+        assert_eq!(map_tool_name_alias("default_api.file_read"), "file_read");
+        assert_eq!(map_tool_name_alias("tools.shell"), "shell");
+
+        // MCP-server-name prefixes (Gemini-via-OpenRouter also emits these
+        // when the tool originates from an MCP server; the registry is
+        // indexed by bare tool name, so we must strip them too).
+        assert_eq!(
+            map_tool_name_alias("google_workspace.search_gmail_messages"),
+            "search_gmail_messages"
+        );
+
+        // Only the final segment is kept even with multiple dots.
+        assert_eq!(map_tool_name_alias("a.b.c.final"), "final");
+
+        // Stripped segment still runs through the alias table.
+        assert_eq!(map_tool_name_alias("default_api.bash"), "shell");
+
+        // Names without any dot are unaffected.
+        assert_eq!(map_tool_name_alias("file_read"), "file_read");
     }
 
     #[test]

--- a/crates/zeroclaw-tools/src/google_workspace.rs
+++ b/crates/zeroclaw-tools/src/google_workspace.rs
@@ -136,7 +136,12 @@ impl Tool for GoogleWorkspaceTool {
 
     fn description(&self) -> &str {
         "Interact with Google Workspace services (Drive, Gmail, Calendar, Sheets, Docs, etc.) \
-         via the gws CLI. Requires gws to be installed and authenticated."
+         via the gws CLI. Requires gws to be installed and authenticated. \
+         IMPORTANT: Gmail commands are 4-segment and REQUIRE sub_resource. \
+         To list Gmail messages, use service=gmail, resource=users, sub_resource=messages, method=list \
+         (this becomes `gws gmail users messages list`). \
+         Without sub_resource, Gmail calls will fail. \
+         Drive, Calendar, and Sheets are 3-segment and do NOT use sub_resource."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -149,7 +154,7 @@ impl Tool for GoogleWorkspaceTool {
                 },
                 "resource": {
                     "type": "string",
-                    "description": "Service resource (e.g. files, messages, events, spreadsheets)"
+                    "description": "Top-level resource. For Gmail this is always 'users'. For Drive use 'files'. For Calendar use 'events' or 'calendars'. For Sheets use 'spreadsheets'."
                 },
                 "method": {
                     "type": "string",
@@ -157,11 +162,11 @@ impl Tool for GoogleWorkspaceTool {
                 },
                 "sub_resource": {
                     "type": "string",
-                    "description": "Optional sub-resource for nested operations"
+                    "description": "Sub-resource for 4-segment gws commands. REQUIRED for Gmail: use 'messages', 'threads', 'drafts', or 'labels' (e.g. gmail/users/messages/list). Omit for 3-segment services like Drive, Calendar, and Sheets."
                 },
                 "params": {
                     "type": "object",
-                    "description": "URL/query parameters as key-value pairs (passed as --params JSON)"
+                    "description": "URL/query parameters as key-value pairs (passed as --params JSON). For Gmail, ALWAYS include `userId: \"me\"` to refer to the authenticated user (e.g. {\"userId\":\"me\",\"maxResults\":10}). For Calendar events.list, include `calendarId: \"primary\"`."
                 },
                 "body": {
                     "type": "object",


### PR DESCRIPTION
## Summary

Fixes three independent issues that surfaced when running ZeroClaw against Gemini models routed via OpenRouter, and clarifies the `google_workspace` tool schema so LLMs build correct `gws` invocations.

- **tool-call-parser: strip namespace prefixes.** Gemini emits function names like `default_api.google_workspace`, which fail dispatch as "Unknown tool." Handle them in `map_tool_name_alias` and route the native-JSON tool-call path through it so both XML and JSON call shapes benefit.
- **tool-call-parser: unwrap nested stringified JSON.** Gemini sometimes double-encodes nested object/array parameters as JSON strings inside the outer arguments payload (e.g. `params: "{\"maxResults\":3}"`), which breaks tools that expect `Value::Object`/`Value::Array` at those positions. Recursively unwrap any `String` whose trimmed content starts with `{` or `[` and parses as JSON; leave legitimate strings alone.
- **google_workspace: clarify schema.** Tool description and schema field descriptions were too generic, causing LLMs to omit `sub_resource` for Gmail (4-segment) and to omit `userId: "me"` from `params`. Spell out the Gmail 4-segment shape, the required `userId: "me"`, and common resource names per service. LLM-facing documentation only — no behavioral change.

## Test plan

- [x] `cargo test -p zeroclaw-tool-call-parser` — 107 passed, 0 failed. Includes 5 new tests covering nested-object unwrap, nested-array unwrap, non-JSON strings left alone, double-encoded arguments, and the Gemini end-to-end `function.arguments` shape.
- [x] `cargo build -p zeroclaw-tools` — clean build.
- [x] End-to-end verified against a live Gemini-via-OpenRouter session: `"Show me the titles of my last 3 emails"` now routes correctly through `gws gmail users messages list --params '{"userId":"me","maxResults":3}'` and returns messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)