### PR TITLE
fix(web): dashboard bugfix bundle (Overview crash, model save, editor caret, chat CPU)

### DIFF
--- a/web/src/pages/AgentChat.tsx
+++ b/web/src/pages/AgentChat.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { memo, useState, useEffect, useRef, useCallback } from 'react';
 import { Send, Bot, User, AlertCircle, Copy, Check, X, Trash2, Minimize2, Maximize2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -438,86 +438,15 @@ export default function AgentChat() {
         )}
 
         {messages.map((msg, idx) => (
-          <div
+          <MessageItem
             key={msg.id}
-            className={`group flex items-start ${compact ? 'gap-2' : 'gap-3'} ${
-              msg.role === 'user' ? 'flex-row-reverse animate-slide-in-right' : 'animate-slide-in-left'
-            }`}
-            style={{ animationDelay: `${Math.min(idx * 30, 200)}ms` }}
-          >
-            {!compact && (
-              <div
-                className="flex-shrink-0 w-9 h-9 rounded-2xl flex items-center justify-center border"
-                style={{
-                  background: msg.role === 'user' ? 'var(--pc-accent)' : 'var(--pc-bg-elevated)',
-                  borderColor: msg.role === 'user' ? 'var(--pc-accent)' : 'var(--pc-border)',
-                }}
-              >
-                {msg.role === 'user' ? (
-                  <User className="h-4 w-4 text-white" />
-                ) : (
-                  <Bot className="h-4 w-4" style={{ color: 'var(--pc-accent)' }} />
-                )}
-              </div>
-            )}
-            <div className="relative max-w-[75%]">
-              <div
-                className={compact ? 'rounded-xl px-3 py-1.5 border' : 'rounded-2xl px-4 py-3 border'}
-                style={
-                  msg.role === 'user'
-                    ? { background: 'var(--pc-accent-glow)', borderColor: 'var(--pc-accent-dim)', color: 'var(--pc-text-primary)', }
-                    : { background: 'var(--pc-bg-elevated)', borderColor: 'var(--pc-border)', color: 'var(--pc-text-primary)', }
-                }
-              >
-                {msg.thinking && (
-                  <details className="mb-2">
-                    <summary className="text-xs cursor-pointer select-none" style={{ color: 'var(--pc-text-muted)' }}>Thinking</summary>
-                    <pre className="text-xs mt-1 whitespace-pre-wrap break-words leading-relaxed overflow-auto max-h-60 p-2 rounded-lg" style={{ color: 'var(--pc-text-muted)', background: 'var(--pc-bg-surface)' }}>{msg.thinking}</pre>
-                  </details>
-                )}
-                {msg.toolCall ? (
-                  <ToolCallCard toolCall={msg.toolCall} />
-                ) : msg.markdown ? (
-                  <div className={`${compact ? 'text-xs' : 'text-sm'} break-words leading-relaxed chat-markdown`}><ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown></div>
-                ) : (
-                  <p className={`${compact ? 'text-xs' : 'text-sm'} whitespace-pre-wrap break-words leading-relaxed`}>{msg.content}</p>
-                )}
-                {!compact && (
-                  <p
-                    className="text-[10px] mt-1.5" style={{ color: msg.role === 'user' ? 'var(--pc-accent-light)' : 'var(--pc-text-faint)' }}>
-                    {msg.timestamp.toLocaleTimeString()}
-                  </p>
-                )}
-              </div>
-              {/* Hover action buttons — below the bubble, right-aligned */}
-              <div className="flex items-center justify-end gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                <button
-                  onClick={() => handleCopy(msg.id, msg.content)}
-                  aria-label={t('agent.copy_message')}
-                  className="p-1 rounded-lg"
-                  style={{ color: 'var(--pc-text-muted)' }}
-                  onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--pc-text-primary)'; }}
-                  onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--pc-text-muted)'; }}
-                >
-                  {copiedId === msg.id ? (
-                    <Check className="h-3.5 w-3.5" style={{ color: '#34d399' }} />
-                  ) : (
-                    <Copy className="h-3.5 w-3.5" />
-                  )}
-                </button>
-                <button
-                  onClick={() => handleDeleteMessage(msg.id)}
-                  aria-label={t('agent.delete_message')}
-                  className="p-1 rounded-lg"
-                  style={{ color: 'var(--pc-text-muted)' }}
-                  onMouseEnter={(e) => { e.currentTarget.style.color = '#f87171'; }}
-                  onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--pc-text-muted)'; }}
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              </div>
-            </div>
-          </div>
+            msg={msg}
+            idx={idx}
+            compact={compact}
+            isCopied={copiedId === msg.id}
+            onCopy={handleCopy}
+            onDelete={handleDeleteMessage}
+          />
         ))}
 
         {typing && (
@@ -588,3 +517,107 @@ export default function AgentChat() {
     </div>
   );
 }
+
+// Each chat message is rendered through this memoized component so that
+// typing into the input does not re-render every existing message (and
+// re-run ReactMarkdown on each one). Keep the prop surface small and pass
+// `isCopied` rather than the parent's full copiedId so only the affected
+// row re-renders when the copy indicator flips. See #5125.
+interface MessageItemProps {
+  msg: ChatMessage;
+  idx: number;
+  compact: boolean;
+  isCopied: boolean;
+  onCopy: (id: string, content: string) => void;
+  onDelete: (id: string) => void;
+}
+
+const MessageItem = memo(function MessageItem({
+  msg,
+  idx,
+  compact,
+  isCopied,
+  onCopy,
+  onDelete,
+}: MessageItemProps) {
+  return (
+    <div
+      className={`group flex items-start ${compact ? 'gap-2' : 'gap-3'} ${
+        msg.role === 'user' ? 'flex-row-reverse animate-slide-in-right' : 'animate-slide-in-left'
+      }`}
+      style={{ animationDelay: `${Math.min(idx * 30, 200)}ms` }}
+    >
+      {!compact && (
+        <div
+          className="flex-shrink-0 w-9 h-9 rounded-2xl flex items-center justify-center border"
+          style={{
+            background: msg.role === 'user' ? 'var(--pc-accent)' : 'var(--pc-bg-elevated)',
+            borderColor: msg.role === 'user' ? 'var(--pc-accent)' : 'var(--pc-border)',
+          }}
+        >
+          {msg.role === 'user' ? (
+            <User className="h-4 w-4 text-white" />
+          ) : (
+            <Bot className="h-4 w-4" style={{ color: 'var(--pc-accent)' }} />
+          )}
+        </div>
+      )}
+      <div className="relative max-w-[75%]">
+        <div
+          className={compact ? 'rounded-xl px-3 py-1.5 border' : 'rounded-2xl px-4 py-3 border'}
+          style={
+            msg.role === 'user'
+              ? { background: 'var(--pc-accent-glow)', borderColor: 'var(--pc-accent-dim)', color: 'var(--pc-text-primary)' }
+              : { background: 'var(--pc-bg-elevated)', borderColor: 'var(--pc-border)', color: 'var(--pc-text-primary)' }
+          }
+        >
+          {msg.thinking && (
+            <details className="mb-2">
+              <summary className="text-xs cursor-pointer select-none" style={{ color: 'var(--pc-text-muted)' }}>Thinking</summary>
+              <pre className="text-xs mt-1 whitespace-pre-wrap break-words leading-relaxed overflow-auto max-h-60 p-2 rounded-lg" style={{ color: 'var(--pc-text-muted)', background: 'var(--pc-bg-surface)' }}>{msg.thinking}</pre>
+            </details>
+          )}
+          {msg.toolCall ? (
+            <ToolCallCard toolCall={msg.toolCall} />
+          ) : msg.markdown ? (
+            <div className={`${compact ? 'text-xs' : 'text-sm'} break-words leading-relaxed chat-markdown`}><ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown></div>
+          ) : (
+            <p className={`${compact ? 'text-xs' : 'text-sm'} whitespace-pre-wrap break-words leading-relaxed`}>{msg.content}</p>
+          )}
+          {!compact && (
+            <p
+              className="text-[10px] mt-1.5" style={{ color: msg.role === 'user' ? 'var(--pc-accent-light)' : 'var(--pc-text-faint)' }}>
+              {msg.timestamp.toLocaleTimeString()}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center justify-end gap-1 mt-1 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button
+            onClick={() => onCopy(msg.id, msg.content)}
+            aria-label={t('agent.copy_message')}
+            className="p-1 rounded-lg"
+            style={{ color: 'var(--pc-text-muted)' }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = 'var(--pc-text-primary)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--pc-text-muted)'; }}
+          >
+            {isCopied ? (
+              <Check className="h-3.5 w-3.5" style={{ color: '#34d399' }} />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+          </button>
+          <button
+            onClick={() => onDelete(msg.id)}
+            aria-label={t('agent.delete_message')}
+            className="p-1 rounded-lg"
+            style={{ color: 'var(--pc-text-muted)' }}
+            onMouseEnter={(e) => { e.currentTarget.style.color = '#f87171'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.color = 'var(--pc-text-muted)'; }}
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+});

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -352,7 +352,7 @@ function OverviewTab({
             </h2>
           </div>
           <div className="grid grid-cols-2 gap-3">
-            {Object.entries(status.health.components).length === 0 ? (
+            {!status.health?.components || Object.entries(status.health.components).length === 0 ? (
               <p
                 className="text-sm col-span-2"
                 style={{ color: "var(--pc-text-faint)" }}

--- a/web/src/pages/config/ConfigTomlEditor.tsx
+++ b/web/src/pages/config/ConfigTomlEditor.tsx
@@ -110,8 +110,8 @@ export default function ConfigTomlEditor({ value, onChange }: ConfigTomlEditorPr
         <pre
           ref={preRef}
           aria-hidden="true"
-          className="absolute inset-0 text-sm p-4 font-mono overflow-auto whitespace-pre pointer-events-none m-0"
-          style={{ background: 'var(--pc-bg-base)', tabSize: 4 }}
+          className="absolute inset-0 p-4 overflow-auto pointer-events-none m-0"
+          style={{ ...EDITOR_METRICS, background: 'var(--pc-bg-base)' }}
           dangerouslySetInnerHTML={{ __html: highlightToml(value) }}
         />
         <textarea
@@ -130,10 +130,26 @@ export default function ConfigTomlEditor({ value, onChange }: ConfigTomlEditorPr
             }
           }}
           spellCheck={false}
-          className="absolute inset-0 w-full h-full text-sm p-4 resize-none focus:outline-none font-mono caret-white"
-          style={{ background: 'transparent', color: 'transparent', tabSize: 4 }}
+          wrap="off"
+          className="absolute inset-0 w-full h-full p-4 resize-none focus:outline-none caret-white"
+          style={{ ...EDITOR_METRICS, background: 'transparent', color: 'transparent' }}
         />
       </div>
     </div>
   );
 }
+
+// Both the highlighter <pre> and the typing <textarea> must render text with
+// pixel-identical metrics, otherwise the visible characters from the pre and
+// the caret position from the textarea drift apart. See #6073. Apply the same
+// inline style object to both layers; do not mix Tailwind text/font utilities
+// with inline overrides on one side only.
+const EDITOR_METRICS: React.CSSProperties = {
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+  fontSize: '14px',
+  lineHeight: '20px',
+  letterSpacing: '0',
+  tabSize: 4,
+  whiteSpace: 'pre',
+  fontVariantLigatures: 'none',
+};

--- a/web/src/pages/config/sections/GeneralSection.tsx
+++ b/web/src/pages/config/sections/GeneralSection.tsx
@@ -148,18 +148,35 @@ const MODELS_BY_PROVIDER: Record<string, { value: string; label: string }[]> = {
   ],
 };
 
+// Read the per-provider model entry from the [providers.models.<name>] table.
+function readProviderModel(config: Record<string, unknown>, provider: string): string {
+  const providers = config.providers as Record<string, unknown> | undefined;
+  const models = providers?.models as Record<string, unknown> | undefined;
+  const entry = models?.[provider] as Record<string, unknown> | undefined;
+  return (entry?.model as string) ?? '';
+}
+
 export default function GeneralSection({ config, onUpdate }: Props) {
-  const provider = (config.default_provider as string) ?? 'openrouter';
+  // The runtime reads [providers].fallback and [providers.models.<name>].model.
+  // Older builds of this form wrote top-level `default_provider` / `default_model`
+  // which the runtime ignored, so saves silently no-op'd. See #6047.
+  const providers = config.providers as Record<string, unknown> | undefined;
+  const provider = (providers?.fallback as string) ?? 'openrouter';
   const modelOptions = MODELS_BY_PROVIDER[provider];
-  const currentModel = (config.default_model as string) ?? '';
+  const currentModel = readProviderModel(config, provider);
 
   // When provider changes, auto-select the first model for that provider
   const handleProviderChange = (v: string) => {
-    onUpdate('default_provider', v);
+    onUpdate('providers.fallback', v);
     const models = MODELS_BY_PROVIDER[v];
-    if (models && models.length > 0) {
-      onUpdate('default_model', models[0]!.value);
+    const existing = readProviderModel(config, v);
+    if (!existing && models && models.length > 0) {
+      onUpdate(`providers.models.${v}.model`, models[0]!.value);
     }
+  };
+
+  const handleModelChange = (v: string) => {
+    onUpdate(`providers.models.${provider}.model`, v);
   };
 
   return (
@@ -179,7 +196,7 @@ export default function GeneralSection({ config, onUpdate }: Props) {
         {modelOptions ? (
           <Select
             value={modelOptions.some((o) => o.value === currentModel) ? currentModel : ''}
-            onChange={(v) => onUpdate('default_model', v)}
+            onChange={handleModelChange}
             options={[
               ...(currentModel && !modelOptions.some((o) => o.value === currentModel)
                 ? [{ value: currentModel, label: currentModel }]
@@ -191,7 +208,7 @@ export default function GeneralSection({ config, onUpdate }: Props) {
           <input
             type="text"
             value={currentModel}
-            onChange={(e) => onUpdate('default_model', e.target.value)}
+            onChange={(e) => handleModelChange(e.target.value)}
             placeholder="model name"
             className="input-electric text-sm px-3 py-1.5 w-52 font-mono"
           />


### PR DESCRIPTION
## Summary

- **Base branch:** master (all contributions)
- **What changed and why:**
  - **#5244 Overview render error:** the dashboard's component-health grid crashed with \"Cannot convert undefined to object\" when the /api/health response omitted the components map. Added a single null guard. The Channels-tab half of #5244 was already fixed by #6069; this PR completes the issue.
  - **#6047 Settings model change reverts:** the General Settings form was writing top-level default_provider and default_model keys, which the runtime ignores. The runtime reads [providers].fallback and [providers.models.<name>].model. Saves silently no-op'd, which matches the user's report (success indicator fires, reload shows the original value, editing config.toml directly works). Form now reads/writes the canonical paths.
  - **#6073 Config editor caret misalignment:** the TOML editor renders syntax-highlighted text in a transparent <pre> beneath an actual <textarea>. Both layers were styled with Tailwind utilities only, so font metrics, line-height, letter-spacing, and whitespace handling could drift. The caret rendered from the textarea ended up offset from the visible glyphs from the pre. Pin both layers to one explicit CSSProperties object with identical metrics, and disable line wrap on the textarea so a long value cannot wrap in one layer but not the other.
  - **#5125 Agent chat CPU spike on typing:** the chat held messages and the input draft in the same component state. Every keystroke re-ran .map() over the full history and re-rendered every existing bubble (including ReactMarkdown for markdown messages). Extracted each row into a React.memo'd MessageItem; pass isCopied as a per-row boolean rather than the parent's full copiedId so the copy indicator flipping does not re-render every row.
- **Scope boundary:**
  - No test framework added (web/ has no test infra today; vitest/RTL setup is its own decision and would balloon this PR).
  - No migration for orphan default_provider / default_model keys that previous broken-form saves may have left in users' config.toml. They are inert; users can clean up via zeroclaw config unset, or just resave through the now-correct form.
  - Bundle does NOT touch #6077 (clear-chat / compact mode, already shipped via #6083), #5999 (umbrella UX track), #6070 (provider/onboarding logic).
- **Blast radius:**
  - web/ only. No Rust changes, no API changes, no schema changes, no CSS file changes outside ConfigTomlEditor.
  - Bug 4's MessageItem extraction is the largest behavior-relevant change; visual output is unchanged but the React tree restructures so any future test snapshot would shift.
- **Linked issue(s):** Closes #6047, Closes #6073, Closes #5125, Refs #5244 (Overview half; #6069 covered Channels half)

## Validation Evidence (required)

- **Commands run and tail output:**

\`\`\`
\$ cd web && npm run build
> tsc -b && vite build
vite v6.4.1 building for production...
✓ 1902 modules transformed.
dist/index.html                     0.52 kB │ gzip:   0.32 kB
dist/assets/index-7chH_U7z.css     40.56 kB │ gzip:   8.40 kB
dist/assets/index-CR6Jzg4f.js   1,098.56 kB │ gzip: 278.71 kB
✓ built in 1.92s
\`\`\`

The web/ workspace has no test runner configured (no \`test\` script, no vitest/jest/RTL in deps). \`npm run build\` runs \`tsc -b && vite build\` — passes typecheck and bundles cleanly.

- **Beyond CI, what did you manually verify?** No live browser smoke-test was run before opening this draft. Reviewer should bring up \`npm run dev\` (or load a fresh build) and verify, per fix:
  - **#5244**: load the dashboard while gateway is starting / health endpoint partially populated; Overview should show the empty-state copy instead of crashing.
  - **#6047**: open Settings → General, change the model, save, navigate away and back; the new model should stick. Confirm config.toml on disk has [providers.fallback] and [providers.models.<name>].model updated, not orphan top-level keys.
  - **#6073**: edit config.toml in Settings advanced mode, type a long line; the caret should sit at the same character position as the visible glyphs, with no drift.
  - **#5125**: open Agent Chat with a long history (50+ messages), type into the input; CPU should stay flat instead of pegging a core.
- **If any command was intentionally skipped, why:** Test suite — no framework exists in web/. Live browser verification — author won't be running it; flagged for reviewer.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**.
- New external network calls? **No**.
- Secrets / tokens / credentials handling changed? **No**.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**.

## Compatibility (required)

- Backward compatible? **Yes**. Visual output unchanged. Form schema fix is a write-side correction; existing on-disk configs continue to work.
- Config / env / CLI surface changed? **No**.
- Existing users: nothing required. Anyone who previously used the broken Settings form may have orphan default_provider / default_model keys at the top of their config.toml; these are inert and can be removed at any time via zeroclaw config unset default_provider (and same for default_model), or by resaving the form.

## Rollback (required for risk: medium and risk: high)

Low-risk PR, web/ only. \`git revert\` per commit (each fix is its own commit, isolated to one file).

- **Fast rollback command/path:** git revert <sha> for any single commit; commits are independent and revert cleanly in any order.
- **Feature flags or config toggles:** None.
- **Observable failure symptoms:**
  - #5244 regression: browser console shows TypeError on dashboard load.
  - #6047 regression: model selection in Settings does not persist across navigation.
  - #6073 regression: visible caret drift while typing in advanced config editor (browser-dependent — Chrome/Firefox font rendering may mask).
  - #5125 regression: typing in Agent Chat causes per-key lag on long sessions.