### PR TITLE
fix(sessions): normalize session key to survive filesystem sanitization in forum topics

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -421,12 +421,20 @@ fn conversation_memory_key(msg: &zeroclaw_api::channel::ChannelMessage) -> Strin
 pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
     // Include reply_target for per-channel isolation (e.g. distinct Discord/Slack
     // channels) and thread_ts for per-topic isolation in forum groups.
+    //
+    // Sanitize ':' in reply_target to "__" so the composite key survives
+    // session_store::session_path's filename sanitizer unchanged.  That function
+    // maps every char that is not alphanumeric, '_', or '-' to '_'; "__" is
+    // already in the allow-list and cannot collide with the single-underscore
+    // field separators used in the format! strings below.  Both the JSONL
+    // write path (via session_path) and the in-memory read path (histories.get)
+    // must agree on the same key form — deriving it once here ensures they do.
+    let safe_target = msg.reply_target.replace(':', "__");
     match &msg.thread_ts {
         Some(tid) => format!(
-            "{}_{}_{}_{}",
-            msg.channel, msg.reply_target, tid, msg.sender
+            "{}_{}_{}_{}", msg.channel, safe_target, tid, msg.sender
         ),
-        None => format!("{}_{}_{}", msg.channel, msg.reply_target, msg.sender),
+        None => format!("{}_{}_{}", msg.channel, safe_target, msg.sender),
     }
 }
 

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -431,9 +431,7 @@ pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> 
     // must agree on the same key form — deriving it once here ensures they do.
     let safe_target = msg.reply_target.replace(':', "__");
     match &msg.thread_ts {
-        Some(tid) => format!(
-            "{}_{}_{}_{}", msg.channel, safe_target, tid, msg.sender
-        ),
+        Some(tid) => format!("{}_{}_{}_{}", msg.channel, safe_target, tid, msg.sender),
         None => format!("{}_{}_{}", msg.channel, safe_target, msg.sender),
     }
 }
@@ -5861,12 +5859,8 @@ mod tests {
         // Without sanitization, session_store::session_path would map ':' to
         // '_' on the write path while the in-memory read path kept ':',
         // producing a key mismatch on restart-hydration. See PR #6091.
-        let msg = channel_message_for_history_key(
-            "telegram",
-            "-1003813552641:42",
-            Some("42"),
-            "alice",
-        );
+        let msg =
+            channel_message_for_history_key("telegram", "-1003813552641:42", Some("42"), "alice");
         assert_eq!(
             conversation_history_key(&msg),
             "telegram_-1003813552641__42_42_alice"
@@ -5878,23 +5872,15 @@ mod tests {
         // Slack/Discord and any non-forum-topic Telegram traffic don't put
         // ':' in reply_target — sanitization is a no-op and the key is
         // byte-identical to the pre-fix behaviour.
-        let with_thread = channel_message_for_history_key(
-            "slack",
-            "C12345",
-            Some("1234.5"),
-            "alice",
-        );
+        let with_thread =
+            channel_message_for_history_key("slack", "C12345", Some("1234.5"), "alice");
         assert_eq!(
             conversation_history_key(&with_thread),
             "slack_C12345_1234.5_alice"
         );
 
-        let without_thread = channel_message_for_history_key(
-            "telegram",
-            "-1003813552641",
-            None,
-            "alice",
-        );
+        let without_thread =
+            channel_message_for_history_key("telegram", "-1003813552641", None, "alice");
         assert_eq!(
             conversation_history_key(&without_thread),
             "telegram_-1003813552641_alice"
@@ -5905,18 +5891,10 @@ mod tests {
     fn conversation_history_key_distinguishes_topics_in_same_chat() {
         // Two different forum topics under the same chat must produce
         // distinct history keys; otherwise topic context would cross-pollinate.
-        let topic_42 = channel_message_for_history_key(
-            "telegram",
-            "-1003813552641:42",
-            Some("42"),
-            "alice",
-        );
-        let topic_99 = channel_message_for_history_key(
-            "telegram",
-            "-1003813552641:99",
-            Some("99"),
-            "alice",
-        );
+        let topic_42 =
+            channel_message_for_history_key("telegram", "-1003813552641:42", Some("42"), "alice");
+        let topic_99 =
+            channel_message_for_history_key("telegram", "-1003813552641:99", Some("99"), "alice");
         assert_ne!(
             conversation_history_key(&topic_42),
             conversation_history_key(&topic_99)

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -5836,6 +5836,93 @@ mod tests {
         );
     }
 
+    fn channel_message_for_history_key(
+        channel: &str,
+        reply_target: &str,
+        thread_ts: Option<&str>,
+        sender: &str,
+    ) -> zeroclaw_api::channel::ChannelMessage {
+        zeroclaw_api::channel::ChannelMessage {
+            id: "msg-1".to_string(),
+            sender: sender.to_string(),
+            reply_target: reply_target.to_string(),
+            content: String::new(),
+            channel: channel.to_string(),
+            timestamp: 0,
+            thread_ts: thread_ts.map(str::to_string),
+            interruption_scope_id: None,
+            attachments: vec![],
+        }
+    }
+
+    #[test]
+    fn conversation_history_key_sanitizes_colon_in_forum_topic_reply_target() {
+        // Telegram forum-topic case: reply_target is `<chat_id>:<thread_id>`.
+        // Without sanitization, session_store::session_path would map ':' to
+        // '_' on the write path while the in-memory read path kept ':',
+        // producing a key mismatch on restart-hydration. See PR #6091.
+        let msg = channel_message_for_history_key(
+            "telegram",
+            "-1003813552641:42",
+            Some("42"),
+            "alice",
+        );
+        assert_eq!(
+            conversation_history_key(&msg),
+            "telegram_-1003813552641__42_42_alice"
+        );
+    }
+
+    #[test]
+    fn conversation_history_key_unchanged_when_reply_target_has_no_colon() {
+        // Slack/Discord and any non-forum-topic Telegram traffic don't put
+        // ':' in reply_target — sanitization is a no-op and the key is
+        // byte-identical to the pre-fix behaviour.
+        let with_thread = channel_message_for_history_key(
+            "slack",
+            "C12345",
+            Some("1234.5"),
+            "alice",
+        );
+        assert_eq!(
+            conversation_history_key(&with_thread),
+            "slack_C12345_1234.5_alice"
+        );
+
+        let without_thread = channel_message_for_history_key(
+            "telegram",
+            "-1003813552641",
+            None,
+            "alice",
+        );
+        assert_eq!(
+            conversation_history_key(&without_thread),
+            "telegram_-1003813552641_alice"
+        );
+    }
+
+    #[test]
+    fn conversation_history_key_distinguishes_topics_in_same_chat() {
+        // Two different forum topics under the same chat must produce
+        // distinct history keys; otherwise topic context would cross-pollinate.
+        let topic_42 = channel_message_for_history_key(
+            "telegram",
+            "-1003813552641:42",
+            Some("42"),
+            "alice",
+        );
+        let topic_99 = channel_message_for_history_key(
+            "telegram",
+            "-1003813552641:99",
+            Some("99"),
+            "alice",
+        );
+        assert_ne!(
+            conversation_history_key(&topic_42),
+            conversation_history_key(&topic_99)
+        );
+    }
+
     #[test]
     fn context_window_overflow_error_detector_matches_known_messages() {
         let overflow_err = anyhow::anyhow!(


### PR DESCRIPTION
> **Note for upstream readers:** this PR body is the analysis memo from a downstream investigation (multitenant-personal-assistant β milestone). It includes references to internal hostnames (`agent-beta`) and a downstream spec (`§7.3`); those are the reporter's environment context, not upstream actions. The technical content (root-cause analysis, code citations, fix proposal) is what matters for review.

# ZeroClaw topic-context behaviour — 2026-04-25

**Investigating:** spec §7.3 bugs 2b/2c — on ZeroClaw restart, does the bot treat a
previously-active forum topic as empty for the first post-restart message?

**Verdict:** Bug 2b/2c is **real in v0.7.3 as shipped**, but is **already partially
mitigated** by ZeroClaw's JSONL session persistence path. A separate gap exists:
the `[agent.session]` backend is set to `"none"` in the current config, which
disables a newer SQLite session layer but does not disable the orchestrator-level
JSONL persistence. The actual bug is narrower than the spec described: rows survive
restart (the JSONL files persist and are reloaded), but they are keyed by a
sanitized form of the history key that **collapses the colon separator** in
`chat_id:thread_id` to an underscore, causing **all topics of the same supergroup
to share a single JSONL file** after key sanitization. This means on restart the
bot loads *some* history but may mix turns from different topics. Phase 7 should
still run, but the fix target is different from what the spec anticipated.

---

## 1. Summary

ZeroClaw v0.7.3 does persist conversation history across restarts via
append-only JSONL files in `{workspace}/sessions/`. On daemon startup the
orchestrator's `hydrate` loop reads those files back into its in-memory
`ConversationHistories` LRU cache (logged as "Restored N session(s) from disk").
This disproves the simple form of bug 2c — restart does not produce a blank-slate
agent if the JSONL file exists.

However, bug 2b/2c still manifests through a key-collision: the history key is
`{channel}_{reply_target}_{thread_ts}_{sender}` (e.g.
`telegram_-1003813552641:42_42_k_sixsix`) but `session_path()` in
`session_store.rs` sanitizes all non-alphanumeric, non-`_`, non-`-` characters to
`_`. The colon in `reply_target` (`-1003813552641:42`) is sanitized to an
underscore, making the filename identical to what a non-threaded message would
produce — `telegram_-1003813552641_42_42_k_sixsix.jsonl` — which is distinct
from `telegram_-1003813552641_k_sixsix.jsonl` (non-threaded, no `thread_ts`).

So per-topic files are created with distinct names (via `thread_ts`) but their
contents are written and read back via the **sanitized key**, meaning:
- Topics in the same supergroup with different `thread_ts` values each get
  a distinct JSONL file.
- On restart, `list_sessions()` enumerates `.jsonl` filenames and strips the
  `.jsonl` suffix to recover the (sanitized) key.
- `histories.push(key, msgs)` inserts using that sanitized key.
- When the first live message arrives in topic T1, `conversation_history_key`
  returns the original unsanitized key; `histories.get(unsanitized_key)` finds
  **no entry** because the stored key is sanitized.

**Result:** the history is in memory (Restored log line fires), but the first
lookup by the live message path **misses** the cache because the sanitized stored
key does not match the original key used for live lookups. Bug 2b/2c is confirmed.

Local patches 0001–0006 do not touch this path. None of the six patches modify
`session_store.rs`, `orchestrator::conversation_history_key`, or the startup
hydration loop.

---

## 2. Evidence

### 2.1 SQLite state on agent-beta

```
root@agent-beta:# ls /var/lib/zeroclaw/workspace/sessions/
sessions.db   sessions.db-shm   sessions.db-wal
telegram_-1003813552641_k_sixsix.jsonl
```

One JSONL session file exists. `sessions.db` is present but empty — the
`[agent.session] backend = "none"` setting explicitly disables the newer SQLite
backend introduced in v0.7.3 (see `session_sqlite.rs`). The JSONL store is the
active path.

The file is named `telegram_-1003813552641_k_sixsix.jsonl`, which matches
`{channel}_{sanitized_chat_id}_{sender}` — confirming non-threaded message
behaviour. Both tg-probe messages processed on 2026-04-24 06:19 and 06:25 were
not in a forum topic (no `message_thread_id` in Telegram update), so `thread_ts`
was `None` and `conversation_history_key` returned the two-component form.

```
# sessions table row count (new SQLite backend — not in use):
SELECT COUNT(*) FROM sessions;  →  0

# JSONL file content (two-turn echo exchange, confirmed restored at restart):
{"role":"user","content":"tg-probe send-echo 88691b7f ..."}
{"role":"assistant","content":"88691b7f"}
{"role":"user","content":"tg-probe send-echo cbb4e89c ..."}
{"role":"assistant","content":"cbb4e89c"}
```

Restart log at 10:04:22: `INFO zeroclaw_channels::orchestrator: 📂 Restored 1 session(s) from disk`

### 2.2 Source: history key construction

**File:** `crates/zeroclaw-channels/src/orchestrator/mod.rs`, lines 421–431 (v0.7.3)

```rust
pub fn conversation_history_key(msg: &zeroclaw_api::channel::ChannelMessage) -> String {
    match &msg.thread_ts {
        Some(tid) => format!(
            "{}_{}_{}_{}",
            msg.channel, msg.reply_target, tid, msg.sender
        ),
        None => format!("{}_{}_{}", msg.channel, msg.reply_target, msg.sender),
    }
}
```

When `message_thread_id` is present in a Telegram update, `reply_target` is
`"-1003813552641:42"` (chat_id:thread_id) and `thread_ts` is `"42"` (just the
thread_id). The resulting key is:
`telegram_-1003813552641:42_42_k_sixsix`

### 2.3 Source: JSONL session path sanitization

**File:** `crates/zeroclaw-infra/src/session_store.rs`, lines 26–38 (v0.7.3)

```rust
fn session_path(&self, session_key: &str) -> PathBuf {
    let safe_key: String = session_key
        .chars()
        .map(|c| {
            if c.is_alphanumeric() || c == '_' || c == '-' {
                c
            } else {
                '_'
            }
        })
        .collect();
    self.sessions_dir.join(format!("{safe_key}.jsonl"))
}
```

The colon in `reply_target` becomes `_`. So the on-disk filename is
`telegram_-1003813552641_42_42_k_sixsix.jsonl`.

### 2.4 Source: startup hydration

**File:** `crates/zeroclaw-channels/src/orchestrator/mod.rs`, lines 5569–5618 (v0.7.3)

```rust
let session_keys = store.list_sessions();
// ...
for key in session_keys {
    let mut msgs = store.load(&key);
    // ...
    histories.push(key, msgs);   // ← inserts with SANITIZED key
}
```

`list_sessions()` strips `.jsonl` from filenames — returning the sanitized string
— and `histories.push(key, ...)` stores under that sanitized string.

### 2.5 Source: live-message lookup

**File:** same file, line 2647 (v0.7.3)

```rust
let prior_turns_raw = ...
    ctx.conversation_histories
        .lock()
        ...
        .get(&history_key)   // ← looks up with ORIGINAL (unsanitized) key
        .cloned()
        .unwrap_or_default()
```

`history_key` is the **original** unsanitized key from `conversation_history_key`.
Because the colon in `reply_target` is not present in the stored (sanitized) key,
the lookup misses and `prior_turns_raw` is empty — blank-slate first message.

### 2.6 Telegram channel — how thread_ts is populated

**File:** `crates/zeroclaw-channels/src/telegram.rs`, lines 1111–1199 (v0.7.3)

```rust
let thread_id = message
    .get("message_thread_id")
    .and_then(serde_json::Value::as_i64)
    .map(|id| id.to_string());

let reply_target = if let Some(ref tid) = thread_id {
    format!("{}:{}", chat_id, tid)
} else {
    chat_id.clone()
};
// ...
ChannelMessage { reply_target, thread_ts: thread_id, ... }
```

When `message_thread_id` is absent (non-forum message), `thread_ts = None` and
`reply_target = chat_id`. The colon appears only in forum-topic messages.

### 2.7 Local patches 0001–0006

None of patches 0001–0006 modify `session_store.rs`, `session_sqlite.rs`, or the
`conversation_history_key` / startup hydration path. The patches address:
0001: reply-context skip; 0002/0003: thread_id on approval/typing sends;
0004: approval observability logs; 0005: web-tool system prompt advertisement;
0006: beta commands, loop-v2 detector, budget-rejected formatter. Bug 2b/2c is
unaddressed by any existing local patch.

---

## 3. Proposed fix

The root cause is a key mismatch: **write path uses sanitized key, read path uses
original key.** Two equivalent fixes; the first is simpler:

### Option A — sanitize at key construction time (preferred)

Change `conversation_history_key` to produce a filesystem-safe key directly, so
that both the persistence write and the in-memory lookup use the same form. Replace
the colon separator in `reply_target` with a double-underscore or another
safe separator that cannot collide:

```rust
pub fn conversation_history_key(msg: &ChannelMessage) -> String {
    // Use __ as separator to survive session_store's sanitizer (which
    // maps ':' → '_'). Both the JSONL filename and the in-memory key
    // must agree on this form; we derive it once here.
    let safe_target = msg.reply_target.replace(':', "__");
    match &msg.thread_ts {
        Some(tid) => format!(
            "{}_{}_{}_{}", msg.channel, safe_target, tid, msg.sender
        ),
        None => format!(
            "{}_{}_{}", msg.channel, safe_target, msg.sender
        ),
    }
}
```

This change is in `crates/zeroclaw-channels/src/orchestrator/mod.rs` (one
function). No change needed in `session_store.rs` or the hydration loop. Existing
JSONL files would be unreachable under the new key format (their filenames differ),
so a one-time migration or a `--migrate-session-keys` startup flag would be
needed for existing deployments. For β (fresh-instance containers) no migration
is needed — each container starts empty.

### Option B — normalize at load time

In the startup hydration loop, after `store.list_sessions()`, apply the same
sanitization to the live-message lookup path so keys are compared in their
sanitized form throughout the runtime. This is more invasive (touches the LRU
cache type) and does not fix the long-term inconsistency.

**Recommended patch scope for Phase 7:** Option A — modify
`conversation_history_key` in `orchestrator/mod.rs` to sanitize `reply_target`
before building the composite key. Also update the function comment to document
the separator contract. The change is ~4 lines.

---

## 4. Upstream PR outline

**Title:** `fix(sessions): normalize session key to survive filesystem sanitization in forum topics`

**Body (first paragraph, reuse verbatim in Task 7.2):**

> When ZeroClaw handles a Telegram message in a supergroup forum topic,
> `conversation_history_key` builds a composite key containing `reply_target` in
> `chat_id:thread_id` form. `session_store::session_path` sanitizes all non-word
> characters to `_` before writing the JSONL file, so the on-disk key is
> `..._chat_id_thread_id_...`. On restart, the hydration loop inserts sessions
> under the sanitized (filename-derived) key. The first live message in a topic
> after restart calls `histories.get` with the original unsanitized key and gets
> no match — the bot treats the topic as empty despite the history existing on
> disk. Fix: replace `:` with `__` in `reply_target` inside
> `conversation_history_key` so both write and read paths agree on the same key
> form. All six existing local patches (0001–0006) are unrelated to this path.

---

## 5. Confidence

| Claim | Status |
|---|---|
| Bug 2b/2c (blank-slate on first post-restart message in topic) is real | **Confirmed by code analysis** — write path uses sanitized key, read path uses original key. No live repro needed; the code path is unambiguous. |
| Bug exists in v0.7.3 upstream (no local patch covers it) | **Confirmed** — patches 0001–0006 do not touch `session_store.rs`, `conversation_history_key`, or hydration loop. |
| JSONL files survive restart (rows not lost) | **Confirmed** — "Restored 1 session(s) from disk" in journal at 10:04:22 on agent-beta. Sessions are written and re-read correctly for non-topic (no `thread_ts`) messages. |
| Bug only manifests for forum-topic messages (non-General topics) | **Confirmed** — when `thread_ts = None`, `reply_target` has no colon; sanitization is a no-op; keys agree. Non-threaded sessions (like the tg-probe echo sessions observed on agent-beta) work correctly. |
| Live repro (operator sends in two topics, restarts, checks context) | **Not run** — operator instruction was to avoid sending Telegram messages. The code analysis is conclusive; a live repro would confirm the user-facing symptom but would not change the fix. |
| Fix Option A covers β per-container ZeroClaw correctly | **Confirmed** — each container starts with an empty session directory; no migration path is needed for β. |

**Phase 7 decision:** Run Phase 7. The bug is confirmed, the fix target is clear
(one function, ~4 lines), and the fix must land before β onboards the first
tenant to avoid context amnesia on any container restart.

---

## Appendix: additional observation — `[agent.session]` backend mismatch

The config on agent-beta has `[agent.session] backend = "none"`, which disables
`SqliteSessionBackend` (the newer sessions.db path). The orchestrator-level
`session_persistence = true` (default) is independent and uses `SessionStore`
(JSONL). This means:

- `sessions.db` exists but is empty — created by `SqliteSessionBackend::new` on
  a prior run of v0.7.3 before the config set `backend = "none"`, but never
  written to under the current config.
- The error `Daemon component 'channels' failed: duplicate column name: namespace`
  visible in the 05:52 startup log was a migration error in the SQLite backend
  on a stale database schema; it did not affect the JSONL (orchestrator-level)
  path, which continued normally.

This does not affect the 2b/2c analysis — the bug lives in the JSONL + in-memory
path, which is active regardless of `[agent.session]` backend.

The `namespace` column error should be noted to upstream; it indicates a migration
that tries to add a column that already exists in some schema versions. It is
non-fatal (logged at ERROR but the channels component restarted and continued),
but worth a separate upstream bug report.
