### PR TITLE
fix(infra): add SQLite FTS UPDATE trigger for sessions_fts

### DIFF
--- a/crates/zeroclaw-infra/src/session_sqlite.rs
+++ b/crates/zeroclaw-infra/src/session_sqlite.rs
@@ -759,7 +759,10 @@ mod tests {
             keyword: Some("cats".into()),
             limit: Some(10),
         });
-        assert!(cats.is_empty(), "stale content should not match after update");
+        assert!(
+            cats.is_empty(),
+            "stale content should not match after update"
+        );
 
         let dogs = backend.search(&SessionQuery {
             keyword: Some("dogs".into()),

--- a/crates/zeroclaw-infra/src/session_sqlite.rs
+++ b/crates/zeroclaw-infra/src/session_sqlite.rs
@@ -63,6 +63,13 @@ impl SqliteSessionBackend {
                 INSERT INTO sessions_fts(rowid, session_key, content)
                 VALUES (new.id, new.session_key, new.content);
              END;
+             CREATE TRIGGER IF NOT EXISTS sessions_au AFTER UPDATE ON sessions
+             WHEN old.content != new.content BEGIN
+                INSERT INTO sessions_fts(sessions_fts, rowid, session_key, content)
+                VALUES ('delete', old.id, old.session_key, old.content);
+                INSERT INTO sessions_fts(rowid, session_key, content)
+                VALUES (new.id, new.session_key, new.content);
+             END;
              CREATE TRIGGER IF NOT EXISTS sessions_ad AFTER DELETE ON sessions BEGIN
                 INSERT INTO sessions_fts(sessions_fts, rowid, session_key, content)
                 VALUES ('delete', old.id, old.session_key, old.content);
@@ -261,11 +268,6 @@ impl SessionBackend for SqliteSessionBackend {
             params![message.role, message.content, id],
         )
         .map_err(std::io::Error::other)?;
-
-        // NOTE: FTS index becomes stale here (no UPDATE trigger, only
-        // INSERT/DELETE triggers). This is acceptable — update_last is
-        // used for transient streaming snapshots. The final content will
-        // be correct in the sessions table for load().
 
         let now = chrono::Utc::now().to_rfc3339();
         conn.execute(
@@ -732,6 +734,39 @@ mod tests {
         });
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].key, "code_chat");
+    }
+
+    #[test]
+    fn fts5_update_trigger_reflects_modified_content() {
+        let tmp = TempDir::new().unwrap();
+        let backend = SqliteSessionBackend::new(tmp.path()).unwrap();
+
+        backend
+            .append("s1", &ChatMessage::assistant("draft response about cats"))
+            .unwrap();
+
+        let before = backend.search(&SessionQuery {
+            keyword: Some("cats".into()),
+            limit: Some(10),
+        });
+        assert_eq!(before.len(), 1);
+
+        backend
+            .update_last("s1", &ChatMessage::assistant("final response about dogs"))
+            .unwrap();
+
+        let cats = backend.search(&SessionQuery {
+            keyword: Some("cats".into()),
+            limit: Some(10),
+        });
+        assert!(cats.is_empty(), "stale content should not match after update");
+
+        let dogs = backend.search(&SessionQuery {
+            keyword: Some("dogs".into()),
+            limit: Some(10),
+        });
+        assert_eq!(dogs.len(), 1, "updated content should be searchable");
+        assert_eq!(dogs[0].key, "s1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** The `sessions_fts` full-text search index had INSERT and DELETE triggers but no UPDATE trigger. When `update_last` modifies a row during incremental streaming persistence (#5705), the FTS index went stale — searches could return phantom matches on old content or miss the final content. Added an UPDATE trigger with a `WHEN old.content != new.content` guard to keep the index in sync while avoiding unnecessary churn on non-content updates.
- **Scope boundary:** One file: `crates/zeroclaw-infra/src/session_sqlite.rs`. SQL trigger + comment removal + test.
- **Blast radius:** FTS search accuracy during active streaming. The trigger adds index churn during streaming (~1 FTS delete+insert per `update_last` call at ~500ms intervals), but this is acceptable for a single-user local SQLite database. The `WHEN` guard avoids churn when only `role` or other non-content columns are updated.
- **Linked issue(s):** Closes #5834. Related: #5705 (introduced `update_last`).

## Validation Evidence (required)

- **Commands run:** `cargo check -p zeroclaw-infra` — clean. `cargo clippy -p zeroclaw-infra --all-targets` — clean, no warnings. `cargo test -p zeroclaw-infra -- fts5` — 2 passed, 0 failed.
- **Beyond CI — what did you manually verify?** Verified the trigger pattern matches `memories_au` (sqlite.rs:189) and `nodes_au` (knowledge_graph.rs:184) — all three FTS tables now have complete ai/au/ad trigger sets. Verified `CREATE TRIGGER IF NOT EXISTS` runs on every startup, so existing databases pick up the trigger automatically.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No.
- New external network calls? No.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.

## Compatibility (required)

- Backward compatible? Yes — existing databases gain the trigger on next startup via `CREATE TRIGGER IF NOT EXISTS`. No schema migration needed.
- Config / env / CLI surface changed? No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)