### PR TITLE
fix(config): support env var overrides for channel tokens

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -10868,32 +10868,48 @@ impl Config {
         }
         if let Some(ref mut sl) = self.channels.slack {
             if let Ok(v) = std::env::var("SLACK_BOT_TOKEN") {
-                if !v.is_empty() { sl.bot_token = v; }
+                if !v.is_empty() {
+                    sl.bot_token = v;
+                }
             }
             if let Ok(v) = std::env::var("ZEROCLAW_SLACK_BOT_TOKEN") {
-                if !v.is_empty() { sl.bot_token = v; }
+                if !v.is_empty() {
+                    sl.bot_token = v;
+                }
             }
             if let Ok(v) = std::env::var("SLACK_APP_TOKEN") {
-                if !v.is_empty() { sl.app_token = Some(v); }
+                if !v.is_empty() {
+                    sl.app_token = Some(v);
+                }
             }
             if let Ok(v) = std::env::var("ZEROCLAW_SLACK_APP_TOKEN") {
-                if !v.is_empty() { sl.app_token = Some(v); }
+                if !v.is_empty() {
+                    sl.app_token = Some(v);
+                }
             }
         }
         if let Some(ref mut dc) = self.channels.discord {
             if let Ok(v) = std::env::var("DISCORD_BOT_TOKEN") {
-                if !v.is_empty() { dc.bot_token = v; }
+                if !v.is_empty() {
+                    dc.bot_token = v;
+                }
             }
             if let Ok(v) = std::env::var("ZEROCLAW_DISCORD_BOT_TOKEN") {
-                if !v.is_empty() { dc.bot_token = v; }
+                if !v.is_empty() {
+                    dc.bot_token = v;
+                }
             }
         }
         if let Some(ref mut tg) = self.channels.telegram {
             if let Ok(v) = std::env::var("TELEGRAM_BOT_TOKEN") {
-                if !v.is_empty() { tg.bot_token = v; }
+                if !v.is_empty() {
+                    tg.bot_token = v;
+                }
             }
             if let Ok(v) = std::env::var("ZEROCLAW_TELEGRAM_BOT_TOKEN") {
-                if !v.is_empty() { tg.bot_token = v; }
+                if !v.is_empty() {
+                    tg.bot_token = v;
+                }
             }
         }
         // Proxy enabled flag: ZEROCLAW_PROXY_ENABLED

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -10866,6 +10866,36 @@ impl Config {
         {
             self.storage.provider.config.connect_timeout_secs = Some(timeout_secs);
         }
+        if let Some(ref mut sl) = self.channels.slack {
+            if let Ok(v) = std::env::var("SLACK_BOT_TOKEN") {
+                if !v.is_empty() { sl.bot_token = v; }
+            }
+            if let Ok(v) = std::env::var("ZEROCLAW_SLACK_BOT_TOKEN") {
+                if !v.is_empty() { sl.bot_token = v; }
+            }
+            if let Ok(v) = std::env::var("SLACK_APP_TOKEN") {
+                if !v.is_empty() { sl.app_token = Some(v); }
+            }
+            if let Ok(v) = std::env::var("ZEROCLAW_SLACK_APP_TOKEN") {
+                if !v.is_empty() { sl.app_token = Some(v); }
+            }
+        }
+        if let Some(ref mut dc) = self.channels.discord {
+            if let Ok(v) = std::env::var("DISCORD_BOT_TOKEN") {
+                if !v.is_empty() { dc.bot_token = v; }
+            }
+            if let Ok(v) = std::env::var("ZEROCLAW_DISCORD_BOT_TOKEN") {
+                if !v.is_empty() { dc.bot_token = v; }
+            }
+        }
+        if let Some(ref mut tg) = self.channels.telegram {
+            if let Ok(v) = std::env::var("TELEGRAM_BOT_TOKEN") {
+                if !v.is_empty() { tg.bot_token = v; }
+            }
+            if let Ok(v) = std::env::var("ZEROCLAW_TELEGRAM_BOT_TOKEN") {
+                if !v.is_empty() { tg.bot_token = v; }
+            }
+        }
         // Proxy enabled flag: ZEROCLAW_PROXY_ENABLED
         let explicit_proxy_enabled = std::env::var("ZEROCLAW_PROXY_ENABLED")
             .ok()


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Added env var overrides for Slack (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`), Discord (`DISCORD_BOT_TOKEN`), and Telegram (`TELEGRAM_BOT_TOKEN`) channel tokens
  - Added `ZEROCLAW_`-prefixed variants that take precedence per @JordanTheJet's review feedback on #5310
  - Allows credentials to be supplied via environment instead of hardcoding in config.toml
- **Scope boundary:** `apply_env_overrides()` method only. No config schema, serialization, or channel behavior changes.
- **Blast radius:** Users who set these env vars will see them override config file values. No effect on users who don't set them.
- **Linked issue(s):** Closes #5183. Supersedes #5310.

## Validation Evidence (required)

- `cargo check -p zeroclaw-config` — passes

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `Yes` — tokens can now be supplied via env vars, which is the more secure pattern (avoids plaintext in config files)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `Yes` — new env var names accepted, but they are opt-in

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)