### PR TITLE
fix(infra): add SQLite FTS UPDATE trigger for sessions_fts

### DIFF
--- a/crates/zeroclaw-infra/src/session_sqlite.rs
+++ b/crates/zeroclaw-infra/src/session_sqlite.rs
@@ -66,6 +66,12 @@ impl SqliteSessionBackend {
              CREATE TRIGGER IF NOT EXISTS sessions_ad AFTER DELETE ON sessions BEGIN
                 INSERT INTO sessions_fts(sessions_fts, rowid, session_key, content)
                 VALUES ('delete', old.id, old.session_key, old.content);
+             END;
+             CREATE TRIGGER IF NOT EXISTS sessions_au AFTER UPDATE ON sessions BEGIN
+                INSERT INTO sessions_fts(sessions_fts, rowid, session_key, content)
+                VALUES ('delete', old.id, old.session_key, old.content);
+                INSERT INTO sessions_fts(rowid, session_key, content)
+                VALUES (new.id, new.session_key, new.content);
              END;",
         )
         .context("Failed to initialize session schema")?;
@@ -661,6 +667,49 @@ mod tests {
         });
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].key, "code_chat");
+    }
+
+    #[test]
+    fn fts5_update_trigger_syncs_index() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        backend
+            .append("chat", &ChatMessage::user("hello world"))
+            .unwrap();
+
+        // Verify initial content is searchable
+        let results = backend.search(&SessionQuery {
+            keyword: Some("hello".into()),
+            limit: Some(10),
+        });
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "chat");
+
+        // Directly update the session content (simulates update_last behavior)
+        {
+            let conn = backend.conn.lock();
+            conn.execute(
+                "UPDATE sessions SET content = ?1 WHERE session_key = ?2",
+                params!["goodbye world", "chat"],
+            )
+            .unwrap();
+        }
+
+        // Old keyword should no longer match
+        let results = backend.search(&SessionQuery {
+            keyword: Some("hello".into()),
+            limit: Some(10),
+        });
+        assert!(results.is_empty());
+
+        // New keyword should match after UPDATE trigger syncs FTS index
+        let results = backend.search(&SessionQuery {
+            keyword: Some("goodbye".into()),
+            limit: Some(10),
+        });
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].key, "chat");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The `sessions_fts` full-text search index only had INSERT and DELETE triggers. When the `sessions` table is updated (e.g. via `update_last` during incremental streaming persistence, introduced in #5705), the FTS content goes stale because no trigger synchronizes the index. This PR adds the missing AFTER UPDATE trigger.
- **Scope boundary:** Does NOT change session backend trait, gateway logic, or any other subsystem. Only adds a database trigger and a regression test.
- **Blast radius:** SQLite session backend only. No impact on JSONL backend or other consumers.
- **Linked issue(s):** Closes #5834
- **Related:** #5705 (incremental streaming persistence via `update_last`)

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — skipped (Rust toolchain not available in this environment)
  - `cargo clippy --all-targets -- -D warnings` — skipped
  - `cargo test -p zeroclaw-infra --lib session_sqlite` — skipped
- **Beyond CI — what did you manually verify?**
  - Diff reviewed against existing `sessions_ai` and `sessions_ad` triggers for consistency
  - Verified `old.id` / `new.id` usage matches SQLite trigger semantics
  - Verified `sessions_fts` column order (`rowid, session_key, content`) matches INSERT trigger
  - Regression test directly exercises UPDATE + FTS search path
- **If any command was intentionally skipped, why:** Local Rust toolchain unavailable; relying on CI for `cargo test` / `cargo clippy` / `cargo fmt` validation. The change is a single trigger definition + one test, minimizing review surface.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)

## Compatibility (required)

- Backward compatible? (`Yes`) — trigger uses `IF NOT EXISTS`; existing databases upgrade automatically.
- Config / env / CLI surface changed? (`No`)

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan unless otherwise noted.

## i18n Follow-Through (required only when docs or user-facing wording change)

- N.A. — no docs or user-facing wording changed.

---

**Labels:** `risk: low`, `size: S`, `scope: infra`, `scope: memory`

**Commit trailers:** `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`