### PR TITLE
refactor(tools): use typed session validation errors

### DIFF
--- a/crates/zeroclaw-tools/src/sessions.rs
+++ b/crates/zeroclaw-tools/src/sessions.rs
@@ -25,10 +25,7 @@ enum SessionValidationError {
 impl SessionValidationError {
     fn message(self) -> &'static str {
         match self {
-            SessionValidationError::Empty => {
-                "Invalid 'session_id': must be non-empty and contain at least one alphanumeric character."
-            }
-            SessionValidationError::NoAlphanumeric => {
+            Self::Empty | Self::NoAlphanumeric => {
                 "Invalid 'session_id': must be non-empty and contain at least one alphanumeric character."
             }
         }
@@ -561,6 +558,20 @@ mod tests {
     #[test]
     fn validate_session_id_accepts_valid_id() {
         assert_eq!(validate_session_id("test_session_id"), Ok(()));
+    }
+
+    #[test]
+    fn validation_error_message_starts_with_invalid() {
+        assert!(
+            SessionValidationError::Empty
+                .message()
+                .starts_with("Invalid")
+        );
+        assert!(
+            SessionValidationError::NoAlphanumeric
+                .message()
+                .starts_with("Invalid")
+        );
     }
 
     // ── SessionsListTool tests ──────────────────────────────────────

--- a/crates/zeroclaw-tools/src/sessions.rs
+++ b/crates/zeroclaw-tools/src/sessions.rs
@@ -16,16 +16,40 @@ use zeroclaw_infra::session_backend::SessionBackend;
 
 /// Validate that a session ID is non-empty and contains at least one
 /// alphanumeric character (prevents blank keys after sanitization).
-fn validate_session_id(session_id: &str) -> Result<(), ToolResult> {
-    let trimmed = session_id.trim();
-    if trimmed.is_empty() || !trimmed.chars().any(|c| c.is_alphanumeric()) {
-        return Err(ToolResult {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionValidationError {
+    Empty,
+    NoAlphanumeric,
+}
+
+impl SessionValidationError {
+    fn message(self) -> &'static str {
+        match self {
+            SessionValidationError::Empty => {
+                "Invalid 'session_id': must be non-empty and contain at least one alphanumeric character."
+            }
+            SessionValidationError::NoAlphanumeric => {
+                "Invalid 'session_id': must be non-empty and contain at least one alphanumeric character."
+            }
+        }
+    }
+
+    fn into_tool_result(self) -> ToolResult {
+        ToolResult {
             success: false,
             output: String::new(),
-            error: Some(
-                "Invalid 'session_id': must be non-empty and contain at least one alphanumeric character.".into(),
-            ),
-        });
+            error: Some(self.message().into()),
+        }
+    }
+}
+
+fn validate_session_id(session_id: &str) -> Result<(), SessionValidationError> {
+    let trimmed = session_id.trim();
+    if trimmed.is_empty() {
+        return Err(SessionValidationError::Empty);
+    }
+    if !trimmed.chars().any(|c| c.is_alphanumeric()) {
+        return Err(SessionValidationError::NoAlphanumeric);
     }
     Ok(())
 }
@@ -160,8 +184,8 @@ impl Tool for SessionsHistoryTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing 'session_id' parameter"))?;
 
-        if let Err(result) = validate_session_id(session_id) {
-            return Ok(result);
+        if let Err(error) = validate_session_id(session_id) {
+            return Ok(error.into_tool_result());
         }
 
         #[allow(clippy::cast_possible_truncation)]
@@ -260,8 +284,8 @@ impl Tool for SessionsSendTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing 'session_id' parameter"))?;
 
-        if let Err(result) = validate_session_id(session_id) {
-            return Ok(result);
+        if let Err(error) = validate_session_id(session_id) {
+            return Ok(error.into_tool_result());
         }
 
         let message = args
@@ -350,8 +374,8 @@ impl Tool for SessionResetTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing 'session_id' parameter"))?;
 
-        if let Err(result) = validate_session_id(session_id) {
-            return Ok(result);
+        if let Err(error) = validate_session_id(session_id) {
+            return Ok(error.into_tool_result());
         }
 
         // TOCTOU: a message appended between load() and the last remove_last()
@@ -440,8 +464,8 @@ impl Tool for SessionDeleteTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing 'session_id' parameter"))?;
 
-        if let Err(result) = validate_session_id(session_id) {
-            return Ok(result);
+        if let Err(error) = validate_session_id(session_id) {
+            return Ok(error.into_tool_result());
         }
 
         let existed = !self.backend.load(session_id).is_empty();
@@ -509,6 +533,34 @@ mod tests {
             .append("discord__bob", &ChatMessage::user("Hey from Bob"))
             .unwrap();
         (tmp, Arc::new(store))
+    }
+
+    // ── Session ID validation tests ─────────────────────────────────
+
+    #[test]
+    fn validate_session_id_rejects_empty() {
+        assert_eq!(validate_session_id(""), Err(SessionValidationError::Empty));
+    }
+
+    #[test]
+    fn validate_session_id_rejects_whitespace_only() {
+        assert_eq!(
+            validate_session_id("   "),
+            Err(SessionValidationError::Empty)
+        );
+    }
+
+    #[test]
+    fn validate_session_id_rejects_non_alphanumeric() {
+        assert_eq!(
+            validate_session_id("///"),
+            Err(SessionValidationError::NoAlphanumeric)
+        );
+    }
+
+    #[test]
+    fn validate_session_id_accepts_valid_id() {
+        assert_eq!(validate_session_id("test_session_id"), Ok(()));
     }
 
     // ── SessionsListTool tests ──────────────────────────────────────
@@ -617,7 +669,7 @@ mod tests {
         let tool = SessionsHistoryTool::new(backend, test_security());
         let result = tool.execute(json!({"session_id": "   "})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.unwrap().contains("Invalid"));
+        assert!(result.error.is_some());
     }
 
     #[test]
@@ -703,7 +755,7 @@ mod tests {
             .await
             .unwrap();
         assert!(!result.success);
-        assert!(result.error.unwrap().contains("Invalid"));
+        assert!(result.error.is_some());
     }
 
     #[tokio::test]
@@ -718,7 +770,7 @@ mod tests {
             .await
             .unwrap();
         assert!(!result.success);
-        assert!(result.error.unwrap().contains("Invalid"));
+        assert!(result.error.is_some());
     }
 
     #[tokio::test]
@@ -808,7 +860,7 @@ mod tests {
         let tool = SessionResetTool::new(backend, test_security());
         let result = tool.execute(json!({"session_id": ""})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.unwrap().contains("Invalid"));
+        assert!(result.error.is_some());
     }
 
     #[test]
@@ -874,7 +926,7 @@ mod tests {
         let tool = SessionDeleteTool::new(backend, test_security());
         let result = tool.execute(json!({"session_id": "   "})).await.unwrap();
         assert!(!result.success);
-        assert!(result.error.unwrap().contains("Invalid"));
+        assert!(result.error.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary                                                                                                                       
                                                                                                                                   
  - **Base branch:** `master` (all contributions)                                                                                  
  - **What changed and why:**                                                                                                      
    - Replaced `Result<(), ToolResult>` as the error type on `validate_session_id` with a proper `SessionValidationError` enum     
  (`Empty` | `NoAlphanumeric`). The previous signature conflated domain logic with presentation — using `ToolResult` as an error   
  type made the function hard to test and reason about.                                                                          
    - Added `SessionValidationError::message()` and `::into_tool_result()` to centralize error text and conversion in one place    
  instead of inline at each call site.                                                                                             
    - Added four dedicated unit tests for `validate_session_id` covering empty, whitespace-only, non-alphanumeric, and valid inputs
   — these cases were previously only tested indirectly through the tool execute paths.                                            
    - Relaxed five test assertions from `.contains("Invalid")` to `.is_some()` to decouple tests from specific error message     
  wording; message-content assertions belong in `SessionValidationError::message` unit tests, not in tool integration tests.       
  - **Scope boundary:** No behavioral change — all five session tools accept and reject the same inputs as before. No API surface,
  config, or CLI changes.                                                                                                          
  - **Blast radius:** Contained to `crates/zeroclaw-tools/src/sessions.rs`. `SessionValidationError` is private to the module.   
  - **Linked issue(s):** Closes #6062                                                                                              
   
  ## Validation Evidence (required)                                                                                                
                                                                                                                                 
  - **Commands run and tail output:**
    cargo fmt --all -- --check
    → exit 0, no output (tree is clean)                                                                                            
   
    cargo clippy --all-targets -- -D warnings                                                                                      
    → pre-existing error in zeroclaw-config (collapsible_match); confirmed on master before this branch, not introduced here     
                                                                                                                                   
    cargo test -p zeroclaw-tools
    → test result: ok. 1114 passed; 0 failed; 0 ignored; finished in 3.45s                                                         
  - **Beyond CI — what did you manually verify?** Four new unit tests directly exercise `validate_session_id` across all three     
  error paths and the happy path. Five tool-level invalid-session-id tests still produce `success: false` with a non-None error.
  - **If any command was intentionally skipped, why:** `cargo build` skipped — `cargo test` implies a successful build.            
                                                                                                                                 
  ## Security & Privacy Impact (required)                                                                                          
                                                                                                                                 
  - New permissions, capabilities, or file system access scope? `No`                                                               
  - New external network calls? `No`                                                                                             
  - Secrets / tokens / credentials handling changed? `No`
  - PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
                                                                                                                                   
  ## Compatibility (required)
                                                                                                                                   
  - Backward compatible? `Yes`                                                                                                   
  - Config / env / CLI surface changed? `No`
                                            
  ## Rollback (required for `risk: medium` and `risk: high`)
                                                                                                                                   
  `git revert c5910bc3` is the plan. Risk is low — pure internal refactor with no behavior change.