### PR TITLE
fix(#5697): pass allow_scripts through ReadSkillTool to skill loader

### DIFF
--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -145,12 +145,13 @@ pub fn load_skills_with_open_skills_settings(
     workspace_dir: &Path,
     open_skills_enabled: bool,
     open_skills_dir: Option<&str>,
+    allow_scripts: bool,
 ) -> Vec<Skill> {
     load_skills_with_open_skills_config(
         workspace_dir,
         Some(open_skills_enabled),
         open_skills_dir,
-        None,
+        Some(allow_scripts),
     )
 }
 

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -429,6 +429,7 @@ pub fn all_tools_with_runtime(
             workspace_dir.to_path_buf(),
             root_config.skills.open_skills_enabled,
             root_config.skills.open_skills_dir.clone(),
+            root_config.skills.allow_scripts,
         )));
     }
 

--- a/crates/zeroclaw-runtime/src/tools/read_skill.rs
+++ b/crates/zeroclaw-runtime/src/tools/read_skill.rs
@@ -8,6 +8,7 @@ pub struct ReadSkillTool {
     workspace_dir: PathBuf,
     open_skills_enabled: bool,
     open_skills_dir: Option<String>,
+    allow_scripts: bool,
 }
 
 impl ReadSkillTool {
@@ -15,11 +16,13 @@ impl ReadSkillTool {
         workspace_dir: PathBuf,
         open_skills_enabled: bool,
         open_skills_dir: Option<String>,
+        allow_scripts: bool,
     ) -> Self {
         Self {
             workspace_dir,
             open_skills_enabled,
             open_skills_dir,
+            allow_scripts,
         }
     }
 }
@@ -59,6 +62,7 @@ impl Tool for ReadSkillTool {
             &self.workspace_dir,
             self.open_skills_enabled,
             self.open_skills_dir.as_deref(),
+            self.allow_scripts,
         );
 
         let Some(skill) = skills
@@ -118,7 +122,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn make_tool(tmp: &TempDir) -> ReadSkillTool {
-        ReadSkillTool::new(tmp.path().join("workspace"), false, None)
+        ReadSkillTool::new(tmp.path().join("workspace"), false, None, false)
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `ReadSkillTool` constructed without `allow_scripts` and hardcoded `None` when calling `load_skills_with_open_skills_settings`; `unwrap_or(false)` inside `load_skills_with_open_skills_config` then blocked every script-bearing skill even when `skills.allow_scripts = true` was explicitly set. Threading the value end-to-end restores config respect.
- **Three-step propagation fix:** add `allow_scripts: bool` field + `new()` param to `ReadSkillTool`; add `allow_scripts` param to `load_skills_with_open_skills_settings` and forward as `Some(allow_scripts)`; pass `root_config.skills.allow_scripts` at the construction site in `tools/mod.rs`.
- **Scope boundary:** does not touch the security audit logic, the open-skills sandbox, or the delegate-tool path. No behaviour change when `skills.allow_scripts = false` (the default).
- **Blast radius:** `ReadSkillTool` is only instantiated when `skills.prompt_injection_mode = "compact"`. Callers of the public helper `load_skills_with_open_skills_settings` pick up a new required param (internal to `zeroclaw-runtime`; see below).
- **Linked issue(s):** Closes #5697. Supersedes #5725 (closed by me after the original branch was garbage-collected; this is a clean refile off current `master`).

## Validation Evidence

Ran on macOS arm64, Rust 1.95.0.

```bash
cargo fmt --all -- --check         # clean
cargo build -p zeroclaw-runtime    # clean (58s)
cargo test -p zeroclaw-runtime --lib tools::read_skill
cargo test -p zeroclaw-runtime --lib tools::tests::all_tools
```

Tail output:

```
test tools::read_skill::tests::reads_toml_skill_manifest_by_name ... ok
test tools::read_skill::tests::unknown_skill_lists_available_names ... ok
test tools::read_skill::tests::reads_markdown_skill_by_name ... ok
test result: ok. 3 passed; 0 failed

test tools::tests::all_tools_includes_read_skill_in_compact_mode ... ok
test tools::tests::all_tools_includes_browser_when_enabled ... ok
test tools::tests::all_tools_excludes_delegate_when_no_agents ... ok
test tools::tests::all_tools_excludes_browser_when_disabled ... ok
test tools::tests::all_tools_includes_delegate_when_agents_configured ... ok
test tools::tests::all_tools_excludes_read_skill_in_full_mode ... ok
test result: ok. 6 passed; 0 failed
```

- **Beyond CI — what I manually verified:** walked the three call sites under the debugger with `allow_scripts = true` set in config to confirm the value now reaches `load_skills_with_open_skills_config` as `Some(true)`, so the `unwrap_or(false)` no longer silently downgrades.
- **Intentionally skipped:** workspace-wide `cargo clippy --all-targets -- -D warnings` fails in `zeroclaw-config` on a pre-existing `clippy::collapsible-match` lint that also fails on unmodified `origin/master` (verified via `git stash` + re-run). Not introduced by this PR.

## Security & Privacy Impact

- New permissions / capabilities? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII in diff/tests/fixtures/docs? No

This PR strictly restores the documented behaviour of an existing opt-in (`skills.allow_scripts`). The default `false` is unchanged; users must still explicitly enable scripts.

## Compatibility

- Backward compatible? Yes, for end users — default behaviour unchanged.
- Config / env / CLI surface changed? No new user-facing surface; the existing `skills.allow_scripts` toml option is now correctly honoured by `read_skill`.
- Caller-facing (library) note: `ReadSkillTool::new` and `load_skills_with_open_skills_settings` each take one additional `bool`. Both are internal to `zeroclaw-runtime`; no public SDK surface is affected.

## Rollback

Low-risk. `git revert <sha>` restores prior behaviour (scripts blocked in compact mode).

## Supersede Attribution

- Superseded PRs + authors: #5725 by @perlowja (this author)
- Scope materially carried forward: same three-step fix, rebased off current `master` after the original branch was deleted.
- `Co-authored-by` trailers added? N/A — no other contributors.

## i18n Follow-Through

N/A — no user-facing wording or docs changed.
