### PR TITLE
fix(provider): strip media markers in auxiliary LLM calls

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -2104,7 +2104,11 @@ async fn classify_channel_reply_intent(
             "assistant" => "assistant",
             _ => "user",
         };
-        let _ = writeln!(convo, "[{role}] {}", msg.content);
+        // Strip media markers — auxiliary classifier does not need image
+        // content, and forwarding `[IMAGE:/local/path]` would reach the
+        // provider as a malformed `image_url.url` and trigger 400 errors.
+        let safe_content = zeroclaw_providers::multimodal::strip_media_markers(&msg.content);
+        let _ = writeln!(convo, "[{role}] {safe_content}");
     }
 
     let response = provider

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -2223,7 +2223,11 @@ async fn classify_channel_reply_intent(
             "assistant" => "assistant",
             _ => "user",
         };
-        let _ = writeln!(convo, "[{role}] {}", msg.content);
+        // Strip media markers — auxiliary classifier does not need image
+        // content, and forwarding `[IMAGE:/local/path]` would reach the
+        // provider as a malformed `image_url.url` and trigger 400 errors.
+        let safe_content = zeroclaw_providers::multimodal::strip_media_markers(&msg.content);
+        let _ = writeln!(convo, "[{role}] {safe_content}");
     }
 
     let response = provider

--- a/crates/zeroclaw-providers/src/multimodal.rs
+++ b/crates/zeroclaw-providers/src/multimodal.rs
@@ -142,8 +142,12 @@ pub fn contains_image_markers(messages: &[ChatMessage]) -> bool {
     count_image_markers(messages) > 0
 }
 
-/// Replace media markers (`[IMAGE:...]`, `[DOCUMENT:...]`, `[FILE:...]`,
-/// `[VIDEO:...]`, `[VOICE:...]`, `[AUDIO:...]`) with `[media attachment]`.
+/// Replace media markers (`[IMAGE:...]`, `[PHOTO:...]`, `[DOCUMENT:...]`,
+/// `[FILE:...]`, `[VIDEO:...]`, `[VOICE:...]`, `[AUDIO:...]`) with
+/// `[media attachment]`. Match is case-insensitive to align with the channel
+/// attachment parsers, which all uppercase the kind before comparing
+/// (`crates/zeroclaw-channels/src/util.rs::ATTACHMENT_KINDS`,
+/// `telegram.rs`, `discord.rs`, `qq.rs`, `whatsapp_web.rs`).
 ///
 /// Use before passing user-facing text to auxiliary `chat_with_system` calls
 /// (intent classification, summarization, delegation) so that local file
@@ -156,7 +160,8 @@ pub fn contains_image_markers(messages: &[ChatMessage]) -> bool {
 /// continues to call `prepare_messages_for_provider` for full normalization.
 pub fn strip_media_markers(text: &str) -> String {
     static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
-        regex::Regex::new(r"\[(?:IMAGE|DOCUMENT|FILE|VIDEO|VOICE|AUDIO):[^\]]*\]").unwrap()
+        regex::Regex::new(r"(?i)\[(?:IMAGE|PHOTO|DOCUMENT|FILE|VIDEO|VOICE|AUDIO):[^\]]*\]")
+            .unwrap()
     });
     RE.replace_all(text, "[media attachment]").into_owned()
 }
@@ -573,8 +578,22 @@ mod tests {
 
     #[test]
     fn strip_media_markers_replaces_all_supported_kinds() {
-        let input = "[IMAGE:/a.jpg] [DOCUMENT:/b.pdf] [FILE:/c.zip] [VIDEO:/d.mp4] [VOICE:/e.ogg] [AUDIO:/f.wav]";
-        let expected = "[media attachment] [media attachment] [media attachment] [media attachment] [media attachment] [media attachment]";
+        // Mirrors `ATTACHMENT_KINDS` in
+        // `crates/zeroclaw-channels/src/util.rs`, which is the source of
+        // truth for which marker spellings inbound channels can produce.
+        let input = "[IMAGE:/a.jpg] [PHOTO:/b.jpg] [DOCUMENT:/c.pdf] [FILE:/d.zip] [VIDEO:/e.mp4] [VOICE:/f.ogg] [AUDIO:/g.wav]";
+        let expected = "[media attachment] [media attachment] [media attachment] [media attachment] [media attachment] [media attachment] [media attachment]";
+        assert_eq!(strip_media_markers(input), expected);
+    }
+
+    #[test]
+    fn strip_media_markers_is_case_insensitive() {
+        // Channel parsers uppercase the kind before comparing, so by the time
+        // a marker reaches conversation history it is normally upper-case —
+        // but accept lower/mixed case too so we don't depend on that
+        // invariant downstream.
+        let input = "[image:/a.jpg] [Photo:/b.jpg] [video:/c.mp4]";
+        let expected = "[media attachment] [media attachment] [media attachment]";
         assert_eq!(strip_media_markers(input), expected);
     }
 

--- a/crates/zeroclaw-providers/src/multimodal.rs
+++ b/crates/zeroclaw-providers/src/multimodal.rs
@@ -142,6 +142,25 @@ pub fn contains_image_markers(messages: &[ChatMessage]) -> bool {
     count_image_markers(messages) > 0
 }
 
+/// Replace media markers (`[IMAGE:...]`, `[DOCUMENT:...]`, `[FILE:...]`,
+/// `[VIDEO:...]`, `[VOICE:...]`, `[AUDIO:...]`) with `[media attachment]`.
+///
+/// Use before passing user-facing text to auxiliary `chat_with_system` calls
+/// (intent classification, summarization, delegation) so that local file
+/// paths from inbound channels do not leak to the upstream provider — the
+/// upstream API would otherwise receive a filesystem path as `image_url.url`
+/// and reject the request.
+///
+/// Auxiliary calls do not need to *see* the media content; they only route
+/// or summarize, so the placeholder is sufficient. The main agent loop
+/// continues to call `prepare_messages_for_provider` for full normalization.
+pub fn strip_media_markers(text: &str) -> String {
+    static RE: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+        regex::Regex::new(r"\[(?:IMAGE|DOCUMENT|FILE|VIDEO|VOICE|AUDIO):[^\]]*\]").unwrap()
+    });
+    RE.replace_all(text, "[media attachment]").into_owned()
+}
+
 pub fn extract_ollama_image_payload(image_ref: &str) -> Option<String> {
     if image_ref.starts_with("data:") {
         let comma_idx = image_ref.find(',')?;
@@ -539,6 +558,41 @@ fn mime_from_magic(bytes: &[u8]) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn strip_media_markers_replaces_image_local_path() {
+        let input = "Look at [IMAGE:/zeroclaw-data/workspace/telegram_files/photo_1.jpg]";
+        assert_eq!(strip_media_markers(input), "Look at [media attachment]");
+    }
+
+    #[test]
+    fn strip_media_markers_replaces_image_data_uri() {
+        let input = "Inline [IMAGE:data:image/png;base64,abcd]";
+        assert_eq!(strip_media_markers(input), "Inline [media attachment]");
+    }
+
+    #[test]
+    fn strip_media_markers_replaces_all_supported_kinds() {
+        let input = "[IMAGE:/a.jpg] [DOCUMENT:/b.pdf] [FILE:/c.zip] [VIDEO:/d.mp4] [VOICE:/e.ogg] [AUDIO:/f.wav]";
+        let expected = "[media attachment] [media attachment] [media attachment] [media attachment] [media attachment] [media attachment]";
+        assert_eq!(strip_media_markers(input), expected);
+    }
+
+    #[test]
+    fn strip_media_markers_leaves_plain_text_untouched() {
+        let input = "No markers here, just text with [brackets] and (parens).";
+        assert_eq!(strip_media_markers(input), input);
+    }
+
+    #[test]
+    fn strip_media_markers_preserves_unrelated_brackets() {
+        // Markers that don't match the media kinds are left alone.
+        let input = "Use [TODO:foo] and [NOTE:bar] but replace [IMAGE:/x.jpg]";
+        assert_eq!(
+            strip_media_markers(input),
+            "Use [TODO:foo] and [NOTE:bar] but replace [media attachment]"
+        );
+    }
 
     #[test]
     fn parse_image_markers_extracts_multiple_markers() {

--- a/crates/zeroclaw-runtime/src/agent/context_compressor.rs
+++ b/crates/zeroclaw-runtime/src/agent/context_compressor.rs
@@ -486,7 +486,11 @@ fn build_transcript(messages: &[ChatMessage], max_chars: usize) -> String {
     let mut transcript = String::new();
     for msg in messages {
         let role = msg.role.to_uppercase();
-        let _ = writeln!(transcript, "{role}: {}", msg.content.trim());
+        // Strip media markers — the summarizer auxiliary call does not need
+        // image content, and forwarding `[IMAGE:/local/path]` would reach
+        // the provider as a malformed `image_url.url` and trigger 400 errors.
+        let safe_content = zeroclaw_providers::multimodal::strip_media_markers(msg.content.trim());
+        let _ = writeln!(transcript, "{role}: {safe_content}");
     }
 
     if transcript.len() > max_chars {
@@ -724,6 +728,29 @@ mod tests {
         let t = build_transcript(&messages, 10_000);
         assert!(t.contains("USER: hello"));
         assert!(t.contains("ASSISTANT: hi there"));
+    }
+
+    #[test]
+    fn test_build_transcript_strips_media_markers() {
+        // Regression: image markers in history must be stripped so that
+        // local file paths do not reach the summarizer auxiliary call and
+        // fail with `unsupported image url: /local/path` 400 errors.
+        let messages = vec![
+            msg(
+                "user",
+                "Look at [IMAGE:/zeroclaw-data/workspace/telegram_files/photo_1.jpg]",
+            ),
+            msg("assistant", "Cute cat!"),
+        ];
+        let t = build_transcript(&messages, 10_000);
+        assert!(
+            !t.contains("[IMAGE:"),
+            "transcript should not contain raw IMAGE marker: {t}"
+        );
+        assert!(
+            t.contains("[media attachment]"),
+            "transcript should contain placeholder: {t}"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/context_compressor.rs
+++ b/crates/zeroclaw-runtime/src/agent/context_compressor.rs
@@ -481,7 +481,11 @@ fn build_transcript(messages: &[ChatMessage], max_chars: usize) -> String {
     let mut transcript = String::new();
     for msg in messages {
         let role = msg.role.to_uppercase();
-        let _ = writeln!(transcript, "{role}: {}", msg.content.trim());
+        // Strip media markers — the summarizer auxiliary call does not need
+        // image content, and forwarding `[IMAGE:/local/path]` would reach
+        // the provider as a malformed `image_url.url` and trigger 400 errors.
+        let safe_content = zeroclaw_providers::multimodal::strip_media_markers(msg.content.trim());
+        let _ = writeln!(transcript, "{role}: {safe_content}");
     }
 
     if transcript.len() > max_chars {
@@ -671,6 +675,29 @@ mod tests {
         let t = build_transcript(&messages, 10_000);
         assert!(t.contains("USER: hello"));
         assert!(t.contains("ASSISTANT: hi there"));
+    }
+
+    #[test]
+    fn test_build_transcript_strips_media_markers() {
+        // Regression: image markers in history must be stripped so that
+        // local file paths do not reach the summarizer auxiliary call and
+        // fail with `unsupported image url: /local/path` 400 errors.
+        let messages = vec![
+            msg(
+                "user",
+                "Look at [IMAGE:/zeroclaw-data/workspace/telegram_files/photo_1.jpg]",
+            ),
+            msg("assistant", "Cute cat!"),
+        ];
+        let t = build_transcript(&messages, 10_000);
+        assert!(
+            !t.contains("[IMAGE:"),
+            "transcript should not contain raw IMAGE marker: {t}"
+        );
+        assert!(
+            t.contains("[media attachment]"),
+            "transcript should contain placeholder: {t}"
+        );
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/agent/context_compressor.rs
+++ b/crates/zeroclaw-runtime/src/agent/context_compressor.rs
@@ -486,11 +486,7 @@ fn build_transcript(messages: &[ChatMessage], max_chars: usize) -> String {
     let mut transcript = String::new();
     for msg in messages {
         let role = msg.role.to_uppercase();
-        // Strip media markers — the summarizer auxiliary call does not need
-        // image content, and forwarding `[IMAGE:/local/path]` would reach
-        // the provider as a malformed `image_url.url` and trigger 400 errors.
-        let safe_content = zeroclaw_providers::multimodal::strip_media_markers(msg.content.trim());
-        let _ = writeln!(transcript, "{role}: {safe_content}");
+        let _ = writeln!(transcript, "{role}: {}", msg.content.trim());
     }
 
     if transcript.len() > max_chars {
@@ -507,11 +503,17 @@ fn build_summarizer_transcript(
 ) -> String {
     let transcript = build_transcript(messages, max_chars);
     if supports_vision {
+        // Vision-capable summarizer can read media markers; preserve them so
+        // visual content is reflected in the summary (per #6189 contract).
         return transcript;
     }
 
-    let (cleaned, refs) = multimodal::parse_image_markers(&transcript);
-    if refs.is_empty() { transcript } else { cleaned }
+    // Non-vision summarizer cannot consume media markers. Strip ALL inbound
+    // attachment-kind markers (IMAGE, PHOTO, DOCUMENT, FILE, VIDEO, VOICE,
+    // AUDIO — case-insensitive) instead of just `[IMAGE:...]`, otherwise a
+    // local filesystem path can leak into the auxiliary `chat_with_system`
+    // payload and the upstream API rejects it as a malformed `image_url.url`.
+    multimodal::strip_media_markers(&transcript)
 }
 
 fn truncate_chars(s: &str, max: usize) -> String {
@@ -731,26 +733,40 @@ mod tests {
     }
 
     #[test]
-    fn test_build_transcript_strips_media_markers() {
-        // Regression: image markers in history must be stripped so that
-        // local file paths do not reach the summarizer auxiliary call and
-        // fail with `unsupported image url: /local/path` 400 errors.
-        let messages = vec![
-            msg(
-                "user",
-                "Look at [IMAGE:/zeroclaw-data/workspace/telegram_files/photo_1.jpg]",
-            ),
-            msg("assistant", "Cute cat!"),
-        ];
-        let t = build_transcript(&messages, 10_000);
+    fn test_build_summarizer_transcript_strips_all_attachment_kinds_for_non_vision_provider() {
+        // The non-vision summarizer branch must strip every inbound
+        // attachment-kind alias the channel parsers can emit, not just
+        // `[IMAGE:]`. Mirrors `ATTACHMENT_KINDS` in
+        // `crates/zeroclaw-channels/src/util.rs`. Regression: a `[PHOTO:]`
+        // or `[DOCUMENT:]` marker still leaking through would surface a
+        // local filesystem path in the auxiliary `chat_with_system` payload
+        // and the upstream API would reject it.
+        let messages = vec![msg(
+            "user",
+            "Take a look at [IMAGE:/a.jpg] [PHOTO:/b.jpg] [DOCUMENT:/c.pdf] \
+             [FILE:/d.zip] [VIDEO:/e.mp4] [VOICE:/f.ogg] [AUDIO:/g.wav] please",
+        )];
+        let transcript = build_summarizer_transcript(&messages, 10_000, false);
+        for prefix in [
+            "[IMAGE:",
+            "[PHOTO:",
+            "[DOCUMENT:",
+            "[FILE:",
+            "[VIDEO:",
+            "[VOICE:",
+            "[AUDIO:",
+        ] {
+            assert!(
+                !transcript.contains(prefix),
+                "non-vision transcript should not contain raw {prefix} marker: {transcript}"
+            );
+        }
         assert!(
-            !t.contains("[IMAGE:"),
-            "transcript should not contain raw IMAGE marker: {t}"
+            transcript.contains("[media attachment]"),
+            "non-vision transcript should contain placeholder: {transcript}"
         );
-        assert!(
-            t.contains("[media attachment]"),
-            "transcript should contain placeholder: {t}"
-        );
+        assert!(transcript.contains("Take a look at"));
+        assert!(transcript.contains("please"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Auxiliary `chat_with_system` paths (Telegram intent classifier in `orchestrator/mod.rs`, summarizer in `agent/context_compressor.rs`) built prompt strings from history that could contain `[IMAGE:/local/path]` markers from inbound channels.
  - `compatible.rs::to_message_content()` then parsed those markers and forwarded the raw local path verbatim as `image_url.url`, which vision-capable upstream APIs reject — for Moonshot/Kimi: `Moonshot API error (400 Bad Request): Invalid request: unsupported image url: /zeroclaw-data/workspace/telegram_files/photo_xxx.jpg`.
  - Added `multimodal::strip_media_markers(text) -> String` as a public helper that replaces `[IMAGE|DOCUMENT|FILE|VIDEO|VOICE|AUDIO]` markers with `[media attachment]`, mirroring the local helper PR #4757 introduced for memory consolidation.
  - Applied at the two auxiliary call sites listed above, so the placeholder reaches the provider while real image content continues to flow through the main agent loop unchanged.
- **Scope boundary:** Does NOT change the main agent loop's multimodal pipeline — `multimodal::prepare_messages_for_provider` continues to fully normalize local paths to base64 data URIs for the primary LLM call. Does NOT modify channel-side marker parsing/storage, the existing `memory/consolidation.rs::strip_media_markers` (left as-is to keep PR scope tight), or `tools/delegate.rs` (whose prompt is sourced from tool args, not history replay).
- **Blast radius:** Provider-facing payloads on auxiliary classifier/summarizer calls only. Their job is routing/summary, not vision; a placeholder is sufficient information for them. No effect on user-facing replies or vision-capable main-loop calls.
- **Linked issue(s):** Related #4753 — that issue's body called out three providers (`compatible.rs`, `openrouter.rs`, `copilot.rs`) as forwarding raw `[IMAGE:...]` markers without normalization. PR #4757 fixed only the memory-consolidation portion. This PR covers the auxiliary `chat_with_system` portion of the same root cause.

## Validation Evidence (required)

```
$ cargo fmt --all -- --check
# (no output — exit 0)

$ ./scripts/ci/rust_quality_gate.sh
==> rust quality: cargo fmt --all -- --check
==> rust quality: cargo clippy --locked --all-targets -- -D clippy::correctness
warning: `zeroclawlabs` (lib test) generated 1 warning (1 duplicate)
warning: `zeroclawlabs` (bin "zeroclaw") generated 1 warning
warning: `zeroclawlabs` (bin "zeroclaw" test) generated 1 warning (1 duplicate)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.95s
# exit 0 — these warnings exist on plain upstream/master, unrelated to this PR

$ cargo test --locked -p zeroclaw-providers --lib multimodal::tests
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 758 filtered out

$ cargo test --locked -p zeroclaw-runtime --lib agent::context_compressor::tests
test result: ok. 28 passed; 0 failed; 0 ignored; 0 measured; 1541 filtered out
```

- **Commands run and tail output:** see above.
- **Beyond CI — what did you manually verify?** Reproduced the original 400 against a self-hosted ZeroClaw deployment using Telegram + Kimi K2.6: every post-photo message logged `Non-retryable error ... Invalid request: unsupported image url: /zeroclaw-data/workspace/telegram_files/photo_xxx.jpg`, exhausted retries, then recovered via fallback. After this fix the same scenario produces no errors, no wasted retries, and replies in roughly half the time (saving one 700ms round-trip per turn).
- **If any command was intentionally skipped, why:** None. `cargo test --locked --workspace --lib` shows two pre-existing failures in `orchestrator::tests::build_channel_by_id_*` and one parallel-only flake in `telegram::tests::truncate_telegram_command_description_multibyte_within_char_limit` that all reproduce on plain `upstream/master` independently of this PR (verified via `git checkout upstream/master && cargo test --locked -p zeroclaw-channels --lib`). The new tests added in this PR pass deterministically.

New tests added:

- `multimodal::tests::strip_media_markers_replaces_image_local_path`
- `multimodal::tests::strip_media_markers_replaces_image_data_uri`
- `multimodal::tests::strip_media_markers_replaces_all_supported_kinds`
- `multimodal::tests::strip_media_markers_leaves_plain_text_untouched`
- `multimodal::tests::strip_media_markers_preserves_unrelated_brackets`
- `agent::context_compressor::tests::test_build_summarizer_transcript_strips_all_attachment_kinds_for_non_vision_provider`

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**
- New external network calls? **No**
- Secrets / tokens / credentials handling changed? **No**
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**

Net direction is *less* leakage: local filesystem paths previously surfaced in upstream provider error logs (e.g. Moonshot 400 bodies); after this PR they are stripped to `[media attachment]` before any auxiliary call.

## Compatibility (required)

- Backward compatible? **Yes**
- Config / env / CLI surface changed? **No**

No schema changes; existing configs continue to work unchanged. The new public helper `multimodal::strip_media_markers` is additive; existing `prepare_messages_for_provider` semantics are unchanged.

## Rollback

Risk: **medium** (matches the `risk: medium` label — the diff touches provider-facing behavior plus channel/runtime auxiliary call paths).

- **Fast rollback path:** `git revert <sha>` — the change is isolated to one regex-based replacement helper plus two two-line call-site updates; reverting fully restores prior behavior with no data migration or config change required.
- **Feature flags or config toggles:** None. The helper is unconditionally applied at the two auxiliary `chat_with_system` call sites (intent classifier, summarizer); there is no runtime opt-out.
- **Observable failure symptoms after merge:**
  - Grep daemon logs for any auxiliary call site emitting raw `[IMAGE:`, `[PHOTO:`, `[DOCUMENT:`, `[FILE:`, `[VIDEO:`, `[VOICE:`, or `[AUDIO:` markers in the prompt — the helper should have rewritten those to `[media attachment]`.
  - Watch for a regression of the original symptom: `Moonshot API error (400 Bad Request): unsupported image url: /zeroclaw-data/workspace/...` (or the equivalent from any other provider that parses `[IMAGE:]` markers).
  - Telegram intent-classifier prompts containing literal local filesystem paths in the LLM-side request log.

