### PR TITLE
fix(docker): include web dashboard in release image

### DIFF
--- a/.github/workflows/release-stable-manual.yml
+++ b/.github/workflows/release-stable-manual.yml
@@ -533,6 +533,7 @@ jobs:
             'port = 42617' \
             'host = "[::]"' \
             'allow_public_bind = true' \
+            'web_dist_dir = "/zeroclaw-data/web/dist"' \
             > docker-ctx/zeroclaw-data/.zeroclaw/config.toml
 
           cp Dockerfile.ci docker-ctx/Dockerfile

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -10,6 +10,12 @@ ARG TARGETARCH
 # Copy the pre-built binary for this platform (amd64 or arm64)
 COPY bin/${TARGETARCH}/zeroclaw /usr/local/bin/zeroclaw
 
+# Copy the web dashboard bundled alongside the binary in the release tarball.
+# The dashboard was decoupled from the binary in #5665 and is now served from
+# disk at `gateway.web_dist_dir`; without this COPY the distroless image has
+# no `/zeroclaw-data/web/dist` and `GET /` returns HTTP 503.
+COPY bin/${TARGETARCH}/web/dist /zeroclaw-data/web/dist
+
 # Runtime directory structure and default config
 COPY --chown=65534:65534 zeroclaw-data/ /zeroclaw-data/
 

--- a/Dockerfile.debian.ci
+++ b/Dockerfile.debian.ci
@@ -19,6 +19,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy the pre-built binary for this platform (amd64 or arm64)
 COPY bin/${TARGETARCH}/zeroclaw /usr/local/bin/zeroclaw
 
+# Copy the web dashboard bundled alongside the binary in the release tarball.
+# The dashboard was decoupled from the binary in #5665 and is now served from
+# disk at `gateway.web_dist_dir`; without this COPY the image has no
+# `/zeroclaw-data/web/dist` and `GET /` returns HTTP 503.
+COPY bin/${TARGETARCH}/web/dist /zeroclaw-data/web/dist
+
 # Runtime directory structure and default config
 COPY --chown=65534:65534 zeroclaw-data/ /zeroclaw-data/
 


### PR DESCRIPTION
## Summary

- Copies `web/dist/` from the release tarball into the Docker image in both `Dockerfile.ci` and `Dockerfile.debian.ci`, restoring the web dashboard in published `ghcr.io` images.
- Adds `web_dist_dir = "/zeroclaw-data/web/dist"` to the baked `config.toml` written by the `docker` job so the path is explicit.

Fixes #5995.

## Background

The dashboard was decoupled from the binary in #5665 (it now lives on disk at `gateway.web_dist_dir` instead of being embedded via `rust-embed`). The follow-up #5675 wired it back into binary releases, AUR, and `cargo install`, but missed the Docker path. As a result, `ghcr.io/zeroclaw-labs/zeroclaw:v0.7.3` and `:latest` ship without `/zeroclaw-data/web/dist`, and `GET /` returns HTTP 503 with `Web dashboard not available`.

The release tarballs themselves already contain `web/dist/` (alongside the binary), and CI extracts them into `docker-ctx/bin/${TARGETARCH}/`, so the files are present in the build context — the CI Dockerfiles just weren't copying them.

## Test plan

Validated locally by reproducing the CI docker context with the v0.7.3 release tarball:

```sh
# Reproduce what the `docker` job in release-stable-manual.yml does
mkdir -p ctx/bin/amd64 ctx/zeroclaw-data/.zeroclaw ctx/zeroclaw-data/workspace
curl -sL https://github.com/zeroclaw-labs/zeroclaw/releases/download/v0.7.3/zeroclaw-x86_64-unknown-linux-gnu.tar.gz \
  | tar xz -C ctx/bin/amd64
# (write baked config.toml as the workflow does, with this PR's web_dist_dir line)
cp Dockerfile.ci ctx/Dockerfile
docker build --platform linux/amd64 --build-arg TARGETARCH=amd64 -t zc-test ctx
docker run --rm -d --name zc-test -p 42619:42617 zc-test
```

Results **before** this patch (unchanged `Dockerfile.ci`):

```
GET /                                        → HTTP 503, "Web dashboard not available..."
docker cp zc:/zeroclaw-data/web /tmp/...     → "Could not find the file"
log: "Web dashboard: not available (set gateway.web_dist_dir ...)"
```

Results **after** this patch:

```
GET /                                        → HTTP 200  (524 bytes, dashboard HTML)
GET /_app/assets/index-0moaj04v.js           → HTTP 200  (1.07 MB, real JS)
GET /_app/assets/index-U88q_gzZ.css          → HTTP 200
GET /logo.png                                → HTTP 200
log: "Web dashboard: serving from /zeroclaw-data/web/dist"
```

## Checklist

- [x] `Dockerfile.ci` copies `web/dist` from the per-arch release tarball
- [x] `Dockerfile.debian.ci` mirrors the same change
- [x] Baked `config.toml` in the workflow sets `web_dist_dir`
- [x] Local repro verified: 503 before patch, 200 after patch
- [ ] Full CI dry-run (would require maintainer to trigger `release-stable-manual.yml` on a test tag)

## Notes

- No changes to `Dockerfile` (local dev / multi-stage build) — that path already copies `web/dist` via `COPY --from=web-builder` and sets `web_dist_dir` in its baked config.
- A small orthogonal issue noticed while testing: the shipped `index.html` references `/_app/zeroclaw-trans.png` which isn't present in the tarball (the tarball has `logo.png`). Loading the dashboard works (the `<link rel="icon">` just 404s), but might be worth a separate tracking issue. Not addressed here.