### PR TITLE
fix(docs): point mdBook header links to upstream repo

### DIFF
--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -8,8 +8,8 @@ src = "src"
 [output.html]
 default-theme = "ayu"
 preferred-dark-theme = "ayu"
-git-repository-url = "https://github.com/singlerider/zeroclaw"
-edit-url-template = "https://github.com/singlerider/zeroclaw/edit/master/docs/book/{path}"
+git-repository-url = "https://github.com/zeroclaw-labs/zeroclaw"
+edit-url-template = "https://github.com/zeroclaw-labs/zeroclaw/edit/master/docs/book/{path}"
 site-url = "/"
 additional-js = ["theme/lang-switcher.js", "mermaid.min.js", "mermaid-init.js"]
 additional-css = ["theme/custom.css"]


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `book.toml` `git-repository-url` and `edit-url-template` pointed to `singlerider/zeroclaw` (the fork where #5788 was developed) instead of `zeroclaw-labs/zeroclaw`. This caused the GitHub icon and "suggest changes" links in the deployed docs header to direct readers to the fork.
- **Scope boundary:** Only `docs/book/book.toml` — no content, build, or translation changes.
- **Blast radius:** Deployed docs header links only.
- **Linked issue(s):** Closes #6115

## Validation Evidence (required)

Docs-only change — two string replacements in a TOML config file.

- **Commands run:** `bash -n` not applicable (TOML, not a script). Verified valid TOML syntax by inspection.
- **Beyond CI:** Confirmed `git-repository-url` and `edit-url-template` are the only two references to `singlerider/zeroclaw` in the file.
- **Skipped:** `cargo fmt`/`clippy`/`test` — no Rust changes.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? No
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No

## Compatibility (required)

- Backward compatible? Yes
- Config / env / CLI surface changed? No