### PR TITLE
fix(config): preserve user-supplied providers.fallback through load/save

### DIFF
--- a/crates/zeroclaw-config/src/providers.rs
+++ b/crates/zeroclaw-config/src/providers.rs
@@ -39,4 +39,31 @@ impl ProvidersConfig {
         let name = self.fallback.clone()?;
         self.models.get_mut(&name)
     }
+
+    /// Return the first concrete `model` string available for use as a default.
+    ///
+    /// Resolution order:
+    ///
+    /// 1. The fallback provider's `model` field, if set.
+    /// 2. The first entry in `models` (iteration order) that has `model` set.
+    ///
+    /// Returns `None` only when no provider entry has any model configured at all.
+    /// Callers should treat `None` as a configuration error and surface it rather
+    /// than silently substituting a hardcoded model identifier.
+    pub fn resolve_default_model(&self) -> Option<String> {
+        if let Some(model) = self
+            .fallback_provider()
+            .and_then(|e| e.model.as_deref())
+            .map(str::trim)
+            .filter(|m| !m.is_empty())
+        {
+            return Some(model.to_string());
+        }
+
+        self.models
+            .values()
+            .filter_map(|entry| entry.model.as_deref().map(str::trim))
+            .find(|m| !m.is_empty())
+            .map(ToString::to_string)
+    }
 }

--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -9875,6 +9875,27 @@ impl Config {
             .map(|(name, profile)| (name.clone(), profile.clone()))
     }
 
+    /// Apply Codex-app-server compatibility shims to the resolved fallback provider entry.
+    ///
+    /// Historically this method mutated `self.providers.fallback` to a "canonical" key
+    /// derived from the profile's `name` field, `wire_api`, or `base_url`. That mutation
+    /// caused two problems:
+    ///
+    /// 1. **CLI get/set divergence.** `Config::load_or_init` calls `apply_env_overrides`,
+    ///    which calls this function. After load, `providers.fallback` no longer matched
+    ///    what was on disk, so `zeroclaw config get providers.fallback` returned the
+    ///    rewritten value while the file still had the user's literal value. The next
+    ///    `save()` would then persist the rewrite, silently changing the user's config.
+    /// 2. **Orphaned references.** When the rewrite pointed at a key that did not exist
+    ///    in `providers.models` (e.g. profile had `name = "gemini"` but no
+    ///    `[providers.models.gemini]` entry), runtime `fallback_provider()` lookups
+    ///    returned `None` and downstream code fell through to a hardcoded default model.
+    ///
+    /// The fix: keep `self.providers.fallback` as the literal user-supplied key.
+    /// Propagate the profile's `base_url` / `api_path` / `max_tokens` / `api_key` onto the
+    /// resolved entry as before, and mirror the entry under any canonical alias keys so
+    /// runtime lookups by either name still resolve. The user's `[providers] fallback`
+    /// value is preserved end-to-end through load → save → load.
     fn apply_named_model_provider_profile(&mut self) {
         let Some(current_provider) = self.providers.fallback.clone() else {
             return;
@@ -9965,29 +9986,30 @@ impl Config {
             .map(str::trim)
             .filter(|value| !value.is_empty());
 
+        // Mirror the resolved entry under any canonical alias keys so that runtime
+        // lookups by the profile-implied name (e.g. wire_api → "openai-codex",
+        // explicit `name = ...`, or `custom:<base_url>`) also resolve. We do NOT
+        // rewrite `providers.fallback` itself: that is the user's literal config
+        // value and must round-trip cleanly through CLI get/set/save.
+        let mut alias_keys: Vec<String> = Vec::new();
         if normalized_wire_api == Some("responses") {
-            self.providers.fallback = Some("openai-codex".to_string());
-            return;
+            alias_keys.push("openai-codex".to_string());
         }
-
         if let Some(profile_name) = profile_name
             && !profile_name.eq_ignore_ascii_case(&profile_key)
         {
-            self.providers.fallback = Some(profile_name.to_string());
-            return;
+            alias_keys.push(profile_name.to_string());
+        }
+        if let Some(ref base_url) = base_url {
+            alias_keys.push(format!("custom:{base_url}"));
         }
 
-        if let Some(base_url) = base_url {
-            let canonical_key = format!("custom:{base_url}");
-            // Mirror the profile under the canonical key so runtime
-            // `fallback_provider()` lookups resolve — without this the rename
-            // would orphan the entry still keyed under the original profile name.
-            if !self.providers.models.contains_key(&canonical_key)
+        for alias in alias_keys {
+            if !self.providers.models.contains_key(&alias)
                 && let Some(entry) = self.providers.models.get(&profile_key).cloned()
             {
-                self.providers.models.insert(canonical_key.clone(), entry);
+                self.providers.models.insert(alias, entry);
             }
-            self.providers.fallback = Some(canonical_key);
         }
     }
 
@@ -14058,10 +14080,10 @@ requires_openai_auth = true
         );
 
         config.apply_env_overrides();
-        assert_eq!(
-            config.providers.fallback.as_deref(),
-            Some("custom:https://api.tonsof.blue/v1")
-        );
+        // The user's literal fallback key is preserved; we no longer rewrite it
+        // to a canonical alias. This is the round-trip-safe contract that the
+        // `zeroclaw config get/set` CLI relies on.
+        assert_eq!(config.providers.fallback.as_deref(), Some("sub2api"));
         // The original entry is still stored under its config key.
         assert_eq!(
             config
@@ -14071,8 +14093,9 @@ requires_openai_auth = true
                 .and_then(|e| e.base_url.as_deref()),
             Some("https://api.tonsof.blue/v1")
         );
-        // The entry is also mirrored under the canonical fallback key so
-        // runtime fallback_provider() lookups resolve.
+        // The entry is also mirrored under the canonical alias key so runtime
+        // lookups by `custom:<base_url>` still resolve even though the user's
+        // fallback string is the original profile key.
         assert_eq!(
             config
                 .providers
@@ -14111,7 +14134,10 @@ requires_openai_auth = true
         // SAFETY: test-only, single-threaded test runner.
         unsafe { std::env::remove_var("OPENAI_API_KEY") };
 
-        assert_eq!(config.providers.fallback.as_deref(), Some("openai-codex"));
+        // The user's literal fallback key is preserved; we no longer rewrite it
+        // to "openai-codex". The Codex-app-server compatibility shim instead
+        // mirrors the resolved entry under that alias key for runtime lookups.
+        assert_eq!(config.providers.fallback.as_deref(), Some("sub2api"));
         // The original entry is still stored under its config key.
         let entry = config
             .providers
@@ -14120,6 +14146,175 @@ requires_openai_auth = true
             .expect("sub2api entry");
         assert_eq!(entry.base_url.as_deref(), Some("https://api.tonsof.blue"));
         assert_eq!(entry.api_key.as_deref(), Some("sk-test-codex-key"));
+        // The entry is mirrored under the "openai-codex" alias so any code
+        // path that looks providers up by that canonical key still finds it.
+        let aliased = config
+            .providers
+            .models
+            .get("openai-codex")
+            .expect("openai-codex alias entry");
+        assert_eq!(aliased.base_url.as_deref(), Some("https://api.tonsof.blue"));
+        assert_eq!(aliased.api_key.as_deref(), Some("sk-test-codex-key"));
+    }
+
+    /// Regression test for the config CLI get/set divergence bug.
+    ///
+    /// Before the fix, `apply_named_model_provider_profile` rewrote
+    /// `self.providers.fallback` to the profile's `name` field whenever they
+    /// differed. That meant:
+    ///
+    /// - `zeroclaw config get providers.fallback` returned the rewritten value
+    ///   even though the on-disk TOML still held the user's literal key.
+    /// - `zeroclaw config set providers.fallback <new>` would persist `<new>`
+    ///   to disk, but the next load mutated it back in memory, so a subsequent
+    ///   `get` reported a stale value and the daemon's resolver looked up a
+    ///   provider key that did not exist in `[providers.models.*]`.
+    ///
+    /// The fix preserves the literal fallback key end-to-end. The named-profile
+    /// shim now only mirrors the resolved entry under canonical alias keys for
+    /// runtime lookup convenience.
+    #[test]
+    async fn apply_env_overrides_preserves_user_supplied_fallback_key() {
+        let _env_guard = env_override_lock().await;
+        let mut config = Config::default();
+        // User configures fallback = "primary" with a profile whose `name` field
+        // differs from the key. This is the exact shape that triggered the bug.
+        config.providers.fallback = Some("primary".to_string());
+        config.providers.models.insert(
+            "primary".to_string(),
+            ModelProviderConfig {
+                name: Some("alias-name".to_string()),
+                base_url: Some("https://example.invalid/v1".to_string()),
+                model: Some("primary-model".to_string()),
+                ..Default::default()
+            },
+        );
+
+        config.apply_env_overrides();
+
+        // The literal user key must survive. This is what `config get` returns
+        // and what `config set` persists.
+        assert_eq!(
+            config.providers.fallback.as_deref(),
+            Some("primary"),
+            "providers.fallback must preserve the user's literal key after \
+             apply_env_overrides; got {:?}",
+            config.providers.fallback,
+        );
+        // Runtime resolution must still find the entry under the original key.
+        assert!(
+            config.providers.fallback_provider().is_some(),
+            "fallback_provider() must still resolve via the user's literal key",
+        );
+    }
+
+    /// Round-trip test for the config CLI: a TOML file with the user's value
+    /// must deserialize, apply env overrides, and serialize back to the same
+    /// `providers.fallback`. This is the full path that backed the user-visible
+    /// `config set` -> `config get` divergence.
+    #[test]
+    async fn fallback_round_trips_through_load_apply_serialize() {
+        let _env_guard = env_override_lock().await;
+        let toml_in = r#"
+schema_version = 1
+
+[providers]
+fallback = "primary"
+
+[providers.models.primary]
+name = "alias-name"
+base_url = "https://example.invalid/v1"
+model = "primary-model"
+"#;
+
+        let mut config: Config = toml::from_str(toml_in).expect("parse toml");
+        config.apply_env_overrides();
+
+        // What `config get providers.fallback` returns post-load.
+        assert_eq!(
+            config.get_prop("providers.fallback").unwrap(),
+            "primary",
+            "config get providers.fallback must return the user's literal value",
+        );
+
+        // What `config save` would write back to disk.
+        let toml_out = toml::to_string(&config).expect("serialize toml");
+        assert!(
+            toml_out.contains(r#"fallback = "primary""#),
+            "serialized config must keep fallback = \"primary\"; got:\n{toml_out}",
+        );
+    }
+
+    /// `set_prop` followed by `get_prop` must return the value that was set,
+    /// even when the surrounding profile shape would historically have caused
+    /// the in-memory value to be rewritten.
+    #[test]
+    async fn set_prop_then_get_prop_round_trips_for_fallback() {
+        let _env_guard = env_override_lock().await;
+        let mut config = Config::default();
+        config.providers.models.insert(
+            "primary".to_string(),
+            ModelProviderConfig {
+                name: Some("alias-name".to_string()),
+                model: Some("primary-model".to_string()),
+                ..Default::default()
+            },
+        );
+        // Simulate the daemon's load path before the user runs `config set`.
+        config.apply_env_overrides();
+
+        config.set_prop("providers.fallback", "primary").unwrap();
+        // Mimic any post-set normalization a future codepath might add.
+        config.apply_env_overrides();
+
+        assert_eq!(config.get_prop("providers.fallback").unwrap(), "primary");
+    }
+
+    /// `resolve_default_model` returns the fallback provider's model when set,
+    /// and falls through to the first available `models.*` entry otherwise.
+    /// Returning `None` is reserved for "no provider has any model configured",
+    /// which callers must surface as a configuration error rather than silently
+    /// substituting a vendor default.
+    #[test]
+    async fn resolve_default_model_prefers_fallback_then_first_available() {
+        let _env_guard = env_override_lock().await;
+        let mut config = Config::default();
+        // Empty config: no model anywhere -> None (caller errors loudly).
+        assert_eq!(config.providers.resolve_default_model(), None);
+
+        // Add an entry without a model -> still None.
+        config
+            .providers
+            .models
+            .insert("secondary".to_string(), ModelProviderConfig::default());
+        assert_eq!(config.providers.resolve_default_model(), None);
+
+        // Add an entry with a model -> first-available wins when no fallback.
+        config.providers.models.insert(
+            "tertiary".to_string(),
+            ModelProviderConfig {
+                model: Some("tertiary-model".to_string()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            config.providers.resolve_default_model().as_deref(),
+            Some("tertiary-model"),
+        );
+
+        // Set fallback to a provider with its own model -> fallback wins.
+        config.providers.fallback = Some("primary".to_string());
+        config.providers.models.insert(
+            "primary".to_string(),
+            ModelProviderConfig {
+                model: Some("primary-model".to_string()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            config.providers.resolve_default_model().as_deref(),
+            Some("primary-model"),
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/agent.rs
+++ b/crates/zeroclaw-runtime/src/agent/agent.rs
@@ -306,9 +306,12 @@ impl AgentBuilder {
                 .memory_loader
                 .unwrap_or_else(|| Box::new(DefaultMemoryLoader::default())),
             config: self.config.unwrap_or_default(),
-            model_name: self
-                .model_name
-                .unwrap_or_else(|| "anthropic/claude-sonnet-4-20250514".into()),
+            // No silent vendor-default model. Callers that construct `Agent` via the
+            // builder must set `model_name` explicitly (via `.model_name(...)` or via
+            // `Agent::from_config`, which resolves from `[providers]`). The sentinel
+            // keeps the field non-empty so accidental dispatch surfaces a clear 4xx
+            // rather than misrouting to a real vendor model.
+            model_name: self.model_name.unwrap_or_else(|| "<unconfigured>".into()),
             temperature: self.temperature.unwrap_or(0.7),
             workspace_dir: self
                 .workspace_dir
@@ -489,10 +492,34 @@ impl Agent {
 
         let provider_name = config.providers.fallback.as_deref().unwrap_or("openrouter");
 
-        let model_name = fallback_provider_ag
+        let model_name = match fallback_provider_ag
             .and_then(|e| e.model.as_deref())
-            .unwrap_or("anthropic/claude-sonnet-4-20250514")
-            .to_string();
+            .map(str::trim)
+            .filter(|m| !m.is_empty())
+        {
+            Some(m) => m.to_string(),
+            None => match config.providers.resolve_default_model() {
+                Some(m) => {
+                    tracing::warn!(
+                        provider = provider_name,
+                        model = %m,
+                        "fallback provider has no `model` set; using first configured \
+                         providers.models entry as default. Set [providers.models.{provider_name}] \
+                         model = \"...\" to silence this warning.",
+                    );
+                    m
+                }
+                None => {
+                    anyhow::bail!(
+                        "no model configured: providers.fallback = {:?} resolves with no model, \
+                         and no [[providers.models.*]] entry has a `model` field set. \
+                         Configure at least one [providers.models.<name>] model = \"...\" \
+                         or define a [[model_routes]] hint.",
+                        config.providers.fallback,
+                    )
+                }
+            },
+        };
 
         let provider_runtime_options =
             zeroclaw_providers::provider_runtime_options_from_config(config);
@@ -1343,12 +1370,19 @@ pub async fn run(
         .as_deref()
         .unwrap_or("openrouter")
         .to_string();
+    // `Agent::from_config` above has already errored if no model could be resolved,
+    // so this telemetry line should always find one. We keep `resolve_default_model`
+    // as a cheap secondary lookup and emit "<unresolved>" only if nothing matches —
+    // never silently substitute a hardcoded vendor model.
     let model_name = effective_config
         .providers
         .fallback_provider()
         .and_then(|e| e.model.as_deref())
-        .unwrap_or("anthropic/claude-sonnet-4-20250514")
-        .to_string();
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| effective_config.providers.resolve_default_model())
+        .unwrap_or_else(|| "<unresolved>".to_string());
 
     agent.observer.record_event(&ObserverEvent::AgentStart {
         provider: provider_name.clone(),

--- a/crates/zeroclaw-runtime/src/agent/loop_.rs
+++ b/crates/zeroclaw-runtime/src/agent/loop_.rs
@@ -3206,9 +3206,34 @@ pub async fn process_message(
     }
 
     let provider_name = config.providers.fallback.as_deref().unwrap_or("openrouter");
-    let model_name = fallback_provider_pm
-        .and_then(|e| e.model.clone())
-        .unwrap_or_else(|| "anthropic/claude-sonnet-4-20250514".into());
+    let model_name = match fallback_provider_pm
+        .and_then(|e| e.model.as_deref())
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+    {
+        Some(m) => m.to_string(),
+        None => match config.providers.resolve_default_model() {
+            Some(m) => {
+                tracing::warn!(
+                    provider = provider_name,
+                    model = %m,
+                    "fallback provider has no `model` set; using first configured \
+                     providers.models entry as default. Set [providers.models.{provider_name}] \
+                     model = \"...\" to silence this warning.",
+                );
+                m
+            }
+            None => {
+                anyhow::bail!(
+                    "no model configured: providers.fallback = {:?} resolves with no model, \
+                     and no [[providers.models.*]] entry has a `model` field set. \
+                     Configure at least one [providers.models.<name>] model = \"...\" \
+                     or define a [[model_routes]] hint.",
+                    config.providers.fallback,
+                )
+            }
+        },
+    };
     let provider_runtime_options =
         zeroclaw_providers::provider_runtime_options_from_config(&config);
     let provider: Box<dyn Provider> = zeroclaw_providers::create_routed_provider_with_options(


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Stopped `apply_named_model_provider_profile` from rewriting `self.providers.fallback` during load. The user's literal `[providers] fallback = "..."` value now survives `load → apply_env_overrides → save → reload` round-trips, fixing a silent CLI get/set divergence and the orphaned-models-entry symptom in #5815.
  - Added `ProvidersConfig::resolve_default_model()` and replaced three runtime sites that used `.unwrap_or("anthropic/claude-sonnet-4-20250514")` with a three-step resolver (fallback model → first configured model with WARN → hard error).
  - Builder/telemetry paths now emit `<unconfigured>` / `<unresolved>` sentinels rather than a real vendor identifier, so unconfigured agents fail with a clear 4xx instead of misrouting to a vendor we never picked.
- **Scope boundary:** No schema/CLI/migration changes. No new config keys. The Codex-app-server compatibility shim (`name`, `wire_api = "responses"`, `custom:<base_url>`) still resolves at runtime — it's now non-mutating, mirroring the entry under canonical alias keys instead of overwriting the user's `fallback`.
- **Blast radius:** `crates/zeroclaw-config` (load + helper) and `crates/zeroclaw-runtime` (two model-resolution sites + one builder default + one telemetry line). No channel/tool/memory/security touch.
- **Linked issue(s):** `Refs #5989` (the closed issue's "Expected behavior" recommended exactly this drop; commit 321e96ff partially addressed it by mirroring the entry but left the rewrite in place). `Closes #5815` (the still-open llamacpp regression has the same root cause).

## The bugs

### Bug A — `config get` and `config set` disagree on `providers.fallback`

`Config::load_or_init` calls `apply_env_overrides`, which calls `apply_named_model_provider_profile`. Whenever the matched profile had a `name = "..."` field that differed from the key, a `wire_api = "responses"` shim, or a `base_url` (the common case), the function overwrote `self.providers.fallback` to the canonical alias. Because that mutation happened on every load, the CLI surface diverged:

```toml
# config.toml on disk (verbatim)
[providers]
fallback = "primary"

[providers.models.primary]
name = "alias-name"
base_url = "https://example.invalid/v1"
model = "primary-model"
```

```text
$ zeroclaw config get providers.fallback
alias-name           # ← rewritten in-memory; does NOT match disk

$ zeroclaw config set providers.fallback primary
providers.fallback updated.

$ zeroclaw config get providers.fallback
alias-name           # ← still rewritten on next load
```

The on-disk file kept the user's literal value, but the daemon's in-memory state used the rewritten one — and `save()` wrote the in-memory state, silently corrupting any config the user touched after the rewrite ran. The daemon's startup logs included:

```
WARN providers.fallback references 'alias-name' which does not exist in providers.models;
     provider resolution will fail at runtime
```

### Bug B — silent fallback to a hardcoded vendor model

When the rewrite from Bug A pointed at a key not present in `providers.models` (the common shape for the `[providers.models.<key>] name = "<other>"` pattern, where `<other>` has no entry of its own), `fallback_provider()` returned `None` and three runtime sites substituted `"anthropic/claude-sonnet-4-20250514"`:

- `crates/zeroclaw-runtime/src/agent/agent.rs:494` (gateway path)
- `crates/zeroclaw-runtime/src/agent/agent.rs:1374` (interactive `agent run` telemetry)
- `crates/zeroclaw-runtime/src/agent/loop_.rs:3211` (`process_message` / webhook + `/ws/chat` paths)

Both `/webhook` and `/ws/chat` ended up emitting:

```
WARN provider="<broken-key>" model="anthropic/claude-sonnet-4-20250514"
     error=... API error (404 Not Found)
ERROR Webhook provider error: All providers/models failed
```

Setting `model` in the request payload didn't help because the routing path resolved off `fallback_provider().model.unwrap_or(<hardcoded>)` before the per-request override merged.

This is the same shape #5989 documented (`model="anthropic/claude-sonnet-4"` in the failure log) and what #5815 still trips on with `[providers.models.llamacpp]`.

## Fix direction

### Bug A: keep the user's literal key

`apply_named_model_provider_profile` no longer mutates `self.providers.fallback`. The Codex-app-server compatibility surface is preserved by **mirroring** the resolved entry under each implied alias key — `openai-codex` for `wire_api = "responses"`, the profile's `name = "..."` value if it differs from the key, and `custom:<base_url>` when a `base_url` is set. Code that looks the provider up by the user's key or by any canonical alias resolves to the same entry. Code that reads `self.providers.fallback` for display, CLI surface, or persistence sees the literal user value.

This is a strict superset of commit 321e96ff's fix (which already mirrored under the `custom:<base_url>` key). The remaining mutation was the load-bearing problem #5989's "Expected behavior" called out: `Drop the fallback-rewrite at schema.rs:9903-9905. The custom:<base_url> identifier was load-bearing in the V1 schema (flat top-level fields, no HashMap lookup) but is not needed in V2.`

### Bug B: never silently substitute a vendor identifier

Added `ProvidersConfig::resolve_default_model()` with explicit semantics:

1. Fallback provider's `model`, if set.
2. First entry in `models` with `model` set.
3. Otherwise `None` — caller must surface as a configuration error.

Each previously-silent runtime site now does:

1. Honour `fallback_provider().model` (the existing happy path).
2. If unset, log a WARN naming the substituted model and the config key the operator should set to silence it, then use the first configured model.
3. If no provider has any model configured anywhere, hard-fail with an actionable error message:

   ```
   no model configured: providers.fallback = Some("primary") resolves with no model,
   and no [[providers.models.*]] entry has a `model` field set. Configure at least
   one [providers.models.<name>] model = "..." or define a [[model_routes]] hint.
   ```

The `AgentBuilder` default (programmatic-construction path) and `agent::run`'s post-construction telemetry line now use `<unconfigured>` / `<unresolved>` sentinels instead of a real vendor model. The lean-loud direction matches AGENTS.md ("Do not silently weaken security policy or access constraints" / "Do not hide behavior-changing side effects in refactor commits") and the maintainer pattern in #5989's closure note.

I considered a `[providers] default_model = "..."` configurable, but introducing a new key for what's already expressible via `[providers.models.<x>] model = "..."` would add a fourth source of truth without removing any. Failing loud is the right default.

## Tests added

`crates/zeroclaw-config/src/schema.rs` (in `mod tests`):

- `apply_env_overrides_preserves_user_supplied_fallback_key` — direct fixture for Bug A: literal fallback key survives `apply_env_overrides`.
- `fallback_round_trips_through_load_apply_serialize` — TOML-text-in → `apply_env_overrides` → TOML-text-out preserves `fallback = "primary"`. This is the round-trip that backed the user-visible CLI bug.
- `set_prop_then_get_prop_round_trips_for_fallback` — `set_prop` followed by `get_prop` returns the same value, even after a re-`apply_env_overrides`.
- `resolve_default_model_prefers_fallback_then_first_available` — helper-function semantics across the three branches (none → some → fallback wins).

Two existing tests had to update because they asserted the rewrite as the contract:

- `model_provider_profile_maps_to_custom_endpoint` — now asserts the literal `fallback` survives and the entry is mirrored under `custom:<base_url>`.
- `model_provider_profile_responses_uses_openai_codex_and_openai_key` — now asserts the literal `fallback` survives and the entry is mirrored under `openai-codex`.

Reproduce the original Bug A by running the new test on `e1f722f9` (master at time of writing) — it fails. Apply this PR and it passes.

## Validation Evidence (required)

```bash
$ cargo fmt --all -- --check
# clean

$ cargo clippy -p zeroclaw-config -p zeroclaw-runtime --all-targets -- -D warnings
# clean

$ cargo test -p zeroclaw-config --lib
# 575 passed; 2 failed; 0 ignored
# Failures (memory_config_pgvector_*) are pre-existing on master and unrelated to
# this change — verified by stashing the patch and re-running. They concern
# MemoryConfig deserialization missing an `auto_save` field.

$ cargo test -p zeroclaw-runtime --lib
# 1662 passed; 2 failed; 1 ignored
# Failures (cron::scheduler::tests::persist_job_result_delivery_stubbed_succeeds,
# onboard::wizard::tests::backend_key_from_choice_maps_supported_backends) are
# pre-existing on master and unrelated to this change — verified by stashing the
# patch and re-running.

$ cargo check --workspace
# clean (2m 58s)
```

- **Beyond CI — what did you manually verify?**
  - Built the modified workspace clean.
  - Ran the four new tests in isolation; all pass.
  - Confirmed the two updated tests still cover the alias-mirroring contract on the resolved-entry side.
  - Did NOT smoke-test against a live daemon end-to-end (no live config harness on this box). The unit tests cover the load → apply → save → reload round trip and the runtime-resolution branches. CI on PR will run the full suite.
- **If any command was intentionally skipped, why:** None.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No` — `apply_named_model_provider_profile` still propagates `api_key` from the profile to the resolved entry under the same conditions it did before.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`. Test fixtures use `primary` / `alias-name` / `https://example.invalid/v1` placeholders. The bug-reproduction quote in this description includes the literal model identifier `anthropic/claude-sonnet-4-20250514` because that is the on-the-wire string the daemon currently emits — it is not introduced by this PR, only removed.

## Compatibility (required)

- Backward compatible? **Yes for end-user configs.** Any `config.toml` that already worked continues to work; the user's `fallback` key is now preserved instead of silently rewritten, which fixes the symptom rather than introducing one.
- Config / env / CLI surface changed? `No` schema changes. Two CLI behaviors do change:
  1. `zeroclaw config get providers.fallback` now returns the on-disk value rather than the in-memory rewritten value. For users hitting Bug A, this is the correction. For anyone who happened to depend on the rewrite, the canonical name is still discoverable: it's the alias key under `providers.models`.
  2. When `fallback_provider().model` is unset and no `[providers.models.*]` has a `model`, the daemon now errors with an actionable message instead of attempting a request as `model="anthropic/claude-sonnet-4-20250514"`. Operators on a misconfigured setup will see a clear failure instead of an opaque 404. Operators on a correct setup see no behavior change.
- Upgrade steps for existing users: none required. Anyone who applied a workaround like `default_provider = "custom:https://..."` (mentioned in #5989) can revert it; the literal profile key now works.

## Rollback (required for `risk: medium` and `risk: high`)

This change is on a hot path (`config::load_or_init`, gateway request routing). Classifying as **medium**.

- **Fast rollback command/path:** `git revert <merge-sha>` reverts both the config crate and runtime crate changes atomically.
- **Feature flags or config toggles:** None. The fix is unconditional.
- **Observable failure symptoms:**
  - If the alias-mirroring regresses, look for `WARN providers.fallback references '<key>' which does not exist in providers.models` followed by `404 Not Found` from the wrong endpoint.
  - If the silent-fallback regresses, grep the agent logs for `model="anthropic/claude-sonnet-4-20250514"` on a config that does not name that model anywhere — that's the smoking gun.
  - If the loud-fail path triggers on a previously-working config, the error message itself names the missing key (`"providers.fallback = Some(...) resolves with no model"`) and the operator can either set `model` on the named provider or add an entry that has one.