### PR TITLE
fix(memory): add closing tag to memory context in cron and daemon

### DIFF
--- a/crates/zeroclaw-runtime/src/cron/scheduler.rs
+++ b/crates/zeroclaw-runtime/src/cron/scheduler.rs
@@ -303,7 +303,7 @@ async fn run_agent_job(
                     if ctx.is_empty() {
                         String::new()
                     } else {
-                        format!("[Memory context]\n{ctx}\n\n")
+                        format!("[Memory context]\n{ctx}\n[/Memory context]\n\n")
                     }
                 }
                 _ => String::new(),

--- a/crates/zeroclaw-runtime/src/daemon/mod.rs
+++ b/crates/zeroclaw-runtime/src/daemon/mod.rs
@@ -513,7 +513,7 @@ async fn run_heartbeat_worker(config: Config) -> Result<()> {
                         if ctx.is_empty() {
                             None
                         } else {
-                            Some(format!("[Memory context]\n{ctx}\n"))
+                            Some(format!("[Memory context]\n{ctx}\n[/Memory context]\n\n"))
                         }
                     }
                     _ => None,


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The memory context block was injected with `[Memory context]` but no matching `[/Memory context]` closing tag in the cron scheduler and daemon heartbeat injection sites. Without the closing tag, the model cannot distinguish where memory context ends and user content begins. The agent loop (`memory_loader.rs`, `loop_.rs`) and channel orchestrator already include the closing tag — only cron and daemon were missing it.
- **Scope boundary:** Two format strings in `cron/scheduler.rs` and `daemon/mod.rs`. No logic changes.
- **Blast radius:** Cron job prompts and daemon heartbeat prompts now include the closing marker, matching all other memory injection paths.
- **Linked issue(s):** Recovers commit 59ad6da0 (#4687 by @vannini-gv, fixing #4642), lost in bulk revert c3ff635. Tracked in #6074.

## Supersedes

- Commit 59ad6da0826b2f0027d419ef0529b38d4b5cc679 by @vannini-gv

### What was incorporated

- The closing `[/Memory context]` tag addition. The original fix addressed three injection sites; two were independently re-applied during the microkernel refactor (`memory_loader.rs`, `loop_.rs`). This PR recovers the remaining two (`scheduler.rs`, `daemon/mod.rs`) plus aligns the `daemon/mod.rs` trailing whitespace (`\n` → `\n\n`) to match all other sites.

## Attribution

- Co-authored-by trailers added for materially incorporated contributors: Yes

## Follow-ups

- #6081 — extract `[Memory context]` / `[/Memory context]` into shared constants

## Validation Evidence (required)

- **Commands run:** `cargo check -p zeroclaw-runtime` — clean. `cargo clippy -p zeroclaw-runtime -p zeroclaw-gateway --all-targets` — clean, no warnings. `cargo test -p zeroclaw-runtime` — 1663 passed, 1 failed (pre-existing on master: `persist_job_result_delivery_stubbed_succeeds`), 1 ignored.
- **Beyond CI — what did you manually verify?** Confirmed all 5 injection sites now include the closing tag. Verified the format string matches the pattern used by `memory_loader.rs:80` and `loop_.rs:374`. Verified the one test failure reproduces on master without this change.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.

## Compatibility (required)

- Backward compatible? Yes — adds a closing marker to prompt text. No API, config, or CLI changes.
- Config / env / CLI surface changed? No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
