### PR TITLE
fix(ci/docs-deploy): persist CNAME on every Pages deploy

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -88,4 +88,5 @@ jobs:
           publish_dir: docs/book/book
           publish_branch: gh-pages
           force_orphan: true
+          cname: docs.zeroclawlabs.ai
           commit_message: "deploy: ${{ github.event.head_commit.message }}"


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:**
  - Adds `cname: docs.zeroclawlabs.ai` to the `peaceiris/actions-gh-pages` step in `docs-deploy.yml` so every deploy writes a `CNAME` file onto the `gh-pages` branch.
  - The current workflow uses `force_orphan: true` with `publish_dir: docs/book/book`. The repo-root `CNAME` is never inside that publish dir, so each deploy lands a fresh `gh-pages` with no `CNAME`. GitHub Pages reacts by clearing the custom-domain binding (`pages` API returned `"cname": null`), and `docs.zeroclawlabs.ai` 404s until someone re-binds it manually — then the next docs-affecting push to `master` strips it again, producing the "randomly down throughout the day" pattern.
  - The action's `cname:` input is the documented way to persist the binding without checking `CNAME` into the publish directory.
- **Scope boundary:** Only the `cname:` input is added. No build steps, no `publish_dir`, no `force_orphan`, no Pages settings touched. The repo-root `CNAME` file is left in place.
- **Blast radius:** `docs-deploy.yml` workflow only. After merge, the next deploy will write `CNAME` onto `gh-pages` and rebind the domain on Pages. No code changes, no runtime impact.
- **Linked issue(s):** None filed; surfaced from a live incident report.

## Validation Evidence (required)

Workflow-only YAML change. No code paths exercised; CI cannot meaningfully gate this beyond YAML parsing.

- **Commands run and tail output:** N/A — single-line YAML input addition. `cargo fmt`, `clippy`, and `cargo test` are unaffected.
- **Beyond CI — what did you manually verify?**
  - Confirmed pre-fix state with `gh api repos/zeroclaw-labs/zeroclaw/pages` returning `"cname": null` and `"html_url": "https://zeroclaw-labs.github.io/zeroclaw/"`.
  - Confirmed `gh-pages` branch had no `CNAME` file (`gh api .../contents/CNAME?ref=gh-pages` → 404).
  - Confirmed DNS already correct (`dig +short docs.zeroclawlabs.ai` → `zeroclaw-labs.github.io.` + `185.199.108-111.153`).
  - Re-bound the domain manually via `gh api -X PUT repos/zeroclaw-labs/zeroclaw/pages -f cname=docs.zeroclawlabs.ai`; site came back (`HTTP/2 200` on `https://docs.zeroclawlabs.ai/en/`). This PR prevents the next deploy from un-binding it.
  - Did NOT verify a live deploy with the new input — that will happen when this merges.
- **If any command was intentionally skipped, why:** Rust toolchain checks are not relevant to a CI workflow YAML diff.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No`
- New external network calls? `No`
- Secrets / tokens / credentials handling changed? `No` — same `${{ secrets.GITHUB_TOKEN }}` usage.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`

## Compatibility (required)

- Backward compatible? `Yes`
- Config / env / CLI surface changed? `No` (CI workflow input only).

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk: `git revert <sha>` reverts the YAML line. After revert, the binding will need to be re-set manually once before any further deploys re-strip it (the original failure mode).