### PR TITLE
fix(tauri): install rustls crypto provider to prevent desktop crash

### DIFF
--- a/apps/tauri/Cargo.toml
+++ b/apps/tauri/Cargo.toml
@@ -15,7 +15,7 @@ tauri-plugin-store = "2.0"
 tauri-plugin-single-instance = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots-no-provider"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
 tokio = { version = "1.50", features = ["rt-multi-thread", "macros", "sync", "time"] }
 anyhow = "1.0"
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `apps/tauri/Cargo.toml`: switch reqwest feature from `rustls-tls-webpki-roots-no-provider` to `rustls-tls-webpki-roots`.
  - The `-no-provider` variant expects the binary to install a rustls `CryptoProvider` (e.g. via `__rustls-ring` or `CryptoProvider::install_default(...)` in `main`). The Tauri app did neither, so `reqwest::ClientBuilder::build` hit the `unwrap_or_else` at `reqwest-0.12.28/src/async_impl/client.rs:767` and panicked with `No provider set` immediately after launch.
  - The non-`-no-provider` feature bundles reqwest's ring-based provider and registers it as the process default, which is the minimal fix for a desktop shell that doesn't otherwise customize rustls.
- **Scope boundary:** Only `apps/tauri/Cargo.toml`. No code changes, no behavior change for other crates. `crates/robot-kit/Cargo.toml` has the same vulnerable pattern (no `__rustls-ring`, no `-no-provider` install) but is out of scope for this PR — filing follow-up if wanted.
- **Blast radius:** Desktop binary only. Other workspace crates that use `-no-provider` (`zeroclaw-channels`, `zeroclaw-tools`, `zeroclaw-providers`, `zeroclaw-runtime`, `zeroclaw-config`, `zeroclaw-memory`) already pair it with `__rustls-ring` and are unaffected.
- **Linked issue(s):** Closes #5984

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy -p zeroclaw-desktop --all-targets -- -D warnings
cargo build -p zeroclaw-desktop
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` → clean (no output, exit 0).
  - `cargo clippy -p zeroclaw-desktop --all-targets -- -D warnings` → `Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 2m 38s`, no warnings.
  - `cargo build -p zeroclaw-desktop` → `Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 4m 14s`.
- **Beyond CI — what did you manually verify?** Traced the panic site (`reqwest-0.12.28/src/async_impl/client.rs:767`) and confirmed it is the `CryptoProvider::get_default().unwrap_or_else(...)` path, which is only reachable when the default provider is unset. Inspected every other `reqwest = { ... }` spec in the workspace to confirm they install ring and therefore don't regress.
- **If any command was intentionally skipped, why:** Full-workspace `cargo test` was not run; the change is a single-feature-flag swap in a leaf binary with no code paths touched, and per-crate clippy + build cover the blast radius.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No` (the desktop already used reqwest with webpki roots; only the TLS provider wiring changed).
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`

## Rollback (required for `risk: medium` and `risk: high`)

Low risk — `git revert <sha>` restores the previous feature flag. No feature toggle needed.

---

## Maintainer note (added 2026-04-30 by @singlerider)

Marking this PR as **`Supersedes #5964`** at merge time.

### Supersede Attribution
- Superseded PRs + authors: `#5964 by @dougmorato`
- Scope materially carried forward: same bug fix (rustls panic on reqwest construction in the bundled desktop app). Implementation is independent and meaningfully simpler — #5964 added a direct `rustls` dependency plus manual `install_default()` calls in `main.rs` and `GatewayClient::new()`; this PR achieves the same fix with a one-line feature-flag swap (`-no-provider` → no suffix), letting reqwest pick the provider per its own feature set. Workspace convention (`crates/zeroclaw-{channels,providers,runtime}/Cargo.toml`) reserves the `-no-provider` + `__rustls-ring` pairing for crates that need provider control; the desktop app doesn't.
- `Co-authored-by` trailer added? **No.** Independent parallel implementation against the same root cause, not a code port from #5964. Filing as inspiration-only.
- @dougmorato's PR carried strong bundle-level validation evidence (reproduced original crash from the installed `.app`, confirmed patched binary stays running) that this PR did not include — that validation is recorded in the closed #5964 thread for future debugging.
