### PR TITLE
feat(channels): implement request_approval() for Discord, Slack, Signal, Matrix, WhatsApp

### DIFF
--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -6,9 +6,12 @@ use serde_json::json;
 use std::collections::HashMap;
 use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{oneshot, Mutex as AsyncMutex};
 use tokio_tungstenite::tungstenite::Message;
 use uuid::Uuid;
-use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+use zeroclaw_api::channel::{Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage};
 
 /// Discord channel — connects via Gateway WebSocket for real-time messages
 pub struct DiscordChannel {
@@ -38,6 +41,8 @@ pub struct DiscordChannel {
     multi_message_thread_ts: Mutex<HashMap<String, Option<String>>>,
     /// Stall-watchdog timeout in seconds (0 = disabled).
     stall_timeout_secs: u64,
+    pending_approvals: Arc<AsyncMutex<HashMap<String, oneshot::Sender<ChannelApprovalResponse>>>>,
+    approval_timeout_secs: u64,
 }
 
 impl DiscordChannel {
@@ -65,12 +70,19 @@ impl DiscordChannel {
             multi_message_sent_len: Mutex::new(HashMap::new()),
             multi_message_thread_ts: Mutex::new(HashMap::new()),
             stall_timeout_secs: 0,
+            pending_approvals: Arc::new(AsyncMutex::new(HashMap::new())),
+            approval_timeout_secs: 300,
         }
     }
 
     /// Set a per-channel proxy URL that overrides the global proxy config.
     pub fn with_proxy_url(mut self, proxy_url: Option<String>) -> Self {
         self.proxy_url = proxy_url;
+        self
+    }
+
+    pub fn with_approval_timeout_secs(mut self, secs: u64) -> Self {
+        self.approval_timeout_secs = secs;
         self
     }
 
@@ -1166,6 +1178,17 @@ impl Channel for DiscordChannel {
                         format!("{clean_content}\n\n[Attachments]\n{attachment_text}")
                     };
 
+                    // Intercept approval replies before forwarding to the agent.
+                    if let Some((token, response)) =
+                        crate::util::parse_approval_reply(&final_content)
+                    {
+                        let mut map = self.pending_approvals.lock().await;
+                        if let Some(sender) = map.remove(&token) {
+                            let _ = sender.send(response);
+                            continue;
+                        }
+                    }
+
                     let message_id = d.get("id").and_then(|i| i.as_str()).unwrap_or("");
                     let channel_id = d
                         .get("channel_id")
@@ -1641,6 +1664,57 @@ impl Channel for DiscordChannel {
         }
 
         Ok(())
+    }
+
+    async fn request_approval(
+        &self,
+        recipient: &str,
+        request: &ChannelApprovalRequest,
+    ) -> anyhow::Result<Option<ChannelApprovalResponse>> {
+        let token = crate::util::new_approval_token();
+        let text = format!(
+            "APPROVAL REQUIRED [{}]\nTool: {}\nArgs: {}\n\nReply: \"{} yes\", \"{} no\", or \"{} always\"",
+            token,
+            request.tool_name,
+            request.arguments_summary,
+            token,
+            token,
+            token,
+        );
+
+        let (tx, rx) = oneshot::channel();
+        self.pending_approvals
+            .lock()
+            .await
+            .insert(token.clone(), tx);
+
+        // Strip thread suffix — approval message goes to the channel root.
+        let channel_id = recipient.split(':').next().unwrap_or(recipient);
+        if let Err(err) = self
+            .send(&SendMessage {
+                recipient: channel_id.to_string(),
+                content: text,
+                attachments: vec![],
+            })
+            .await
+        {
+            self.pending_approvals.lock().await.remove(&token);
+            return Err(err);
+        }
+
+        let response = match tokio::time::timeout(
+            Duration::from_secs(self.approval_timeout_secs),
+            rx,
+        )
+        .await
+        {
+            Ok(Ok(resp)) => resp,
+            _ => {
+                self.pending_approvals.lock().await.remove(&token);
+                ChannelApprovalResponse::Deny
+            }
+        };
+        Ok(Some(response))
     }
 }
 
@@ -2446,5 +2520,42 @@ mod tests {
     fn split_message_for_discord_multi_empty_input() {
         let chunks = split_message_for_discord_multi("", 2000);
         assert!(chunks.is_empty());
+    }
+
+    fn make_discord_channel() -> DiscordChannel {
+        DiscordChannel::new("token".into(), None, vec![], false, false)
+    }
+
+    #[test]
+    fn pending_approvals_map_is_initially_empty() {
+        let ch = make_discord_channel();
+        let map = ch.pending_approvals.try_lock().unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn approval_timeout_defaults_to_300_and_is_overridable() {
+        let ch = make_discord_channel();
+        assert_eq!(ch.approval_timeout_secs, 300);
+        let ch = ch.with_approval_timeout_secs(60);
+        assert_eq!(ch.approval_timeout_secs, 60);
+    }
+
+    #[tokio::test]
+    async fn pending_approval_oneshot_delivers_response() {
+        let ch = make_discord_channel();
+        let (tx, rx) = oneshot::channel();
+        ch.pending_approvals
+            .lock()
+            .await
+            .insert("abc123".to_string(), tx);
+        let sender = ch
+            .pending_approvals
+            .lock()
+            .await
+            .remove("abc123")
+            .unwrap();
+        sender.send(ChannelApprovalResponse::Deny).unwrap();
+        assert_eq!(rx.await.unwrap(), ChannelApprovalResponse::Deny);
     }
 }

--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -8,10 +8,12 @@ use std::fmt::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{oneshot, Mutex as AsyncMutex};
+use tokio::sync::{Mutex as AsyncMutex, oneshot};
 use tokio_tungstenite::tungstenite::Message;
 use uuid::Uuid;
-use zeroclaw_api::channel::{Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage};
+use zeroclaw_api::channel::{
+    Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage,
+};
 
 /// Discord channel — connects via Gateway WebSocket for real-time messages
 pub struct DiscordChannel {
@@ -1674,12 +1676,7 @@ impl Channel for DiscordChannel {
         let token = crate::util::new_approval_token();
         let text = format!(
             "APPROVAL REQUIRED [{}]\nTool: {}\nArgs: {}\n\nReply: \"{} yes\", \"{} no\", or \"{} always\"",
-            token,
-            request.tool_name,
-            request.arguments_summary,
-            token,
-            token,
-            token,
+            token, request.tool_name, request.arguments_summary, token, token, token,
         );
 
         let (tx, rx) = oneshot::channel();
@@ -1702,18 +1699,14 @@ impl Channel for DiscordChannel {
             return Err(err);
         }
 
-        let response = match tokio::time::timeout(
-            Duration::from_secs(self.approval_timeout_secs),
-            rx,
-        )
-        .await
-        {
-            Ok(Ok(resp)) => resp,
-            _ => {
-                self.pending_approvals.lock().await.remove(&token);
-                ChannelApprovalResponse::Deny
-            }
-        };
+        let response =
+            match tokio::time::timeout(Duration::from_secs(self.approval_timeout_secs), rx).await {
+                Ok(Ok(resp)) => resp,
+                _ => {
+                    self.pending_approvals.lock().await.remove(&token);
+                    ChannelApprovalResponse::Deny
+                }
+            };
         Ok(Some(response))
     }
 }
@@ -2549,12 +2542,7 @@ mod tests {
             .lock()
             .await
             .insert("abc123".to_string(), tx);
-        let sender = ch
-            .pending_approvals
-            .lock()
-            .await
-            .remove("abc123")
-            .unwrap();
+        let sender = ch.pending_approvals.lock().await.remove("abc123").unwrap();
         sender.send(ChannelApprovalResponse::Deny).unwrap();
         assert_eq!(rx.await.unwrap(), ChannelApprovalResponse::Deny);
     }

--- a/crates/zeroclaw-channels/src/discord.rs
+++ b/crates/zeroclaw-channels/src/discord.rs
@@ -1687,14 +1687,7 @@ impl Channel for DiscordChannel {
 
         // Strip thread suffix — approval message goes to the channel root.
         let channel_id = recipient.split(':').next().unwrap_or(recipient);
-        if let Err(err) = self
-            .send(&SendMessage {
-                recipient: channel_id.to_string(),
-                content: text,
-                attachments: vec![],
-            })
-            .await
-        {
+        if let Err(err) = self.send(&SendMessage::new(text, channel_id)).await {
             self.pending_approvals.lock().await.remove(&token);
             return Err(err);
         }

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -24,8 +24,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use tokio::sync::{Mutex, OnceCell, RwLock, mpsc};
-use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+use tokio::sync::{Mutex, OnceCell, RwLock, mpsc, oneshot};
+use zeroclaw_api::channel::{Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage};
 
 /// Matrix channel for Matrix Client-Server API.
 /// Uses matrix-sdk for reliable sync and encrypted-room decryption.
@@ -61,6 +61,8 @@ pub struct MatrixChannel {
     multi_message_sent_len: Arc<Mutex<HashMap<String, usize>>>,
     /// Thread context captured from `send_draft()` for MultiMessage paragraph delivery.
     multi_message_thread_ts: Arc<Mutex<HashMap<String, Option<String>>>>,
+    pending_approvals: Arc<Mutex<HashMap<String, oneshot::Sender<ChannelApprovalResponse>>>>,
+    approval_timeout_secs: u64,
 }
 
 impl std::fmt::Debug for MatrixChannel {
@@ -269,7 +271,14 @@ impl MatrixChannel {
             last_draft_edit: Arc::new(Mutex::new(HashMap::new())),
             multi_message_sent_len: Arc::new(Mutex::new(HashMap::new())),
             multi_message_thread_ts: Arc::new(Mutex::new(HashMap::new())),
+            pending_approvals: Arc::new(Mutex::new(HashMap::new())),
+            approval_timeout_secs: 300,
         }
+    }
+
+    pub fn with_approval_timeout_secs(mut self, secs: u64) -> Self {
+        self.approval_timeout_secs = secs;
+        self
     }
 
     /// Extract body text and media source from a message type.
@@ -1025,6 +1034,41 @@ impl Channel for MatrixChannel {
         Ok(())
     }
 
+    async fn request_approval(
+        &self,
+        recipient: &str,
+        request: &ChannelApprovalRequest,
+    ) -> anyhow::Result<Option<ChannelApprovalResponse>> {
+        let token = crate::util::new_approval_token();
+        let (tx_approval, rx_approval) = oneshot::channel();
+        {
+            let mut map = self.pending_approvals.lock().await;
+            map.insert(token.clone(), tx_approval);
+        }
+
+        let text = format!(
+            "APPROVAL REQUIRED [{}]\nTool: {}\nArgs: {}\n\nReply: \"{} yes\", \"{} no\", or \"{} always\"",
+            token, request.tool_name, request.arguments_summary, token, token, token
+        );
+        self.send(&SendMessage {
+            content: text,
+            recipient: recipient.to_string(),
+            thread_ts: None,
+        })
+        .await?;
+
+        let timeout = std::time::Duration::from_secs(self.approval_timeout_secs);
+        let response = match tokio::time::timeout(timeout, rx_approval).await {
+            Ok(Ok(response)) => response,
+            _ => {
+                let mut map = self.pending_approvals.lock().await;
+                map.remove(&token);
+                ChannelApprovalResponse::Deny
+            }
+        };
+        Ok(Some(response))
+    }
+
     async fn listen(&self, tx: mpsc::Sender<ChannelMessage>) -> anyhow::Result<()> {
         if self.otk_conflict_detected.load(Ordering::Relaxed) {
             tracing::debug!("Matrix OTK conflict flag is set, refusing listen");
@@ -1082,6 +1126,7 @@ impl Channel for MatrixChannel {
         let voice_mode_for_handler = Arc::clone(&self.voice_mode);
         let transcription_mgr_for_handler = self.transcription_manager.clone();
         let mention_only_for_handler = self.mention_only;
+        let pending_approvals_for_handler = Arc::clone(&self.pending_approvals);
 
         client.add_event_handler(move |event: OriginalSyncRoomMessageEvent, room: Room| {
             let tx = tx_handler.clone();
@@ -1094,6 +1139,7 @@ impl Channel for MatrixChannel {
             let voice_mode = Arc::clone(&voice_mode_for_handler);
             let transcription_mgr = transcription_mgr_for_handler.clone();
             let mention_only = mention_only_for_handler;
+            let pending_approvals = Arc::clone(&pending_approvals_for_handler);
 
             async move {
                 // Room filtering: use allowed_rooms if set, otherwise fall back to single room_id
@@ -1279,6 +1325,14 @@ impl Channel for MatrixChannel {
                 // Start typing notification while processing begins
                 if let Err(error) = room.typing_notice(true).await {
                     tracing::warn!("Matrix failed to start typing notification: {error}");
+                }
+
+                if let Some((token, response)) = crate::util::parse_approval_reply(&body) {
+                    let mut map = pending_approvals.lock().await;
+                    if let Some(sender) = map.remove(&token) {
+                        let _ = sender.send(response);
+                        return;
+                    }
                 }
 
                 let thread_ts = match &event.content.relates_to {
@@ -2624,5 +2678,20 @@ mod tests {
         let (body, media) = MatrixChannel::extract_media_info(&msgtype);
         assert_eq!(body, "hello world");
         assert!(media.is_none());
+    }
+
+    #[test]
+    fn pending_approvals_map_is_initially_empty() {
+        let ch = make_channel();
+        let map = ch.pending_approvals.blocking_lock();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn approval_timeout_defaults_to_300_and_is_overridable() {
+        let ch = make_channel();
+        assert_eq!(ch.approval_timeout_secs, 300);
+        let ch2 = ch.with_approval_timeout_secs(60);
+        assert_eq!(ch2.approval_timeout_secs, 60);
     }
 }

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -1052,12 +1052,7 @@ impl Channel for MatrixChannel {
             "APPROVAL REQUIRED [{}]\nTool: {}\nArgs: {}\n\nReply: \"{} yes\", \"{} no\", or \"{} always\"",
             token, request.tool_name, request.arguments_summary, token, token, token
         );
-        self.send(&SendMessage {
-            content: text,
-            recipient: recipient.to_string(),
-            thread_ts: None,
-        })
-        .await?;
+        self.send(&SendMessage::new(text, recipient)).await?;
 
         let timeout = std::time::Duration::from_secs(self.approval_timeout_secs);
         let response = match tokio::time::timeout(timeout, rx_approval).await {

--- a/crates/zeroclaw-channels/src/matrix.rs
+++ b/crates/zeroclaw-channels/src/matrix.rs
@@ -25,7 +25,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::sync::{Mutex, OnceCell, RwLock, mpsc, oneshot};
-use zeroclaw_api::channel::{Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage};
+use zeroclaw_api::channel::{
+    Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage,
+};
 
 /// Matrix channel for Matrix Client-Server API.
 /// Uses matrix-sdk for reliable sync and encrypted-room decryption.

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -3951,7 +3951,8 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                     dc.multi_message_delay_ms,
                 )
                 .with_transcription(config.transcription.clone())
-                .with_stall_timeout(dc.stall_timeout_secs),
+                .with_stall_timeout(dc.stall_timeout_secs)
+                .with_approval_timeout_secs(dc.approval_timeout_secs),
             ))
         }
         "slack" => {
@@ -3971,7 +3972,8 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 .with_markdown_blocks(sl.use_markdown_blocks)
                 .with_transcription(config.transcription.clone())
                 .with_streaming(sl.stream_drafts, sl.draft_update_interval_ms)
-                .with_cancel_reaction(sl.cancel_reaction.clone()),
+                .with_cancel_reaction(sl.cancel_reaction.clone())
+                .with_approval_timeout_secs(sl.approval_timeout_secs),
             ))
         }
         "mattermost" => {
@@ -3995,14 +3997,17 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                 .signal
                 .as_ref()
                 .context("Signal channel is not configured")?;
-            Ok(Arc::new(SignalChannel::new(
-                sg.http_url.clone(),
-                sg.account.clone(),
-                sg.group_id.clone(),
-                sg.allowed_from.clone(),
-                sg.ignore_attachments,
-                sg.ignore_stories,
-            )))
+            Ok(Arc::new(
+                SignalChannel::new(
+                    sg.http_url.clone(),
+                    sg.account.clone(),
+                    sg.group_id.clone(),
+                    sg.allowed_from.clone(),
+                    sg.ignore_attachments,
+                    sg.ignore_stories,
+                )
+                .with_approval_timeout_secs(sg.approval_timeout_secs),
+            ))
         }
         "matrix" => {
             #[cfg(feature = "channel-matrix")]
@@ -4012,14 +4017,17 @@ fn build_channel_by_id(config: &Config, channel_id: &str) -> Result<Arc<dyn Chan
                     .matrix
                     .as_ref()
                     .context("Matrix channel is not configured")?;
-                Ok(Arc::new(MatrixChannel::new(
-                    mx.homeserver.clone(),
-                    mx.access_token.clone(),
-                    // "" sentinel = no specific room (join logic handles "allow all")
-                    mx.allowed_rooms.first().cloned().unwrap_or_default(),
-                    mx.allowed_users.clone(),
-                    mx.mention_only,
-                )))
+                Ok(Arc::new(
+                    MatrixChannel::new(
+                        mx.homeserver.clone(),
+                        mx.access_token.clone(),
+                        // "" sentinel = no specific room (join logic handles "allow all")
+                        mx.allowed_rooms.first().cloned().unwrap_or_default(),
+                        mx.allowed_users.clone(),
+                        mx.mention_only,
+                    )
+                    .with_approval_timeout_secs(mx.approval_timeout_secs),
+                ))
             }
             #[cfg(not(feature = "channel-matrix"))]
             {
@@ -4385,7 +4393,8 @@ fn collect_configured_channels(
                     )
                     .with_proxy_url(dc.proxy_url.clone())
                     .with_transcription(config.transcription.clone())
-                    .with_stall_timeout(dc.stall_timeout_secs),
+                    .with_stall_timeout(dc.stall_timeout_secs)
+                    .with_approval_timeout_secs(dc.approval_timeout_secs),
                 ),
             });
         } else {
@@ -4440,7 +4449,8 @@ fn collect_configured_channels(
                     .with_proxy_url(sl.proxy_url.clone())
                     .with_transcription(config.transcription.clone())
                     .with_streaming(sl.stream_drafts, sl.draft_update_interval_ms)
-                    .with_cancel_reaction(sl.cancel_reaction.clone()),
+                    .with_cancel_reaction(sl.cancel_reaction.clone())
+                    .with_approval_timeout_secs(sl.approval_timeout_secs),
                 ),
             });
         } else {
@@ -4505,7 +4515,8 @@ fn collect_configured_channels(
                         mx.draft_update_interval_ms,
                         mx.multi_message_delay_ms,
                     )
-                    .with_transcription(config.transcription.clone()),
+                    .with_transcription(config.transcription.clone())
+                    .with_approval_timeout_secs(mx.approval_timeout_secs),
                 ),
             });
         } else {
@@ -4534,7 +4545,8 @@ fn collect_configured_channels(
                         sig.ignore_attachments,
                         sig.ignore_stories,
                     )
-                    .with_proxy_url(sig.proxy_url.clone()),
+                    .with_proxy_url(sig.proxy_url.clone())
+                    .with_approval_timeout_secs(sig.approval_timeout_secs),
                 ),
             });
         } else {
@@ -4565,7 +4577,8 @@ fn collect_configured_channels(
                                 )
                                 .with_proxy_url(wa.proxy_url.clone())
                                 .with_dm_mention_patterns(wa.dm_mention_patterns.clone())
-                                .with_group_mention_patterns(wa.group_mention_patterns.clone()),
+                                .with_group_mention_patterns(wa.group_mention_patterns.clone())
+                                .with_approval_timeout_secs(wa.approval_timeout_secs),
                             ),
                         });
                     } else {

--- a/crates/zeroclaw-channels/src/signal.rs
+++ b/crates/zeroclaw-channels/src/signal.rs
@@ -2,10 +2,12 @@ use async_trait::async_trait;
 use futures_util::StreamExt;
 use reqwest::Client;
 use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot, Mutex};
 use uuid::Uuid;
-use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+use zeroclaw_api::channel::{Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage};
 
 const GROUP_TARGET_PREFIX: &str = "group:";
 
@@ -30,6 +32,8 @@ pub struct SignalChannel {
     ignore_stories: bool,
     /// Per-channel proxy URL override.
     proxy_url: Option<String>,
+    pending_approvals: Arc<Mutex<HashMap<String, oneshot::Sender<ChannelApprovalResponse>>>>,
+    approval_timeout_secs: u64,
 }
 
 // ── signal-cli SSE event JSON shapes ────────────────────────────
@@ -90,12 +94,19 @@ impl SignalChannel {
             ignore_attachments,
             ignore_stories,
             proxy_url: None,
+            pending_approvals: Arc::new(Mutex::new(HashMap::new())),
+            approval_timeout_secs: 300,
         }
     }
 
     /// Set a per-channel proxy URL that overrides the global proxy config.
     pub fn with_proxy_url(mut self, proxy_url: Option<String>) -> Self {
         self.proxy_url = proxy_url;
+        self
+    }
+
+    pub fn with_approval_timeout_secs(mut self, secs: u64) -> Self {
+        self.approval_timeout_secs = secs;
         self
     }
 
@@ -383,11 +394,23 @@ impl Channel for SignalChannel {
                         if !current_data.is_empty() {
                             match serde_json::from_str::<SseEnvelope>(&current_data) {
                                 Ok(sse) => {
-                                    if let Some(ref envelope) = sse.envelope
-                                        && let Some(msg) = self.process_envelope(envelope)
-                                        && tx.send(msg).await.is_err()
-                                    {
-                                        return Ok(());
+                                    if let Some(ref envelope) = sse.envelope {
+                                        if let Some(msg) = self.process_envelope(envelope) {
+                                            if let Some((token, response)) =
+                                                crate::util::parse_approval_reply(&msg.content)
+                                            {
+                                                let mut map =
+                                                    self.pending_approvals.lock().await;
+                                                if let Some(sender) = map.remove(&token) {
+                                                    let _ = sender.send(response);
+                                                    current_data.clear();
+                                                    continue;
+                                                }
+                                            }
+                                            if tx.send(msg).await.is_err() {
+                                                return Ok(());
+                                            }
+                                        }
                                     }
                                 }
                                 Err(e) => {
@@ -409,10 +432,19 @@ impl Channel for SignalChannel {
             if !current_data.is_empty() {
                 match serde_json::from_str::<SseEnvelope>(&current_data) {
                     Ok(sse) => {
-                        if let Some(ref envelope) = sse.envelope
-                            && let Some(msg) = self.process_envelope(envelope)
-                        {
-                            let _ = tx.send(msg).await;
+                        if let Some(ref envelope) = sse.envelope {
+                            if let Some(msg) = self.process_envelope(envelope) {
+                                if let Some((token, response)) =
+                                    crate::util::parse_approval_reply(&msg.content)
+                                {
+                                    let mut map = self.pending_approvals.lock().await;
+                                    if let Some(sender) = map.remove(&token) {
+                                        let _ = sender.send(response);
+                                        continue;
+                                    }
+                                }
+                                let _ = tx.send(msg).await;
+                            }
                         }
                     }
                     Err(e) => {
@@ -459,6 +491,55 @@ impl Channel for SignalChannel {
         // signal-cli doesn't have a stop-typing RPC; typing indicators
         // auto-expire after ~15s on the client side.
         Ok(())
+    }
+
+    async fn request_approval(
+        &self,
+        recipient: &str,
+        request: &ChannelApprovalRequest,
+    ) -> anyhow::Result<Option<ChannelApprovalResponse>> {
+        let token = crate::util::new_approval_token();
+        let text = format!(
+            "APPROVAL REQUIRED [{}]\nTool: {}\nArgs: {}\n\nReply: \"{} yes\", \"{} no\", or \"{} always\"",
+            token,
+            request.tool_name,
+            request.arguments_summary,
+            token,
+            token,
+            token,
+        );
+
+        let (tx, rx) = oneshot::channel();
+        self.pending_approvals
+            .lock()
+            .await
+            .insert(token.clone(), tx);
+
+        if let Err(err) = self
+            .send(&SendMessage {
+                recipient: recipient.to_string(),
+                content: text,
+                attachments: vec![],
+            })
+            .await
+        {
+            self.pending_approvals.lock().await.remove(&token);
+            return Err(err);
+        }
+
+        let response = match tokio::time::timeout(
+            Duration::from_secs(self.approval_timeout_secs),
+            rx,
+        )
+        .await
+        {
+            Ok(Ok(resp)) => resp,
+            _ => {
+                self.pending_approvals.lock().await.remove(&token);
+                ChannelApprovalResponse::Deny
+            }
+        };
+        Ok(Some(response))
     }
 }
 
@@ -920,5 +1001,39 @@ mod tests {
         assert!(env.data_message.is_none());
         assert!(env.story_message.is_none());
         assert!(env.timestamp.is_none());
+    }
+
+    #[test]
+    fn pending_approvals_map_is_initially_empty() {
+        let ch = make_channel();
+        let map = ch.pending_approvals.try_lock().unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn approval_timeout_defaults_to_300_and_is_overridable() {
+        let ch = make_channel();
+        assert_eq!(ch.approval_timeout_secs, 300);
+        let ch = ch.with_approval_timeout_secs(60);
+        assert_eq!(ch.approval_timeout_secs, 60);
+    }
+
+    #[tokio::test]
+    async fn pending_approval_oneshot_delivers_response() {
+        let ch = make_channel();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        ch.pending_approvals
+            .lock()
+            .await
+            .insert("abc123".to_string(), tx);
+        // simulate listen() routing
+        let sender = ch
+            .pending_approvals
+            .lock()
+            .await
+            .remove("abc123")
+            .unwrap();
+        sender.send(ChannelApprovalResponse::Approve).unwrap();
+        assert_eq!(rx.await.unwrap(), ChannelApprovalResponse::Approve);
     }
 }

--- a/crates/zeroclaw-channels/src/signal.rs
+++ b/crates/zeroclaw-channels/src/signal.rs
@@ -5,9 +5,11 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::sync::{Mutex, mpsc, oneshot};
 use uuid::Uuid;
-use zeroclaw_api::channel::{Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage};
+use zeroclaw_api::channel::{
+    Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage,
+};
 
 const GROUP_TARGET_PREFIX: &str = "group:";
 
@@ -399,8 +401,7 @@ impl Channel for SignalChannel {
                                             if let Some((token, response)) =
                                                 crate::util::parse_approval_reply(&msg.content)
                                             {
-                                                let mut map =
-                                                    self.pending_approvals.lock().await;
+                                                let mut map = self.pending_approvals.lock().await;
                                                 if let Some(sender) = map.remove(&token) {
                                                     let _ = sender.send(response);
                                                     current_data.clear();
@@ -501,12 +502,7 @@ impl Channel for SignalChannel {
         let token = crate::util::new_approval_token();
         let text = format!(
             "APPROVAL REQUIRED [{}]\nTool: {}\nArgs: {}\n\nReply: \"{} yes\", \"{} no\", or \"{} always\"",
-            token,
-            request.tool_name,
-            request.arguments_summary,
-            token,
-            token,
-            token,
+            token, request.tool_name, request.arguments_summary, token, token, token,
         );
 
         let (tx, rx) = oneshot::channel();
@@ -527,18 +523,14 @@ impl Channel for SignalChannel {
             return Err(err);
         }
 
-        let response = match tokio::time::timeout(
-            Duration::from_secs(self.approval_timeout_secs),
-            rx,
-        )
-        .await
-        {
-            Ok(Ok(resp)) => resp,
-            _ => {
-                self.pending_approvals.lock().await.remove(&token);
-                ChannelApprovalResponse::Deny
-            }
-        };
+        let response =
+            match tokio::time::timeout(Duration::from_secs(self.approval_timeout_secs), rx).await {
+                Ok(Ok(resp)) => resp,
+                _ => {
+                    self.pending_approvals.lock().await.remove(&token);
+                    ChannelApprovalResponse::Deny
+                }
+            };
         Ok(Some(response))
     }
 }
@@ -1027,12 +1019,7 @@ mod tests {
             .await
             .insert("abc123".to_string(), tx);
         // simulate listen() routing
-        let sender = ch
-            .pending_approvals
-            .lock()
-            .await
-            .remove("abc123")
-            .unwrap();
+        let sender = ch.pending_approvals.lock().await.remove("abc123").unwrap();
         sender.send(ChannelApprovalResponse::Approve).unwrap();
         assert_eq!(rx.await.unwrap(), ChannelApprovalResponse::Approve);
     }

--- a/crates/zeroclaw-channels/src/signal.rs
+++ b/crates/zeroclaw-channels/src/signal.rs
@@ -396,21 +396,21 @@ impl Channel for SignalChannel {
                         if !current_data.is_empty() {
                             match serde_json::from_str::<SseEnvelope>(&current_data) {
                                 Ok(sse) => {
-                                    if let Some(ref envelope) = sse.envelope {
-                                        if let Some(msg) = self.process_envelope(envelope) {
-                                            if let Some((token, response)) =
-                                                crate::util::parse_approval_reply(&msg.content)
-                                            {
-                                                let mut map = self.pending_approvals.lock().await;
-                                                if let Some(sender) = map.remove(&token) {
-                                                    let _ = sender.send(response);
-                                                    current_data.clear();
-                                                    continue;
-                                                }
+                                    if let Some(ref envelope) = sse.envelope
+                                        && let Some(msg) = self.process_envelope(envelope)
+                                    {
+                                        if let Some((token, response)) =
+                                            crate::util::parse_approval_reply(&msg.content)
+                                        {
+                                            let mut map = self.pending_approvals.lock().await;
+                                            if let Some(sender) = map.remove(&token) {
+                                                let _ = sender.send(response);
+                                                current_data.clear();
+                                                continue;
                                             }
-                                            if tx.send(msg).await.is_err() {
-                                                return Ok(());
-                                            }
+                                        }
+                                        if tx.send(msg).await.is_err() {
+                                            return Ok(());
                                         }
                                     }
                                 }
@@ -433,19 +433,19 @@ impl Channel for SignalChannel {
             if !current_data.is_empty() {
                 match serde_json::from_str::<SseEnvelope>(&current_data) {
                     Ok(sse) => {
-                        if let Some(ref envelope) = sse.envelope {
-                            if let Some(msg) = self.process_envelope(envelope) {
-                                if let Some((token, response)) =
-                                    crate::util::parse_approval_reply(&msg.content)
-                                {
-                                    let mut map = self.pending_approvals.lock().await;
-                                    if let Some(sender) = map.remove(&token) {
-                                        let _ = sender.send(response);
-                                        continue;
-                                    }
+                        if let Some(ref envelope) = sse.envelope
+                            && let Some(msg) = self.process_envelope(envelope)
+                        {
+                            if let Some((token, response)) =
+                                crate::util::parse_approval_reply(&msg.content)
+                            {
+                                let mut map = self.pending_approvals.lock().await;
+                                if let Some(sender) = map.remove(&token) {
+                                    let _ = sender.send(response);
+                                    continue;
                                 }
-                                let _ = tx.send(msg).await;
                             }
+                            let _ = tx.send(msg).await;
                         }
                     }
                     Err(e) => {
@@ -511,14 +511,7 @@ impl Channel for SignalChannel {
             .await
             .insert(token.clone(), tx);
 
-        if let Err(err) = self
-            .send(&SendMessage {
-                recipient: recipient.to_string(),
-                content: text,
-                attachments: vec![],
-            })
-            .await
-        {
+        if let Err(err) = self.send(&SendMessage::new(text, recipient)).await {
             self.pending_approvals.lock().await.remove(&token);
             return Err(err);
         }

--- a/crates/zeroclaw-channels/src/slack.rs
+++ b/crates/zeroclaw-channels/src/slack.rs
@@ -6,11 +6,12 @@ use futures_util::{SinkExt, StreamExt};
 use reqwest::header::HeaderMap;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::AsyncWriteExt;
+use tokio::sync::{oneshot, Mutex as AsyncMutex};
 use tokio_tungstenite::tungstenite::Message as WsMessage;
-use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+use zeroclaw_api::channel::{Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage};
 
 #[derive(Clone)]
 struct CachedSlackDisplayName {
@@ -52,6 +53,8 @@ pub struct SlackChannel {
     lazy_draft_ts: tokio::sync::Mutex<HashMap<String, String>>,
     /// Emoji reaction name (without colons) that cancels an in-flight request.
     cancel_reaction: Option<String>,
+    pending_approvals: Arc<AsyncMutex<HashMap<String, oneshot::Sender<ChannelApprovalResponse>>>>,
+    approval_timeout_secs: u64,
 }
 
 const SLACK_HISTORY_MAX_RETRIES: u32 = 3;
@@ -179,6 +182,8 @@ impl SlackChannel {
             last_draft_edit: Mutex::new(HashMap::new()),
             lazy_draft_ts: tokio::sync::Mutex::new(HashMap::new()),
             cancel_reaction: None,
+            pending_approvals: Arc::new(AsyncMutex::new(HashMap::new())),
+            approval_timeout_secs: 300,
         }
     }
 
@@ -216,6 +221,11 @@ impl SlackChannel {
 
     pub fn with_proxy_url(mut self, proxy_url: Option<String>) -> Self {
         self.proxy_url = proxy_url;
+        self
+    }
+
+    pub fn with_approval_timeout_secs(mut self, secs: u64) -> Self {
+        self.approval_timeout_secs = secs;
         self
     }
 
@@ -2429,6 +2439,37 @@ impl SlackChannel {
             .clone()
     }
 
+    /// Try to parse a Socket Mode `interactive` envelope as an approval button tap.
+    ///
+    /// Returns `Some((token, response))` when the first action's `action_id` matches
+    /// `"approval_{TOKEN}_{approve|deny|always}"`, `None` otherwise.
+    fn try_parse_approval_block_action(
+        envelope: &serde_json::Value,
+    ) -> Option<(String, ChannelApprovalResponse)> {
+        let payload = envelope.get("payload")?;
+        if payload.get("type").and_then(|v| v.as_str())? != "block_actions" {
+            return None;
+        }
+        let action_id = payload
+            .get("actions")
+            .and_then(|a| a.as_array())
+            .and_then(|a| a.first())
+            .and_then(|a| a.get("action_id"))
+            .and_then(|v| v.as_str())?;
+        let rest = action_id.strip_prefix("approval_")?;
+        let (token, action) = rest.rsplit_once('_')?;
+        if token.len() != 6 || !token.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return None;
+        }
+        let response = match action {
+            "approve" => ChannelApprovalResponse::Approve,
+            "deny" => ChannelApprovalResponse::Deny,
+            "always" => ChannelApprovalResponse::AlwaysApprove,
+            _ => return None,
+        };
+        Some((token.to_string(), response))
+    }
+
     /// Parse a Socket Mode `interactive` envelope containing a `block_actions`
     /// payload from the `/config` Block Kit UI.  Translates provider/model
     /// dropdown selections into synthetic `/models <provider>` or `/model <id>`
@@ -2643,8 +2684,17 @@ impl SlackChannel {
                     break;
                 }
 
-                // Handle interactive payloads (block_actions from /config UI).
+                // Handle interactive payloads (block_actions from /config UI or approval buttons).
                 if envelope_type == "interactive" {
+                    if let Some((token, response)) =
+                        Self::try_parse_approval_block_action(&envelope)
+                    {
+                        let mut map = self.pending_approvals.lock().await;
+                        if let Some(sender) = map.remove(&token) {
+                            let _ = sender.send(response);
+                        }
+                        continue;
+                    }
                     if let Some(msg) = Self::parse_block_action_as_command(&envelope, bot_user_id)
                         && tx.send(msg).await.is_err()
                     {
@@ -2809,6 +2859,16 @@ impl SlackChannel {
                 else {
                     continue;
                 };
+
+                if let Some((token, response)) =
+                    crate::util::parse_approval_reply(&normalized_text)
+                {
+                    let mut map = self.pending_approvals.lock().await;
+                    if let Some(ap_sender) = map.remove(&token) {
+                        let _ = ap_sender.send(response);
+                        continue;
+                    }
+                }
 
                 last_ts_by_channel.insert(channel_id.clone(), ts.to_string());
                 let sender = self.resolve_sender_identity(user).await;
@@ -3816,6 +3876,16 @@ impl Channel for SlackChannel {
                         last_ts_by_channel.insert(channel_id.clone(), ts.to_string());
                         let sender = self.resolve_sender_identity(user).await;
 
+                        if let Some((token, response)) =
+                            crate::util::parse_approval_reply(&normalized_text)
+                        {
+                            let mut map = self.pending_approvals.lock().await;
+                            if let Some(ap_sender) = map.remove(&token) {
+                                let _ = ap_sender.send(response);
+                                continue;
+                            }
+                        }
+
                         let channel_msg = ChannelMessage {
                             id: format!("slack_{channel_id}_{ts}"),
                             sender,
@@ -3903,6 +3973,16 @@ impl Channel for SlackChannel {
                     }
 
                     let sender = self.resolve_sender_identity(user).await;
+
+                    if let Some((token, response)) =
+                        crate::util::parse_approval_reply(&normalized_text)
+                    {
+                        let mut map = self.pending_approvals.lock().await;
+                        if let Some(ap_sender) = map.remove(&token) {
+                            let _ = ap_sender.send(response);
+                            continue;
+                        }
+                    }
 
                     let channel_msg = ChannelMessage {
                         id: format!("slack_{thread_channel_id}_{reply_ts}"),
@@ -3996,6 +4076,80 @@ impl Channel for SlackChannel {
             self.set_assistant_status(recipient, "").await;
         }
         Ok(())
+    }
+
+    async fn request_approval(
+        &self,
+        recipient: &str,
+        request: &ChannelApprovalRequest,
+    ) -> anyhow::Result<Option<ChannelApprovalResponse>> {
+        let token = crate::util::new_approval_token();
+
+        let (tx, rx) = oneshot::channel();
+        self.pending_approvals
+            .lock()
+            .await
+            .insert(token.clone(), tx);
+
+        // Socket Mode: send interactive Block Kit buttons.
+        // Polling mode: send plain text with token-echo instructions.
+        let send_result = if self.app_token.is_some() {
+            let body = serde_json::json!({
+                "channel": recipient,
+                "text": format!("APPROVAL REQUIRED [{token}]\nTool: {}\nArgs: {}", request.tool_name, request.arguments_summary),
+                "blocks": [{
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": format!("*APPROVAL REQUIRED* [`{token}`]\n*Tool:* `{}`\n*Args:* {}", request.tool_name, request.arguments_summary),
+                    }
+                }, {
+                    "type": "actions",
+                    "elements": [
+                        { "type": "button", "text": { "type": "plain_text", "text": "Approve" }, "action_id": format!("approval_{token}_approve"), "style": "primary" },
+                        { "type": "button", "text": { "type": "plain_text", "text": "Deny" }, "action_id": format!("approval_{token}_deny"), "style": "danger" },
+                        { "type": "button", "text": { "type": "plain_text", "text": "Always" }, "action_id": format!("approval_{token}_always") },
+                    ]
+                }]
+            });
+            self.http_client()
+                .post("https://slack.com/api/chat.postMessage")
+                .bearer_auth(&self.bot_token)
+                .json(&body)
+                .send()
+                .await
+                .map(|_| ())
+                .map_err(anyhow::Error::from)
+        } else {
+            self.send(&SendMessage {
+                recipient: recipient.to_string(),
+                content: format!(
+                    "APPROVAL REQUIRED [{token}]\nTool: {}\nArgs: {}\n\nReply: \"{token} yes\", \"{token} no\", or \"{token} always\"",
+                    request.tool_name, request.arguments_summary,
+                ),
+                attachments: vec![],
+            })
+            .await
+        };
+
+        if let Err(err) = send_result {
+            self.pending_approvals.lock().await.remove(&token);
+            return Err(err);
+        }
+
+        let response = match tokio::time::timeout(
+            Duration::from_secs(self.approval_timeout_secs),
+            rx,
+        )
+        .await
+        {
+            Ok(Ok(resp)) => resp,
+            _ => {
+                self.pending_approvals.lock().await.remove(&token);
+                ChannelApprovalResponse::Deny
+            }
+        };
+        Ok(Some(response))
     }
 }
 
@@ -5033,5 +5187,81 @@ mod tests {
             assert_eq!(map.get("C123"), Some(&"1741234567.000100".to_string()),);
             assert_eq!(map.get("C999"), None);
         }
+    }
+
+    fn make_slack_channel() -> SlackChannel {
+        SlackChannel::new("xoxb-token".into(), None, vec![], vec![])
+    }
+
+    #[test]
+    fn pending_approvals_map_is_initially_empty() {
+        let ch = make_slack_channel();
+        let map = ch.pending_approvals.try_lock().unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn approval_timeout_defaults_to_300_and_is_overridable() {
+        let ch = make_slack_channel();
+        assert_eq!(ch.approval_timeout_secs, 300);
+        let ch = ch.with_approval_timeout_secs(90);
+        assert_eq!(ch.approval_timeout_secs, 90);
+    }
+
+    #[tokio::test]
+    async fn pending_approval_oneshot_delivers_response() {
+        let ch = make_slack_channel();
+        let (tx, rx) = oneshot::channel();
+        ch.pending_approvals
+            .lock()
+            .await
+            .insert("abc123".to_string(), tx);
+        let sender = ch
+            .pending_approvals
+            .lock()
+            .await
+            .remove("abc123")
+            .unwrap();
+        sender.send(ChannelApprovalResponse::AlwaysApprove).unwrap();
+        assert_eq!(rx.await.unwrap(), ChannelApprovalResponse::AlwaysApprove);
+    }
+
+    #[test]
+    fn approval_block_action_parsed_correctly() {
+        let envelope = serde_json::json!({
+            "payload": {
+                "type": "block_actions",
+                "actions": [{ "action_id": "approval_abc123_approve" }]
+            }
+        });
+        let (token, response) =
+            SlackChannel::try_parse_approval_block_action(&envelope).unwrap();
+        assert_eq!(token, "abc123");
+        assert_eq!(response, ChannelApprovalResponse::Approve);
+    }
+
+    #[test]
+    fn approval_block_action_deny_parsed() {
+        let envelope = serde_json::json!({
+            "payload": {
+                "type": "block_actions",
+                "actions": [{ "action_id": "approval_xz9q1w_deny" }]
+            }
+        });
+        let (token, response) =
+            SlackChannel::try_parse_approval_block_action(&envelope).unwrap();
+        assert_eq!(token, "xz9q1w");
+        assert_eq!(response, ChannelApprovalResponse::Deny);
+    }
+
+    #[test]
+    fn approval_block_action_non_approval_returns_none() {
+        let envelope = serde_json::json!({
+            "payload": {
+                "type": "block_actions",
+                "actions": [{ "action_id": "zeroclaw_config_provider", "selected_option": { "value": "anthropic" } }]
+            }
+        });
+        assert!(SlackChannel::try_parse_approval_block_action(&envelope).is_none());
     }
 }

--- a/crates/zeroclaw-channels/src/slack.rs
+++ b/crates/zeroclaw-channels/src/slack.rs
@@ -4122,14 +4122,13 @@ impl Channel for SlackChannel {
                 .map(|_| ())
                 .map_err(anyhow::Error::from)
         } else {
-            self.send(&SendMessage {
-                recipient: recipient.to_string(),
-                content: format!(
+            self.send(&SendMessage::new(
+                format!(
                     "APPROVAL REQUIRED [{token}]\nTool: {}\nArgs: {}\n\nReply: \"{token} yes\", \"{token} no\", or \"{token} always\"",
                     request.tool_name, request.arguments_summary,
                 ),
-                attachments: vec![],
-            })
+                recipient,
+            ))
             .await
         };
 

--- a/crates/zeroclaw-channels/src/slack.rs
+++ b/crates/zeroclaw-channels/src/slack.rs
@@ -9,9 +9,11 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::io::AsyncWriteExt;
-use tokio::sync::{oneshot, Mutex as AsyncMutex};
+use tokio::sync::{Mutex as AsyncMutex, oneshot};
 use tokio_tungstenite::tungstenite::Message as WsMessage;
-use zeroclaw_api::channel::{Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage};
+use zeroclaw_api::channel::{
+    Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage,
+};
 
 #[derive(Clone)]
 struct CachedSlackDisplayName {
@@ -2860,8 +2862,7 @@ impl SlackChannel {
                     continue;
                 };
 
-                if let Some((token, response)) =
-                    crate::util::parse_approval_reply(&normalized_text)
+                if let Some((token, response)) = crate::util::parse_approval_reply(&normalized_text)
                 {
                     let mut map = self.pending_approvals.lock().await;
                     if let Some(ap_sender) = map.remove(&token) {
@@ -4137,18 +4138,14 @@ impl Channel for SlackChannel {
             return Err(err);
         }
 
-        let response = match tokio::time::timeout(
-            Duration::from_secs(self.approval_timeout_secs),
-            rx,
-        )
-        .await
-        {
-            Ok(Ok(resp)) => resp,
-            _ => {
-                self.pending_approvals.lock().await.remove(&token);
-                ChannelApprovalResponse::Deny
-            }
-        };
+        let response =
+            match tokio::time::timeout(Duration::from_secs(self.approval_timeout_secs), rx).await {
+                Ok(Ok(resp)) => resp,
+                _ => {
+                    self.pending_approvals.lock().await.remove(&token);
+                    ChannelApprovalResponse::Deny
+                }
+            };
         Ok(Some(response))
     }
 }
@@ -5216,12 +5213,7 @@ mod tests {
             .lock()
             .await
             .insert("abc123".to_string(), tx);
-        let sender = ch
-            .pending_approvals
-            .lock()
-            .await
-            .remove("abc123")
-            .unwrap();
+        let sender = ch.pending_approvals.lock().await.remove("abc123").unwrap();
         sender.send(ChannelApprovalResponse::AlwaysApprove).unwrap();
         assert_eq!(rx.await.unwrap(), ChannelApprovalResponse::AlwaysApprove);
     }
@@ -5234,8 +5226,7 @@ mod tests {
                 "actions": [{ "action_id": "approval_abc123_approve" }]
             }
         });
-        let (token, response) =
-            SlackChannel::try_parse_approval_block_action(&envelope).unwrap();
+        let (token, response) = SlackChannel::try_parse_approval_block_action(&envelope).unwrap();
         assert_eq!(token, "abc123");
         assert_eq!(response, ChannelApprovalResponse::Approve);
     }
@@ -5248,8 +5239,7 @@ mod tests {
                 "actions": [{ "action_id": "approval_xz9q1w_deny" }]
             }
         });
-        let (token, response) =
-            SlackChannel::try_parse_approval_block_action(&envelope).unwrap();
+        let (token, response) = SlackChannel::try_parse_approval_block_action(&envelope).unwrap();
         assert_eq!(token, "xz9q1w");
         assert_eq!(response, ChannelApprovalResponse::Deny);
     }

--- a/crates/zeroclaw-channels/src/util.rs
+++ b/crates/zeroclaw-channels/src/util.rs
@@ -171,9 +171,18 @@ pub fn parse_attachment_markers(message: &str) -> (String, Vec<(String, String)>
 }
 
 /// Generate a short 6-character lowercase alphanumeric approval token.
+///
+/// Uses the full `[a-z0-9]` alphabet (36 options per position, 36^6 ≈ 2.2B
+/// combinations) — not UUID hex (which would give only 16^6 ≈ 16.7M and
+/// would materially weaken the WhatsApp no-per-sender-check design
+/// described in the PR #6010 security note).
 pub(crate) fn new_approval_token() -> String {
-    let id = uuid::Uuid::new_v4().to_string().replace('-', "");
-    id[..6].to_string()
+    use rand::RngExt;
+    const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
+    let mut rng = rand::rng();
+    (0..6)
+        .map(|_| CHARSET[rng.random_range(0..CHARSET.len())] as char)
+        .collect()
 }
 
 /// Parse an approval reply of the form `"TOKEN yes|no|always ..."`.

--- a/crates/zeroclaw-channels/src/util.rs
+++ b/crates/zeroclaw-channels/src/util.rs
@@ -170,6 +170,37 @@ pub fn parse_attachment_markers(message: &str) -> (String, Vec<(String, String)>
     (cleaned.trim().to_string(), attachments)
 }
 
+/// Generate a short 6-character lowercase alphanumeric approval token.
+pub(crate) fn new_approval_token() -> String {
+    let id = uuid::Uuid::new_v4().to_string().replace('-', "");
+    id[..6].to_string()
+}
+
+/// Parse an approval reply of the form `"TOKEN yes|no|always ..."`.
+///
+/// Returns `Some((token, response))` when the text begins with a 6-character
+/// alphanumeric token followed by a recognised action word. Returns `None`
+/// for any other input so normal messages are not intercepted.
+pub fn parse_approval_reply(
+    text: &str,
+) -> Option<(String, zeroclaw_api::channel::ChannelApprovalResponse)> {
+    use zeroclaw_api::channel::ChannelApprovalResponse;
+    let lower = text.trim().to_lowercase();
+    let mut parts = lower.splitn(2, ' ');
+    let token = parts.next()?.to_string();
+    if token.len() != 6 || !token.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return None;
+    }
+    let action_word = parts.next()?.trim().split_whitespace().next()?;
+    let response = match action_word {
+        "yes" | "y" | "approve" => ChannelApprovalResponse::Approve,
+        "no" | "n" | "deny" => ChannelApprovalResponse::Deny,
+        "always" => ChannelApprovalResponse::AlwaysApprove,
+        _ => return None,
+    };
+    Some((token, response))
+}
+
 /// Generate a conversation history key from a channel message.
 pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
     match &msg.thread_ts {
@@ -228,5 +259,55 @@ mod tests {
         let (_, attachments) = parse_attachment_markers("[image:/tmp/a.png]");
         assert_eq!(attachments.len(), 1);
         assert_eq!(attachments[0].0, "IMAGE");
+    }
+
+    #[test]
+    fn new_approval_token_is_6_char_alphanumeric() {
+        let token = super::new_approval_token();
+        assert_eq!(token.len(), 6);
+        assert!(token.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+
+    #[test]
+    fn parse_approval_reply_accepts_canonical_forms() {
+        use zeroclaw_api::channel::ChannelApprovalResponse;
+        let cases = [
+            ("abc123 yes", ChannelApprovalResponse::Approve),
+            ("abc123 y", ChannelApprovalResponse::Approve),
+            ("abc123 approve", ChannelApprovalResponse::Approve),
+            ("ABC123 YES", ChannelApprovalResponse::Approve),
+            ("abc123 yes please go ahead", ChannelApprovalResponse::Approve),
+            ("abc123 no", ChannelApprovalResponse::Deny),
+            ("abc123 n", ChannelApprovalResponse::Deny),
+            ("abc123 deny", ChannelApprovalResponse::Deny),
+            ("abc123 always", ChannelApprovalResponse::AlwaysApprove),
+        ];
+        for (input, expected) in cases {
+            let (token, response) = super::parse_approval_reply(input).unwrap_or_else(|| {
+                panic!("expected Some for input {:?}", input)
+            });
+            assert_eq!(token, input.trim().to_lowercase().split(' ').next().unwrap());
+            assert_eq!(response, expected, "input: {input:?}");
+        }
+    }
+
+    #[test]
+    fn parse_approval_reply_rejects_bad_input() {
+        let bad = [
+            "yes",
+            "abc123",
+            "abc 123 yes",
+            "toolname yes",
+            "abc123 maybe",
+            "",
+            "abc123 ",
+        ];
+        for input in bad {
+            assert!(
+                super::parse_approval_reply(input).is_none(),
+                "expected None for input {:?}",
+                input
+            );
+        }
     }
 }

--- a/crates/zeroclaw-channels/src/util.rs
+++ b/crates/zeroclaw-channels/src/util.rs
@@ -276,17 +276,22 @@ mod tests {
             ("abc123 y", ChannelApprovalResponse::Approve),
             ("abc123 approve", ChannelApprovalResponse::Approve),
             ("ABC123 YES", ChannelApprovalResponse::Approve),
-            ("abc123 yes please go ahead", ChannelApprovalResponse::Approve),
+            (
+                "abc123 yes please go ahead",
+                ChannelApprovalResponse::Approve,
+            ),
             ("abc123 no", ChannelApprovalResponse::Deny),
             ("abc123 n", ChannelApprovalResponse::Deny),
             ("abc123 deny", ChannelApprovalResponse::Deny),
             ("abc123 always", ChannelApprovalResponse::AlwaysApprove),
         ];
         for (input, expected) in cases {
-            let (token, response) = super::parse_approval_reply(input).unwrap_or_else(|| {
-                panic!("expected Some for input {:?}", input)
-            });
-            assert_eq!(token, input.trim().to_lowercase().split(' ').next().unwrap());
+            let (token, response) = super::parse_approval_reply(input)
+                .unwrap_or_else(|| panic!("expected Some for input {:?}", input));
+            assert_eq!(
+                token,
+                input.trim().to_lowercase().split(' ').next().unwrap()
+            );
             assert_eq!(response, expected, "input: {input:?}");
         }
     }

--- a/crates/zeroclaw-channels/src/util.rs
+++ b/crates/zeroclaw-channels/src/util.rs
@@ -191,7 +191,7 @@ pub fn parse_approval_reply(
     if token.len() != 6 || !token.chars().all(|c| c.is_ascii_alphanumeric()) {
         return None;
     }
-    let action_word = parts.next()?.trim().split_whitespace().next()?;
+    let action_word = parts.next()?.split_whitespace().next()?;
     let response = match action_word {
         "yes" | "y" | "approve" => ChannelApprovalResponse::Approve,
         "no" | "n" | "deny" => ChannelApprovalResponse::Deny,

--- a/crates/zeroclaw-channels/src/whatsapp.rs
+++ b/crates/zeroclaw-channels/src/whatsapp.rs
@@ -1,7 +1,10 @@
 use async_trait::async_trait;
 use regex::Regex;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{Mutex, oneshot};
 use uuid::Uuid;
-use zeroclaw_api::channel::{Channel, ChannelMessage, SendMessage};
+use zeroclaw_api::channel::{Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage};
 
 /// `WhatsApp` channel — uses `WhatsApp` Business Cloud API
 ///
@@ -34,6 +37,8 @@ pub struct WhatsAppChannel {
     dm_mention_patterns: Vec<Regex>,
     /// Compiled mention patterns for group-chat mention gating.
     group_mention_patterns: Vec<Regex>,
+    pub pending_approvals: Arc<Mutex<HashMap<String, oneshot::Sender<ChannelApprovalResponse>>>>,
+    approval_timeout_secs: u64,
 }
 
 impl WhatsAppChannel {
@@ -51,7 +56,14 @@ impl WhatsAppChannel {
             proxy_url: None,
             dm_mention_patterns: Vec::new(),
             group_mention_patterns: Vec::new(),
+            pending_approvals: Arc::new(Mutex::new(HashMap::new())),
+            approval_timeout_secs: 300,
         }
+    }
+
+    pub fn with_approval_timeout_secs(mut self, secs: u64) -> Self {
+        self.approval_timeout_secs = secs;
+        self
     }
 
     /// Set a per-channel proxy URL that overrides the global proxy config.
@@ -339,6 +351,41 @@ impl Channel for WhatsAppChannel {
         }
 
         Ok(())
+    }
+
+    async fn request_approval(
+        &self,
+        recipient: &str,
+        request: &ChannelApprovalRequest,
+    ) -> anyhow::Result<Option<ChannelApprovalResponse>> {
+        let token = crate::util::new_approval_token();
+        let (tx_approval, rx_approval) = oneshot::channel();
+        {
+            let mut map = self.pending_approvals.lock().await;
+            map.insert(token.clone(), tx_approval);
+        }
+
+        let text = format!(
+            "APPROVAL REQUIRED [{}]\nTool: {}\nArgs: {}\n\nReply: \"{} yes\", \"{} no\", or \"{} always\"",
+            token, request.tool_name, request.arguments_summary, token, token, token
+        );
+        self.send(&SendMessage {
+            content: text,
+            recipient: recipient.to_string(),
+            thread_ts: None,
+        })
+        .await?;
+
+        let timeout = std::time::Duration::from_secs(self.approval_timeout_secs);
+        let response = match tokio::time::timeout(timeout, rx_approval).await {
+            Ok(Ok(response)) => response,
+            _ => {
+                let mut map = self.pending_approvals.lock().await;
+                map.remove(&token);
+                ChannelApprovalResponse::Deny
+            }
+        };
+        Ok(Some(response))
     }
 
     async fn listen(&self, _tx: tokio::sync::mpsc::Sender<ChannelMessage>) -> anyhow::Result<()> {
@@ -1818,5 +1865,20 @@ mod tests {
             "Group messages should pass through when only DM patterns are set"
         );
         assert_eq!(msgs[0].content, "Hello without mention");
+    }
+
+    #[test]
+    fn pending_approvals_map_is_initially_empty() {
+        let ch = make_channel();
+        let map = ch.pending_approvals.blocking_lock();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn approval_timeout_defaults_to_300_and_is_overridable() {
+        let ch = make_channel();
+        assert_eq!(ch.approval_timeout_secs, 300);
+        let ch2 = ch.with_approval_timeout_secs(60);
+        assert_eq!(ch2.approval_timeout_secs, 60);
     }
 }

--- a/crates/zeroclaw-channels/src/whatsapp.rs
+++ b/crates/zeroclaw-channels/src/whatsapp.rs
@@ -1,12 +1,30 @@
 use async_trait::async_trait;
 use regex::Regex;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tokio::sync::{Mutex, oneshot};
 use uuid::Uuid;
 use zeroclaw_api::channel::{
     Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage,
 };
+
+/// Module-level `pending_approvals` map shared across every
+/// `Arc<WhatsAppChannel>` regardless of who constructs it.
+///
+/// WhatsApp uses webhooks, so `request_approval()` (called by the runtime's
+/// channel pool) and the reply intercept (in the gateway's
+/// `handle_whatsapp_message`) can run on *different* `Arc<WhatsAppChannel>`
+/// instances — the orchestrator constructs one, the gateway constructs
+/// another. An instance-local pending-approvals map would leave one side
+/// registering tokens the other side can never find, silently timing out
+/// every approval request.
+///
+/// Hoisting the map to a process-wide static sidesteps the Arc-sharing
+/// problem entirely: whoever calls `request_approval()` inserts; whoever
+/// receives the webhook reply looks up; both hit the same `HashMap`.
+type PendingApprovalsMap = Mutex<HashMap<String, oneshot::Sender<ChannelApprovalResponse>>>;
+static PENDING_APPROVALS: LazyLock<Arc<PendingApprovalsMap>> =
+    LazyLock::new(|| Arc::new(Mutex::new(HashMap::new())));
 
 /// `WhatsApp` channel — uses `WhatsApp` Business Cloud API
 ///
@@ -39,7 +57,6 @@ pub struct WhatsAppChannel {
     dm_mention_patterns: Vec<Regex>,
     /// Compiled mention patterns for group-chat mention gating.
     group_mention_patterns: Vec<Regex>,
-    pending_approvals: Arc<Mutex<HashMap<String, oneshot::Sender<ChannelApprovalResponse>>>>,
     approval_timeout_secs: u64,
 }
 
@@ -58,7 +75,6 @@ impl WhatsAppChannel {
             proxy_url: None,
             dm_mention_patterns: Vec::new(),
             group_mention_patterns: Vec::new(),
-            pending_approvals: Arc::new(Mutex::new(HashMap::new())),
             approval_timeout_secs: 300,
         }
     }
@@ -68,10 +84,11 @@ impl WhatsAppChannel {
         self
     }
 
-    pub fn pending_approvals(
-        &self,
-    ) -> &Arc<Mutex<HashMap<String, oneshot::Sender<ChannelApprovalResponse>>>> {
-        &self.pending_approvals
+    /// Access the process-wide pending-approvals map shared across every
+    /// `WhatsAppChannel` instance. See [`PENDING_APPROVALS`] for why this
+    /// must be a static rather than per-instance.
+    pub fn pending_approvals(&self) -> &Arc<PendingApprovalsMap> {
+        &PENDING_APPROVALS
     }
 
     /// Set a per-channel proxy URL that overrides the global proxy config.
@@ -369,7 +386,7 @@ impl Channel for WhatsAppChannel {
         let token = crate::util::new_approval_token();
         let (tx_approval, rx_approval) = oneshot::channel();
         {
-            let mut map = self.pending_approvals.lock().await;
+            let mut map = PENDING_APPROVALS.lock().await;
             map.insert(token.clone(), tx_approval);
         }
 
@@ -383,7 +400,7 @@ impl Channel for WhatsAppChannel {
         let response = match tokio::time::timeout(timeout, rx_approval).await {
             Ok(Ok(response)) => response,
             _ => {
-                let mut map = self.pending_approvals.lock().await;
+                let mut map = PENDING_APPROVALS.lock().await;
                 map.remove(&token);
                 ChannelApprovalResponse::Deny
             }
@@ -1871,17 +1888,39 @@ mod tests {
     }
 
     #[test]
-    fn pending_approvals_map_is_initially_empty() {
-        let ch = make_channel();
-        let map = ch.pending_approvals.blocking_lock();
-        assert!(map.is_empty());
-    }
-
-    #[test]
     fn approval_timeout_defaults_to_300_and_is_overridable() {
         let ch = make_channel();
         assert_eq!(ch.approval_timeout_secs, 300);
         let ch2 = ch.with_approval_timeout_secs(60);
         assert_eq!(ch2.approval_timeout_secs, 60);
+    }
+
+    #[tokio::test]
+    async fn pending_approvals_are_shared_across_instances() {
+        // Two independent WhatsAppChannel instances — the orchestrator's and
+        // the gateway's — must see the same pending-approvals map so that a
+        // reply intercepted on one instance resolves a token registered on
+        // the other. Without the module-level static this test would fail.
+        let orchestrator_ch = make_channel();
+        let gateway_ch = make_channel();
+
+        let (tx, _rx) = oneshot::channel::<ChannelApprovalResponse>();
+        {
+            let mut map = orchestrator_ch.pending_approvals().lock().await;
+            map.insert("test_share_tok".to_string(), tx);
+        }
+        {
+            let map = gateway_ch.pending_approvals().lock().await;
+            assert!(
+                map.contains_key("test_share_tok"),
+                "gateway instance must see orchestrator's registration"
+            );
+        }
+        // Cleanup so later tests aren't polluted by this entry.
+        gateway_ch
+            .pending_approvals()
+            .lock()
+            .await
+            .remove("test_share_tok");
     }
 }

--- a/crates/zeroclaw-channels/src/whatsapp.rs
+++ b/crates/zeroclaw-channels/src/whatsapp.rs
@@ -377,12 +377,7 @@ impl Channel for WhatsAppChannel {
             "APPROVAL REQUIRED [{}]\nTool: {}\nArgs: {}\n\nReply: \"{} yes\", \"{} no\", or \"{} always\"",
             token, request.tool_name, request.arguments_summary, token, token, token
         );
-        self.send(&SendMessage {
-            content: text,
-            recipient: recipient.to_string(),
-            thread_ts: None,
-        })
-        .await?;
+        self.send(&SendMessage::new(text, recipient)).await?;
 
         let timeout = std::time::Duration::from_secs(self.approval_timeout_secs);
         let response = match tokio::time::timeout(timeout, rx_approval).await {

--- a/crates/zeroclaw-channels/src/whatsapp.rs
+++ b/crates/zeroclaw-channels/src/whatsapp.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{Mutex, oneshot};
 use uuid::Uuid;
-use zeroclaw_api::channel::{Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage};
+use zeroclaw_api::channel::{
+    Channel, ChannelApprovalRequest, ChannelApprovalResponse, ChannelMessage, SendMessage,
+};
 
 /// `WhatsApp` channel — uses `WhatsApp` Business Cloud API
 ///

--- a/crates/zeroclaw-channels/src/whatsapp.rs
+++ b/crates/zeroclaw-channels/src/whatsapp.rs
@@ -37,7 +37,7 @@ pub struct WhatsAppChannel {
     dm_mention_patterns: Vec<Regex>,
     /// Compiled mention patterns for group-chat mention gating.
     group_mention_patterns: Vec<Regex>,
-    pub pending_approvals: Arc<Mutex<HashMap<String, oneshot::Sender<ChannelApprovalResponse>>>>,
+    pending_approvals: Arc<Mutex<HashMap<String, oneshot::Sender<ChannelApprovalResponse>>>>,
     approval_timeout_secs: u64,
 }
 
@@ -64,6 +64,12 @@ impl WhatsAppChannel {
     pub fn with_approval_timeout_secs(mut self, secs: u64) -> Self {
         self.approval_timeout_secs = secs;
         self
+    }
+
+    pub fn pending_approvals(
+        &self,
+    ) -> &Arc<Mutex<HashMap<String, oneshot::Sender<ChannelApprovalResponse>>>> {
+        &self.pending_approvals
     }
 
     /// Set a per-channel proxy URL that overrides the global proxy config.

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -6823,6 +6823,10 @@ fn default_telegram_approval_timeout_secs() -> u64 {
     120
 }
 
+fn default_channel_approval_timeout_secs() -> u64 {
+    300
+}
+
 fn default_matrix_draft_update_interval_ms() -> u64 {
     1500
 }
@@ -6928,6 +6932,9 @@ pub struct DiscordConfig {
     /// and retry if no progress is made within this duration. 0 = disabled.
     #[serde(default)]
     pub stall_timeout_secs: u64,
+    /// Seconds to wait for operator approval on `always_ask` tools before auto-denying.
+    #[serde(default = "default_channel_approval_timeout_secs")]
+    pub approval_timeout_secs: u64,
 }
 
 impl ChannelConfig for DiscordConfig {
@@ -7033,6 +7040,9 @@ pub struct SlackConfig {
     /// Leave unset to disable reaction-based cancellation.
     #[serde(default)]
     pub cancel_reaction: Option<String>,
+    /// Seconds to wait for operator approval on `always_ask` tools before auto-denying.
+    #[serde(default = "default_channel_approval_timeout_secs")]
+    pub approval_timeout_secs: u64,
 }
 
 fn default_slack_draft_update_interval_ms() -> u64 {
@@ -7205,6 +7215,9 @@ pub struct MatrixConfig {
     #[secret]
     #[serde(default)]
     pub password: Option<String>,
+    /// Seconds to wait for operator approval on `always_ask` tools before auto-denying.
+    #[serde(default = "default_channel_approval_timeout_secs")]
+    pub approval_timeout_secs: u64,
 }
 
 impl ChannelConfig for MatrixConfig {
@@ -7246,6 +7259,9 @@ pub struct SignalConfig {
     /// Overrides the global `[proxy]` setting for this channel only.
     #[serde(default)]
     pub proxy_url: Option<String>,
+    /// Seconds to wait for operator approval on `always_ask` tools before auto-denying.
+    #[serde(default = "default_channel_approval_timeout_secs")]
+    pub approval_timeout_secs: u64,
 }
 
 impl ChannelConfig for SignalConfig {
@@ -7371,6 +7387,9 @@ pub struct WhatsAppConfig {
     /// Overrides the global `[proxy]` setting for this channel only.
     #[serde(default)]
     pub proxy_url: Option<String>,
+    /// Seconds to wait for operator approval on `always_ask` tools before auto-denying.
+    #[serde(default = "default_channel_approval_timeout_secs")]
+    pub approval_timeout_secs: u64,
 }
 
 impl ChannelConfig for WhatsAppConfig {
@@ -12624,6 +12643,7 @@ default_temperature = 0.7
             draft_update_interval_ms: 1000,
             multi_message_delay_ms: 800,
             stall_timeout_secs: 0,
+            approval_timeout_secs: 300,
         };
         let json = serde_json::to_string(&dc).unwrap();
         let parsed: DiscordConfig = serde_json::from_str(&json).unwrap();
@@ -12646,6 +12666,7 @@ default_temperature = 0.7
             draft_update_interval_ms: 1000,
             multi_message_delay_ms: 800,
             stall_timeout_secs: 0,
+            approval_timeout_secs: 300,
         };
         let json = serde_json::to_string(&dc).unwrap();
         let parsed: DiscordConfig = serde_json::from_str(&json).unwrap();
@@ -12705,6 +12726,7 @@ default_temperature = 0.7
             recovery_key: None,
             mention_only: false,
             password: None,
+            approval_timeout_secs: 300,
         };
         let json = serde_json::to_string(&mc).unwrap();
         let parsed: MatrixConfig = serde_json::from_str(&json).unwrap();
@@ -12736,6 +12758,7 @@ default_temperature = 0.7
             recovery_key: None,
             mention_only: false,
             password: None,
+            approval_timeout_secs: 300,
         };
         let toml_str = toml::to_string(&mc).unwrap();
         let parsed: MatrixConfig = toml::from_str(&toml_str).unwrap();
@@ -12772,6 +12795,7 @@ allowed_rooms = ["!ops:matrix.org"]
             ignore_attachments: true,
             ignore_stories: false,
             proxy_url: None,
+            approval_timeout_secs: 300,
         };
         let json = serde_json::to_string(&sc).unwrap();
         let parsed: SignalConfig = serde_json::from_str(&json).unwrap();
@@ -12794,6 +12818,7 @@ allowed_rooms = ["!ops:matrix.org"]
             ignore_attachments: false,
             ignore_stories: true,
             proxy_url: None,
+            approval_timeout_secs: 300,
         };
         let toml_str = toml::to_string(&sc).unwrap();
         let parsed: SignalConfig = toml::from_str(&toml_str).unwrap();
@@ -12842,6 +12867,7 @@ allowed_rooms = ["!ops:matrix.org"]
                 recovery_key: None,
                 mention_only: false,
                 password: None,
+                approval_timeout_secs: 300,
             }),
             signal: None,
             whatsapp: None,
@@ -13068,6 +13094,7 @@ bot_token = "xoxb-tok"
             dm_mention_patterns: vec![],
             group_mention_patterns: vec![],
             proxy_url: None,
+            approval_timeout_secs: 300,
         };
         let json = serde_json::to_string(&wc).unwrap();
         let parsed: WhatsAppConfig = serde_json::from_str(&json).unwrap();
@@ -13097,6 +13124,7 @@ bot_token = "xoxb-tok"
             dm_mention_patterns: vec![],
             group_mention_patterns: vec![],
             proxy_url: None,
+            approval_timeout_secs: 300,
         };
         let toml_str = toml::to_string(&wc).unwrap();
         let parsed: WhatsAppConfig = toml::from_str(&toml_str).unwrap();
@@ -13131,6 +13159,7 @@ bot_token = "xoxb-tok"
             dm_mention_patterns: vec![],
             group_mention_patterns: vec![],
             proxy_url: None,
+            approval_timeout_secs: 300,
         };
         let toml_str = toml::to_string(&wc).unwrap();
         let parsed: WhatsAppConfig = toml::from_str(&toml_str).unwrap();
@@ -13157,6 +13186,7 @@ bot_token = "xoxb-tok"
             dm_mention_patterns: vec![],
             group_mention_patterns: vec![],
             proxy_url: None,
+            approval_timeout_secs: 300,
         };
         assert!(wc.is_ambiguous_config());
         assert_eq!(wc.backend_type(), "cloud");
@@ -13182,6 +13212,7 @@ bot_token = "xoxb-tok"
             dm_mention_patterns: vec![],
             group_mention_patterns: vec![],
             proxy_url: None,
+            approval_timeout_secs: 300,
         };
         assert!(!wc.is_ambiguous_config());
         assert_eq!(wc.backend_type(), "web");
@@ -13218,6 +13249,7 @@ bot_token = "xoxb-tok"
                 dm_mention_patterns: vec![],
                 group_mention_patterns: vec![],
                 proxy_url: None,
+                approval_timeout_secs: 300,
             }),
             linq: None,
             wati: None,
@@ -16676,6 +16708,7 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
             recovery_key: None,
             mention_only: false,
             password: None,
+            approval_timeout_secs: 300,
         };
         let fields = mx.secret_fields();
         assert_eq!(fields.len(), 3);
@@ -16705,6 +16738,7 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
             recovery_key: None,
             mention_only: false,
             password: None,
+            approval_timeout_secs: 300,
         };
         let fields = mx.secret_fields();
         assert!(!fields[0].is_set);
@@ -16727,6 +16761,7 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
             recovery_key: None,
             mention_only: false,
             password: None,
+            approval_timeout_secs: 300,
         };
         mx.set_secret("channels.matrix.access-token", "new-token".into())
             .unwrap();
@@ -16750,6 +16785,7 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
             recovery_key: None,
             mention_only: false,
             password: None,
+            approval_timeout_secs: 300,
         };
         assert!(
             mx.set_secret("channels.matrix.nonexistent", "val".into())
@@ -16790,6 +16826,7 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
             recovery_key: None,
             mention_only: false,
             password: None,
+            approval_timeout_secs: 300,
         });
 
         let fields = config.secret_fields();
@@ -16816,6 +16853,7 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
             recovery_key: None,
             mention_only: false,
             password: None,
+            approval_timeout_secs: 300,
         });
 
         config
@@ -16842,6 +16880,7 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
             mention_only: false,
             recovery_key: None,
             password: None,
+            approval_timeout_secs: 300,
         });
         config
             .set_secret("channels.matrix.access-token", "sk-test".into())
@@ -16882,6 +16921,7 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
             recovery_key: None,
             mention_only: false,
             password: None,
+            approval_timeout_secs: 300,
         };
 
         // Encrypt
@@ -16914,6 +16954,7 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
             recovery_key: None,
             mention_only: false,
             password: None,
+            approval_timeout_secs: 300,
         };
 
         mx.encrypt_secrets(&store).unwrap();
@@ -16944,6 +16985,7 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
             recovery_key: None,
             mention_only: false,
             password: None,
+            approval_timeout_secs: 300,
         };
 
         mx.encrypt_secrets(&store).unwrap();
@@ -16969,6 +17011,7 @@ auto_approve = ["file_read", "file_write", "file_edit", "memory_recall", "memory
             recovery_key: None,
             mention_only: false,
             password: None,
+            approval_timeout_secs: 300,
         }
     }
 
@@ -17389,5 +17432,60 @@ allowed_users = ["@u:m"]
             config.channels.matrix.as_ref().unwrap().enabled,
             "backfill should activate channel even when config has comments"
         );
+    }
+
+    #[test]
+    fn channel_approval_timeout_secs_defaults_to_300() {
+        // Omitting approval_timeout_secs from each config should deserialize to 300
+        let discord: DiscordConfig =
+            serde_json::from_str(r#"{"bot_token":"tok","enabled":true}"#).unwrap();
+        assert_eq!(discord.approval_timeout_secs, 300);
+
+        let slack: SlackConfig =
+            serde_json::from_str(r#"{"bot_token":"tok","enabled":true}"#).unwrap();
+        assert_eq!(slack.approval_timeout_secs, 300);
+
+        let signal: SignalConfig =
+            serde_json::from_str(r#"{"http_url":"http://localhost","account":"+1","enabled":true}"#)
+                .unwrap();
+        assert_eq!(signal.approval_timeout_secs, 300);
+
+        let matrix: MatrixConfig = serde_json::from_str(
+            r#"{"homeserver":"https://matrix.org","access_token":"tok","enabled":true}"#,
+        )
+        .unwrap();
+        assert_eq!(matrix.approval_timeout_secs, 300);
+
+        let whatsapp: WhatsAppConfig = serde_json::from_str(r#"{"enabled":true}"#).unwrap();
+        assert_eq!(whatsapp.approval_timeout_secs, 300);
+    }
+
+    #[test]
+    fn channel_approval_timeout_secs_explicit_override() {
+        let discord: DiscordConfig =
+            serde_json::from_str(r#"{"bot_token":"tok","enabled":true,"approval_timeout_secs":60}"#)
+                .unwrap();
+        assert_eq!(discord.approval_timeout_secs, 60);
+
+        let slack: SlackConfig =
+            serde_json::from_str(r#"{"bot_token":"tok","enabled":true,"approval_timeout_secs":120}"#)
+                .unwrap();
+        assert_eq!(slack.approval_timeout_secs, 120);
+
+        let signal: SignalConfig = serde_json::from_str(
+            r#"{"http_url":"http://localhost","account":"+1","enabled":true,"approval_timeout_secs":90}"#,
+        )
+        .unwrap();
+        assert_eq!(signal.approval_timeout_secs, 90);
+
+        let matrix: MatrixConfig = serde_json::from_str(
+            r#"{"homeserver":"https://matrix.org","access_token":"tok","enabled":true,"approval_timeout_secs":45}"#,
+        )
+        .unwrap();
+        assert_eq!(matrix.approval_timeout_secs, 45);
+
+        let whatsapp: WhatsAppConfig =
+            serde_json::from_str(r#"{"enabled":true,"approval_timeout_secs":180}"#).unwrap();
+        assert_eq!(whatsapp.approval_timeout_secs, 180);
     }
 }

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -17452,7 +17452,7 @@ allowed_users = ["@u:m"]
         assert_eq!(signal.approval_timeout_secs, 300);
 
         let matrix: MatrixConfig = serde_json::from_str(
-            r#"{"homeserver":"https://matrix.org","access_token":"tok","enabled":true}"#,
+            r#"{"homeserver":"https://matrix.org","access_token":"tok","enabled":true,"allowed_users":[]}"#,
         )
         .unwrap();
         assert_eq!(matrix.approval_timeout_secs, 300);
@@ -17482,7 +17482,7 @@ allowed_users = ["@u:m"]
         assert_eq!(signal.approval_timeout_secs, 90);
 
         let matrix: MatrixConfig = serde_json::from_str(
-            r#"{"homeserver":"https://matrix.org","access_token":"tok","enabled":true,"approval_timeout_secs":45}"#,
+            r#"{"homeserver":"https://matrix.org","access_token":"tok","enabled":true,"allowed_users":[],"approval_timeout_secs":45}"#,
         )
         .unwrap();
         assert_eq!(matrix.approval_timeout_secs, 45);

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -17445,9 +17445,10 @@ allowed_users = ["@u:m"]
             serde_json::from_str(r#"{"bot_token":"tok","enabled":true}"#).unwrap();
         assert_eq!(slack.approval_timeout_secs, 300);
 
-        let signal: SignalConfig =
-            serde_json::from_str(r#"{"http_url":"http://localhost","account":"+1","enabled":true}"#)
-                .unwrap();
+        let signal: SignalConfig = serde_json::from_str(
+            r#"{"http_url":"http://localhost","account":"+1","enabled":true}"#,
+        )
+        .unwrap();
         assert_eq!(signal.approval_timeout_secs, 300);
 
         let matrix: MatrixConfig = serde_json::from_str(
@@ -17462,14 +17463,16 @@ allowed_users = ["@u:m"]
 
     #[test]
     fn channel_approval_timeout_secs_explicit_override() {
-        let discord: DiscordConfig =
-            serde_json::from_str(r#"{"bot_token":"tok","enabled":true,"approval_timeout_secs":60}"#)
-                .unwrap();
+        let discord: DiscordConfig = serde_json::from_str(
+            r#"{"bot_token":"tok","enabled":true,"approval_timeout_secs":60}"#,
+        )
+        .unwrap();
         assert_eq!(discord.approval_timeout_secs, 60);
 
-        let slack: SlackConfig =
-            serde_json::from_str(r#"{"bot_token":"tok","enabled":true,"approval_timeout_secs":120}"#)
-                .unwrap();
+        let slack: SlackConfig = serde_json::from_str(
+            r#"{"bot_token":"tok","enabled":true,"approval_timeout_secs":120}"#,
+        )
+        .unwrap();
         assert_eq!(slack.approval_timeout_secs, 120);
 
         let signal: SignalConfig = serde_json::from_str(

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -17435,7 +17435,7 @@ allowed_users = ["@u:m"]
     }
 
     #[test]
-    fn channel_approval_timeout_secs_defaults_to_300() {
+    async fn channel_approval_timeout_secs_defaults_to_300() {
         // Omitting approval_timeout_secs from each config should deserialize to 300
         let discord: DiscordConfig =
             serde_json::from_str(r#"{"bot_token":"tok","enabled":true}"#).unwrap();
@@ -17462,7 +17462,7 @@ allowed_users = ["@u:m"]
     }
 
     #[test]
-    fn channel_approval_timeout_secs_explicit_override() {
+    async fn channel_approval_timeout_secs_explicit_override() {
         let discord: DiscordConfig = serde_json::from_str(
             r#"{"bot_token":"tok","enabled":true,"approval_timeout_secs":60}"#,
         )

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1724,6 +1724,16 @@ async fn handle_whatsapp_message(
             msg.sender,
             truncate_with_ellipsis(&msg.content, 50)
         );
+
+        // Route approval replies to pending approval requests before dispatching to agent
+        if let Some((token, response)) = zeroclaw_channels::util::parse_approval_reply(&msg.content) {
+            let mut map = wa.pending_approvals.lock().await;
+            if let Some(sender) = map.remove(&token) {
+                let _ = sender.send(response);
+                continue;
+            }
+        }
+
         let session_id = sender_session_id("whatsapp", msg);
 
         // Auto-save to memory

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1727,7 +1727,7 @@ async fn handle_whatsapp_message(
 
         // Route approval replies to pending approval requests before dispatching to agent
         if let Some((token, response)) = zeroclaw_channels::util::parse_approval_reply(&msg.content) {
-            let mut map = wa.pending_approvals.lock().await;
+            let mut map = wa.pending_approvals().lock().await;
             if let Some(sender) = map.remove(&token) {
                 let _ = sender.send(response);
                 continue;

--- a/crates/zeroclaw-gateway/src/lib.rs
+++ b/crates/zeroclaw-gateway/src/lib.rs
@@ -1726,7 +1726,8 @@ async fn handle_whatsapp_message(
         );
 
         // Route approval replies to pending approval requests before dispatching to agent
-        if let Some((token, response)) = zeroclaw_channels::util::parse_approval_reply(&msg.content) {
+        if let Some((token, response)) = zeroclaw_channels::util::parse_approval_reply(&msg.content)
+        {
             let mut map = wa.pending_approvals().lock().await;
             if let Some(sender) = map.remove(&token) {
                 let _ = sender.send(response);

--- a/crates/zeroclaw-runtime/src/integrations/registry.rs
+++ b/crates/zeroclaw-runtime/src/integrations/registry.rs
@@ -938,6 +938,7 @@ mod tests {
             recovery_key: None,
             password: None,
             mention_only: false,
+            approval_timeout_secs: 300,
         });
         let entries = all_integrations();
         let mx = entries.iter().find(|e| e.name == "Matrix").unwrap();

--- a/crates/zeroclaw-runtime/src/onboard/wizard.rs
+++ b/crates/zeroclaw-runtime/src/onboard/wizard.rs
@@ -4141,6 +4141,9 @@ fn setup_channels(
                         .map(|d| d.multi_message_delay_ms)
                         .unwrap_or(800),
                     stall_timeout_secs: existing_dc.map(|d| d.stall_timeout_secs).unwrap_or(0),
+                    approval_timeout_secs: existing_dc
+                        .map(|d| d.approval_timeout_secs)
+                        .unwrap_or(300),
                 });
             }
             ChannelMenuChoice::Slack => {
@@ -4322,6 +4325,9 @@ fn setup_channels(
                         .map(|s| s.draft_update_interval_ms)
                         .unwrap_or(1200),
                     cancel_reaction: existing_sl.and_then(|s| s.cancel_reaction.clone()),
+                    approval_timeout_secs: existing_sl
+                        .map(|s| s.approval_timeout_secs)
+                        .unwrap_or(300),
                 });
             }
             ChannelMenuChoice::IMessage => {
@@ -4554,6 +4560,9 @@ fn setup_channels(
                     mention_only: existing_mx.map(|m| m.mention_only).unwrap_or(false),
                     recovery_key,
                     password: existing_mx.and_then(|m| m.password.clone()),
+                    approval_timeout_secs: existing_mx
+                        .map(|m| m.approval_timeout_secs)
+                        .unwrap_or(300),
                 });
             }
             ChannelMenuChoice::Signal => {
@@ -4650,6 +4659,11 @@ fn setup_channels(
                     ignore_attachments,
                     ignore_stories,
                     proxy_url: config.signal.as_ref().and_then(|s| s.proxy_url.clone()),
+                    approval_timeout_secs: config
+                        .signal
+                        .as_ref()
+                        .map(|s| s.approval_timeout_secs)
+                        .unwrap_or(300),
                 });
 
                 println!("  {} Signal configured", style("✅").green().bold());
@@ -4761,6 +4775,9 @@ fn setup_channels(
                             .map(|w| w.group_mention_patterns.clone())
                             .unwrap_or_default(),
                         proxy_url: existing_wa.and_then(|w| w.proxy_url.clone()),
+                        approval_timeout_secs: existing_wa
+                            .map(|w| w.approval_timeout_secs)
+                            .unwrap_or(300),
                     });
 
                     println!(
@@ -4878,6 +4895,9 @@ fn setup_channels(
                         .map(|w| w.group_mention_patterns.clone())
                         .unwrap_or_default(),
                     proxy_url: existing_wa.and_then(|w| w.proxy_url.clone()),
+                    approval_timeout_secs: existing_wa
+                        .map(|w| w.approval_timeout_secs)
+                        .unwrap_or(300),
                 });
             }
             ChannelMenuChoice::Linq => {

--- a/crates/zeroclaw-runtime/src/onboard/wizard.rs
+++ b/crates/zeroclaw-runtime/src/onboard/wizard.rs
@@ -8352,6 +8352,7 @@ mod tests {
             ignore_attachments: false,
             ignore_stories: true,
             proxy_url: None,
+            approval_timeout_secs: 300,
         });
         assert!(has_launchable_channels(&channels));
 
@@ -8442,6 +8443,7 @@ mod tests {
                 draft_update_interval_ms: 1500,
                 multi_message_delay_ms: 800,
                 stall_timeout_secs: 0,
+                approval_timeout_secs: 300,
             }),
             matrix: Some(MatrixConfig {
                 enabled: true,
@@ -8458,6 +8460,7 @@ mod tests {
                 recovery_key: None,
                 mention_only: false,
                 password: None,
+                approval_timeout_secs: 300,
             }),
             ..Default::default()
         };
@@ -8494,6 +8497,7 @@ mod tests {
                 recovery_key: Some("recovery-secret".into()),
                 mention_only: false,
                 password: None,
+                approval_timeout_secs: 300,
             }),
             ..Default::default()
         };

--- a/crates/zeroclaw-tui/src/onboarding.rs
+++ b/crates/zeroclaw-tui/src/onboarding.rs
@@ -774,6 +774,7 @@ fn apply_tui_selections_to_config(app: &App, config: &mut Config) {
                     draft_update_interval_ms: 1000,
                     multi_message_delay_ms: 800,
                     stall_timeout_secs: 0,
+                    approval_timeout_secs: 300,
                 });
             }
         }
@@ -793,6 +794,7 @@ fn apply_tui_selections_to_config(app: &App, config: &mut Config) {
                     stream_drafts: false,
                     draft_update_interval_ms: 1200,
                     cancel_reaction: None,
+                    approval_timeout_secs: 300,
                 });
             }
         }
@@ -816,6 +818,7 @@ fn apply_tui_selections_to_config(app: &App, config: &mut Config) {
                     dm_mention_patterns: vec![],
                     group_mention_patterns: vec![],
                     proxy_url: None,
+                    approval_timeout_secs: 300,
                 });
             }
         }
@@ -830,6 +833,7 @@ fn apply_tui_selections_to_config(app: &App, config: &mut Config) {
                     ignore_attachments: false,
                     ignore_stories: true,
                     proxy_url: None,
+                    approval_timeout_secs: 300,
                 });
             }
         }
@@ -876,6 +880,9 @@ fn apply_tui_selections_to_config(app: &App, config: &mut Config) {
                     mention_only: existing_mx.map(|m| m.mention_only).unwrap_or(false),
                     recovery_key: existing_mx.and_then(|m| m.recovery_key.clone()),
                     password: existing_mx.and_then(|m| m.password.clone()),
+                    approval_timeout_secs: existing_mx
+                        .map(|m| m.approval_timeout_secs)
+                        .unwrap_or(300),
                 });
             }
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -279,6 +279,7 @@ mod tests {
             draft_update_interval_ms: 1000,
             multi_message_delay_ms: 800,
             stall_timeout_secs: 0,
+            approval_timeout_secs: 300,
         };
 
         let lark = LarkConfig {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `Channel::request_approval()` was a no-op (`Ok(None)`) for every channel except Telegram, causing all `always_ask` tool calls to be silently auto-denied when running outside the CLI. This PR implements the method for Discord, Slack, Signal, Matrix, and WhatsApp, giving users an interactive approval prompt instead of a silent deny.
- Each channel generates a 6-char random alphanumeric token (`[a-z0-9]`, 36⁶ ≈ 2.2B combinations), embeds it in the approval message, and routes the reply through a `oneshot` channel before the message reaches the agent. Slack Socket Mode gets Block Kit buttons; all other channels use a text-reply pattern (`"abc123 yes/no/always"`).
- `approval_timeout_secs` (default 300) is added to all five config structs and preserved through the onboard wizard.
- **Scope boundary:** Does not change Telegram's existing approval implementation, the CLI approval path, or the `always_ask` / `never_ask` policy evaluation in `loop_.rs`.
- **Blast radius:** Any code that constructs `DiscordConfig`, `SlackConfig`, `MatrixConfig`, `SignalConfig`, or `WhatsAppConfig` as a struct literal must now include `approval_timeout_secs`. The wizard and all known literal sites are updated. The gateway's `handle_whatsapp_message` now has a pre-dispatch approval intercept that runs before `run_gateway_chat_with_tools`.
- **Linked issue(s):** Closes #2324

## Validation Evidence (required)

- **Commands run and tail output:**

```
cargo fmt --all -- --check
  (clean)

cargo clippy --workspace --all-targets -- -D warnings
  Finished `dev` profile in 1m 09s — zero warnings

cargo test --workspace
  1243 tests passed across binary/gateway/channels/config/etc.
  1 pre-existing failure: schema::tests::every_prop_is_gettable_and_settable
  (confirmed failing on upstream/master; tracked for fix by #6021)
```

- **Beyond CI — what did you manually verify?** Oneshot registration ordering (register before send in all 5 channels), Arc clone chain in Matrix's `add_event_handler` closure, intercept placement at all `listen()` dispatch sites, `#[async_trait]` presence, timeout cleanup on both error and timeout branches, and trait signature match (`&ChannelApprovalRequest` not by value). Verified token entropy: new generator uses `rand::rng().random_range` against `[a-z0-9]`, so 36⁶ ≈ 2.2B combinations is now accurate (was 16⁶ ≈ 16.7M under the old UUID-hex prefix approach).
- **If any command was intentionally skipped, why:** Runtime end-to-end test (send an `always_ask` tool call from each channel, confirm prompt fires and routes) requires live credentials — not included in CI.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No — approval messages use each channel's existing send path.
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

> **Token guessability note:** Approval tokens are 6-char alphanumeric (`[a-z0-9]`, 36⁶ ≈ 2.2B combinations), valid for at most 300 seconds, and delivered only to the configured recipient channel. In WhatsApp webhook mode there is no per-sender check on the reply — the token itself is the shared secret. This matches the acceptable-risk bar for the existing Telegram implementation.

## Compatibility (required)

- Backward compatible? Yes — `approval_timeout_secs` has a serde default of 300; existing configs that omit the field continue to work.
- Config / env / CLI surface changed? Yes — five config structs gain `approval_timeout_secs: u64` (optional in TOML/JSON, defaults to 300).
- Upgrade steps: none required. Existing configs load unchanged.

## Rollback

- **Fast rollback command/path:** `git revert cf913669 f088978b a810d60a` — reverts all three commits cleanly.
- **Feature flags or config toggles:** None — set `approval_timeout_secs: 0` to make approvals time out immediately (effectively restoring auto-deny behavior per channel).
- **Observable failure symptoms:** If approval routing breaks, `always_ask` tools will time out and be denied after `approval_timeout_secs`; look for `"auto-denying tool"` in agent logs.

## i18n Follow-Through

N.A. — no user-facing wording or docs changed.