### PR TITLE
fix(providers): apply [providers.X] config to fallback providers

### DIFF
--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -901,7 +901,10 @@ fn decrypt_optional_secret_for_runtime_reload(
 
 async fn load_runtime_defaults_from_config_file(
     path: &Path,
-) -> Result<(ChannelRuntimeDefaults, zeroclaw_providers::ProviderRuntimeOptions)> {
+) -> Result<(
+    ChannelRuntimeDefaults,
+    zeroclaw_providers::ProviderRuntimeOptions,
+)> {
     let contents = tokio::fs::read_to_string(path)
         .await
         .with_context(|| format!("Failed to read {}", path.display()))?;

--- a/crates/zeroclaw-channels/src/orchestrator/mod.rs
+++ b/crates/zeroclaw-channels/src/orchestrator/mod.rs
@@ -899,7 +899,9 @@ fn decrypt_optional_secret_for_runtime_reload(
     Ok(())
 }
 
-async fn load_runtime_defaults_from_config_file(path: &Path) -> Result<ChannelRuntimeDefaults> {
+async fn load_runtime_defaults_from_config_file(
+    path: &Path,
+) -> Result<(ChannelRuntimeDefaults, zeroclaw_providers::ProviderRuntimeOptions)> {
     let contents = tokio::fs::read_to_string(path)
         .await
         .with_context(|| format!("Failed to read {}", path.display()))?;
@@ -942,7 +944,8 @@ async fn load_runtime_defaults_from_config_file(path: &Path) -> Result<ChannelRu
     }
 
     parsed.apply_env_overrides();
-    Ok(runtime_defaults_from_config(&parsed))
+    let options = zeroclaw_providers::provider_runtime_options_from_config(&parsed);
+    Ok((runtime_defaults_from_config(&parsed), options))
 }
 
 async fn maybe_apply_runtime_config_update(ctx: &ChannelRuntimeContext) -> Result<()> {
@@ -965,13 +968,14 @@ async fn maybe_apply_runtime_config_update(ctx: &ChannelRuntimeContext) -> Resul
         }
     }
 
-    let next_defaults = load_runtime_defaults_from_config_file(&config_path).await?;
+    let (next_defaults, fresh_provider_options) =
+        load_runtime_defaults_from_config_file(&config_path).await?;
     let next_default_provider = zeroclaw_providers::create_resilient_provider_with_options(
         &next_defaults.default_provider,
         next_defaults.api_key.as_deref(),
         next_defaults.api_url.as_deref(),
         &next_defaults.reliability,
-        &ctx.provider_runtime_options,
+        &fresh_provider_options,
     )?;
     let next_default_provider: Arc<dyn Provider> = Arc::from(next_default_provider);
 

--- a/crates/zeroclaw-providers/src/lib.rs
+++ b/crates/zeroclaw-providers/src/lib.rs
@@ -717,6 +717,11 @@ pub struct ProviderRuntimeOptions {
     /// Extra JSON parameters merged into API request bodies at the top level.
     /// Propagated from `ModelProviderConfig::provider_extra`.
     pub provider_extra: Option<serde_json::Value>,
+    /// All named provider profiles from `[providers.X]` config blocks, keyed by
+    /// provider name. Used by the fallback chain to resolve each fallback's
+    /// `api_key` and `base_url` from config before falling back to env vars.
+    pub providers_models:
+        std::collections::HashMap<String, zeroclaw_config::schema::ModelProviderConfig>,
 }
 
 impl Default for ProviderRuntimeOptions {
@@ -734,6 +739,7 @@ impl Default for ProviderRuntimeOptions {
             provider_max_tokens: None,
             merge_system_into_user: false,
             provider_extra: None,
+            providers_models: std::collections::HashMap::new(),
         }
     }
 }
@@ -777,6 +783,7 @@ pub fn provider_runtime_options_from_config(
         provider_max_tokens: fallback.and_then(|e| e.max_tokens),
         merge_system_into_user,
         provider_extra: fallback.and_then(|e| e.provider_extra.clone()),
+        providers_models: config.providers.models.clone(),
     }
 }
 
@@ -1787,6 +1794,10 @@ pub fn create_resilient_provider(
 }
 
 /// Create provider chain with retry/fallback behavior and auth runtime options.
+///
+/// Fallback provider credentials and base URLs are resolved from
+/// `options.providers_models` (populated by `provider_runtime_options_from_config`)
+/// before falling back to environment variables.
 pub fn create_resilient_provider_with_options(
     primary_name: &str,
     api_key: Option<&str>,
@@ -1804,6 +1815,8 @@ pub fn create_resilient_provider_with_options(
     };
     providers.push((primary_name.to_string(), primary_provider));
 
+    let mut provider_model_overrides = std::collections::HashMap::new();
+
     for fallback in &reliability.fallback_providers {
         if fallback == primary_name || providers.iter().any(|(name, _)| name == fallback) {
             continue;
@@ -1811,15 +1824,18 @@ pub fn create_resilient_provider_with_options(
 
         let (provider_name, profile_override) = parse_provider_profile(fallback);
 
-        // Each fallback provider resolves its own credential via provider-
-        // specific env vars (e.g. DEEPSEEK_API_KEY for "deepseek") instead
-        // of inheriting the primary provider's key. Passing `None` lets
-        // `resolve_provider_credential` check the correct env var for the
-        // fallback provider name.
-        //
-        // When a profile override is present (e.g. "openai-codex:second"),
-        // propagate it through `auth_profile_override` so the provider
-        // picks up the correct OAuth credential set.
+        // Resolve credentials for this fallback from the [providers.X] config block first,
+        // then let `resolve_provider_credential` fall through to provider-specific env vars.
+        // When a profile override is present (e.g. "openai-codex:second"), propagate it
+        // through `auth_profile_override` so the provider picks up the correct OAuth set.
+        let fallback_cfg = options.providers_models.get(provider_name);
+        let fallback_api_key = fallback_cfg.and_then(|c| c.api_key.as_deref());
+        let fallback_base_url = fallback_cfg.and_then(|c| c.base_url.as_deref());
+
+        if let Some(model) = fallback_cfg.and_then(|c| c.model.as_deref()) {
+            provider_model_overrides.insert(fallback.clone(), model.to_string());
+        }
+
         let fallback_options = match profile_override {
             Some(profile) => {
                 let mut opts = options.clone();
@@ -1829,7 +1845,12 @@ pub fn create_resilient_provider_with_options(
             None => options.clone(),
         };
 
-        match create_provider_with_options(provider_name, None, &fallback_options) {
+        match create_provider_with_url_and_options(
+            provider_name,
+            fallback_api_key,
+            fallback_base_url,
+            &fallback_options,
+        ) {
             Ok(provider) => providers.push((fallback.clone(), provider)),
             Err(_error) => {
                 tracing::warn!(
@@ -1846,7 +1867,8 @@ pub fn create_resilient_provider_with_options(
         reliability.provider_backoff_ms,
     )
     .with_api_keys(reliability.api_keys.clone())
-    .with_model_fallbacks(reliability.model_fallbacks.clone());
+    .with_model_fallbacks(reliability.model_fallbacks.clone())
+    .with_provider_model_overrides(provider_model_overrides);
 
     Ok(Box::new(reliable))
 }
@@ -1874,6 +1896,9 @@ pub fn create_routed_provider(
 }
 
 /// Create a routed provider using explicit runtime options.
+///
+/// Fallback credentials and base URLs for each sub-provider are resolved from
+/// `options.providers_models` (populated by `provider_runtime_options_from_config`).
 pub fn create_routed_provider_with_options(
     primary_name: &str,
     api_key: Option<&str>,
@@ -3376,6 +3401,113 @@ mod tests {
         assert!(provider.is_ok());
     }
 
+    /// Fallback providers use api_key from ProviderRuntimeOptions.providers_models (populated
+    /// by provider_runtime_options_from_config) rather than relying solely on env vars.
+    /// Regression test for issue #5803 where [providers.X] config blocks were silently
+    /// ignored for fallback providers.
+    #[test]
+    fn resilient_fallback_reads_api_key_from_providers_models() {
+        let reliability = zeroclaw_config::schema::ReliabilityConfig {
+            provider_retries: 1,
+            provider_backoff_ms: 100,
+            fallback_providers: vec!["openai".into()],
+            api_keys: Vec::new(),
+            model_fallbacks: std::collections::HashMap::new(),
+            channel_initial_backoff_secs: 2,
+            channel_max_backoff_secs: 60,
+            scheduler_poll_secs: 15,
+            scheduler_retries: 2,
+        };
+
+        let mut providers_models = std::collections::HashMap::new();
+        providers_models.insert(
+            "openai".to_string(),
+            zeroclaw_config::schema::ModelProviderConfig {
+                api_key: Some("sk-config-provided-key".to_string()),
+                ..Default::default()
+            },
+        );
+        let options = ProviderRuntimeOptions {
+            providers_models,
+            ..Default::default()
+        };
+
+        let provider = create_resilient_provider_with_options(
+            "anthropic",
+            Some("sk-ant-test"),
+            None,
+            &reliability,
+            &options,
+        );
+        assert!(provider.is_ok());
+    }
+
+    /// Fallback provider uses base_url from ProviderRuntimeOptions.providers_models so
+    /// custom endpoints are respected for fallback providers (issue #5803).
+    #[test]
+    fn resilient_fallback_reads_base_url_from_providers_models() {
+        let reliability = zeroclaw_config::schema::ReliabilityConfig {
+            provider_retries: 1,
+            provider_backoff_ms: 100,
+            fallback_providers: vec!["openai".into()],
+            api_keys: Vec::new(),
+            model_fallbacks: std::collections::HashMap::new(),
+            channel_initial_backoff_secs: 2,
+            channel_max_backoff_secs: 60,
+            scheduler_poll_secs: 15,
+            scheduler_retries: 2,
+        };
+
+        let mut providers_models = std::collections::HashMap::new();
+        providers_models.insert(
+            "openai".to_string(),
+            zeroclaw_config::schema::ModelProviderConfig {
+                api_key: Some("xai-config-key".to_string()),
+                base_url: Some("https://api.x.ai/v1".to_string()),
+                ..Default::default()
+            },
+        );
+        let options = ProviderRuntimeOptions {
+            providers_models,
+            ..Default::default()
+        };
+
+        let provider = create_resilient_provider_with_options(
+            "anthropic",
+            Some("sk-ant-test"),
+            None,
+            &reliability,
+            &options,
+        );
+        assert!(provider.is_ok());
+    }
+
+    /// When providers_models is empty (ProviderRuntimeOptions::default()), fallbacks
+    /// still resolve via env vars — backward compat with callers that have no config map.
+    #[test]
+    fn resilient_fallback_empty_providers_models_falls_back_to_env() {
+        let reliability = zeroclaw_config::schema::ReliabilityConfig {
+            provider_retries: 1,
+            provider_backoff_ms: 100,
+            fallback_providers: vec!["ollama".into(), "lmstudio".into()],
+            api_keys: Vec::new(),
+            model_fallbacks: std::collections::HashMap::new(),
+            channel_initial_backoff_secs: 2,
+            channel_max_backoff_secs: 60,
+            scheduler_poll_secs: 15,
+            scheduler_retries: 2,
+        };
+
+        let provider = create_resilient_provider_with_options(
+            "anthropic",
+            Some("sk-ant-test"),
+            None,
+            &reliability,
+            &ProviderRuntimeOptions::default(),
+        );
+        assert!(provider.is_ok());
+    }
+
     /// Osaurus works as a fallback provider alongside other named providers.
     #[test]
     fn resilient_fallback_includes_osaurus() {
@@ -3803,5 +3935,33 @@ mod tests {
 
         // SAFETY: test-only, single-threaded test runner.
         unsafe { std::env::remove_var("ZEROCLAW_PROVIDER_URL") };
+    }
+
+    /// `provider_runtime_options_from_config` must copy all three per-provider
+    /// fields (api_key, base_url, model) from `config.providers.models` into
+    /// `options.providers_models` so the fallback chain can use them without
+    /// consulting env vars.  Regression test for issue #5803.
+    #[test]
+    fn provider_runtime_options_from_config_populates_providers_models() {
+        let mut config = zeroclaw_config::schema::Config::default();
+        config.providers.models.insert(
+            "xai".to_string(),
+            zeroclaw_config::schema::ModelProviderConfig {
+                api_key: Some("xai-test-key".to_string()),
+                base_url: Some("https://api.x.ai/v1".to_string()),
+                model: Some("grok-3".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let options = provider_runtime_options_from_config(&config);
+
+        let entry = options
+            .providers_models
+            .get("xai")
+            .expect("[providers.xai] must be present in options.providers_models");
+        assert_eq!(entry.api_key.as_deref(), Some("xai-test-key"));
+        assert_eq!(entry.base_url.as_deref(), Some("https://api.x.ai/v1"));
+        assert_eq!(entry.model.as_deref(), Some("grok-3"));
     }
 }

--- a/crates/zeroclaw-providers/src/openai_codex.rs
+++ b/crates/zeroclaw-providers/src/openai_codex.rs
@@ -1147,6 +1147,7 @@ data: [DONE]
             provider_max_tokens: None,
             merge_system_into_user: false,
             provider_extra: None,
+            providers_models: std::collections::HashMap::new(),
         };
         let provider =
             OpenAiCodexProvider::new(&options, None).expect("provider should initialize");

--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -374,6 +374,11 @@ pub struct ReliableProvider {
     key_index: AtomicUsize,
     /// Per-model fallback chains: model_name → [fallback_model_1, fallback_model_2, ...]
     model_fallbacks: HashMap<String, Vec<String>>,
+    /// Per-provider model overrides: provider_name → model to use for that provider.
+    /// When set, overrides the model passed by the caller for the specified provider.
+    /// Populated from `[providers.<name>].model` config entries so each fallback
+    /// provider uses its own configured model instead of the primary's model.
+    provider_model_overrides: HashMap<String, String>,
 }
 
 impl ReliableProvider {
@@ -389,6 +394,7 @@ impl ReliableProvider {
             api_keys: Vec::new(),
             key_index: AtomicUsize::new(0),
             model_fallbacks: HashMap::new(),
+            provider_model_overrides: HashMap::new(),
         }
     }
 
@@ -402,6 +408,22 @@ impl ReliableProvider {
     pub fn with_model_fallbacks(mut self, fallbacks: HashMap<String, Vec<String>>) -> Self {
         self.model_fallbacks = fallbacks;
         self
+    }
+
+    /// Set per-provider model overrides from `[providers.<name>].model` config entries.
+    /// When a provider has an override, it receives its own configured model instead of
+    /// whatever model the caller requested.
+    pub fn with_provider_model_overrides(mut self, overrides: HashMap<String, String>) -> Self {
+        self.provider_model_overrides = overrides;
+        self
+    }
+
+    /// Resolve the effective model for a given provider, applying any per-provider override.
+    fn effective_model<'a>(&'a self, provider_name: &str, requested_model: &'a str) -> &'a str {
+        self.provider_model_overrides
+            .get(provider_name)
+            .map(|s| s.as_str())
+            .unwrap_or(requested_model)
     }
 
     /// Build the list of models to try: [original, fallback1, fallback2, ...]
@@ -462,10 +484,11 @@ impl Provider for ReliableProvider {
         for current_model in &models {
             for (provider_name, provider) in &self.providers {
                 let mut backoff_ms = self.base_backoff_ms;
+                let eff_model = self.effective_model(provider_name, current_model);
 
                 for attempt in 0..=self.max_retries {
                     match provider
-                        .chat_with_system(system_prompt, message, current_model, temperature)
+                        .chat_with_system(system_prompt, message, eff_model, temperature)
                         .await
                     {
                         Ok(resp) => {
@@ -476,7 +499,7 @@ impl Provider for ReliableProvider {
                             {
                                 tracing::info!(
                                     provider = provider_name,
-                                    model = *current_model,
+                                    model = eff_model,
                                     attempt,
                                     original_model = model,
                                     "Provider recovered (failover/retry)"
@@ -490,7 +513,7 @@ impl Provider for ReliableProvider {
                                     primary,
                                     model,
                                     provider_name,
-                                    current_model,
+                                    eff_model,
                                 );
                             }
                             return Ok(resp);
@@ -503,7 +526,7 @@ impl Provider for ReliableProvider {
                                 push_failure(
                                     &mut failures,
                                     provider_name,
-                                    current_model,
+                                    eff_model,
                                     attempt + 1,
                                     self.max_retries + 1,
                                     "non_retryable",
@@ -524,7 +547,7 @@ impl Provider for ReliableProvider {
                             push_failure(
                                 &mut failures,
                                 provider_name,
-                                current_model,
+                                eff_model,
                                 attempt + 1,
                                 self.max_retries + 1,
                                 failure_reason,
@@ -550,7 +573,7 @@ impl Provider for ReliableProvider {
                             if non_retryable {
                                 tracing::warn!(
                                     provider = provider_name,
-                                    model = *current_model,
+                                    model = eff_model,
                                     error = %error_detail,
                                     "Non-retryable error, moving on"
                                 );
@@ -561,7 +584,7 @@ impl Provider for ReliableProvider {
                                 let wait = self.compute_backoff(backoff_ms, &e);
                                 tracing::warn!(
                                     provider = provider_name,
-                                    model = *current_model,
+                                    model = eff_model,
                                     attempt = attempt + 1,
                                     backoff_ms = wait,
                                     reason = failure_reason,
@@ -577,7 +600,7 @@ impl Provider for ReliableProvider {
 
                 tracing::warn!(
                     provider = provider_name,
-                    model = *current_model,
+                    model = eff_model,
                     "Exhausted retries, trying next provider/model"
                 );
             }
@@ -611,10 +634,11 @@ impl Provider for ReliableProvider {
         for current_model in &models {
             for (provider_name, provider) in &self.providers {
                 let mut backoff_ms = self.base_backoff_ms;
+                let eff_model = self.effective_model(provider_name, current_model);
 
                 for attempt in 0..=self.max_retries {
                     match provider
-                        .chat_with_history(&effective_messages, current_model, temperature)
+                        .chat_with_history(&effective_messages, eff_model, temperature)
                         .await
                     {
                         Ok(resp) => {
@@ -626,7 +650,7 @@ impl Provider for ReliableProvider {
                             {
                                 tracing::info!(
                                     provider = provider_name,
-                                    model = *current_model,
+                                    model = eff_model,
                                     attempt,
                                     original_model = model,
                                     context_truncated,
@@ -641,7 +665,7 @@ impl Provider for ReliableProvider {
                                     primary,
                                     model,
                                     provider_name,
-                                    current_model,
+                                    eff_model,
                                 );
                             }
                             return Ok(resp);
@@ -654,7 +678,7 @@ impl Provider for ReliableProvider {
                                     context_truncated = true;
                                     tracing::warn!(
                                         provider = provider_name,
-                                        model = *current_model,
+                                        model = eff_model,
                                         dropped,
                                         remaining = effective_messages.len(),
                                         "Context window exceeded; truncated history and retrying"
@@ -668,7 +692,7 @@ impl Provider for ReliableProvider {
                                 push_failure(
                                     &mut failures,
                                     provider_name,
-                                    current_model,
+                                    eff_model,
                                     attempt + 1,
                                     self.max_retries + 1,
                                     "non_retryable",
@@ -691,7 +715,7 @@ impl Provider for ReliableProvider {
                             push_failure(
                                 &mut failures,
                                 provider_name,
-                                current_model,
+                                eff_model,
                                 attempt + 1,
                                 self.max_retries + 1,
                                 failure_reason,
@@ -715,7 +739,7 @@ impl Provider for ReliableProvider {
                             if non_retryable {
                                 tracing::warn!(
                                     provider = provider_name,
-                                    model = *current_model,
+                                    model = eff_model,
                                     error = %error_detail,
                                     "Non-retryable error, moving on"
                                 );
@@ -726,7 +750,7 @@ impl Provider for ReliableProvider {
                                 let wait = self.compute_backoff(backoff_ms, &e);
                                 tracing::warn!(
                                     provider = provider_name,
-                                    model = *current_model,
+                                    model = eff_model,
                                     attempt = attempt + 1,
                                     backoff_ms = wait,
                                     reason = failure_reason,
@@ -742,7 +766,7 @@ impl Provider for ReliableProvider {
 
                 tracing::warn!(
                     provider = provider_name,
-                    model = *current_model,
+                    model = eff_model,
                     "Exhausted retries, trying next provider/model"
                 );
             }
@@ -782,10 +806,11 @@ impl Provider for ReliableProvider {
         for current_model in &models {
             for (provider_name, provider) in &self.providers {
                 let mut backoff_ms = self.base_backoff_ms;
+                let eff_model = self.effective_model(provider_name, current_model);
 
                 for attempt in 0..=self.max_retries {
                     match provider
-                        .chat_with_tools(&effective_messages, tools, current_model, temperature)
+                        .chat_with_tools(&effective_messages, tools, eff_model, temperature)
                         .await
                     {
                         Ok(resp) => {
@@ -797,7 +822,7 @@ impl Provider for ReliableProvider {
                             {
                                 tracing::info!(
                                     provider = provider_name,
-                                    model = *current_model,
+                                    model = eff_model,
                                     attempt,
                                     original_model = model,
                                     context_truncated,
@@ -812,7 +837,7 @@ impl Provider for ReliableProvider {
                                     primary,
                                     model,
                                     provider_name,
-                                    current_model,
+                                    eff_model,
                                 );
                             }
                             return Ok(resp);
@@ -825,7 +850,7 @@ impl Provider for ReliableProvider {
                                     context_truncated = true;
                                     tracing::warn!(
                                         provider = provider_name,
-                                        model = *current_model,
+                                        model = eff_model,
                                         dropped,
                                         remaining = effective_messages.len(),
                                         "Context window exceeded; truncated history and retrying"
@@ -839,7 +864,7 @@ impl Provider for ReliableProvider {
                                 push_failure(
                                     &mut failures,
                                     provider_name,
-                                    current_model,
+                                    eff_model,
                                     attempt + 1,
                                     self.max_retries + 1,
                                     "non_retryable",
@@ -862,7 +887,7 @@ impl Provider for ReliableProvider {
                             push_failure(
                                 &mut failures,
                                 provider_name,
-                                current_model,
+                                eff_model,
                                 attempt + 1,
                                 self.max_retries + 1,
                                 failure_reason,
@@ -886,7 +911,7 @@ impl Provider for ReliableProvider {
                             if non_retryable {
                                 tracing::warn!(
                                     provider = provider_name,
-                                    model = *current_model,
+                                    model = eff_model,
                                     error = %error_detail,
                                     "Non-retryable error, moving on"
                                 );
@@ -897,7 +922,7 @@ impl Provider for ReliableProvider {
                                 let wait = self.compute_backoff(backoff_ms, &e);
                                 tracing::warn!(
                                     provider = provider_name,
-                                    model = *current_model,
+                                    model = eff_model,
                                     attempt = attempt + 1,
                                     backoff_ms = wait,
                                     reason = failure_reason,
@@ -913,7 +938,7 @@ impl Provider for ReliableProvider {
 
                 tracing::warn!(
                     provider = provider_name,
-                    model = *current_model,
+                    model = eff_model,
                     "Exhausted retries, trying next provider/model"
                 );
             }
@@ -939,13 +964,14 @@ impl Provider for ReliableProvider {
         for current_model in &models {
             for (provider_name, provider) in &self.providers {
                 let mut backoff_ms = self.base_backoff_ms;
+                let eff_model = self.effective_model(provider_name, current_model);
 
                 for attempt in 0..=self.max_retries {
                     let req = ChatRequest {
                         messages: &effective_messages,
                         tools: request.tools,
                     };
-                    match provider.chat(req, current_model, temperature).await {
+                    match provider.chat(req, eff_model, temperature).await {
                         Ok(resp) => {
                             if attempt > 0
                                 || *current_model != model
@@ -955,7 +981,7 @@ impl Provider for ReliableProvider {
                             {
                                 tracing::info!(
                                     provider = provider_name,
-                                    model = *current_model,
+                                    model = eff_model,
                                     attempt,
                                     original_model = model,
                                     context_truncated,
@@ -970,7 +996,7 @@ impl Provider for ReliableProvider {
                                     primary,
                                     model,
                                     provider_name,
-                                    current_model,
+                                    eff_model,
                                 );
                             }
                             return Ok(resp);
@@ -983,7 +1009,7 @@ impl Provider for ReliableProvider {
                                     context_truncated = true;
                                     tracing::warn!(
                                         provider = provider_name,
-                                        model = *current_model,
+                                        model = eff_model,
                                         dropped,
                                         remaining = effective_messages.len(),
                                         "Context window exceeded; truncated history and retrying"
@@ -997,7 +1023,7 @@ impl Provider for ReliableProvider {
                                 push_failure(
                                     &mut failures,
                                     provider_name,
-                                    current_model,
+                                    eff_model,
                                     attempt + 1,
                                     self.max_retries + 1,
                                     "non_retryable",
@@ -1020,7 +1046,7 @@ impl Provider for ReliableProvider {
                             push_failure(
                                 &mut failures,
                                 provider_name,
-                                current_model,
+                                eff_model,
                                 attempt + 1,
                                 self.max_retries + 1,
                                 failure_reason,
@@ -1044,7 +1070,7 @@ impl Provider for ReliableProvider {
                             if non_retryable {
                                 tracing::warn!(
                                     provider = provider_name,
-                                    model = *current_model,
+                                    model = eff_model,
                                     error = %error_detail,
                                     "Non-retryable error, moving on"
                                 );
@@ -1055,7 +1081,7 @@ impl Provider for ReliableProvider {
                                 let wait = self.compute_backoff(backoff_ms, &e);
                                 tracing::warn!(
                                     provider = provider_name,
-                                    model = *current_model,
+                                    model = eff_model,
                                     attempt = attempt + 1,
                                     backoff_ms = wait,
                                     reason = failure_reason,
@@ -1071,7 +1097,7 @@ impl Provider for ReliableProvider {
 
                 tracing::warn!(
                     provider = provider_name,
-                    model = *current_model,
+                    model = eff_model,
                     "Exhausted retries, trying next provider/model"
                 );
             }
@@ -2990,5 +3016,202 @@ mod tests {
             assert!(take_last_provider_fallback().is_none());
         })
         .await;
+    }
+
+    /// When a fallback provider has a `model` override configured, ReliableProvider
+    /// passes that model to the fallback instead of the caller's requested model.
+    /// Regression test for issue #5803 (model field in [providers.X] config blocks).
+    #[tokio::test]
+    async fn provider_model_override_used_for_fallback() {
+        // Primary always fails so we fall through to the fallback.
+        let primary_mock = Arc::new(AtomicUsize::new(0));
+        let fallback_models = parking_lot::Mutex::new(Vec::<String>::new());
+        let fallback_models = Arc::new(fallback_models);
+        let fallback_models_clone = Arc::clone(&fallback_models);
+
+        struct FailProvider;
+        #[async_trait]
+        impl Provider for FailProvider {
+            async fn chat_with_system(
+                &self,
+                _system: Option<&str>,
+                _msg: &str,
+                _model: &str,
+                _temp: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("401 primary unavailable");
+            }
+        }
+
+        struct RecordingProvider {
+            models_seen: Arc<parking_lot::Mutex<Vec<String>>>,
+        }
+        #[async_trait]
+        impl Provider for RecordingProvider {
+            async fn chat_with_system(
+                &self,
+                _system: Option<&str>,
+                _msg: &str,
+                model: &str,
+                _temp: Option<f64>,
+            ) -> anyhow::Result<String> {
+                self.models_seen.lock().push(model.to_string());
+                Ok("fallback response".to_string())
+            }
+        }
+
+        let _ = primary_mock; // suppress unused warning
+
+        let mut overrides = HashMap::new();
+        overrides.insert("fallback".to_string(), "gpt-4o-fallback".to_string());
+
+        let provider = ReliableProvider::new(
+            vec![
+                ("primary".into(), Box::new(FailProvider) as Box<dyn Provider>),
+                (
+                    "fallback".into(),
+                    Box::new(RecordingProvider {
+                        models_seen: Arc::clone(&fallback_models_clone),
+                    }),
+                ),
+            ],
+            0,
+            1,
+        )
+        .with_provider_model_overrides(overrides);
+
+        let result = provider
+            .simple_chat("hello", "gpt-3.5-turbo", Some(0.0))
+            .await
+            .unwrap();
+        assert_eq!(result, "fallback response");
+
+        let seen = fallback_models_clone.lock();
+        assert_eq!(seen.len(), 1, "fallback should have been called once");
+        assert_eq!(
+            seen[0], "gpt-4o-fallback",
+            "fallback must use its configured model, not the caller's model"
+        );
+    }
+
+    /// Same as `provider_model_override_used_for_fallback` but exercises
+    /// `chat_with_history` — the most common path in agentic loops.
+    #[tokio::test]
+    async fn provider_model_override_used_for_fallback_chat_with_history() {
+        struct FailProvider;
+        #[async_trait]
+        impl Provider for FailProvider {
+            async fn chat_with_system(
+                &self,
+                _system: Option<&str>,
+                _msg: &str,
+                _model: &str,
+                _temp: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("401 primary unavailable");
+            }
+
+            async fn chat_with_history(
+                &self,
+                _messages: &[ChatMessage],
+                _model: &str,
+                _temp: Option<f64>,
+            ) -> anyhow::Result<String> {
+                anyhow::bail!("401 primary unavailable");
+            }
+        }
+
+        let models_seen: Arc<parking_lot::Mutex<Vec<String>>> =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let models_seen_clone = Arc::clone(&models_seen);
+
+        struct RecordingProvider {
+            models_seen: Arc<parking_lot::Mutex<Vec<String>>>,
+        }
+        #[async_trait]
+        impl Provider for RecordingProvider {
+            async fn chat_with_system(
+                &self,
+                _system: Option<&str>,
+                _msg: &str,
+                model: &str,
+                _temp: Option<f64>,
+            ) -> anyhow::Result<String> {
+                self.models_seen.lock().push(model.to_string());
+                Ok("fallback response".to_string())
+            }
+
+            async fn chat_with_history(
+                &self,
+                _messages: &[ChatMessage],
+                model: &str,
+                _temp: Option<f64>,
+            ) -> anyhow::Result<String> {
+                self.models_seen.lock().push(model.to_string());
+                Ok("fallback response".to_string())
+            }
+        }
+
+        let mut overrides = HashMap::new();
+        overrides.insert("fallback".to_string(), "claude-haiku-override".to_string());
+
+        let provider = ReliableProvider::new(
+            vec![
+                ("primary".into(), Box::new(FailProvider) as Box<dyn Provider>),
+                (
+                    "fallback".into(),
+                    Box::new(RecordingProvider {
+                        models_seen: Arc::clone(&models_seen_clone),
+                    }),
+                ),
+            ],
+            0,
+            1,
+        )
+        .with_provider_model_overrides(overrides);
+
+        let messages = vec![ChatMessage::user("hello")];
+
+        let result = provider
+            .chat_with_history(&messages, "claude-opus-primary", Some(0.0))
+            .await
+            .unwrap();
+        assert_eq!(result, "fallback response");
+
+        let seen = models_seen_clone.lock();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(
+            seen[0], "claude-haiku-override",
+            "chat_with_history must apply per-provider model override"
+        );
+    }
+
+    /// When a fallback is specified with a profile suffix (e.g. "openai-codex:second"),
+    /// `effective_model` must match on the full key — not the stripped base name.
+    /// This mirrors how lib.rs inserts the override: key = full fallback string,
+    /// value = model from [providers.<base_name>].model.
+    #[test]
+    fn effective_model_matches_full_profile_key_not_base_name() {
+        let mut overrides = HashMap::new();
+        overrides.insert("openai-codex:second".to_string(), "gpt-4o".to_string());
+
+        let provider = ReliableProvider::new(vec![], 0, 1)
+            .with_provider_model_overrides(overrides);
+
+        // Full profile key → override applied
+        assert_eq!(
+            provider.effective_model("openai-codex:second", "caller-model"),
+            "gpt-4o"
+        );
+        // Base name alone → no match, caller's model passes through
+        assert_eq!(
+            provider.effective_model("openai-codex", "caller-model"),
+            "caller-model"
+        );
+        // Unrelated provider → no match
+        assert_eq!(
+            provider.effective_model("openai", "caller-model"),
+            "caller-model"
+        );
     }
 }

--- a/crates/zeroclaw-providers/src/reliable.rs
+++ b/crates/zeroclaw-providers/src/reliable.rs
@@ -509,12 +509,7 @@ impl Provider for ReliableProvider {
                                     .first()
                                     .map(|(n, _)| n.as_str())
                                     .unwrap_or("");
-                                record_provider_fallback(
-                                    primary,
-                                    model,
-                                    provider_name,
-                                    eff_model,
-                                );
+                                record_provider_fallback(primary, model, provider_name, eff_model);
                             }
                             return Ok(resp);
                         }
@@ -661,12 +656,7 @@ impl Provider for ReliableProvider {
                                     .first()
                                     .map(|(n, _)| n.as_str())
                                     .unwrap_or("");
-                                record_provider_fallback(
-                                    primary,
-                                    model,
-                                    provider_name,
-                                    eff_model,
-                                );
+                                record_provider_fallback(primary, model, provider_name, eff_model);
                             }
                             return Ok(resp);
                         }
@@ -833,12 +823,7 @@ impl Provider for ReliableProvider {
                                     .first()
                                     .map(|(n, _)| n.as_str())
                                     .unwrap_or("");
-                                record_provider_fallback(
-                                    primary,
-                                    model,
-                                    provider_name,
-                                    eff_model,
-                                );
+                                record_provider_fallback(primary, model, provider_name, eff_model);
                             }
                             return Ok(resp);
                         }
@@ -992,12 +977,7 @@ impl Provider for ReliableProvider {
                                     .first()
                                     .map(|(n, _)| n.as_str())
                                     .unwrap_or("");
-                                record_provider_fallback(
-                                    primary,
-                                    model,
-                                    provider_name,
-                                    eff_model,
-                                );
+                                record_provider_fallback(primary, model, provider_name, eff_model);
                             }
                             return Ok(resp);
                         }
@@ -3067,7 +3047,10 @@ mod tests {
 
         let provider = ReliableProvider::new(
             vec![
-                ("primary".into(), Box::new(FailProvider) as Box<dyn Provider>),
+                (
+                    "primary".into(),
+                    Box::new(FailProvider) as Box<dyn Provider>,
+                ),
                 (
                     "fallback".into(),
                     Box::new(RecordingProvider {
@@ -3157,7 +3140,10 @@ mod tests {
 
         let provider = ReliableProvider::new(
             vec![
-                ("primary".into(), Box::new(FailProvider) as Box<dyn Provider>),
+                (
+                    "primary".into(),
+                    Box::new(FailProvider) as Box<dyn Provider>,
+                ),
                 (
                     "fallback".into(),
                     Box::new(RecordingProvider {
@@ -3195,8 +3181,7 @@ mod tests {
         let mut overrides = HashMap::new();
         overrides.insert("openai-codex:second".to_string(), "gpt-4o".to_string());
 
-        let provider = ReliableProvider::new(vec![], 0, 1)
-            .with_provider_model_overrides(overrides);
+        let provider = ReliableProvider::new(vec![], 0, 1).with_provider_model_overrides(overrides);
 
         // Full profile key → override applied
         assert_eq!(

--- a/tests/live/openai_codex_vision_e2e.rs
+++ b/tests/live/openai_codex_vision_e2e.rs
@@ -165,6 +165,7 @@ async fn openai_codex_second_vision_support() -> Result<()> {
         api_path: None,
         merge_system_into_user: false,
         provider_extra: None,
+        providers_models: std::collections::HashMap::new(),
     };
 
     let provider = zeroclaw::providers::create_provider_with_options("openai-codex", None, &opts)?;


### PR DESCRIPTION
## Summary

  - Base branch: master
  - What changed and why:
    - ProviderRuntimeOptions gains a providers_models: HashMap<String, ModelProviderConfig> field, populated from config.providers.models by provider_runtime_options_from_config() — this is the carrier that threads per-provider config through the factory chain without adding positional parameters.
    - create_resilient_provider_with_options now reads api_key and base_url from providers_models before the env-var lookup runs inside
  resolve_provider_credential, fixing the silent ignore of [providers.X] config blocks for fallback providers (issue #5803).
    - ReliableProvider gains provider_model_overrides and an effective_model() helper; all four chat_* dispatch methods now call it so each fallback provider sends its own configured model instead of inheriting the caller's primary model.
    - load_runtime_defaults_from_config_file now returns (ChannelRuntimeDefaults, ProviderRuntimeOptions) and the hot-reload path uses the freshly parsed ProviderRuntimeOptions — preventing stale startup-time credentials from surviving a config reload.
    - The previously positional Option<&HashMap<…>> parameter was removed from both factory function signatures; callers that had been passing Some(&config.providers.models) now get the same data automatically through options.providers_models.
  - Scope boundary: Primary-provider credential resolution is unchanged. Env vars remain the last resort for all providers. No changes to the Provider trait, any provider implementation, or routing logic. ChannelRuntimeDefaults no longer carries providers_models (it never needed to).
  - Blast radius: All direct callers of create_resilient_provider_with_options and create_routed_provider_with_options (zeroclaw-channels, zeroclaw-gateway, zeroclaw-runtime) — each had the now-removed positional argument patched out. New callers of these functions must populate ProviderRuntimeOptions via provider_runtime_options_from_config to get config-backed fallback credentials; callers that construct ProviderRuntimeOptions by hand will get an empty providers_models and fall back to env vars (backward-compatible).

## Validation Evidence (required)

- Commands run and tail output:

  $ cargo test --package zeroclaw-providers
  ...
  test result: ok. 786 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.66s

  $ cargo build --package zeroclaw-providers
  ...
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 24.79s

  cargo fmt --all -- --check, cargo clippy --all-targets -- -D warnings, and the full workspace cargo test were not run locally.

  - Beyond CI — what did you manually verify?
    - Confirmed the three new unit tests in lib.rs (resilient_fallback_reads_api_key_from_providers_models, resilient_fallback_reads_base_url_from_providers_models, resilient_fallback_empty_providers_models_falls_back_to_env) exercise the wiring at construction time.
    - Confirmed the two behavioral tests in reliable.rs (provider_model_override_used_for_fallback, provider_model_override_used_for_fallback_chat_with_history) verify the model override actually reaches the provider at call time.
    - Confirmed effective_model_matches_full_profile_key_not_base_name catches the profile-suffix key subtlety ("openai-codex:second" vs "openai-codex").
    - Did not verify: end-to-end with a real config file containing [providers.xai]; hot-reload path in a running channel; the chat_with_tools and chat override paths under real traffic.
  - If any command was intentionally skipped, why: Full workspace test run and clippy were skipped — ran package-scoped tests only to keep feedback loops short during iteration.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? No
- New external network calls? No
- Secrets / tokens / credentials handling changed? Yes — api_key values from [providers.X] config blocks now flow into provider constructors for fallback providers, the same path used by primary providers. No new storage or logging of keys; the existing sanitize_api_error path and #[secret] annotation on ModelProviderConfig.api_key are unchanged.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No — test keys are clearly synthetic ("sk-config-provided-key", "xai-test-key", "gpt-4o-fallback").

## Compatibility (required)

  - Backward compatible? Yes — callers that do not populate providers_models get an empty map and env-var resolution proceeds as before.
  - Config / env / CLI surface changed? No — [providers.X] config blocks already existed; this PR makes them effective rather than introducing new syntax.

## Rollback (required for risk: medium and risk: high)

git revert 2f063b0b is the plan. No feature flags. Observable failure symptoms if the revert is needed: fallback providers returning 401/403 errors for users who configured [providers.X] credentials in config (look for non_retryable error, moving on log lines paired with provider=<fallback_name>).