### PR TITLE
fix(tests): make Windows dev tests portable

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -178,6 +178,19 @@ fn current_target_triple() -> &'static str {
         } else {
             "x86_64-unknown-linux-gnu"
         }
+    } else if cfg!(target_os = "windows") {
+        match (
+            cfg!(target_arch = "aarch64"),
+            cfg!(target_arch = "x86"),
+            cfg!(target_env = "gnu"),
+        ) {
+            (true, _, true) => "aarch64-pc-windows-gnu",
+            (true, _, false) => "aarch64-pc-windows-msvc",
+            (_, true, true) => "i686-pc-windows-gnu",
+            (_, true, false) => "i686-pc-windows-msvc",
+            (_, _, true) => "x86_64-pc-windows-gnu",
+            _ => "x86_64-pc-windows-msvc",
+        }
     } else {
         "unknown"
     }
@@ -420,6 +433,16 @@ mod tests {
         assert!(
             triple.matches('-').count() >= 2,
             "triple should have at least two hyphens: {triple}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn current_target_triple_windows_uses_windows_suffix() {
+        let triple = current_target_triple();
+        assert!(
+            triple.contains("windows"),
+            "windows targets should include windows in the triple: {triple}"
         );
     }
 

--- a/src/tunnel/mod.rs
+++ b/src/tunnel/mod.rs
@@ -10,6 +10,26 @@ mod tests {
     };
     use tokio::process::Command;
 
+    fn spawn_lifecycle_test_child() -> std::io::Result<tokio::process::Child> {
+        #[cfg(windows)]
+        {
+            Command::new("cmd")
+                .args(["/C", "ping 127.0.0.1 -n 30 >NUL"])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+        }
+
+        #[cfg(not(windows))]
+        {
+            Command::new("sleep")
+                .arg("30")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+        }
+    }
+
     /// Helper: assert `create_tunnel` returns an error containing `needle`.
     fn assert_tunnel_err(cfg: &TunnelConfig, needle: &str) {
         match create_tunnel(cfg) {
@@ -272,12 +292,8 @@ mod tests {
     async fn kill_shared_terminates_and_clears_child() {
         let proc = new_shared_process();
 
-        let child = Command::new("sleep")
-            .arg("30")
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .expect("sleep should spawn for lifecycle test");
+        let child = spawn_lifecycle_test_child()
+            .expect("platform lifecycle command should spawn for tunnel test");
 
         {
             let mut guard = proc.lock().await;


### PR DESCRIPTION
## Summary

- Base branch target (master for all contributions): master
- Problem: Windows contributors can hit two failing tests during `cargo test --locked`: update target detection reports `unknown`, and the tunnel lifecycle test assumes a Unix-only `sleep` binary.
- Why it matters: this breaks the documented local development flow on Windows for an otherwise healthy checkout.
- What changed: added Windows target triple detection to the update command helper and replaced the tunnel lifecycle test's hard-coded `sleep` command with a platform-aware child process launcher.
- What did **not** change (scope boundary): no runtime tunnel behavior changes, no update download/asset matching rewrite beyond platform triple reporting, no CI workflow changes.

## Label Snapshot (required)

- Risk label (risk: low|medium|high): risk: low
- Size label (size: XS|S|M|L|XL, auto-managed/read-only): size: XS
- Scope labels (core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev, comma-separated): tests, tunnel, dev
- Module labels (<module>: <component>, for example channel: telegram, provider: kimi, tool: shell): tunnel: lifecycle, dev: update
- Contributor tier label (trusted contributor|experienced contributor|principal contributor|distinguished contributor, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (bug|feature|refactor|docs|security|chore): bug
- Primary scope (runtime|provider|channel|memory|security|ci|docs|multi): multi

## Linked Issue

- Closes #6020
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when Supersedes # is used)

- Superseded PRs + authors (#<pr> by @<author>, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- Co-authored-by trailers added for materially incorporated contributors? (Yes/No): No
- If No, explain why (for example: inspiration-only, no direct code/design carry-over): no superseded PR
- Trailer format check (separate lines, no escaped \n): (Pass/Fail): Pass

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): `cargo test current_target_triple_is_not_empty` and `cargo test kill_shared_terminates_and_clears_child` both passed after the patch.
- If any command is intentionally skipped, explain why: full clippy and full cargo test were skipped; validation targeted the two failing tests reported in the issue.

## Security Impact (required)

- New permissions/capabilities? (Yes/No): No
- New external network calls? (Yes/No): No
- Secrets/tokens handling changed? (Yes/No): No
- File system access scope changed? (Yes/No): No
- If any Yes, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (pass|needs-follow-up): pass
- Redaction/anonymization notes: no sensitive data added
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (Yes/No): Yes
- Config/env changes? (Yes/No): No
- Migration needed? (Yes/No): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (Yes/No): No
- If Yes, locale navigation parity updated in README*, docs/README*, and docs/SUMMARY.md for supported locales (en, zh-CN, ja, ru, fr, vi)? (Yes/No): N/A
- If Yes, localized runtime-contract docs updated where equivalents exist (minimum for fr/vi: commands-reference, config-reference, troubleshooting)? (Yes/No/N.A.): N/A
- If Yes, Vietnamese canonical docs under docs/i18n/vi/** synced and compatibility shims under docs/*.vi.md validated? (Yes/No/N.A.): N/A
- If any No/N.A., link follow-up issue/PR and explain scope decision: no docs changed

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: target triple helper no longer reports `unknown` on supported platforms; tunnel lifecycle test uses a platform-aware child process command.
- Edge cases checked: Windows helper includes both MSVC and GNU triples; non-Windows test path still uses `sleep`.
- What was not verified: live Windows execution in this local environment and full workspace regression suite.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: local test portability for update command helpers and tunnel tests.
- Potential unintended effects: release asset lookup on Windows now depends on the release asset names containing the full Rust target triple.
- Guardrails/monitoring for early detection: targeted tests cover the two previously failing paths.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex local shell/test workflow
- Workflow/plan summary (if any): patched only the failing Windows assumptions reported in the issue
- Verification focus: exact test failures from the issue
- Confirmation: naming + architecture boundaries followed (AGENTS.md + CONTRIBUTING.md): Yes

## Rollback Plan (required)

- Fast rollback command/path: revert commit 88da94c9
- Feature flags or config toggles (if any): none
- Observable failure symptoms: Windows `cargo test --locked` again fails on `current_target_triple_is_not_empty` or `kill_shared_terminates_and_clears_child`.

## Risks and Mitigations

- Risk:
  - Release assets may use a Windows naming scheme that does not include the full Rust target triple.
- Mitigation:
  - The change is limited to platform reporting and can be adjusted easily if asset naming differs; the issue itself already shows the current helper is definitively wrong on Windows.
