### PR TITLE
fix(#5697): pass allow_scripts through ReadSkillTool to skill loader

### DIFF
--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -145,12 +145,13 @@ pub fn load_skills_with_open_skills_settings(
     workspace_dir: &Path,
     open_skills_enabled: bool,
     open_skills_dir: Option<&str>,
+    allow_scripts: bool,
 ) -> Vec<Skill> {
     load_skills_with_open_skills_config(
         workspace_dir,
         Some(open_skills_enabled),
         open_skills_dir,
-        None,
+        Some(allow_scripts),
     )
 }
 

--- a/crates/zeroclaw-runtime/src/tools/mod.rs
+++ b/crates/zeroclaw-runtime/src/tools/mod.rs
@@ -429,6 +429,7 @@ pub fn all_tools_with_runtime(
             workspace_dir.to_path_buf(),
             root_config.skills.open_skills_enabled,
             root_config.skills.open_skills_dir.clone(),
+            root_config.skills.allow_scripts,
         )));
     }
 

--- a/crates/zeroclaw-runtime/src/tools/read_skill.rs
+++ b/crates/zeroclaw-runtime/src/tools/read_skill.rs
@@ -187,5 +187,40 @@ description = "Ship safely"
             result.error.as_deref(),
             Some("Unknown skill 'calendar'. Available skills: weather")
         );
+    
+    }
+
+    #[tokio::test]
+    async fn script_skill_is_returned_when_allow_scripts_true() {
+        // Regression pin for #5697: a skill directory containing a script
+        // file (.sh) must be returned by read_skill when the tool was
+        // constructed with allow_scripts=true. Prior to the fix,
+        // ReadSkillTool forwarded a hardcoded None to
+        // load_skills_with_open_skills_settings, which unwrap_or(false)
+        // resolved to false, silently blocking the skill.
+        let tmp = TempDir::new().unwrap();
+        let skill_dir = tmp.path().join("workspace/skills/setup");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "# Setup\n\nRuns ./configure and logs.\n",
+        )
+        .unwrap();
+        std::fs::write(skill_dir.join("configure.sh"), "#!/bin/sh\necho ok\n").unwrap();
+
+        // Construct with allow_scripts=true. Pre-fix this resolved to false
+        // inside the loader and the skill was skipped.
+        let tool = ReadSkillTool::new(tmp.path().join("workspace"), false, None, true);
+        let result = tool
+            .execute(json!({ "name": "setup" }))
+            .await
+            .unwrap();
+
+        assert!(
+            result.success,
+            "script-bearing skill must be returned when allow_scripts=true; got error={:?}",
+            result.error
+        );
+        assert!(result.output.contains("# Setup"));
     }
 }

--- a/crates/zeroclaw-runtime/src/tools/read_skill.rs
+++ b/crates/zeroclaw-runtime/src/tools/read_skill.rs
@@ -187,7 +187,6 @@ description = "Ship safely"
             result.error.as_deref(),
             Some("Unknown skill 'calendar'. Available skills: weather")
         );
-    
     }
 
     #[tokio::test]
@@ -211,10 +210,7 @@ description = "Ship safely"
         // Construct with allow_scripts=true. Pre-fix this resolved to false
         // inside the loader and the skill was skipped.
         let tool = ReadSkillTool::new(tmp.path().join("workspace"), false, None, true);
-        let result = tool
-            .execute(json!({ "name": "setup" }))
-            .await
-            .unwrap();
+        let result = tool.execute(json!({ "name": "setup" })).await.unwrap();
 
         assert!(
             result.success,

--- a/crates/zeroclaw-runtime/src/tools/read_skill.rs
+++ b/crates/zeroclaw-runtime/src/tools/read_skill.rs
@@ -8,6 +8,7 @@ pub struct ReadSkillTool {
     workspace_dir: PathBuf,
     open_skills_enabled: bool,
     open_skills_dir: Option<String>,
+    allow_scripts: bool,
 }
 
 impl ReadSkillTool {
@@ -15,11 +16,13 @@ impl ReadSkillTool {
         workspace_dir: PathBuf,
         open_skills_enabled: bool,
         open_skills_dir: Option<String>,
+        allow_scripts: bool,
     ) -> Self {
         Self {
             workspace_dir,
             open_skills_enabled,
             open_skills_dir,
+            allow_scripts,
         }
     }
 }
@@ -59,6 +62,7 @@ impl Tool for ReadSkillTool {
             &self.workspace_dir,
             self.open_skills_enabled,
             self.open_skills_dir.as_deref(),
+            self.allow_scripts,
         );
 
         let Some(skill) = skills
@@ -118,7 +122,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn make_tool(tmp: &TempDir) -> ReadSkillTool {
-        ReadSkillTool::new(tmp.path().join("workspace"), false, None)
+        ReadSkillTool::new(tmp.path().join("workspace"), false, None, false)
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **Supersedes:** #5977 (closed to scrub residual corporate-email author on the orphaned pre-amend commit; this PR is the clean refile)
- **What changed and why:** `ReadSkillTool` was constructed without `allow_scripts` and hardcoded `None` when calling `load_skills_with_open_skills_settings`; `unwrap_or(false)` inside `load_skills_with_open_skills_config` then blocked every script-bearing skill even when `skills.allow_scripts = true` was explicitly set. Threading the value end-to-end restores config respect.
- **Three-step propagation fix:** add `allow_scripts: bool` field + `new()` param to `ReadSkillTool`; add `allow_scripts` param to `load_skills_with_open_skills_settings` and forward as `Some(allow_scripts)`; pass `root_config.skills.allow_scripts` at the construction site in `tools/mod.rs`.
- **Scope boundary:** does not touch the security audit logic, the open-skills sandbox, or the delegate-tool path. No behaviour change when `skills.allow_scripts = false` (the default).
- **Blast radius:** `ReadSkillTool` is only instantiated when `skills.prompt_injection_mode = "compact"`. Callers of the public helper `load_skills_with_open_skills_settings` pick up a new required param (internal to `zeroclaw-runtime`).
- **Linked issue(s):** Closes #5697.

## Validation Evidence

Ran on macOS arm64, Rust 1.95.0.

```
cargo fmt --all -- --check          clean
cargo build -p zeroclaw-runtime     clean
cargo test -p zeroclaw-runtime --lib tools::read_skill      3/3 pass
cargo test -p zeroclaw-runtime --lib tools::tests::all_tools 6/6 pass
```

- **Beyond CI — manually verified:** walked the three call sites with `allow_scripts = true` set in config to confirm the value now reaches `load_skills_with_open_skills_config` as `Some(true)`, so the `unwrap_or(false)` no longer silently downgrades.
- **Intentionally skipped:** workspace-wide `cargo clippy --all-targets -- -D warnings` fails in `zeroclaw-config` on a pre-existing `clippy::collapsible-match` lint that also fails on unmodified `origin/master`. Not introduced by this PR.

## Security & Privacy Impact

- New permissions / capabilities? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII in diff/tests/fixtures/docs? No

Strictly restores documented behaviour of an existing opt-in (`skills.allow_scripts`). Default `false` unchanged.

## Compatibility

- Backward compatible? Yes, for end users.
- Config / env / CLI surface changed? No new user-facing surface.
- Caller-facing note: `ReadSkillTool::new` and `load_skills_with_open_skills_settings` each take one additional `bool` — both internal to `zeroclaw-runtime`.

## Rollback

Low-risk. `git revert <sha>` restores prior behaviour.

## Supersede Attribution

- Superseded: #5977 by @perlowja (this author)
- Scope materially carried forward: identical three-file fix.
- Co-authored-by trailers: N/A.
