### PR TITLE
fix(ollama): avoid native tool payload on fallback path

### DIFF
--- a/crates/zeroclaw-providers/src/ollama.rs
+++ b/crates/zeroclaw-providers/src/ollama.rs
@@ -836,31 +836,13 @@ impl Provider for OllamaProvider {
         model: &str,
         temperature: f64,
     ) -> anyhow::Result<ChatResponse> {
-        // Convert ToolSpec to OpenAI-compatible JSON and delegate to chat_with_tools.
-        if let Some(specs) = request.tools
-            && !specs.is_empty()
-        {
-            let tools: Vec<serde_json::Value> = specs
-                .iter()
-                .map(|s| {
-                    let params =
-                        zeroclaw_api::schema::SchemaCleanr::clean_for_openai(s.parameters.clone());
-                    serde_json::json!({
-                        "type": "function",
-                        "function": {
-                            "name": s.name,
-                            "description": s.description,
-                            "parameters": params
-                        }
-                    })
-                })
-                .collect();
-            return self
-                .chat_with_tools(request.messages, &tools, model, temperature)
-                .await;
+        if request.tools.is_some_and(|specs| !specs.is_empty()) {
+            tracing::debug!(
+                model = model,
+                "Ollama ignoring native tool specs and using prompt-guided tool calling"
+            );
         }
 
-        // No tools — fall back to plain text chat.
         let text = self
             .chat_with_history(request.messages, model, temperature)
             .await?;
@@ -1381,5 +1363,14 @@ mod tests {
         let text = result.unwrap();
         assert!(text.contains("<tool_call>"));
         assert!(text.contains("date"));
+    }
+
+    #[test]
+    fn capabilities_keep_native_tool_calling_disabled() {
+        let provider = OllamaProvider::new(None, None);
+        assert!(
+            !provider.supports_native_tools(),
+            "Ollama should not advertise native tool calling"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Base branch target (master for all contributions): master
- Problem: the Ollama provider advertises prompt-guided tool calling, but still sends native tool payloads when tool specs are present.
- Why it matters: some Ollama-served models fail those requests with 500 EOF, which blocks tool-based prompts such as file reads.
- What changed: the provider now ignores native tool specs in the Ollama chat path and consistently uses the existing prompt-guided flow; a regression test was added to lock in the non-native tool policy.
- What did **not** change (scope boundary): no retry policy changes, no session recovery changes, no general Ollama transport rewrite.

## Label Snapshot (required)

- Risk label (risk: low|medium|high): risk: medium
- Size label (size: XS|S|M|L|XL, auto-managed/read-only): size: XS
- Scope labels (core|agent|channel|config|cron|daemon|doctor|gateway|health|heartbeat|integration|memory|observability|onboard|provider|runtime|security|service|skillforge|skills|tool|tunnel|docs|dependencies|ci|tests|scripts|dev, comma-separated): provider, runtime, tests
- Module labels (<module>: <component>, for example channel: telegram, provider: kimi, tool: shell): provider: ollama
- Contributor tier label (trusted contributor|experienced contributor|principal contributor|distinguished contributor, auto-managed/read-only; author merged PRs >=5/10/20/50): auto-managed
- If any auto-label is incorrect, note requested correction: none

## Change Metadata

- Change type (bug|feature|refactor|docs|security|chore): bug
- Primary scope (runtime|provider|channel|memory|security|ci|docs|multi): provider

## Linked Issue

- Closes #5962
- Related #
- Depends on # (if stacked)
- Supersedes # (if replacing older PR)

## Supersede Attribution (required when Supersedes # is used)

- Superseded PRs + authors (#<pr> by @<author>, one per line): N/A
- Integrated scope by source PR (what was materially carried forward): N/A
- Co-authored-by trailers added for materially incorporated contributors? (Yes/No): No
- If No, explain why (for example: inspiration-only, no direct code/design carry-over): no superseded PR
- Trailer format check (separate lines, no escaped \n): (Pass/Fail): Pass

## Validation Evidence (required)

Commands and result summary:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

- Evidence provided (test/log/trace/screenshot/perf): `cargo test -p zeroclaw-providers ollama` and `cargo test -p zeroclaw-runtime turn_without_tools_returns_text` both passed.
- If any command is intentionally skipped, explain why: full clippy and full cargo test were skipped; validation focused on the changed provider path and a lightweight runtime sanity check.

## Security Impact (required)

- New permissions/capabilities? (Yes/No): No
- New external network calls? (Yes/No): No
- Secrets/tokens handling changed? (Yes/No): No
- File system access scope changed? (Yes/No): No
- If any Yes, describe risk and mitigation: N/A

## Privacy and Data Hygiene (required)

- Data-hygiene status (pass|needs-follow-up): pass
- Redaction/anonymization notes: no sensitive data added
- Neutral wording confirmation (use ZeroClaw/project-native labels if identity-like wording is needed): confirmed

## Compatibility / Migration

- Backward compatible? (Yes/No): Yes
- Config/env changes? (Yes/No): No
- Migration needed? (Yes/No): No
- If yes, exact upgrade steps: N/A

## i18n Follow-Through (required when docs or user-facing wording changes)

- i18n follow-through triggered? (Yes/No): No
- If Yes, locale navigation parity updated in README*, docs/README*, and docs/SUMMARY.md for supported locales (en, zh-CN, ja, ru, fr, vi)? (Yes/No): N/A
- If Yes, localized runtime-contract docs updated where equivalents exist (minimum for fr/vi: commands-reference, config-reference, troubleshooting)? (Yes/No/N.A.): N/A
- If Yes, Vietnamese canonical docs under docs/i18n/vi/** synced and compatibility shims under docs/*.vi.md validated? (Yes/No/N.A.): N/A
- If any No/N.A., link follow-up issue/PR and explain scope decision: no docs changed

## Human Verification (required)

What was personally validated beyond CI:

- Verified scenarios: Ollama keeps native tool calling disabled in both capabilities and the live chat path; the provider test suite still passes.
- Edge cases checked: plain chat path remains unchanged when no tools are requested.
- What was not verified: live Ollama interaction against the reporter's exact models on Windows.

## Side Effects / Blast Radius (required)

- Affected subsystems/workflows: Ollama provider tool-call routing only.
- Potential unintended effects: models that genuinely support Ollama native tools will continue using prompt-guided tool calling until explicit support is added.
- Guardrails/monitoring for early detection: the provider capability test and Ollama provider test suite cover the intended non-native policy.

## Agent Collaboration Notes (recommended)

- Agent tools used (if any): Codex local shell/test workflow
- Workflow/plan summary (if any): aligned the live chat path with the provider's existing non-native-tools contract
- Verification focus: Ollama-only regressions
- Confirmation: naming + architecture boundaries followed (AGENTS.md + CONTRIBUTING.md): Yes

## Rollback Plan (required)

- Fast rollback command/path: revert commit 3f2ae5ab
- Feature flags or config toggles (if any): none
- Observable failure symptoms: Ollama tool-based prompts start returning 500 EOF again on models that do not support native tool arrays.

## Risks and Mitigations

- Risk:
  - Native-tool-capable Ollama models will not use native tools through this provider path.
- Mitigation:
  - That is already the advertised provider behavior (`supports_native_tools() == false`); this change only makes the live request path consistent with the contract.
