### PR TITLE
fix(rag-pdf): unbreak --features rag-pdf end-to-end and restore Windows tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -311,7 +311,7 @@ sandbox-bubblewrap = ["zeroclaw-runtime/sandbox-bubblewrap"]
 browser-native = ["zeroclaw-tools/browser-native"]
 plugins-wasm = ["dep:zeroclaw-plugins", "zeroclaw-runtime/plugins-wasm"]
 probe = ["dep:zeroclaw-hardware", "zeroclaw-hardware/probe"]
-rag-pdf = ["zeroclaw-tools/rag-pdf"]
+rag-pdf = ["zeroclaw-tools/rag-pdf", "zeroclaw-runtime/rag-pdf"]
 webauthn = ["zeroclaw-runtime/webauthn"]
 
 # Backward-compatible aliases

--- a/crates/zeroclaw-runtime/Cargo.toml
+++ b/crates/zeroclaw-runtime/Cargo.toml
@@ -76,15 +76,14 @@ prometheus = { version = "0.14", default-features = false, optional = true }
 opentelemetry = { version = "0.31", default-features = false, features = ["trace", "metrics"], optional = true }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace", "metrics"], optional = true }
 opentelemetry-otlp = { version = "0.31", default-features = false, features = ["trace", "metrics", "http-proto", "reqwest-blocking-client", "reqwest-rustls-webpki-roots"], optional = true }
+# Optional deps for specific features
+pdf-extract = { version = "0.10", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = { version = "0.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-
-# Optional deps for specific features
-pdf-extract = { version = "0.10", optional = true }
 
 [features]
 default = ["observability-prometheus", "schema-export"]

--- a/crates/zeroclaw-runtime/src/tools/file_read.rs
+++ b/crates/zeroclaw-runtime/src/tools/file_read.rs
@@ -340,7 +340,16 @@ mod tests {
     #[tokio::test]
     async fn file_read_blocks_absolute_path() {
         let tool = FileReadTool::new(test_security(std::env::temp_dir()));
-        let result = tool.execute(json!({"path": "/etc/passwd"})).await.unwrap();
+
+        #[cfg(unix)]
+        let target = "/etc/passwd";
+        #[cfg(windows)]
+        let target = {
+            let sysroot = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
+            std::path::PathBuf::from(sysroot).join(r"System32\drivers\etc\hosts")
+        };
+
+        let result = tool.execute(json!({"path": target})).await.unwrap();
         assert!(!result.success);
         assert!(result.error.as_ref().unwrap().contains("not allowed"));
     }
@@ -640,7 +649,7 @@ mod tests {
         tokio::fs::create_dir_all(&dir).await.unwrap();
 
         let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/test_document.pdf");
+            .join("../../tests/fixtures/test_document.pdf");
         tokio::fs::copy(&fixture, dir.join("report.pdf"))
             .await
             .expect("copy PDF fixture");
@@ -789,7 +798,7 @@ mod tests {
         tokio::fs::create_dir_all(&workspace).await.unwrap();
 
         let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/test_document.pdf");
+            .join("../../tests/fixtures/test_document.pdf");
         tokio::fs::copy(&fixture, workspace.join("report.pdf"))
             .await
             .expect("copy PDF fixture");
@@ -982,7 +991,7 @@ mod tests {
         tokio::fs::create_dir_all(&workspace).await.unwrap();
 
         let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/fixtures/test_document.pdf");
+            .join("../../tests/fixtures/test_document.pdf");
         tokio::fs::copy(&fixture, workspace.join("report.pdf"))
             .await
             .expect("copy PDF fixture");

--- a/crates/zeroclaw-runtime/tests/fixtures
+++ b/crates/zeroclaw-runtime/tests/fixtures
@@ -1,1 +1,0 @@
-../../../tests/fixtures

--- a/crates/zeroclaw-tools/src/pdf_read.rs
+++ b/crates/zeroclaw-tools/src/pdf_read.rs
@@ -296,7 +296,16 @@ mod tests {
     #[tokio::test]
     async fn absolute_path_is_blocked() {
         let tool = PdfReadTool::new(test_security(std::env::temp_dir()));
-        let result = tool.execute(json!({"path": "/etc/passwd"})).await.unwrap();
+
+        #[cfg(unix)]
+        let target = "/etc/passwd";
+        #[cfg(windows)]
+        let target = {
+            let sysroot = std::env::var("SystemRoot").unwrap_or_else(|_| r"C:\Windows".to_string());
+            std::path::PathBuf::from(sysroot).join(r"System32\drivers\etc\hosts")
+        };
+
+        let result = tool.execute(json!({"path": target})).await.unwrap();
         assert!(!result.success);
         assert!(
             result


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - `--features rag-pdf` was silently inert on the runtime crate because the root `Cargo.toml` forwarded the feature only to `zeroclaw-tools`. Forward it to `zeroclaw-runtime` too. This is the primary bug — `PdfReadTool` was never registered and `FileReadTool::try_extract_pdf_text` was cfg-out despite users explicitly opting into the feature. See issue #6066 .
  - The `pdf-extract` optional dep in `crates/zeroclaw-runtime/Cargo.toml` was declared inside `[target.'cfg(unix)'.dependencies]` (TOML scoping is table-bounded, the blank line is cosmetic). On Windows, once the feature was properly forwarded, activating `dep:pdf-extract` pointed at a dep that didn't exist for the target, producing `E0433 unresolved module pdf_extract`. Move the dep into the platform-agnostic `[dependencies]` table.
  - Two Windows test failures surfaced once the feature was actually on: `file_read_blocks_absolute_path` (and its `pdf_read` twin `absolute_path_is_blocked`) hardcoded `/etc/passwd` as an absolute path — `Path::is_absolute` returns false for that on Windows, so the workspace-only rejection in `SecurityPolicy::is_path_allowed` was skipped. Use a cfg-gated `%SystemRoot%`-derived path on Windows (with `C:\Windows` as a defensive fallback).
  - Three PDF tests loaded their fixture via a git symlink at `crates/zeroclaw-runtime/tests/fixtures`. Windows Git defaults check symlinks out as text files, so the fixture never resolved. Replace the symlink with an explicit `../../tests/fixtures/test_document.pdf` path jump from `CARGO_MANIFEST_DIR`; drop the now-dead symlink from the index.
- **Scope boundary:**
  - Does **not** modify other tracked git symlinks in the tree (`crates/zeroclaw-hardware/firmware`, `crates/zeroclaw-runtime/firmware`, `crates/zeroclaw-runtime/src/firmware`) — they may face the same Windows-checkout issue if a test exercises them, but nothing in the current test suite does, so they're out of scope here.
  - Does **not** harden `SecurityPolicy::is_path_allowed` to reject `/`-prefixed paths on Windows (which would also fix failure `#1` at the library level rather than the test level). That is a security hardening discussion worth its own PR.
  - Does **not** sweep other root `Cargo.toml` features for similar forwarding gaps. A full audit would be worthwhile but belongs in a separate change.
- **Blast radius:**
  - Anyone installing/building with `--features rag-pdf` on any platform — `pdf_read` now appears in `/api/tools` and `file_read` extracts PDF text for real.
  - No behavior change for builds without `rag-pdf` (default installs remain identical).
  - Linux/macOS developers: symlink removal is a clean replacement — the `../../tests/fixtures/...` path resolves to the same location the symlink was pointing at.
- **Linked issue(s):** `Closes #6066`

## Validation Evidence (required)

- **Commands run and tail output:**

  ```text
  $ cargo fmt --all -- --check
  EXIT=0   (no output)

  $ cargo build --features rag-pdf
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.78s

  $ cargo test --features rag-pdf -p zeroclaw-runtime tools::file_read
      Finished `test` profile [unoptimized + debuginfo] target(s) in 0.57s
      Running unittests src\lib.rs (target\debug\deps\zeroclaw_runtime-4bfd4ab1fb26a952.exe)

      running 23 tests
      test tools::file_read::tests::e2e_live_file_read_pdf ... ignored, requires valid OpenAI Codex OAuth credentials
      test tools::file_read::tests::file_read_name ... ok
      test tools::file_read::tests::file_read_blocks_absolute_path ... ok
      test tools::file_read::tests::file_read_missing_path_param ... ok
      test tools::file_read::tests::file_read_blocks_path_traversal ... ok
      test tools::file_read::tests::file_read_blocks_when_rate_limited ... ok
      test tools::file_read::tests::file_read_schema_has_path ... ok
      test tools::file_read::tests::file_read_blocks_null_byte_in_path ... ok
      test tools::file_read::tests::file_read_empty_file ... ok
      test tools::file_read::tests::file_read_allows_readonly_mode ... ok
      test tools::file_read::tests::file_read_existing_file ... ok
      test tools::file_read::tests::file_read_nonexistent_consumes_rate_limit_budget ... ok
      test tools::file_read::tests::file_read_nonexistent_file ... ok
      test tools::file_read::tests::file_read_lossy_reads_binary_file ... ok
      test tools::file_read::tests::file_read_offset_beyond_end ... ok
      test tools::file_read::tests::e2e_agent_file_read_lossy_binary ... ok
      test tools::file_read::tests::file_read_extracts_pdf_text ... ok
      test tools::file_read::tests::e2e_agent_file_read_pdf_extraction ... ok
      test tools::file_read::tests::file_read_nested_path ... ok
      test tools::file_read::tests::file_read_allowed_root_with_workspace_only ... ok
      test tools::file_read::tests::file_read_outside_workspace_allowed_when_workspace_only_disabled ... ok
      test tools::file_read::tests::file_read_with_offset_and_limit ... ok
      test tools::file_read::tests::file_read_rejects_oversized_file ... ok

  $ cargo test --features rag-pdf -p zeroclaw-tools pdf_read
      Finished `test` profile [unoptimized + debuginfo] target(s) in 0.47s
      Running unittests src\lib.rs (target\debug\deps\zeroclaw_tools-b6dbb2ba369fe40d.exe)

      running 13 tests
      test pdf_read::tests::description_not_empty ... ok
      test pdf_read::tests::name_is_pdf_read ... ok
      test pdf_read::tests::schema_has_path_required ... ok
      test pdf_read::tests::missing_path_param_returns_error ... ok
      test pdf_read::tests::spec_matches_metadata ... ok
      test pdf_read::tests::absolute_path_is_blocked ... ok
      test pdf_read::tests::path_traversal_is_blocked ... ok
      test pdf_read::tests::rate_limit_blocks_request ... ok
      test pdf_read::tests::nonexistent_file_returns_error ... ok
      test pdf_read::tests::probing_nonexistent_consumes_rate_limit_budget ... ok
      test pdf_read::tests::extraction::image_only_pdf_returns_empty_text_warning ... ok
      test pdf_read::tests::extraction::extracts_text_from_valid_pdf ... ok
      test pdf_read::tests::extraction::max_chars_truncates_output ... ok

      test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 1080 filtered out; finished in 0.01s
  ```
<img width="557" height="840" alt="image" src="https://github.com/user-attachments/assets/c370ad34-0a4f-49ee-8422-3ca78652b5d8" />


- **Beyond CI — what did you manually verify?**
  - Reproduced the original `E0433` failure on Windows by running `cargo build --features rag-pdf` before the fix; confirmed it compiles after.
  - Verified `pdf_read` appears in `GET /api/tools` after a fresh `./install.sh --features rag-pdf --skip-onboard` + gateway restart, alongside the already-present `file_read`.
  - Dropped a sample PDF into the workspace and asked the agent to call `file_read` on it — extracted text is returned rather than lossy UTF-8 garbage.
  - Cross-checked that a default-feature install (no `rag-pdf`) is unchanged: `pdf_read` correctly absent, `file_read` returns lossy UTF-8 for PDFs (pre-existing behavior, not modified here).
- **If any command was intentionally skipped, why:**
  - `cargo clippy --all-targets -- -D warnings` not run locally in this change session. CI will enforce.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

## Rollback

Low-risk. `git revert <sha>` on either commit independently:

- `4d9f62aa fix(features): make --features rag-pdf link pdf-extract on all platforms` — reverting this restores the pre-existing silent-no-op behavior (non-ideal but not harmful).
- `28df7643 fix(tests): make file_read and pdf_read tests portable on Windows` — reverting this restores the Windows test failures but does not affect Linux/macOS.

Full revert of both leaves the tree equivalent to `master` before this PR.

## Supersede Attribution

_N/A — no superseded PR._

## i18n Follow-Through

_N/A — no docs or user-facing wording changed._
