### PR TITLE
fix(config): default session_ttl_hours to 168h and trim history on seed

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -2209,8 +2209,8 @@ pub struct GatewayConfig {
     #[serde(default = "default_true")]
     pub session_persistence: bool,
 
-    /// Auto-archive stale gateway sessions older than N hours. 0 = disabled. Default: 0.
-    #[serde(default)]
+    /// Auto-archive stale gateway sessions older than N hours. 0 = disabled. Default: 168 (7 days).
+    #[serde(default = "default_session_ttl_hours")]
     pub session_ttl_hours: u32,
 
     /// Pairing dashboard configuration
@@ -2252,6 +2252,10 @@ fn default_idempotency_ttl_secs() -> u64 {
     300
 }
 
+fn default_session_ttl_hours() -> u32 {
+    168
+}
+
 fn default_gateway_rate_limit_max_keys() -> usize {
     10_000
 }
@@ -2284,7 +2288,7 @@ impl Default for GatewayConfig {
             idempotency_ttl_secs: default_idempotency_ttl_secs(),
             idempotency_max_keys: default_gateway_idempotency_max_keys(),
             session_persistence: true,
-            session_ttl_hours: 0,
+            session_ttl_hours: default_session_ttl_hours(),
             pairing_dashboard: PairingDashboardConfig::default(),
             web_dist_dir: None,
             tls: None,
@@ -6590,8 +6594,8 @@ pub struct ChannelsConfig {
     /// SQLite provides FTS5 search, metadata tracking, and TTL cleanup.
     #[serde(default = "default_session_backend")]
     pub session_backend: String,
-    /// Auto-archive stale sessions older than this many hours. `0` disables. Default: `0`.
-    #[serde(default)]
+    /// Auto-archive stale sessions older than this many hours. `0` disables. Default: `168` (7 days).
+    #[serde(default = "default_session_ttl_hours")]
     pub session_ttl_hours: u32,
     /// Inbound message debounce window in milliseconds. When a sender fires
     /// multiple messages within this window, they are accumulated and dispatched
@@ -6798,7 +6802,7 @@ impl Default for ChannelsConfig {
             show_tool_calls: false,
             session_persistence: true,
             session_backend: default_session_backend(),
-            session_ttl_hours: 0,
+            session_ttl_hours: default_session_ttl_hours(),
             debounce_ms: 0,
         }
     }

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -369,6 +369,8 @@ impl Agent {
                 self.history.push(ConversationMessage::Chat(msg.clone()));
             }
         }
+        // Enforce history window so seeded sessions respect max_history.
+        self.trim_history();
     }
 
     pub async fn from_config(config: &Config) -> Result<Self> {


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Changed `session_ttl_hours` default from `0` (disabled) to `168` (7 days) in both `GatewayConfig` and `ChannelsConfig` to prevent unbounded session accumulation
  - Added `self.trim_history()` call after `seed_history` to enforce `max_history` on seeded sessions
- **Scope boundary:** Config defaults and agent history trimming only. No gateway, channel, or persistence logic changes.
- **Blast radius:** All gateway and channel sessions will now auto-archive after 7 days by default. Existing configs with explicit `session_ttl_hours` are unaffected.
- **Linked issue(s):** Closes #5542. Supersedes #5548.

## Validation Evidence (required)

- `cargo check -p zeroclaw-config -p zeroclaw-runtime` — passes
- `tsc --noEmit` — N/A (no web changes)
- **Beyond CI:** Verified both `GatewayConfig::default()` and `ChannelsConfig::default()` now return `session_ttl_hours: 168`.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes` — users who explicitly set `session_ttl_hours = 0` retain disabled behavior
- Config / env / CLI surface changed? `No` — only the default value changed

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)