### PR TITLE
feat(skills): deidentify pr-review-session skill, add milestone alignment phase

### DIFF
--- a/.claude/skills/github-pr-review-session/SKILL.md
+++ b/.claude/skills/github-pr-review-session/SKILL.md
@@ -6,11 +6,14 @@ description: "Human-reviewer co-pilot for ZeroClaw PR reviews. Use this skill wh
 # ZeroClaw PR Review Session — Human Reviewer Co-Pilot
 
 You are assisting the **active `gh` account holder** in conducting PR reviews
-for the `zeroclaw-labs/zeroclaw` repository. You read everything, cross-check
-against the local source, write the review body, and post it via `gh` — but
-the judgment and identity are the reviewer's. Every review is posted under
-the logged-in account, in the first-person voice of that reviewer — never as
-"an AI" or in a third party's voice.
+for the `zeroclaw-labs/zeroclaw` repository. Reviewer identity is resolved from
+`tmp/handoff.md` at session start (the `reviewer:` field); if absent, detect it
+via `gh auth status` and persist it to the handoff immediately so continuation
+sessions reuse it without a redundant call. You read everything, cross-check
+against the local source, write the review body, and post it via `gh` — but the
+judgment and identity are the reviewer's. Every review is posted under the
+logged-in account, in the first-person voice of that reviewer — never as "an AI"
+or in a third party's voice.
 
 ---
 
@@ -23,6 +26,10 @@ Read these files at the start of every session. They are authoritative.
   follow it exactly for every PR
 - `.github/pull_request_template.md` — required PR body sections; used to
   check template completeness
+- `docs/book/src/foundations/fnd-003-governance.md` — label taxonomy, tracking
+  issue format conventions, definition of done (§9–10)
+- `docs/book/src/foundations/fnd-005-contribution-culture.md` — review voice,
+  feedback taxonomy, and the norms every review must follow
 - `tmp/handoff.md` — session state; tells you which PRs are already reviewed,
   what's still open, and what's next in the queue
 
@@ -61,10 +68,12 @@ is 1234 ready to merge
 
 ### Phase 1 — Load context
 
-1. **Identify the reviewer.** Run `gh auth status` and capture the active
-   account login. That login is the reviewer — write every review body in
-   the first-person voice of that account. Never sign with another person's
-   name, and never frame the review as AI-generated.
+1. **Resolve reviewer identity.** Check whether `tmp/handoff.md` contains a
+   stored `reviewer:` field. If it does, use that value for all subsequent `gh`
+   commands and review prose. If it does not (new session or no handoff yet),
+   run `gh auth status` to capture the active account login, record the result
+   as `reviewer: <login>` in `tmp/handoff.md` immediately, and use it for the
+   rest of the session. Never hardcode any identity.
 2. Read `tmp/handoff.md`. Establish which PRs have already been reviewed this
    session, which verdict was posted, and what commit that verdict was on.
 3. For the target PR, check if `tmp/review-<number>.md` already exists. If it
@@ -79,8 +88,9 @@ Follow `docs/book/src/contributing/pr-review-protocol.md` exactly for every PR.
 The protocol specifies:
 - **What to fetch** (PR metadata, comments, inline threads, formal reviews,
   diff, RFCs) — run all fetches in a single parallel batch
-- **Which RFCs to read** based on what the PR touches — the relevance table
-  is in the protocol; always read at minimum #5615
+- **Which foundations documents to read** based on what the PR touches — the
+  relevance table is in the protocol; always read at minimum
+  `docs/book/src/foundations/fnd-005-contribution-culture.md`
 - **How to cross-check** the diff against local source files
 - **The take-stock checkpoint** before writing anything
 - **The verdict decision tree** — which flag to use based on review state
@@ -102,12 +112,82 @@ fetches sequentially wastes time and the results are independent.
    ```
 3. Confirm the post succeeded.
 
+### Phase 3.5 — Milestone alignment
+
+After posting, determine whether the PR belongs in an active milestone. Skip
+this phase only for documented no-milestone types: commit title prefix `chore:`
+or `deps:`, or a diff that is deps-only (`Cargo.lock` / `Cargo.toml` bumps
+only). For all other PRs, run the full alignment path and record the outcome in
+the handoff.
+
+1. **Fetch open milestones:**
+   ```bash
+   gh api repos/zeroclaw-labs/zeroclaw/milestones \
+     --jq '.[] | select(.state=="open") | {number: .number, title: .title, description: .description}'
+   ```
+
+2. **Compare scope.** Check the PR's title, labels, linked issues, and files
+   changed against each milestone's scope boundary (found in the `description`
+   field). A PR fits a milestone if it falls within the stated scope and does
+   not violate its stated exclusions.
+
+3. **If the PR fits a milestone:**
+
+   a. Set the milestone on the PR:
+      ```bash
+      gh pr edit <number> --repo zeroclaw-labs/zeroclaw \
+        --milestone "<milestone-title>"
+      ```
+
+   b. Find the milestone's tracking issue:
+      ```bash
+      gh issue list --repo zeroclaw-labs/zeroclaw \
+        --milestone "<milestone-title>" --state open \
+        --search "milestone tracking" --json number,title
+      ```
+      If the search returns zero results, skip the body update and fall
+      through to step 4 — treat a missing tracking issue the same as no
+      matching milestone.
+
+   c. Derive the entry format, section placement, and verdict emoji directly
+      from the existing entries in the tracking issue body — the live content
+      is the authority. Do not guess or invent a format; read what is already
+      there and match it exactly.
+
+      > **Design note:** format is intentionally not prescribed here. The
+      > tracking issue body evolves with team convention; deriving from it
+      > keeps the skill aligned automatically. If genuine ambiguity arises,
+      > `docs/book/src/foundations/fnd-003-governance.md` §9–10 and
+      > `docs/book/src/foundations/fnd-005-contribution-culture.md` document
+      > the underlying conventions.
+
+      Write the full updated body to `tmp/tracking-<milestone-title>.md`
+      before posting. Preserve all existing content exactly; only append the
+      new entry in the appropriate section. Then update with:
+      ```bash
+      gh issue edit <tracking-issue-number> --repo zeroclaw-labs/zeroclaw \
+        --body-file tmp/tracking-<milestone-title>.md
+      ```
+
+4. **If the PR does not fit any open milestone:**
+
+   Post a comment on the PR tagging @JordanTheJet for milestone alignment:
+   ```bash
+   gh pr comment <number> --repo zeroclaw-labs/zeroclaw \
+     --body "@JordanTheJet — milestone alignment needed: this PR does not clearly fit within the scope boundary of any open milestone. Please advise on placement or deferral."
+   ```
+
+   Note this in `tmp/handoff.md` so the next session knows alignment is
+   pending.
+
 ### Phase 4 — Update the handoff
 
 After every posted review, update `tmp/handoff.md`:
 
 - Mark the PR with the verdict posted, the commit reviewed (`head.sha`), and
   what remains open (if anything).
+- Record the milestone alignment action taken (milestone set, tracking issue
+  updated, @JordanTheJet tagged, or skipped with reason).
 - If the PR queue changed (e.g., a PR was approved and is now merge-ready),
   reflect that in the queue section.
 - Keep the handoff accurate enough that a new session starting cold can pick
@@ -118,9 +198,9 @@ After every posted review, update `tmp/handoff.md`:
 ## Review voice and tone
 
 Every review is written in the first-person voice of the `gh`-authenticated
-reviewer (whoever ran Phase 1's `gh auth status` check) — a thoughtful,
-senior contributor who has read everything and cares about the outcome. No
-third-party signatures, no "AI generated" framing.
+reviewer (resolved in Phase 1) — a thoughtful, senior contributor who has read
+everything and cares about the outcome. No third-party signatures, no "AI
+generated" framing.
 
 - **Be specific.** Vague feedback creates anxiety without direction.
   Explain the principle behind every finding, not just the verdict.
@@ -133,24 +213,33 @@ third-party signatures, no "AI generated" framing.
 - **Reference RFCs by section** when they are the basis for a finding.
   "Per FND-006 §4.3" is more useful than "per our standards."
 
-These norms come from FND-005 (#5615). Read it.
+These norms are documented in
+`docs/book/src/foundations/fnd-005-contribution-culture.md`. Read it.
 
 ---
 
-
 ## Execution rules
 
-1. **Always read `tmp/handoff.md` first.** Never start a review without
-   knowing what has already been done this session.
-2. **Always follow the protocol in `docs/book/src/contributing/pr-review-protocol.md`.** Do not
-   improvise the fetch sequence or skip the RFC step.
-3. **Always write to `tmp/review-<number>.md` before posting.** The tmp
-   file is the source of truth for what was posted. It also lets you
-   inspect before posting if the user asks.
-4. **Always update `tmp/handoff.md` after posting.** The handoff is
-   useless if it's not current.
-5. **Never merge.** Never push to contributor branches.
-6. **Never approve over another reviewer's active CHANGES_REQUESTED.**
+1. **Always read `tmp/handoff.md` first.** It carries session state and the
+   cached reviewer identity — reading it first avoids a redundant auth call on
+   warm sessions.
+2. **Always resolve reviewer identity from the handoff before falling back to
+   `gh auth status`.** If the handoff has no `reviewer:` field, detect it,
+   write it to the handoff immediately, and use it for the rest of the session.
+   Never hardcode a username.
+3. **Always follow the protocol in
+   `docs/book/src/contributing/pr-review-protocol.md`.** Do not improvise the
+   fetch sequence or skip the foundations document step.
+4. **Always write to `tmp/review-<number>.md` before posting.** The tmp file
+   is the source of truth for what was posted. It also lets you inspect before
+   posting if the user asks.
+5. **Always run milestone alignment after posting**, unless the PR is a
+   documented no-milestone type (`chore:`/`deps:` prefix or deps-only diff).
+   Note the skip reason in the handoff when bypassing.
+6. **Always update `tmp/handoff.md` after posting.** The handoff is useless if
+   it's not current. Include the milestone alignment outcome.
+7. **Never merge.** Never push to contributor branches.
+8. **Never approve over another reviewer's active CHANGES_REQUESTED.**
    Check the reviews API output before choosing a verdict flag.
-7. **Never post a review that re-raises a settled point** without
-   explicitly noting it is already resolved.
+9. **Never post a review that re-raises a settled point** without explicitly
+   noting it is already resolved.

--- a/docs/book/src/contributing/pr-review-protocol.md
+++ b/docs/book/src/contributing/pr-review-protocol.md
@@ -38,22 +38,20 @@ Run all of these. The data informs every step that follows.
 
    Note which `CHANGES_REQUESTED` are still active (not superseded by a later `APPROVED` or `DISMISSED`). Check whether you've already reviewed this PR.
 
-5. **Relevant RFCs**
+5. **Relevant foundations documents**
 
-   Always fetch FND-005 (Contribution Culture, issue #5615). For other RFCs, use the relevance table below — read what applies to the PR's scope.
+   Always read FND-005 (Contribution Culture). For others, use the relevance
+   table below — read what applies to the PR's scope. The ratified versions
+   are local files; no API call needed.
 
-   ```bash
-   gh issue view <RFC-number> --repo zeroclaw-labs/zeroclaw
-   ```
-
-   | RFC | Issue |
+   | Foundation | Local file |
    |---|---|
-   | Microkernel Architecture | #5574 |
-   | Documentation Standards | #5576 |
-   | Team Governance | #5577 |
-   | CI/CD Pipeline | #5579 |
-   | Contribution Culture | #5615 |
-   | Zero Compromise in Practice | #5653 |
+   | Microkernel Architecture | `docs/book/src/foundations/fnd-001-intentional-architecture.md` |
+   | Documentation Standards | `docs/book/src/foundations/fnd-002-documentation-standards.md` |
+   | Team Governance | `docs/book/src/foundations/fnd-003-governance.md` |
+   | Engineering Infrastructure | `docs/book/src/foundations/fnd-004-engineering-infrastructure.md` |
+   | Contribution Culture | `docs/book/src/foundations/fnd-005-contribution-culture.md` |
+   | Zero Compromise in Practice | `docs/book/src/foundations/fnd-006-zero-compromise-in-practice.md` |
 
 6. **Diff**
 


### PR DESCRIPTION
## Summary

Remove the hardcoded `WareWolf-MoonWall` identity from the `github-pr-review-session` skill and add a milestone alignment phase to the review workflow.

## Changes

### Identity de-hardcoding
- `description` field: removed `(WareWolf-MoonWall)` — skill now references "the authenticated reviewer"
- Opening paragraph: updated to describe the handoff-first identity resolution strategy
- **Phase 1**: reviewer identity is now resolved from `tmp/handoff.md` (`reviewer:` field) at session start; only falls back to `gh api user --jq '.login'` if absent, persisting the result immediately so continuation sessions reuse it without redundant API calls
- **Execution rules 1–2**: rewritten to reflect the handoff-first approach

### Milestone alignment (new Phase 3.5)
After every posted review:
1. Fetch open milestones and compare PR scope (title, labels, files, linked issues) against each milestone's scope boundary
2. **Fits a milestone** → set milestone on PR via `gh pr edit`, find the milestone tracking issue, append a new entry to its Open section, update its body
3. **No fit** → post a comment tagging `@JordanTheJet` for milestone alignment
4. Outcome recorded in `tmp/handoff.md`

### .gitignore
No change needed — `tmp/` is already present on upstream `master` (line 44).

## Risk tier
**Low** — `.claude/skills/` only; no runtime, gateway, tools, or security paths touched. Fits v0.7.4 scope boundary ("docs/skills foundation").

## Checklist
- [x] `tmp/` gitignore confirmed upstream (no change required)
- [x] No hardcoded identity remaining in skill
- [x] Milestone alignment covers both the "fits" and "does not fit" paths
- [x] Handoff updated to carry identity and milestone outcome across sessions
- [x] Conventional commit title
- [x] No secrets, personal data, or real identity information in changes