### PR TITLE
fix(windows): unbreak cargo test and add update self-update target triples

### DIFF
--- a/crates/zeroclaw-tui/src/onboarding.rs
+++ b/crates/zeroclaw-tui/src/onboarding.rs
@@ -12,7 +12,10 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Paragraph},
 };
-use std::io::{self, IsTerminal};
+
+use std::io;
+#[cfg(unix)]
+use std::io::IsTerminal;
 
 use zeroclaw_config::schema::Config;
 use zeroclaw_config::schema::{

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -178,6 +178,14 @@ fn current_target_triple() -> &'static str {
         } else {
             "x86_64-unknown-linux-gnu"
         }
+    } else if cfg!(target_os = "windows") {
+        if cfg!(target_arch = "aarch64") {
+            "aarch64-pc-windows-msvc"
+        } else if cfg!(target_env = "gnu") {
+            "x86_64-pc-windows-gnu"
+        } else {
+            "x86_64-pc-windows-msvc"
+        }
     } else {
         "unknown"
     }
@@ -444,6 +452,8 @@ mod tests {
             "zeroclaw-x86_64-unknown-linux-gnu.tar.gz",
             "zeroclaw-x86_64-apple-darwin.tar.gz",
             "zeroclaw-aarch64-apple-darwin.tar.gz",
+            "zeroclaw-x86_64-pc-windows-msvc.zip",
+            "zeroclaw-aarch64-pc-windows-msvc.zip",
         ]);
 
         let url = find_asset_url(&release);

--- a/src/tunnel/mod.rs
+++ b/src/tunnel/mod.rs
@@ -272,8 +272,17 @@ mod tests {
     async fn kill_shared_terminates_and_clears_child() {
         let proc = new_shared_process();
 
-        let child = Command::new("sleep")
-            .arg("30")
+        let mut cmd = if cfg!(target_os = "windows") {
+            let mut c = Command::new("ping");
+            c.args(["-n", "30", "127.0.0.1"]);
+            c
+        } else {
+            let mut c = Command::new("sleep");
+            c.args(["30"]);
+            c
+        };
+
+        let child = cmd
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - The tunnel lifecycle test `kill_shared_terminates_and_clears_child` hardcoded `Command::new("sleep")`, which is not a Windows built-in or on the default `PATH`. Cfg-gated the spawn so Unix keeps `sleep 30` and Windows uses `ping -n 30 127.0.0.1` (`ping.exe` ships with Windows and needs no stdin). The child is killed immediately, so the duration is irrelevant.
  - `IsTerminal` was imported unconditionally in `crates/zeroclaw-tui/src/onboarding.rs` but is only referenced inside a `#[cfg(unix)]` block, producing an `unused_imports` warning on Windows. Gated the import with `#[cfg(unix)]` so the trait is only brought into scope where it is used.
  - `current_target_triple` in `src/commands/update.rs` had no Windows branches, so `zeroclaw update` resolved to `"unknown"` on Windows and silently skipped self-update. Added `x86_64-pc-windows-msvc`, `x86_64-pc-windows-gnu`, and `aarch64-pc-windows-msvc`, and extended the asset-matcher test with the corresponding `.zip` release artifacts so the matcher proves it selects the right Windows asset.
- **Scope boundary:**
  - Does **not** modify the duplicate `kill_shared_terminates_and_clears_child` test in `crates/zeroclaw-runtime/src/tunnel/mod.rs:430` — it currently passes (it resolves `sleep` when Git-for-Windows/MSYS provides it on `PATH`) and fixing it is a cosmetic consistency change that belongs in a follow-up.
  - Does **not** add the Windows release-artifact build/packaging pipeline — only the target-triple detection and matcher. Producing `.zip` artifacts remains the responsibility of release CI.
  - Does **not** add Windows to CI coverage.
- **Blast radius:**
  - `zeroclaw update` on Windows hosts now resolves to a real triple; Linux/macOS triple detection paths are untouched (the new branches are gated on `cfg!(target_os = "windows")`).
  - TUI onboarding entry point on Windows: no runtime change, only silences the compile warning.
  - The tunnel lifecycle test is now deterministic on Windows regardless of `PATH` contents; Unix behavior is byte-identical.
- **Linked issue(s):** Related #6020 

## Validation Evidence (required)

- **Commands run and tail output:**

  ```text
  $ cargo fmt --all -- --check
  EXIT=0   (no output)

  $ cargo test --locked
       Running unittests src\lib.rs       — ok. 234 passed; 0 failed; 0 ignored
       Running unittests src\main.rs      — ok. 226 passed; 0 failed; 0 ignored
       Running tests\test_component.rs    — ok. 205 passed; 0 failed; 0 ignored
       Running tests\test_integration.rs  — ok. 159 passed; 0 failed; 0 ignored
       Running tests\test_live.rs         — ok.   0 passed; 0 failed; 7 ignored
       Running tests\test_system.rs       — ok.   5 passed; 0 failed; 0 ignored
       Doc-tests zeroclaw                 — ok.   0 passed; 0 failed; 0 ignored
  Total: 829 passed, 0 failed, 7 ignored (live-provider OAuth tests, by design).
  ```

- **Beyond CI — what did you manually verify?**
  - Reproduced the original failure on Windows 11 with a shell whose `PATH` does not contain a Unix `sleep` (panic `NotFound: program not found` at `src/tunnel/mod.rs:280`).
  - After the fix, ran the previously failing test both in isolation and as part of the full `cargo test --locked` suite on Windows 11 — green.
  - Confirmed the `unused_imports` warning for `IsTerminal` no longer appears on a Windows build.
  - Did **not** verify the `update.rs` change end-to-end against a real Windows GitHub release payload — only the asset-matcher unit test covers the behavior.
- **If any command was intentionally skipped, why:**
  - `cargo clippy --all-targets -- -D warnings` was not run locally in this change session; deferring to CI. Please re-run locally if CI surfaces anything.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk. `git revert <sha>` on either or both of:
- `fix(tests): spawn cross-platform lifecycle process in tunnel kill_shared test` (6bb7c2d6)
- `feat(update): detect Windows target triples and match Windows release assets` (493d4b81)

## Supersede Attribution

_N/A — no superseded PR._

## i18n Follow-Through

_N/A — no docs or user-facing wording changed._