### PR TITLE
feat(codex): support native Responses tool calls

### DIFF
--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -2,13 +2,20 @@ use crate::ProviderRuntimeOptions;
 use crate::auth::AuthService;
 use crate::auth::openai_oauth::extract_account_id_from_jwt;
 use crate::multimodal;
-use crate::traits::{ChatMessage, Provider, ProviderCapabilities};
+use crate::traits::{
+    ChatMessage, ChatRequest as ProviderChatRequest, ChatResponse as ProviderChatResponse,
+    Provider, ProviderCapabilities, StreamChunk, StreamError, StreamEvent, StreamOptions,
+    StreamResult, ToolCall as ProviderToolCall,
+};
 use async_trait::async_trait;
 use futures_util::StreamExt;
+use futures_util::stream;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use zeroclaw_api::tool::ToolSpec;
 
 const DEFAULT_CODEX_RESPONSES_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
 const CODEX_RESPONSES_URL_ENV: &str = "ZEROCLAW_CODEX_RESPONSES_URL";
@@ -18,6 +25,7 @@ const DEFAULT_CODEX_INSTRUCTIONS: &str =
 /// OpenAI Codex speaks the "responses" wire protocol, not chat_completions.
 const WIRE_API: &str = "responses";
 
+#[derive(Clone)]
 pub struct OpenAiCodexProvider {
     auth: AuthService,
     auth_profile_override: Option<String>,
@@ -31,31 +39,29 @@ pub struct OpenAiCodexProvider {
 #[derive(Debug, Serialize)]
 struct ResponsesRequest {
     model: String,
-    input: Vec<ResponsesInput>,
+    input: Vec<Value>,
     instructions: String,
     store: bool,
     stream: bool,
     text: ResponsesTextOptions,
     reasoning: ResponsesReasoningOptions,
     include: Vec<String>,
-    tool_choice: String,
-    parallel_tool_calls: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<ResponsesToolSpec>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parallel_tool_calls: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
-struct ResponsesInput {
-    role: String,
-    content: Vec<ResponsesInputContent>,
-}
-
-#[derive(Debug, Serialize)]
-struct ResponsesInputContent {
+struct ResponsesToolSpec {
     #[serde(rename = "type")]
     kind: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    text: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    image_url: Option<String>,
+    name: String,
+    description: String,
+    parameters: Value,
+    strict: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -79,6 +85,16 @@ struct ResponsesResponse {
 
 #[derive(Debug, Deserialize)]
 struct ResponsesOutput {
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    call_id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
     #[serde(default)]
     content: Vec<ResponsesContent>,
 }
@@ -87,7 +103,32 @@ struct ResponsesOutput {
 struct ResponsesContent {
     #[serde(rename = "type")]
     kind: Option<String>,
+    #[serde(default)]
     text: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct ResponsesStreamState {
+    saw_text_delta: bool,
+    text_accumulator: String,
+    fallback_text: Option<String>,
+    tool_calls: HashMap<String, PendingToolCall>,
+    emitted_tool_call_ids: HashSet<String>,
+    collected_tool_calls: Vec<ProviderToolCall>,
+}
+
+#[derive(Debug, Default, Clone)]
+struct PendingToolCall {
+    item_id: Option<String>,
+    call_id: Option<String>,
+    name: Option<String>,
+    arguments: String,
+}
+
+#[derive(Debug, Default)]
+struct ResponsesTurnResult {
+    text: Option<String>,
+    tool_calls: Vec<ProviderToolCall>,
 }
 
 impl OpenAiCodexProvider {
@@ -213,9 +254,37 @@ fn normalize_model_id(model: &str) -> &str {
     model.rsplit('/').next().unwrap_or(model)
 }
 
-fn build_responses_input(messages: &[ChatMessage]) -> (String, Vec<ResponsesInput>) {
+fn convert_tools(tools: Option<&[ToolSpec]>) -> Option<Vec<ResponsesToolSpec>> {
+    let items = tools?;
+    if items.is_empty() {
+        return None;
+    }
+
+    Some(
+        items
+            .iter()
+            .map(|tool| ResponsesToolSpec {
+                kind: "function".to_string(),
+                name: tool.name.clone(),
+                description: tool.description.clone(),
+                parameters: tool.parameters.clone(),
+                strict: false,
+            })
+            .collect(),
+    )
+}
+
+fn response_message_item(role: &str, content: Vec<Value>) -> Value {
+    serde_json::json!({
+        "type": "message",
+        "role": role,
+        "content": content,
+    })
+}
+
+fn build_responses_input(messages: &[ChatMessage]) -> (String, Vec<Value>) {
     let mut system_parts: Vec<&str> = Vec::new();
-    let mut input: Vec<ResponsesInput> = Vec::new();
+    let mut input: Vec<Value> = Vec::new();
 
     for msg in messages {
         match msg.role.as_str() {
@@ -225,47 +294,95 @@ fn build_responses_input(messages: &[ChatMessage]) -> (String, Vec<ResponsesInpu
 
                 let mut content_items = Vec::new();
 
-                // Add text if present
                 if !cleaned_text.trim().is_empty() {
-                    content_items.push(ResponsesInputContent {
-                        kind: "input_text".to_string(),
-                        text: Some(cleaned_text),
-                        image_url: None,
-                    });
+                    content_items.push(serde_json::json!({
+                        "type": "input_text",
+                        "text": cleaned_text,
+                    }));
                 }
 
-                // Add images
                 for image_ref in image_refs {
-                    content_items.push(ResponsesInputContent {
-                        kind: "input_image".to_string(),
-                        text: None,
-                        image_url: Some(image_ref),
-                    });
+                    content_items.push(serde_json::json!({
+                        "type": "input_image",
+                        "image_url": image_ref,
+                    }));
                 }
 
-                // If no content at all, add empty text
                 if content_items.is_empty() {
-                    content_items.push(ResponsesInputContent {
-                        kind: "input_text".to_string(),
-                        text: Some(String::new()),
-                        image_url: None,
-                    });
+                    content_items.push(serde_json::json!({
+                        "type": "input_text",
+                        "text": "",
+                    }));
                 }
 
-                input.push(ResponsesInput {
-                    role: "user".to_string(),
-                    content: content_items,
-                });
+                input.push(response_message_item("user", content_items));
             }
             "assistant" => {
-                input.push(ResponsesInput {
-                    role: "assistant".to_string(),
-                    content: vec![ResponsesInputContent {
-                        kind: "output_text".to_string(),
-                        text: Some(msg.content.clone()),
-                        image_url: None,
-                    }],
-                });
+                if let Ok(value) = serde_json::from_str::<Value>(&msg.content)
+                    && let Some(tool_calls_value) = value.get("tool_calls")
+                    && let Ok(parsed_calls) =
+                        serde_json::from_value::<Vec<ProviderToolCall>>(tool_calls_value.clone())
+                {
+                    if let Some(content) = value
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .filter(|content| !content.trim().is_empty())
+                    {
+                        input.push(response_message_item(
+                            "assistant",
+                            vec![serde_json::json!({
+                                "type": "output_text",
+                                "text": content,
+                            })],
+                        ));
+                    }
+
+                    for call in parsed_calls {
+                        input.push(serde_json::json!({
+                            "type": "function_call",
+                            "call_id": call.id,
+                            "name": call.name,
+                            "arguments": call.arguments,
+                        }));
+                    }
+                } else if !msg.content.trim().is_empty() {
+                    input.push(response_message_item(
+                        "assistant",
+                        vec![serde_json::json!({
+                            "type": "output_text",
+                            "text": msg.content,
+                        })],
+                    ));
+                }
+            }
+            "tool" => {
+                if let Ok(value) = serde_json::from_str::<Value>(&msg.content) {
+                    if let Some(call_id) = value.get("tool_call_id").and_then(Value::as_str) {
+                        let output = value
+                            .get("content")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default();
+                        input.push(serde_json::json!({
+                            "type": "function_call_output",
+                            "call_id": call_id,
+                            "output": output,
+                        }));
+                    } else if !msg.content.trim().is_empty() {
+                        input.push(response_message_item(
+                            "tool",
+                            vec![serde_json::json!({
+                                "type": "output_text",
+                                "text": msg.content,
+                            })],
+                        ));
+                    }
+                } else if !msg.content.trim().is_empty() {
+                    input.push(serde_json::json!({
+                        "type": "function_call_output",
+                        "call_id": uuid::Uuid::new_v4().to_string(),
+                        "output": msg.content,
+                    }));
+                }
             }
             _ => {}
         }
@@ -355,77 +472,274 @@ fn extract_responses_text(response: &ResponsesResponse) -> Option<String> {
     None
 }
 
-fn extract_stream_event_text(event: &Value, saw_delta: bool) -> Option<String> {
-    let event_type = event.get("type").and_then(Value::as_str);
-    match event_type {
-        Some("response.output_text.delta") => {
-            nonempty_preserve(event.get("delta").and_then(Value::as_str))
-        }
-        Some("response.output_text.done") if !saw_delta => {
-            nonempty_preserve(event.get("text").and_then(Value::as_str))
-        }
-        Some("response.completed" | "response.done") => event
-            .get("response")
-            .and_then(|value| serde_json::from_value::<ResponsesResponse>(value.clone()).ok())
-            .and_then(|response| extract_responses_text(&response)),
-        _ => None,
+fn extract_responses_tool_calls(response: &ResponsesResponse) -> Vec<ProviderToolCall> {
+    response
+        .output
+        .iter()
+        .filter(|item| item.kind.as_deref() == Some("function_call"))
+        .filter_map(|item| {
+            let name = item.name.clone()?;
+            let arguments = item.arguments.clone().unwrap_or_default();
+            Some(ProviderToolCall {
+                id: item
+                    .call_id
+                    .clone()
+                    .or_else(|| item.id.clone())
+                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+                name,
+                arguments,
+            })
+        })
+        .collect()
+}
+
+fn response_output_text_from_event_item(item: &Value) -> Option<String> {
+    if item.get("type").and_then(Value::as_str) != Some("message") {
+        return None;
+    }
+
+    item.get("content")
+        .and_then(Value::as_array)
+        .and_then(|parts| {
+            parts.iter().find_map(|part| {
+                if part.get("type").and_then(Value::as_str) == Some("output_text") {
+                    first_nonempty(part.get("text").and_then(Value::as_str))
+                } else {
+                    None
+                }
+            })
+        })
+}
+
+fn pending_tool_call_key(item_id: Option<&str>, output_index: Option<u64>) -> Option<String> {
+    item_id
+        .map(ToString::to_string)
+        .or_else(|| output_index.map(|index| format!("output:{index}")))
+}
+
+fn emit_tool_call(
+    state: &mut ResponsesStreamState,
+    tool_call: ProviderToolCall,
+) -> Option<ProviderToolCall> {
+    if state.emitted_tool_call_ids.insert(tool_call.id.clone()) {
+        state.collected_tool_calls.push(tool_call.clone());
+        Some(tool_call)
+    } else {
+        None
     }
 }
 
-fn parse_sse_text(body: &str) -> anyhow::Result<Option<String>> {
-    let mut saw_delta = false;
-    let mut delta_accumulator = String::new();
-    let mut fallback_text = None;
+fn process_responses_stream_event(
+    event: Value,
+    state: &mut ResponsesStreamState,
+) -> anyhow::Result<Vec<StreamEvent>> {
+    if let Some(message) = extract_stream_error_message(&event) {
+        anyhow::bail!("OpenAI Codex stream error: {message}");
+    }
+
+    let mut emitted = Vec::new();
+    match event.get("type").and_then(Value::as_str) {
+        Some("response.output_text.delta") => {
+            if let Some(text) = nonempty_preserve(event.get("delta").and_then(Value::as_str)) {
+                state.saw_text_delta = true;
+                state.text_accumulator.push_str(&text);
+                emitted.push(StreamEvent::TextDelta(StreamChunk::delta(text)));
+            }
+        }
+        Some("response.output_text.done") if !state.saw_text_delta => {
+            state.fallback_text = nonempty_preserve(event.get("text").and_then(Value::as_str));
+        }
+        Some("response.output_item.added") => {
+            let item = event.get("item");
+            let item_type = item
+                .and_then(|value| value.get("type"))
+                .and_then(Value::as_str);
+            if item_type == Some("function_call") {
+                let key = pending_tool_call_key(
+                    item.and_then(|value| value.get("id"))
+                        .and_then(Value::as_str),
+                    event.get("output_index").and_then(Value::as_u64),
+                );
+                if let Some(key) = key {
+                    let entry = state.tool_calls.entry(key).or_default();
+                    entry.item_id = item
+                        .and_then(|value| value.get("id"))
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string);
+                    entry.call_id = item
+                        .and_then(|value| value.get("call_id"))
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string);
+                    entry.name = item
+                        .and_then(|value| value.get("name"))
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string);
+                    if let Some(arguments) = item
+                        .and_then(|value| value.get("arguments"))
+                        .and_then(Value::as_str)
+                    {
+                        entry.arguments = arguments.to_string();
+                    }
+                }
+            }
+        }
+        Some("response.function_call_arguments.delta") => {
+            if let Some(key) = pending_tool_call_key(
+                event.get("item_id").and_then(Value::as_str),
+                event.get("output_index").and_then(Value::as_u64),
+            ) {
+                let entry = state.tool_calls.entry(key).or_default();
+                entry.item_id = event
+                    .get("item_id")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string);
+                entry.arguments.push_str(
+                    event
+                        .get("delta")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default(),
+                );
+            }
+        }
+        Some("response.function_call_arguments.done") => {
+            let key = pending_tool_call_key(
+                event.get("item_id").and_then(Value::as_str),
+                event.get("output_index").and_then(Value::as_u64),
+            );
+            let mut pending = key
+                .as_ref()
+                .and_then(|key| state.tool_calls.remove(key))
+                .unwrap_or_default();
+            pending.item_id = pending.item_id.or_else(|| {
+                event
+                    .get("item_id")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            });
+            pending.call_id = pending.call_id.or_else(|| {
+                event
+                    .get("call_id")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            });
+            pending.name = pending.name.or_else(|| {
+                event
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            });
+            if let Some(arguments) = event.get("arguments").and_then(Value::as_str) {
+                pending.arguments = arguments.to_string();
+            }
+
+            if let Some(name) = pending.name {
+                let tool_call = ProviderToolCall {
+                    id: pending
+                        .call_id
+                        .or(pending.item_id)
+                        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+                    name,
+                    arguments: pending.arguments,
+                };
+                if let Some(tool_call) = emit_tool_call(state, tool_call) {
+                    emitted.push(StreamEvent::ToolCall(tool_call));
+                }
+            }
+        }
+        Some("response.output_item.done") => {
+            if let Some(item) = event.get("item") {
+                match item.get("type").and_then(Value::as_str) {
+                    Some("message") if !state.saw_text_delta => {
+                        if state.fallback_text.is_none() {
+                            state.fallback_text = response_output_text_from_event_item(item);
+                        }
+                    }
+                    Some("function_call") => {
+                        if let Some(name) = item.get("name").and_then(Value::as_str) {
+                            let tool_call = ProviderToolCall {
+                                id: item
+                                    .get("call_id")
+                                    .and_then(Value::as_str)
+                                    .or_else(|| item.get("id").and_then(Value::as_str))
+                                    .unwrap_or_default()
+                                    .to_string(),
+                                name: name.to_string(),
+                                arguments: item
+                                    .get("arguments")
+                                    .and_then(Value::as_str)
+                                    .unwrap_or_default()
+                                    .to_string(),
+                            };
+                            if let Some(tool_call) = emit_tool_call(state, tool_call) {
+                                emitted.push(StreamEvent::ToolCall(tool_call));
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Some("response.completed" | "response.done") => {
+            if let Some(response) = event
+                .get("response")
+                .and_then(|value| serde_json::from_value::<ResponsesResponse>(value.clone()).ok())
+            {
+                if !state.saw_text_delta && state.fallback_text.is_none() {
+                    state.fallback_text = extract_responses_text(&response);
+                }
+                for tool_call in extract_responses_tool_calls(&response) {
+                    if let Some(tool_call) = emit_tool_call(state, tool_call) {
+                        emitted.push(StreamEvent::ToolCall(tool_call));
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+
+    Ok(emitted)
+}
+
+fn process_sse_chunk(
+    chunk: &str,
+    state: &mut ResponsesStreamState,
+) -> anyhow::Result<Vec<StreamEvent>> {
+    let data_lines: Vec<String> = chunk
+        .lines()
+        .filter_map(|line| line.strip_prefix("data:"))
+        .map(|line| line.trim().to_string())
+        .collect();
+    if data_lines.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let joined = data_lines.join("\n");
+    let trimmed = joined.trim();
+    if trimmed.is_empty() || trimmed == "[DONE]" {
+        return Ok(Vec::new());
+    }
+
+    if let Ok(event) = serde_json::from_str::<Value>(trimmed) {
+        return process_responses_stream_event(event, state);
+    }
+
+    let mut emitted = Vec::new();
+    for line in data_lines {
+        let line = line.trim();
+        if line.is_empty() || line == "[DONE]" {
+            continue;
+        }
+        if let Ok(event) = serde_json::from_str::<Value>(line) {
+            emitted.extend(process_responses_stream_event(event, state)?);
+        }
+    }
+
+    Ok(emitted)
+}
+
+fn parse_sse_turn(body: &str) -> anyhow::Result<ResponsesTurnResult> {
+    let mut state = ResponsesStreamState::default();
     let mut buffer = body.to_string();
-
-    let mut process_event = |event: Value| -> anyhow::Result<()> {
-        if let Some(message) = extract_stream_error_message(&event) {
-            return Err(anyhow::anyhow!("OpenAI Codex stream error: {message}"));
-        }
-        if let Some(text) = extract_stream_event_text(&event, saw_delta) {
-            let event_type = event.get("type").and_then(Value::as_str);
-            if event_type == Some("response.output_text.delta") {
-                saw_delta = true;
-                delta_accumulator.push_str(&text);
-            } else if fallback_text.is_none() {
-                fallback_text = Some(text);
-            }
-        }
-        Ok(())
-    };
-
-    let mut process_chunk = |chunk: &str| -> anyhow::Result<()> {
-        let data_lines: Vec<String> = chunk
-            .lines()
-            .filter_map(|line| line.strip_prefix("data:"))
-            .map(|line| line.trim().to_string())
-            .collect();
-        if data_lines.is_empty() {
-            return Ok(());
-        }
-
-        let joined = data_lines.join("\n");
-        let trimmed = joined.trim();
-        if trimmed.is_empty() || trimmed == "[DONE]" {
-            return Ok(());
-        }
-
-        if let Ok(event) = serde_json::from_str::<Value>(trimmed) {
-            return process_event(event);
-        }
-
-        for line in data_lines {
-            let line = line.trim();
-            if line.is_empty() || line == "[DONE]" {
-                continue;
-            }
-            if let Ok(event) = serde_json::from_str::<Value>(line) {
-                process_event(event)?;
-            }
-        }
-
-        Ok(())
-    };
 
     loop {
         let Some(idx) = buffer.find("\n\n") else {
@@ -434,18 +748,21 @@ fn parse_sse_text(body: &str) -> anyhow::Result<Option<String>> {
 
         let chunk = buffer[..idx].to_string();
         buffer = buffer[idx + 2..].to_string();
-        process_chunk(&chunk)?;
+        process_sse_chunk(&chunk, &mut state)?;
     }
 
     if !buffer.trim().is_empty() {
-        process_chunk(&buffer)?;
+        process_sse_chunk(&buffer, &mut state)?;
     }
 
-    if saw_delta {
-        return Ok(nonempty_preserve(Some(&delta_accumulator)));
-    }
-
-    Ok(fallback_text)
+    Ok(ResponsesTurnResult {
+        text: if state.saw_text_delta {
+            nonempty_preserve(Some(&state.text_accumulator))
+        } else {
+            state.fallback_text
+        },
+        tool_calls: state.collected_tool_calls,
+    })
 }
 
 fn extract_stream_error_message(event: &Value) -> Option<String> {
@@ -555,7 +872,7 @@ where
 /// every byte has arrived — on high-latency links the long-lived connection
 /// often drops mid-read, producing the "error decoding response body" failure
 /// reported in #3544.
-async fn decode_responses_body(response: reqwest::Response) -> anyhow::Result<String> {
+async fn decode_responses_body(response: reqwest::Response) -> anyhow::Result<ResponsesTurnResult> {
     let mut body = String::new();
     let mut pending_utf8 = Vec::new();
     let mut stream = response.bytes_stream();
@@ -574,8 +891,8 @@ async fn decode_responses_body(response: reqwest::Response) -> anyhow::Result<St
         ));
     }
 
-    if let Some(text) = parse_sse_text(&body)? {
-        return Ok(text);
+    if body.contains("data:") || body.contains("event:") {
+        return parse_sse_turn(&body);
     }
 
     let body_trimmed = body.trim_start();
@@ -593,16 +910,20 @@ async fn decode_responses_body(response: reqwest::Response) -> anyhow::Result<St
             super::sanitize_api_error(&body)
         )
     })?;
-    extract_responses_text(&parsed).ok_or_else(|| anyhow::anyhow!("No response from OpenAI Codex"))
+    Ok(ResponsesTurnResult {
+        text: extract_responses_text(&parsed),
+        tool_calls: extract_responses_tool_calls(&parsed),
+    })
 }
 
 impl OpenAiCodexProvider {
     async fn send_responses_request(
         &self,
-        input: Vec<ResponsesInput>,
+        input: Vec<Value>,
         instructions: String,
+        tools: Option<Vec<ResponsesToolSpec>>,
         model: &str,
-    ) -> anyhow::Result<String> {
+    ) -> anyhow::Result<ResponsesTurnResult> {
         let use_gateway_api_key_auth = self.custom_endpoint && self.gateway_api_key.is_some();
         let profile = match self
             .auth
@@ -660,6 +981,7 @@ impl OpenAiCodexProvider {
         };
         let normalized_model = normalize_model_id(model);
 
+        let has_tools = tools.is_some();
         let request = ResponsesRequest {
             model: normalized_model.to_string(),
             input,
@@ -677,8 +999,9 @@ impl OpenAiCodexProvider {
                 summary: "auto".to_string(),
             },
             include: vec!["reasoning.encrypted_content".to_string()],
-            tool_choice: "auto".to_string(),
-            parallel_tool_calls: true,
+            tools,
+            tool_choice: has_tools.then(|| "auto".to_string()),
+            parallel_tool_calls: has_tools.then_some(true),
         };
 
         let bearer_token = if use_gateway_api_key_auth {
@@ -732,7 +1055,7 @@ impl Provider for OpenAiCodexProvider {
 
     fn capabilities(&self) -> ProviderCapabilities {
         ProviderCapabilities {
-            native_tool_calling: false,
+            native_tool_calling: true,
             vision: true,
             prompt_caching: false,
         }
@@ -757,8 +1080,9 @@ impl Provider for OpenAiCodexProvider {
         let prepared = crate::multimodal::prepare_messages_for_provider(&messages, &config).await?;
 
         let (instructions, input) = build_responses_input(&prepared.messages);
-        self.send_responses_request(input, instructions, model)
+        self.send_responses_request(input, instructions, None, model)
             .await
+            .map(|response| response.text.unwrap_or_default())
     }
 
     async fn chat_with_history(
@@ -772,8 +1096,111 @@ impl Provider for OpenAiCodexProvider {
         let prepared = crate::multimodal::prepare_messages_for_provider(messages, &config).await?;
 
         let (instructions, input) = build_responses_input(&prepared.messages);
-        self.send_responses_request(input, instructions, model)
+        self.send_responses_request(input, instructions, None, model)
             .await
+            .map(|response| response.text.unwrap_or_default())
+    }
+
+    async fn chat(
+        &self,
+        request: ProviderChatRequest<'_>,
+        model: &str,
+        _temperature: Option<f64>,
+    ) -> anyhow::Result<ProviderChatResponse> {
+        let config = zeroclaw_config::schema::MultimodalConfig::default();
+        let prepared =
+            crate::multimodal::prepare_messages_for_provider(request.messages, &config).await?;
+        let (instructions, input) = build_responses_input(&prepared.messages);
+        let response = self
+            .send_responses_request(input, instructions, convert_tools(request.tools), model)
+            .await?;
+
+        Ok(ProviderChatResponse {
+            text: response.text,
+            tool_calls: response.tool_calls,
+            usage: None,
+            reasoning_content: None,
+        })
+    }
+
+    fn supports_streaming(&self) -> bool {
+        true
+    }
+
+    fn supports_streaming_tool_events(&self) -> bool {
+        true
+    }
+
+    fn stream_chat(
+        &self,
+        request: ProviderChatRequest<'_>,
+        model: &str,
+        _temperature: Option<f64>,
+        options: StreamOptions,
+    ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+        if !options.enabled {
+            return stream::once(async { Ok(StreamEvent::Final) }).boxed();
+        }
+
+        let provider = self.clone();
+        let messages = request.messages.to_vec();
+        let tools = request.tools.map(|items| items.to_vec());
+        let model = model.to_string();
+        let count_tokens = options.count_tokens;
+        let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(16);
+
+        tokio::spawn(async move {
+            let config = zeroclaw_config::schema::MultimodalConfig::default();
+            let prepared =
+                match crate::multimodal::prepare_messages_for_provider(&messages, &config).await {
+                    Ok(prepared) => prepared,
+                    Err(err) => {
+                        let _ = tx.send(Err(StreamError::Provider(err.to_string()))).await;
+                        return;
+                    }
+                };
+
+            let (instructions, input) = build_responses_input(&prepared.messages);
+            let result = provider
+                .send_responses_request(
+                    input,
+                    instructions,
+                    convert_tools(tools.as_deref()),
+                    &model,
+                )
+                .await;
+
+            match result {
+                Ok(response) => {
+                    for tool_call in response.tool_calls {
+                        if tx.send(Ok(StreamEvent::ToolCall(tool_call))).await.is_err() {
+                            return;
+                        }
+                    }
+
+                    if let Some(text) = response.text.filter(|text| !text.is_empty()) {
+                        let chunk = if count_tokens {
+                            StreamChunk::delta(text).with_token_estimate()
+                        } else {
+                            StreamChunk::delta(text)
+                        };
+                        if tx.send(Ok(StreamEvent::TextDelta(chunk))).await.is_err() {
+                            return;
+                        }
+                    }
+
+                    let _ = tx.send(Ok(StreamEvent::Final)).await;
+                }
+                Err(err) => {
+                    let _ = tx.send(Err(StreamError::Provider(err.to_string()))).await;
+                }
+            }
+        });
+
+        stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|event| (event, rx))
+        })
+        .boxed()
     }
 }
 
@@ -795,6 +1222,11 @@ mod tests {
     fn extracts_nested_output_text() {
         let response = ResponsesResponse {
             output: vec![ResponsesOutput {
+                kind: None,
+                id: None,
+                call_id: None,
+                name: None,
+                arguments: None,
                 content: vec![ResponsesContent {
                     kind: Some("output_text".into()),
                     text: Some("nested".into()),
@@ -968,7 +1400,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_sse_text_reads_output_text_delta() {
+    fn parse_sse_turn_reads_output_text_delta() {
         let payload = r#"data: {"type":"response.created","response":{"id":"resp_123"}}
 
 data: {"type":"response.output_text.delta","delta":"Hello"}
@@ -978,18 +1410,21 @@ data: [DONE]
 "#;
 
         assert_eq!(
-            parse_sse_text(payload).unwrap().as_deref(),
+            parse_sse_turn(payload).unwrap().text.as_deref(),
             Some("Hello world")
         );
     }
 
     #[test]
-    fn parse_sse_text_falls_back_to_completed_response() {
+    fn parse_sse_turn_falls_back_to_completed_response() {
         let payload = r#"data: {"type":"response.completed","response":{"output_text":"Done"}}
 data: [DONE]
 "#;
 
-        assert_eq!(parse_sse_text(payload).unwrap().as_deref(), Some("Done"));
+        assert_eq!(
+            parse_sse_turn(payload).unwrap().text.as_deref(),
+            Some("Done")
+        );
     }
 
     #[test]
@@ -1001,7 +1436,7 @@ data: [DONE]
         let decoded = decode_utf8_stream_chunks([&bytes[..split_at], &bytes[split_at..]]).unwrap();
         assert_eq!(decoded, payload);
         assert_eq!(
-            parse_sse_text(&decoded).unwrap().as_deref(),
+            parse_sse_turn(&decoded).unwrap().text.as_deref(),
             Some("Hello 世")
         );
     }
@@ -1054,11 +1489,11 @@ data: [DONE]
     }
 
     #[test]
-    fn build_responses_input_ignores_unknown_roles() {
+    fn build_responses_input_maps_tool_outputs() {
         let messages = vec![
             ChatMessage {
                 role: "tool".into(),
-                content: "result".into(),
+                content: r#"{"tool_call_id":"call_123","content":"result"}"#.into(),
             },
             ChatMessage {
                 role: "user".into(),
@@ -1067,9 +1502,67 @@ data: [DONE]
         ];
         let (instructions, input) = build_responses_input(&messages);
         assert_eq!(instructions, DEFAULT_CODEX_INSTRUCTIONS);
-        assert_eq!(input.len(), 1);
-        let json = serde_json::to_value(&input[0]).unwrap();
-        assert_eq!(json["role"], "user");
+        assert_eq!(input.len(), 2);
+        assert_eq!(input[0]["type"], "function_call_output");
+        assert_eq!(input[0]["call_id"], "call_123");
+        assert_eq!(input[0]["output"], "result");
+        assert_eq!(input[1]["role"], "user");
+    }
+
+    #[test]
+    fn build_responses_input_maps_native_assistant_tool_calls() {
+        let messages = vec![ChatMessage::assistant(
+            r#"{"content":"Using shell","tool_calls":[{"id":"call_abc","name":"shell","arguments":"{\"command\":\"pwd\"}"}]}"#,
+        )];
+        let (_, input) = build_responses_input(&messages);
+
+        assert_eq!(input.len(), 2);
+        assert_eq!(input[0]["type"], "message");
+        assert_eq!(input[0]["role"], "assistant");
+        assert_eq!(input[0]["content"][0]["type"], "output_text");
+        assert_eq!(input[1]["type"], "function_call");
+        assert_eq!(input[1]["call_id"], "call_abc");
+        assert_eq!(input[1]["name"], "shell");
+    }
+
+    #[test]
+    fn convert_tools_opts_out_of_responses_strict_mode() {
+        let tools = vec![ToolSpec {
+            name: "jira".to_string(),
+            description: "Interact with Jira".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "action": { "type": "string" },
+                    "issue_key": { "type": "string" }
+                },
+                "required": ["action"]
+            }),
+        }];
+
+        let converted = convert_tools(Some(&tools)).expect("tool should convert");
+        let value = serde_json::to_value(&converted[0]).expect("tool should serialize");
+        assert_eq!(value["type"], "function");
+        assert_eq!(value["name"], "jira");
+        assert_eq!(value["strict"], false);
+        assert_eq!(value["parameters"]["required"][0], "action");
+    }
+
+    #[test]
+    fn parse_sse_turn_collects_function_calls() {
+        let payload = r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"shell","arguments":""}}
+
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\"command\":\"pw"}
+data: {"type":"response.function_call_arguments.done","item_id":"fc_1","output_index":0,"call_id":"call_1","name":"shell","arguments":"{\"command\":\"pwd\"}"}
+data: {"type":"response.completed","response":{"output":[]}}
+data: [DONE]
+"#;
+
+        let result = parse_sse_turn(payload).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].id, "call_1");
+        assert_eq!(result.tool_calls[0].name, "shell");
+        assert_eq!(result.tool_calls[0].arguments, "{\"command\":\"pwd\"}");
     }
 
     #[test]
@@ -1080,14 +1573,10 @@ data: [DONE]
         let (_, input) = build_responses_input(&messages);
 
         assert_eq!(input.len(), 1);
-        assert_eq!(input[0].role, "user");
-        assert_eq!(input[0].content.len(), 2);
+        assert_eq!(input[0]["role"], "user");
+        assert_eq!(input[0]["content"].as_array().unwrap().len(), 2);
 
-        let json: Vec<Value> = input[0]
-            .content
-            .iter()
-            .map(|item| serde_json::to_value(item).unwrap())
-            .collect();
+        let json = input[0]["content"].as_array().unwrap();
 
         // First content = text
         assert_eq!(json[0]["type"], "input_text");
@@ -1104,9 +1593,9 @@ data: [DONE]
         let (_, input) = build_responses_input(&messages);
 
         assert_eq!(input.len(), 1);
-        assert_eq!(input[0].content.len(), 1);
+        assert_eq!(input[0]["content"].as_array().unwrap().len(), 1);
 
-        let json = serde_json::to_value(&input[0].content[0]).unwrap();
+        let json = &input[0]["content"][0];
         assert_eq!(json["type"], "input_text");
         assert_eq!(json["text"], "Hello without images");
     }
@@ -1119,13 +1608,9 @@ data: [DONE]
         let (_, input) = build_responses_input(&messages);
 
         assert_eq!(input.len(), 1);
-        assert_eq!(input[0].content.len(), 3); // text + 2 images
+        assert_eq!(input[0]["content"].as_array().unwrap().len(), 3); // text + 2 images
 
-        let json: Vec<Value> = input[0]
-            .content
-            .iter()
-            .map(|item| serde_json::to_value(item).unwrap())
-            .collect();
+        let json = input[0]["content"].as_array().unwrap();
 
         assert_eq!(json[0]["type"], "input_text");
         assert_eq!(json[1]["type"], "input_image");
@@ -1152,7 +1637,7 @@ data: [DONE]
             OpenAiCodexProvider::new(&options, None).expect("provider should initialize");
         let caps = provider.capabilities();
 
-        assert!(!caps.native_tool_calling);
+        assert!(caps.native_tool_calling);
         assert!(caps.vision);
     }
 }

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -2,13 +2,20 @@ use crate::ProviderRuntimeOptions;
 use crate::auth::AuthService;
 use crate::auth::openai_oauth::extract_account_id_from_jwt;
 use crate::multimodal;
-use crate::traits::{ChatMessage, Provider, ProviderCapabilities};
+use crate::traits::{
+    ChatMessage, ChatRequest as ProviderChatRequest, ChatResponse as ProviderChatResponse,
+    Provider, ProviderCapabilities, StreamChunk, StreamError, StreamEvent, StreamOptions,
+    StreamResult, ToolCall as ProviderToolCall,
+};
 use async_trait::async_trait;
 use futures_util::StreamExt;
+use futures_util::stream;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use zeroclaw_api::tool::ToolSpec;
 
 const DEFAULT_CODEX_RESPONSES_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
 const CODEX_RESPONSES_URL_ENV: &str = "ZEROCLAW_CODEX_RESPONSES_URL";
@@ -17,7 +24,10 @@ const DEFAULT_CODEX_INSTRUCTIONS: &str =
     "You are ZeroClaw, a concise and helpful coding assistant.";
 /// OpenAI Codex speaks the "responses" wire protocol, not chat_completions.
 const WIRE_API: &str = "responses";
+const RESPONSES_HISTORY_PROVIDER: &str = "openai_codex";
+const RESPONSES_HISTORY_KIND: &str = "responses_output_items";
 
+#[derive(Clone)]
 pub struct OpenAiCodexProvider {
     auth: AuthService,
     auth_profile_override: Option<String>,
@@ -31,31 +41,29 @@ pub struct OpenAiCodexProvider {
 #[derive(Debug, Serialize)]
 struct ResponsesRequest {
     model: String,
-    input: Vec<ResponsesInput>,
+    input: Vec<Value>,
     instructions: String,
     store: bool,
     stream: bool,
     text: ResponsesTextOptions,
     reasoning: ResponsesReasoningOptions,
     include: Vec<String>,
-    tool_choice: String,
-    parallel_tool_calls: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<ResponsesToolSpec>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parallel_tool_calls: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
-struct ResponsesInput {
-    role: String,
-    content: Vec<ResponsesInputContent>,
-}
-
-#[derive(Debug, Serialize)]
-struct ResponsesInputContent {
+struct ResponsesToolSpec {
     #[serde(rename = "type")]
     kind: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    text: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    image_url: Option<String>,
+    name: String,
+    description: String,
+    parameters: Value,
+    strict: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -72,22 +80,35 @@ struct ResponsesReasoningOptions {
 #[derive(Debug, Deserialize)]
 struct ResponsesResponse {
     #[serde(default)]
-    output: Vec<ResponsesOutput>,
+    output: Vec<Value>,
     #[serde(default)]
     output_text: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-struct ResponsesOutput {
-    #[serde(default)]
-    content: Vec<ResponsesContent>,
+#[derive(Debug, Default)]
+struct ResponsesStreamState {
+    saw_text_delta: bool,
+    text_accumulator: String,
+    fallback_text: Option<String>,
+    tool_calls: HashMap<String, PendingToolCall>,
+    emitted_tool_call_ids: HashSet<String>,
+    collected_tool_calls: Vec<ProviderToolCall>,
+    output_items: Vec<Value>,
 }
 
-#[derive(Debug, Deserialize)]
-struct ResponsesContent {
-    #[serde(rename = "type")]
-    kind: Option<String>,
+#[derive(Debug, Default, Clone)]
+struct PendingToolCall {
+    item_id: Option<String>,
+    call_id: Option<String>,
+    name: Option<String>,
+    arguments: String,
+}
+
+#[derive(Debug, Default)]
+struct ResponsesTurnResult {
     text: Option<String>,
+    tool_calls: Vec<ProviderToolCall>,
+    reasoning_content: Option<String>,
 }
 
 impl OpenAiCodexProvider {
@@ -213,9 +234,93 @@ fn normalize_model_id(model: &str) -> &str {
     model.rsplit('/').next().unwrap_or(model)
 }
 
-fn build_responses_input(messages: &[ChatMessage]) -> (String, Vec<ResponsesInput>) {
+fn convert_tools(tools: Option<&[ToolSpec]>) -> Option<Vec<ResponsesToolSpec>> {
+    let items = tools?;
+    if items.is_empty() {
+        return None;
+    }
+
+    Some(
+        items
+            .iter()
+            .map(|tool| ResponsesToolSpec {
+                kind: "function".to_string(),
+                name: tool.name.clone(),
+                description: tool.description.clone(),
+                parameters: tool.parameters.clone(),
+                strict: false,
+            })
+            .collect(),
+    )
+}
+
+fn response_message_item(role: &str, content: Vec<Value>) -> Value {
+    serde_json::json!({
+        "type": "message",
+        "role": role,
+        "content": content,
+    })
+}
+
+fn response_item_type(item: &Value) -> Option<&str> {
+    item.get("type").and_then(Value::as_str)
+}
+
+fn is_replayable_responses_output_item(item: &Value) -> bool {
+    matches!(
+        response_item_type(item),
+        Some("message" | "reasoning" | "function_call")
+    )
+}
+
+fn encode_responses_history_items(output_items: &[Value], has_tool_calls: bool) -> Option<String> {
+    if !has_tool_calls {
+        return None;
+    }
+
+    let replay_items = output_items
+        .iter()
+        .filter(|item| is_replayable_responses_output_item(item))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if !replay_items
+        .iter()
+        .any(|item| response_item_type(item) == Some("function_call"))
+    {
+        return None;
+    }
+
+    serde_json::to_string(&serde_json::json!({
+        "provider": RESPONSES_HISTORY_PROVIDER,
+        "kind": RESPONSES_HISTORY_KIND,
+        "items": replay_items,
+    }))
+    .ok()
+}
+
+fn decode_responses_history_items(reasoning_content: &str) -> Option<Vec<Value>> {
+    let value = serde_json::from_str::<Value>(reasoning_content).ok()?;
+    if value.get("provider").and_then(Value::as_str) != Some(RESPONSES_HISTORY_PROVIDER)
+        || value.get("kind").and_then(Value::as_str) != Some(RESPONSES_HISTORY_KIND)
+    {
+        return None;
+    }
+
+    let items = value
+        .get("items")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter(|item| is_replayable_responses_output_item(item))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    (!items.is_empty()).then_some(items)
+}
+
+fn build_responses_input(messages: &[ChatMessage]) -> (String, Vec<Value>) {
     let mut system_parts: Vec<&str> = Vec::new();
-    let mut input: Vec<ResponsesInput> = Vec::new();
+    let mut input: Vec<Value> = Vec::new();
 
     for msg in messages {
         match msg.role.as_str() {
@@ -225,47 +330,123 @@ fn build_responses_input(messages: &[ChatMessage]) -> (String, Vec<ResponsesInpu
 
                 let mut content_items = Vec::new();
 
-                // Add text if present
                 if !cleaned_text.trim().is_empty() {
-                    content_items.push(ResponsesInputContent {
-                        kind: "input_text".to_string(),
-                        text: Some(cleaned_text),
-                        image_url: None,
-                    });
+                    content_items.push(serde_json::json!({
+                        "type": "input_text",
+                        "text": cleaned_text,
+                    }));
                 }
 
-                // Add images
                 for image_ref in image_refs {
-                    content_items.push(ResponsesInputContent {
-                        kind: "input_image".to_string(),
-                        text: None,
-                        image_url: Some(image_ref),
-                    });
+                    content_items.push(serde_json::json!({
+                        "type": "input_image",
+                        "image_url": image_ref,
+                    }));
                 }
 
-                // If no content at all, add empty text
                 if content_items.is_empty() {
-                    content_items.push(ResponsesInputContent {
-                        kind: "input_text".to_string(),
-                        text: Some(String::new()),
-                        image_url: None,
-                    });
+                    content_items.push(serde_json::json!({
+                        "type": "input_text",
+                        "text": "",
+                    }));
                 }
 
-                input.push(ResponsesInput {
-                    role: "user".to_string(),
-                    content: content_items,
-                });
+                input.push(response_message_item("user", content_items));
             }
             "assistant" => {
-                input.push(ResponsesInput {
-                    role: "assistant".to_string(),
-                    content: vec![ResponsesInputContent {
-                        kind: "output_text".to_string(),
-                        text: Some(msg.content.clone()),
-                        image_url: None,
-                    }],
-                });
+                if let Ok(value) = serde_json::from_str::<Value>(&msg.content)
+                    && let Some(tool_calls_value) = value.get("tool_calls")
+                    && let Ok(parsed_calls) =
+                        serde_json::from_value::<Vec<ProviderToolCall>>(tool_calls_value.clone())
+                {
+                    let content = value
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .filter(|content| !content.trim().is_empty());
+                    let responses_history_items = value
+                        .get("reasoning_content")
+                        .and_then(Value::as_str)
+                        .and_then(decode_responses_history_items);
+
+                    if let Some(items) = responses_history_items {
+                        if let Some(content) = content
+                            && !items
+                                .iter()
+                                .any(|item| response_item_type(item) == Some("message"))
+                        {
+                            input.push(response_message_item(
+                                "assistant",
+                                vec![serde_json::json!({
+                                    "type": "output_text",
+                                    "text": content,
+                                })],
+                            ));
+                        }
+
+                        input.extend(items);
+                        continue;
+                    }
+
+                    if let Some(content) = value
+                        .get("content")
+                        .and_then(Value::as_str)
+                        .filter(|content| !content.trim().is_empty())
+                    {
+                        input.push(response_message_item(
+                            "assistant",
+                            vec![serde_json::json!({
+                                "type": "output_text",
+                                "text": content,
+                            })],
+                        ));
+                    }
+
+                    for call in parsed_calls {
+                        input.push(serde_json::json!({
+                            "type": "function_call",
+                            "call_id": call.id,
+                            "name": call.name,
+                            "arguments": call.arguments,
+                        }));
+                    }
+                } else if !msg.content.trim().is_empty() {
+                    input.push(response_message_item(
+                        "assistant",
+                        vec![serde_json::json!({
+                            "type": "output_text",
+                            "text": msg.content,
+                        })],
+                    ));
+                }
+            }
+            "tool" => {
+                if let Ok(value) = serde_json::from_str::<Value>(&msg.content) {
+                    if let Some(call_id) = value.get("tool_call_id").and_then(Value::as_str) {
+                        let output = value
+                            .get("content")
+                            .and_then(Value::as_str)
+                            .unwrap_or_default();
+                        input.push(serde_json::json!({
+                            "type": "function_call_output",
+                            "call_id": call_id,
+                            "output": output,
+                        }));
+                    } else if !msg.content.trim().is_empty() {
+                        input.push(response_message_item(
+                            "tool",
+                            vec![serde_json::json!({
+                                "type": "output_text",
+                                "text": msg.content,
+                            })],
+                        ));
+                    }
+                } else if !msg.content.trim().is_empty() {
+                    input.push(serde_json::json!({
+                        "type": "function_call_output",
+                        "call_id": uuid::Uuid::new_v4().to_string(),
+                        "output": msg.content,
+                    }));
+                }
             }
             _ => {}
         }
@@ -335,19 +516,27 @@ fn extract_responses_text(response: &ResponsesResponse) -> Option<String> {
     }
 
     for item in &response.output {
-        for content in &item.content {
-            if content.kind.as_deref() == Some("output_text")
-                && let Some(text) = first_nonempty(content.text.as_deref())
-            {
-                return Some(text);
+        if response_item_type(item) != Some("message") {
+            continue;
+        }
+
+        if let Some(parts) = item.get("content").and_then(Value::as_array) {
+            for content in parts {
+                if response_item_type(content) == Some("output_text")
+                    && let Some(text) = first_nonempty(content.get("text").and_then(Value::as_str))
+                {
+                    return Some(text);
+                }
             }
         }
     }
 
     for item in &response.output {
-        for content in &item.content {
-            if let Some(text) = first_nonempty(content.text.as_deref()) {
-                return Some(text);
+        if let Some(parts) = item.get("content").and_then(Value::as_array) {
+            for content in parts {
+                if let Some(text) = first_nonempty(content.get("text").and_then(Value::as_str)) {
+                    return Some(text);
+                }
             }
         }
     }
@@ -355,93 +544,367 @@ fn extract_responses_text(response: &ResponsesResponse) -> Option<String> {
     None
 }
 
-fn extract_stream_event_text(event: &Value, saw_delta: bool) -> Option<String> {
-    let event_type = event.get("type").and_then(Value::as_str);
-    match event_type {
-        Some("response.output_text.delta") => {
-            nonempty_preserve(event.get("delta").and_then(Value::as_str))
-        }
-        Some("response.output_text.done") if !saw_delta => {
-            nonempty_preserve(event.get("text").and_then(Value::as_str))
-        }
-        Some("response.completed" | "response.done") => event
-            .get("response")
-            .and_then(|value| serde_json::from_value::<ResponsesResponse>(value.clone()).ok())
-            .and_then(|response| extract_responses_text(&response)),
-        _ => None,
+fn extract_responses_tool_calls(response: &ResponsesResponse) -> Vec<ProviderToolCall> {
+    response
+        .output
+        .iter()
+        .filter(|item| response_item_type(item) == Some("function_call"))
+        .filter_map(|item| {
+            let name = item.get("name").and_then(Value::as_str)?.to_string();
+            let arguments = item
+                .get("arguments")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            Some(ProviderToolCall {
+                id: item
+                    .get("call_id")
+                    .and_then(Value::as_str)
+                    .or_else(|| item.get("id").and_then(Value::as_str))
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+                name,
+                arguments,
+                extra_content: None,
+            })
+        })
+        .collect()
+}
+
+fn responses_turn_from_response(response: &ResponsesResponse) -> ResponsesTurnResult {
+    let tool_calls = extract_responses_tool_calls(response);
+    let reasoning_content =
+        encode_responses_history_items(&response.output, !tool_calls.is_empty());
+
+    ResponsesTurnResult {
+        text: extract_responses_text(response),
+        tool_calls,
+        reasoning_content,
     }
 }
 
-fn parse_sse_text(body: &str) -> anyhow::Result<Option<String>> {
-    let mut saw_delta = false;
-    let mut delta_accumulator = String::new();
-    let mut fallback_text = None;
+fn record_responses_output_item(state: &mut ResponsesStreamState, item: Value) {
+    if !is_replayable_responses_output_item(&item) {
+        return;
+    }
+
+    let item_id = item
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| item.get("call_id").and_then(Value::as_str));
+    if let Some(item_id) = item_id
+        && state.output_items.iter().any(|existing| {
+            existing
+                .get("id")
+                .and_then(Value::as_str)
+                .or_else(|| existing.get("call_id").and_then(Value::as_str))
+                == Some(item_id)
+        })
+    {
+        return;
+    }
+
+    state.output_items.push(item);
+}
+
+fn replace_responses_output_items(state: &mut ResponsesStreamState, items: &[Value]) {
+    let replay_items = items
+        .iter()
+        .filter(|item| is_replayable_responses_output_item(item))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if !replay_items.is_empty() {
+        state.output_items = replay_items;
+    }
+}
+
+fn response_output_text_from_event_item(item: &Value) -> Option<String> {
+    if item.get("type").and_then(Value::as_str) != Some("message") {
+        return None;
+    }
+
+    item.get("content")
+        .and_then(Value::as_array)
+        .and_then(|parts| {
+            parts.iter().find_map(|part| {
+                if part.get("type").and_then(Value::as_str) == Some("output_text") {
+                    first_nonempty(part.get("text").and_then(Value::as_str))
+                } else {
+                    None
+                }
+            })
+        })
+}
+
+fn pending_tool_call_key(item_id: Option<&str>, output_index: Option<u64>) -> Option<String> {
+    item_id
+        .map(ToString::to_string)
+        .or_else(|| output_index.map(|index| format!("output:{index}")))
+}
+
+fn emit_tool_call(
+    state: &mut ResponsesStreamState,
+    tool_call: ProviderToolCall,
+) -> Option<ProviderToolCall> {
+    if state.emitted_tool_call_ids.insert(tool_call.id.clone()) {
+        state.collected_tool_calls.push(tool_call.clone());
+        Some(tool_call)
+    } else {
+        None
+    }
+}
+
+fn process_responses_stream_event(
+    event: Value,
+    state: &mut ResponsesStreamState,
+) -> anyhow::Result<Vec<StreamEvent>> {
+    if let Some(message) = extract_stream_error_message(&event) {
+        anyhow::bail!("OpenAI Codex stream error: {message}");
+    }
+
+    let mut emitted = Vec::new();
+    match event.get("type").and_then(Value::as_str) {
+        Some("response.output_text.delta") => {
+            if let Some(text) = nonempty_preserve(event.get("delta").and_then(Value::as_str)) {
+                state.saw_text_delta = true;
+                state.text_accumulator.push_str(&text);
+                emitted.push(StreamEvent::TextDelta(StreamChunk::delta(text)));
+            }
+        }
+        Some("response.output_text.done") if !state.saw_text_delta => {
+            state.fallback_text = nonempty_preserve(event.get("text").and_then(Value::as_str));
+        }
+        Some("response.output_item.added") => {
+            let item = event.get("item");
+            let item_type = item
+                .and_then(|value| value.get("type"))
+                .and_then(Value::as_str);
+            if item_type == Some("function_call") {
+                let key = pending_tool_call_key(
+                    item.and_then(|value| value.get("id"))
+                        .and_then(Value::as_str),
+                    event.get("output_index").and_then(Value::as_u64),
+                );
+                if let Some(key) = key {
+                    let entry = state.tool_calls.entry(key).or_default();
+                    entry.item_id = item
+                        .and_then(|value| value.get("id"))
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string);
+                    entry.call_id = item
+                        .and_then(|value| value.get("call_id"))
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string);
+                    entry.name = item
+                        .and_then(|value| value.get("name"))
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string);
+                    if let Some(arguments) = item
+                        .and_then(|value| value.get("arguments"))
+                        .and_then(Value::as_str)
+                    {
+                        entry.arguments = arguments.to_string();
+                    }
+                }
+            }
+        }
+        Some("response.function_call_arguments.delta") => {
+            if let Some(key) = pending_tool_call_key(
+                event.get("item_id").and_then(Value::as_str),
+                event.get("output_index").and_then(Value::as_u64),
+            ) {
+                let entry = state.tool_calls.entry(key).or_default();
+                entry.item_id = event
+                    .get("item_id")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string);
+                entry.arguments.push_str(
+                    event
+                        .get("delta")
+                        .and_then(Value::as_str)
+                        .unwrap_or_default(),
+                );
+            }
+        }
+        Some("response.function_call_arguments.done") => {
+            let key = pending_tool_call_key(
+                event.get("item_id").and_then(Value::as_str),
+                event.get("output_index").and_then(Value::as_u64),
+            );
+            let mut pending = key
+                .as_ref()
+                .and_then(|key| state.tool_calls.remove(key))
+                .unwrap_or_default();
+            pending.item_id = pending.item_id.or_else(|| {
+                event
+                    .get("item_id")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            });
+            pending.call_id = pending.call_id.or_else(|| {
+                event
+                    .get("call_id")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            });
+            pending.name = pending.name.or_else(|| {
+                event
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            });
+            if let Some(arguments) = event.get("arguments").and_then(Value::as_str) {
+                pending.arguments = arguments.to_string();
+            }
+
+            if let Some(name) = pending.name {
+                let tool_call = ProviderToolCall {
+                    id: pending
+                        .call_id
+                        .or(pending.item_id)
+                        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+                    name,
+                    arguments: pending.arguments,
+                    extra_content: None,
+                };
+                if let Some(tool_call) = emit_tool_call(state, tool_call) {
+                    emitted.push(StreamEvent::ToolCall(tool_call));
+                }
+            }
+        }
+        Some("response.output_item.done") => {
+            if let Some(item) = event.get("item") {
+                record_responses_output_item(state, item.clone());
+                match item.get("type").and_then(Value::as_str) {
+                    Some("message") if !state.saw_text_delta => {
+                        if state.fallback_text.is_none() {
+                            state.fallback_text = response_output_text_from_event_item(item);
+                        }
+                    }
+                    Some("function_call") => {
+                        if let Some(name) = item.get("name").and_then(Value::as_str) {
+                            let tool_call = ProviderToolCall {
+                                id: item
+                                    .get("call_id")
+                                    .and_then(Value::as_str)
+                                    .or_else(|| item.get("id").and_then(Value::as_str))
+                                    .unwrap_or_default()
+                                    .to_string(),
+                                name: name.to_string(),
+                                arguments: item
+                                    .get("arguments")
+                                    .and_then(Value::as_str)
+                                    .unwrap_or_default()
+                                    .to_string(),
+                                extra_content: None,
+                            };
+                            if let Some(tool_call) = emit_tool_call(state, tool_call) {
+                                emitted.push(StreamEvent::ToolCall(tool_call));
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+        Some("response.completed" | "response.done") => {
+            if let Some(response) = event
+                .get("response")
+                .and_then(|value| serde_json::from_value::<ResponsesResponse>(value.clone()).ok())
+            {
+                if !state.saw_text_delta && state.fallback_text.is_none() {
+                    state.fallback_text = extract_responses_text(&response);
+                }
+                replace_responses_output_items(state, &response.output);
+                for tool_call in extract_responses_tool_calls(&response) {
+                    if let Some(tool_call) = emit_tool_call(state, tool_call) {
+                        emitted.push(StreamEvent::ToolCall(tool_call));
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+
+    Ok(emitted)
+}
+
+fn process_sse_chunk(
+    chunk: &str,
+    state: &mut ResponsesStreamState,
+) -> anyhow::Result<Vec<StreamEvent>> {
+    let data_lines: Vec<String> = chunk
+        .lines()
+        .filter_map(|line| line.strip_prefix("data:"))
+        .map(|line| line.trim().to_string())
+        .collect();
+    if data_lines.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let joined = data_lines.join("\n");
+    let trimmed = joined.trim();
+    if trimmed.is_empty() || trimmed == "[DONE]" {
+        return Ok(Vec::new());
+    }
+
+    if let Ok(event) = serde_json::from_str::<Value>(trimmed) {
+        return process_responses_stream_event(event, state);
+    }
+
+    let mut emitted = Vec::new();
+    for line in data_lines {
+        let line = line.trim();
+        if line.is_empty() || line == "[DONE]" {
+            continue;
+        }
+        if let Ok(event) = serde_json::from_str::<Value>(line) {
+            emitted.extend(process_responses_stream_event(event, state)?);
+        }
+    }
+
+    Ok(emitted)
+}
+
+fn parse_sse_turn(body: &str) -> anyhow::Result<ResponsesTurnResult> {
+    let mut state = ResponsesStreamState::default();
     let mut buffer = body.to_string();
-
-    let mut process_event = |event: Value| -> anyhow::Result<()> {
-        if let Some(message) = extract_stream_error_message(&event) {
-            return Err(anyhow::anyhow!("OpenAI Codex stream error: {message}"));
-        }
-        if let Some(text) = extract_stream_event_text(&event, saw_delta) {
-            let event_type = event.get("type").and_then(Value::as_str);
-            if event_type == Some("response.output_text.delta") {
-                saw_delta = true;
-                delta_accumulator.push_str(&text);
-            } else if fallback_text.is_none() {
-                fallback_text = Some(text);
-            }
-        }
-        Ok(())
-    };
-
-    let mut process_chunk = |chunk: &str| -> anyhow::Result<()> {
-        let data_lines: Vec<String> = chunk
-            .lines()
-            .filter_map(|line| line.strip_prefix("data:"))
-            .map(|line| line.trim().to_string())
-            .collect();
-        if data_lines.is_empty() {
-            return Ok(());
-        }
-
-        let joined = data_lines.join("\n");
-        let trimmed = joined.trim();
-        if trimmed.is_empty() || trimmed == "[DONE]" {
-            return Ok(());
-        }
-
-        if let Ok(event) = serde_json::from_str::<Value>(trimmed) {
-            return process_event(event);
-        }
-
-        for line in data_lines {
-            let line = line.trim();
-            if line.is_empty() || line == "[DONE]" {
-                continue;
-            }
-            if let Ok(event) = serde_json::from_str::<Value>(line) {
-                process_event(event)?;
-            }
-        }
-
-        Ok(())
-    };
 
     while let Some(idx) = buffer.find("\n\n") {
         let chunk = buffer[..idx].to_string();
         buffer = buffer[idx + 2..].to_string();
-        process_chunk(&chunk)?;
+        process_sse_chunk(&chunk, &mut state)?;
     }
 
     if !buffer.trim().is_empty() {
-        process_chunk(&buffer)?;
+        process_sse_chunk(&buffer, &mut state)?;
     }
 
-    if saw_delta {
-        return Ok(nonempty_preserve(Some(&delta_accumulator)));
-    }
+    Ok(ResponsesTurnResult {
+        text: if state.saw_text_delta {
+            nonempty_preserve(Some(&state.text_accumulator))
+        } else {
+            state.fallback_text
+        },
+        reasoning_content: encode_responses_history_items(
+            &state.output_items,
+            !state.collected_tool_calls.is_empty(),
+        ),
+        tool_calls: state.collected_tool_calls,
+    })
+}
 
-    Ok(fallback_text)
+fn ensure_nonempty_responses_turn(
+    result: ResponsesTurnResult,
+    empty_error: impl FnOnce() -> anyhow::Error,
+) -> anyhow::Result<ResponsesTurnResult> {
+    if result.text.as_deref().is_some_and(|text| !text.is_empty()) || !result.tool_calls.is_empty()
+    {
+        Ok(result)
+    } else {
+        Err(empty_error())
+    }
 }
 
 fn extract_stream_error_message(event: &Value) -> Option<String> {
@@ -545,13 +1008,41 @@ where
     Ok(body)
 }
 
+fn parse_responses_body(body: &str) -> anyhow::Result<ResponsesTurnResult> {
+    let body_trimmed = body.trim_start();
+    let looks_like_sse = body_trimmed.starts_with("event:") || body_trimmed.starts_with("data:");
+    if looks_like_sse {
+        let result = parse_sse_turn(body)?;
+        return ensure_nonempty_responses_turn(result, || {
+            anyhow::anyhow!(
+                "No response from OpenAI Codex stream payload: {}",
+                super::sanitize_api_error(body)
+            )
+        });
+    }
+
+    let parsed: ResponsesResponse = serde_json::from_str(body).map_err(|err| {
+        anyhow::anyhow!(
+            "OpenAI Codex JSON parse failed: {err}. Payload: {}",
+            super::sanitize_api_error(body)
+        )
+    })?;
+    let result = responses_turn_from_response(&parsed);
+    ensure_nonempty_responses_turn(result, || {
+        anyhow::anyhow!(
+            "No response from OpenAI Codex: {}",
+            super::sanitize_api_error(body)
+        )
+    })
+}
+
 /// Read the response body incrementally via `bytes_stream()` to avoid
 /// buffering the entire SSE payload in memory.  The previous implementation
 /// used `response.text().await?` which holds the HTTP connection open until
 /// every byte has arrived — on high-latency links the long-lived connection
 /// often drops mid-read, producing the "error decoding response body" failure
 /// reported in #3544.
-async fn decode_responses_body(response: reqwest::Response) -> anyhow::Result<String> {
+async fn decode_responses_body(response: reqwest::Response) -> anyhow::Result<ResponsesTurnResult> {
     let mut body = String::new();
     let mut pending_utf8 = Vec::new();
     let mut stream = response.bytes_stream();
@@ -570,35 +1061,17 @@ async fn decode_responses_body(response: reqwest::Response) -> anyhow::Result<St
         ));
     }
 
-    if let Some(text) = parse_sse_text(&body)? {
-        return Ok(text);
-    }
-
-    let body_trimmed = body.trim_start();
-    let looks_like_sse = body_trimmed.starts_with("event:") || body_trimmed.starts_with("data:");
-    if looks_like_sse {
-        return Err(anyhow::anyhow!(
-            "No response from OpenAI Codex stream payload: {}",
-            super::sanitize_api_error(&body)
-        ));
-    }
-
-    let parsed: ResponsesResponse = serde_json::from_str(&body).map_err(|err| {
-        anyhow::anyhow!(
-            "OpenAI Codex JSON parse failed: {err}. Payload: {}",
-            super::sanitize_api_error(&body)
-        )
-    })?;
-    extract_responses_text(&parsed).ok_or_else(|| anyhow::anyhow!("No response from OpenAI Codex"))
+    parse_responses_body(&body)
 }
 
 impl OpenAiCodexProvider {
     async fn send_responses_request(
         &self,
-        input: Vec<ResponsesInput>,
+        input: Vec<Value>,
         instructions: String,
+        tools: Option<Vec<ResponsesToolSpec>>,
         model: &str,
-    ) -> anyhow::Result<String> {
+    ) -> anyhow::Result<ResponsesTurnResult> {
         let use_gateway_api_key_auth = self.custom_endpoint && self.gateway_api_key.is_some();
         let profile = match self
             .auth
@@ -656,6 +1129,7 @@ impl OpenAiCodexProvider {
         };
         let normalized_model = normalize_model_id(model);
 
+        let has_tools = tools.is_some();
         let request = ResponsesRequest {
             model: normalized_model.to_string(),
             input,
@@ -673,8 +1147,9 @@ impl OpenAiCodexProvider {
                 summary: "auto".to_string(),
             },
             include: vec!["reasoning.encrypted_content".to_string()],
-            tool_choice: "auto".to_string(),
-            parallel_tool_calls: true,
+            tools,
+            tool_choice: has_tools.then(|| "auto".to_string()),
+            parallel_tool_calls: has_tools.then_some(true),
         };
 
         let bearer_token = if use_gateway_api_key_auth {
@@ -728,7 +1203,7 @@ impl Provider for OpenAiCodexProvider {
 
     fn capabilities(&self) -> ProviderCapabilities {
         ProviderCapabilities {
-            native_tool_calling: false,
+            native_tool_calling: true,
             vision: true,
             prompt_caching: false,
         }
@@ -753,8 +1228,9 @@ impl Provider for OpenAiCodexProvider {
         let prepared = crate::multimodal::prepare_messages_for_provider(&messages, &config).await?;
 
         let (instructions, input) = build_responses_input(&prepared.messages);
-        self.send_responses_request(input, instructions, model)
+        self.send_responses_request(input, instructions, None, model)
             .await
+            .map(|response| response.text.unwrap_or_default())
     }
 
     async fn chat_with_history(
@@ -768,8 +1244,111 @@ impl Provider for OpenAiCodexProvider {
         let prepared = crate::multimodal::prepare_messages_for_provider(messages, &config).await?;
 
         let (instructions, input) = build_responses_input(&prepared.messages);
-        self.send_responses_request(input, instructions, model)
+        self.send_responses_request(input, instructions, None, model)
             .await
+            .map(|response| response.text.unwrap_or_default())
+    }
+
+    async fn chat(
+        &self,
+        request: ProviderChatRequest<'_>,
+        model: &str,
+        _temperature: Option<f64>,
+    ) -> anyhow::Result<ProviderChatResponse> {
+        let config = zeroclaw_config::schema::MultimodalConfig::default();
+        let prepared =
+            crate::multimodal::prepare_messages_for_provider(request.messages, &config).await?;
+        let (instructions, input) = build_responses_input(&prepared.messages);
+        let response = self
+            .send_responses_request(input, instructions, convert_tools(request.tools), model)
+            .await?;
+
+        Ok(ProviderChatResponse {
+            text: response.text,
+            tool_calls: response.tool_calls,
+            usage: None,
+            reasoning_content: response.reasoning_content,
+        })
+    }
+
+    fn supports_streaming(&self) -> bool {
+        false
+    }
+
+    fn supports_streaming_tool_events(&self) -> bool {
+        false
+    }
+
+    fn stream_chat(
+        &self,
+        request: ProviderChatRequest<'_>,
+        model: &str,
+        _temperature: Option<f64>,
+        options: StreamOptions,
+    ) -> stream::BoxStream<'static, StreamResult<StreamEvent>> {
+        if !options.enabled {
+            return stream::once(async { Ok(StreamEvent::Final) }).boxed();
+        }
+
+        let provider = self.clone();
+        let messages = request.messages.to_vec();
+        let tools = request.tools.map(|items| items.to_vec());
+        let model = model.to_string();
+        let count_tokens = options.count_tokens;
+        let (tx, rx) = tokio::sync::mpsc::channel::<StreamResult<StreamEvent>>(16);
+
+        tokio::spawn(async move {
+            let config = zeroclaw_config::schema::MultimodalConfig::default();
+            let prepared =
+                match crate::multimodal::prepare_messages_for_provider(&messages, &config).await {
+                    Ok(prepared) => prepared,
+                    Err(err) => {
+                        let _ = tx.send(Err(StreamError::Provider(err.to_string()))).await;
+                        return;
+                    }
+                };
+
+            let (instructions, input) = build_responses_input(&prepared.messages);
+            let result = provider
+                .send_responses_request(
+                    input,
+                    instructions,
+                    convert_tools(tools.as_deref()),
+                    &model,
+                )
+                .await;
+
+            match result {
+                Ok(response) => {
+                    for tool_call in response.tool_calls {
+                        if tx.send(Ok(StreamEvent::ToolCall(tool_call))).await.is_err() {
+                            return;
+                        }
+                    }
+
+                    if let Some(text) = response.text.filter(|text| !text.is_empty()) {
+                        let chunk = if count_tokens {
+                            StreamChunk::delta(text).with_token_estimate()
+                        } else {
+                            StreamChunk::delta(text)
+                        };
+                        if tx.send(Ok(StreamEvent::TextDelta(chunk))).await.is_err() {
+                            return;
+                        }
+                    }
+
+                    let _ = tx.send(Ok(StreamEvent::Final)).await;
+                }
+                Err(err) => {
+                    let _ = tx.send(Err(StreamError::Provider(err.to_string()))).await;
+                }
+            }
+        });
+
+        stream::unfold(rx, |mut rx| async move {
+            rx.recv().await.map(|event| (event, rx))
+        })
+        .boxed()
     }
 }
 
@@ -790,12 +1369,16 @@ mod tests {
     #[test]
     fn extracts_nested_output_text() {
         let response = ResponsesResponse {
-            output: vec![ResponsesOutput {
-                content: vec![ResponsesContent {
-                    kind: Some("output_text".into()),
-                    text: Some("nested".into()),
-                }],
-            }],
+            output: vec![serde_json::json!({
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "nested"
+                    }
+                ]
+            })],
             output_text: None,
         };
         assert_eq!(extract_responses_text(&response).as_deref(), Some("nested"));
@@ -964,7 +1547,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_sse_text_reads_output_text_delta() {
+    fn parse_sse_turn_reads_output_text_delta() {
         let payload = r#"data: {"type":"response.created","response":{"id":"resp_123"}}
 
 data: {"type":"response.output_text.delta","delta":"Hello"}
@@ -974,18 +1557,103 @@ data: [DONE]
 "#;
 
         assert_eq!(
-            parse_sse_text(payload).unwrap().as_deref(),
+            parse_sse_turn(payload).unwrap().text.as_deref(),
             Some("Hello world")
         );
     }
 
     #[test]
-    fn parse_sse_text_falls_back_to_completed_response() {
+    fn parse_sse_turn_falls_back_to_completed_response() {
         let payload = r#"data: {"type":"response.completed","response":{"output_text":"Done"}}
 data: [DONE]
 "#;
 
-        assert_eq!(parse_sse_text(payload).unwrap().as_deref(), Some("Done"));
+        assert_eq!(
+            parse_sse_turn(payload).unwrap().text.as_deref(),
+            Some("Done")
+        );
+    }
+
+    #[test]
+    fn parse_responses_body_rejects_unrecognized_sse_without_payload() {
+        let payload = r#"data: not-json
+data: [DONE]
+"#;
+
+        let err = parse_responses_body(payload).expect_err("empty SSE should fail closed");
+        assert!(
+            err.to_string()
+                .contains("No response from OpenAI Codex stream payload"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn parse_responses_body_rejects_json_without_text_or_tool_calls() {
+        let payload = r#"{"output":[]}"#;
+
+        let err = parse_responses_body(payload).expect_err("empty JSON should fail closed");
+        assert!(
+            err.to_string().contains("No response from OpenAI Codex"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn parse_responses_body_allows_sse_markers_inside_json_text() {
+        let payload = serde_json::json!({
+            "output_text": "Example SSE frame:\ndata: {\"type\":\"example\"}\nevent: response.done",
+            "output": []
+        })
+        .to_string();
+
+        let result = parse_responses_body(&payload).expect("JSON text should not be parsed as SSE");
+        assert_eq!(
+            result.text.as_deref(),
+            Some("Example SSE frame:\ndata: {\"type\":\"example\"}\nevent: response.done")
+        );
+        assert!(result.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn parse_responses_body_preserves_reasoning_items_for_tool_calls() {
+        let payload = serde_json::json!({
+            "output": [
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [],
+                    "encrypted_content": "enc_reasoning"
+                },
+                {
+                    "type": "function_call",
+                    "id": "fc_1",
+                    "call_id": "call_1",
+                    "name": "shell",
+                    "arguments": "{\"command\":\"pwd\"}",
+                    "status": "completed"
+                }
+            ]
+        })
+        .to_string();
+
+        let result = parse_responses_body(&payload).expect("tool call response should parse");
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].id, "call_1");
+
+        let items = decode_responses_history_items(
+            result
+                .reasoning_content
+                .as_deref()
+                .expect("Responses history items should be captured"),
+        )
+        .expect("history envelope should decode");
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["type"], "reasoning");
+        assert_eq!(items[0]["encrypted_content"], "enc_reasoning");
+        assert_eq!(items[1]["type"], "function_call");
+        assert_eq!(items[1]["call_id"], "call_1");
     }
 
     #[test]
@@ -997,7 +1665,7 @@ data: [DONE]
         let decoded = decode_utf8_stream_chunks([&bytes[..split_at], &bytes[split_at..]]).unwrap();
         assert_eq!(decoded, payload);
         assert_eq!(
-            parse_sse_text(&decoded).unwrap().as_deref(),
+            parse_sse_turn(&decoded).unwrap().text.as_deref(),
             Some("Hello 世")
         );
     }
@@ -1050,11 +1718,11 @@ data: [DONE]
     }
 
     #[test]
-    fn build_responses_input_ignores_unknown_roles() {
+    fn build_responses_input_maps_tool_outputs() {
         let messages = vec![
             ChatMessage {
                 role: "tool".into(),
-                content: "result".into(),
+                content: r#"{"tool_call_id":"call_123","content":"result"}"#.into(),
             },
             ChatMessage {
                 role: "user".into(),
@@ -1063,9 +1731,121 @@ data: [DONE]
         ];
         let (instructions, input) = build_responses_input(&messages);
         assert_eq!(instructions, DEFAULT_CODEX_INSTRUCTIONS);
-        assert_eq!(input.len(), 1);
-        let json = serde_json::to_value(&input[0]).unwrap();
-        assert_eq!(json["role"], "user");
+        assert_eq!(input.len(), 2);
+        assert_eq!(input[0]["type"], "function_call_output");
+        assert_eq!(input[0]["call_id"], "call_123");
+        assert_eq!(input[0]["output"], "result");
+        assert_eq!(input[1]["role"], "user");
+    }
+
+    #[test]
+    fn build_responses_input_maps_native_assistant_tool_calls() {
+        let messages = vec![ChatMessage::assistant(
+            r#"{"content":"Using shell","tool_calls":[{"id":"call_abc","name":"shell","arguments":"{\"command\":\"pwd\"}"}]}"#,
+        )];
+        let (_, input) = build_responses_input(&messages);
+
+        assert_eq!(input.len(), 2);
+        assert_eq!(input[0]["type"], "message");
+        assert_eq!(input[0]["role"], "assistant");
+        assert_eq!(input[0]["content"][0]["type"], "output_text");
+        assert_eq!(input[1]["type"], "function_call");
+        assert_eq!(input[1]["call_id"], "call_abc");
+        assert_eq!(input[1]["name"], "shell");
+    }
+
+    #[test]
+    fn build_responses_input_replays_reasoning_item_before_tool_result() {
+        let reasoning_item = serde_json::json!({
+            "type": "reasoning",
+            "id": "rs_1",
+            "summary": [],
+            "encrypted_content": "enc_reasoning"
+        });
+        let function_call_item = serde_json::json!({
+            "type": "function_call",
+            "id": "fc_1",
+            "call_id": "call_1",
+            "name": "shell",
+            "arguments": "{\"command\":\"pwd\"}",
+            "status": "completed"
+        });
+        let reasoning_content =
+            encode_responses_history_items(&[reasoning_item, function_call_item], true)
+                .expect("history envelope should encode");
+        let messages = vec![
+            ChatMessage::assistant(
+                serde_json::json!({
+                    "content": null,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "name": "shell",
+                            "arguments": "{\"command\":\"pwd\"}"
+                        }
+                    ],
+                    "reasoning_content": reasoning_content
+                })
+                .to_string(),
+            ),
+            ChatMessage::tool(
+                serde_json::json!({
+                    "tool_call_id": "call_1",
+                    "content": "ok"
+                })
+                .to_string(),
+            ),
+        ];
+
+        let (_, input) = build_responses_input(&messages);
+        assert_eq!(input.len(), 3);
+        assert_eq!(input[0]["type"], "reasoning");
+        assert_eq!(input[0]["encrypted_content"], "enc_reasoning");
+        assert_eq!(input[1]["type"], "function_call");
+        assert_eq!(input[1]["call_id"], "call_1");
+        assert_eq!(input[2]["type"], "function_call_output");
+        assert_eq!(input[2]["call_id"], "call_1");
+        assert_eq!(input[2]["output"], "ok");
+    }
+
+    #[test]
+    fn convert_tools_opts_out_of_responses_strict_mode() {
+        let tools = vec![ToolSpec {
+            name: "jira".to_string(),
+            description: "Interact with Jira".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "action": { "type": "string" },
+                    "issue_key": { "type": "string" }
+                },
+                "required": ["action"]
+            }),
+        }];
+
+        let converted = convert_tools(Some(&tools)).expect("tool should convert");
+        let value = serde_json::to_value(&converted[0]).expect("tool should serialize");
+        assert_eq!(value["type"], "function");
+        assert_eq!(value["name"], "jira");
+        assert_eq!(value["strict"], false);
+        assert_eq!(value["parameters"]["required"][0], "action");
+    }
+
+    #[test]
+    fn parse_sse_turn_collects_function_calls() {
+        let payload = r#"data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"shell","arguments":""}}
+
+data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","output_index":0,"delta":"{\"command\":\"pw"}
+data: {"type":"response.function_call_arguments.done","item_id":"fc_1","output_index":0,"name":"shell","arguments":"{\"command\":\"pwd\"}"}
+data: {"type":"response.completed","response":{"output":[]}}
+data: [DONE]
+"#;
+
+        let result = parse_sse_turn(payload).unwrap();
+        assert_eq!(result.tool_calls.len(), 1);
+        assert_eq!(result.tool_calls[0].id, "call_1");
+        assert_eq!(result.tool_calls[0].name, "shell");
+        assert_eq!(result.tool_calls[0].arguments, "{\"command\":\"pwd\"}");
     }
 
     #[test]
@@ -1076,14 +1856,10 @@ data: [DONE]
         let (_, input) = build_responses_input(&messages);
 
         assert_eq!(input.len(), 1);
-        assert_eq!(input[0].role, "user");
-        assert_eq!(input[0].content.len(), 2);
+        assert_eq!(input[0]["role"], "user");
+        assert_eq!(input[0]["content"].as_array().unwrap().len(), 2);
 
-        let json: Vec<Value> = input[0]
-            .content
-            .iter()
-            .map(|item| serde_json::to_value(item).unwrap())
-            .collect();
+        let json = input[0]["content"].as_array().unwrap();
 
         // First content = text
         assert_eq!(json[0]["type"], "input_text");
@@ -1100,9 +1876,9 @@ data: [DONE]
         let (_, input) = build_responses_input(&messages);
 
         assert_eq!(input.len(), 1);
-        assert_eq!(input[0].content.len(), 1);
+        assert_eq!(input[0]["content"].as_array().unwrap().len(), 1);
 
-        let json = serde_json::to_value(&input[0].content[0]).unwrap();
+        let json = &input[0]["content"][0];
         assert_eq!(json["type"], "input_text");
         assert_eq!(json["text"], "Hello without images");
     }
@@ -1115,13 +1891,9 @@ data: [DONE]
         let (_, input) = build_responses_input(&messages);
 
         assert_eq!(input.len(), 1);
-        assert_eq!(input[0].content.len(), 3); // text + 2 images
+        assert_eq!(input[0]["content"].as_array().unwrap().len(), 3); // text + 2 images
 
-        let json: Vec<Value> = input[0]
-            .content
-            .iter()
-            .map(|item| serde_json::to_value(item).unwrap())
-            .collect();
+        let json = input[0]["content"].as_array().unwrap();
 
         assert_eq!(json[0]["type"], "input_text");
         assert_eq!(json[1]["type"], "input_image");
@@ -1155,7 +1927,16 @@ data: [DONE]
             OpenAiCodexProvider::new(&options, None).expect("provider should initialize");
         let caps = provider.capabilities();
 
-        assert!(!caps.native_tool_calling);
+        assert!(caps.native_tool_calling);
         assert!(caps.vision);
+    }
+
+    #[test]
+    fn provider_does_not_advertise_streaming_until_live_sse_is_wired() {
+        let provider = OpenAiCodexProvider::new(&ProviderRuntimeOptions::default(), None)
+            .expect("provider should initialize");
+
+        assert!(!provider.supports_streaming());
+        assert!(!provider.supports_streaming_tool_events());
     }
 }


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Adds native OpenAI Responses API tool-call support inside the `openai-codex` provider only.
  - Emits Responses-compatible `function` tool definitions from `ToolSpec`, including `name`, `description`, JSON-schema `parameters`, and `strict: false`.
  - Maps prior assistant tool calls and tool results into Responses `function_call` / `function_call_output` input items so Codex can continue multi-turn tool execution through the native API path.
  - Preserves raw Responses `reasoning` items with encrypted content plus their matching `function_call` output items on tool-call turns, then replays them before `function_call_output` on the follow-up request.
  - Parses non-streaming and SSE Responses output into ZeroClaw `ToolCall`s, including function-call argument delta/done events for aggregate response decoding.
  - Stops advertising provider streaming support until the Codex provider has true live incremental SSE forwarding that preserves text/tool-call event order.
  - Keeps action-style tools such as the current Jira tool compatible by avoiding over-strict schema enforcement; Jira uses one schema with conditionally required fields depending on the selected `action`.
- **Scope boundary:** This PR is intentionally limited to `crates/zeroclaw-providers/src/openai_codex.rs`. It does not change runtime prompt construction, agent loop behavior, Jira tool behavior, tool execution permissions, config keys, CLI flags, or provider selection.
- **Blast radius:** High risk. The changed behavior is scoped to the OpenAI Codex provider's native Responses tool-call and stream-capability mapping; non-Codex providers and runtime/tool modules are not modified.
- **Linked issue(s):** `N/A`

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test
```

Docs-only changes: replace with markdown lint + link-integrity (`scripts/ci/docs_quality_gate.sh`). Bootstrap scripts: add `bash -n install.sh`.

- **Commands run and tail output:**

```bash
$ cargo fmt --all -- --check
# no output
```

```bash
$ cargo test -p zeroclaw-providers openai_codex
...
test openai_codex::tests::parse_responses_body_preserves_reasoning_items_for_tool_calls ... ok
test openai_codex::tests::provider_does_not_advertise_streaming_until_live_sse_is_wired ... ok
...
test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 795 filtered out; finished in 0.01s
```

```bash
$ cargo clippy -p zeroclaw-providers --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 29.39s
```

```bash
$ cargo test
...
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s

   Doc-tests zeroclaw

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

```bash
$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 24s
```

- **Beyond CI — what did you manually verify?**
  - Synced `aliasliao/zeroclaw-contribute:master` to `zeroclaw-labs/zeroclaw:master` at `6a1c6ff09`, then rebased `codex/codex-native-tool-calls` onto that updated master.
  - Checked the OpenAI Responses reasoning/function-calling guidance for passing reasoning items back with function-call outputs when using stateless `store: false` requests and `reasoning.encrypted_content`.
  - Verified Responses reasoning/function-call output items are retained as an opaque provider history envelope and replayed before the matching `function_call_output` in the next request.
  - Verified the provider no longer advertises streaming/tool-event streaming support, so the runtime stays on the non-streaming native tool-call path until live SSE forwarding is implemented.
  - Verified the GitHub PR file list contains only `crates/zeroclaw-providers/src/openai_codex.rs` after narrowing the branch.
  - Did not perform a live OpenAI Codex API call; coverage is through request/response/SSE parser unit tests and full local cargo validation.
- **If any command was intentionally skipped, why:** `N/A`

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: `N/A`

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: Existing users do not need migration steps. The change is provider-capability driven and scoped to the existing `openai-codex` provider.

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <sha>` is the plan unless otherwise noted.

Medium/high-risk PRs must fill:

- **Fast rollback command/path:** `git revert b26bb37b9`
- **Feature flags or config toggles:** No dedicated feature flag. Operational fallback is to select a provider other than `openai-codex`.
- **Observable failure symptoms:** OpenAI Codex API errors mentioning tool schema, reasoning item replay, `function_call`, or `function_call_output`; repeated/invalid tool calls; missing tool execution after a model tool request; turns stalling after aggregate SSE function-call decoding.

## Supersede Attribution (required only when `Supersedes #` is used)

- Superseded PRs + authors (`#<pr> by @<author>`, one per line): `N/A`
- Scope materially carried forward: `N/A`
- `Co-authored-by` trailers added in commit messages for incorporated contributors? (`N/A`)
- If `No`, why (inspiration-only, no direct code/design carry-over): `N/A`
