### PR TITLE
fix(docs): correct build badge workflow and make version badge dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/zeroclaw-labs/zeroclaw/actions/workflows/ci-run.yml"><img src="https://img.shields.io/github/actions/workflow/status/zeroclaw-labs/zeroclaw/ci-run.yml?branch=master&label=build" alt="Build Status" /></a>
+  <a href="https://github.com/zeroclaw-labs/zeroclaw/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/zeroclaw-labs/zeroclaw/ci.yml?branch=master&label=build" alt="Build Status" /></a>
   <a href="LICENSE-APACHE"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache%202.0-blue.svg" alt="License: MIT OR Apache-2.0" /></a>
   <a href="https://www.rust-lang.org"><img src="https://img.shields.io/badge/rust-edition%202024-orange?logo=rust" alt="Rust Edition 2024" /></a>
-  <a href="https://github.com/zeroclaw-labs/zeroclaw/releases/latest"><img src="https://img.shields.io/badge/version-v0.7.1-blue" alt="Version v0.7.1" /></a>
+  <a href="https://github.com/zeroclaw-labs/zeroclaw/releases/latest"><img src="https://img.shields.io/github/v/release/zeroclaw-labs/zeroclaw?label=version" alt="Latest Version" /></a>
   <a href="https://github.com/zeroclaw-labs/zeroclaw/graphs/contributors"><img src="https://img.shields.io/github/contributors/zeroclaw-labs/zeroclaw?color=green" alt="Contributors" /></a>
   <a href="https://x.com/zeroclawlabs?s=21"><img src="https://img.shields.io/badge/X-%40zeroclawlabs-000000?style=flat&logo=x&logoColor=white" alt="X: @zeroclawlabs" /></a>
   <a href="https://discord.com/invite/wDshRVqRjx"><img src="https://img.shields.io/badge/Discord-Join-5865F2?style=flat&logo=discord&logoColor=white" alt="Discord" /></a>


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Build status badge URL pointed to `ci-run.yml` which does not exist — corrected to `ci.yml`, the actual CI workflow. This was causing the build badge to fail/not render on the README.
  - Version badge was hardcoded at `v0.7.1` while `Cargo.toml` is at `v0.7.3` — replaced with a dynamic `shields.io` badge (`github/v/release`) so it auto-updates with each release.
- **Scope boundary:** Only README badge URLs are changed. No code, CI, or documentation prose changes.
- **Blast radius:** None — badge URLs are display-only and do not affect builds, tests, or runtime behavior.
- **Linked issue(s):** N/A

## Validation Evidence (required)

- **Commands run and tail output:**
  ```
  scripts/ci/docs_quality_gate.sh:
  No blocking markdown issues on changed lines.
  ```
  `cargo fmt`, `cargo clippy`, `cargo test` intentionally skipped (see below).

- **Beyond CI — what did you manually verify?**
  - Confirmed `.github/workflows/ci.yml` exists and `ci-run.yml` does not.
  - Verified `shields.io` `github/v/release` badge endpoint resolves correctly for the repo pattern.
  - Confirmed `Cargo.toml` version is `v0.7.3`, not `v0.7.1` as the old hardcoded badge stated.

- **If any command was intentionally skipped, why:**
  Docs-only change (README badge URLs). Per template guidance, docs-only changes use markdown lint + link-integrity instead of `cargo fmt/clippy/test`. The docs quality gate was run and passed.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No`
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No`

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PR: `git revert <sha>` is the plan unless otherwise noted.