### PR TITLE
feat(web): add chat message deletion, clear-all, and compact mode

### DIFF
--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -488,6 +488,9 @@ const translations: Record<Locale, Record<string, string>> = {
     'agent.copy_message': 'Copy message',
     'agent.connected_status': 'Connected',
     'agent.disconnected_status': 'Disconnected',
+    'agent.clear_all': 'Clear all',
+    'agent.delete_message': 'Delete message',
+    'agent.compact_mode': 'Compact',
 
     // Tools
     'tools.title': 'Available Tools',

--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Send, Bot, User, AlertCircle, Copy, Check } from 'lucide-react';
+import { Send, Bot, User, AlertCircle, Copy, Check, X, Trash2, Minimize2, Maximize2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type { WsMessage } from '@/types/api';
@@ -34,8 +34,6 @@ export default function AgentChat() {
   const sessionIdRef = useRef(getOrCreateSessionId());
   const { draft, saveDraft, clearDraft } = useDraft(DRAFT_KEY);
   const [messages, setMessages] = useState<ChatMessage[]>(() => {
-    // Synchronously hydrate from localStorage so messages survive tab switches
-    // without a flash of empty state. Server hydration may override later.
     const persisted = loadChatHistory(sessionIdRef.current);
     return persisted.length > 0 ? persistedToUiMessages(persisted) : [];
   });
@@ -49,6 +47,9 @@ export default function AgentChat() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [compact, setCompact] = useState(() => {
+    try { return localStorage.getItem('zeroclaw_chat_compact') === '1'; } catch { return false; }
+  });
   const pendingContentRef = useRef('');
   const pendingThinkingRef = useRef('');
   // Snapshot of thinking captured at chunk_reset, so it survives the reset.
@@ -348,6 +349,22 @@ export default function AgentChat() {
     }
   }, []);
 
+  const handleDeleteMessage = useCallback((msgId: string) => {
+    setMessages((prev) => prev.filter((m) => m.id !== msgId));
+  }, []);
+
+  const handleClearAll = useCallback(() => {
+    setMessages([]);
+  }, []);
+
+  const toggleCompact = useCallback(() => {
+    setCompact((prev) => {
+      const next = !prev;
+      try { localStorage.setItem('zeroclaw_chat_compact', next ? '1' : '0'); } catch { /* noop */ }
+      return next;
+    });
+  }, []);
+
   /**
    * Fallback copy using a temporary textarea for HTTP contexts
    * where navigator.clipboard is unavailable.
@@ -379,8 +396,37 @@ export default function AgentChat() {
         </div>
       )}
 
+      {/* Chat toolbar */}
+      {messages.length > 0 && (
+        <div
+          className="flex items-center justify-end gap-2 px-4 py-2 border-b"
+          style={{ background: 'var(--pc-bg-surface)', borderColor: 'var(--pc-border)' }}
+        >
+          <button
+            type="button"
+            onClick={toggleCompact}
+            className="btn-secondary flex items-center gap-1.5 text-xs"
+            style={{ padding: '0.3rem 0.75rem', borderRadius: '0.5rem' }}
+            aria-label={t('agent.compact_mode')}
+          >
+            {compact ? <Maximize2 className="h-3 w-3" /> : <Minimize2 className="h-3 w-3" />}
+            {t('agent.compact_mode')}
+          </button>
+          <button
+            type="button"
+            onClick={handleClearAll}
+            className="btn-danger flex items-center gap-1.5 text-xs"
+            style={{ padding: '0.3rem 0.75rem', borderRadius: '0.5rem' }}
+            aria-label={t('agent.clear_all')}
+          >
+            <Trash2 className="h-3 w-3" />
+            {t('agent.clear_all')}
+          </button>
+        </div>
+      )}
+
       {/* Messages area */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div className={`flex-1 overflow-y-auto p-4 ${compact ? 'space-y-1.5' : 'space-y-4'}`}>
         {messages.length === 0 && (
           <div className="flex flex-col items-center justify-center h-full text-center animate-fade-in" style={{ color: 'var(--pc-text-muted)' }}>
             <div className="h-16 w-16 rounded-3xl flex items-center justify-center mb-4 animate-float" style={{ background: 'var(--pc-accent-glow)' }}>
@@ -394,27 +440,29 @@ export default function AgentChat() {
         {messages.map((msg, idx) => (
           <div
             key={msg.id}
-            className={`group flex items-start gap-3 ${
+            className={`group flex items-start ${compact ? 'gap-2' : 'gap-3'} ${
               msg.role === 'user' ? 'flex-row-reverse animate-slide-in-right' : 'animate-slide-in-left'
             }`}
             style={{ animationDelay: `${Math.min(idx * 30, 200)}ms` }}
           >
-            <div
-              className="flex-shrink-0 w-9 h-9 rounded-2xl flex items-center justify-center border"
-              style={{
-                background: msg.role === 'user' ? 'var(--pc-accent)' : 'var(--pc-bg-elevated)',
-                borderColor: msg.role === 'user' ? 'var(--pc-accent)' : 'var(--pc-border)',
-              }}
-            >
-              {msg.role === 'user' ? (
-                <User className="h-4 w-4 text-white" />
-              ) : (
-                <Bot className="h-4 w-4" style={{ color: 'var(--pc-accent)' }} />
-              )}
-            </div>
+            {!compact && (
+              <div
+                className="flex-shrink-0 w-9 h-9 rounded-2xl flex items-center justify-center border"
+                style={{
+                  background: msg.role === 'user' ? 'var(--pc-accent)' : 'var(--pc-bg-elevated)',
+                  borderColor: msg.role === 'user' ? 'var(--pc-accent)' : 'var(--pc-border)',
+                }}
+              >
+                {msg.role === 'user' ? (
+                  <User className="h-4 w-4 text-white" />
+                ) : (
+                  <Bot className="h-4 w-4" style={{ color: 'var(--pc-accent)' }} />
+                )}
+              </div>
+            )}
             <div className="relative max-w-[75%]">
               <div
-                className="rounded-2xl px-4 py-3 border"
+                className={compact ? 'rounded-xl px-3 py-1.5 border' : 'rounded-2xl px-4 py-3 border'}
                 style={
                   msg.role === 'user'
                     ? { background: 'var(--pc-accent-glow)', borderColor: 'var(--pc-accent-dim)', color: 'var(--pc-text-primary)', }
@@ -430,29 +478,44 @@ export default function AgentChat() {
                 {msg.toolCall ? (
                   <ToolCallCard toolCall={msg.toolCall} />
                 ) : msg.markdown ? (
-                  <div className="text-sm break-words leading-relaxed chat-markdown"><ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown></div>
+                  <div className={`${compact ? 'text-xs' : 'text-sm'} break-words leading-relaxed chat-markdown`}><ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown></div>
                 ) : (
-                  <p className="text-sm whitespace-pre-wrap break-words leading-relaxed">{msg.content}</p>
+                  <p className={`${compact ? 'text-xs' : 'text-sm'} whitespace-pre-wrap break-words leading-relaxed`}>{msg.content}</p>
                 )}
-                <p
-                  className="text-[10px] mt-1.5" style={{ color: msg.role === 'user' ? 'var(--pc-accent-light)' : 'var(--pc-text-faint)' }}>
-                  {msg.timestamp.toLocaleTimeString()}
-                </p>
+                {!compact && (
+                  <p
+                    className="text-[10px] mt-1.5" style={{ color: msg.role === 'user' ? 'var(--pc-accent-light)' : 'var(--pc-text-faint)' }}>
+                    {msg.timestamp.toLocaleTimeString()}
+                  </p>
+                )}
               </div>
-              <button
-                onClick={() => handleCopy(msg.id, msg.content)}
-                aria-label={t('agent.copy_message')}
-                className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 transition-all p-1.5 rounded-xl"
-                style={{ background: 'var(--pc-bg-elevated)', border: '1px solid var(--pc-border)', color: 'var(--pc-text-muted)', }}
-                onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--pc-text-primary)'; e.currentTarget.style.borderColor = 'var(--pc-accent-dim)'; }}
-                onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--pc-text-muted)'; e.currentTarget.style.borderColor = 'var(--pc-border)'; }}
-              >
-                {copiedId === msg.id ? (
-                  <Check className="h-3 w-3" style={{ color: '#34d399' }} />
-                ) : (
-                  <Copy className="h-3 w-3" />
-                )}
-              </button>
+              {/* Hover action buttons — below the bubble, right-aligned */}
+              <div className="flex items-center justify-end gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                <button
+                  onClick={() => handleCopy(msg.id, msg.content)}
+                  aria-label={t('agent.copy_message')}
+                  className="p-1 rounded-lg"
+                  style={{ color: 'var(--pc-text-muted)' }}
+                  onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--pc-text-primary)'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--pc-text-muted)'; }}
+                >
+                  {copiedId === msg.id ? (
+                    <Check className="h-3.5 w-3.5" style={{ color: '#34d399' }} />
+                  ) : (
+                    <Copy className="h-3.5 w-3.5" />
+                  )}
+                </button>
+                <button
+                  onClick={() => handleDeleteMessage(msg.id)}
+                  aria-label={t('agent.delete_message')}
+                  className="p-1 rounded-lg"
+                  style={{ color: 'var(--pc-text-muted)' }}
+                  onMouseEnter={(e) => { e.currentTarget.style.color = '#f87171'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--pc-text-muted)'; }}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Added per-message delete (`X`) button that appears on hover below each message bubble, letting users remove individual messages from the chat view
  - Added "Clear All" toolbar button with a `Trash2` icon to wipe the entire chat in one action
  - Added a "Compact" mode toggle that shrinks message spacing/padding, hides avatars and timestamps, and uses smaller text — persists preference to `localStorage` under key `zeroclaw_chat_compact`
  - Added three new i18n keys (`agent.clear_all`, `agent.delete_message`, `agent.compact_mode`) in the English locale
- **Scope boundary:** This PR does not change WebSocket logic, session management, chat persistence (server-side), or any backend code. Deletion is UI-only and does not remove messages from localStorage history or server.
- **Blast radius:** Confined to the Agent Chat page (`AgentChat.tsx`) and the i18n dictionary. No other pages or components are affected.
- **Linked issue(s):** Closes #6077

## Validation Evidence (required)

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — N/A, no Rust files changed
  - `cargo clippy --all-targets -- -D warnings` — N/A, no Rust files changed
  - `cargo test` — N/A, no Rust files changed
  - Changes are TypeScript/TSX only in the `web/` directory
  - `tsc --noEmit` — passes with no errors
  - `npm run build` — succeeds
- **Beyond CI — what did you manually verify?** Per-message delete button appears on hover and removes the correct message. Clear All button removes all messages and the toolbar disappears. Compact mode toggle shrinks spacing, hides avatars and timestamps, persists across page reloads via localStorage. Normal mode restore works correctly.
- **If any command was intentionally skipped, why:** Rust validation commands skipped because this PR touches zero Rust files — only `web/src/pages/AgentChat.tsx` and `web/src/lib/i18n.ts`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan unless otherwise noted.

## i18n Follow-Through (required only when docs or user-facing wording change)

- Locale navigation parity updated? `N/A`
- Localized runtime-contract docs updated? `N/A`
- Vietnamese canonical docs synced? `N/A`
- If any `N/A`, explain scope decision: Only runtime i18n keys were added in the English source locale. No documentation, README, or markdown docs were changed. Locale translations for these three new keys are a follow-up task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)