### PR TITLE
fix(config): mirror provider entry under canonical fallback key

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -9901,7 +9901,16 @@ impl Config {
         }
 
         if let Some(base_url) = base_url {
-            self.providers.fallback = Some(format!("custom:{base_url}"));
+            let canonical_key = format!("custom:{base_url}");
+            // Mirror the profile under the canonical key so runtime
+            // `fallback_provider()` lookups resolve — without this the rename
+            // would orphan the entry still keyed under the original profile name.
+            if !self.providers.models.contains_key(&canonical_key)
+                && let Some(entry) = self.providers.models.get(&profile_key).cloned()
+            {
+                self.providers.models.insert(canonical_key.clone(), entry);
+            }
+            self.providers.fallback = Some(canonical_key);
         }
     }
 
@@ -13936,6 +13945,17 @@ requires_openai_auth = true
                 .and_then(|e| e.base_url.as_deref()),
             Some("https://api.tonsof.blue/v1")
         );
+        // The entry is also mirrored under the canonical fallback key so
+        // runtime fallback_provider() lookups resolve.
+        assert_eq!(
+            config
+                .providers
+                .models
+                .get("custom:https://api.tonsof.blue/v1")
+                .and_then(|e| e.base_url.as_deref()),
+            Some("https://api.tonsof.blue/v1")
+        );
+        assert!(config.providers.fallback_provider().is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `Config::apply_named_model_provider_profile` rewrites `providers.fallback` to `custom:{base_url}` whenever a profile's `name` matches its config key. The rewrite left the matching `providers.models` entry keyed under the original profile name, so runtime `fallback_provider()` (a plain `models.get(name)`) returned `None` on every subsequent lookup.
  - Downstream effect: every read of `api_key`, `model`, `base_url`, `extra_headers`, `api_path`, `timeout_secs`, `max_tokens` through the fallback path silently became `None` — producing 401s and misleading `zeroclaw doctor` warnings ("no api_key set" / "no default_model configured") even when the config was fully populated.
  - Fix: mirror the profile entry under the canonical `custom:{base_url}` key at rewrite time so the fallback rename stays consistent with the models map.
- **Scope boundary:** does not touch `crates/zeroclaw-config/src/migration.rs` (migration was correct), does not alter the `profile.name != profile_key` branch, does not change how `create_provider` dispatches `custom:` URLs in `zeroclaw-providers`.
- **Blast radius:** `zeroclaw-config` (Beta). Any consumer reading through `ProvidersConfig::fallback_provider()` — `doctor`, provider creation in `zeroclaw-providers`, env-override propagation — now sees the populated entry instead of `None`. No behavior change for configs where `providers.fallback` already pointed at a resolvable key.
- **Linked issue(s):** Closes #5989. Relates to #5815 (fixes the schema.rs half of hsuenaga's report; the onboard-side half lives in #5960).

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- **Commands run and tail output:** `fmt --check` clean (no output). `clippy -D warnings` clean — `Finished dev profile ... in 31.15s`, no diagnostics. `cargo test` — 0 failures across all crates; `zeroclaw-config` tail: `test result: ok. 562 passed; 0 failed; 0 ignored`.
- **Beyond CI — what did you manually verify?** Traced the rewrite path (`schema.rs:9801-9906`), env-override invocation (`schema.rs:10626`), and `ProvidersConfig::fallback_provider` (`providers.rs:33-37`). Confirmed the regression origin via `git log -S "custom:{base_url}"` and `git show e76d3e63`: V1 wrote to flat top-level `self.api_url` / `self.default_provider` so the rename was harmless; the V2 extraction in `d8f09f02` mechanically ported the function into the HashMap-keyed layout but left the lookup path orphaned. Not verified: live daemon run against OpenRouter — reporter (Frank, via @JordanTheJet) can confirm S1 clearance on the real v0 config.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.** The existing `api_key` propagation path is *restored*, not extended — no new reads, writes, or logging of credentials.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No.**

## Compatibility (required)

- Backward compatible? **Yes.**
- Config / env / CLI surface changed? **No.**
- No upgrade steps. Configs that already resolved continue to resolve identically; configs silently broken by the orphaned-key bug (v0 loads with a short provider name + matching `[model_providers.<name>]`, or equivalent v2 configs) now resolve correctly on next start.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert b3d776d9`
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:** `provider="custom:<url>" ... 401 Unauthorized` in provider logs, or `zeroclaw doctor` warning "no api_key set" / "no default_model configured" on configs where `[providers.models.<fallback>]` is actually populated.

## i18n Follow-Through

N.A. — behavior fix in `crates/zeroclaw-config/src/schema.rs`; no user-facing strings, docs, or locale surfaces touched.

