### PR TITLE
feature(security) Implement bypass for shell policy validation (DO NOT MERGE)

### DIFF
--- a/crates/zeroclaw-runtime/src/tools/shell.rs
+++ b/crates/zeroclaw-runtime/src/tools/shell.rs
@@ -107,6 +107,16 @@ fn collect_allowed_shell_env_vars(security: &SecurityPolicy) -> Vec<String> {
     out
 }
 
+fn bypass_shell_policy_enabled() -> bool {
+    std::env::var("ZEROCLAW_BYPASS_SHELL_POLICY")
+        .ok()
+        .map(|v| {
+            let normalized = v.trim().to_ascii_lowercase();
+            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+        })
+        .unwrap_or(false)
+}
+
 #[async_trait]
 impl Tool for ShellTool {
     fn name(&self) -> &str {
@@ -145,15 +155,21 @@ impl Tool for ShellTool {
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        match self.security.validate_command_execution(command, approved) {
-            Ok(_) => {}
-            Err(reason) => {
-                return Ok(ToolResult {
-                    success: false,
-                    output: String::new(),
-                    error: Some(reason),
-                });
+        if !bypass_shell_policy_enabled() {
+            match self.security.validate_command_execution(command, approved) {
+                Ok(_) => {}
+                Err(reason) => {
+                    return Ok(ToolResult {
+                        success: false,
+                        output: String::new(),
+                        error: Some(reason),
+                    });
+                }
             }
+        } else {
+            tracing::warn!(
+                "ZEROCLAW_BYPASS_SHELL_POLICY is enabled; skipping shell command policy validation"
+            );
         }
 
         // Execute with timeout to prevent hanging commands.


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** Adds a `ZEROCLAW_BYPASS_SHELL_POLICY` environment variable that, when set to a truthy value (`1`/`true`/`yes`/`on`), skips `validate_command_execution` for the shell tool and emits a `tracing::warn!` instead. Intended as a local-dev escape hatch for debugging shell policy rules.
- **Scope boundary:** Shell tool only. Does not touch other security validators (filesystem, network, subprocess) nor the policy configuration surface.
- **Blast radius:** The entire shell-command trust boundary — if the env var is set, every shell invocation executes unchecked, including in agent loops where untrusted input can reach the tool.
- **Linked issue(s):** _none_

## Validation Evidence (required)

- **Commands run and tail output:** Not provided.
- **Beyond CI — what did you manually verify?** Author states "I ran this in my setup. It does exactly that."
- **If any command was intentionally skipped, why:** Not documented.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **Yes** — the env var grants unchecked shell execution, effectively removing the shell policy trust boundary at runtime when set.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.
- **Risk and mitigation:** Mitigation is the `tracing::warn!` log line. No config-level gating, no onboarding friction (single env var), no audit trail beyond the log line.

## Compatibility (required)

- Backward compatible? Yes — opt-in via a new env var. Existing deployments without the env var keep the current policy enforcement.
- Config / env / CLI surface changed? Yes — introduces `ZEROCLAW_BYPASS_SHELL_POLICY`.
- Upgrade steps: none for existing users.

## Rollback (required for `risk: high`)

- **Fast rollback command/path:** `git revert <sha>` or `unset ZEROCLAW_BYPASS_SHELL_POLICY` on affected deployments.
- **Feature flags or config toggles:** The env var itself. No config schema entry.
- **Observable failure symptoms:** `tracing::warn!` messages matching `ZEROCLAW_BYPASS_SHELL_POLICY is enabled`. Any shell command executing without a corresponding policy-validated audit trail.

## i18n Follow-Through

Not applicable — no user-facing strings or docs changed.

---

_Note from @singlerider: I reformatted this PR body to conform to the repo's PR template. The original body was a placeholder; diff contents and author intent are unchanged._