### PR TITLE
fix(web): guard array-returning api helpers against non-array responses

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -161,9 +161,10 @@ export function putConfig(toml: string): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export function getTools(): Promise<ToolSpec[]> {
-  return apiFetch<ToolSpec[] | { tools: ToolSpec[] }>('/api/tools').then((data) =>
-    unwrapField(data, 'tools'),
-  );
+  return apiFetch<ToolSpec[] | { tools: ToolSpec[] }>('/api/tools').then((data) => {
+    const result = unwrapField(data, 'tools');
+    return Array.isArray(result) ? result : [];
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -171,9 +172,10 @@ export function getTools(): Promise<ToolSpec[]> {
 // ---------------------------------------------------------------------------
 
 export function getCronJobs(): Promise<CronJob[]> {
-  return apiFetch<CronJob[] | { jobs: CronJob[] }>('/api/cron').then((data) =>
-    unwrapField(data, 'jobs'),
-  );
+  return apiFetch<CronJob[] | { jobs: CronJob[] }>('/api/cron').then((data) => {
+    const result = unwrapField(data, 'jobs');
+    return Array.isArray(result) ? result : [];
+  });
 }
 
 export function addCronJob(body: {
@@ -219,7 +221,10 @@ export function getCronRuns(
   const params = new URLSearchParams({ limit: String(limit) });
   return apiFetch<CronRun[] | { runs: CronRun[] }>(
     `/api/cron/${encodeURIComponent(jobId)}/runs?${params}`,
-  ).then((data) => unwrapField(data, 'runs'));
+  ).then((data) => {
+    const result = unwrapField(data, 'runs');
+    return Array.isArray(result) ? result : [];
+  });
 }
 
 export interface CronSettings {
@@ -247,7 +252,10 @@ export function patchCronSettings(
 
 export function getIntegrations(): Promise<Integration[]> {
   return apiFetch<Integration[] | { integrations: Integration[] }>('/api/integrations').then(
-    (data) => unwrapField(data, 'integrations'),
+    (data) => {
+      const result = unwrapField(data, 'integrations');
+      return Array.isArray(result) ? result : [];
+    },
   );
 }
 
@@ -275,7 +283,10 @@ export function getMemory(
   if (category) params.set('category', category);
   const qs = params.toString();
   return apiFetch<MemoryEntry[] | { entries: MemoryEntry[] }>(`/api/memory${qs ? `?${qs}` : ''}`).then(
-    (data) => unwrapField(data, 'entries'),
+    (data) => {
+      const result = unwrapField(data, 'entries');
+      return Array.isArray(result) ? result : [];
+    },
   );
 }
 
@@ -311,9 +322,10 @@ export function getCost(): Promise<CostSummary> {
 // ---------------------------------------------------------------------------
 
 export function getSessions(): Promise<Session[]> {
-  return apiFetch<Session[] | { sessions: Session[] }>('/api/sessions').then((data) =>
-    unwrapField(data, 'sessions'),
-  );
+  return apiFetch<Session[] | { sessions: Session[] }>('/api/sessions').then((data) => {
+    const result = unwrapField(data, 'sessions');
+    return Array.isArray(result) ? result : [];
+  });
 }
 
 export function getSession(id: string): Promise<Session> {
@@ -332,9 +344,10 @@ export function getSessionMessages(id: string): Promise<SessionMessagesResponse>
 // ---------------------------------------------------------------------------
 
 export function getChannels(): Promise<ChannelDetail[]> {
-  return apiFetch<ChannelDetail[] | { channels: ChannelDetail[] }>('/api/channels').then((data) =>
-    unwrapField(data, 'channels'),
-  );
+  return apiFetch<ChannelDetail[] | { channels: ChannelDetail[] }>('/api/channels').then((data) => {
+    const result = unwrapField(data, 'channels');
+    return Array.isArray(result) ? result : [];
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -342,7 +355,8 @@ export function getChannels(): Promise<ChannelDetail[]> {
 // ---------------------------------------------------------------------------
 
 export function getCliTools(): Promise<CliTool[]> {
-  return apiFetch<CliTool[] | { cli_tools: CliTool[] }>('/api/cli-tools').then((data) =>
-    unwrapField(data, 'cli_tools'),
-  );
+  return apiFetch<CliTool[] | { cli_tools: CliTool[] }>('/api/cli-tools').then((data) => {
+    const result = unwrapField(data, 'cli_tools');
+    return Array.isArray(result) ? result : [];
+  });
 }

--- a/web/src/pages/Cron.tsx
+++ b/web/src/pages/Cron.tsx
@@ -628,7 +628,7 @@ export default function Cron() {
                         ) : (
                           <ChevronRight className="h-3.5 w-3.5" />
                         )}
-                        {job.id.slice(0, 8)}
+                        {job.id?.slice(0, 8) ?? job.id}
                       </button>
                     </td>
                     <td className="font-medium text-sm" style={{ color: 'var(--pc-text-primary)' }}>


### PR DESCRIPTION
## Summary

- **Base branch:** master (all contributions)
- **What changed and why:**
  - Defensive Array.isArray guards on every array-returning helper in web/src/lib/api.ts so a malformed or partial API response (empty object, null body, error envelope) cannot silently hand back a non-array to callers that immediately .map() / .slice() over it.
  - Same defense added to Cron.tsx for job.id?.slice(...).
  - Reviving @rareba's #5096, which had bit-rotted past clean rebase. The original PR is the work of @rareba (Giulio V); this PR is a refresh, not a rewrite. Authorship of the commit is preserved on the rareba GitHub identity.
- **Scope boundary:**
  - Dashboard.tsx changes from the original PR are intentionally **omitted**: that PR's session.id?.slice(...) guard targeted an older Session schema that has since been replaced by a required session_id field. The TypeScript type now enforces non-null at the call site, so the runtime guard is unnecessary.
  - No test infrastructure added (web/ has no test runner today; not in scope for a defensive-guard fix).
- **Blast radius:** web/ only. No Rust, no schema, no API surface change. The guards are no-ops on well-behaved responses (the input is already an array, returns it; only diverges when the upstream contract is broken).
- **Linked issue(s):** Closes #4918, Supersedes #5096

## Validation Evidence (required)

- **Commands run and tail output:**

\`\`\`
\$ cd web && npm run build
> tsc -b && vite build
✓ 1902 modules transformed.
dist/index.html                     0.52 kB │ gzip:   0.32 kB
dist/assets/index-qaHgQ68Z.css     40.57 kB │ gzip:   8.41 kB
dist/assets/index-D1isV96g.js   1,098.38 kB │ gzip: 278.48 kB
✓ built in 2.07s
\`\`\`

- **Beyond CI, what did you manually verify?** No live browser smoke-test; the change is a narrow defensive guard with no UI impact when the upstream is well-behaved. Reviewer can validate by stubbing /api/sessions to return {} and confirming the dashboard sessions tab shows the empty-state copy instead of throwing.
- **If any command was intentionally skipped, why:** Test suite — no framework in web/. Live verification — pure defensive code path, only matters during gateway misbehavior.

## Security & Privacy Impact (required)

- New permissions, capabilities, or file system access scope? **No**.
- New external network calls? **No**.
- Secrets / tokens / credentials handling changed? **No**.
- PII, real identities, or personal data in diff, tests, fixtures, or docs? **No**.

## Compatibility (required)

- Backward compatible? **Yes**. No API surface change.
- Config / env / CLI surface changed? **No**.

## Rollback (required for risk: medium and risk: high)

Low-risk; \`git revert <sha>\` is the plan.

## Supersede Attribution (required only when Supersedes # is used)

- Superseded PRs + authors:
  - #5096 by @rareba
- Scope materially carried forward: api.ts defensive guards (full); Cron.tsx defensive guard (retained). Dashboard.tsx changes intentionally dropped because the Session schema removed the fields they targeted.
- Co-authored-by trailers added in commit messages for incorporated contributors? **N/A — the single commit is authored directly by rareba (Author: line on the commit), which is the equivalent attribution. Co-Authored-By would double-attribute.**