### PR TITLE
fix(cron): add claim/release lock to prevent repeated job execution

### DIFF
--- a/crates/zeroclaw-runtime/src/cron/mod.rs
+++ b/crates/zeroclaw-runtime/src/cron/mod.rs
@@ -14,8 +14,9 @@ pub use schedule::{
 };
 #[allow(unused_imports)]
 pub use store::{
-    add_agent_job, all_overdue_jobs, due_jobs, get_job, list_jobs, list_runs, record_last_run,
-    record_run, remove_job, reschedule_after_run, sync_declarative_jobs, update_job,
+    add_agent_job, all_overdue_jobs, claim_job, due_jobs, get_job, list_jobs, list_runs,
+    record_last_run, record_run, release_job, remove_job, reschedule_after_run,
+    sync_declarative_jobs, unlock_all_jobs, update_job,
 };
 pub use types::{
     CronJob, CronJobPatch, CronRun, DeliveryConfig, JobType, Schedule, SessionTarget,

--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -1,7 +1,7 @@
 use crate::cron::{
     CronJob, CronJobPatch, DeliveryConfig, JobType, Schedule, SessionTarget, all_overdue_jobs,
-    due_jobs, next_run_for_schedule, record_last_run, record_run, remove_job, reschedule_after_run,
-    sync_declarative_jobs, update_job,
+    claim_job, due_jobs, next_run_for_schedule, record_last_run, record_run, release_job,
+    remove_job, reschedule_after_run, sync_declarative_jobs, unlock_all_jobs, update_job,
 };
 use crate::security::SecurityPolicy;
 use anyhow::Result;
@@ -70,6 +70,11 @@ pub async fn run(config: Config, event_tx: EventBroadcast) -> Result<()> {
             }
         }
         Err(e) => tracing::warn!("Failed to sync declarative cron jobs: {e}"),
+    }
+
+    // Clear any stale execution locks left behind by a previous crash.
+    if let Err(e) = unlock_all_jobs(&config) {
+        tracing::warn!("Failed to unlock cron jobs at startup: {e}");
     }
 
     // ── Startup catch-up: run ALL overdue jobs before entering the
@@ -228,6 +233,25 @@ async fn execute_and_persist_job(
     crate::health::mark_component_ok(component);
     warn_if_high_frequency_agent_job(job);
 
+    // Claim the job atomically so concurrent scheduler polls cannot
+    // select it again while it is already in flight.
+    match claim_job(config, &job.id) {
+        Ok(true) => {}
+        Ok(false) => {
+            // In test environments a job may be constructed directly and passed
+            // to process_due_jobs without ever being inserted into the DB.
+            // Only skip when the job really exists and is already locked.
+            if crate::cron::get_job(config, &job.id).is_ok() {
+                tracing::warn!(job_id = %job.id, "Cron job is already locked; skipping duplicate execution");
+                return (job.id.clone(), false, "job already in flight".to_string());
+            }
+        }
+        Err(e) => {
+            tracing::warn!(job_id = %job.id, "Failed to claim cron job: {e}");
+            return (job.id.clone(), false, format!("claim failed: {e}"));
+        }
+    }
+
     let started_at = Utc::now();
     let (success, output) = Box::pin(execute_job_with_retry(config, security, job)).await;
     let finished_at = Utc::now();
@@ -240,6 +264,10 @@ async fn execute_and_persist_job(
         finished_at,
     ))
     .await;
+
+    if let Err(e) = release_job(config, &job.id) {
+        tracing::warn!(job_id = %job.id, "Failed to release cron job lock: {e}");
+    }
 
     (job.id.clone(), success, output)
 }

--- a/crates/zeroclaw-runtime/src/cron/store.rs
+++ b/crates/zeroclaw-runtime/src/cron/store.rs
@@ -180,7 +180,7 @@ pub fn due_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJob>> {
                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
                     allowed_tools, source, uses_memory
              FROM cron_jobs
-             WHERE enabled = 1 AND next_run <= ?1
+             WHERE enabled = 1 AND next_run <= ?1 AND locked_at IS NULL
              ORDER BY next_run ASC
              LIMIT ?2",
         )?;
@@ -210,7 +210,7 @@ pub fn all_overdue_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJ
                     enabled, delivery, delete_after_run, created_at, next_run, last_run, last_status, last_output,
                     allowed_tools, source, uses_memory
              FROM cron_jobs
-             WHERE enabled = 1 AND next_run <= ?1
+             WHERE enabled = 1 AND next_run <= ?1 AND locked_at IS NULL
              ORDER BY next_run ASC",
         )?;
 
@@ -224,6 +224,52 @@ pub fn all_overdue_jobs(config: &Config, now: DateTime<Utc>) -> Result<Vec<CronJ
             }
         }
         Ok(jobs)
+    })
+}
+
+/// Atomically claim a cron job for execution by setting `locked_at`.
+///
+/// Returns `true` if the claim succeeded (the job was not already locked),
+/// `false` if another execution already holds the lock.
+pub fn claim_job(config: &Config, job_id: &str) -> Result<bool> {
+    let now = Utc::now();
+    with_connection(config, |conn| {
+        let changed = conn
+            .execute(
+                "UPDATE cron_jobs SET locked_at = ?1 WHERE id = ?2 AND locked_at IS NULL",
+                params![now.to_rfc3339(), job_id],
+            )
+            .context("Failed to claim cron job")?;
+        Ok(changed > 0)
+    })
+}
+
+/// Release the execution lock on a cron job.
+pub fn release_job(config: &Config, job_id: &str) -> Result<()> {
+    with_connection(config, |conn| {
+        conn.execute(
+            "UPDATE cron_jobs SET locked_at = NULL WHERE id = ?1",
+            params![job_id],
+        )
+        .context("Failed to release cron job lock")?;
+        Ok(())
+    })
+}
+
+/// Unlock all jobs. Called once at scheduler startup to clear stale locks
+/// left behind by a previous process crash.
+pub fn unlock_all_jobs(config: &Config) -> Result<()> {
+    with_connection(config, |conn| {
+        let changed = conn
+            .execute(
+                "UPDATE cron_jobs SET locked_at = NULL WHERE locked_at IS NOT NULL",
+                [],
+            )
+            .context("Failed to unlock cron jobs")?;
+        if changed > 0 {
+            tracing::info!(count = changed, "Unlocked stale cron jobs after restart");
+        }
+        Ok(())
     })
 }
 
@@ -944,6 +990,7 @@ fn with_connection<T>(config: &Config, f: impl FnOnce(&Connection) -> Result<T>)
     add_column_if_missing(&conn, "allowed_tools", "TEXT")?;
     add_column_if_missing(&conn, "source", "TEXT DEFAULT 'imperative'")?;
     add_column_if_missing(&conn, "uses_memory", "INTEGER NOT NULL DEFAULT 1")?;
+    add_column_if_missing(&conn, "locked_at", "TEXT")?;
 
     f(&conn)
 }
@@ -1704,5 +1751,96 @@ schedule = { kind = "every", every_ms = 300000 }
             parsed.jobs[1].schedule,
             zeroclaw_config::schema::CronScheduleDecl::Every { every_ms: 300_000 }
         ));
+    }
+
+    // ── Job locking tests ──────────────────────────────────────────
+
+    #[test]
+    fn claim_job_prevents_duplicate_claims() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let job = add_job(&config, "*/5 * * * *", "echo lock-test").unwrap();
+
+        // First claim should succeed
+        assert!(claim_job(&config, &job.id).unwrap());
+
+        // Second claim should fail (already locked)
+        assert!(!claim_job(&config, &job.id).unwrap());
+    }
+
+    #[test]
+    fn release_job_allows_reclaim() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let job = add_job(&config, "*/5 * * * *", "echo lock-test").unwrap();
+
+        assert!(claim_job(&config, &job.id).unwrap());
+        release_job(&config, &job.id).unwrap();
+
+        // After release, claim should succeed again
+        assert!(claim_job(&config, &job.id).unwrap());
+    }
+
+    #[test]
+    fn due_jobs_excludes_locked_jobs() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let job = add_job(&config, "* * * * *", "echo due").unwrap();
+        let far_future = Utc::now() + ChronoDuration::days(365);
+
+        // Job should be due
+        let due = due_jobs(&config, far_future).unwrap();
+        assert_eq!(due.len(), 1);
+
+        // Lock the job
+        assert!(claim_job(&config, &job.id).unwrap());
+
+        // Locked job should no longer appear as due
+        let due_after_lock = due_jobs(&config, far_future).unwrap();
+        assert!(due_after_lock.is_empty(), "locked job should not be due");
+    }
+
+    #[test]
+    fn all_overdue_jobs_excludes_locked_jobs() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let job = add_job(&config, "* * * * *", "echo overdue").unwrap();
+        let far_future = Utc::now() + ChronoDuration::days(365);
+
+        let overdue = all_overdue_jobs(&config, far_future).unwrap();
+        assert_eq!(overdue.len(), 1);
+
+        claim_job(&config, &job.id).unwrap();
+
+        let overdue_after_lock = all_overdue_jobs(&config, far_future).unwrap();
+        assert!(
+            overdue_after_lock.is_empty(),
+            "locked job should not be overdue"
+        );
+    }
+
+    #[test]
+    fn unlock_all_jobs_clears_stale_locks() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let job1 = add_job(&config, "* * * * *", "echo unlock-1").unwrap();
+        let job2 = add_job(&config, "* * * * *", "echo unlock-2").unwrap();
+
+        claim_job(&config, &job1.id).unwrap();
+        claim_job(&config, &job2.id).unwrap();
+
+        let far_future = Utc::now() + ChronoDuration::days(365);
+        assert!(due_jobs(&config, far_future).unwrap().is_empty());
+
+        unlock_all_jobs(&config).unwrap();
+
+        // After unlock_all_jobs, both jobs should be due again
+        let due = due_jobs(&config, far_future).unwrap();
+        assert_eq!(due.len(), 2);
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  The scheduler selected due jobs based only on `next_run <= now`, without checking whether a job was already in flight. If a job ran longer than the poll interval (default 15s), the next poll would select it again and launch duplicate executions. In the reported case (#6037), a daily job was executed 20 times in a 3-minute window.

- **Scope boundary:** Only `crates/zeroclaw-runtime/src/cron/store.rs` and `scheduler.rs`. No change to job semantics, schedule calculation, or external APIs.

## Changes

1. **Schema migration:** Added `locked_at TEXT` column to `cron_jobs` (auto-migrated via `add_column_if_missing`).
2. **Query filters:** `due_jobs()` and `all_overdue_jobs()` now exclude rows where `locked_at IS NOT NULL`.
3. **Claim before execute:** `claim_job()` atomically sets `locked_at` via `UPDATE ... WHERE locked_at IS NULL`.
4. **Release after execute:** `release_job()` clears the lock in `persist_job_result` (runs on both success and failure).
5. **Crash recovery:** `unlock_all_jobs()` runs once at scheduler startup to clear stale locks left by a previous crash.

## Verification

Added 5 regression tests in `store.rs`:
- `claim_job_prevents_duplicate_claims`
- `release_job_allows_reclaim`
- `due_jobs_excludes_locked_jobs`
- `all_overdue_jobs_excludes_locked_jobs`
- `unlock_all_jobs_clears_stale_locks`

## Compatibility

- Existing databases are auto-migrated on next scheduler startup.
- No config changes required.
- No behavior change for jobs that finish within the poll interval.

Closes #6037