### PR TITLE
fix(providers): omit Bedrock temperature for Opus 4.7

### DIFF
--- a/crates/zeroclaw-providers/src/bedrock.rs
+++ b/crates/zeroclaw-providers/src/bedrock.rs
@@ -374,7 +374,16 @@ enum SystemBlock {
 #[serde(rename_all = "camelCase")]
 struct InferenceConfig {
     max_tokens: u32,
-    temperature: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
+}
+
+/// Some Bedrock models (the Claude opus-4-7 family) reject `temperature` in
+/// `inferenceConfig` with a 400 "temperature is deprecated for this model".
+/// Substring match covers region/profile prefixes (e.g. `us.anthropic.…`)
+/// and version suffixes (e.g. `-v1:0`).
+fn bedrock_model_omits_temperature(model: &str) -> bool {
+    model.contains("claude-opus-4-7")
 }
 
 #[derive(Debug, Serialize)]
@@ -1133,7 +1142,11 @@ impl Provider for BedrockProvider {
             messages,
             inference_config: Some(InferenceConfig {
                 max_tokens: self.max_tokens,
-                temperature,
+                temperature: if bedrock_model_omits_temperature(model) {
+                    None
+                } else {
+                    Some(temperature)
+                },
             }),
             tool_config: None,
         };
@@ -1190,7 +1203,11 @@ impl Provider for BedrockProvider {
             messages: converse_messages,
             inference_config: Some(InferenceConfig {
                 max_tokens: self.max_tokens,
-                temperature,
+                temperature: if bedrock_model_omits_temperature(model) {
+                    None
+                } else {
+                    Some(temperature)
+                },
             }),
             tool_config,
         };
@@ -1606,7 +1623,7 @@ mod tests {
             }],
             inference_config: Some(InferenceConfig {
                 max_tokens: 4096,
-                temperature: 0.7,
+                temperature: Some(0.7),
             }),
             tool_config: None,
         };
@@ -1614,6 +1631,59 @@ mod tests {
         assert!(!json.contains("system"));
         assert!(json.contains("Hello"));
         assert!(json.contains("maxTokens"));
+    }
+
+    // ── Opus 4.7 temperature-omission tests (issue #6095) ────────
+
+    #[test]
+    fn bedrock_model_omits_temperature_matches_opus_4_7() {
+        assert!(bedrock_model_omits_temperature(
+            "us.anthropic.claude-opus-4-7"
+        ));
+        assert!(bedrock_model_omits_temperature(
+            "anthropic.claude-opus-4-7-v1:0"
+        ));
+    }
+
+    #[test]
+    fn bedrock_model_omits_temperature_skips_other_models() {
+        assert!(!bedrock_model_omits_temperature(
+            "us.anthropic.claude-opus-4-6-v1"
+        ));
+        assert!(!bedrock_model_omits_temperature(
+            "us.anthropic.claude-sonnet-4-6-v1"
+        ));
+        assert!(!bedrock_model_omits_temperature(
+            "us.anthropic.claude-haiku-4-5-v1"
+        ));
+    }
+
+    #[test]
+    fn inference_config_serializes_without_temperature_when_none() {
+        let cfg = InferenceConfig {
+            max_tokens: 4096,
+            temperature: None,
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(json.contains("maxTokens"));
+        assert!(
+            !json.contains("temperature"),
+            "expected temperature to be omitted, got: {json}"
+        );
+    }
+
+    #[test]
+    fn inference_config_serializes_with_temperature_when_some() {
+        let cfg = InferenceConfig {
+            max_tokens: 4096,
+            temperature: Some(0.7),
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(json.contains("maxTokens"));
+        assert!(
+            json.contains("temperature"),
+            "expected temperature to be present, got: {json}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary                                                                                                                       
   
  - **Base branch:** `master`                                                                                                      
  - **What changed and why:**                                         
    - Made `InferenceConfig.temperature` an `Option<f64>` with `#[serde(skip_serializing_if = "Option::is_none")]` so the field can
   actually be omitted from the wire payload — previously `f64` forced serde to always emit it.                                    
    - Added a private `bedrock_model_omits_temperature(model)` predicate that substring-matches `claude-opus-4-7`. Substring (not
  exact) match is intentional: Bedrock IDs carry region/profile prefixes (`us.anthropic.…`) and version suffixes (`-v1:0`), so any 
  stricter match would silently miss new inference profiles.          
    - Both production call sites (`chat_with_system`, `chat`) now pass `None` for Opus 4.7 family models and `Some(temperature)`   
  for everything else, fixing the non-retryable Bedrock 400 `` `temperature` is deprecated for this model `` that made interactive 
  mode unusable on `us.anthropic.claude-opus-4-7`.
    - Added 4 focused unit tests: predicate true/false matrix across opus-4-7 / opus-4-6 / sonnet-4-6 / haiku-4-5, plus serde proof
   that `temperature: None` is omitted from JSON and `Some(0.7)` is present.                                                       
  - **Scope boundary:** Bedrock provider only. Does **not** touch the Anthropic native provider — the same `temperature: f64` shape
   exists in `anthropic.rs:32` and `:64` and is tracked separately in #6146 (verify whether the native API also rejects on Opus    
  4.7, apply the same carve-out if confirmed). Also out of scope: the `Provider` trait, config schema, retry/reliable
  classification, and the model catalog. No `retry-after-strip` behavior added.                                                    
  - **Blast radius:** Confined to `crates/zeroclaw-providers/src/bedrock.rs`. Non-Opus-4.7 Bedrock models keep emitting
  `temperature` byte-for-byte the same as before (`Some(temperature)` round-trips identically through the existing serde rename).  
  No change to streaming, tool use, caching heuristics, or auth paths.
  - **Linked issue(s):** `Closes #6095`                                                                                            
                                                                                                                                   
  ## Validation Evidence (required)            
                                                                                                                                   
  - **Commands run and tail output:**                                 
                                               
  `cargo fmt --all -- --check`                                                                                                     
  ```
  (no output, exit 0)                                                                                                              
  ```                                                                 
                                               
  `cargo clippy -p zeroclaw-providers --all-targets -- -D warnings`
  ```
      Checking zeroclaw-providers v0.7.3 (/…/crates/zeroclaw-providers)
      Finished `dev` profile [unoptimized + debuginfo] target(s) in 22.17s                                                         
  (exit 0)
  ```                                                                                                                              
                                                                      
  `cargo test -p zeroclaw-providers --lib bedrock:: -- --test-threads=1`                                                           
  ```                                                                 
  test bedrock::tests::bedrock_model_omits_temperature_matches_opus_4_7 ... ok
  test bedrock::tests::bedrock_model_omits_temperature_skips_other_models ... ok                                                   
  test bedrock::tests::inference_config_serializes_with_temperature_when_some ... ok
  test bedrock::tests::inference_config_serializes_without_temperature_when_none ... ok                                            
  test bedrock::tests::converse_request_serializes_without_system ... ok
  …                                                                                                                                
  test result: ok. 54 passed; 0 failed; 0 ignored; 0 measured; 729 filtered out; finished in 3.07s
  ```                                                                                                                              
                                                                      
  - **Beyond CI — what did you manually verify?**                                                                                  
    - Predicate behavior across the realistic Bedrock model-ID surface (regional prefix `us.anthropic.…`, suffix `-v1:0`, and the
  negative cases for opus-4-6 / sonnet-4-6 / haiku-4-5) — covered by the new unit tests.                                           
    - Wire-format proof via serde: `InferenceConfig { temperature: None, .. }` produces JSON without the `temperature` key;
  `Some(0.7)` keeps it. This is the actual bug surface (the field was always serialized) so it's asserted directly rather than via 
  a live AWS call.                                                    
    - Did **not** run a live Bedrock Converse call against `us.anthropic.claude-opus-4-7` from this machine — no AWS creds in the  
  dev env. The fix is mechanical (omit a field via serde) and the reporter's repro is exact, so the unit-level assertion that the  
  field is absent from the serialized payload is the load-bearing check.
  - **If any command was intentionally skipped, why:**                                                                             
    - Full-workspace `cargo test` was scoped to `-p zeroclaw-providers` because the diff is single-file and crate-local; running
  just the affected crate is faster and CI runs the full suite. One pre-existing parallel-execution flake in                       
  `resolve_provider_credential_bedrock_returns_bearer_token_from_env` (env-var race on `BEDROCK_API_KEY`, present on master,
  unrelated to this change) is why bedrock tests were run with `--test-threads=1`; all 54 pass deterministically in that mode.     
                                                                      
  ## Security & Privacy Impact (required)                                                                                          
   
  - New permissions, capabilities, or file system access scope? `No`                                                               
  - New external network calls? `No`                                  
  - Secrets / tokens / credentials handling changed? `No`
  - PII, real identities, or personal data in diff, tests, fixtures, or docs? `No`
  - If any `Yes`, describe the risk and mitigation: N/A                                                                            
   
  ## Compatibility (required)                                                                                                      
                                                                      
  - Backward compatible? `Yes`                                                                                                     
  - Config / env / CLI surface changed? `No`
  - If `No` or `Yes` to either: exact upgrade steps for existing users:                                                            
    - None required. Users currently pinned to `us.anthropic.claude-opus-4-6-v1` as a workaround can switch back to
  `us.anthropic.claude-opus-4-7` once this lands; no config edits needed. Non-Opus-4.7 model behavior is byte-identical to master. 
   
  ## Rollback (required for `risk: medium` and `risk: high`)                                                                       
                                                                      
  Low-risk: `git revert <sha>` is the plan. Single-file, additive change with no migrations or shared state.                       
   
  ## Supersede Attribution (required only when `Supersedes #` is used)                                                             
                                                                      
  N/A — does not supersede a prior PR.     