### PR TITLE
fix(config): add allowed_path/allowed_paths aliases for allowed_roots

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -5581,7 +5581,7 @@ pub struct AutonomyConfig {
     /// Extra directory roots the agent may read/write outside the workspace.
     /// Supports absolute, `~/...`, and workspace-relative entries.
     /// Resolved paths under any of these roots pass `is_resolved_path_allowed`.
-    #[serde(default)]
+    #[serde(default, alias = "allowed_path", alias = "allowed_paths")]
     pub allowed_roots: Vec<String>,
 
     /// Tools to exclude from non-CLI channels (e.g. Telegram, Discord).

--- a/tests/component/config_schema.rs
+++ b/tests/component/config_schema.rs
@@ -364,6 +364,26 @@ fn autonomy_config_toml_roundtrip() {
     assert!(!parsed.autonomy.workspace_only);
 }
 
+#[test]
+fn autonomy_config_allowed_path_alias_maps_to_allowed_roots() {
+    let toml_str = r#"
+[autonomy]
+allowed_path = ["~/work", "~/"]
+"#;
+    let parsed: Config = toml::from_str(toml_str).expect("allowed_path alias should parse");
+    assert_eq!(parsed.autonomy.allowed_roots, vec!["~/work", "~/"]);
+}
+
+#[test]
+fn autonomy_config_allowed_paths_alias_maps_to_allowed_roots() {
+    let toml_str = r#"
+[autonomy]
+allowed_paths = ["/tmp/data"]
+"#;
+    let parsed: Config = toml::from_str(toml_str).expect("allowed_paths alias should parse");
+    assert_eq!(parsed.autonomy.allowed_roots, vec!["/tmp/data"]);
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Backward compatibility
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added `allowed_path` and `allowed_paths` as serde aliases for `allowed_roots` in `AutonomyConfig` so users can use the more intuitive names
  - Added two component tests verifying both aliases deserialize correctly
- **Scope boundary:** Serde alias only — no behavior change, no new fields, no migration.
- **Blast radius:** None. Existing `allowed_roots` configs continue to work. New aliases are additive.
- **Linked issue(s):** Closes #5533. Supersedes #5546.

## Validation Evidence (required)

- `cargo test --test component -- autonomy_config_allowed` — 2 passed, 0 failed
- `cargo check -p zeroclaw-config` — passes

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` — aliases are additive

## Rollback (required for `risk: medium` and `risk: high`)

This is an additive config-schema alias change. Fast rollback: `git revert <merge commit for PR #6086>`.

## Supersede Attribution (required only when `Supersedes #` is used)

#5546 was the same author's earlier pre-workspace-split version of this patch. #6086 is the rebased/re-targeted replacement, so no additional external co-author attribution is needed.
