### PR TITLE
fix(docker): copy web/dist to runtime stage in Dockerfile.debian

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -116,6 +116,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /app/zeroclaw /usr/local/bin/zeroclaw
 COPY --from=builder /zeroclaw-data /zeroclaw-data
+COPY --from=builder /app/web/dist /zeroclaw-data/web/dist
 
 # Environment setup
 # Ensure UTF-8 locale so CJK / multibyte input is handled correctly


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The `Dockerfile.debian` runtime stage was missing the `web/dist` copy, preventing the web dashboard from being served in the Debian variant image. The default `Dockerfile` already included this step, but the Debian variant was overlooked.
- **Scope boundary:** Does NOT change the default `Dockerfile`, gateway logic, or web build process. Only adds the missing `COPY` in the Debian runtime stage.
- **Blast radius:** Debian Docker image consumers only. No impact on binary releases, AUR, `cargo install`, or the default distroless image.
- **Linked issue(s):** Closes #5959

## Validation Evidence (required)

Docs-only / Docker-only change. No Rust code changed.

- **Commands run and tail output:**
  - `docker build -f Dockerfile.debian .` syntax validated (build context confirms `web/dist` is present in builder stage and absent in runtime stage before fix)
  - Diff reviewed against default `Dockerfile` to ensure parity
- **Beyond CI — what did you manually verify?**
  - Confirmed gateway auto-detect paths include `/zeroclaw-data/web/dist` (`crates/zeroclaw-gateway/src/lib.rs:770`)
  - Confirmed default `Dockerfile` already copies `web/dist` to `/zeroclaw-data/web/dist` in its runtime stage
  - Confirmed `Dockerfile.debian` builder stage already produces `web/dist` (`COPY --from=web-builder /web/dist web/dist`)
- **If any command was intentionally skipped, why:** Full `cargo` test suite skipped because no Rust source was modified.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan unless otherwise noted.

## i18n Follow-Through (required only when docs or user-facing wording change)

- N.A. — no docs or user-facing wording changed.

---

**Labels:** `risk: low`, `size: XS`, `scope: docker`, `scope: gateway`

**Commit trailers:** `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`