### PR TITLE
feat(channels): configurable reply-intent precheck model + timeout

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -3066,15 +3066,59 @@ async fn process_channel_message(
     }
 
     // ── Reply-intent precheck ────────────────────────────────────────
-    let reply_intent = classify_channel_reply_intent(
-        active_provider.as_ref(),
-        history[0].content.as_str(),
-        &history,
-        route.model.as_str(),
-        runtime_defaults.temperature,
-    )
-    .await
-    .unwrap_or(AssistantChannelOutcome::Reply(String::new()));
+    let precheck_cfg = ctx.prompt_config.agent.precheck.clone();
+    let reply_intent = if precheck_cfg.enabled {
+        let precheck_model = precheck_cfg
+            .model
+            .as_deref()
+            .unwrap_or(route.model.as_str());
+        let precheck_start = Instant::now();
+        let precheck_timeout = Duration::from_secs(precheck_cfg.timeout_secs);
+        match tokio::time::timeout(
+            precheck_timeout,
+            classify_channel_reply_intent(
+                active_provider.as_ref(),
+                history[0].content.as_str(),
+                &history,
+                precheck_model,
+                runtime_defaults.temperature,
+            ),
+        )
+        .await
+        {
+            Ok(Ok(outcome)) => {
+                #[allow(clippy::cast_possible_truncation)]
+                let elapsed_ms = precheck_start.elapsed().as_millis() as u64;
+                tracing::info!(
+                    elapsed_ms,
+                    model = precheck_model,
+                    "⏱ Reply-intent precheck completed"
+                );
+                outcome
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(
+                    error = %e,
+                    model = precheck_model,
+                    "Reply-intent precheck failed, defaulting to REPLY"
+                );
+                AssistantChannelOutcome::Reply(String::new())
+            }
+            Err(_) => {
+                #[allow(clippy::cast_possible_truncation)]
+                let elapsed_ms = precheck_start.elapsed().as_millis() as u64;
+                tracing::warn!(
+                    elapsed_ms,
+                    timeout_secs = precheck_cfg.timeout_secs,
+                    model = precheck_model,
+                    "Reply-intent precheck timed out, defaulting to REPLY"
+                );
+                AssistantChannelOutcome::Reply(String::new())
+            }
+        }
+    } else {
+        AssistantChannelOutcome::Reply(String::new())
+    };
 
     if let AssistantChannelOutcome::NoReply { kind, reason } = reply_intent {
         let history_response = AssistantChannelOutcome::NoReply {
@@ -7151,6 +7195,55 @@ mod tests {
         }
     }
 
+    /// Provider that records every `model` value passed to `chat_with_system`
+    /// and short-circuits the agent loop with `NO_REPLY`. Lets a test assert
+    /// which model the precheck used vs the route model.
+    #[derive(Default)]
+    struct PrecheckModelCaptureProvider {
+        models: std::sync::Mutex<Vec<String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for PrecheckModelCaptureProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            self.models
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .push(model.to_string());
+            Ok("NO_REPLY: not addressed".to_string())
+        }
+    }
+
+    /// Provider that stalls the precheck call (detected by the classifier's
+    /// prompt prefix) so the orchestrator's `tokio::time::timeout` fires, while
+    /// returning instantly for any post-fail-open agent calls so the test does
+    /// not hang.
+    struct PrecheckSlowProvider;
+
+    #[async_trait::async_trait]
+    impl Provider for PrecheckSlowProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            message: &str,
+            _model: &str,
+            _temperature: Option<f64>,
+        ) -> anyhow::Result<String> {
+            if message.starts_with("Decide whether the assistant should send any visible reply") {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                Ok("REPLY".to_string())
+            } else {
+                Ok("ok".to_string())
+            }
+        }
+    }
+
     struct FormatErrorProvider;
 
     #[async_trait::async_trait]
@@ -9984,6 +10077,218 @@ BTC is currently around $65,000 based on latest tool output."#
 
         let starts = channel_impl.start_typing_calls.load(Ordering::SeqCst);
         assert_eq!(starts, 0, "no-reply precheck should not show typing");
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_precheck_uses_configured_model_override() {
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let provider_impl = Arc::new(PrecheckModelCaptureProvider::default());
+        let provider: Arc<dyn Provider> = provider_impl.clone();
+
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.agent.precheck.model = Some("precheck-fast".to_string());
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider,
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("main-route-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 10,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(MAX_CONVERSATION_SENDERS).unwrap(),
+            ))),
+            pending_new_sessions: Arc::new(Mutex::new(HashSet::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
+            provider_runtime_options: zeroclaw_providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            prompt_config: Arc::new(config),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: InterruptOnNewMessageConfig {
+                telegram: false,
+                slack: false,
+                discord: false,
+                mattermost: false,
+                matrix: false,
+            },
+            multimodal: zeroclaw_config::schema::MultimodalConfig::default(),
+            media_pipeline: zeroclaw_config::schema::MediaPipelineConfig::default(),
+            transcription_config: zeroclaw_config::schema::TranscriptionConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Vec::new()),
+            autonomy_level: AutonomyLevel::default(),
+            tool_call_dedup_exempt: Arc::new(Vec::new()),
+            model_routes: Arc::new(Vec::new()),
+            query_classification: zeroclaw_config::schema::QueryClassificationConfig::default(),
+            ack_reactions: true,
+            show_tool_calls: true,
+            session_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(
+                &zeroclaw_config::schema::AutonomyConfig::default(),
+            )),
+            activated_tools: None,
+            cost_tracking: None,
+            pacing: zeroclaw_config::schema::PacingConfig::default(),
+            max_tool_result_chars: 0,
+            context_token_budget: 0,
+            debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
+                Duration::ZERO,
+            )),
+        });
+
+        process_channel_message(
+            runtime_ctx,
+            zeroclaw_api::channel::ChannelMessage {
+                id: "precheck-model-msg".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-precheck-model".to_string(),
+                content: "hello".to_string(),
+                channel: "test-channel".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+            },
+            CancellationToken::new(),
+        )
+        .await;
+
+        let models = provider_impl
+            .models
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        assert_eq!(
+            models.as_slice(),
+            &["precheck-fast".to_string()],
+            "precheck must use the configured model override; main loop must be skipped on NO_REPLY"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_channel_message_precheck_timeout_fails_open_to_reply() {
+        let channel_impl = Arc::new(RecordingChannel::default());
+        let channel: Arc<dyn Channel> = channel_impl.clone();
+
+        let mut channels_by_name = HashMap::new();
+        channels_by_name.insert(channel.name().to_string(), channel);
+
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.agent.precheck.timeout_secs = 1;
+
+        let runtime_ctx = Arc::new(ChannelRuntimeContext {
+            channels_by_name: Arc::new(channels_by_name),
+            provider: Arc::new(PrecheckSlowProvider),
+            default_provider: Arc::new("test-provider".to_string()),
+            memory: Arc::new(NoopMemory),
+            tools_registry: Arc::new(vec![]),
+            observer: Arc::new(NoopObserver),
+            system_prompt: Arc::new("test-system-prompt".to_string()),
+            model: Arc::new("test-model".to_string()),
+            temperature: 0.0,
+            auto_save_memory: false,
+            max_tool_iterations: 10,
+            min_relevance_score: 0.0,
+            conversation_histories: Arc::new(Mutex::new(lru::LruCache::new(
+                std::num::NonZeroUsize::new(MAX_CONVERSATION_SENDERS).unwrap(),
+            ))),
+            pending_new_sessions: Arc::new(Mutex::new(HashSet::new())),
+            provider_cache: Arc::new(Mutex::new(HashMap::new())),
+            route_overrides: Arc::new(Mutex::new(HashMap::new())),
+            api_key: None,
+            api_url: None,
+            reliability: Arc::new(zeroclaw_config::schema::ReliabilityConfig::default()),
+            provider_runtime_options: zeroclaw_providers::ProviderRuntimeOptions::default(),
+            workspace_dir: Arc::new(std::env::temp_dir()),
+            prompt_config: Arc::new(config),
+            message_timeout_secs: CHANNEL_MESSAGE_TIMEOUT_SECS,
+            interrupt_on_new_message: InterruptOnNewMessageConfig {
+                telegram: false,
+                slack: false,
+                discord: false,
+                mattermost: false,
+                matrix: false,
+            },
+            multimodal: zeroclaw_config::schema::MultimodalConfig::default(),
+            media_pipeline: zeroclaw_config::schema::MediaPipelineConfig::default(),
+            transcription_config: zeroclaw_config::schema::TranscriptionConfig::default(),
+            hooks: None,
+            non_cli_excluded_tools: Arc::new(Vec::new()),
+            autonomy_level: AutonomyLevel::default(),
+            tool_call_dedup_exempt: Arc::new(Vec::new()),
+            model_routes: Arc::new(Vec::new()),
+            query_classification: zeroclaw_config::schema::QueryClassificationConfig::default(),
+            ack_reactions: true,
+            show_tool_calls: true,
+            session_store: None,
+            approval_manager: Arc::new(ApprovalManager::for_non_interactive(
+                &zeroclaw_config::schema::AutonomyConfig::default(),
+            )),
+            activated_tools: None,
+            cost_tracking: None,
+            pacing: zeroclaw_config::schema::PacingConfig::default(),
+            max_tool_result_chars: 0,
+            context_token_budget: 0,
+            debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
+                Duration::ZERO,
+            )),
+        });
+
+        let started = Instant::now();
+        process_channel_message(
+            runtime_ctx,
+            zeroclaw_api::channel::ChannelMessage {
+                id: "precheck-timeout-msg".to_string(),
+                sender: "alice".to_string(),
+                reply_target: "chat-precheck-timeout".to_string(),
+                content: "hello".to_string(),
+                channel: "test-channel".to_string(),
+                timestamp: 1,
+                thread_ts: None,
+                interruption_scope_id: None,
+                attachments: vec![],
+            },
+            CancellationToken::new(),
+        )
+        .await;
+        let total = started.elapsed();
+
+        // Fail-open after precheck timeout means the main agent loop runs and
+        // delivers a reply. The slow precheck would otherwise hang for 60s.
+        let sent = channel_impl.sent_messages.lock().await.clone();
+        assert_eq!(
+            sent.len(),
+            1,
+            "fail-open after precheck timeout should send exactly one reply, got {sent:?}"
+        );
+        assert!(
+            sent[0].ends_with(":ok"),
+            "expected reply body 'ok' from main loop, got {:?}",
+            sent[0]
+        );
+        assert!(
+            total >= Duration::from_millis(900),
+            "process_channel_message returned in {total:?}; precheck timeout should have waited ~1s"
+        );
+        assert!(
+            total < Duration::from_secs(10),
+            "process_channel_message took {total:?}; should not have waited for the 60s slow precheck"
+        );
     }
 
     #[tokio::test]

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -10149,6 +10149,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         process_channel_message(
@@ -10247,6 +10249,8 @@ BTC is currently around $65,000 based on latest tool output."#
             debouncer: Arc::new(zeroclaw_infra::debounce::MessageDebouncer::new(
                 Duration::ZERO,
             )),
+            receipt_generator: None,
+            show_receipts_in_response: false,
         });
 
         let started = Instant::now();

--- a/crates/zeroclaw-config/src/scattered_types.rs
+++ b/crates/zeroclaw-config/src/scattered_types.rs
@@ -231,6 +231,54 @@ impl Default for ContextCompressionConfig {
     }
 }
 
+fn default_precheck_enabled() -> bool {
+    true
+}
+fn default_precheck_timeout_secs() -> u64 {
+    5
+}
+
+/// Channel reply-intent precheck configuration.
+///
+/// The precheck runs a lightweight `REPLY` / `NO_REPLY` classifier before the
+/// main agent loop so group-chat messages that are not addressed to the
+/// assistant do not trigger a full tool-using turn. By default it reuses the
+/// main route model, which can be unnecessarily slow on large reasoning
+/// models — set `model` to a literal model name served by the same provider
+/// to delegate the classification to a faster/cheaper model. A hard
+/// `timeout_secs` keeps a slow provider from blocking the whole turn; on
+/// timeout the precheck fails open to REPLY.
+#[derive(Debug, Clone, Serialize, Deserialize, Configurable)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+#[prefix = "agent.precheck"]
+pub struct ChannelPrecheckConfig {
+    /// When false, the precheck is skipped entirely and every channel message
+    /// triggers the full agent loop. Default: `true`.
+    #[serde(default = "default_precheck_enabled")]
+    pub enabled: bool,
+    /// Model used for the precheck classification call. When `None`, falls
+    /// back to the route model used by the main agent turn. Must be a literal
+    /// model name served by the same provider as the route model — the
+    /// channel orchestrator does not resolve `hint:<name>` routing hints.
+    /// Default: `None`.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Hard ceiling (seconds) on the precheck LLM call. On timeout the
+    /// precheck fails open to REPLY. Default: `5`.
+    #[serde(default = "default_precheck_timeout_secs")]
+    pub timeout_secs: u64,
+}
+
+impl Default for ChannelPrecheckConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_precheck_enabled(),
+            model: None,
+            timeout_secs: default_precheck_timeout_secs(),
+        }
+    }
+}
+
 // ── Tools config types ──────────────────────────────────────────
 
 fn default_browser_cli() -> String {

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -1635,6 +1635,11 @@ pub struct AgentConfig {
     #[serde(default)]
     pub context_compression: crate::scattered_types::ContextCompressionConfig,
 
+    /// Channel reply-intent precheck configuration (model override, timeout).
+    #[nested]
+    #[serde(default)]
+    pub precheck: crate::scattered_types::ChannelPrecheckConfig,
+
     /// Maximum characters for a single tool result before truncation.
     /// Head (2/3) and tail (1/3) are preserved with a truncation marker in the
     /// middle. Set to `0` to disable truncation. Default: `50000`.
@@ -1700,6 +1705,7 @@ impl Default for AgentConfig {
             eval: crate::scattered_types::EvalConfig::default(),
             auto_classify: None,
             context_compression: crate::scattered_types::ContextCompressionConfig::default(),
+            precheck: crate::scattered_types::ChannelPrecheckConfig::default(),
             max_tool_result_chars: default_max_tool_result_chars(),
             keep_tool_context_turns: default_keep_tool_context_turns(),
             tool_receipts: ToolReceiptsConfig::default(),

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -11354,6 +11354,26 @@ impl Config {
             }
         }
 
+        // Channel reply-intent precheck. Zero timeout or empty/whitespace model would
+        // silently fail open to REPLY and quietly disable the group-chat noise filter
+        // — reject the typo cases explicitly. Use `enabled = false` to disable instead.
+        if self.agent.precheck.timeout_secs == 0 {
+            validation_bail!(
+                InvalidNumericRange,
+                "agent.precheck.timeout_secs",
+                "agent.precheck.timeout_secs must be greater than 0 (use agent.precheck.enabled = false to disable the precheck)"
+            );
+        }
+        if let Some(ref model) = self.agent.precheck.model
+            && model.trim().is_empty()
+        {
+            validation_bail!(
+                RequiredFieldEmpty,
+                "agent.precheck.model",
+                "agent.precheck.model must not be empty or whitespace; omit the key to fall back to the route model"
+            );
+        }
+
         Ok(())
     }
 
@@ -15989,6 +16009,47 @@ default_model = "persisted-profile"
                 ..Default::default()
             },
         );
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    async fn validate_rejects_precheck_timeout_zero() {
+        let mut config = Config::default();
+        config.agent.precheck.timeout_secs = 0;
+        let err = config.validate().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("agent.precheck.timeout_secs") && msg.contains("greater than 0"),
+            "expected precheck timeout validation error, got: {msg}"
+        );
+    }
+
+    #[test]
+    async fn validate_rejects_precheck_empty_model() {
+        let mut config = Config::default();
+        config.agent.precheck.model = Some("   ".into());
+        let err = config.validate().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("agent.precheck.model"),
+            "expected precheck model validation error, got: {msg}"
+        );
+    }
+
+    #[test]
+    async fn validate_accepts_default_precheck() {
+        let config = Config::default();
+        assert!(
+            config.validate().is_ok(),
+            "default ChannelPrecheckConfig must pass validation"
+        );
+    }
+
+    #[test]
+    async fn validate_accepts_precheck_model_override() {
+        let mut config = Config::default();
+        config.agent.precheck.model = Some("fast-classifier".into());
+        config.agent.precheck.timeout_secs = 3;
         assert!(config.validate().is_ok());
     }
 


### PR DESCRIPTION
## Summary

- Adds `[agent.precheck]` config so the channel reply-intent classifier can route to a lighter/faster model, instead of always using the main route model.
- Wraps the precheck call in a hard `timeout_secs` (default `5`); on timeout or error it fails open to `REPLY` so a slow provider cannot block the whole turn.
- Emits an `elapsed_ms` tracing log — the precheck cost used to be invisible and showed up only as a silent gap between `Memory recall completed` and `Starting LLM call` (see #6067 for the 57-second Venice case).

Pattern mirrors the existing `ContextCompressionConfig.summary_model` precedent (`crates/zeroclaw-runtime/src/agent/context_compressor.rs:311`, `crates/zeroclaw-config/src/scattered_types.rs:206`).

## Configuration

```toml
[agent.precheck]
enabled = true              # default true; set false to skip the precheck entirely
model = "gpt-4o-mini"       # default None → falls back to route.model
timeout_secs = 5            # default 5
```

`model` must be a literal model name served by the **same provider** as the route model. The channel orchestrator builds its provider via `create_resilient_provider_nonblocking` and does **not** wrap it in `RouterProvider`, so `hint:<name>` routing hints are not resolved here — passing one would forward the literal string `"hint:<name>"` to the provider and silently fail open to `REPLY`. Only the runtime agent loop resolves hints today.

## Backward compatibility

Defaults preserve current behavior except for the new 5s timeout — previously a slow precheck would block indefinitely. Operators who want the old indefinite behavior can set `timeout_secs` to a large value.

No schema migration required; the new block is fully optional.

## Test plan

- [x] `cargo check -p zeroclaw-config -p zeroclaw-channels` — clean
- [x] `cargo clippy -p zeroclaw-channels --lib --tests -- -D warnings` — clean
- [x] `cargo test -p zeroclaw-channels --lib -- precheck` — 3/3 pass:
  - `process_channel_message_no_reply_precheck_skips_typing_indicator` (pre-existing)
  - `process_channel_message_precheck_uses_configured_model_override` — provider records the `model` arg passed to `chat_with_system`; with `precheck.model = Some("precheck-fast")` and `ctx.model = "main-route-model"`, asserts the captured value is `"precheck-fast"` and the main agent loop is skipped on `NO_REPLY`
  - `process_channel_message_precheck_timeout_fails_open_to_reply` — `precheck.timeout_secs = 1` paired with a provider whose precheck call sleeps 60s; asserts the call returns within ~1s and the main loop runs, sending one reply to the recording channel
- [ ] Manual validation with a Venice route + a fast same-provider model — measure precheck latency drop via the new `elapsed_ms` log

## Related

Related #6067

This PR intentionally supports only literal same-provider model names — it does not resolve `hint:<name>` routing hints, which #6067 also asks for. Leaving the issue open so the routing-hint piece can be tracked separately.
