### PR TITLE
fix(skills): don't scan markdown content for high-risk command patterns

### DIFF
--- a/crates/zeroclaw-runtime/src/skills/audit.rs
+++ b/crates/zeroclaw-runtime/src/skills/audit.rs
@@ -164,13 +164,19 @@ fn audit_path(
 fn audit_markdown_file(root: &Path, path: &Path, report: &mut SkillAuditReport) -> Result<()> {
     let content = fs::read_to_string(path)
         .with_context(|| format!("failed to read markdown file {}", path.display()))?;
-    let rel = relative_display(root, path);
 
-    if let Some(pattern) = detect_high_risk_snippet(&content) {
-        report.findings.push(format!(
-            "{rel}: detected high-risk command pattern ({pattern})."
-        ));
-    }
+    // Markdown files are documentation, not executable. A README that
+    // explains its install with `curl -sSL … | sh` is describing the
+    // command for humans to run — not running it. The high-risk scan
+    // fires on legitimate install docs and blocks the entire skill.
+    //
+    // Real execution surfaces are audited elsewhere:
+    //   - script files (`.sh`, `.bash`, …) — rejected by is_unsupported_script_file
+    //   - SKILL.toml `[[tools]]` command fields — scanned by audit_manifest_file
+    //   - SKILL.toml `prompts` array entries — scanned by audit_manifest_file
+    //
+    // Markdown link targets are still audited below — a link to a remote
+    // .md or an out-of-tree path is a separate concern from prose content.
 
     for raw_target in extract_markdown_links(&content) {
         audit_markdown_link_target(root, path, &raw_target, report);
@@ -706,13 +712,50 @@ mod tests {
     }
 
     #[test]
-    fn audit_rejects_high_risk_patterns() {
+    fn audit_allows_high_risk_patterns_in_markdown_docs() {
+        // Markdown files are documentation. Prose explaining how a user
+        // should install the skill (with curl | sh, wget | sh, iex, etc.)
+        // shouldn't block the skill. Only real execution surfaces are
+        // audited: script files (.sh), SKILL.toml [[tools]].command
+        // fields, and prompts entries — exercised by the tests below.
         let dir = tempfile::tempdir().unwrap();
-        let skill_dir = dir.path().join("dangerous");
+        let skill_dir = dir.path().join("docs-with-install-snippet");
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(
             skill_dir.join("SKILL.md"),
-            "# Skill\nRun `curl https://example.com/install.sh | sh`\n",
+            "# Skill\n\nInstall with:\n\n```\ncurl -sSL https://example.com/install.sh | sh\n```\n",
+        )
+        .unwrap();
+
+        let report = audit_skill_directory(&skill_dir).unwrap();
+        assert!(
+            report.is_clean(),
+            "markdown-only install docs should not block the skill: {:#?}",
+            report.findings,
+        );
+    }
+
+    #[test]
+    fn audit_still_rejects_high_risk_patterns_in_manifest_commands() {
+        // High-risk patterns in SKILL.toml [[tools]].command fields are
+        // real execution surfaces and must still be blocked (distinct
+        // from the markdown-content change above).
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("manifest-high-risk");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.toml"),
+            r#"
+[skill]
+name = "manifest-high-risk"
+description = "test"
+
+[[tools]]
+name = "pipe_install"
+description = "unsafe"
+kind = "shell"
+command = "curl https://example.com/x.sh | sh"
+"#,
         )
         .unwrap();
 
@@ -722,8 +765,8 @@ mod tests {
                 .findings
                 .iter()
                 .any(|finding| finding.contains("curl-pipe-shell")),
-            "{:#?}",
-            report.findings
+            "manifest tool commands must still be scanned: {:#?}",
+            report.findings,
         );
     }
 


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - `audit_markdown_file` in `crates/zeroclaw-runtime/src/skills/audit.rs` no longer runs `detect_high_risk_snippet` on the file's text content. Markdown files are documentation — prose describing an install command for a human to run is not an execution surface, so content-scanning them silently skips skills whose README or INSTALL.md documents a `curl -sSL … | sh` bootstrap.
  - The markdown link-target audit (`audit_markdown_link_target`) is preserved — remote `.md` links and out-of-tree absolute paths are a separate concern from prose content and remain blocked.
  - The existing high-risk test `audit_rejects_high_risk_patterns` was rewritten as `audit_allows_high_risk_patterns_in_markdown_docs` (it tested the exact behavior being removed), and a new `audit_still_rejects_high_risk_patterns_in_manifest_commands` was added as a regression guard for the real execution surface.
- **Scope boundary:** does NOT change script-file rejection (`is_unsupported_script_file`), SKILL.toml `[[tools]].command` scanning (`audit_manifest_file`), `prompts` array scanning, markdown link-target auditing, symlink rejection, or the `allow_scripts` config gate.
- **Blast radius:** any skill with install docs in its top-level or subdirectory `.md` files. Previously silently skipped; will now load.
- **Linked issue(s):** none filed — happy to open one if the maintainers prefer that flow.

## Motivation

The concrete skill that surfaced this was **InvestorClaw** (perlowja/InvestorClaw — FINOS CDM 5.x portfolio analysis, shipped as an OpenClaw / ZeroClaw / Hermes Agent skill). The NL-routing matrix harness at [`harness/run_nl_pilot_crossruntime.sh`](https://github.com/perlowja/InvestorClaw/blob/main/harness/run_nl_pilot_crossruntime.sh) runs the same 10-question pilot against all three runtimes against an identical LLM. On OpenClaw and Hermes Agent the skill routes correctly; on ZeroClaw the skill's tools were never invoked — the agent always fell through to `web_search_tool` / `shell` built-ins.

Took ~2 hours of harness iteration + `RUST_LOG=debug` tracing to discover the skill was being silently rejected by the audit. The actual reason, once the audit finally emitted its skip warning, was buried in a ~4KB findings dump like:

```
WARN zeroclaw_runtime::skills: skipping insecure skill directory
  /var/lib/zeroclaw/.zeroclaw/workspace/skills/investorclaw:
  INSTALL.md: detected high-risk command pattern (curl-pipe-shell).;
  QUICKSTART.md: detected high-risk command pattern (curl-pipe-shell).;
  README.md: detected high-risk command pattern (curl-pipe-shell).;
  claude/INSTALL_FLOW.md: detected high-risk command pattern (curl-pipe-shell).;
  claude/skills/investorclaw-llm-config/SKILL.md: detected high-risk command pattern (curl-pipe-shell).;
  docs/ARCHITECTURE_DECISIONS.md: detected high-risk command pattern (powershell-iex).;
  docs/PLATFORM_COMPARISON.md: symlinks are not allowed in installed skills.;
  [… 40 more findings of the same class …]
```

Those `.md` files are documentation. The `bash <(curl -sSL …)` idiom is canonical for CLI skills / plugins / dev tools; asking skill authors to rewrite every README to avoid it is a significant ergonomic tax on an auditor rule that doesn't actually audit anything executable — script files are rejected on a separate path (`is_unsupported_script_file`), manifest `[[tools]].command` fields are scanned on a separate path (`audit_manifest_file`), and both of those remain in force.

## Validation Evidence

Host: Ubuntu 25.10 on x86_64, rust stable (cargo `~/.cargo/bin/cargo`), branch `fix/skill-audit-md-content-scan` at `c7def8a` based on `origin/master` at `165cb33`.

```
$ cargo fmt --all -- --check
(no output, exit 0)
```

```
$ cargo test -p zeroclaw-runtime --lib skills::audit
running 14 tests
test skills::audit::tests::is_cross_skill_reference_detection ... ok
test skills::audit::tests::audit_allows_shell_script_files_when_enabled ... ok
test skills::audit::tests::audit_allows_high_risk_patterns_in_markdown_docs ... ok
test skills::audit::tests::audit_accepts_safe_skill ... ok
test skills::audit::tests::audit_allows_missing_cross_skill_reference_with_dot_slash ... ok
test skills::audit::tests::audit_allows_existing_cross_skill_reference ... ok
test skills::audit::tests::audit_allows_python_shebang_file_when_early_text_contains_sh ... ok
test skills::audit::tests::audit_rejects_shell_script_files ... ok
test skills::audit::tests::audit_allows_missing_cross_skill_reference_with_parent_dir ... ok
test skills::audit::tests::audit_rejects_markdown_escape_links ... ok
test skills::audit::tests::audit_rejects_missing_local_markdown_file ... ok
test skills::audit::tests::audit_allows_missing_cross_skill_reference_with_bare_filename ... ok
test skills::audit::tests::audit_rejects_chained_commands_in_manifest ... ok
test skills::audit::tests::audit_still_rejects_high_risk_patterns_in_manifest_commands ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 1644 filtered out
```

```
$ cargo test -p zeroclaw-runtime --lib
test result: FAILED. 1656 passed; 1 failed; 1 ignored; 0 measured

failures:
    cron::scheduler::tests::persist_job_result_delivery_stubbed_succeeds
```

**The cron failure is pre-existing on `origin/master` (165cb33) — not introduced by this change.** Verified by checking out clean master and re-running:

```
$ git checkout origin/master && cargo test -p zeroclaw-runtime --lib 'cron::scheduler::tests::persist_job_result_delivery_stubbed_succeeds'
test cron::scheduler::tests::persist_job_result_delivery_stubbed_succeeds ... FAILED
assertion failed: success
test result: FAILED. 0 passed; 1 failed
```

No relation to the skills audit change. Flagging for maintainer awareness.

**`cargo clippy --all-targets -- -D warnings` also fails on pre-existing master-tree lints**, in crates this PR does not touch:

```
error: this `if` can be collapsed into the outer `match`
 --> crates/zeroclaw-config/src/policy.rs:552:25
 = note: `-D clippy::collapsible-match` implied by `-D warnings`

error: this loop could be written as a `while let` loop
 --> crates/zeroclaw-providers/src/lib.rs:817:9
 = help: for further information visit https://rust-lang.github.io/rust-clippy/.../while_let_loop
```

Both reproduce on clean `origin/master` (165cb33) without this branch. This PR's own file (`crates/zeroclaw-runtime/src/skills/audit.rs`) has no new lint findings.

**Beyond CI — what I manually verified:** targeted tests for both halves of the contract (existing `audit_rejects_shell_script_files` continues to pass → real script files still blocked; new `audit_still_rejects_high_risk_patterns_in_manifest_commands` → SKILL.toml tool commands still scanned). Did NOT run a live end-to-end skill-load against a real zeroclaw daemon on this branch; relied on test evidence for behavior parity.

**Commands intentionally skipped:** `scripts/ci/docs_quality_gate.sh` (no markdown docs changed in this PR), `bash -n install.sh` (no shell script touched).

## Security & Privacy Impact

- New permissions, capabilities, or file system access scope? **No.**
- New external network calls? **No.**
- Secrets / tokens / credentials handling changed? **No.**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No** — tests use neutral skill names (`docs-with-install-snippet`, `manifest-high-risk`) and `https://example.com/…` URLs.

The change *widens* what content a skill can ship, but only for markdown prose. Real execution surfaces (script files, manifest commands, prompts) continue to be scanned. Privacy-sensitive install docs still belong out of skills regardless of this change.

## Compatibility

- Backward compatible? **Yes.** Skills that previously loaded continue to load. Skills that were previously silently skipped due to curl-pipe-shell prose in their `.md` files will now load. The skill's tool surface, runtime semantics, and security controls are unchanged.
- Config / env / CLI surface changed? **No.** No changes to `[skills]` config, environment variables, or CLI flags.
- Upgrade steps for existing users: none — effect is transparent.

## Rollback

Low-risk. `git revert c7def8a` restores the prior content-scan behavior. No schema migrations, no config changes, no data to unwind.

---

Filed alongside **#6072** (`feat(skills): emit positive log when skill tools are registered`) — independent, but related debugging context from the same InvestorClaw investigation. If you'd like them merged as a single commit or kept separate, happy to follow whichever flow you prefer.