### PR TITLE
fix(install): restore web dashboard extraction in prebuilt install path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -178,6 +178,7 @@ install_prebuilt() {
   if [ "$DRY_RUN" = true ]; then
     info "[dry-run] Would download $asset_url"
     info "[dry-run] Would install to $CARGO_HOME/bin/zeroclaw"
+    info "[dry-run] Would install web dashboard to \${XDG_DATA_HOME:-$PREFIX/.local/share}/zeroclaw/web/dist"
     return 0
   fi
 
@@ -216,6 +217,14 @@ install_prebuilt() {
   tar -xzf "$tmp_dir/$asset_name" -C "$tmp_dir"
   mkdir -p "$CARGO_HOME/bin"
   install -m 755 "$tmp_dir/zeroclaw" "$CARGO_HOME/bin/zeroclaw"
+
+  # Install web dashboard assets bundled in the release tarball
+  if [ -d "$tmp_dir/web/dist" ]; then
+    web_data_dir="${XDG_DATA_HOME:-$PREFIX/.local/share}/zeroclaw/web/dist"
+    mkdir -p "$web_data_dir"
+    cp -r "$tmp_dir/web/dist/." "$web_data_dir/"
+    info "Web dashboard installed to $web_data_dir"
+  fi
 
   rm -rf "$tmp_dir"
   trap - EXIT

--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,7 @@ detect_target_triple() {
 # ── Pre-built binary install ──────────────────────────────────────
 
 install_prebuilt() {
-  local triple version asset_name asset_url sha256_url tmp_dir
+  local triple version asset_name asset_url sha256_url tmp_dir web_data_dir
   triple=$(detect_target_triple)
 
   if [ -z "$triple" ]; then

--- a/install.sh
+++ b/install.sh
@@ -175,10 +175,23 @@ install_prebuilt() {
   info "Source:   $asset_url"
   echo
 
+  # Resolve platform-correct web data directory to match gateway auto-detect
+  case "$(uname -s)" in
+    Darwin)
+      web_data_dir="${HOME}/Library/Application Support/zeroclaw/web/dist"
+      ;;
+    MINGW*|CYGWIN*|MSYS*)
+      web_data_dir="${LOCALAPPDATA}/zeroclaw/web/dist"
+      ;;
+    *)
+      web_data_dir="${XDG_DATA_HOME:-${PREFIX}/.local/share}/zeroclaw/web/dist"
+      ;;
+  esac
+
   if [ "$DRY_RUN" = true ]; then
     info "[dry-run] Would download $asset_url"
     info "[dry-run] Would install to $CARGO_HOME/bin/zeroclaw"
-    info "[dry-run] Would install web dashboard to \${XDG_DATA_HOME:-$PREFIX/.local/share}/zeroclaw/web/dist"
+    info "[dry-run] Would install web dashboard to $web_data_dir"
     return 0
   fi
 
@@ -220,7 +233,6 @@ install_prebuilt() {
 
   # Install web dashboard assets bundled in the release tarball
   if [ -d "$tmp_dir/web/dist" ]; then
-    web_data_dir="${XDG_DATA_HOME:-$PREFIX/.local/share}/zeroclaw/web/dist"
     mkdir -p "$web_data_dir"
     cp -r "$tmp_dir/web/dist/." "$web_data_dir/"
     info "Web dashboard installed to $web_data_dir"


### PR DESCRIPTION
## Summary

- **Base branch:** `master`
- **What changed and why:** `install_prebuilt()` now extracts `web/dist/` from the release tarball and copies it to `${XDG_DATA_HOME:-~/.local/share}/zeroclaw/web/dist`. The release tarball has always bundled `web/dist/` alongside the binary (see `release-stable-manual.yml` Package step), but the extraction step was silently dropped when #5666 rewrote `install.sh` and renamed `install_prebuilt_binary()` to `install_prebuilt()`. Users who installed via `--prebuilt` were left with no web dashboard assets, causing the gateway to serve a blank or broken UI.
- **Scope boundary:** Pre-built path only. Source-build path is unaffected (web assets are built and served from the checkout). No changes to the gateway, the tarball format, or CI release packaging.
- **Blast radius:** `install.sh` only. The web extraction is guarded by `[ -d "$tmp_dir/web/dist" ]` so a tarball without `web/dist` (e.g. an older release or a platform variant that omits it) silently skips the step and the binary still installs correctly.
- **Linked issue(s):** Closes #6096

## Validation Evidence (required)

```bash
sh -n install.sh
# exit: 0 (no syntax errors)
```

- **Commands run and tail output:** `sh -n install.sh` exits 0. Full E2E install not run (requires a published release tarball with a matching SHA256SUMS entry).
- **Beyond CI — what did you manually verify?** Verified the release tarball structure in `.github/workflows/release-stable-manual.yml`: the Package step packs `web/dist` alongside the binary into `zeroclaw-${triple}.tar.gz`. Verified the original extraction logic from PR #5675 (`install_prebuilt_binary`). Confirmed `tmp_dir/web/dist` is the correct path after `tar -xzf ... -C "$tmp_dir"`. Confirmed the dry-run branch returns before reaching the extraction block, and added a dry-run info line for the web dashboard destination.
- **If any command was intentionally skipped, why:** Full integration test (curl | bash against a live release) skipped; requires a matching published tarball and would make a real filesystem change. The logic is a straightforward `cp -r` guarded by a directory check.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? Yes: writes to `${XDG_DATA_HOME:-~/.local/share}/zeroclaw/web/dist`. This is within the user's own home directory, the same scope the installer already uses for config and binary. No elevated permissions.
- New external network calls? No: the tarball download URL is unchanged.
- Secrets / tokens / credentials handling changed? No.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? No.

## Compatibility (required)

- Backward compatible? Yes: the extraction is guarded; if `web/dist` is absent in the tarball (older release), install proceeds normally.
- Config / env / CLI surface changed? No. `--dry-run --prebuilt` now shows the web dashboard destination path in its output (additive only).

## Rollback (required for `risk: medium` and `risk: high`)

`git revert 821fbfcf` is the plan.
