### PR TITLE
feat(skills): universal skill registry support (agentskills.io, skills.sh)

### DIFF
--- a/crates/zeroclaw-config/src/schema.rs
+++ b/crates/zeroclaw-config/src/schema.rs
@@ -1694,6 +1694,26 @@ fn parse_skills_prompt_injection_mode(raw: &str) -> Option<SkillsPromptInjection
     }
 }
 
+/// An external skill registry that ZeroClaw can pull from.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
+pub struct ExternalRegistry {
+    /// Human-readable name for this registry.
+    pub name: String,
+    /// Base URL of the registry API.
+    pub url: String,
+    /// Registry protocol: `"zip-api"` (HTTP JSON + ZIP download) or `"git"`.
+    #[serde(default = "default_registry_kind")]
+    pub kind: String,
+    /// Whether this registry is enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+fn default_registry_kind() -> String {
+    "zip-api".into()
+}
+
 /// Skills loading configuration (`[skills]` section).
 #[derive(Debug, Clone, Serialize, Deserialize, Default, Configurable)]
 #[cfg_attr(feature = "schema-export", derive(schemars::JsonSchema))]
@@ -1715,6 +1735,9 @@ pub struct SkillsConfig {
     /// Default: `https://github.com/zeroclaw-labs/zeroclaw-skills`
     #[serde(default)]
     pub registry_url: Option<String>,
+    /// Additional external skill registries for install and search.
+    #[serde(default)]
+    pub extra_registries: Vec<ExternalRegistry>,
     /// Controls how skills are injected into the system prompt.
     /// `full` preserves legacy behavior. `compact` keeps context small and loads skills on demand.
     #[serde(default)]

--- a/crates/zeroclaw-runtime/src/skillforge/mod.rs
+++ b/crates/zeroclaw-runtime/src/skillforge/mod.rs
@@ -14,7 +14,7 @@ use tracing::{info, warn};
 
 use self::evaluate::{EvalResult, Evaluator, Recommendation};
 use self::integrate::Integrator;
-use self::scout::{GitHubScout, Scout, ScoutResult, ScoutSource};
+use self::scout::{GitHubScout, HttpJsonScout, Scout, ScoutResult, ScoutSource};
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -44,7 +44,12 @@ fn default_auto_integrate() -> bool {
     true
 }
 fn default_sources() -> Vec<String> {
-    vec!["github".into(), "clawhub".into()]
+    vec![
+        "github".into(),
+        "clawhub".into(),
+        "agentskills".into(),
+        "skillssh".into(),
+    ]
 }
 fn default_scan_interval() -> u64 {
     24
@@ -151,10 +156,58 @@ impl SkillForge {
                         }
                     }
                 }
-                ScoutSource::ClawHub | ScoutSource::HuggingFace => {
+                ScoutSource::ClawHub => {
+                    let scout = HttpJsonScout::new(
+                        "https://clawhub.ai/api/v1/search".into(),
+                        ScoutSource::ClawHub,
+                        "ClawhHub",
+                    );
+                    match scout.discover().await {
+                        Ok(mut found) => {
+                            info!(count = found.len(), "ClawhHub scout returned candidates");
+                            candidates.append(&mut found);
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "ClawhHub scout failed, continuing with other sources");
+                        }
+                    }
+                }
+                ScoutSource::AgentSkillsIo => {
+                    let scout = HttpJsonScout::new(
+                        "https://agentskills.io/api/v1/search".into(),
+                        ScoutSource::AgentSkillsIo,
+                        "agentskills.io",
+                    );
+                    match scout.discover().await {
+                        Ok(mut found) => {
+                            info!(count = found.len(), "agentskills.io scout returned candidates");
+                            candidates.append(&mut found);
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "agentskills.io scout failed, continuing with other sources");
+                        }
+                    }
+                }
+                ScoutSource::SkillsSh => {
+                    let scout = HttpJsonScout::new(
+                        "https://skills.sh/api/v1/search".into(),
+                        ScoutSource::SkillsSh,
+                        "skills.sh",
+                    );
+                    match scout.discover().await {
+                        Ok(mut found) => {
+                            info!(count = found.len(), "skills.sh scout returned candidates");
+                            candidates.append(&mut found);
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "skills.sh scout failed, continuing with other sources");
+                        }
+                    }
+                }
+                ScoutSource::HuggingFace => {
                     info!(
                         source = src.as_str(),
-                        "Source not yet implemented — skipping"
+                        "HuggingFace source not yet implemented — skipping"
                     );
                 }
             }
@@ -250,6 +303,6 @@ mod tests {
         assert!(cfg.auto_integrate);
         assert_eq!(cfg.scan_interval_hours, 24);
         assert!((cfg.min_score - 0.7).abs() < f64::EPSILON);
-        assert_eq!(cfg.sources, vec!["github", "clawhub"]);
+        assert_eq!(cfg.sources, vec!["github", "clawhub", "agentskills", "skillssh"]);
     }
 }

--- a/crates/zeroclaw-runtime/src/skillforge/mod.rs
+++ b/crates/zeroclaw-runtime/src/skillforge/mod.rs
@@ -180,7 +180,10 @@ impl SkillForge {
                     );
                     match scout.discover().await {
                         Ok(mut found) => {
-                            info!(count = found.len(), "agentskills.io scout returned candidates");
+                            info!(
+                                count = found.len(),
+                                "agentskills.io scout returned candidates"
+                            );
                             candidates.append(&mut found);
                         }
                         Err(e) => {
@@ -303,6 +306,9 @@ mod tests {
         assert!(cfg.auto_integrate);
         assert_eq!(cfg.scan_interval_hours, 24);
         assert!((cfg.min_score - 0.7).abs() < f64::EPSILON);
-        assert_eq!(cfg.sources, vec!["github", "clawhub", "agentskills", "skillssh"]);
+        assert_eq!(
+            cfg.sources,
+            vec!["github", "clawhub", "agentskills", "skillssh"]
+        );
     }
 }

--- a/crates/zeroclaw-runtime/src/skillforge/scout.rs
+++ b/crates/zeroclaw-runtime/src/skillforge/scout.rs
@@ -337,7 +337,11 @@ impl Scout for HttpJsonScout {
         };
 
         let items = self.parse_items(&body);
-        debug!(count = items.len(), source = self.source_label, "Parsed items");
+        debug!(
+            count = items.len(),
+            source = self.source_label,
+            "Parsed items"
+        );
         Ok(items)
     }
 }

--- a/crates/zeroclaw-runtime/src/skillforge/scout.rs
+++ b/crates/zeroclaw-runtime/src/skillforge/scout.rs
@@ -15,6 +15,8 @@ pub enum ScoutSource {
     GitHub,
     ClawHub,
     HuggingFace,
+    AgentSkillsIo,
+    SkillsSh,
 }
 
 impl std::str::FromStr for ScoutSource {
@@ -25,6 +27,8 @@ impl std::str::FromStr for ScoutSource {
             "github" => Self::GitHub,
             "clawhub" => Self::ClawHub,
             "huggingface" | "hf" => Self::HuggingFace,
+            "agentskills" | "agentskills.io" => Self::AgentSkillsIo,
+            "skillssh" | "skills.sh" => Self::SkillsSh,
             _ => {
                 warn!(source = s, "Unknown scout source, defaulting to GitHub");
                 Self::GitHub
@@ -212,6 +216,133 @@ impl Scout for GitHubScout {
 }
 
 // ---------------------------------------------------------------------------
+// HttpJsonScout — reusable scout for HTTP JSON search APIs
+// ---------------------------------------------------------------------------
+
+pub struct HttpJsonScout {
+    client: reqwest::Client,
+    search_url: String,
+    source: ScoutSource,
+    source_label: &'static str,
+}
+
+impl HttpJsonScout {
+    pub fn new(search_url: String, source: ScoutSource, source_label: &'static str) -> Self {
+        use std::time::Duration;
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("failed to build reqwest client");
+
+        Self {
+            client,
+            search_url,
+            source,
+            source_label,
+        }
+    }
+
+    fn parse_items(&self, body: &serde_json::Value) -> Vec<ScoutResult> {
+        let items = body
+            .get("skills")
+            .or_else(|| body.get("results"))
+            .or_else(|| body.get("data"))
+            .and_then(|v| v.as_array());
+
+        let Some(items) = items else {
+            return vec![];
+        };
+
+        items
+            .iter()
+            .filter_map(|item| {
+                let name = item
+                    .get("name")
+                    .or_else(|| item.get("slug"))
+                    .and_then(|v| v.as_str())?
+                    .to_string();
+                let url = item
+                    .get("url")
+                    .or_else(|| item.get("html_url"))
+                    .or_else(|| item.get("source_url"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let description = item
+                    .get("description")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let stars = item
+                    .get("stars")
+                    .or_else(|| item.get("downloads"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+
+                Some(ScoutResult {
+                    name,
+                    url,
+                    description,
+                    stars,
+                    language: None,
+                    updated_at: None,
+                    source: self.source,
+                    owner: self.source_label.to_string(),
+                    has_license: false,
+                })
+            })
+            .collect()
+    }
+}
+
+#[async_trait]
+impl Scout for HttpJsonScout {
+    async fn discover(&self) -> Result<Vec<ScoutResult>> {
+        let query = "agent skill";
+        let url = format!("{}?q={}&limit=30", self.search_url, urlencoding(query));
+        debug!(source = self.source_label, "Searching registry");
+
+        let resp = match self.client.get(&url).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(
+                    source = self.source_label,
+                    error = %e,
+                    "Registry search failed, skipping"
+                );
+                return Ok(vec![]);
+            }
+        };
+
+        if !resp.status().is_success() {
+            warn!(
+                status = %resp.status(),
+                source = self.source_label,
+                "Registry search returned non-200"
+            );
+            return Ok(vec![]);
+        }
+
+        let body: serde_json::Value = match resp.json().await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(
+                    source = self.source_label,
+                    error = %e,
+                    "Failed to parse registry response"
+                );
+                return Ok(vec![]);
+            }
+        };
+
+        let items = self.parse_items(&body);
+        debug!(count = items.len(), source = self.source_label, "Parsed items");
+        Ok(items)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -255,6 +386,22 @@ mod tests {
         assert_eq!(
             "hf".parse::<ScoutSource>().unwrap(),
             ScoutSource::HuggingFace
+        );
+        assert_eq!(
+            "agentskills".parse::<ScoutSource>().unwrap(),
+            ScoutSource::AgentSkillsIo
+        );
+        assert_eq!(
+            "agentskills.io".parse::<ScoutSource>().unwrap(),
+            ScoutSource::AgentSkillsIo
+        );
+        assert_eq!(
+            "skillssh".parse::<ScoutSource>().unwrap(),
+            ScoutSource::SkillsSh
+        );
+        assert_eq!(
+            "skills.sh".parse::<ScoutSource>().unwrap(),
+            ScoutSource::SkillsSh
         );
         // unknown falls back to GitHub
         assert_eq!(

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -1,3 +1,4 @@
+pub mod registry;
 pub mod skill_http;
 pub mod skill_tool;
 use anyhow::{Context, Result};
@@ -1223,7 +1224,7 @@ fn detect_newly_installed_directory(
     }
 }
 
-fn enforce_skill_security_audit(
+pub(crate) fn enforce_skill_security_audit(
     skill_path: &Path,
     allow_scripts: bool,
 ) -> Result<audit::SkillAuditReport> {

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -1105,11 +1105,18 @@ fn clawhub_download_url(source: &str) -> Result<String> {
     anyhow::bail!("unrecognised ClawhHub source format: {source}")
 }
 
+/// Normalize a registry-derived slug into a filesystem-safe skill directory
+/// name.
+///
+/// **Preserves hyphens** so the on-disk directory matches the install slug
+/// the user typed — `skills install clawhub:foo-bar` lands in
+/// `skills/foo-bar/`, not `skills/foo_bar/`. Without this, subsequent
+/// `skills audit foo-bar` and `skills remove foo-bar` invocations couldn't
+/// find the skill the user just installed.
 fn normalize_skill_name(s: &str) -> String {
     s.to_lowercase()
         .chars()
-        .map(|c| if c == '-' { '_' } else { c })
-        .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
         .collect()
 }
 

--- a/crates/zeroclaw-runtime/src/skills/mod.rs
+++ b/crates/zeroclaw-runtime/src/skills/mod.rs
@@ -1248,7 +1248,7 @@ fn remove_git_metadata(skill_path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn copy_dir_recursive_secure(src: &Path, dest: &Path) -> Result<()> {
+pub(crate) fn copy_dir_recursive_secure(src: &Path, dest: &Path) -> Result<()> {
     let src_meta = std::fs::symlink_metadata(src)
         .with_context(|| format!("failed to read metadata for {}", src.display()))?;
     if src_meta.file_type().is_symlink() {

--- a/crates/zeroclaw-runtime/src/skills/registry.rs
+++ b/crates/zeroclaw-runtime/src/skills/registry.rs
@@ -164,10 +164,7 @@ fn search_http_json_registry(
     };
 
     if !resp.status().is_success() {
-        tracing::warn!(
-            "{registry_name} search returned HTTP {}",
-            resp.status()
-        );
+        tracing::warn!("{registry_name} search returned HTTP {}", resp.status());
         return Ok(vec![]);
     }
 
@@ -238,22 +235,50 @@ impl ClawhubRegistry {
             "https" | "http" => {}
             _ => return None,
         }
-        if !parsed
-            .host_str()
-            .is_some_and(Self::is_clawhub_host)
-        {
+        if !parsed.host_str().is_some_and(Self::is_clawhub_host) {
             return None;
         }
         Some(parsed)
     }
 
+    /// Bare `owner/slug` (no scheme, exactly one `/`, no leading dot/tilde,
+    /// safe characters only) is treated as a ClawHub shorthand so users can
+    /// run `zeroclaw skills install pskoett/self-improving-agent` without
+    /// typing the full URL or `clawhub:` prefix.
+    fn is_bare_owner_slug(source: &str) -> bool {
+        if source.contains("://") || source.contains(':') {
+            return false;
+        }
+        if source.starts_with('.') || source.starts_with('~') || source.starts_with('/') {
+            return false;
+        }
+        if source.contains('\\') || source.contains("..") {
+            return false;
+        }
+        let parts: Vec<&str> = source.split('/').collect();
+        if parts.len() != 2 {
+            return false;
+        }
+        let segment_ok = |s: &&str| {
+            !s.is_empty()
+                && s.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.')
+                && !s.starts_with('.')
+        };
+        parts.iter().all(segment_ok)
+    }
+
     fn download_url(source: &str) -> Result<String> {
         if let Some(slug) = source.strip_prefix("clawhub:") {
             let slug = slug.trim().trim_end_matches('/');
-            if slug.is_empty() || slug.contains('/') {
+            if slug.is_empty() {
                 anyhow::bail!("invalid clawhub source '{source}': expected 'clawhub:<slug>'");
             }
             return Ok(format!("{CLAWHUB_DOWNLOAD_API}?slug={slug}"));
+        }
+
+        if Self::is_bare_owner_slug(source) {
+            return Ok(format!("{CLAWHUB_DOWNLOAD_API}?slug={source}"));
         }
 
         if let Some(parsed) = Self::parse_url(source) {
@@ -274,15 +299,27 @@ impl ClawhubRegistry {
 
     fn skill_dir_name(source: &str) -> Result<String> {
         let raw = if let Some(slug) = source.strip_prefix("clawhub:") {
-            slug.trim().trim_end_matches('/').rsplit('/').next().unwrap_or(slug)
+            slug.trim()
+                .trim_end_matches('/')
+                .rsplit('/')
+                .next()
+                .unwrap_or(slug)
+        } else if Self::is_bare_owner_slug(source) {
+            source.rsplit('/').next().unwrap_or(source)
         } else if let Some(parsed) = Self::parse_url(source) {
             let segs: Vec<_> = parsed.path_segments().into_iter().flatten().collect();
-            return Ok(normalize_skill_name(segs.last().copied().unwrap_or("skill")));
+            return Ok(normalize_skill_name(
+                segs.last().copied().unwrap_or("skill"),
+            ));
         } else {
             "skill"
         };
         let name = normalize_skill_name(raw);
-        Ok(if name.is_empty() { "skill".into() } else { name })
+        Ok(if name.is_empty() {
+            "skill".into()
+        } else {
+            name
+        })
     }
 }
 
@@ -292,7 +329,9 @@ impl SkillRegistry for ClawhubRegistry {
     }
 
     fn matches_source(&self, source: &str) -> bool {
-        source.starts_with("clawhub:") || Self::parse_url(source).is_some()
+        source.starts_with("clawhub:")
+            || Self::parse_url(source).is_some()
+            || Self::is_bare_owner_slug(source)
     }
 
     fn search(&self, query: &str) -> Result<Vec<SkillSearchResult>> {
@@ -332,10 +371,7 @@ impl AgentSkillsIoRegistry {
             "https" | "http" => {}
             _ => return None,
         }
-        if !parsed
-            .host_str()
-            .is_some_and(Self::is_agentskills_host)
-        {
+        if !parsed.host_str().is_some_and(Self::is_agentskills_host) {
             return None;
         }
         Some(parsed)
@@ -345,7 +381,9 @@ impl AgentSkillsIoRegistry {
         if let Some(slug) = source.strip_prefix("agentskills:") {
             let slug = slug.trim().trim_end_matches('/');
             if slug.is_empty() {
-                anyhow::bail!("invalid agentskills source '{source}': expected 'agentskills:<slug>'");
+                anyhow::bail!(
+                    "invalid agentskills source '{source}': expected 'agentskills:<slug>'"
+                );
             }
             return Ok(format!("{AGENTSKILLS_DOWNLOAD_API}?slug={slug}"));
         }
@@ -371,7 +409,11 @@ impl AgentSkillsIoRegistry {
         if let Some(slug) = source.strip_prefix("agentskills:") {
             let base = slug.trim().trim_end_matches('/');
             let name = normalize_skill_name(base);
-            return if name.is_empty() { "skill".into() } else { name };
+            return if name.is_empty() {
+                "skill".into()
+            } else {
+                name
+            };
         }
         if let Some(parsed) = Self::parse_url(source) {
             let segs: Vec<_> = parsed.path_segments().into_iter().flatten().collect();
@@ -402,7 +444,13 @@ impl SkillRegistry for AgentSkillsIoRegistry {
     ) -> Result<(PathBuf, usize)> {
         let url = Self::download_url(source)?;
         let dir_name = Self::skill_dir_name(source);
-        install_http_zip_skill(&url, &dir_name, skills_path, allow_scripts, "agentskills.io")
+        install_http_zip_skill(
+            &url,
+            &dir_name,
+            skills_path,
+            allow_scripts,
+            "agentskills.io",
+        )
     }
 }
 
@@ -417,8 +465,7 @@ pub struct SkillsShRegistry;
 
 impl SkillsShRegistry {
     fn is_skillssh_host(host: &str) -> bool {
-        host.eq_ignore_ascii_case(SKILLSSH_DOMAIN)
-            || host.eq_ignore_ascii_case(SKILLSSH_WWW_DOMAIN)
+        host.eq_ignore_ascii_case(SKILLSSH_DOMAIN) || host.eq_ignore_ascii_case(SKILLSSH_WWW_DOMAIN)
     }
 
     fn parse_url(source: &str) -> Option<reqwest::Url> {
@@ -427,10 +474,7 @@ impl SkillsShRegistry {
             "https" | "http" => {}
             _ => return None,
         }
-        if !parsed
-            .host_str()
-            .is_some_and(Self::is_skillssh_host)
-        {
+        if !parsed.host_str().is_some_and(Self::is_skillssh_host) {
             return None;
         }
         Some(parsed)
@@ -466,7 +510,11 @@ impl SkillsShRegistry {
         if let Some(slug) = source.strip_prefix("skillssh:") {
             let base = slug.trim().trim_end_matches('/');
             let name = normalize_skill_name(base);
-            return if name.is_empty() { "skill".into() } else { name };
+            return if name.is_empty() {
+                "skill".into()
+            } else {
+                name
+            };
         }
         if let Some(parsed) = Self::parse_url(source) {
             let segs: Vec<_> = parsed.path_segments().into_iter().flatten().collect();
@@ -627,7 +675,16 @@ impl RegistryDispatcher {
     ) -> Option<Result<(PathBuf, usize)>> {
         for reg in &self.registries {
             if reg.matches_source(source) {
-                return Some(reg.install(source, skills_path, allow_scripts));
+                // HTTP-based registries use reqwest::blocking, which spins up
+                // its own tokio runtime. Dropping that nested runtime panics
+                // when this function is called from inside an existing async
+                // context (e.g. the CLI's #[tokio::main]). block_in_place
+                // detaches the current worker thread so nested-runtime drop
+                // is allowed. is_in_async_runtime gates this so tests and
+                // sync callers aren't forced through the wrapper.
+                return Some(call_blocking(|| {
+                    reg.install(source, skills_path, allow_scripts)
+                }));
             }
         }
         None
@@ -636,7 +693,9 @@ impl RegistryDispatcher {
     pub fn search(&self, query: &str) -> Vec<SkillSearchResult> {
         let mut results = Vec::new();
         for reg in &self.registries {
-            match reg.search(query) {
+            // Same async-runtime concern as `install` — see comment there.
+            let outcome = call_blocking(|| reg.search(query));
+            match outcome {
                 Ok(mut r) => results.append(&mut r),
                 Err(e) => {
                     tracing::warn!("search failed for {}: {e}", reg.name());
@@ -644,6 +703,20 @@ impl RegistryDispatcher {
             }
         }
         results
+    }
+}
+
+/// Run blocking I/O work, isolated from any enclosing tokio runtime.
+///
+/// Inside a multi-thread tokio runtime we use `block_in_place` so that the
+/// dropped `reqwest::blocking` runtime doesn't trip the "cannot drop a
+/// runtime in async context" panic. Outside a runtime (sync callers, unit
+/// tests) we just run the closure directly.
+fn call_blocking<R>(f: impl FnOnce() -> R) -> R {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        tokio::task::block_in_place(f)
+    } else {
+        f()
     }
 }
 
@@ -660,14 +733,12 @@ impl SkillRegistry for CustomHttpRegistry {
     }
 
     fn matches_source(&self, source: &str) -> bool {
-        if let Ok(parsed) = reqwest::Url::parse(source) {
-            if let Some(host) = parsed.host_str() {
-                if let Ok(base) = reqwest::Url::parse(&self.base_url) {
-                    if let Some(base_host) = base.host_str() {
-                        return host.eq_ignore_ascii_case(base_host);
-                    }
-                }
-            }
+        if let Ok(parsed) = reqwest::Url::parse(source)
+            && let Some(host) = parsed.host_str()
+            && let Ok(base) = reqwest::Url::parse(&self.base_url)
+            && let Some(base_host) = base.host_str()
+        {
+            return host.eq_ignore_ascii_case(base_host);
         }
         false
     }
@@ -689,8 +760,7 @@ impl SkillRegistry for CustomHttpRegistry {
             .path_segments()
             .into_iter()
             .flatten()
-            .filter(|s| !s.is_empty())
-            .last()
+            .rfind(|s| !s.is_empty())
             .unwrap_or("skill");
         let dir_name = normalize_skill_name(slug);
         let download_url = format!(
@@ -729,6 +799,40 @@ mod tests {
         assert!(r.matches_source("https://clawhub.ai/user/skill"));
         assert!(!r.matches_source("agentskills:foo"));
         assert!(!r.matches_source("https://agentskills.io/foo"));
+    }
+
+    #[test]
+    fn clawhub_accepts_owner_slug_with_slash_in_prefix_form() {
+        // Real ClawHub slugs are owner/name, e.g. `pskoett/self-improving-agent`.
+        // The previous parser hardcoded `slug.contains('/')` as invalid.
+        let url = ClawhubRegistry::download_url("clawhub:pskoett/self-improving-agent").unwrap();
+        assert_eq!(
+            url,
+            "https://clawhub.ai/api/v1/download?slug=pskoett/self-improving-agent"
+        );
+    }
+
+    #[test]
+    fn clawhub_accepts_bare_owner_slug() {
+        let r = ClawhubRegistry;
+        assert!(r.matches_source("pskoett/self-improving-agent"));
+        let url = ClawhubRegistry::download_url("pskoett/self-improving-agent").unwrap();
+        assert_eq!(
+            url,
+            "https://clawhub.ai/api/v1/download?slug=pskoett/self-improving-agent"
+        );
+        let dir = ClawhubRegistry::skill_dir_name("pskoett/self-improving-agent").unwrap();
+        assert_eq!(dir, "self_improving_agent");
+    }
+
+    #[test]
+    fn clawhub_rejects_three_segment_paths() {
+        // path/to/something is a local path, not a ClawHub shorthand.
+        let r = ClawhubRegistry;
+        assert!(!r.matches_source("path/to/something"));
+        assert!(!r.matches_source("./local/path"));
+        assert!(!r.matches_source("../other/skill"));
+        assert!(!r.matches_source("/abs/path"));
     }
 
     #[test]

--- a/crates/zeroclaw-runtime/src/skills/registry.rs
+++ b/crates/zeroclaw-runtime/src/skills/registry.rs
@@ -1,0 +1,769 @@
+use anyhow::{Context, Result};
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use zip::ZipArchive;
+
+// ─── Shared types ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct SkillSearchResult {
+    pub name: String,
+    pub description: String,
+    pub registry: String,
+    pub source_url: String,
+    pub version: Option<String>,
+}
+
+pub trait SkillRegistry: Send + Sync {
+    fn name(&self) -> &str;
+    fn matches_source(&self, source: &str) -> bool;
+    fn search(&self, query: &str) -> Result<Vec<SkillSearchResult>>;
+    fn install(
+        &self,
+        source: &str,
+        skills_path: &Path,
+        allow_scripts: bool,
+    ) -> Result<(PathBuf, usize)>;
+}
+
+// ─── Shared HTTP ZIP installer ───────────────────────────────────────────────
+
+const MAX_ZIP_BYTES: u64 = 50 * 1024 * 1024; // 50 MiB
+const MAX_ZIP_ENTRIES: usize = 500;
+const MAX_DECOMPRESSION_RATIO: u64 = 10;
+
+fn http_client() -> Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("failed to build HTTP client")
+}
+
+pub fn install_http_zip_skill(
+    download_url: &str,
+    skill_dir_name: &str,
+    skills_path: &Path,
+    allow_scripts: bool,
+    registry_name: &str,
+) -> Result<(PathBuf, usize)> {
+    let installed_dir = skills_path.join(skill_dir_name);
+    if installed_dir.exists() {
+        anyhow::bail!(
+            "Destination skill already exists: {}",
+            installed_dir.display()
+        );
+    }
+
+    let client = http_client()?;
+    let resp = client
+        .get(download_url)
+        .send()
+        .with_context(|| format!("failed to fetch zip from {download_url}"))?;
+
+    if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        anyhow::bail!("{registry_name} rate limit reached (HTTP 429). Wait a moment and retry.");
+    }
+    if !resp.status().is_success() {
+        anyhow::bail!("{registry_name} download failed (HTTP {})", resp.status());
+    }
+
+    let bytes = resp.bytes()?.to_vec();
+    let compressed_size = bytes.len() as u64;
+    if compressed_size > MAX_ZIP_BYTES {
+        anyhow::bail!(
+            "{registry_name} zip rejected: too large ({compressed_size} bytes > {MAX_ZIP_BYTES})"
+        );
+    }
+
+    std::fs::create_dir_all(&installed_dir)?;
+
+    let cursor = Cursor::new(bytes);
+    let mut archive = ZipArchive::new(cursor).context("downloaded content is not a valid zip")?;
+
+    if archive.len() > MAX_ZIP_ENTRIES {
+        let _ = std::fs::remove_dir_all(&installed_dir);
+        anyhow::bail!(
+            "{registry_name} zip rejected: too many entries ({} > {MAX_ZIP_ENTRIES})",
+            archive.len()
+        );
+    }
+
+    let mut decompressed_total: u64 = 0;
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i)?;
+        let raw_name = entry.name().to_string();
+
+        if raw_name.is_empty()
+            || raw_name.contains("..")
+            || raw_name.starts_with('/')
+            || raw_name.contains('\\')
+            || raw_name.contains(':')
+        {
+            let _ = std::fs::remove_dir_all(&installed_dir);
+            anyhow::bail!("zip entry contains unsafe path: {raw_name}");
+        }
+
+        decompressed_total += entry.size();
+        if compressed_size > 0 && decompressed_total > compressed_size * MAX_DECOMPRESSION_RATIO {
+            let _ = std::fs::remove_dir_all(&installed_dir);
+            anyhow::bail!(
+                "{registry_name} zip rejected: decompression ratio exceeds {MAX_DECOMPRESSION_RATIO}x (zip bomb protection)"
+            );
+        }
+
+        let out_path = installed_dir.join(&raw_name);
+        if entry.is_dir() {
+            std::fs::create_dir_all(&out_path)?;
+            continue;
+        }
+
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let mut out_file = std::fs::File::create(&out_path)
+            .with_context(|| format!("failed to create extracted file: {}", out_path.display()))?;
+        std::io::copy(&mut entry, &mut out_file)?;
+    }
+
+    let has_manifest = installed_dir.join("SKILL.md").exists()
+        || installed_dir.join("SKILL.toml").exists()
+        || installed_dir.join("manifest.toml").exists();
+    if !has_manifest {
+        std::fs::write(
+            installed_dir.join("SKILL.toml"),
+            format!(
+                "[skill]\nname = \"{skill_dir_name}\"\ndescription = \"{registry_name} installed skill\"\nversion = \"0.1.0\"\n"
+            ),
+        )?;
+    }
+
+    match super::enforce_skill_security_audit(&installed_dir, allow_scripts) {
+        Ok(report) => Ok((installed_dir, report.files_scanned)),
+        Err(err) => {
+            let _ = std::fs::remove_dir_all(&installed_dir);
+            Err(err)
+        }
+    }
+}
+
+fn search_http_json_registry(
+    api_url: &str,
+    query: &str,
+    registry_name: &str,
+) -> Result<Vec<SkillSearchResult>> {
+    let client = http_client()?;
+    let url = format!("{api_url}?q={}", urlencoding::encode(query));
+    let resp = match client.get(&url).send() {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("{registry_name} search failed: {e}");
+            return Ok(vec![]);
+        }
+    };
+
+    if !resp.status().is_success() {
+        tracing::warn!(
+            "{registry_name} search returned HTTP {}",
+            resp.status()
+        );
+        return Ok(vec![]);
+    }
+
+    let body: serde_json::Value = resp.json().context("invalid JSON from registry")?;
+
+    let items = body
+        .get("skills")
+        .or_else(|| body.get("results"))
+        .or_else(|| body.get("data"))
+        .and_then(|v| v.as_array());
+
+    let Some(items) = items else {
+        return Ok(vec![]);
+    };
+
+    Ok(items
+        .iter()
+        .filter_map(|item| {
+            let name = item
+                .get("name")
+                .or_else(|| item.get("slug"))
+                .and_then(|v| v.as_str())?
+                .to_string();
+            let description = item
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let version = item
+                .get("version")
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            let source_url = item
+                .get("url")
+                .or_else(|| item.get("source_url"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            Some(SkillSearchResult {
+                name,
+                description,
+                registry: registry_name.to_string(),
+                source_url,
+                version,
+            })
+        })
+        .collect())
+}
+
+// ─── ClawhHub registry ──────────────────────────────────────────────────────
+
+const CLAWHUB_DOMAIN: &str = "clawhub.ai";
+const CLAWHUB_WWW_DOMAIN: &str = "www.clawhub.ai";
+const CLAWHUB_DOWNLOAD_API: &str = "https://clawhub.ai/api/v1/download";
+const CLAWHUB_SEARCH_API: &str = "https://clawhub.ai/api/v1/search";
+
+pub struct ClawhubRegistry;
+
+impl ClawhubRegistry {
+    fn is_clawhub_host(host: &str) -> bool {
+        host.eq_ignore_ascii_case(CLAWHUB_DOMAIN) || host.eq_ignore_ascii_case(CLAWHUB_WWW_DOMAIN)
+    }
+
+    fn parse_url(source: &str) -> Option<reqwest::Url> {
+        let parsed = reqwest::Url::parse(source).ok()?;
+        match parsed.scheme() {
+            "https" | "http" => {}
+            _ => return None,
+        }
+        if !parsed
+            .host_str()
+            .is_some_and(Self::is_clawhub_host)
+        {
+            return None;
+        }
+        Some(parsed)
+    }
+
+    fn download_url(source: &str) -> Result<String> {
+        if let Some(slug) = source.strip_prefix("clawhub:") {
+            let slug = slug.trim().trim_end_matches('/');
+            if slug.is_empty() || slug.contains('/') {
+                anyhow::bail!("invalid clawhub source '{source}': expected 'clawhub:<slug>'");
+            }
+            return Ok(format!("{CLAWHUB_DOWNLOAD_API}?slug={slug}"));
+        }
+
+        if let Some(parsed) = Self::parse_url(source) {
+            let path = parsed
+                .path_segments()
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>()
+                .join("/");
+            if path.is_empty() {
+                anyhow::bail!("could not extract slug from ClawhHub URL: {source}");
+            }
+            return Ok(format!("{CLAWHUB_DOWNLOAD_API}?slug={path}"));
+        }
+
+        anyhow::bail!("unrecognised ClawhHub source format: {source}")
+    }
+
+    fn skill_dir_name(source: &str) -> Result<String> {
+        let raw = if let Some(slug) = source.strip_prefix("clawhub:") {
+            slug.trim().trim_end_matches('/').rsplit('/').next().unwrap_or(slug)
+        } else if let Some(parsed) = Self::parse_url(source) {
+            let segs: Vec<_> = parsed.path_segments().into_iter().flatten().collect();
+            return Ok(normalize_skill_name(segs.last().copied().unwrap_or("skill")));
+        } else {
+            "skill"
+        };
+        let name = normalize_skill_name(raw);
+        Ok(if name.is_empty() { "skill".into() } else { name })
+    }
+}
+
+impl SkillRegistry for ClawhubRegistry {
+    fn name(&self) -> &str {
+        "ClawhHub"
+    }
+
+    fn matches_source(&self, source: &str) -> bool {
+        source.starts_with("clawhub:") || Self::parse_url(source).is_some()
+    }
+
+    fn search(&self, query: &str) -> Result<Vec<SkillSearchResult>> {
+        search_http_json_registry(CLAWHUB_SEARCH_API, query, "ClawhHub")
+    }
+
+    fn install(
+        &self,
+        source: &str,
+        skills_path: &Path,
+        allow_scripts: bool,
+    ) -> Result<(PathBuf, usize)> {
+        let url = Self::download_url(source)?;
+        let dir_name = Self::skill_dir_name(source)?;
+        install_http_zip_skill(&url, &dir_name, skills_path, allow_scripts, "ClawhHub")
+    }
+}
+
+// ─── agentskills.io registry ─────────────────────────────────────────────────
+
+const AGENTSKILLS_DOMAIN: &str = "agentskills.io";
+const AGENTSKILLS_WWW_DOMAIN: &str = "www.agentskills.io";
+const AGENTSKILLS_DOWNLOAD_API: &str = "https://agentskills.io/api/v1/download";
+const AGENTSKILLS_SEARCH_API: &str = "https://agentskills.io/api/v1/search";
+
+pub struct AgentSkillsIoRegistry;
+
+impl AgentSkillsIoRegistry {
+    fn is_agentskills_host(host: &str) -> bool {
+        host.eq_ignore_ascii_case(AGENTSKILLS_DOMAIN)
+            || host.eq_ignore_ascii_case(AGENTSKILLS_WWW_DOMAIN)
+    }
+
+    fn parse_url(source: &str) -> Option<reqwest::Url> {
+        let parsed = reqwest::Url::parse(source).ok()?;
+        match parsed.scheme() {
+            "https" | "http" => {}
+            _ => return None,
+        }
+        if !parsed
+            .host_str()
+            .is_some_and(Self::is_agentskills_host)
+        {
+            return None;
+        }
+        Some(parsed)
+    }
+
+    fn download_url(source: &str) -> Result<String> {
+        if let Some(slug) = source.strip_prefix("agentskills:") {
+            let slug = slug.trim().trim_end_matches('/');
+            if slug.is_empty() {
+                anyhow::bail!("invalid agentskills source '{source}': expected 'agentskills:<slug>'");
+            }
+            return Ok(format!("{AGENTSKILLS_DOWNLOAD_API}?slug={slug}"));
+        }
+
+        if let Some(parsed) = Self::parse_url(source) {
+            let path = parsed
+                .path_segments()
+                .into_iter()
+                .flatten()
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .join("/");
+            if path.is_empty() {
+                anyhow::bail!("could not extract slug from agentskills.io URL: {source}");
+            }
+            return Ok(format!("{AGENTSKILLS_DOWNLOAD_API}?slug={path}"));
+        }
+
+        anyhow::bail!("unrecognised agentskills.io source format: {source}")
+    }
+
+    fn skill_dir_name(source: &str) -> String {
+        if let Some(slug) = source.strip_prefix("agentskills:") {
+            let base = slug.trim().trim_end_matches('/');
+            let name = normalize_skill_name(base);
+            return if name.is_empty() { "skill".into() } else { name };
+        }
+        if let Some(parsed) = Self::parse_url(source) {
+            let segs: Vec<_> = parsed.path_segments().into_iter().flatten().collect();
+            return normalize_skill_name(segs.last().copied().unwrap_or("skill"));
+        }
+        "skill".into()
+    }
+}
+
+impl SkillRegistry for AgentSkillsIoRegistry {
+    fn name(&self) -> &str {
+        "agentskills.io"
+    }
+
+    fn matches_source(&self, source: &str) -> bool {
+        source.starts_with("agentskills:") || Self::parse_url(source).is_some()
+    }
+
+    fn search(&self, query: &str) -> Result<Vec<SkillSearchResult>> {
+        search_http_json_registry(AGENTSKILLS_SEARCH_API, query, "agentskills.io")
+    }
+
+    fn install(
+        &self,
+        source: &str,
+        skills_path: &Path,
+        allow_scripts: bool,
+    ) -> Result<(PathBuf, usize)> {
+        let url = Self::download_url(source)?;
+        let dir_name = Self::skill_dir_name(source);
+        install_http_zip_skill(&url, &dir_name, skills_path, allow_scripts, "agentskills.io")
+    }
+}
+
+// ─── skills.sh registry ─────────────────────────────────────────────────────
+
+const SKILLSSH_DOMAIN: &str = "skills.sh";
+const SKILLSSH_WWW_DOMAIN: &str = "www.skills.sh";
+const SKILLSSH_DOWNLOAD_API: &str = "https://skills.sh/api/v1/download";
+const SKILLSSH_SEARCH_API: &str = "https://skills.sh/api/v1/search";
+
+pub struct SkillsShRegistry;
+
+impl SkillsShRegistry {
+    fn is_skillssh_host(host: &str) -> bool {
+        host.eq_ignore_ascii_case(SKILLSSH_DOMAIN)
+            || host.eq_ignore_ascii_case(SKILLSSH_WWW_DOMAIN)
+    }
+
+    fn parse_url(source: &str) -> Option<reqwest::Url> {
+        let parsed = reqwest::Url::parse(source).ok()?;
+        match parsed.scheme() {
+            "https" | "http" => {}
+            _ => return None,
+        }
+        if !parsed
+            .host_str()
+            .is_some_and(Self::is_skillssh_host)
+        {
+            return None;
+        }
+        Some(parsed)
+    }
+
+    fn download_url(source: &str) -> Result<String> {
+        if let Some(slug) = source.strip_prefix("skillssh:") {
+            let slug = slug.trim().trim_end_matches('/');
+            if slug.is_empty() {
+                anyhow::bail!("invalid skills.sh source '{source}': expected 'skillssh:<slug>'");
+            }
+            return Ok(format!("{SKILLSSH_DOWNLOAD_API}?slug={slug}"));
+        }
+
+        if let Some(parsed) = Self::parse_url(source) {
+            let path = parsed
+                .path_segments()
+                .into_iter()
+                .flatten()
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .join("/");
+            if path.is_empty() {
+                anyhow::bail!("could not extract slug from skills.sh URL: {source}");
+            }
+            return Ok(format!("{SKILLSSH_DOWNLOAD_API}?slug={path}"));
+        }
+
+        anyhow::bail!("unrecognised skills.sh source format: {source}")
+    }
+
+    fn skill_dir_name(source: &str) -> String {
+        if let Some(slug) = source.strip_prefix("skillssh:") {
+            let base = slug.trim().trim_end_matches('/');
+            let name = normalize_skill_name(base);
+            return if name.is_empty() { "skill".into() } else { name };
+        }
+        if let Some(parsed) = Self::parse_url(source) {
+            let segs: Vec<_> = parsed.path_segments().into_iter().flatten().collect();
+            return normalize_skill_name(segs.last().copied().unwrap_or("skill"));
+        }
+        "skill".into()
+    }
+}
+
+impl SkillRegistry for SkillsShRegistry {
+    fn name(&self) -> &str {
+        "skills.sh"
+    }
+
+    fn matches_source(&self, source: &str) -> bool {
+        source.starts_with("skillssh:") || Self::parse_url(source).is_some()
+    }
+
+    fn search(&self, query: &str) -> Result<Vec<SkillSearchResult>> {
+        search_http_json_registry(SKILLSSH_SEARCH_API, query, "skills.sh")
+    }
+
+    fn install(
+        &self,
+        source: &str,
+        skills_path: &Path,
+        allow_scripts: bool,
+    ) -> Result<(PathBuf, usize)> {
+        let url = Self::download_url(source)?;
+        let dir_name = Self::skill_dir_name(source);
+        install_http_zip_skill(&url, &dir_name, skills_path, allow_scripts, "skills.sh")
+    }
+}
+
+// ─── Git registry ────────────────────────────────────────────────────────────
+
+pub struct GitRegistry;
+
+impl SkillRegistry for GitRegistry {
+    fn name(&self) -> &str {
+        "git"
+    }
+
+    fn matches_source(&self, source: &str) -> bool {
+        if ClawhubRegistry.matches_source(source)
+            || AgentSkillsIoRegistry.matches_source(source)
+            || SkillsShRegistry.matches_source(source)
+        {
+            return false;
+        }
+        super::is_git_source(source)
+    }
+
+    fn search(&self, _query: &str) -> Result<Vec<SkillSearchResult>> {
+        Ok(vec![])
+    }
+
+    fn install(
+        &self,
+        source: &str,
+        skills_path: &Path,
+        allow_scripts: bool,
+    ) -> Result<(PathBuf, usize)> {
+        super::install_git_skill_source(source, skills_path, allow_scripts)
+    }
+}
+
+// ─── ZeroClaw skills registry (bare-name git repo) ──────────────────────────
+
+pub struct ZeroClawSkillsRegistry {
+    pub workspace_dir: PathBuf,
+    pub registry_url: Option<String>,
+}
+
+impl SkillRegistry for ZeroClawSkillsRegistry {
+    fn name(&self) -> &str {
+        "zeroclaw-skills"
+    }
+
+    fn matches_source(&self, source: &str) -> bool {
+        super::is_registry_source(source)
+    }
+
+    fn search(&self, query: &str) -> Result<Vec<SkillSearchResult>> {
+        let registry_dir =
+            super::ensure_skills_registry(&self.workspace_dir, self.registry_url.as_deref())?;
+        let names = super::list_registry_skill_names(&registry_dir);
+        let query_lower = query.to_lowercase();
+        Ok(names
+            .into_iter()
+            .filter(|n| n.to_lowercase().contains(&query_lower))
+            .map(|n| SkillSearchResult {
+                source_url: n.clone(),
+                name: n,
+                description: String::new(),
+                registry: "zeroclaw-skills".into(),
+                version: None,
+            })
+            .collect())
+    }
+
+    fn install(
+        &self,
+        source: &str,
+        skills_path: &Path,
+        allow_scripts: bool,
+    ) -> Result<(PathBuf, usize)> {
+        super::install_registry_skill_source(
+            source,
+            skills_path,
+            allow_scripts,
+            &self.workspace_dir,
+            self.registry_url.as_deref(),
+        )
+    }
+}
+
+// ─── Registry dispatcher ────────────────────────────────────────────────────
+
+pub struct RegistryDispatcher {
+    registries: Vec<Box<dyn SkillRegistry>>,
+}
+
+impl RegistryDispatcher {
+    pub fn from_config(
+        skills_config: &zeroclaw_config::schema::SkillsConfig,
+        workspace_dir: &Path,
+    ) -> Self {
+        let mut registries: Vec<Box<dyn SkillRegistry>> = vec![
+            Box::new(ClawhubRegistry),
+            Box::new(AgentSkillsIoRegistry),
+            Box::new(SkillsShRegistry),
+            Box::new(GitRegistry),
+            Box::new(ZeroClawSkillsRegistry {
+                workspace_dir: workspace_dir.to_path_buf(),
+                registry_url: skills_config.registry_url.clone(),
+            }),
+        ];
+
+        for ext in &skills_config.extra_registries {
+            if !ext.enabled {
+                continue;
+            }
+            registries.push(Box::new(CustomHttpRegistry {
+                reg_name: ext.name.clone(),
+                base_url: ext.url.clone(),
+            }));
+        }
+
+        Self { registries }
+    }
+
+    pub fn install(
+        &self,
+        source: &str,
+        skills_path: &Path,
+        allow_scripts: bool,
+    ) -> Option<Result<(PathBuf, usize)>> {
+        for reg in &self.registries {
+            if reg.matches_source(source) {
+                return Some(reg.install(source, skills_path, allow_scripts));
+            }
+        }
+        None
+    }
+
+    pub fn search(&self, query: &str) -> Vec<SkillSearchResult> {
+        let mut results = Vec::new();
+        for reg in &self.registries {
+            match reg.search(query) {
+                Ok(mut r) => results.append(&mut r),
+                Err(e) => {
+                    tracing::warn!("search failed for {}: {e}", reg.name());
+                }
+            }
+        }
+        results
+    }
+}
+
+// ─── Custom HTTP registry (user-configured) ─────────────────────────────────
+
+struct CustomHttpRegistry {
+    reg_name: String,
+    base_url: String,
+}
+
+impl SkillRegistry for CustomHttpRegistry {
+    fn name(&self) -> &str {
+        &self.reg_name
+    }
+
+    fn matches_source(&self, source: &str) -> bool {
+        if let Ok(parsed) = reqwest::Url::parse(source) {
+            if let Some(host) = parsed.host_str() {
+                if let Ok(base) = reqwest::Url::parse(&self.base_url) {
+                    if let Some(base_host) = base.host_str() {
+                        return host.eq_ignore_ascii_case(base_host);
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    fn search(&self, query: &str) -> Result<Vec<SkillSearchResult>> {
+        let search_url = format!("{}/search", self.base_url.trim_end_matches('/'));
+        search_http_json_registry(&search_url, query, &self.reg_name)
+    }
+
+    fn install(
+        &self,
+        source: &str,
+        skills_path: &Path,
+        allow_scripts: bool,
+    ) -> Result<(PathBuf, usize)> {
+        let parsed = reqwest::Url::parse(source)
+            .with_context(|| format!("invalid URL for {}: {source}", self.reg_name))?;
+        let slug = parsed
+            .path_segments()
+            .into_iter()
+            .flatten()
+            .filter(|s| !s.is_empty())
+            .last()
+            .unwrap_or("skill");
+        let dir_name = normalize_skill_name(slug);
+        let download_url = format!(
+            "{}/download?slug={}",
+            self.base_url.trim_end_matches('/'),
+            slug
+        );
+        install_http_zip_skill(
+            &download_url,
+            &dir_name,
+            skills_path,
+            allow_scripts,
+            &self.reg_name,
+        )
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn normalize_skill_name(s: &str) -> String {
+    s.to_lowercase()
+        .chars()
+        .map(|c| if c == '-' { '_' } else { c })
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clawhub_matches() {
+        let r = ClawhubRegistry;
+        assert!(r.matches_source("clawhub:my-skill"));
+        assert!(r.matches_source("https://clawhub.ai/user/skill"));
+        assert!(!r.matches_source("agentskills:foo"));
+        assert!(!r.matches_source("https://agentskills.io/foo"));
+    }
+
+    #[test]
+    fn agentskills_matches() {
+        let r = AgentSkillsIoRegistry;
+        assert!(r.matches_source("agentskills:my-skill"));
+        assert!(r.matches_source("https://agentskills.io/skills/my-skill"));
+        assert!(!r.matches_source("clawhub:foo"));
+        assert!(!r.matches_source("skillssh:foo"));
+    }
+
+    #[test]
+    fn skillssh_matches() {
+        let r = SkillsShRegistry;
+        assert!(r.matches_source("skillssh:my-skill"));
+        assert!(r.matches_source("https://skills.sh/skills/my-skill"));
+        assert!(!r.matches_source("clawhub:foo"));
+        assert!(!r.matches_source("agentskills:foo"));
+    }
+
+    #[test]
+    fn git_registry_excludes_known_registries() {
+        let r = GitRegistry;
+        assert!(!r.matches_source("clawhub:foo"));
+        assert!(!r.matches_source("agentskills:foo"));
+        assert!(!r.matches_source("skillssh:foo"));
+        assert!(!r.matches_source("https://clawhub.ai/user/skill"));
+        assert!(!r.matches_source("https://agentskills.io/foo"));
+        assert!(!r.matches_source("https://skills.sh/foo"));
+    }
+
+    #[test]
+    fn normalize_names() {
+        assert_eq!(normalize_skill_name("My-Skill"), "my_skill");
+        assert_eq!(normalize_skill_name("web_scraper"), "web_scraper");
+        assert_eq!(normalize_skill_name("foo/bar"), "foobar");
+    }
+}

--- a/crates/zeroclaw-runtime/src/skills/registry.rs
+++ b/crates/zeroclaw-runtime/src/skills/registry.rs
@@ -529,22 +529,39 @@ impl SkillRegistry for AgentSkillsIoRegistry {
         skills_path: &Path,
         allow_scripts: bool,
     ) -> Result<(PathBuf, usize)> {
-        // Translate the source into a skillssh: triplet and delegate.
-        let translated = if let Some(rest) = source.strip_prefix("agentskills:") {
-            format!("skillssh:{}", rest.trim().trim_matches('/'))
+        // Extract the path portion from either the `agentskills:` prefix
+        // form or a full agentskills.io URL.
+        let path = if let Some(rest) = source.strip_prefix("agentskills:") {
+            rest.trim().trim_matches('/').to_string()
         } else if let Some(parsed) = Self::parse_url(source) {
-            let path = parsed
+            parsed
                 .path_segments()
                 .into_iter()
                 .flatten()
                 .filter(|s| !s.is_empty())
                 .collect::<Vec<_>>()
-                .join("/");
-            format!("skillssh:{path}")
+                .join("/")
         } else {
             anyhow::bail!("unrecognised agentskills.io source format: {source}")
         };
-        SkillsShRegistry.install(&translated, skills_path, allow_scripts)
+
+        // agentskills.io delegates downloads to skills.sh, which requires a
+        // `<owner>/<repo>/<skill>` triplet. Validate up front with an
+        // agentskills-shaped error so users don't see the internal
+        // skillssh: translation leak through (which previously made the
+        // error message look like they'd typed `skillssh:` when they
+        // hadn't).
+        let segs: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+        if segs.len() != 3 {
+            anyhow::bail!(
+                "invalid agentskills.io source '{source}': expected \
+                 'agentskills:<owner>/<repo>/<skill>' \
+                 (e.g. agentskills:anthropics/skills/webapp-testing). Got {} segment(s).",
+                segs.len()
+            );
+        }
+
+        SkillsShRegistry.install(&format!("skillssh:{path}"), skills_path, allow_scripts)
     }
 }
 
@@ -969,11 +986,18 @@ impl SkillRegistry for CustomHttpRegistry {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
+/// Normalize a registry-derived slug into a filesystem-safe skill directory
+/// name.
+///
+/// **Preserves hyphens** so the on-disk directory matches the install slug
+/// the user typed — `skills install clawhub:foo-bar` lands in
+/// `skills/foo-bar/`, not `skills/foo_bar/`. Without this, subsequent
+/// `skills audit foo-bar` and `skills remove foo-bar` invocations couldn't
+/// find the skill the user just installed.
 fn normalize_skill_name(s: &str) -> String {
     s.to_lowercase()
         .chars()
-        .map(|c| if c == '-' { '_' } else { c })
-        .filter(|c| c.is_ascii_alphanumeric() || *c == '_')
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
         .collect()
 }
 
@@ -1011,7 +1035,10 @@ mod tests {
             "https://clawhub.ai/api/v1/download?slug=pskoett/self-improving-agent"
         );
         let dir = ClawhubRegistry::skill_dir_name("pskoett/self-improving-agent").unwrap();
-        assert_eq!(dir, "self_improving_agent");
+        // Hyphens are now preserved so the on-disk dir matches the install
+        // slug, allowing `skills audit/remove self-improving-agent` to
+        // resolve to the same directory after install.
+        assert_eq!(dir, "self-improving-agent");
     }
 
     #[test]
@@ -1054,9 +1081,58 @@ mod tests {
     }
 
     #[test]
-    fn normalize_names() {
-        assert_eq!(normalize_skill_name("My-Skill"), "my_skill");
+    fn normalize_names_preserves_hyphens() {
+        // Hyphens are now preserved so the on-disk dir matches the install
+        // slug. Previously this asserted "my_skill" — that broke
+        // `skills audit my-skill` and `skills remove my-skill` after a
+        // ClawhHub install of `clawhub:my-skill`.
+        assert_eq!(normalize_skill_name("My-Skill"), "my-skill");
         assert_eq!(normalize_skill_name("web_scraper"), "web_scraper");
+        assert_eq!(
+            normalize_skill_name("acong-hello-world"),
+            "acong-hello-world"
+        );
         assert_eq!(normalize_skill_name("foo/bar"), "foobar");
+        // Underscores and lowercasing are still applied.
+        assert_eq!(normalize_skill_name("FOO_BAR"), "foo_bar");
+        // Other punctuation is still stripped.
+        assert_eq!(normalize_skill_name("a.b@c"), "abc");
+    }
+
+    #[test]
+    fn agentskills_install_validates_three_segment_format() {
+        // The pre-fix routing silently translated `agentskills:hello-world`
+        // into `skillssh:hello-world` and then leaked the skills.sh-shaped
+        // error to the user. Now we validate up front and produce an
+        // agentskills-shaped message.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let r = AgentSkillsIoRegistry;
+
+        let err = r
+            .install("agentskills:hello-world", tmp.path(), false)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("invalid agentskills.io source"),
+            "expected agentskills-shaped error, got: {err}"
+        );
+        assert!(
+            err.contains("<owner>/<repo>/<skill>"),
+            "expected format hint in error, got: {err}"
+        );
+        assert!(
+            !err.contains("skillssh:"),
+            "internal skillssh: translation should not leak into error: {err}"
+        );
+
+        // Two-segment input is also invalid.
+        let err = r
+            .install("agentskills:foo/bar", tmp.path(), false)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("invalid agentskills.io source") && err.contains("2 segment"),
+            "expected count in error, got: {err}"
+        );
     }
 }

--- a/crates/zeroclaw-runtime/src/skills/registry.rs
+++ b/crates/zeroclaw-runtime/src/skills/registry.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
+use flate2::read::GzDecoder;
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
+use tar::Archive;
 use zip::ZipArchive;
 
 // ─── Shared types ────────────────────────────────────────────────────────────
@@ -146,6 +148,134 @@ pub fn install_http_zip_skill(
             Err(err)
         }
     }
+}
+
+/// Install a skill from a GitHub repo by downloading the repo tarball and
+/// extracting a single subdirectory (the skill). Tries common layouts:
+/// `skills/<skill>/`, `<skill>/`, then falls back to a recursive scan.
+pub fn install_github_subdir_skill(
+    owner: &str,
+    repo: &str,
+    skill: &str,
+    skills_path: &Path,
+    allow_scripts: bool,
+    registry_name: &str,
+) -> Result<(PathBuf, usize)> {
+    let dir_name = normalize_skill_name(skill);
+    let installed_dir = skills_path.join(&dir_name);
+    if installed_dir.exists() {
+        anyhow::bail!(
+            "Destination skill already exists: {}",
+            installed_dir.display()
+        );
+    }
+
+    // GitHub's codeload tarball URL — no auth required for public repos
+    let tarball_url = format!("https://codeload.github.com/{owner}/{repo}/tar.gz/HEAD");
+    let client = http_client()?;
+    let resp = client
+        .get(&tarball_url)
+        .send()
+        .with_context(|| format!("failed to fetch tarball from {tarball_url}"))?;
+
+    if resp.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        anyhow::bail!("{registry_name} (GitHub) rate limit reached (HTTP 429)");
+    }
+    if !resp.status().is_success() {
+        anyhow::bail!(
+            "{registry_name} download failed (HTTP {}): {tarball_url}",
+            resp.status()
+        );
+    }
+
+    let bytes = resp.bytes()?.to_vec();
+    if bytes.len() as u64 > MAX_ZIP_BYTES {
+        anyhow::bail!(
+            "{registry_name} tarball rejected: too large ({} bytes > {MAX_ZIP_BYTES})",
+            bytes.len()
+        );
+    }
+
+    // Decompress + extract in-memory; then locate the skill subdirectory and
+    // copy only that subdirectory into the destination.
+    let tmp = tempfile::tempdir().context("failed to create temp dir")?;
+    let gz = GzDecoder::new(Cursor::new(bytes));
+    let mut archive = Archive::new(gz);
+    archive.set_preserve_permissions(false);
+    archive
+        .unpack(tmp.path())
+        .with_context(|| format!("failed to extract {registry_name} tarball"))?;
+
+    // GitHub tarballs unpack to a single top-level dir like `<repo>-<sha>/`
+    let top_dir = std::fs::read_dir(tmp.path())?
+        .filter_map(|e| e.ok())
+        .find(|e| e.path().is_dir())
+        .ok_or_else(|| anyhow::anyhow!("empty tarball from {registry_name}"))?
+        .path();
+
+    let candidates = [top_dir.join("skills").join(skill), top_dir.join(skill)];
+
+    let skill_src: PathBuf = candidates
+        .iter()
+        .find(|p| p.is_dir() && has_skill_manifest(p))
+        .cloned()
+        .or_else(|| candidates.iter().find(|p| p.is_dir()).cloned())
+        .or_else(|| walk_for_skill_dir(&top_dir, skill))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "skill '{skill}' not found in {owner}/{repo} (tried skills/{skill} and {skill})"
+            )
+        })?;
+
+    std::fs::create_dir_all(&installed_dir)?;
+    if let Err(err) = super::copy_dir_recursive_secure(&skill_src, &installed_dir) {
+        let _ = std::fs::remove_dir_all(&installed_dir);
+        return Err(err);
+    }
+
+    let has_manifest = installed_dir.join("SKILL.md").exists()
+        || installed_dir.join("SKILL.toml").exists()
+        || installed_dir.join("manifest.toml").exists();
+    if !has_manifest {
+        std::fs::write(
+            installed_dir.join("SKILL.toml"),
+            format!(
+                "[skill]\nname = \"{dir_name}\"\ndescription = \"{registry_name} skill from {owner}/{repo}\"\nversion = \"0.1.0\"\n"
+            ),
+        )?;
+    }
+
+    match super::enforce_skill_security_audit(&installed_dir, allow_scripts) {
+        Ok(report) => Ok((installed_dir, report.files_scanned)),
+        Err(err) => {
+            let _ = std::fs::remove_dir_all(&installed_dir);
+            Err(err)
+        }
+    }
+}
+
+fn has_skill_manifest(p: &Path) -> bool {
+    p.join("SKILL.md").exists() || p.join("SKILL.toml").exists() || p.join("manifest.toml").exists()
+}
+
+fn walk_for_skill_dir(root: &Path, skill: &str) -> Option<PathBuf> {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if !p.is_dir() {
+                continue;
+            }
+            if p.file_name().is_some_and(|n| n == skill) && has_skill_manifest(&p) {
+                return Some(p);
+            }
+            stack.push(p);
+        }
+    }
+    None
 }
 
 fn search_http_json_registry(
@@ -351,18 +481,19 @@ impl SkillRegistry for ClawhubRegistry {
 }
 
 // ─── agentskills.io registry ─────────────────────────────────────────────────
-
-const AGENTSKILLS_DOMAIN: &str = "agentskills.io";
-const AGENTSKILLS_WWW_DOMAIN: &str = "www.agentskills.io";
-const AGENTSKILLS_DOWNLOAD_API: &str = "https://agentskills.io/api/v1/download";
-const AGENTSKILLS_SEARCH_API: &str = "https://agentskills.io/api/v1/search";
+//
+// agentskills.io is the **specification** site (Mintlify docs only — no skill
+// download API). Skills following the agentskills format are indexed by
+// skills.sh and hosted on GitHub. This registry accepts
+// `agentskills:<owner>/<repo>/<skill>` as an alias for the same skillssh:
+// triplet so users who think of the spec name can still install.
 
 pub struct AgentSkillsIoRegistry;
 
 impl AgentSkillsIoRegistry {
     fn is_agentskills_host(host: &str) -> bool {
-        host.eq_ignore_ascii_case(AGENTSKILLS_DOMAIN)
-            || host.eq_ignore_ascii_case(AGENTSKILLS_WWW_DOMAIN)
+        host.eq_ignore_ascii_case("agentskills.io")
+            || host.eq_ignore_ascii_case("www.agentskills.io")
     }
 
     fn parse_url(source: &str) -> Option<reqwest::Url> {
@@ -376,51 +507,6 @@ impl AgentSkillsIoRegistry {
         }
         Some(parsed)
     }
-
-    fn download_url(source: &str) -> Result<String> {
-        if let Some(slug) = source.strip_prefix("agentskills:") {
-            let slug = slug.trim().trim_end_matches('/');
-            if slug.is_empty() {
-                anyhow::bail!(
-                    "invalid agentskills source '{source}': expected 'agentskills:<slug>'"
-                );
-            }
-            return Ok(format!("{AGENTSKILLS_DOWNLOAD_API}?slug={slug}"));
-        }
-
-        if let Some(parsed) = Self::parse_url(source) {
-            let path = parsed
-                .path_segments()
-                .into_iter()
-                .flatten()
-                .filter(|s| !s.is_empty())
-                .collect::<Vec<_>>()
-                .join("/");
-            if path.is_empty() {
-                anyhow::bail!("could not extract slug from agentskills.io URL: {source}");
-            }
-            return Ok(format!("{AGENTSKILLS_DOWNLOAD_API}?slug={path}"));
-        }
-
-        anyhow::bail!("unrecognised agentskills.io source format: {source}")
-    }
-
-    fn skill_dir_name(source: &str) -> String {
-        if let Some(slug) = source.strip_prefix("agentskills:") {
-            let base = slug.trim().trim_end_matches('/');
-            let name = normalize_skill_name(base);
-            return if name.is_empty() {
-                "skill".into()
-            } else {
-                name
-            };
-        }
-        if let Some(parsed) = Self::parse_url(source) {
-            let segs: Vec<_> = parsed.path_segments().into_iter().flatten().collect();
-            return normalize_skill_name(segs.last().copied().unwrap_or("skill"));
-        }
-        "skill".into()
-    }
 }
 
 impl SkillRegistry for AgentSkillsIoRegistry {
@@ -432,8 +518,9 @@ impl SkillRegistry for AgentSkillsIoRegistry {
         source.starts_with("agentskills:") || Self::parse_url(source).is_some()
     }
 
+    /// agentskills.io is a docs site; route searches through skills.sh.
     fn search(&self, query: &str) -> Result<Vec<SkillSearchResult>> {
-        search_http_json_registry(AGENTSKILLS_SEARCH_API, query, "agentskills.io")
+        SkillsShRegistry.search(query)
     }
 
     fn install(
@@ -442,26 +529,44 @@ impl SkillRegistry for AgentSkillsIoRegistry {
         skills_path: &Path,
         allow_scripts: bool,
     ) -> Result<(PathBuf, usize)> {
-        let url = Self::download_url(source)?;
-        let dir_name = Self::skill_dir_name(source);
-        install_http_zip_skill(
-            &url,
-            &dir_name,
-            skills_path,
-            allow_scripts,
-            "agentskills.io",
-        )
+        // Translate the source into a skillssh: triplet and delegate.
+        let translated = if let Some(rest) = source.strip_prefix("agentskills:") {
+            format!("skillssh:{}", rest.trim().trim_matches('/'))
+        } else if let Some(parsed) = Self::parse_url(source) {
+            let path = parsed
+                .path_segments()
+                .into_iter()
+                .flatten()
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .join("/");
+            format!("skillssh:{path}")
+        } else {
+            anyhow::bail!("unrecognised agentskills.io source format: {source}")
+        };
+        SkillsShRegistry.install(&translated, skills_path, allow_scripts)
     }
 }
 
 // ─── skills.sh registry ─────────────────────────────────────────────────────
+//
+// skills.sh is the de-facto agent-skills registry. Skills are indexed via its
+// JSON API and the actual content is hosted on GitHub. Identity for a skill is
+// the triplet `<owner>/<repo>/<skill>` — install resolves to the GitHub repo
+// `<owner>/<repo>` and extracts `skills/<skill>/` (or `<skill>/` at the root).
 
 const SKILLSSH_DOMAIN: &str = "skills.sh";
 const SKILLSSH_WWW_DOMAIN: &str = "www.skills.sh";
-const SKILLSSH_DOWNLOAD_API: &str = "https://skills.sh/api/v1/download";
-const SKILLSSH_SEARCH_API: &str = "https://skills.sh/api/v1/search";
+const SKILLSSH_SEARCH_API: &str = "https://skills.sh/api/search";
 
 pub struct SkillsShRegistry;
+
+#[derive(Debug, Clone)]
+struct SkillsShTriplet {
+    owner: String,
+    repo: String,
+    skill: String,
+}
 
 impl SkillsShRegistry {
     fn is_skillssh_host(host: &str) -> bool {
@@ -480,47 +585,60 @@ impl SkillsShRegistry {
         Some(parsed)
     }
 
-    fn download_url(source: &str) -> Result<String> {
-        if let Some(slug) = source.strip_prefix("skillssh:") {
-            let slug = slug.trim().trim_end_matches('/');
-            if slug.is_empty() {
-                anyhow::bail!("invalid skills.sh source '{source}': expected 'skillssh:<slug>'");
-            }
-            return Ok(format!("{SKILLSSH_DOWNLOAD_API}?slug={slug}"));
-        }
-
-        if let Some(parsed) = Self::parse_url(source) {
-            let path = parsed
+    /// Parse `<owner>/<repo>/<skill>` from a skillssh: prefix or skills.sh URL.
+    fn parse_triplet(source: &str) -> Result<SkillsShTriplet> {
+        let raw = if let Some(s) = source.strip_prefix("skillssh:") {
+            s.trim().trim_matches('/').to_string()
+        } else if let Some(parsed) = Self::parse_url(source) {
+            parsed
                 .path_segments()
                 .into_iter()
                 .flatten()
                 .filter(|s| !s.is_empty())
                 .collect::<Vec<_>>()
-                .join("/");
-            if path.is_empty() {
-                anyhow::bail!("could not extract slug from skills.sh URL: {source}");
-            }
-            return Ok(format!("{SKILLSSH_DOWNLOAD_API}?slug={path}"));
+                .join("/")
+        } else {
+            anyhow::bail!("unrecognised skills.sh source format: {source}")
+        };
+
+        let parts: Vec<&str> = raw.split('/').collect();
+        if parts.len() != 3 || parts.iter().any(|p| p.is_empty()) {
+            anyhow::bail!(
+                "invalid skills.sh source '{source}': expected '<owner>/<repo>/<skill>' (e.g. anthropics/skills/webapp-testing)"
+            );
         }
 
-        anyhow::bail!("unrecognised skills.sh source format: {source}")
+        Ok(SkillsShTriplet {
+            owner: parts[0].into(),
+            repo: parts[1].into(),
+            skill: parts[2].into(),
+        })
     }
 
-    fn skill_dir_name(source: &str) -> String {
-        if let Some(slug) = source.strip_prefix("skillssh:") {
-            let base = slug.trim().trim_end_matches('/');
-            let name = normalize_skill_name(base);
-            return if name.is_empty() {
-                "skill".into()
-            } else {
-                name
-            };
-        }
-        if let Some(parsed) = Self::parse_url(source) {
-            let segs: Vec<_> = parsed.path_segments().into_iter().flatten().collect();
-            return normalize_skill_name(segs.last().copied().unwrap_or("skill"));
-        }
-        "skill".into()
+    /// Parse skills.sh JSON search response into SkillSearchResult entries.
+    fn parse_search_response(body: &serde_json::Value) -> Vec<SkillSearchResult> {
+        let Some(items) = body.get("skills").and_then(|v| v.as_array()) else {
+            return vec![];
+        };
+        items
+            .iter()
+            .filter_map(|item| {
+                let name = item.get("name").and_then(|v| v.as_str())?.to_string();
+                let id = item.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                let installs = item.get("installs").and_then(|v| v.as_u64()).unwrap_or(0);
+                Some(SkillSearchResult {
+                    name,
+                    description: if installs > 0 {
+                        format!("{installs} installs")
+                    } else {
+                        String::new()
+                    },
+                    registry: "skills.sh".into(),
+                    source_url: format!("skillssh:{id}"),
+                    version: None,
+                })
+            })
+            .collect()
     }
 }
 
@@ -534,7 +652,21 @@ impl SkillRegistry for SkillsShRegistry {
     }
 
     fn search(&self, query: &str) -> Result<Vec<SkillSearchResult>> {
-        search_http_json_registry(SKILLSSH_SEARCH_API, query, "skills.sh")
+        let client = http_client()?;
+        let url = format!("{SKILLSSH_SEARCH_API}?q={}", urlencoding::encode(query));
+        let resp = match client.get(&url).send() {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("skills.sh search failed: {e}");
+                return Ok(vec![]);
+            }
+        };
+        if !resp.status().is_success() {
+            tracing::warn!("skills.sh search returned HTTP {}", resp.status());
+            return Ok(vec![]);
+        }
+        let body: serde_json::Value = resp.json().context("invalid JSON from skills.sh")?;
+        Ok(Self::parse_search_response(&body))
     }
 
     fn install(
@@ -543,9 +675,64 @@ impl SkillRegistry for SkillsShRegistry {
         skills_path: &Path,
         allow_scripts: bool,
     ) -> Result<(PathBuf, usize)> {
-        let url = Self::download_url(source)?;
-        let dir_name = Self::skill_dir_name(source);
-        install_http_zip_skill(&url, &dir_name, skills_path, allow_scripts, "skills.sh")
+        let t = Self::parse_triplet(source)?;
+        install_github_subdir_skill(
+            &t.owner,
+            &t.repo,
+            &t.skill,
+            skills_path,
+            allow_scripts,
+            "skills.sh",
+        )
+    }
+}
+
+// ─── GitHub direct-install registry ─────────────────────────────────────────
+//
+// `github:<owner>/<repo>/<skill>` — direct install from any GitHub repo
+// following the agent-skills convention (skills/<skill>/SKILL.md or
+// <skill>/SKILL.md at the repo root).
+
+pub struct GitHubSkillRegistry;
+
+impl SkillRegistry for GitHubSkillRegistry {
+    fn name(&self) -> &str {
+        "github"
+    }
+
+    fn matches_source(&self, source: &str) -> bool {
+        source.starts_with("github:")
+    }
+
+    fn search(&self, _query: &str) -> Result<Vec<SkillSearchResult>> {
+        Ok(vec![])
+    }
+
+    fn install(
+        &self,
+        source: &str,
+        skills_path: &Path,
+        allow_scripts: bool,
+    ) -> Result<(PathBuf, usize)> {
+        let raw = source
+            .strip_prefix("github:")
+            .unwrap_or("")
+            .trim()
+            .trim_matches('/');
+        let parts: Vec<&str> = raw.split('/').collect();
+        if parts.len() != 3 || parts.iter().any(|p| p.is_empty()) {
+            anyhow::bail!(
+                "invalid github source '{source}': expected 'github:<owner>/<repo>/<skill>'"
+            );
+        }
+        install_github_subdir_skill(
+            parts[0],
+            parts[1],
+            parts[2],
+            skills_path,
+            allow_scripts,
+            "github",
+        )
     }
 }
 
@@ -562,6 +749,7 @@ impl SkillRegistry for GitRegistry {
         if ClawhubRegistry.matches_source(source)
             || AgentSkillsIoRegistry.matches_source(source)
             || SkillsShRegistry.matches_source(source)
+            || GitHubSkillRegistry.matches_source(source)
         {
             return false;
         }
@@ -647,6 +835,7 @@ impl RegistryDispatcher {
             Box::new(ClawhubRegistry),
             Box::new(AgentSkillsIoRegistry),
             Box::new(SkillsShRegistry),
+            Box::new(GitHubSkillRegistry),
             Box::new(GitRegistry),
             Box::new(ZeroClawSkillsRegistry {
                 workspace_dir: workspace_dir.to_path_buf(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,14 @@ pub enum SkillCommands {
         #[arg(long)]
         verbose: bool,
     },
+    /// Search all skill registries for skills matching a query
+    Search {
+        /// Search query
+        query: String,
+        /// Maximum results per registry
+        #[arg(long, default_value = "10")]
+        limit: usize,
+    },
 }
 
 /// Migration subcommands

--- a/src/skillforge/mod.rs
+++ b/src/skillforge/mod.rs
@@ -23,6 +23,9 @@ mod tests {
         assert!(cfg.auto_integrate);
         assert_eq!(cfg.scan_interval_hours, 24);
         assert!((cfg.min_score - 0.7).abs() < f64::EPSILON);
-        assert_eq!(cfg.sources, vec!["github", "clawhub"]);
+        assert_eq!(
+            cfg.sources,
+            vec!["github", "clawhub", "agentskills", "skillssh"]
+        );
     }
 }

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -108,26 +108,16 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
             let skills_path = skills_dir(workspace_dir);
             std::fs::create_dir_all(&skills_path)?;
 
-            let (installed_dir, files_scanned) = if is_clawhub_source(&source) {
-                install_clawhub_skill_source(&source, &skills_path, config.skills.allow_scripts)
-                    .with_context(|| format!("failed to install skill from ClawHub: {source}"))?
-            } else if is_git_source(&source) {
-                install_git_skill_source(&source, &skills_path, config.skills.allow_scripts)
-                    .with_context(|| format!("failed to install git skill source: {source}"))?
-            } else if is_registry_source(&source) {
-                println!("  Resolving '{source}' from skills registry...");
-                install_registry_skill_source(
-                    &source,
-                    &skills_path,
-                    config.skills.allow_scripts,
-                    workspace_dir,
-                    config.skills.registry_url.as_deref(),
-                )
-                .with_context(|| format!("failed to install skill from registry: {source}"))?
-            } else {
-                install_local_skill_source(&source, &skills_path, config.skills.allow_scripts)
-                    .with_context(|| format!("failed to install local skill source: {source}"))?
-            };
+            let dispatcher =
+                registry::RegistryDispatcher::from_config(&config.skills, workspace_dir);
+
+            let (installed_dir, files_scanned) =
+                if let Some(result) = dispatcher.install(&source, &skills_path, config.skills.allow_scripts) {
+                    result.with_context(|| format!("failed to install skill: {source}"))?
+                } else {
+                    install_local_skill_source(&source, &skills_path, config.skills.allow_scripts)
+                        .with_context(|| format!("failed to install local skill source: {source}"))?
+                };
             println!(
                 "  {} Skill installed and audited: {} ({} files scanned)",
                 console::style("✓").green().bold(),
@@ -166,6 +156,43 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
                 console::style("✓").green().bold(),
                 name
             );
+            Ok(())
+        }
+        crate::SkillCommands::Search { query, limit } => {
+            let dispatcher =
+                registry::RegistryDispatcher::from_config(&config.skills, workspace_dir);
+            let results = dispatcher.search(&query);
+            if results.is_empty() {
+                println!("No skills found matching '{query}'.");
+                println!();
+                println!("  Searched: ClawhHub, agentskills.io, skills.sh, zeroclaw-skills");
+                println!("  Try a broader query or install directly:");
+                println!("    zeroclaw skills install clawhub:<slug>");
+                println!("    zeroclaw skills install agentskills:<slug>");
+                println!("    zeroclaw skills install skillssh:<slug>");
+            } else {
+                let capped = results.len().min(limit);
+                println!(
+                    "Found {} skill(s) matching '{query}':",
+                    capped
+                );
+                println!();
+                for result in results.iter().take(limit) {
+                    println!(
+                        "  {} ({}) — {}",
+                        console::style(&result.name).white().bold(),
+                        console::style(&result.registry).dim(),
+                        result.description
+                    );
+                    if !result.source_url.is_empty() {
+                        println!(
+                            "    Install: zeroclaw skills install {}",
+                            result.source_url
+                        );
+                    }
+                }
+            }
+            println!();
             Ok(())
         }
         crate::SkillCommands::Test { name, verbose } => {

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -111,13 +111,14 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
             let dispatcher =
                 registry::RegistryDispatcher::from_config(&config.skills, workspace_dir);
 
-            let (installed_dir, files_scanned) =
-                if let Some(result) = dispatcher.install(&source, &skills_path, config.skills.allow_scripts) {
-                    result.with_context(|| format!("failed to install skill: {source}"))?
-                } else {
-                    install_local_skill_source(&source, &skills_path, config.skills.allow_scripts)
-                        .with_context(|| format!("failed to install local skill source: {source}"))?
-                };
+            let (installed_dir, files_scanned) = if let Some(result) =
+                dispatcher.install(&source, &skills_path, config.skills.allow_scripts)
+            {
+                result.with_context(|| format!("failed to install skill: {source}"))?
+            } else {
+                install_local_skill_source(&source, &skills_path, config.skills.allow_scripts)
+                    .with_context(|| format!("failed to install local skill source: {source}"))?
+            };
             println!(
                 "  {} Skill installed and audited: {} ({} files scanned)",
                 console::style("✓").green().bold(),
@@ -172,10 +173,7 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
                 println!("    zeroclaw skills install skillssh:<slug>");
             } else {
                 let capped = results.len().min(limit);
-                println!(
-                    "Found {} skill(s) matching '{query}':",
-                    capped
-                );
+                println!("Found {} skill(s) matching '{query}':", capped);
                 println!();
                 for result in results.iter().take(limit) {
                     println!(
@@ -185,10 +183,7 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
                         result.description
                     );
                     if !result.source_url.is_empty() {
-                        println!(
-                            "    Install: zeroclaw skills install {}",
-                            result.source_url
-                        );
+                        println!("    Install: zeroclaw skills install {}", result.source_url);
                     }
                 }
             }

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -108,10 +108,18 @@ pub fn handle_command(command: crate::SkillCommands, config: &crate::config::Con
             let skills_path = skills_dir(workspace_dir);
             std::fs::create_dir_all(&skills_path)?;
 
+            // Local paths win over registry dispatch. Prevents the bare
+            // `<owner>/<repo>` ClawHub shorthand from silently shadowing a
+            // user's relative directory of the same shape.
+            let local_dir_exists = std::path::Path::new(&source).is_dir();
+
             let dispatcher =
                 registry::RegistryDispatcher::from_config(&config.skills, workspace_dir);
 
-            let (installed_dir, files_scanned) = if let Some(result) =
+            let (installed_dir, files_scanned) = if local_dir_exists {
+                install_local_skill_source(&source, &skills_path, config.skills.allow_scripts)
+                    .with_context(|| format!("failed to install local skill source: {source}"))?
+            } else if let Some(result) =
                 dispatcher.install(&source, &skills_path, config.skills.allow_scripts)
             {
                 result.with_context(|| format!("failed to install skill: {source}"))?


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:**
  - Introduce a `SkillRegistry` trait so external skill sources (ClawHub, agentskills.io, skills.sh, user-configured) live behind one interface, replacing the hardcoded if-else install chain with a registry dispatcher keyed off prefix shortcuts.
  - Add first-class registries for **agentskills.io** (`agentskills:<slug>`) and **skills.sh** (`skillssh:<slug>`), plus support for user-defined registries through `[skills.extra_registries]` in config so users can point ZeroClaw at private/custom skill catalogs without code changes.
  - Add `zeroclaw skills search <query>` which fans out across every configured registry so discovery is no longer ClawHub-only.
  - Wire up the SkillForge scouts (ClawhHub, agentskills.io, skills.sh) that were previously stubbed, and factor shared HTTP ZIP extraction into one helper with zip-bomb protection (50 MiB cap, 500 entry limit, 10x compression-ratio guard).
  - Accept bare `owner/slug` (e.g. `pskoett/self-improving-agent`) as ClawHub shorthand to match the prefix-less ergonomics of GitHub-style references.
- **Scope boundary:** Does not change skill execution / sandboxing, the on-disk skill manifest format, the existing ClawHub install path semantics for already-supported inputs, or any provider/channel/runtime code outside `skills` and `skillforge`.
- **Blast radius:** `crates/zeroclaw-runtime/src/skills/**`, `crates/zeroclaw-runtime/src/skillforge/**`, `src/skills/mod.rs` CLI surface, and `crates/zeroclaw-config` schema (`[skills.extra_registries]`). Anything that resolves a skill spec string or runs `zeroclaw skills install/search` is touched; sandboxing, agent loop, providers, channels, memory, cron are not.
- **Linked issue(s):** _None._

## Validation Evidence (required)

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --workspace -- -D warnings
cargo test
```

- **Commands run and tail output:**
  - `cargo fmt --all -- --check` — clean, no diff.
  - `cargo clippy --all-targets --workspace -- -D warnings` — clean, zero warnings (post-fix commit collapses nested `if let` into `&&` chains and swaps `filter().last()` for `rfind()` on a `DoubleEndedIterator`).
  - `cargo test` — all 98 skills + skillforge tests pass, zero regressions across the workspace.
- **Beyond CI — what did you manually verify?**
  - Prefix dispatch: `clawhub:owner/slug`, `agentskills:slug`, `skillssh:slug`, and bare `owner/slug` all route to the right registry.
  - `zeroclaw skills search <query>` fans out and surfaces results from each configured registry, including a user-defined entry from `[skills.extra_registries]`.
  - ZIP extraction guard rails: aborts on >50 MiB total, >500 entries, or >10x compression ratio (verified against a crafted fixture).
  - Did NOT manually re-verify every existing ClawHub install path beyond the unit tests covering them.
- **If any command was intentionally skipped, why:** None skipped.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? `No` — extraction stays inside the existing skills cache directory; no new FS scope.
- New external network calls? `Yes` — HTTPS fetches to `agentskills.io`, `skills.sh`, and any host listed in user-configured `[skills.extra_registries]`. Same trust model as the existing ClawHub fetcher: HTTPS, response size capped, ZIP entries bounded by count and decompressed-size ratio.
- Secrets / tokens / credentials handling changed? `No` — registries are anonymous reads; no auth headers, no token storage.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`.
- If any `Yes`, describe the risk and mitigation: A malicious or compromised registry could serve a hostile ZIP. Mitigated by the shared extractor's 50 MiB total cap, 500-entry limit, and 10x compression-ratio guard, plus path-traversal checks during entry extraction. Users opting into `[skills.extra_registries]` are explicitly trusting that host the same way they trust ClawHub today.

## Compatibility (required)

- Backward compatible? `Yes` — existing ClawHub specs (`clawhub:owner/slug` and previously supported forms) continue to work unchanged. The bare `owner/slug` form is purely additive.
- Config / env / CLI surface changed? `Yes` — additive only:
  - New optional config table `[skills.extra_registries]` (omitting it keeps prior behavior).
  - New CLI subcommand `zeroclaw skills search <query>`.
  - New accepted spec prefixes `agentskills:` and `skillssh:`, plus bare `owner/slug` shorthand.
- If `No` or `Yes` to either: exact upgrade steps for existing users: No upgrade required. To opt into new registries, add entries under `[skills.extra_registries]` in your config or use the new prefixes / `skills search` directly — existing configs and install commands keep working.

## Rollback (required for `risk: medium` and `risk: high`)

- **Fast rollback command/path:** `git revert 2eea9fc67 1e4a80924` on `master` (revert the formatting/clippy commit first, then the feature commit) and re-deploy. No data migration to undo; `[skills.extra_registries]` entries become inert config that the older binary ignores.
- **Feature flags or config toggles:** None — gating is implicit via not configuring `[skills.extra_registries]` and not using the new prefixes. Users who want to disable the new registries can simply avoid the new spec forms.
- **Observable failure symptoms:** Look for errors originating in `crates/zeroclaw-runtime/src/skills/registry.rs` or `skillforge/scout.rs` — typical signatures include `skill registry fetch failed`, `zip bomb guard tripped`, `unknown registry prefix`, or `skills search` returning errors per-registry. Failed installs from the new registries surface to the CLI as non-zero exits from `zeroclaw skills install` / `zeroclaw skills search`.