### PR TITLE
docs(contributing): clarify AGENTS code-style rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,8 @@ Branch/commit/PR rules:
 - Do not modify unrelated modules "while here".
 - Do not bypass failing checks without explicit explanation.
 - Do not hide behavior-changing side effects in refactor commits.
+- Do not suppress unused production code with underscore prefixes or `#[allow(dead_code)]`; delete it, wire it into behavior, or document a tracked follow-up.
+- Do not leave `unwrap()` / `expect()` in production paths; propagate errors or document why the invariant makes a panic impossible.
 - Do not include personal identity or sensitive information in test data, examples, docs, or commits.
 
 ## Skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,8 +113,8 @@ Branch/commit/PR rules:
 - Do not modify unrelated modules "while here".
 - Do not bypass failing checks without explicit explanation.
 - Do not hide behavior-changing side effects in refactor commits.
-- Do not suppress unused production code with underscore prefixes or `#[allow(dead_code)]`; delete it, wire it into behavior, or document a tracked follow-up.
-- Do not leave `unwrap()` / `expect()` in production paths; propagate errors or document why the invariant makes a panic impossible.
+- Do not suppress unused production code with underscore prefixes or `#[allow(dead_code)]`; delete it, wire it into behavior, or track a follow-up issue. Reserve underscore names for required but intentionally unused API, trait, or callback parameters.
+- Do not leave `unwrap()` / `expect()` in production paths; propagate errors or document the invariant that makes panic impossible.
 - Do not include personal identity or sensitive information in test data, examples, docs, or commits.
 
 ## Skills

--- a/docs/book/src/contributing/how-to.md
+++ b/docs/book/src/contributing/how-to.md
@@ -31,8 +31,8 @@ The key checkpoints:
 
 - `cargo fmt` clean (checked in CI)
 - `cargo clippy -D warnings` clean (checked in CI)
-- No dead code — if it's unused, delete it, don't `#[allow(dead_code)]` it
-- Error handling: `anyhow::Result` at binary boundaries, typed errors in library crates. No `unwrap()` / `expect()` in production code paths — propagate with `?` or convert to a typed error
+- No unused production code — delete it, wire it into behavior, or track a follow-up issue. Do not silence it with underscore prefixes or `#[allow(dead_code)]`; reserve underscore names for required but intentionally unused API, trait, or callback parameters.
+- Error handling: `anyhow::Result` at binary boundaries, typed errors in library crates. No `unwrap()` / `expect()` in production code paths — propagate with `?` or document the invariant that makes panic impossible.
 - Minimal dependencies — every dep adds to binary size; weigh the trade before adding one
 - Trait-first — define the trait in `zeroclaw-api`, then implement in the right edge crate
 - Security by default — allowlists, not blocklists. New external surface defaults closed


### PR DESCRIPTION
## Summary

- **Base branch:** `master` (all contributions)
- **What changed and why:** Align root `AGENTS.md` and `docs/book/src/contributing/how-to.md` on code-style guidance for unused production code and production `unwrap()` / `expect()`, because the contributor guide tells contributors to treat `AGENTS.md` as the canonical source of repository conventions.
- **Scope boundary:** Documentation/process guidance only; this does not change Rust code, tests, CI, or generated docs.
- **Blast radius:** AI coding assistants and contributors who read root `AGENTS.md` or the contributor guide; no runtime behavior impact.
- **Linked issue(s):** Related #6130

## Validation Evidence (required)

Local validation is the signal CI cannot replace. Run the full battery and paste literal output (tails, failures, warnings — not "all passed").

```bash
$ git diff --check
```

No output.

```bash
$ DOCS_FILES=$'AGENTS.md
docs/book/src/contributing/how-to.md' scripts/ci/docs_quality_gate.sh
Linting docs files: AGENTS.md docs/book/src/contributing/how-to.md
markdownlint-cli2 v0.20.0 (markdownlint v0.40.0)
Finding: AGENTS.md docs/book/src/contributing/how-to.md !target/**
Linting: 2 file(s)
Summary: 0 error(s)
```

- **Commands run and tail output:** See above.
- **Beyond CI — what did you manually verify?** Compared the `AGENTS.md` and `docs/book/src/contributing/how-to.md` wording to ensure the canonical agent guidance and contributor-facing guide now agree on unused production code, underscore-name exceptions, and production `unwrap()` / `expect()` handling.
- **If any command was intentionally skipped, why:** Rust validation was skipped because this is a docs-only guidance change with no code or generated docs changes.

## Security & Privacy Impact (required)

Yes/No for each. Answer any `Yes` with a 1–2 sentence explanation.

- New permissions, capabilities, or file system access scope? (`No`)
- New external network calls? (`No`)
- Secrets / tokens / credentials handling changed? (`No`)
- PII, real identities, or personal data in diff, tests, fixtures, or docs? (`No`)
- If any `Yes`, describe the risk and mitigation: N/A

## Compatibility (required)

- Backward compatible? (`Yes`)
- Config / env / CLI surface changed? (`No`)
- If `No` or `Yes` to either: N/A

## Rollback (required for `risk: medium` and `risk: high`)

Low-risk PRs: `git revert <merge commit>` is the plan.

## Supersede Attribution (required only when `Supersedes #` is used)

N/A — this PR does not supersede another PR.
