### PR TITLE
fix(providers): read api_key, base_url, and name from config for fallback providers

### DIFF
--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -716,6 +716,10 @@ pub struct ProviderRuntimeOptions {
     /// Extra JSON parameters merged into API request bodies at the top level.
     /// Propagated from `ModelProviderConfig::provider_extra`.
     pub provider_extra: Option<serde_json::Value>,
+    /// Full `[providers]` config, used to resolve `api_key`, `base_url`, and
+    /// provider-type overrides for fallback providers from `[providers.models.<name>]`.
+    /// When `None`, fallback credentials are resolved from env vars only.
+    pub fallback_providers_config: Option<zeroclaw_config::providers::ProvidersConfig>,
 }
 
 impl Default for ProviderRuntimeOptions {
@@ -733,6 +737,7 @@ impl Default for ProviderRuntimeOptions {
             provider_max_tokens: None,
             merge_system_into_user: false,
             provider_extra: None,
+            fallback_providers_config: None,
         }
     }
 }
@@ -776,6 +781,7 @@ pub fn provider_runtime_options_from_config(
         provider_max_tokens: fallback.and_then(|e| e.max_tokens),
         merge_system_into_user,
         provider_extra: fallback.and_then(|e| e.provider_extra.clone()),
+        fallback_providers_config: Some(config.providers.clone()),
     }
 }
 
@@ -1810,12 +1816,23 @@ pub fn create_resilient_provider_with_options(
 
         let (provider_name, profile_override) = parse_provider_profile(fallback);
 
-        // Each fallback provider resolves its own credential via provider-
-        // specific env vars (e.g. DEEPSEEK_API_KEY for "deepseek") instead
-        // of inheriting the primary provider's key. Passing `None` lets
-        // `resolve_provider_credential` check the correct env var for the
-        // fallback provider name.
-        //
+        // Look up api_key, base_url, and provider-type from [providers.models.<name>]
+        // before falling back to env var resolution. This makes fallback providers
+        // config-aware the same way the primary provider is. If no profile entry
+        // exists, resolve_provider_credential falls through to provider-specific env
+        // vars (e.g. XAI_API_KEY for "xai") as before.
+        let model_profile = options
+            .fallback_providers_config
+            .as_ref()
+            .and_then(|pc| pc.models.get(provider_name));
+        let config_api_key = model_profile.and_then(|m| m.api_key.as_deref());
+        let config_api_url = model_profile.and_then(|m| m.base_url.as_deref());
+        // If the profile has a name override (e.g. name = "ollama" for a custom
+        // profile key), use it as the actual provider type for the factory.
+        let actual_provider_name = model_profile
+            .and_then(|m| m.name.as_deref())
+            .unwrap_or(provider_name);
+
         // When a profile override is present (e.g. "openai-codex:second"),
         // propagate it through `auth_profile_override` so the provider
         // picks up the correct OAuth credential set.
@@ -1828,7 +1845,18 @@ pub fn create_resilient_provider_with_options(
             None => options.clone(),
         };
 
-        match create_provider_with_options(provider_name, None, &fallback_options) {
+        let create_result = match actual_provider_name {
+            "openai-codex" | "openai_codex" | "codex" => {
+                create_provider_with_options(actual_provider_name, config_api_key, &fallback_options)
+            }
+            _ => create_provider_with_url_and_options(
+                actual_provider_name,
+                config_api_key,
+                config_api_url,
+                &fallback_options,
+            ),
+        };
+        match create_result {
             Ok(provider) => providers.push((fallback.clone(), provider)),
             Err(_error) => {
                 tracing::warn!(

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -1792,6 +1792,23 @@ struct FallbackResolution {
     base_url: Option<String>,
 }
 
+/// True when `name` matches a registered provider's canonical name or one
+/// of its aliases (case-insensitive), per `list_providers()` — the same
+/// catalogue the onboarding flow and `create_provider_with_url_and_options`
+/// dispatch consult. Used by `resolve_fallback_provider` to decide whether
+/// a `[providers.models.<name>] { base_url = ... }` profile should keep
+/// its named-provider dispatch (recognized name) or be promoted to a
+/// `custom:<url>` shorthand (unrecognized name).
+fn is_known_provider(name: &str) -> bool {
+    list_providers().iter().any(|info| {
+        info.name.eq_ignore_ascii_case(name)
+            || info
+                .aliases
+                .iter()
+                .any(|alias| alias.eq_ignore_ascii_case(name))
+    })
+}
+
 fn resolve_fallback_provider(
     fallback_name: &str,
     providers_config: Option<&zeroclaw_config::providers::ProvidersConfig>,
@@ -1826,14 +1843,25 @@ fn resolve_fallback_provider(
         name
     } else if !provider_name.starts_with("custom:")
         && !provider_name.starts_with("anthropic-custom:")
+        && !is_known_provider(provider_name)
         && let Some(ref url) = base_url
     {
-        // Profile carries a base_url and no name override. Promote to the
+        // Profile carries a base_url, no name override, AND the profile key
+        // does not match a registered provider name or alias. Promote to the
         // same custom:<url> shape that `apply_named_model_provider_profile`
         // produces for the primary path, so a fallback like
         // `[providers.models.local] { base_url = ... }` is accepted by the
         // factory instead of being dropped as `Unknown provider`. Mirrors
         // schema.rs::apply_named_model_provider_profile for consistency.
+        //
+        // Recognized providers (ollama, xai/grok, anthropic, etc.) keep their
+        // name so `create_provider_with_url_and_options(name, key, Some(url),
+        // ...)` routes through the provider-specific factory, which already
+        // knows how to honor `base_url` for that provider. Without the
+        // is_known_provider gate, named profiles like
+        // `[providers.models.ollama] { base_url = ... }` would be reduced to
+        // `custom:<url>` and lose provider-specific behavior (#5803, #6092
+        // review thread).
         format!("custom:{url}")
     } else {
         provider_name.to_string()
@@ -3990,6 +4018,72 @@ mod tests {
             resolution.base_url.as_deref(),
             Some("http://192.168.2.4:11434")
         );
+    }
+
+    #[test]
+    fn resolve_fallback_named_ollama_with_base_url_keeps_named_dispatch() {
+        // Regression for Audacity88's review on #6092: a profile keyed on a
+        // recognized provider name (here, "ollama") that supplies a base_url
+        // and no name override must NOT be reduced to `custom:<url>`. The
+        // ollama factory has its own URL handling — promotion would route
+        // through the generic OpenAI-compatible custom provider and lose
+        // provider-specific behavior.
+        let cfg = make_providers_config(vec![(
+            "ollama",
+            zeroclaw_config::schema::ModelProviderConfig {
+                base_url: Some("http://192.168.2.4:11434".to_string()),
+                ..Default::default()
+            },
+        )]);
+        let resolution = resolve_fallback_provider("ollama", Some(&cfg));
+        assert_eq!(
+            resolution.actual_provider_name, "ollama",
+            "named-provider profile must keep its dispatch name when only base_url is set"
+        );
+        assert_eq!(
+            resolution.base_url.as_deref(),
+            Some("http://192.168.2.4:11434"),
+            "base_url must still flow through to the named-provider factory"
+        );
+    }
+
+    #[test]
+    fn resolve_fallback_named_xai_alias_with_base_url_keeps_named_dispatch() {
+        // Regression for Audacity88's review on #6092: aliases of recognized
+        // providers (here `grok` is an alias of `xai`) must also retain their
+        // named-provider dispatch when only base_url is set.
+        let cfg = make_providers_config(vec![(
+            "grok",
+            zeroclaw_config::schema::ModelProviderConfig {
+                api_key: Some("xai-test".to_string()),
+                base_url: Some("https://api.x.ai/v1".to_string()),
+                ..Default::default()
+            },
+        )]);
+        let resolution = resolve_fallback_provider("grok", Some(&cfg));
+        assert_eq!(
+            resolution.actual_provider_name, "grok",
+            "alias of a recognized provider must keep its dispatch name"
+        );
+        assert_eq!(resolution.api_key.as_deref(), Some("xai-test"));
+        assert_eq!(resolution.base_url.as_deref(), Some("https://api.x.ai/v1"));
+    }
+
+    #[test]
+    fn is_known_provider_recognizes_canonical_and_aliases() {
+        assert!(is_known_provider("ollama"));
+        assert!(is_known_provider("openrouter"));
+        assert!(is_known_provider("anthropic"));
+        // Aliases
+        assert!(is_known_provider("grok")); // alias of xai
+        assert!(is_known_provider("codex")); // alias of openai-codex
+        // Case-insensitive
+        assert!(is_known_provider("Ollama"));
+        assert!(is_known_provider("OPENROUTER"));
+        // Negative
+        assert!(!is_known_provider("local"));
+        assert!(!is_known_provider("my-local"));
+        assert!(!is_known_provider("definitely-not-a-provider"));
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -1846,9 +1846,11 @@ pub fn create_resilient_provider_with_options(
         };
 
         let create_result = match actual_provider_name {
-            "openai-codex" | "openai_codex" | "codex" => {
-                create_provider_with_options(actual_provider_name, config_api_key, &fallback_options)
-            }
+            "openai-codex" | "openai_codex" | "codex" => create_provider_with_options(
+                actual_provider_name,
+                config_api_key,
+                &fallback_options,
+            ),
             _ => create_provider_with_url_and_options(
                 actual_provider_name,
                 config_api_key,

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -1113,6 +1113,19 @@ pub fn create_provider_with_url(
     create_provider_with_url_and_options(name, api_key, api_url, &ProviderRuntimeOptions::default())
 }
 
+/// Pick the effective xAI/Grok endpoint, honoring a configured `base_url`
+/// override (typically from `[providers.models.xai].base_url` or
+/// `[providers.models.grok].base_url`) and falling back to the public API.
+///
+/// Empty/whitespace-only overrides are treated as unset so a misconfigured
+/// `base_url = ""` doesn't silently route requests to nowhere.
+fn xai_base_url(configured: Option<&str>) -> &str {
+    configured
+        .map(str::trim)
+        .filter(|u| !u.is_empty())
+        .unwrap_or("https://api.x.ai")
+}
+
 /// Factory: create provider with optional base URL and runtime options.
 #[allow(clippy::too_many_lines)]
 fn create_provider_with_url_and_options(
@@ -1423,7 +1436,7 @@ fn create_provider_with_url_and_options(
         ))),
         "xai" | "grok" => Ok(compat(OpenAiCompatibleProvider::new(
             "xAI",
-            "https://api.x.ai",
+            xai_base_url(api_url),
             key,
             AuthStyle::Bearer,
         ))),
@@ -4067,6 +4080,77 @@ mod tests {
         );
         assert_eq!(resolution.api_key.as_deref(), Some("xai-test"));
         assert_eq!(resolution.base_url.as_deref(), Some("https://api.x.ai/v1"));
+    }
+
+    // ── xai_base_url helper (Audacity88 follow-up on #6092) ──────────
+    //
+    // The `xai` / `grok` factory arm previously hardcoded `"https://api.x.ai"`
+    // and ignored its `api_url` parameter, so the resolver-level URL flow
+    // proved by `resolve_fallback_named_xai_alias_with_base_url_keeps_named_dispatch`
+    // never actually reached the constructed provider. The factory now reads
+    // through `xai_base_url`. The tests below cover the helper's contract
+    // directly because the factory returns `Box<dyn Provider>` (the trait
+    // does not surface `base_url`); guarding the helper guarantees the
+    // factory's URL pick is correct.
+
+    #[test]
+    fn xai_base_url_returns_default_when_none() {
+        assert_eq!(xai_base_url(None), "https://api.x.ai");
+    }
+
+    #[test]
+    fn xai_base_url_returns_default_when_empty_or_whitespace() {
+        assert_eq!(xai_base_url(Some("")), "https://api.x.ai");
+        assert_eq!(xai_base_url(Some("   ")), "https://api.x.ai");
+        assert_eq!(xai_base_url(Some("\t\n")), "https://api.x.ai");
+    }
+
+    #[test]
+    fn xai_base_url_honors_configured_override() {
+        assert_eq!(
+            xai_base_url(Some("https://my-proxy.example.com/x")),
+            "https://my-proxy.example.com/x",
+            "configured `[providers.models.xai].base_url` must override the public default"
+        );
+    }
+
+    #[test]
+    fn xai_base_url_trims_whitespace_around_override() {
+        assert_eq!(
+            xai_base_url(Some("  https://api.x.ai/v1  ")),
+            "https://api.x.ai/v1",
+            "leading/trailing whitespace in the override must be trimmed"
+        );
+    }
+
+    #[test]
+    fn create_provider_for_xai_with_base_url_does_not_error() {
+        // End-to-end: the factory consumes `api_url` for the xai/grok arm.
+        // We can't inspect the boxed provider's base_url through the trait,
+        // but we can prove the factory accepts the configured override and
+        // builds a provider — combined with the helper tests above this
+        // closes the URL-flow path Audacity88 flagged.
+        let provider = create_provider_with_url_and_options(
+            "xai",
+            Some("xai-key"),
+            Some("https://my-proxy.example.com/x"),
+            &ProviderRuntimeOptions::default(),
+        );
+        assert!(
+            provider.is_ok(),
+            "xai factory must accept a configured base_url"
+        );
+
+        let provider = create_provider_with_url_and_options(
+            "grok",
+            Some("xai-key"),
+            Some("https://my-proxy.example.com/x"),
+            &ProviderRuntimeOptions::default(),
+        );
+        assert!(
+            provider.is_ok(),
+            "grok alias must accept a configured base_url"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -1775,6 +1775,77 @@ fn parse_provider_profile(s: &str) -> (&str, Option<&str>) {
     }
 }
 
+/// Resolved fallback-provider construction inputs derived from a fallback
+/// reference and the workspace `[providers.models]` table.
+///
+/// Mirrors the same precedence the primary-provider load path follows in
+/// `apply_named_model_provider_profile`: a `name` override on the profile
+/// wins; otherwise a profile carrying only `base_url` is promoted to the
+/// canonical `custom:<base_url>` provider id so the factory accepts it
+/// instead of failing with `Unknown provider`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FallbackResolution {
+    actual_provider_name: String,
+    profile_override: Option<String>,
+    api_key: Option<String>,
+    base_url: Option<String>,
+}
+
+fn resolve_fallback_provider(
+    fallback_name: &str,
+    providers_config: Option<&zeroclaw_config::providers::ProvidersConfig>,
+) -> FallbackResolution {
+    let (provider_name, profile_override_raw) = parse_provider_profile(fallback_name);
+    let profile_override = profile_override_raw.map(str::to_string);
+
+    let model_profile = providers_config.and_then(|pc| {
+        pc.models
+            .iter()
+            .find(|(key, _)| key.eq_ignore_ascii_case(provider_name))
+            .map(|(_, value)| value)
+    });
+
+    let api_key = model_profile.and_then(|m| m.api_key.clone());
+    let base_url = model_profile.and_then(|m| {
+        m.base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(String::from)
+    });
+    let name_override = model_profile.and_then(|m| {
+        m.name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty() && !value.eq_ignore_ascii_case(provider_name))
+            .map(String::from)
+    });
+
+    let actual_provider_name = if let Some(name) = name_override {
+        name
+    } else if !provider_name.starts_with("custom:")
+        && !provider_name.starts_with("anthropic-custom:")
+        && let Some(ref url) = base_url
+    {
+        // Profile carries a base_url and no name override. Promote to the
+        // same custom:<url> shape that `apply_named_model_provider_profile`
+        // produces for the primary path, so a fallback like
+        // `[providers.models.local] { base_url = ... }` is accepted by the
+        // factory instead of being dropped as `Unknown provider`. Mirrors
+        // schema.rs::apply_named_model_provider_profile for consistency.
+        format!("custom:{url}")
+    } else {
+        provider_name.to_string()
+    };
+
+    FallbackResolution {
+        actual_provider_name,
+        profile_override,
+        api_key,
+        base_url,
+    }
+}
+
 /// Create provider chain with retry and fallback behavior.
 pub fn create_resilient_provider(
     primary_name: &str,
@@ -1814,50 +1885,41 @@ pub fn create_resilient_provider_with_options(
             continue;
         }
 
-        let (provider_name, profile_override) = parse_provider_profile(fallback);
+        // Look up api_key, base_url, and provider-type from
+        // [providers.models.<name>] before falling back to env var resolution.
+        // This makes fallback providers config-aware the same way the primary
+        // provider is. When no profile entry exists, the per-provider factories
+        // fall through to env vars (e.g. XAI_API_KEY for "xai") as before.
+        let resolution =
+            resolve_fallback_provider(fallback, options.fallback_providers_config.as_ref());
 
-        // Look up api_key, base_url, and provider-type from [providers.<name>]
-        // before falling back to env var resolution. This makes fallback providers
-        // config-aware the same way the primary provider is. If no profile entry
-        // exists, resolve_provider_credential falls through to provider-specific env
-        // vars (e.g. XAI_API_KEY for "xai") as before.
-        let model_profile = options
-            .fallback_providers_config
-            .as_ref()
-            .and_then(|pc| pc.models.get(provider_name));
-        let config_api_key = model_profile.and_then(|m| m.api_key.as_deref());
-        let config_api_url = model_profile.and_then(|m| m.base_url.as_deref());
-        // If the profile has a name override (e.g. name = "ollama" for a custom
-        // profile key), use it as the actual provider type for the factory.
-        let actual_provider_name = model_profile
-            .and_then(|m| m.name.as_deref())
-            .unwrap_or(provider_name);
+        // Propagate auth profile override (e.g. "openai-codex:second") through
+        // ProviderRuntimeOptions so the provider picks up the right OAuth
+        // credential set.
+        let mut fallback_options = options.clone();
+        if let Some(profile) = resolution.profile_override.as_deref() {
+            fallback_options.auth_profile_override = Some(profile.to_string());
+        }
 
-        // When a profile override is present (e.g. "openai-codex:second"),
-        // propagate it through `auth_profile_override` so the provider
-        // picks up the correct OAuth credential set.
-        let fallback_options = match profile_override {
-            Some(profile) => {
-                let mut opts = options.clone();
-                opts.auth_profile_override = Some(profile.to_string());
-                opts
+        let create_result = match resolution.actual_provider_name.as_str() {
+            // Codex manages its own endpoint via OAuth token exchange and
+            // reads the override from `provider_api_url`, not from a positional
+            // url argument. Forward the resolved base_url through that field
+            // so a fallback profile's base_url is honored on the codex path.
+            "openai-codex" | "openai_codex" | "codex" => {
+                if let Some(ref url) = resolution.base_url {
+                    fallback_options.provider_api_url = Some(url.clone());
+                }
+                create_provider_with_options(
+                    &resolution.actual_provider_name,
+                    resolution.api_key.as_deref(),
+                    &fallback_options,
+                )
             }
-            None => options.clone(),
-        };
-
-        let create_result = match actual_provider_name {
-            // Codex manages its own endpoint via OAuth token exchange; config
-            // base_url is intentionally not forwarded — use provider_api_url
-            // in ProviderRuntimeOptions if an endpoint override is needed.
-            "openai-codex" | "openai_codex" | "codex" => create_provider_with_options(
-                actual_provider_name,
-                config_api_key,
-                &fallback_options,
-            ),
             _ => create_provider_with_url_and_options(
-                actual_provider_name,
-                config_api_key,
-                config_api_url,
+                &resolution.actual_provider_name,
+                resolution.api_key.as_deref(),
+                resolution.base_url.as_deref(),
                 &fallback_options,
             ),
         };
@@ -3799,82 +3861,126 @@ mod tests {
         assert_eq!(check_api_key_prefix("anthropic", "some-random-key"), None);
     }
 
-    // --- config-aware fallback ---
+    // --- config-aware fallback resolver ---
+    //
+    // These tests target `resolve_fallback_provider` directly because the
+    // `create_resilient_provider_with_options` call site swallows errors for
+    // invalid fallbacks (a single bad fallback must not poison the chain).
+    // Asserting on the resolver gives behaviour-first coverage that fails
+    // when the lookup is broken, instead of relying on the outer Ok signal
+    // which holds even when no profile data is read.
 
-    #[test]
-    fn fallback_uses_config_api_key_when_set() {
+    fn make_providers_config(
+        entries: Vec<(&str, zeroclaw_config::schema::ModelProviderConfig)>,
+    ) -> zeroclaw_config::providers::ProvidersConfig {
         let mut models = std::collections::HashMap::new();
-        models.insert(
-            "ollama".to_string(),
-            zeroclaw_config::schema::ModelProviderConfig {
-                api_key: Some("config-test-key".to_string()),
-                base_url: Some("http://localhost:11434".to_string()),
-                ..Default::default()
-            },
-        );
-        let providers_config = zeroclaw_config::providers::ProvidersConfig {
+        for (key, value) in entries {
+            models.insert(key.to_string(), value);
+        }
+        zeroclaw_config::providers::ProvidersConfig {
             models,
             ..Default::default()
-        };
-
-        let reliability = zeroclaw_config::schema::ReliabilityConfig {
-            provider_retries: 1,
-            provider_backoff_ms: 100,
-            fallback_providers: vec!["ollama".into()],
-            api_keys: Vec::new(),
-            model_fallbacks: std::collections::HashMap::new(),
-            channel_initial_backoff_secs: 2,
-            channel_max_backoff_secs: 60,
-            scheduler_poll_secs: 15,
-            scheduler_retries: 2,
-        };
-
-        let options = ProviderRuntimeOptions {
-            fallback_providers_config: Some(providers_config),
-            ..ProviderRuntimeOptions::default()
-        };
-
-        let provider =
-            create_resilient_provider_with_options("lmstudio", None, None, &reliability, &options);
-        assert!(provider.is_ok());
+        }
     }
 
     #[test]
-    fn fallback_name_override_routes_to_correct_provider() {
-        let mut models = std::collections::HashMap::new();
-        models.insert(
-            "my-local".to_string(),
+    fn resolve_fallback_uses_config_api_key_when_set() {
+        let cfg = make_providers_config(vec![(
+            "xai",
+            zeroclaw_config::schema::ModelProviderConfig {
+                api_key: Some("config-xai-key".to_string()),
+                ..Default::default()
+            },
+        )]);
+        let resolution = resolve_fallback_provider("xai", Some(&cfg));
+        assert_eq!(resolution.actual_provider_name, "xai");
+        assert_eq!(resolution.api_key.as_deref(), Some("config-xai-key"));
+        assert_eq!(resolution.base_url, None);
+        assert_eq!(resolution.profile_override, None);
+    }
+
+    #[test]
+    fn resolve_fallback_uses_name_override_for_factory_dispatch() {
+        let cfg = make_providers_config(vec![(
+            "my-local",
             zeroclaw_config::schema::ModelProviderConfig {
                 name: Some("ollama".to_string()),
                 base_url: Some("http://localhost:11434".to_string()),
                 ..Default::default()
             },
+        )]);
+        let resolution = resolve_fallback_provider("my-local", Some(&cfg));
+        // Name override wins over the base_url-only promotion path.
+        assert_eq!(resolution.actual_provider_name, "ollama");
+        assert_eq!(
+            resolution.base_url.as_deref(),
+            Some("http://localhost:11434")
         );
-        let providers_config = zeroclaw_config::providers::ProvidersConfig {
-            models,
-            ..Default::default()
-        };
+    }
 
-        let reliability = zeroclaw_config::schema::ReliabilityConfig {
-            provider_retries: 1,
-            provider_backoff_ms: 100,
-            fallback_providers: vec!["my-local".into()],
-            api_keys: Vec::new(),
-            model_fallbacks: std::collections::HashMap::new(),
-            channel_initial_backoff_secs: 2,
-            channel_max_backoff_secs: 60,
-            scheduler_poll_secs: 15,
-            scheduler_retries: 2,
-        };
+    #[test]
+    fn resolve_fallback_promotes_base_url_only_profile_to_custom_url() {
+        // Profile carries only a base_url and no canonical name. Without
+        // promotion the factory would reject "local" as Unknown provider and
+        // the fallback would be silently dropped (Audacity finding on #6092).
+        let cfg = make_providers_config(vec![(
+            "local",
+            zeroclaw_config::schema::ModelProviderConfig {
+                base_url: Some("http://192.168.2.4:11434".to_string()),
+                ..Default::default()
+            },
+        )]);
+        let resolution = resolve_fallback_provider("local", Some(&cfg));
+        assert_eq!(
+            resolution.actual_provider_name,
+            "custom:http://192.168.2.4:11434"
+        );
+        assert_eq!(
+            resolution.base_url.as_deref(),
+            Some("http://192.168.2.4:11434")
+        );
+    }
 
-        let options = ProviderRuntimeOptions {
-            fallback_providers_config: Some(providers_config),
-            ..ProviderRuntimeOptions::default()
-        };
+    #[test]
+    fn resolve_fallback_returns_raw_name_when_no_profile() {
+        let resolution = resolve_fallback_provider("xai", None);
+        assert_eq!(resolution.actual_provider_name, "xai");
+        assert!(resolution.api_key.is_none());
+        assert!(resolution.base_url.is_none());
+        assert!(resolution.profile_override.is_none());
 
-        let provider =
-            create_resilient_provider_with_options("lmstudio", None, None, &reliability, &options);
-        assert!(provider.is_ok());
+        let empty = make_providers_config(vec![]);
+        let resolution = resolve_fallback_provider("xai", Some(&empty));
+        assert_eq!(resolution.actual_provider_name, "xai");
+        assert!(resolution.api_key.is_none());
+    }
+
+    #[test]
+    fn resolve_fallback_propagates_profile_override() {
+        let resolution = resolve_fallback_provider("openai-codex:second", None);
+        assert_eq!(resolution.actual_provider_name, "openai-codex");
+        assert_eq!(resolution.profile_override.as_deref(), Some("second"));
+    }
+
+    #[test]
+    fn resolve_fallback_does_not_promote_existing_custom_url_key() {
+        // A fallback already named `custom:<url>` must not be re-wrapped into
+        // `custom:custom:<url>` even if a matching profile exists.
+        let cfg = make_providers_config(vec![(
+            "custom:http://proxy.example.com/v1",
+            zeroclaw_config::schema::ModelProviderConfig {
+                base_url: Some("http://proxy.example.com/v1".to_string()),
+                api_key: Some("proxy-key".to_string()),
+                ..Default::default()
+            },
+        )]);
+        let resolution =
+            resolve_fallback_provider("custom:http://proxy.example.com/v1", Some(&cfg));
+        assert_eq!(
+            resolution.actual_provider_name,
+            "custom:http://proxy.example.com/v1"
+        );
+        assert_eq!(resolution.api_key.as_deref(), Some("proxy-key"));
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -1847,6 +1847,70 @@ fn resolve_fallback_provider(
     }
 }
 
+/// Which factory the fallback dispatch should call, with the credentials
+/// to hand it. The url-bearing variant carries the resolved base_url as a
+/// positional arg; the codex variant relies on `provider_api_url` already
+/// being set on the accompanying `ProviderRuntimeOptions` (because the
+/// codex factory does not accept a positional url).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FallbackFactoryCall {
+    Codex {
+        api_key: Option<String>,
+    },
+    UrlBased {
+        api_key: Option<String>,
+        api_url: Option<String>,
+    },
+}
+
+/// Plan for constructing a single fallback provider: which factory to call,
+/// the provider-name string to hand it, and the per-call options (already
+/// patched with `auth_profile_override` and `provider_api_url` where they
+/// belong). Pure data — no provider construction happens here, which makes
+/// the dispatch logic unit-testable without standing up real providers.
+#[derive(Debug, Clone)]
+struct FallbackBuildPlan {
+    actual_provider_name: String,
+    options: ProviderRuntimeOptions,
+    call: FallbackFactoryCall,
+}
+
+fn build_fallback_call(
+    resolution: FallbackResolution,
+    base_options: &ProviderRuntimeOptions,
+) -> FallbackBuildPlan {
+    let mut options = base_options.clone();
+    if let Some(profile) = resolution.profile_override.as_deref() {
+        options.auth_profile_override = Some(profile.to_string());
+    }
+
+    let call = match resolution.actual_provider_name.as_str() {
+        // Codex manages its own endpoint via OAuth token exchange and reads
+        // the override from `provider_api_url`, not from a positional URL.
+        // Forward the resolved base_url so a fallback profile's base_url is
+        // honored on the codex path. Without this the codex fallback would
+        // silently fall back to the OAuth-default endpoint.
+        "openai-codex" | "openai_codex" | "codex" => {
+            if let Some(ref url) = resolution.base_url {
+                options.provider_api_url = Some(url.clone());
+            }
+            FallbackFactoryCall::Codex {
+                api_key: resolution.api_key.clone(),
+            }
+        }
+        _ => FallbackFactoryCall::UrlBased {
+            api_key: resolution.api_key.clone(),
+            api_url: resolution.base_url.clone(),
+        },
+    };
+
+    FallbackBuildPlan {
+        actual_provider_name: resolution.actual_provider_name,
+        options,
+        call,
+    }
+}
+
 /// Create provider chain with retry and fallback behavior.
 pub fn create_resilient_provider(
     primary_name: &str,
@@ -1893,36 +1957,22 @@ pub fn create_resilient_provider_with_options(
         // fall through to env vars (e.g. XAI_API_KEY for "xai") as before.
         let resolution =
             resolve_fallback_provider(fallback, options.fallback_providers_config.as_ref());
+        let plan = build_fallback_call(resolution, options);
 
-        // Propagate auth profile override (e.g. "openai-codex:second") through
-        // ProviderRuntimeOptions so the provider picks up the right OAuth
-        // credential set.
-        let mut fallback_options = options.clone();
-        if let Some(profile) = resolution.profile_override.as_deref() {
-            fallback_options.auth_profile_override = Some(profile.to_string());
-        }
-
-        let create_result = match resolution.actual_provider_name.as_str() {
-            // Codex manages its own endpoint via OAuth token exchange and
-            // reads the override from `provider_api_url`, not from a positional
-            // url argument. Forward the resolved base_url through that field
-            // so a fallback profile's base_url is honored on the codex path.
-            "openai-codex" | "openai_codex" | "codex" => {
-                if let Some(ref url) = resolution.base_url {
-                    fallback_options.provider_api_url = Some(url.clone());
-                }
-                create_provider_with_options(
-                    &resolution.actual_provider_name,
-                    resolution.api_key.as_deref(),
-                    &fallback_options,
+        let create_result = match plan.call {
+            FallbackFactoryCall::Codex { api_key } => create_provider_with_options(
+                &plan.actual_provider_name,
+                api_key.as_deref(),
+                &plan.options,
+            ),
+            FallbackFactoryCall::UrlBased { api_key, api_url } => {
+                create_provider_with_url_and_options(
+                    &plan.actual_provider_name,
+                    api_key.as_deref(),
+                    api_url.as_deref(),
+                    &plan.options,
                 )
             }
-            _ => create_provider_with_url_and_options(
-                &resolution.actual_provider_name,
-                resolution.api_key.as_deref(),
-                resolution.base_url.as_deref(),
-                &fallback_options,
-            ),
         };
         match create_result {
             Ok(provider) => providers.push((fallback.clone(), provider)),
@@ -3961,6 +4011,99 @@ mod tests {
         let resolution = resolve_fallback_provider("openai-codex:second", None);
         assert_eq!(resolution.actual_provider_name, "openai-codex");
         assert_eq!(resolution.profile_override.as_deref(), Some("second"));
+    }
+
+    #[test]
+    fn build_fallback_call_codex_writes_base_url_to_provider_api_url() {
+        // Codex factory has no positional URL parameter — it reads the
+        // override from ProviderRuntimeOptions::provider_api_url. The plan
+        // must move the resolved base_url into options before dispatch,
+        // otherwise a Codex fallback with a configured base_url silently
+        // falls back to the OAuth-default endpoint.
+        let resolution = FallbackResolution {
+            actual_provider_name: "openai-codex".to_string(),
+            profile_override: None,
+            api_key: Some("oauth-token".to_string()),
+            base_url: Some("https://codex.internal/v1".to_string()),
+        };
+        let base = ProviderRuntimeOptions::default();
+        let plan = build_fallback_call(resolution, &base);
+
+        assert_eq!(plan.actual_provider_name, "openai-codex");
+        assert_eq!(
+            plan.options.provider_api_url.as_deref(),
+            Some("https://codex.internal/v1"),
+            "Codex base_url must be forwarded via provider_api_url"
+        );
+        assert_eq!(
+            plan.call,
+            FallbackFactoryCall::Codex {
+                api_key: Some("oauth-token".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn build_fallback_call_codex_without_base_url_leaves_options_unchanged() {
+        let resolution = FallbackResolution {
+            actual_provider_name: "codex".to_string(),
+            profile_override: None,
+            api_key: None,
+            base_url: None,
+        };
+        let base = ProviderRuntimeOptions {
+            provider_api_url: Some("https://default.example/v1".to_string()),
+            ..ProviderRuntimeOptions::default()
+        };
+        let plan = build_fallback_call(resolution, &base);
+
+        // Original provider_api_url must be preserved when the resolution
+        // carries no base_url, so we don't clobber an upstream override.
+        assert_eq!(
+            plan.options.provider_api_url.as_deref(),
+            Some("https://default.example/v1")
+        );
+        assert!(matches!(plan.call, FallbackFactoryCall::Codex { .. }));
+    }
+
+    #[test]
+    fn build_fallback_call_url_based_carries_base_url_in_call_args() {
+        let resolution = FallbackResolution {
+            actual_provider_name: "ollama".to_string(),
+            profile_override: None,
+            api_key: Some("ollama-key".to_string()),
+            base_url: Some("http://192.168.2.4:11434".to_string()),
+        };
+        let base = ProviderRuntimeOptions::default();
+        let plan = build_fallback_call(resolution, &base);
+
+        // For non-Codex providers the URL goes through the positional arg,
+        // not options. options.provider_api_url stays at its base value.
+        assert_eq!(plan.options.provider_api_url, None);
+        assert_eq!(
+            plan.call,
+            FallbackFactoryCall::UrlBased {
+                api_key: Some("ollama-key".to_string()),
+                api_url: Some("http://192.168.2.4:11434".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn build_fallback_call_propagates_profile_override_to_options() {
+        let resolution = FallbackResolution {
+            actual_provider_name: "openai-codex".to_string(),
+            profile_override: Some("second".to_string()),
+            api_key: None,
+            base_url: None,
+        };
+        let base = ProviderRuntimeOptions::default();
+        let plan = build_fallback_call(resolution, &base);
+        assert_eq!(
+            plan.options.auth_profile_override.as_deref(),
+            Some("second"),
+            "auth_profile_override must reach the per-call options"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -717,8 +717,9 @@ pub struct ProviderRuntimeOptions {
     /// Propagated from `ModelProviderConfig::provider_extra`.
     pub provider_extra: Option<serde_json::Value>,
     /// Full `[providers]` config, used to resolve `api_key`, `base_url`, and
-    /// provider-type overrides for fallback providers from `[providers.<name>]`.
-    /// When `None`, fallback credentials are resolved from env vars only.
+    /// provider-type overrides for fallback providers from
+    /// `[providers.models.<name>]`. When `None`, fallback credentials are
+    /// resolved from env vars only.
     pub fallback_providers_config: Option<zeroclaw_config::providers::ProvidersConfig>,
 }
 

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -717,7 +717,7 @@ pub struct ProviderRuntimeOptions {
     /// Propagated from `ModelProviderConfig::provider_extra`.
     pub provider_extra: Option<serde_json::Value>,
     /// Full `[providers]` config, used to resolve `api_key`, `base_url`, and
-    /// provider-type overrides for fallback providers from `[providers.models.<name>]`.
+    /// provider-type overrides for fallback providers from `[providers.<name>]`.
     /// When `None`, fallback credentials are resolved from env vars only.
     pub fallback_providers_config: Option<zeroclaw_config::providers::ProvidersConfig>,
 }
@@ -1816,7 +1816,7 @@ pub fn create_resilient_provider_with_options(
 
         let (provider_name, profile_override) = parse_provider_profile(fallback);
 
-        // Look up api_key, base_url, and provider-type from [providers.models.<name>]
+        // Look up api_key, base_url, and provider-type from [providers.<name>]
         // before falling back to env var resolution. This makes fallback providers
         // config-aware the same way the primary provider is. If no profile entry
         // exists, resolve_provider_credential falls through to provider-specific env
@@ -3797,6 +3797,84 @@ mod tests {
         // Keys without a recognisable prefix should never flag a mismatch.
         assert_eq!(check_api_key_prefix("openai", "my-custom-key-123"), None);
         assert_eq!(check_api_key_prefix("anthropic", "some-random-key"), None);
+    }
+
+    // --- config-aware fallback ---
+
+    #[test]
+    fn fallback_uses_config_api_key_when_set() {
+        let mut models = std::collections::HashMap::new();
+        models.insert(
+            "ollama".to_string(),
+            zeroclaw_config::schema::ModelProviderConfig {
+                api_key: Some("config-test-key".to_string()),
+                base_url: Some("http://localhost:11434".to_string()),
+                ..Default::default()
+            },
+        );
+        let providers_config = zeroclaw_config::providers::ProvidersConfig {
+            models,
+            ..Default::default()
+        };
+
+        let reliability = zeroclaw_config::schema::ReliabilityConfig {
+            provider_retries: 1,
+            provider_backoff_ms: 100,
+            fallback_providers: vec!["ollama".into()],
+            api_keys: Vec::new(),
+            model_fallbacks: std::collections::HashMap::new(),
+            channel_initial_backoff_secs: 2,
+            channel_max_backoff_secs: 60,
+            scheduler_poll_secs: 15,
+            scheduler_retries: 2,
+        };
+
+        let options = ProviderRuntimeOptions {
+            fallback_providers_config: Some(providers_config),
+            ..ProviderRuntimeOptions::default()
+        };
+
+        let provider =
+            create_resilient_provider_with_options("lmstudio", None, None, &reliability, &options);
+        assert!(provider.is_ok());
+    }
+
+    #[test]
+    fn fallback_name_override_routes_to_correct_provider() {
+        let mut models = std::collections::HashMap::new();
+        models.insert(
+            "my-local".to_string(),
+            zeroclaw_config::schema::ModelProviderConfig {
+                name: Some("ollama".to_string()),
+                base_url: Some("http://localhost:11434".to_string()),
+                ..Default::default()
+            },
+        );
+        let providers_config = zeroclaw_config::providers::ProvidersConfig {
+            models,
+            ..Default::default()
+        };
+
+        let reliability = zeroclaw_config::schema::ReliabilityConfig {
+            provider_retries: 1,
+            provider_backoff_ms: 100,
+            fallback_providers: vec!["my-local".into()],
+            api_keys: Vec::new(),
+            model_fallbacks: std::collections::HashMap::new(),
+            channel_initial_backoff_secs: 2,
+            channel_max_backoff_secs: 60,
+            scheduler_poll_secs: 15,
+            scheduler_retries: 2,
+        };
+
+        let options = ProviderRuntimeOptions {
+            fallback_providers_config: Some(providers_config),
+            ..ProviderRuntimeOptions::default()
+        };
+
+        let provider =
+            create_resilient_provider_with_options("lmstudio", None, None, &reliability, &options);
+        assert!(provider.is_ok());
     }
 
     #[test]

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -1846,6 +1846,9 @@ pub fn create_resilient_provider_with_options(
         };
 
         let create_result = match actual_provider_name {
+            // Codex manages its own endpoint via OAuth token exchange; config
+            // base_url is intentionally not forwarded — use provider_api_url
+            // in ProviderRuntimeOptions if an endpoint override is needed.
             "openai-codex" | "openai_codex" | "codex" => create_provider_with_options(
                 actual_provider_name,
                 config_api_key,

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -1136,6 +1136,7 @@ data: [DONE]
             provider_max_tokens: None,
             merge_system_into_user: false,
             provider_extra: None,
+            fallback_providers_config: None,
         };
         let provider =
             OpenAiCodexProvider::new(&options, None).expect("provider should initialize");

--- a/tests/live/openai_codex_vision_e2e.rs
+++ b/tests/live/openai_codex_vision_e2e.rs
@@ -158,6 +158,7 @@ async fn openai_codex_second_vision_support() -> Result<()> {
         api_path: None,
         merge_system_into_user: false,
         provider_extra: None,
+        fallback_providers_config: None,
     };
 
     let provider = zeroclaw::providers::create_provider_with_options("openai-codex", None, &opts)?;


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Fallback entries in `[reliability].fallback_providers` were resolved exclusively via env vars. Provider profiles defined under `[providers.models.<name>]` — including `api_key`, `base_url`, and the `name` override that maps custom profile keys to a real provider type — were silently ignored during fallback chain construction.
  - Added `fallback_providers_config: Option<ProvidersConfig>` to `ProviderRuntimeOptions`. Populated in `provider_runtime_options_from_config`, which already has full config access. The fallback construction loop now looks up each entry in that map to resolve the actual provider type, API key, and base URL before calling the factory.
  - Extracted `resolve_fallback_provider()` and `build_fallback_call()` as pure-data helpers so the resolution logic and the dispatch logic are both unit-testable in isolation, without standing up real provider HTTP clients.
  - **Base_url-only profiles are now honored.** A fallback like `[providers.models.local] { base_url = "http://192.168.2.4:11434" }` previously resolved to provider name `"local"`, which the factory rejected as `Unknown provider`; the error was swallowed and the fallback silently dropped. The resolver now promotes such profiles to `custom:<base_url>`, mirroring what `apply_named_model_provider_profile` already does for the primary path at config-load time.
  - **Codex fallback `base_url` is now honored.** The Codex factory has no positional URL parameter — it reads the override from `ProviderRuntimeOptions::provider_api_url`. The dispatch helper now sets `provider_api_url` from the resolved base_url before calling `create_provider_with_options`.
  - `openai_codex.rs` exhaustive struct literal in tests updated for the new field.
- **Scope boundary:** Primary provider construction path is unchanged. Only the fallback loop in `create_resilient_provider_with_options` gains config-aware resolution. Hot-reload of fallback profile fields is a pre-existing snapshotting limitation of `ProviderRuntimeOptions` — not introduced or addressed here. Resolving `[providers.models.<name>].model` from config (#5803 item #2) is a follow-up; this PR addresses items #1 and #4 of the original report plus the base_url and Codex gaps surfaced in review.
- **Blast radius:** Any code path that calls `create_resilient_provider_with_options` or `create_resilient_provider_nonblocking` with a populated `ProviderRuntimeOptions` (i.e., all runtime orchestrator paths) will now honour `[providers.models.<name>]` config for fallback entries. No behaviour change for callers that do not set `fallback_providers_config` (field defaults to `None`).
- **Linked issue(s):** Refs #5803 (partial: resolves api_key + base_url + name-override gap and base_url-only / Codex base_url normalization; model-from-config resolution remains a follow-up and #5803 stays open)

## Validation Evidence (required)

- **Commands run and tail output:**

```
$ cargo fmt --all -- --check
# clean — no diff

$ cargo clippy --workspace --exclude zeroclaw-desktop --all-targets --features ci-all -- -D warnings
    Finished `dev` profile in 1m 17s

$ cargo test -p zeroclaw-providers
test result: ok. 787 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.01s
```

- **Beyond CI — what was manually verified:**
  - Cross-checked all `ProviderRuntimeOptions { ... }` struct literal sites — exhaustive literals at `openai_codex.rs:1136` and `tests/live/openai_codex_vision_e2e.rs:158` updated; struct-update (`..default()`) sites require no change.
  - Confirmed `provider_runtime_options_from_config` is the sole runtime population path and has full `Config` access.
  - Traced the resolver and dispatch helpers to confirm the loop change is mechanically equivalent to the prior inline form for callers that don't use the new resolution branches.
  - Codex dispatch branch now forwards base_url through `provider_api_url` (commit `88d4f2de`); verified `OpenAiCodexProvider::resolve_endpoint` reads from that field.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? Yes — config-supplied `api_key` values for fallback providers are now passed to the provider factory instead of being ignored. This is the intended fix: credentials written to `zeroclaw.toml` under `[providers.models.<name>]` now take effect for the fallback chain, consistent with how the primary provider already behaves.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes — `fallback_providers_config` defaults to `None`; existing callers that do not go through `provider_runtime_options_from_config` see no behaviour change.
- Config / env / CLI surface changed? No — no new config keys; existing `[providers.models.<name>]` keys now take effect for fallback providers as users already expect.

## Rollback (required for `risk: medium` and `risk: high`)

`git revert <sha>` is the plan for any of the three new commits; no feature flags needed.

**Observable failure symptoms after a bad merge:**
- Fallback providers begin failing with auth errors immediately after the primary provider fails — check logs for `tracing::warn!` from the fallback construction loop, look for provider name in the warn message and compare against configured `[providers.models.<name>]` entries.
- `api_key` passed to provider factory is empty string despite being set in `zeroclaw.toml` — the `fallback_providers_config` lookup is not reaching the correct profile key.
- Provider type mismatch errors where a custom-named profile (e.g. `[providers.models.myxai]`) routes to the wrong factory — `name` override in `ModelProviderConfig` is not being read from the fallback config map.
- Codex fallback ignores configured `base_url` and falls back to its OAuth-default endpoint — `build_fallback_call` is not writing `resolution.base_url` into `plan.options.provider_api_url`.

**Partial scope note:** Issue #5803 item #2 (resolving `[providers.models.<name>].model` from config to avoid a separate `[reliability.model_fallbacks]` entry) is not addressed here. `ModelProviderConfig.model` is present and available; reading it in the fallback loop is a follow-up. #5803 is left open.

